### PR TITLE
[DOCS]Adding ESS icon to xpack.security.session.сoncurrentSessions.maxSessi…

### DIFF
--- a/docs/settings/security-settings.asciidoc
+++ b/docs/settings/security-settings.asciidoc
@@ -210,7 +210,7 @@ Sets the interval at which {kib} tries to remove expired and invalid sessions fr
 +
 TIP: Use a string of `<count>[ms\|s\|m\|h\|d\|w\|M\|Y]` (e.g. '20m', '24h', '7d', '1w').
 
-xpack.security.session.сoncurrentSessions.maxSessions::
+xpack.security.session.concurrentSessions.maxSessions {ess-icon}::
 Set the maximum number of sessions each user is allowed to have active at any given time.
 By default, no limit is applied.
 If set, the value of this option should be an integer between `1` and `1000`.


### PR DESCRIPTION
`xpack.security.session.сoncurrentSessions.maxSessons` in Kibana docs.

## Summary

Adding the Elastic Cloud icon to `xpack.security.session.сoncurrentSessions.maxSessons` security setting on [docs page](https://www.elastic.co/guide/en/kibana/current/security-settings-kb.html). Need to raise another PR from cloud repo to add security setting to [cloud docs page](https://www.elastic.co/guide/en/cloud/current/ec-manage-kibana-settings.html#ec-kibana-config). 

Relates to: #160958


<!--ONMERGE {"backportTargets":["8.7","8.9"]} ONMERGE-->