### PR TITLE
[DOCS] Remove coming 8.9.0 tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -48,8 +48,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.9.0]]
 == {kib} 8.9.0
 
-coming::[8.9.0]
-
 For information about the {kib} 8.9.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
## Summary

This PR removes `coming::[8.9.0]` where it is no longer required.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->