### PR TITLE
[Cases] Update docs for remaining guardrails

### DIFF
--- a/docs/api-generated/cases/case-apis-passthru.asciidoc
+++ b/docs/api-generated/cases/case-apis-passthru.asciidoc
@@ -126,8 +126,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -246,8 +252,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -366,8 +378,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -480,8 +498,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -869,7 +893,7 @@ Any modifications made to this file will be overwritten.
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      <a href="#findCaseActivityDefaultSpace_200_response">findCaseActivityDefaultSpace_200_response</a>
+      <a href="#findCaseActivity_200_response">findCaseActivity_200_response</a>
       
     </div>
 
@@ -922,7 +946,7 @@ Any modifications made to this file will be overwritten.
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Indicates a successful call.
-        <a href="#findCaseActivityDefaultSpace_200_response">findCaseActivityDefaultSpace_200_response</a>
+        <a href="#findCaseActivity_200_response">findCaseActivity_200_response</a>
     <h4 class="field-label">401</h4>
     Authorization information is missing or invalid.
         <a href="#4xx_response">4xx_response</a>
@@ -971,6 +995,48 @@ Any modifications made to this file will be overwritten.
     <div class="example-data-content-type">Content-Type: application/json</div>
     <pre class="example"><code>{
   "userActions" : [ {
+    "owner" : "cases",
+    "action" : "create",
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "id" : "22fd3e30-03b1-11ed-920c-974bfa104448",
+    "comment_id" : "578608d0-03b1-11ed-920c-974bfa104448",
+    "type" : "create_case",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzM1ODg4LDFd"
+  }, {
+    "owner" : "cases",
+    "action" : "create",
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "id" : "22fd3e30-03b1-11ed-920c-974bfa104448",
+    "comment_id" : "578608d0-03b1-11ed-920c-974bfa104448",
+    "type" : "create_case",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzM1ODg4LDFd"
+  }, {
+    "owner" : "cases",
+    "action" : "create",
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "id" : "22fd3e30-03b1-11ed-920c-974bfa104448",
+    "comment_id" : "578608d0-03b1-11ed-920c-974bfa104448",
+    "type" : "create_case",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzM1ODg4LDFd"
+  }, {
     "owner" : "cases",
     "action" : "create",
     "created_at" : "2022-05-13T09:16:17.416Z",
@@ -1069,8 +1135,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1302,7 +1374,7 @@ Any modifications made to this file will be overwritten.
 
     <h3 class="field-label">Return type</h3>
     <div class="return-type">
-      <a href="#findCasesDefaultSpace_200_response">findCasesDefaultSpace_200_response</a>
+      <a href="#findCases_200_response">findCases_200_response</a>
       
     </div>
 
@@ -1322,8 +1394,14 @@ Any modifications made to this file will be overwritten.
     },
     "totalAlerts" : 0,
     "closed_at" : "2000-01-23T04:56:07.000+00:00",
-    "comments" : [ null, null ],
+    "comments" : [ null, null, null, null, null ],
     "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
     }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1376,8 +1454,14 @@ Any modifications made to this file will be overwritten.
     },
     "totalAlerts" : 0,
     "closed_at" : "2000-01-23T04:56:07.000+00:00",
-    "comments" : [ null, null ],
+    "comments" : [ null, null, null, null, null ],
     "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
     }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1438,7 +1522,7 @@ Any modifications made to this file will be overwritten.
     <h3 class="field-label">Responses</h3>
     <h4 class="field-label">200</h4>
     Indicates a successful call.
-        <a href="#findCasesDefaultSpace_200_response">findCasesDefaultSpace_200_response</a>
+        <a href="#findCases_200_response">findCases_200_response</a>
     <h4 class="field-label">401</h4>
     Authorization information is missing or invalid.
         <a href="#4xx_response">4xx_response</a>
@@ -1515,8 +1599,14 @@ Any modifications made to this file will be overwritten.
     },
     "totalAlerts" : 0,
     "closed_at" : "2000-01-23T04:56:07.000+00:00",
-    "comments" : [ null, null ],
+    "comments" : [ null, null, null, null, null ],
     "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
     }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1569,8 +1659,194 @@ Any modifications made to this file will be overwritten.
     },
     "totalAlerts" : 0,
     "closed_at" : "2000-01-23T04:56:07.000+00:00",
