### PR TITLE
[8.9] Revert "[Reporting] Fix task manager not to run tasks before Kibana is initialized (#162364)

### DIFF
--- a/x-pack/plugins/reporting/server/core.ts
+++ b/x-pack/plugins/reporting/server/core.ts
@@ -21,7 +21,7 @@ import type {
   StatusServiceSetup,
   UiSettingsServiceStart,
 } from '@kbn/core/server';
-import { CoreKibanaRequest, ServiceStatusLevels } from '@kbn/core/server';
+import { CoreKibanaRequest } from '@kbn/core/server';
 import type { PluginStart as DataPluginStart } from '@kbn/data-plugin/server';
 import type { DiscoverServerPluginStart } from '@kbn/discover-plugin/server';
 import type { PluginSetupContract as FeaturesPluginSetup } from '@kbn/features-plugin/server';
@@ -42,7 +42,7 @@ import type {
 } from '@kbn/task-manager-plugin/server';
 import type { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import * as Rx from 'rxjs';
-import { filter, first, map, switchMap, take } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import type { ReportingSetup } from '.';
 import { REPORTING_REDIRECT_LOCATOR_STORE_KEY } from '../common/constants';
 import { createConfig, ReportingConfigType } from './config';
@@ -158,8 +158,6 @@ export class ReportingCore {
     this.pluginStart$.next(startDeps); // trigger the observer
     this.pluginStartDeps = startDeps; // cache
 
-    await this.assertKibanaIsAvailable();
-
     const { taskManager } = startDeps;
     const { executeTask, monitorTask } = this;
     // enable this instance to generate reports and to monitor for pending reports
@@ -172,17 +170,6 @@ export class ReportingCore {
 
   public getKibanaShutdown$(): Rx.Observable<void> {
     return this.kibanaShuttingDown$.pipe(take(1));
-  }
-
-  private async assertKibanaIsAvailable(): Promise<void> {
-    const { status } = this.getPluginSetupDeps();
-
-    await status.overall$
-      .pipe(
-        filter((current) => current.level === ServiceStatusLevels.available),
-        first()
-      )
-      .toPromise();
   }
 
   /*


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Revert "[Reporting] Fix task manager not to run tasks before Kibana is initialized (#162364)](https://github.com/elastic/kibana/pull/162364)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rachel Shen","email":"rshen@elastic.co"},"sourceCommit":{"committedDate":"2023-07-24T18:14:05Z","message":"Revert \"[Reporting] Fix task manager not to run tasks before Kibana is initialized (#162364)\n\n## Summary\r\n\r\nThis reverts commit e774ece489edb74e02bbb1be09a3bfe4162fe48b.\r\n\r\nReporting registers tasks with Task Manager in its setup phase, but\r\ntoday, it's own start phase is not guaranteed to initialize. During\r\ninitialization, Reporting injects dependencies into the objects\r\nresponsible for internal handling of tasks.\r\n\r\nThe `Kibana instance ID is undefined` error can happen when Task Manager\r\ncalls the runTask before the \"execute report\" object receives its\r\ndependencies.\r\n\r\nThe `Reporting task runner has not been initialized` error can happen\r\nwhen a user or a Watch trigger tries to request report generation before\r\ninternal dependencies are set. This can also happen if Reporting\r\nattempts to retry a stuck job before the internal dependencies are set.\r\n\r\nInitializing the task objects (execute_report, monitor_reports) is\r\nmission-critical for Reporting internals. The tasks were register in our\r\nsetup method. That means, we need to prioritize getting the start\r\ndependencies into the task objects in the code - it can't be blocked.","sha":"e1d188287c5f552333d8a1b1e9137606362da313","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Reporting","release_note:skip","backport:skip","ci:cloud-deploy","ci:cloud-redeploy","v8.10.0"],"number":162364,"url":"https://github.com/elastic/kibana/pull/162364","mergeCommit":{"message":"Revert \"[Reporting] Fix task manager not to run tasks before Kibana is initialized (#162364)\n\n## Summary\r\n\r\nThis reverts commit e774ece489edb74e02bbb1be09a3bfe4162fe48b.\r\n\r\nReporting registers tasks with Task Manager in its setup phase, but\r\ntoday, it's own start phase is not guaranteed to initialize. During\r\ninitialization, Reporting injects dependencies into the objects\r\nresponsible for internal handling of tasks.\r\n\r\nThe `Kibana instance ID is undefined` error can happen when Task Manager\r\ncalls the runTask before the \"execute report\" object receives its\r\ndependencies.\r\n\r\nThe `Reporting task runner has not been initialized` error can happen\r\nwhen a user or a Watch trigger tries to request report generation before\r\ninternal dependencies are set. This can also happen if Reporting\r\nattempts to retry a stuck job before the internal dependencies are set.\r\n\r\nInitializing the task objects (execute_report, monitor_reports) is\r\nmission-critical for Reporting internals. The tasks were register in our\r\nsetup method. That means, we need to prioritize getting the start\r\ndependencies into the task objects in the code - it can't be blocked.","sha":"e1d188287c5f552333d8a1b1e9137606362da313"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/162364","number":162364,"mergeCommit":{"message":"Revert \"[Reporting] Fix task manager not to run tasks before Kibana is initialized (#162364)\n\n## Summary\r\n\r\nThis reverts commit e774ece489edb74e02bbb1be09a3bfe4162fe48b.\r\n\r\nReporting registers tasks with Task Manager in its setup phase, but\r\ntoday, it's own start phase is not guaranteed to initialize. During\r\ninitialization, Reporting injects dependencies into the objects\r\nresponsible for internal handling of tasks.\r\n\r\nThe `Kibana instance ID is undefined` error can happen when Task Manager\r\ncalls the runTask before the \"execute report\" object receives its\r\ndependencies.\r\n\r\nThe `Reporting task runner has not been initialized` error can happen\r\nwhen a user or a Watch trigger tries to request report generation before\r\ninternal dependencies are set. This can also happen if Reporting\r\nattempts to retry a stuck job before the internal dependencies are set.\r\n\r\nInitializing the task objects (execute_report, monitor_reports) is\r\nmission-critical for Reporting internals. The tasks were register in our\r\nsetup method. That means, we need to prioritize getting the start\r\ndependencies into the task objects in the code - it can't be blocked.","sha":"e1d188287c5f552333d8a1b1e9137606362da313"}}]}] BACKPORT-->