-    "comments" : [ null, null ],
+    "comments" : [ null, null, null, null, null ],
     "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    } ],
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "description" : "A case description.",
+    "title" : "Case title 1",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzUzMiwxXQ==",
+    "closed_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "tags" : [ "tag-1" ],
+    "duration" : 120,
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "updated_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "id" : "66b9aa00-94fa-11ea-9f74-e7e108796192",
+    "external_service" : {
+      "external_title" : "external_title",
+      "pushed_by" : {
+        "full_name" : "full_name",
+        "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+        "email" : "email",
+        "username" : "elastic"
+      },
+      "external_url" : "external_url",
+      "pushed_at" : "2000-01-23T04:56:07.000+00:00",
+      "connector_id" : "connector_id",
+      "external_id" : "external_id",
+      "connector_name" : "connector_name"
+    }
+  }, {
+    "owner" : "cases",
+    "totalComment" : 0,
+    "settings" : {
+      "syncAlerts" : true
+    },
+    "totalAlerts" : 0,
+    "closed_at" : "2000-01-23T04:56:07.000+00:00",
+    "comments" : [ null, null, null, null, null ],
+    "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    } ],
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "description" : "A case description.",
+    "title" : "Case title 1",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzUzMiwxXQ==",
+    "closed_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "tags" : [ "tag-1" ],
+    "duration" : 120,
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "updated_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "id" : "66b9aa00-94fa-11ea-9f74-e7e108796192",
+    "external_service" : {
+      "external_title" : "external_title",
+      "pushed_by" : {
+        "full_name" : "full_name",
+        "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+        "email" : "email",
+        "username" : "elastic"
+      },
+      "external_url" : "external_url",
+      "pushed_at" : "2000-01-23T04:56:07.000+00:00",
+      "connector_id" : "connector_id",
+      "external_id" : "external_id",
+      "connector_name" : "connector_name"
+    }
+  }, {
+    "owner" : "cases",
+    "totalComment" : 0,
+    "settings" : {
+      "syncAlerts" : true
+    },
+    "totalAlerts" : 0,
+    "closed_at" : "2000-01-23T04:56:07.000+00:00",
+    "comments" : [ null, null, null, null, null ],
+    "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    } ],
+    "created_at" : "2022-05-13T09:16:17.416Z",
+    "description" : "A case description.",
+    "title" : "Case title 1",
+    "created_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "version" : "WzUzMiwxXQ==",
+    "closed_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "tags" : [ "tag-1" ],
+    "duration" : 120,
+    "updated_at" : "2000-01-23T04:56:07.000+00:00",
+    "updated_by" : {
+      "full_name" : "full_name",
+      "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+      "email" : "email",
+      "username" : "elastic"
+    },
+    "id" : "66b9aa00-94fa-11ea-9f74-e7e108796192",
+    "external_service" : {
+      "external_title" : "external_title",
+      "pushed_by" : {
+        "full_name" : "full_name",
+        "profile_uid" : "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0",
+        "email" : "email",
+        "username" : "elastic"
+      },
+      "external_url" : "external_url",
+      "pushed_at" : "2000-01-23T04:56:07.000+00:00",
+      "connector_id" : "connector_id",
+      "external_id" : "external_id",
+      "connector_name" : "connector_name"
+    }
+  }, {
+    "owner" : "cases",
+    "totalComment" : 0,
+    "settings" : {
+      "syncAlerts" : true
+    },
+    "totalAlerts" : 0,
+    "closed_at" : "2000-01-23T04:56:07.000+00:00",
+    "comments" : [ null, null, null, null, null ],
+    "assignees" : [ {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
+      "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+    }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
     }, {
       "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1676,8 +1952,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1777,8 +2059,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -1886,8 +2174,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -2491,8 +2785,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -3047,8 +3347,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -3169,8 +3475,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -3485,8 +3797,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -3607,8 +3925,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -3727,8 +4051,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -4045,8 +4375,14 @@ Any modifications made to this file will be overwritten.
   },
   "totalAlerts" : 0,
   "closed_at" : "2000-01-23T04:56:07.000+00:00",
-  "comments" : [ null, null ],
+  "comments" : [ null, null, null, null, null ],
   "assignees" : [ {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
+    "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+  }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
   }, {
     "uid" : "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
@@ -4152,12 +4488,14 @@ Any modifications made to this file will be overwritten.
     <li><a href="#create_case_request_connector"><code>create_case_request_connector</code> - </a></li>
     <li><a href="#external_service"><code>external_service</code> - </a></li>
     <li><a href="#findCaseActivityDefaultSpace_200_response"><code>findCaseActivityDefaultSpace_200_response</code> - </a></li>
+    <li><a href="#findCaseActivity_200_response"><code>findCaseActivity_200_response</code> - </a></li>
     <li><a href="#findCaseConnectorsDefaultSpace_200_response_inner"><code>findCaseConnectorsDefaultSpace_200_response_inner</code> - </a></li>
     <li><a href="#findCaseConnectorsDefaultSpace_200_response_inner_config"><code>findCaseConnectorsDefaultSpace_200_response_inner_config</code> - </a></li>
     <li><a href="#findCasesDefaultSpace_200_response"><code>findCasesDefaultSpace_200_response</code> - </a></li>
     <li><a href="#findCasesDefaultSpace_assignees_parameter"><code>findCasesDefaultSpace_assignees_parameter</code> - </a></li>
     <li><a href="#findCasesDefaultSpace_owner_parameter"><code>findCasesDefaultSpace_owner_parameter</code> - </a></li>
     <li><a href="#findCasesDefaultSpace_searchFields_parameter"><code>findCasesDefaultSpace_searchFields_parameter</code> - </a></li>
+    <li><a href="#findCases_200_response"><code>findCases_200_response</code> - </a></li>
     <li><a href="#getCaseCommentDefaultSpace_200_response"><code>getCaseCommentDefaultSpace_200_response</code> - </a></li>
     <li><a href="#getCaseConfigurationDefaultSpace_200_response_inner"><code>getCaseConfigurationDefaultSpace_200_response_inner</code> - </a></li>
     <li><a href="#getCaseConfigurationDefaultSpace_200_response_inner_connector"><code>getCaseConfigurationDefaultSpace_200_response_inner_connector</code> - </a></li>
@@ -4619,6 +4957,16 @@ Any modifications made to this file will be overwritten.
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="findCaseActivity_200_response"><code>findCaseActivity_200_response</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">page (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">perPage (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">total (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">userActions (optional)</div><div class="param-desc"><span class="param-type"><a href="#user_actions_find_response_properties">array[user_actions_find_response_properties]</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="findCaseConnectorsDefaultSpace_200_response_inner"><code>findCaseConnectorsDefaultSpace_200_response_inner</code> - </a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
@@ -4670,6 +5018,19 @@ Any modifications made to this file will be overwritten.
     <div class='model-description'></div>
     <div class="field-items">
           </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="findCases_200_response"><code>findCases_200_response</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">cases (optional)</div><div class="param-desc"><span class="param-type"><a href="#case_response_properties">array[case_response_properties]</a></span>  </div>
+<div class="param">count_closed_cases (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">count_in_progress_cases (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">count_open_cases (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">page (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">per_page (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+<div class="param">total (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span>  </div>
+    </div>  <!-- field-items -->
   </div>
   <div class="model">
     <h3><a name="getCaseCommentDefaultSpace_200_response"><code>getCaseCommentDefaultSpace_200_response</code> - </a> <a class="up" href="#__Models">Up</a></h3>

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -266,6 +266,7 @@
                   "properties": {
                     "cases": {
                       "type": "array",
+                      "maxItems": 10000,
                       "items": {
                         "$ref": "#/components/schemas/case_response_properties"
                       }
@@ -345,6 +346,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
+                  "maxItems": 10000,
                   "items": {
                     "type": "object",
                     "properties": {
@@ -954,6 +956,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
+                  "maxItems": 10000,
                   "items": {
                     "type": "object",
                     "properties": {
@@ -1094,6 +1097,7 @@
               "application/json": {
                 "schema": {
                   "type": "array",
+                  "maxItems": 10000,
                   "items": {
                     "type": "string"
                   }
@@ -1719,6 +1723,7 @@
                     },
                     "userActions": {
                       "type": "array",
+                      "maxItems": 10000,
                       "items": {
                         "$ref": "#/components/schemas/user_actions_find_response_properties"
                       }
@@ -4157,6 +4162,7 @@
       "assignees": {
         "type": "array",
         "description": "An array containing users that are assigned to the case.",
+        "maxItems": 10,
         "nullable": true,
         "items": {
           "type": "object",
@@ -5069,6 +5075,7 @@
             "title": "Case response properties for comments",
             "description": "An array of comment objects for the case.",
             "type": "array",
+            "maxItems": 10000,
             "items": {
               "discriminator": {
                 "propertyName": "type"

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -150,6 +150,7 @@ paths:
                 properties:
                   cases:
                     type: array
+                    maxItems: 10000
                     items:
                       $ref: '#/components/schemas/case_response_properties'
                   count_closed_cases:
@@ -196,6 +197,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 10000
                 items:
                   type: object
                   properties:
@@ -610,6 +612,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 10000
                 items:
                   type: object
                   properties:
@@ -696,6 +699,7 @@ paths:
             application/json:
               schema:
                 type: array
+                maxItems: 10000
                 items:
                   type: string
               examples:
@@ -1054,6 +1058,7 @@ paths:
                     type: integer
                   userActions:
                     type: array
+                    maxItems: 10000
                     items:
                       $ref: '#/components/schemas/user_actions_find_response_properties'
               examples:
@@ -2565,6 +2570,7 @@ components:
     assignees:
       type: array
       description: An array containing users that are assigned to the case.
+      maxItems: 10
       nullable: true
       items:
         type: object
@@ -3254,6 +3260,7 @@ components:
           title: Case response properties for comments
           description: An array of comment objects for the case.
           type: array
+          maxItems: 10000
           items:
             discriminator:
               propertyName: type

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/assignees.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/assignees.yaml
@@ -1,5 +1,6 @@
 type: array
 description: An array containing users that are assigned to the case.
+maxItems: 10
 nullable: true
 items:
   type: object

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/case_response_properties.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/case_response_properties.yaml
@@ -35,6 +35,7 @@ properties:
     title: Case response properties for comments
     description: An array of comment objects for the case.
     type: array
+    maxItems: 10000
     items:
       discriminator:
         propertyName: type

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@_find.yaml
@@ -34,6 +34,7 @@ get:
             properties:
               cases:
                 type: array
+                maxItems: 10000
                 items:
                   $ref: '../components/schemas/case_response_properties.yaml'
               count_closed_cases:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@alerts@{alertid}.yaml
@@ -18,6 +18,7 @@ get:
         application/json:
           schema:
             type: array
+            maxItems: 10000
             items: 
               type: object
               properties:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@reporters.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@reporters.yaml
@@ -16,6 +16,7 @@ get:
         application/json:
           schema:
             type: array
+            maxItems: 10000
             items:
               type: object
               properties:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@tags.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@tags.yaml
@@ -14,6 +14,7 @@ get:
         application/json:
           schema:
             type: array
+            maxItems: 10000
             items:
               type: string
           examples:

--- a/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
+++ b/x-pack/plugins/cases/docs/openapi/paths/api@cases@{caseid}@user_actions@_find.yaml
@@ -29,6 +29,7 @@ get:
                 type: integer
               userActions:
                 type: array
+                maxItems: 10000
                 items:
                   $ref: '../components/schemas/user_actions_find_response_properties.yaml'
           examples:


### PR DESCRIPTION
## Summary

Connected to https://github.com/elastic/kibana/issues/146945

This PR updates API docs for 

Description | Limit | Done? | Documented? | UI?
-- | -- | -- | -- | --
Total assignees per case | 10 | ✅ | Yes | ✅
Maximum number of cases/user actions/comments returned from the API | 10.000 | ✅ | Yes | N/A
Total number of cases by alert ID returned from the API | 10.000 | ✅ | Yes | N/A
Total number of tags returned from the API | 10.000 | ✅ | Yes | N/A
Total number of reporters returned from the API | 10.000 | ✅ | Yes | N/A

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release Note

Limits are now imposed on the number of objects that cases can process and the amount of data those objects can store. For the full list, refer to https://github.com/elastic/kibana/issues/146945