### PR TITLE
[OAS] Add serverless entrypoint for case APIs

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/README.md
+++ b/x-pack/plugins/cases/docs/openapi/README.md
@@ -17,18 +17,23 @@ It is possible to validate the docs before bundling them with the following
 command in the `x-pack/plugins/cases/docs/openapi/` folder:
 
   ```bash
-    npx swagger-cli validate entrypoint.yaml
+  npx swagger-cli validate entrypoint.yaml
+  npx swagger-cli validate entrypoint-serverless.yaml
   ```
 
 Then you can generate the `bundled` files by running the following commands:
 
   ```bash
-    npx @redocly/cli bundle entrypoint.yaml --output bundled.yaml --ext yaml
-    npx @redocly/cli bundle entrypoint.yaml --output bundled.json --ext json
+  npx @redocly/cli bundle entrypoint.yaml --output bundled.yaml --ext yaml
+  npx @redocly/cli bundle entrypoint.yaml --output bundled.json --ext json
+
+  npx @redocly/cli bundle entrypoint-serverless.yaml --output bundled-serverless.yaml --ext yaml
+  npx @redocly/cli bundle entrypoint-serverless.yaml --output bundled-serverless.json --ext json
   ```
 
 After generating the json bundle ensure that it is also valid by running the following command:
 
   ```bash
-     npx @redocly/cli lint bundled.json
+  npx @redocly/cli lint bundled.json
+  npx @redocly/cli lint bundled-serverless.json
   ```

--- a/x-pack/plugins/cases/docs/openapi/bundled-serverless.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled-serverless.json
@@ -397,7 +397,12 @@
         "in": "query",
         "required": true,
         "schema": {
-          "type": "string"
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minItems": 1,
+            "maxItems": 100
+          }
         },
         "example": "d4e7abb0-b462-11ec-9a8d-698504725a43"
       },
@@ -414,7 +419,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "maxItems": 100
             }
           ]
         }
@@ -490,11 +496,12 @@
       "page_size": {
         "in": "query",
         "name": "perPage",
-        "description": "The number of items to return.",
+        "description": "The number of items to return. Limited to 100 items.",
         "required": false,
         "schema": {
           "type": "integer",
-          "default": 20
+          "default": 20,
+          "maximum": 100
         }
       },
       "reporters": {
@@ -510,7 +517,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "maxItems": 100
             }
           ]
         },
@@ -564,7 +572,12 @@
           "type": "string",
           "enum": [
             "createdAt",
-            "updatedAt"
+            "updatedAt",
+            "closedAt",
+            "title",
+            "category",
+            "status",
+            "severity"
           ],
           "default": "createdAt"
         },
@@ -611,7 +624,8 @@
               "type": "array",
               "items": {
                 "type": "string"
-              }
+              },
+              "maxItems": 100
             }
           ]
         },
@@ -1110,7 +1124,8 @@
           },
           "description": {
             "description": "The description for the case.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 30000
           },
           "owner": {
             "$ref": "#/components/schemas/owners"
@@ -1124,13 +1139,21 @@
           "tags": {
             "description": "The words and phrases that help categorize cases. It can be an empty array.",
             "type": "array",
+            "maxItems": 200,
             "items": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 256
             }
+          },
+          "category": {
+            "description": "Category for the case. It could be a word or a phrase to categorize the case.",
+            "type": "string",
+            "maxLength": 50
           },
           "title": {
             "description": "A title for the case.",
-            "type": "string"
+            "type": "string",
+            "maxLength": 160
           }
         }
       },
@@ -1697,6 +1720,8 @@
           "cases": {
             "type": "array",
             "description": "An array containing one or more case objects.",
+            "maxItems": 100,
+            "minItems": 1,
             "items": {
               "type": "object",
               "required": [
@@ -1738,7 +1763,8 @@
                 },
                 "id": {
                   "description": "The identifier for the case.",
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 30000
                 },
                 "settings": {
                   "$ref": "#/components/schemas/settings"
@@ -1752,13 +1778,21 @@
                 "tags": {
                   "description": "The words and phrases that help categorize cases.",
                   "type": "array",
+                  "maxItems": 200,
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 256
                   }
+                },
+                "category": {
+                  "description": "Category for the case. It could be a word or a phrase to categorize the case.",
+                  "type": "string",
+                  "maxLength": 50
                 },
                 "title": {
                   "description": "A title for the case.",
-                  "type": "string"
+                  "type": "string",
+                  "maxLength": 160
                 },
                 "version": {
                   "description": "The current version of the case. To determine this value, use the get case or find cases APIs.",
@@ -1773,31 +1807,8 @@
         "type": "string",
         "description": "The fields to perform the `simple_query_string` parsed query against.",
         "enum": [
-          "closed_by.username",
-          "closed_by.full_name",
-          "closed_by.email",
-          "closed_by.profile_uid",
-          "created_by.username",
-          "created_by.full_name",
-          "created_by.email",
-          "created_by.profile_uid",
           "description",
-          "connector.name",
-          "connector.type",
-          "external_service.pushed_by.username",
-          "external_service.pushed_by.full_name",
-          "external_service.pushed_by.email",
-          "external_service.pushed_by.profile_uid",
-          "external_service.connector_name",
-          "external_service.external_id",
-          "external_service.external_title",
-          "external_service.external_url",
-          "title",
-          "title.keyword",
-          "updated_by.username",
-          "updated_by.full_name",
-          "updated_by.email",
-          "updated_by.profile_uid"
+          "title"
         ]
       }
     },

--- a/x-pack/plugins/cases/docs/openapi/bundled-serverless.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled-serverless.json
@@ -1,0 +1,2093 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Serverless Cases",
+    "description": "OpenAPI schema for Serverless Cases endpoints",
+    "version": "YYYY-MM-DD",
+    "contact": {
+      "name": "Cases Team"
+    },
+    "license": {
+      "name": "Elastic License 2.0",
+      "url": "https://www.elastic.co/licensing/elastic-license"
+    }
+  },
+  "tags": [
+    {
+      "name": "cases",
+      "description": "Case APIs enable you to open and track issues."
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:5601",
+      "description": "local"
+    }
+  ],
+  "paths": {
+    "/api/cases": {
+      "post": {
+        "summary": "Creates a case in the default space.",
+        "operationId": "createCaseDefaultSpace",
+        "description": "You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're creating.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/create_case_request"
+              },
+              "examples": {
+                "createCaseRequest": {
+                  "$ref": "#/components/examples/create_case_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/case_response_properties"
+                },
+                "examples": {
+                  "createCaseResponse": {
+                    "$ref": "#/components/examples/create_case_response"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "delete": {
+        "summary": "Deletes one or more cases in the default space.",
+        "operationId": "deleteCaseDefaultSpace",
+        "description": "You must have `read` or `all` privileges and the `delete` sub-feature privilege for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "$ref": "#/components/parameters/ids"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Indicates a successful call."
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "patch": {
+        "summary": "Updates one or more cases in the default space.",
+        "operationId": "updateCaseDefaultSpace",
+        "description": "You must have `all` privileges for the **Cases** feature in the  **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're updating.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/update_case_request"
+              },
+              "examples": {
+                "updateCaseRequest": {
+                  "$ref": "#/components/examples/update_case_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/case_response_properties"
+                  }
+                },
+                "examples": {
+                  "updateCaseResponse": {
+                    "$ref": "#/components/examples/update_case_response"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
+    "/api/cases/_find": {
+      "get": {
+        "summary": "Retrieves a paginated subset of cases in the default space.",
+        "operationId": "findCasesDefaultSpace",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/assignees"
+          },
+          {
+            "$ref": "#/components/parameters/category"
+          },
+          {
+            "$ref": "#/components/parameters/defaultSearchOperator"
+          },
+          {
+            "$ref": "#/components/parameters/from"
+          },
+          {
+            "$ref": "#/components/parameters/owner"
+          },
+          {
+            "$ref": "#/components/parameters/page_index"
+          },
+          {
+            "$ref": "#/components/parameters/page_size"
+          },
+          {
+            "$ref": "#/components/parameters/reporters"
+          },
+          {
+            "$ref": "#/components/parameters/search"
+          },
+          {
+            "$ref": "#/components/parameters/searchFields"
+          },
+          {
+            "$ref": "#/components/parameters/severity"
+          },
+          {
+            "$ref": "#/components/parameters/sortField"
+          },
+          {
+            "$ref": "#/components/parameters/sort_order"
+          },
+          {
+            "$ref": "#/components/parameters/status"
+          },
+          {
+            "$ref": "#/components/parameters/tags"
+          },
+          {
+            "$ref": "#/components/parameters/to"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "cases": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/case_response_properties"
+                      }
+                    },
+                    "count_closed_cases": {
+                      "type": "integer"
+                    },
+                    "count_in_progress_cases": {
+                      "type": "integer"
+                    },
+                    "count_open_cases": {
+                      "type": "integer"
+                    },
+                    "page": {
+                      "type": "integer"
+                    },
+                    "per_page": {
+                      "type": "integer"
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                "examples": {
+                  "findCaseResponse": {
+                    "$ref": "#/components/examples/find_case_response"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
+    "/api/cases/{caseId}": {
+      "get": {
+        "summary": "Retrieves information about a case in the default space.",
+        "operationId": "getCaseDefaultSpace",
+        "description": "You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.\n",
+        "tags": [
+          "cases"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/case_id"
+          },
+          {
+            "$ref": "#/components/parameters/includeComments"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/case_response_properties"
+                },
+                "examples": {
+                  "getCaseResponse": {
+                    "$ref": "#/components/examples/get_case_response"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authorization information is missing or invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/4xx_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      },
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "ApiKey"
+      }
+    },
+    "parameters": {
+      "kbn_xsrf": {
+        "schema": {
+          "type": "string"
+        },
+        "in": "header",
+        "name": "kbn-xsrf",
+        "description": "Cross-site request forgery protection",
+        "required": true
+      },
+      "ids": {
+        "name": "ids",
+        "description": "The cases that you want to removed. All non-ASCII characters must be URL encoded.\n",
+        "in": "query",
+        "required": true,
+        "schema": {
+          "type": "string"
+        },
+        "example": "d4e7abb0-b462-11ec-9a8d-698504725a43"
+      },
+      "assignees": {
+        "in": "query",
+        "name": "assignees",
+        "description": "Filters the returned cases by assignees. Valid values are `none` or unique identifiers for the user profiles. These identifiers can be found by using the suggest user profile API.\n",
+        "schema": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "category": {
+        "in": "query",
+        "name": "category",
+        "description": "Filters the returned cases by category.",
+        "schema": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "maxItems": 100
+            }
+          ]
+        },
+        "example": "my-category"
+      },
+      "defaultSearchOperator": {
+        "in": "query",
+        "name": "defaultSearchOperator",
+        "description": "he default operator to use for the simple_query_string.",
+        "schema": {
+          "type": "string",
+          "default": "OR"
+        },
+        "example": "OR"
+      },
+      "from": {
+        "in": "query",
+        "name": "from",
+        "description": "[preview] Returns only cases that were created after a specific date. The date must be specified as a KQL data range or date match expression. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "schema": {
+          "type": "string",
+          "example": "now-1d"
+        }
+      },
+      "owner": {
+        "in": "query",
+        "name": "owner",
+        "description": "A filter to limit the response to a specific set of applications. If this parameter is omitted, the response contains information about all the cases that the user has access to read.\n",
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/owners"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/owners"
+              }
+            }
+          ]
+        },
+        "example": "cases"
+      },
+      "page_index": {
+        "in": "query",
+        "name": "page",
+        "description": "The page number to return.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "default": 1
+        }
+      },
+      "page_size": {
+        "in": "query",
+        "name": "perPage",
+        "description": "The number of items to return.",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "default": 20
+        }
+      },
+      "reporters": {
+        "in": "query",
+        "name": "reporters",
+        "description": "Filters the returned cases by the user name of the reporter.",
+        "schema": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "example": "elastic"
+      },
+      "search": {
+        "in": "query",
+        "name": "search",
+        "description": "An Elasticsearch simple_query_string query that filters the objects in the response.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "searchFields": {
+        "in": "query",
+        "name": "searchFields",
+        "description": "The fields to perform the simple_query_string parsed query against.",
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/searchFieldsType"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/searchFieldsType"
+              }
+            }
+          ]
+        }
+      },
+      "severity": {
+        "in": "query",
+        "name": "severity",
+        "description": "The severity of the case.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "critical",
+            "high",
+            "low",
+            "medium"
+          ]
+        }
+      },
+      "sortField": {
+        "in": "query",
+        "name": "sortField",
+        "description": "Determines which field is used to sort the results.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "createdAt",
+            "updatedAt"
+          ],
+          "default": "createdAt"
+        },
+        "example": "updatedAt"
+      },
+      "sort_order": {
+        "in": "query",
+        "name": "sortOrder",
+        "description": "Determines the sort order.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "asc",
+            "desc"
+          ],
+          "default": "desc"
+        }
+      },
+      "status": {
+        "in": "query",
+        "name": "status",
+        "description": "Filters the returned cases by state.",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "closed",
+            "in-progress",
+            "open"
+          ]
+        },
+        "example": "open"
+      },
+      "tags": {
+        "in": "query",
+        "name": "tags",
+        "description": "Filters the returned cases by tags.",
+        "schema": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "example": "tag-1"
+      },
+      "to": {
+        "in": "query",
+        "name": "to",
+        "description": "[preview] Returns only cases that were created before a specific date. The date must be specified as a KQL data range or date match expression. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "schema": {
+          "type": "string"
+        },
+        "example": "now+1d"
+      },
+      "case_id": {
+        "in": "path",
+        "name": "caseId",
+        "description": "The identifier for the case. To retrieve case IDs, use the find cases API. All non-ASCII characters must be URL encoded.",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "example": "9c235210-6834-11ea-a78c-6ffb38a34414"
+        }
+      },
+      "includeComments": {
+        "in": "query",
+        "name": "includeComments",
+        "description": "Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.",
+        "deprecated": true,
+        "schema": {
+          "type": "boolean",
+          "default": true
+        }
+      }
+    },
+    "schemas": {
+      "assignees": {
+        "type": "array",
+        "description": "An array containing users that are assigned to the case.",
+        "nullable": true,
+        "items": {
+          "type": "object",
+          "required": [
+            "uid"
+          ],
+          "properties": {
+            "uid": {
+              "type": "string",
+              "description": "A unique identifier for the user profile. These identifiers can be found by using the suggest user profile API.",
+              "example": "u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0"
+            }
+          }
+        }
+      },
+      "connector_properties_none": {
+        "title": "Create or update case request properties for no connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.none`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. To create a case without a connector, specify null. To update a case to remove the connector, specify null.",
+            "nullable": true,
+            "type": "string",
+            "example": null
+          },
+          "id": {
+            "description": "The identifier for the connector. To create a case without a connector, use `none`. To update a case to remove the connector, specify `none`.",
+            "type": "string",
+            "example": "none"
+          },
+          "name": {
+            "description": "The name of the connector. To create a case without a connector, use `none`. To update a case to remove the connector, specify `none`.",
+            "type": "string",
+            "example": "none"
+          },
+          "type": {
+            "description": "The type of connector. To create a case without a connector, use `.none`. To update a case to remove the connector, specify `.none`.",
+            "type": "string",
+            "example": ".none",
+            "enum": [
+              ".none"
+            ]
+          }
+        }
+      },
+      "connector_properties_cases_webhook": {
+        "title": "Create or upate case request properties for Cases Webhook connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.cases-webhook`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "type": "string",
+            "nullable": true,
+            "example": null
+          },
+          "id": {
+            "description": "The identifier for the connector. To retrieve connector IDs, use the find connectors API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".cases-webhook",
+            "enum": [
+              ".cases-webhook"
+            ]
+          }
+        }
+      },
+      "connector_properties_jira": {
+        "title": "Create or update case request properties for a Jira connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.jira`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. If you want to omit any individual field, specify null as its value.",
+            "type": "object",
+            "required": [
+              "issueType",
+              "parent",
+              "priority"
+            ],
+            "properties": {
+              "issueType": {
+                "description": "The type of issue.",
+                "type": "string",
+                "nullable": true
+              },
+              "parent": {
+                "description": "The key of the parent issue, when the issue type is sub-task.",
+                "type": "string",
+                "nullable": true
+              },
+              "priority": {
+                "description": "The priority of the issue.",
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "id": {
+            "description": "The identifier for the connector. To retrieve connector IDs, use the find connectors API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".jira",
+            "enum": [
+              ".jira"
+            ]
+          }
+        }
+      },
+      "connector_properties_resilient": {
+        "title": "Create case request properties for a IBM Resilient connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.resilient`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. If you want to omit any individual field, specify null as its value.",
+            "type": "object",
+            "nullable": true,
+            "required": [
+              "issueTypes",
+              "severityCode"
+            ],
+            "properties": {
+              "issueTypes": {
+                "description": "The type of incident.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "severityCode": {
+                "description": "The severity code of the incident.",
+                "type": "string"
+              }
+            }
+          },
+          "id": {
+            "description": "The identifier for the connector.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".resilient",
+            "enum": [
+              ".resilient"
+            ]
+          }
+        }
+      },
+      "connector_properties_servicenow": {
+        "title": "Create case request properties for a ServiceNow ITSM connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.servicenow`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. If you want to omit any individual field, specify null as its value.",
+            "type": "object",
+            "required": [
+              "category",
+              "impact",
+              "severity",
+              "subcategory",
+              "urgency"
+            ],
+            "properties": {
+              "category": {
+                "description": "The category of the incident.",
+                "type": "string",
+                "nullable": true
+              },
+              "impact": {
+                "description": "The effect an incident had on business.",
+                "type": "string",
+                "nullable": true
+              },
+              "severity": {
+                "description": "The severity of the incident.",
+                "type": "string",
+                "nullable": true
+              },
+              "subcategory": {
+                "description": "The subcategory of the incident.",
+                "type": "string",
+                "nullable": true
+              },
+              "urgency": {
+                "description": "The extent to which the incident resolution can be delayed.",
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "id": {
+            "description": "The identifier for the connector. To retrieve connector IDs, use the find connectors API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".servicenow",
+            "enum": [
+              ".servicenow"
+            ]
+          }
+        }
+      },
+      "connector_properties_servicenow_sir": {
+        "title": "Create case request properties for a ServiceNow SecOps connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.servicenow-sir`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. If you want to omit any individual field, specify null as its value.",
+            "type": "object",
+            "required": [
+              "category",
+              "destIp",
+              "malwareHash",
+              "malwareUrl",
+              "priority",
+              "sourceIp",
+              "subcategory"
+            ],
+            "properties": {
+              "category": {
+                "description": "The category of the incident.",
+                "type": "string",
+                "nullable": true
+              },
+              "destIp": {
+                "description": "Indicates whether cases will send a comma-separated list of destination IPs.",
+                "type": "boolean",
+                "nullable": true
+              },
+              "malwareHash": {
+                "description": "Indicates whether cases will send a comma-separated list of malware hashes.",
+                "type": "boolean",
+                "nullable": true
+              },
+              "malwareUrl": {
+                "description": "Indicates whether cases will send a comma-separated list of malware URLs.",
+                "type": "boolean",
+                "nullable": true
+              },
+              "priority": {
+                "description": "The priority of the issue.",
+                "type": "string",
+                "nullable": true
+              },
+              "sourceIp": {
+                "description": "Indicates whether cases will send a comma-separated list of source IPs.",
+                "type": "boolean",
+                "nullable": true
+              },
+              "subcategory": {
+                "description": "The subcategory of the incident.",
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "id": {
+            "description": "The identifier for the connector. To retrieve connector IDs, use the find connectors API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".servicenow-sir",
+            "enum": [
+              ".servicenow-sir"
+            ]
+          }
+        }
+      },
+      "connector_properties_swimlane": {
+        "title": "Create case request properties for a Swimlane connector",
+        "required": [
+          "fields",
+          "id",
+          "name",
+          "type"
+        ],
+        "description": "Defines properties for connectors when type is `.swimlane`.",
+        "type": "object",
+        "properties": {
+          "fields": {
+            "description": "An object containing the connector fields. If you want to omit any individual field, specify null as its value.",
+            "type": "object",
+            "required": [
+              "caseId"
+            ],
+            "properties": {
+              "caseId": {
+                "description": "The case identifier for Swimlane connectors.",
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "id": {
+            "description": "The identifier for the connector. To retrieve connector IDs, use the find connectors API.",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the connector.",
+            "type": "string"
+          },
+          "type": {
+            "description": "The type of connector.",
+            "type": "string",
+            "example": ".swimlane",
+            "enum": [
+              ".swimlane"
+            ]
+          }
+        }
+      },
+      "owners": {
+        "type": "string",
+        "description": "The application that owns the cases: Stack Management, Observability, or Elastic Security.\n",
+        "enum": [
+          "cases",
+          "observability",
+          "securitySolution"
+        ],
+        "example": "cases"
+      },
+      "settings": {
+        "type": "object",
+        "description": "An object that contains the case settings.",
+        "required": [
+          "syncAlerts"
+        ],
+        "properties": {
+          "syncAlerts": {
+            "description": "Turns alert syncing on or off.",
+            "type": "boolean",
+            "example": true
+          }
+        }
+      },
+      "severity_property": {
+        "type": "string",
+        "description": "The severity of the case.",
+        "enum": [
+          "critical",
+          "high",
+          "low",
+          "medium"
+        ],
+        "default": "low"
+      },
+      "create_case_request": {
+        "title": "Create case request",
+        "description": "The create case API request body varies depending on the type of connector.",
+        "type": "object",
+        "required": [
+          "connector",
+          "description",
+          "owner",
+          "settings",
+          "tags",
+          "title"
+        ],
+        "properties": {
+          "assignees": {
+            "$ref": "#/components/schemas/assignees"
+          },
+          "connector": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/connector_properties_none"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_cases_webhook"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_jira"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_resilient"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_servicenow"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_servicenow_sir"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_swimlane"
+              }
+            ]
+          },
+          "description": {
+            "description": "The description for the case.",
+            "type": "string"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/owners"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/settings"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/severity_property"
+          },
+          "tags": {
+            "description": "The words and phrases that help categorize cases. It can be an empty array.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "title": {
+            "description": "A title for the case.",
+            "type": "string"
+          }
+        }
+      },
+      "case_response_closed_by_properties": {
+        "title": "Case response properties for closed_by",
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "alert_comment_response_properties": {
+        "title": "Add case comment response properties for alerts",
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "alertId": {
+            "type": "string",
+            "example": "6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2022-03-24T02:31:03.210Z"
+          },
+          "created_by": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "full_name": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "username": {
+                "type": "string",
+                "example": "elastic",
+                "nullable": true
+              },
+              "profile_uid": {
+                "type": "string",
+                "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+              }
+            }
+          },
+          "id": {
+            "type": "string",
+            "example": "73362370-ab1a-11ec-985f-97e55adae8b9"
+          },
+          "index": {
+            "type": "string",
+            "example": ".internal.alerts-security.alerts-default-000001"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/owners"
+          },
+          "pushed_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": null,
+            "nullable": true
+          },
+          "pushed_by": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "full_name": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "username": {
+                "type": "string",
+                "example": "elastic",
+                "nullable": true
+              },
+              "profile_uid": {
+                "type": "string",
+                "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+              }
+            },
+            "nullable": true
+          },
+          "rule": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "description": "The rule identifier.",
+                "type": "string",
+                "example": "94d80550-aaf4-11ec-985f-97e55adae8b9"
+              },
+              "name": {
+                "description": "The rule name.",
+                "type": "string",
+                "example": "security_rule"
+              }
+            }
+          },
+          "type": {
+            "type": "string",
+            "example": "alert",
+            "enum": [
+              "alert"
+            ]
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": null
+          },
+          "updated_by": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "full_name": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "username": {
+                "type": "string",
+                "example": "elastic",
+                "nullable": true
+              },
+              "profile_uid": {
+                "type": "string",
+                "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+              }
+            }
+          },
+          "version": {
+            "type": "string",
+            "example": "WzMwNDgsMV0="
+          }
+        }
+      },
+      "case_response_created_by_properties": {
+        "title": "Case response properties for created_by",
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "case_response_pushed_by_properties": {
+        "title": "Case response properties for pushed_by",
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "case_response_updated_by_properties": {
+        "title": "Case response properties for updated_by",
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "full_name": {
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "example": "elastic",
+            "nullable": true
+          },
+          "profile_uid": {
+            "type": "string",
+            "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+          }
+        },
+        "required": [
+          "email",
+          "full_name",
+          "username"
+        ]
+      },
+      "user_comment_response_properties": {
+        "title": "Case response properties for user comments",
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "comment": {
+            "type": "string",
+            "example": "A new comment."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2022-05-13T09:16:17.416Z"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/case_response_created_by_properties"
+          },
+          "id": {
+            "type": "string",
+            "example": "8af6ac20-74f6-11ea-b83a-553aecdb28b6"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/owners"
+          },
+          "pushed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": null
+          },
+          "pushed_by": {
+            "$ref": "#/components/schemas/case_response_pushed_by_properties"
+          },
+          "type": {
+            "type": "string",
+            "example": "user",
+            "enum": [
+              "user"
+            ]
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "example": null
+          },
+          "updated_by": {
+            "$ref": "#/components/schemas/case_response_updated_by_properties"
+          },
+          "version": {
+            "type": "string",
+            "example": "WzIwNDMxLDFd"
+          }
+        }
+      },
+      "external_service": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "connector_id": {
+            "type": "string"
+          },
+          "connector_name": {
+            "type": "string"
+          },
+          "external_id": {
+            "type": "string"
+          },
+          "external_title": {
+            "type": "string"
+          },
+          "external_url": {
+            "type": "string"
+          },
+          "pushed_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "pushed_by": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "full_name": {
+                "type": "string",
+                "example": null,
+                "nullable": true
+              },
+              "username": {
+                "type": "string",
+                "example": "elastic",
+                "nullable": true
+              },
+              "profile_uid": {
+                "type": "string",
+                "example": "u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0"
+              }
+            },
+            "nullable": true
+          }
+        }
+      },
+      "status": {
+        "type": "string",
+        "description": "The status of the case.",
+        "enum": [
+          "closed",
+          "in-progress",
+          "open"
+        ]
+      },
+      "case_response_properties": {
+        "title": "Case response properties",
+        "type": "object",
+        "required": [
+          "closed_at",
+          "closed_by",
+          "comments",
+          "connector",
+          "created_at",
+          "created_by",
+          "description",
+          "duration",
+          "external_service",
+          "id",
+          "owner",
+          "settings",
+          "severity",
+          "status",
+          "tags",
+          "title",
+          "totalAlerts",
+          "totalComment",
+          "updated_at",
+          "updated_by",
+          "version"
+        ],
+        "properties": {
+          "assignees": {
+            "$ref": "#/components/schemas/assignees"
+          },
+          "closed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "closed_by": {
+            "$ref": "#/components/schemas/case_response_closed_by_properties"
+          },
+          "comments": {
+            "title": "Case response properties for comments",
+            "description": "An array of comment objects for the case.",
+            "type": "array",
+            "items": {
+              "discriminator": {
+                "propertyName": "type"
+              },
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/alert_comment_response_properties"
+                },
+                {
+                  "$ref": "#/components/schemas/user_comment_response_properties"
+                }
+              ]
+            }
+          },
+          "connector": {
+            "title": "Case response properties for connectors",
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/connector_properties_none"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_cases_webhook"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_jira"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_resilient"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_servicenow"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_servicenow_sir"
+              },
+              {
+                "$ref": "#/components/schemas/connector_properties_swimlane"
+              }
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2022-05-13T09:16:17.416Z"
+          },
+          "created_by": {
+            "$ref": "#/components/schemas/case_response_created_by_properties"
+          },
+          "description": {
+            "type": "string",
+            "example": "A case description."
+          },
+          "duration": {
+            "type": "integer",
+            "description": "The elapsed time from the creation of the case to its closure (in seconds). If the case has not been closed, the duration is set to null. If the case was closed after less than half a second, the duration is rounded down to zero.\n",
+            "nullable": true,
+            "example": 120
+          },
+          "external_service": {
+            "$ref": "#/components/schemas/external_service"
+          },
+          "id": {
+            "type": "string",
+            "example": "66b9aa00-94fa-11ea-9f74-e7e108796192"
+          },
+          "owner": {
+            "$ref": "#/components/schemas/owners"
+          },
+          "settings": {
+            "$ref": "#/components/schemas/settings"
+          },
+          "severity": {
+            "$ref": "#/components/schemas/severity_property"
+          },
+          "status": {
+            "$ref": "#/components/schemas/status"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "tag-1"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "example": "Case title 1"
+          },
+          "totalAlerts": {
+            "type": "integer",
+            "example": 0
+          },
+          "totalComment": {
+            "type": "integer",
+            "example": 0
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "updated_by": {
+            "$ref": "#/components/schemas/case_response_updated_by_properties"
+          },
+          "version": {
+            "type": "string",
+            "example": "WzUzMiwxXQ=="
+          }
+        }
+      },
+      "4xx_response": {
+        "type": "object",
+        "title": "Unsuccessful cases API response",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "Unauthorized"
+          },
+          "message": {
+            "type": "string"
+          },
+          "statusCode": {
+            "type": "integer",
+            "example": 401
+          }
+        }
+      },
+      "update_case_request": {
+        "title": "Update case request",
+        "description": "The update case API request body varies depending on the type of connector.",
+        "type": "object",
+        "required": [
+          "cases"
+        ],
+        "properties": {
+          "cases": {
+            "type": "array",
+            "description": "An array containing one or more case objects.",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "version"
+              ],
+              "properties": {
+                "assignees": {
+                  "$ref": "#/components/schemas/assignees"
+                },
+                "connector": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/connector_properties_none"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_cases_webhook"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_jira"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_resilient"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_servicenow"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_servicenow_sir"
+                    },
+                    {
+                      "$ref": "#/components/schemas/connector_properties_swimlane"
+                    }
+                  ]
+                },
+                "description": {
+                  "description": "An updated description for the case.",
+                  "type": "string"
+                },
+                "id": {
+                  "description": "The identifier for the case.",
+                  "type": "string"
+                },
+                "settings": {
+                  "$ref": "#/components/schemas/settings"
+                },
+                "severity": {
+                  "$ref": "#/components/schemas/severity_property"
+                },
+                "status": {
+                  "$ref": "#/components/schemas/status"
+                },
+                "tags": {
+                  "description": "The words and phrases that help categorize cases.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "title": {
+                  "description": "A title for the case.",
+                  "type": "string"
+                },
+                "version": {
+                  "description": "The current version of the case. To determine this value, use the get case or find cases APIs.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "searchFieldsType": {
+        "type": "string",
+        "description": "The fields to perform the `simple_query_string` parsed query against.",
+        "enum": [
+          "closed_by.username",
+          "closed_by.full_name",
+          "closed_by.email",
+          "closed_by.profile_uid",
+          "created_by.username",
+          "created_by.full_name",
+          "created_by.email",
+          "created_by.profile_uid",
+          "description",
+          "connector.name",
+          "connector.type",
+          "external_service.pushed_by.username",
+          "external_service.pushed_by.full_name",
+          "external_service.pushed_by.email",
+          "external_service.pushed_by.profile_uid",
+          "external_service.connector_name",
+          "external_service.external_id",
+          "external_service.external_title",
+          "external_service.external_url",
+          "title",
+          "title.keyword",
+          "updated_by.username",
+          "updated_by.full_name",
+          "updated_by.email",
+          "updated_by.profile_uid"
+        ]
+      }
+    },
+    "examples": {
+      "create_case_request": {
+        "summary": "Create a security case that uses a Jira connector.",
+        "value": {
+          "description": "A case description.",
+          "title": "Case title 1",
+          "tags": [
+            "tag-1"
+          ],
+          "connector": {
+            "id": "131d4448-abe0-4789-939d-8ef60680b498",
+            "name": "My connector",
+            "type": ".jira",
+            "fields": {
+              "issueType": "10006",
+              "priority": "High",
+              "parent": null
+            }
+          },
+          "settings": {
+            "syncAlerts": true
+          },
+          "owner": "cases"
+        }
+      },
+      "create_case_response": {
+        "summary": "The create case API returns a JSON object that contains details about the case.",
+        "value": {
+          "comments": [],
+          "totalAlerts": 0,
+          "id": "66b9aa00-94fa-11ea-9f74-e7e108796192",
+          "version": "WzUzMiwxXQ==",
+          "totalComment": 1,
+          "title": "Case title 1",
+          "tags": [
+            "tag 1"
+          ],
+          "assignees": [],
+          "description": "A case description.",
+          "settings": {
+            "syncAlerts": false
+          },
+          "owner": "cases",
+          "duration": null,
+          "severity": "low",
+          "closed_at": null,
+          "closed_by": null,
+          "created_at": "2022-03-24T00:37:03.906Z",
+          "created_by": {
+            "username": "elastic",
+            "full_name": null,
+            "email": null
+          },
+          "status": "open",
+          "updated_at": null,
+          "updated_by": null,
+          "connector": {
+            "id": "131d4448-abe0-4789-939d-8ef60680b498",
+            "name": "My connector",
+            "type": ".jira",
+            "fields": {
+              "issueType": "10006",
+              "parent": null,
+              "priority": "High"
+            }
+          },
+          "external_service": null
+        }
+      },
+      "update_case_request": {
+        "summary": "Update the case description, tags, and connector.",
+        "value": {
+          "cases": [
+            {
+              "id": "a18b38a0-71b0-11ea-a0b2-c51ea50a58e2",
+              "version": "WzIzLDFd",
+              "connector": {
+                "id": "131d4448-abe0-4789-939d-8ef60680b498",
+                "name": "My connector",
+                "type": ".jira",
+                "fields": {
+                  "issueType": "10006",
+                  "priority": null,
+                  "parent": null
+                }
+              },
+              "description": "A case description.",
+              "tags": [
+                "tag-1"
+              ],
+              "settings": {
+                "syncAlerts": true
+              }
+            }
+          ]
+        }
+      },
+      "update_case_response": {
+        "summary": "This is an example response when the case description, tags, and connector were updated.",
+        "value": [
+          {
+            "id": "66b9aa00-94fa-11ea-9f74-e7e108796192",
+            "version": "WzU0OCwxXQ==",
+            "comments": [],
+            "totalComment": 0,
+            "totalAlerts": 0,
+            "title": "Case title 1",
+            "tags": [
+              "tag-1"
+            ],
+            "settings": {
+              "syncAlerts": true
+            },
+            "owner": "cases",
+            "description": "A case description.",
+            "duration": null,
+            "severity": "low",
+            "closed_at": null,
+            "closed_by": null,
+            "created_at": "2022-05-13T09:16:17.416Z",
+            "created_by": {
+              "email": null,
+              "full_name": null,
+              "username": "elastic"
+            },
+            "status": "open",
+            "updated_at": "2022-05-13T09:48:33.043Z",
+            "updated_by": {
+              "email": null,
+              "full_name": null,
+              "username": "elastic"
+            },
+            "assignees": [],
+            "connector": {
+              "id": "131d4448-abe0-4789-939d-8ef60680b498",
+              "name": "My connector",
+              "type": ".jira",
+              "fields": {
+                "issueType": "10006",
+                "parent": null,
+                "priority": null
+              }
+            },
+            "external_service": {
+              "external_title": "IS-4",
+              "pushed_by": {
+                "full_name": null,
+                "email": null,
+                "username": "elastic"
+              },
+              "external_url": "https://hms.atlassian.net/browse/IS-4",
+              "pushed_at": "2022-05-13T09:20:40.672Z",
+              "connector_id": "05da469f-1fde-4058-99a3-91e4807e2de8",
+              "external_id": "10003",
+              "connector_name": "Jira"
+            }
+          }
+        ]
+      },
+      "find_case_response": {
+        "summary": "Retrieve the first five cases with the `tag-1` tag, in ascending order by last update time.",
+        "value": {
+          "page": 1,
+          "per_page": 5,
+          "total": 1,
+          "cases": [
+            {
+              "id": "abed3a70-71bd-11ea-a0b2-c51ea50a58e2",
+              "version": "WzExMCwxXQ==",
+              "comments": [],
+              "totalComment": 1,
+              "totalAlerts": 0,
+              "title": "Case title",
+              "tags": [
+                "tag-1"
+              ],
+              "description": "Case description",
+              "settings": {
+                "syncAlerts": true
+              },
+              "owner": "cases",
+              "duration": null,
+              "severity": "low",
+              "closed_at": null,
+              "closed_by": null,
+              "created_at": "2022-05-12T00:16:36.371Z",
+              "created_by": {
+                "email": null,
+                "full_name": null,
+                "username": "elastic"
+              },
+              "status": "open",
+              "updated_at": "2022-05-12T00:27:58.162Z",
+              "updated_by": {
+                "email": null,
+                "full_name": null,
+                "username": "elastic"
+              },
+              "assignees": [],
+              "connector": {
+                "id": "none",
+                "name": "none",
+                "type": ".none",
+                "fields": null
+              },
+              "external_service": null
+            }
+          ],
+          "count_open_cases": 1,
+          "count_in_progress_cases": 0,
+          "count_closed_cases": 0
+        }
+      },
+      "get_case_response": {
+        "summary": "Retrieves information about a case including its comments.",
+        "value": {
+          "id": "31cdada0-02c1-11ed-85f2-4f7c222ca2fa",
+          "version": "WzM2LDFd",
+          "comments": [
+            {
+              "id": "2134c1d0-02c2-11ed-85f2-4f7c222ca2fa",
+              "version": "WzM3LDFd",
+              "type": "user",
+              "owner": "cases",
+              "comment": "A new comment",
+              "created_at": "2022-07-13T15:40:32.335Z",
+              "created_by": {
+                "email": null,
+                "full_name": null,
+                "username": "elastic"
+              },
+              "pushed_at": null,
+              "pushed_by": null,
+              "updated_at": null,
+              "updated_by": null
+            }
+          ],
+          "totalComment": 1,
+          "totalAlerts": 0,
+          "title": "Case title 1",
+          "tags": [
+            "tag 1"
+          ],
+          "settings": {
+            "syncAlerts": true
+          },
+          "owner": "cases",
+          "description": "A case description",
+          "duration": null,
+          "severity": "low",
+          "closed_at": null,
+          "closed_by": null,
+          "created_at": "2022-07-13T15:33:50.604Z",
+          "created_by": {
+            "username": "elastic",
+            "email": null,
+            "full_name": null
+          },
+          "status": "open",
+          "updated_at": "2022-07-13T15:40:32.335Z",
+          "updated_by": {
+            "full_name": null,
+            "email": null,
+            "username": "elastic"
+          },
+          "assignees": [
+            {
+              "uid": "u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0"
+            }
+          ],
+          "connector": {
+            "id": "none",
+            "name": "none",
+            "type": ".none",
+            "fields": null
+          },
+          "external_service": null
+        }
+      }
+    }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    },
+    {
+      "apiKeyAuth": []
+    }
+  ]
+}

--- a/x-pack/plugins/cases/docs/openapi/bundled-serverless.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled-serverless.yaml
@@ -229,7 +229,11 @@ components:
       in: query
       required: true
       schema:
-        type: string
+        type: array
+        items:
+          type: string
+          minItems: 1
+          maxItems: 100
       example: d4e7abb0-b462-11ec-9a8d-698504725a43
     assignees:
       in: query
@@ -242,6 +246,7 @@ components:
           - type: array
             items:
               type: string
+            maxItems: 100
     category:
       in: query
       name: category
@@ -293,11 +298,12 @@ components:
     page_size:
       in: query
       name: perPage
-      description: The number of items to return.
+      description: The number of items to return. Limited to 100 items.
       required: false
       schema:
         type: integer
         default: 20
+        maximum: 100
     reporters:
       in: query
       name: reporters
@@ -308,6 +314,7 @@ components:
           - type: array
             items:
               type: string
+            maxItems: 100
       example: elastic
     search:
       in: query
@@ -345,6 +352,11 @@ components:
         enum:
           - createdAt
           - updatedAt
+          - closedAt
+          - title
+          - category
+          - status
+          - severity
         default: createdAt
       example: updatedAt
     sort_order:
@@ -379,6 +391,7 @@ components:
           - type: array
             items:
               type: string
+            maxItems: 100
       example: tag-1
     to:
       in: query
@@ -753,6 +766,7 @@ components:
         description:
           description: The description for the case.
           type: string
+          maxLength: 30000
         owner:
           $ref: '#/components/schemas/owners'
         settings:
@@ -762,11 +776,18 @@ components:
         tags:
           description: The words and phrases that help categorize cases. It can be an empty array.
           type: array
+          maxItems: 200
           items:
             type: string
+            maxLength: 256
+        category:
+          description: Category for the case. It could be a word or a phrase to categorize the case.
+          type: string
+          maxLength: 50
         title:
           description: A title for the case.
           type: string
+          maxLength: 160
     case_response_closed_by_properties:
       title: Case response properties for closed_by
       type: object
@@ -1181,6 +1202,8 @@ components:
         cases:
           type: array
           description: An array containing one or more case objects.
+          maxItems: 100
+          minItems: 1
           items:
             type: object
             required:
@@ -1204,6 +1227,7 @@ components:
               id:
                 description: The identifier for the case.
                 type: string
+                maxLength: 30000
               settings:
                 $ref: '#/components/schemas/settings'
               severity:
@@ -1213,11 +1237,18 @@ components:
               tags:
                 description: The words and phrases that help categorize cases.
                 type: array
+                maxItems: 200
                 items:
                   type: string
+                  maxLength: 256
+              category:
+                description: Category for the case. It could be a word or a phrase to categorize the case.
+                type: string
+                maxLength: 50
               title:
                 description: A title for the case.
                 type: string
+                maxLength: 160
               version:
                 description: The current version of the case. To determine this value, use the get case or find cases APIs.
                 type: string
@@ -1225,31 +1256,8 @@ components:
       type: string
       description: The fields to perform the `simple_query_string` parsed query against.
       enum:
-        - closed_by.username
-        - closed_by.full_name
-        - closed_by.email
-        - closed_by.profile_uid
-        - created_by.username
-        - created_by.full_name
-        - created_by.email
-        - created_by.profile_uid
         - description
-        - connector.name
-        - connector.type
-        - external_service.pushed_by.username
-        - external_service.pushed_by.full_name
-        - external_service.pushed_by.email
-        - external_service.pushed_by.profile_uid
-        - external_service.connector_name
-        - external_service.external_id
-        - external_service.external_title
-        - external_service.external_url
         - title
-        - title.keyword
-        - updated_by.username
-        - updated_by.full_name
-        - updated_by.email
-        - updated_by.profile_uid
   examples:
     create_case_request:
       summary: Create a security case that uses a Jira connector.

--- a/x-pack/plugins/cases/docs/openapi/bundled-serverless.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled-serverless.yaml
@@ -1,0 +1,1476 @@
+openapi: 3.0.1
+info:
+  title: Serverless Cases
+  description: OpenAPI schema for Serverless Cases endpoints
+  version: YYYY-MM-DD
+  contact:
+    name: Cases Team
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+tags:
+  - name: cases
+    description: Case APIs enable you to open and track issues.
+servers:
+  - url: http://localhost:5601
+    description: local
+paths:
+  /api/cases:
+    post:
+      summary: Creates a case in the default space.
+      operationId: createCaseDefaultSpace
+      description: |
+        You must have `all` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're creating.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/create_case_request'
+            examples:
+              createCaseRequest:
+                $ref: '#/components/examples/create_case_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/case_response_properties'
+              examples:
+                createCaseResponse:
+                  $ref: '#/components/examples/create_case_response'
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
+      servers:
+        - url: https://localhost:5601
+    delete:
+      summary: Deletes one or more cases in the default space.
+      operationId: deleteCaseDefaultSpace
+      description: |
+        You must have `read` or `all` privileges and the `delete` sub-feature privilege for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're deleting.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+        - $ref: '#/components/parameters/ids'
+      responses:
+        '204':
+          description: Indicates a successful call.
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
+      servers:
+        - url: https://localhost:5601
+    patch:
+      summary: Updates one or more cases in the default space.
+      operationId: updateCaseDefaultSpace
+      description: |
+        You must have `all` privileges for the **Cases** feature in the  **Management**, **Observability**, or **Security** section of the Kibana  feature privileges, depending on the owner of the case you're updating.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/update_case_request'
+            examples:
+              updateCaseRequest:
+                $ref: '#/components/examples/update_case_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/case_response_properties'
+              examples:
+                updateCaseResponse:
+                  $ref: '#/components/examples/update_case_response'
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+  /api/cases/_find:
+    get:
+      summary: Retrieves a paginated subset of cases in the default space.
+      operationId: findCasesDefaultSpace
+      description: |
+        You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the cases you're seeking.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/assignees'
+        - $ref: '#/components/parameters/category'
+        - $ref: '#/components/parameters/defaultSearchOperator'
+        - $ref: '#/components/parameters/from'
+        - $ref: '#/components/parameters/owner'
+        - $ref: '#/components/parameters/page_index'
+        - $ref: '#/components/parameters/page_size'
+        - $ref: '#/components/parameters/reporters'
+        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/searchFields'
+        - $ref: '#/components/parameters/severity'
+        - $ref: '#/components/parameters/sortField'
+        - $ref: '#/components/parameters/sort_order'
+        - $ref: '#/components/parameters/status'
+        - $ref: '#/components/parameters/tags'
+        - $ref: '#/components/parameters/to'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cases:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/case_response_properties'
+                  count_closed_cases:
+                    type: integer
+                  count_in_progress_cases:
+                    type: integer
+                  count_open_cases:
+                    type: integer
+                  page:
+                    type: integer
+                  per_page:
+                    type: integer
+                  total:
+                    type: integer
+              examples:
+                findCaseResponse:
+                  $ref: '#/components/examples/find_case_response'
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+  /api/cases/{caseId}:
+    get:
+      summary: Retrieves information about a case in the default space.
+      operationId: getCaseDefaultSpace
+      description: |
+        You must have `read` privileges for the **Cases** feature in the **Management**, **Observability**, or **Security** section of the Kibana feature privileges, depending on the owner of the case you're seeking.
+      tags:
+        - cases
+      parameters:
+        - $ref: '#/components/parameters/case_id'
+        - $ref: '#/components/parameters/includeComments'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/case_response_properties'
+              examples:
+                getCaseResponse:
+                  $ref: '#/components/examples/get_case_response'
+        '401':
+          description: Authorization information is missing or invalid.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/4xx_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: ApiKey
+  parameters:
+    kbn_xsrf:
+      schema:
+        type: string
+      in: header
+      name: kbn-xsrf
+      description: Cross-site request forgery protection
+      required: true
+    ids:
+      name: ids
+      description: |
+        The cases that you want to removed. All non-ASCII characters must be URL encoded.
+      in: query
+      required: true
+      schema:
+        type: string
+      example: d4e7abb0-b462-11ec-9a8d-698504725a43
+    assignees:
+      in: query
+      name: assignees
+      description: |
+        Filters the returned cases by assignees. Valid values are `none` or unique identifiers for the user profiles. These identifiers can be found by using the suggest user profile API.
+      schema:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+    category:
+      in: query
+      name: category
+      description: Filters the returned cases by category.
+      schema:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+            maxItems: 100
+      example: my-category
+    defaultSearchOperator:
+      in: query
+      name: defaultSearchOperator
+      description: he default operator to use for the simple_query_string.
+      schema:
+        type: string
+        default: OR
+      example: OR
+    from:
+      in: query
+      name: from
+      description: |
+        [preview] Returns only cases that were created after a specific date. The date must be specified as a KQL data range or date match expression. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      schema:
+        type: string
+        example: now-1d
+    owner:
+      in: query
+      name: owner
+      description: |
+        A filter to limit the response to a specific set of applications. If this parameter is omitted, the response contains information about all the cases that the user has access to read.
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/owners'
+          - type: array
+            items:
+              $ref: '#/components/schemas/owners'
+      example: cases
+    page_index:
+      in: query
+      name: page
+      description: The page number to return.
+      required: false
+      schema:
+        type: integer
+        default: 1
+    page_size:
+      in: query
+      name: perPage
+      description: The number of items to return.
+      required: false
+      schema:
+        type: integer
+        default: 20
+    reporters:
+      in: query
+      name: reporters
+      description: Filters the returned cases by the user name of the reporter.
+      schema:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+      example: elastic
+    search:
+      in: query
+      name: search
+      description: An Elasticsearch simple_query_string query that filters the objects in the response.
+      schema:
+        type: string
+    searchFields:
+      in: query
+      name: searchFields
+      description: The fields to perform the simple_query_string parsed query against.
+      schema:
+        oneOf:
+          - $ref: '#/components/schemas/searchFieldsType'
+          - type: array
+            items:
+              $ref: '#/components/schemas/searchFieldsType'
+    severity:
+      in: query
+      name: severity
+      description: The severity of the case.
+      schema:
+        type: string
+        enum:
+          - critical
+          - high
+          - low
+          - medium
+    sortField:
+      in: query
+      name: sortField
+      description: Determines which field is used to sort the results.
+      schema:
+        type: string
+        enum:
+          - createdAt
+          - updatedAt
+        default: createdAt
+      example: updatedAt
+    sort_order:
+      in: query
+      name: sortOrder
+      description: Determines the sort order.
+      required: false
+      schema:
+        type: string
+        enum:
+          - asc
+          - desc
+        default: desc
+    status:
+      in: query
+      name: status
+      description: Filters the returned cases by state.
+      schema:
+        type: string
+        enum:
+          - closed
+          - in-progress
+          - open
+      example: open
+    tags:
+      in: query
+      name: tags
+      description: Filters the returned cases by tags.
+      schema:
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
+      example: tag-1
+    to:
+      in: query
+      name: to
+      description: |
+        [preview] Returns only cases that were created before a specific date. The date must be specified as a KQL data range or date match expression. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      schema:
+        type: string
+      example: now+1d
+    case_id:
+      in: path
+      name: caseId
+      description: The identifier for the case. To retrieve case IDs, use the find cases API. All non-ASCII characters must be URL encoded.
+      required: true
+      schema:
+        type: string
+        example: 9c235210-6834-11ea-a78c-6ffb38a34414
+    includeComments:
+      in: query
+      name: includeComments
+      description: Deprecated in 8.1.0. This parameter is deprecated and will be removed in a future release. It determines whether case comments are returned.
+      deprecated: true
+      schema:
+        type: boolean
+        default: true
+  schemas:
+    assignees:
+      type: array
+      description: An array containing users that are assigned to the case.
+      nullable: true
+      items:
+        type: object
+        required:
+          - uid
+        properties:
+          uid:
+            type: string
+            description: A unique identifier for the user profile. These identifiers can be found by using the suggest user profile API.
+            example: u_0wpfV1MqYDaXzLtRVY-gLMrddKDEmfz51Fszhj7hWC8_0
+    connector_properties_none:
+      title: Create or update case request properties for no connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.none`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. To create a case without a connector, specify null. To update a case to remove the connector, specify null.
+          nullable: true
+          type: string
+          example: null
+        id:
+          description: The identifier for the connector. To create a case without a connector, use `none`. To update a case to remove the connector, specify `none`.
+          type: string
+          example: none
+        name:
+          description: The name of the connector. To create a case without a connector, use `none`. To update a case to remove the connector, specify `none`.
+          type: string
+          example: none
+        type:
+          description: The type of connector. To create a case without a connector, use `.none`. To update a case to remove the connector, specify `.none`.
+          type: string
+          example: .none
+          enum:
+            - .none
+    connector_properties_cases_webhook:
+      title: Create or upate case request properties for Cases Webhook connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.cases-webhook`.
+      type: object
+      properties:
+        fields:
+          type: string
+          nullable: true
+          example: null
+        id:
+          description: The identifier for the connector. To retrieve connector IDs, use the find connectors API.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .cases-webhook
+          enum:
+            - .cases-webhook
+    connector_properties_jira:
+      title: Create or update case request properties for a Jira connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.jira`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. If you want to omit any individual field, specify null as its value.
+          type: object
+          required:
+            - issueType
+            - parent
+            - priority
+          properties:
+            issueType:
+              description: The type of issue.
+              type: string
+              nullable: true
+            parent:
+              description: The key of the parent issue, when the issue type is sub-task.
+              type: string
+              nullable: true
+            priority:
+              description: The priority of the issue.
+              type: string
+              nullable: true
+        id:
+          description: The identifier for the connector. To retrieve connector IDs, use the find connectors API.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .jira
+          enum:
+            - .jira
+    connector_properties_resilient:
+      title: Create case request properties for a IBM Resilient connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.resilient`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. If you want to omit any individual field, specify null as its value.
+          type: object
+          nullable: true
+          required:
+            - issueTypes
+            - severityCode
+          properties:
+            issueTypes:
+              description: The type of incident.
+              type: array
+              items:
+                type: string
+            severityCode:
+              description: The severity code of the incident.
+              type: string
+        id:
+          description: The identifier for the connector.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .resilient
+          enum:
+            - .resilient
+    connector_properties_servicenow:
+      title: Create case request properties for a ServiceNow ITSM connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.servicenow`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. If you want to omit any individual field, specify null as its value.
+          type: object
+          required:
+            - category
+            - impact
+            - severity
+            - subcategory
+            - urgency
+          properties:
+            category:
+              description: The category of the incident.
+              type: string
+              nullable: true
+            impact:
+              description: The effect an incident had on business.
+              type: string
+              nullable: true
+            severity:
+              description: The severity of the incident.
+              type: string
+              nullable: true
+            subcategory:
+              description: The subcategory of the incident.
+              type: string
+              nullable: true
+            urgency:
+              description: The extent to which the incident resolution can be delayed.
+              type: string
+              nullable: true
+        id:
+          description: The identifier for the connector. To retrieve connector IDs, use the find connectors API.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .servicenow
+          enum:
+            - .servicenow
+    connector_properties_servicenow_sir:
+      title: Create case request properties for a ServiceNow SecOps connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.servicenow-sir`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. If you want to omit any individual field, specify null as its value.
+          type: object
+          required:
+            - category
+            - destIp
+            - malwareHash
+            - malwareUrl
+            - priority
+            - sourceIp
+            - subcategory
+          properties:
+            category:
+              description: The category of the incident.
+              type: string
+              nullable: true
+            destIp:
+              description: Indicates whether cases will send a comma-separated list of destination IPs.
+              type: boolean
+              nullable: true
+            malwareHash:
+              description: Indicates whether cases will send a comma-separated list of malware hashes.
+              type: boolean
+              nullable: true
+            malwareUrl:
+              description: Indicates whether cases will send a comma-separated list of malware URLs.
+              type: boolean
+              nullable: true
+            priority:
+              description: The priority of the issue.
+              type: string
+              nullable: true
+            sourceIp:
+              description: Indicates whether cases will send a comma-separated list of source IPs.
+              type: boolean
+              nullable: true
+            subcategory:
+              description: The subcategory of the incident.
+              type: string
+              nullable: true
+        id:
+          description: The identifier for the connector. To retrieve connector IDs, use the find connectors API.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .servicenow-sir
+          enum:
+            - .servicenow-sir
+    connector_properties_swimlane:
+      title: Create case request properties for a Swimlane connector
+      required:
+        - fields
+        - id
+        - name
+        - type
+      description: Defines properties for connectors when type is `.swimlane`.
+      type: object
+      properties:
+        fields:
+          description: An object containing the connector fields. If you want to omit any individual field, specify null as its value.
+          type: object
+          required:
+            - caseId
+          properties:
+            caseId:
+              description: The case identifier for Swimlane connectors.
+              type: string
+              nullable: true
+        id:
+          description: The identifier for the connector. To retrieve connector IDs, use the find connectors API.
+          type: string
+        name:
+          description: The name of the connector.
+          type: string
+        type:
+          description: The type of connector.
+          type: string
+          example: .swimlane
+          enum:
+            - .swimlane
+    owners:
+      type: string
+      description: |
+        The application that owns the cases: Stack Management, Observability, or Elastic Security.
+      enum:
+        - cases
+        - observability
+        - securitySolution
+      example: cases
+    settings:
+      type: object
+      description: An object that contains the case settings.
+      required:
+        - syncAlerts
+      properties:
+        syncAlerts:
+          description: Turns alert syncing on or off.
+          type: boolean
+          example: true
+    severity_property:
+      type: string
+      description: The severity of the case.
+      enum:
+        - critical
+        - high
+        - low
+        - medium
+      default: low
+    create_case_request:
+      title: Create case request
+      description: The create case API request body varies depending on the type of connector.
+      type: object
+      required:
+        - connector
+        - description
+        - owner
+        - settings
+        - tags
+        - title
+      properties:
+        assignees:
+          $ref: '#/components/schemas/assignees'
+        connector:
+          oneOf:
+            - $ref: '#/components/schemas/connector_properties_none'
+            - $ref: '#/components/schemas/connector_properties_cases_webhook'
+            - $ref: '#/components/schemas/connector_properties_jira'
+            - $ref: '#/components/schemas/connector_properties_resilient'
+            - $ref: '#/components/schemas/connector_properties_servicenow'
+            - $ref: '#/components/schemas/connector_properties_servicenow_sir'
+            - $ref: '#/components/schemas/connector_properties_swimlane'
+        description:
+          description: The description for the case.
+          type: string
+        owner:
+          $ref: '#/components/schemas/owners'
+        settings:
+          $ref: '#/components/schemas/settings'
+        severity:
+          $ref: '#/components/schemas/severity_property'
+        tags:
+          description: The words and phrases that help categorize cases. It can be an empty array.
+          type: array
+          items:
+            type: string
+        title:
+          description: A title for the case.
+          type: string
+    case_response_closed_by_properties:
+      title: Case response properties for closed_by
+      type: object
+      nullable: true
+      properties:
+        email:
+          type: string
+          example: null
+          nullable: true
+        full_name:
+          type: string
+          example: null
+          nullable: true
+        username:
+          type: string
+          example: elastic
+          nullable: true
+        profile_uid:
+          type: string
+          example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+      required:
+        - email
+        - full_name
+        - username
+    alert_comment_response_properties:
+      title: Add case comment response properties for alerts
+      type: object
+      required:
+        - type
+      properties:
+        alertId:
+          type: string
+          example: 6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-03-24T02:31:03.210Z'
+        created_by:
+          type: object
+          properties:
+            email:
+              type: string
+              example: null
+              nullable: true
+            full_name:
+              type: string
+              example: null
+              nullable: true
+            username:
+              type: string
+              example: elastic
+              nullable: true
+            profile_uid:
+              type: string
+              example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+        id:
+          type: string
+          example: 73362370-ab1a-11ec-985f-97e55adae8b9
+        index:
+          type: string
+          example: .internal.alerts-security.alerts-default-000001
+        owner:
+          $ref: '#/components/schemas/owners'
+        pushed_at:
+          type: string
+          format: date-time
+          example: null
+          nullable: true
+        pushed_by:
+          type: object
+          properties:
+            email:
+              type: string
+              example: null
+              nullable: true
+            full_name:
+              type: string
+              example: null
+              nullable: true
+            username:
+              type: string
+              example: elastic
+              nullable: true
+            profile_uid:
+              type: string
+              example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+          nullable: true
+        rule:
+          type: object
+          properties:
+            id:
+              description: The rule identifier.
+              type: string
+              example: 94d80550-aaf4-11ec-985f-97e55adae8b9
+            name:
+              description: The rule name.
+              type: string
+              example: security_rule
+        type:
+          type: string
+          example: alert
+          enum:
+            - alert
+        updated_at:
+          type: string
+          format: date-time
+          example: null
+        updated_by:
+          type: object
+          properties:
+            email:
+              type: string
+              example: null
+              nullable: true
+            full_name:
+              type: string
+              example: null
+              nullable: true
+            username:
+              type: string
+              example: elastic
+              nullable: true
+            profile_uid:
+              type: string
+              example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+        version:
+          type: string
+          example: WzMwNDgsMV0=
+    case_response_created_by_properties:
+      title: Case response properties for created_by
+      type: object
+      properties:
+        email:
+          type: string
+          example: null
+          nullable: true
+        full_name:
+          type: string
+          example: null
+          nullable: true
+        username:
+          type: string
+          example: elastic
+          nullable: true
+        profile_uid:
+          type: string
+          example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+      required:
+        - email
+        - full_name
+        - username
+    case_response_pushed_by_properties:
+      title: Case response properties for pushed_by
+      type: object
+      nullable: true
+      properties:
+        email:
+          type: string
+          example: null
+          nullable: true
+        full_name:
+          type: string
+          example: null
+          nullable: true
+        username:
+          type: string
+          example: elastic
+          nullable: true
+        profile_uid:
+          type: string
+          example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+      required:
+        - email
+        - full_name
+        - username
+    case_response_updated_by_properties:
+      title: Case response properties for updated_by
+      type: object
+      nullable: true
+      properties:
+        email:
+          type: string
+          example: null
+          nullable: true
+        full_name:
+          type: string
+          example: null
+          nullable: true
+        username:
+          type: string
+          example: elastic
+          nullable: true
+        profile_uid:
+          type: string
+          example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+      required:
+        - email
+        - full_name
+        - username
+    user_comment_response_properties:
+      title: Case response properties for user comments
+      type: object
+      required:
+        - type
+      properties:
+        comment:
+          type: string
+          example: A new comment.
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-05-13T09:16:17.416Z'
+        created_by:
+          $ref: '#/components/schemas/case_response_created_by_properties'
+        id:
+          type: string
+          example: 8af6ac20-74f6-11ea-b83a-553aecdb28b6
+        owner:
+          $ref: '#/components/schemas/owners'
+        pushed_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: null
+        pushed_by:
+          $ref: '#/components/schemas/case_response_pushed_by_properties'
+        type:
+          type: string
+          example: user
+          enum:
+            - user
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+          example: null
+        updated_by:
+          $ref: '#/components/schemas/case_response_updated_by_properties'
+        version:
+          type: string
+          example: WzIwNDMxLDFd
+    external_service:
+      type: object
+      nullable: true
+      properties:
+        connector_id:
+          type: string
+        connector_name:
+          type: string
+        external_id:
+          type: string
+        external_title:
+          type: string
+        external_url:
+          type: string
+        pushed_at:
+          type: string
+          format: date-time
+        pushed_by:
+          type: object
+          properties:
+            email:
+              type: string
+              example: null
+              nullable: true
+            full_name:
+              type: string
+              example: null
+              nullable: true
+            username:
+              type: string
+              example: elastic
+              nullable: true
+            profile_uid:
+              type: string
+              example: u_J41Oh6L9ki-Vo2tOogS8WRTENzhHurGtRc87NgEAlkc_0
+          nullable: true
+    status:
+      type: string
+      description: The status of the case.
+      enum:
+        - closed
+        - in-progress
+        - open
+    case_response_properties:
+      title: Case response properties
+      type: object
+      required:
+        - closed_at
+        - closed_by
+        - comments
+        - connector
+        - created_at
+        - created_by
+        - description
+        - duration
+        - external_service
+        - id
+        - owner
+        - settings
+        - severity
+        - status
+        - tags
+        - title
+        - totalAlerts
+        - totalComment
+        - updated_at
+        - updated_by
+        - version
+      properties:
+        assignees:
+          $ref: '#/components/schemas/assignees'
+        closed_at:
+          type: string
+          format: date-time
+          nullable: true
+        closed_by:
+          $ref: '#/components/schemas/case_response_closed_by_properties'
+        comments:
+          title: Case response properties for comments
+          description: An array of comment objects for the case.
+          type: array
+          items:
+            discriminator:
+              propertyName: type
+            oneOf:
+              - $ref: '#/components/schemas/alert_comment_response_properties'
+              - $ref: '#/components/schemas/user_comment_response_properties'
+        connector:
+          title: Case response properties for connectors
+          discriminator:
+            propertyName: type
+          oneOf:
+            - $ref: '#/components/schemas/connector_properties_none'
+            - $ref: '#/components/schemas/connector_properties_cases_webhook'
+            - $ref: '#/components/schemas/connector_properties_jira'
+            - $ref: '#/components/schemas/connector_properties_resilient'
+            - $ref: '#/components/schemas/connector_properties_servicenow'
+            - $ref: '#/components/schemas/connector_properties_servicenow_sir'
+            - $ref: '#/components/schemas/connector_properties_swimlane'
+        created_at:
+          type: string
+          format: date-time
+          example: '2022-05-13T09:16:17.416Z'
+        created_by:
+          $ref: '#/components/schemas/case_response_created_by_properties'
+        description:
+          type: string
+          example: A case description.
+        duration:
+          type: integer
+          description: |
+            The elapsed time from the creation of the case to its closure (in seconds). If the case has not been closed, the duration is set to null. If the case was closed after less than half a second, the duration is rounded down to zero.
+          nullable: true
+          example: 120
+        external_service:
+          $ref: '#/components/schemas/external_service'
+        id:
+          type: string
+          example: 66b9aa00-94fa-11ea-9f74-e7e108796192
+        owner:
+          $ref: '#/components/schemas/owners'
+        settings:
+          $ref: '#/components/schemas/settings'
+        severity:
+          $ref: '#/components/schemas/severity_property'
+        status:
+          $ref: '#/components/schemas/status'
+        tags:
+          type: array
+          items:
+            type: string
+          example:
+            - tag-1
+        title:
+          type: string
+          example: Case title 1
+        totalAlerts:
+          type: integer
+          example: 0
+        totalComment:
+          type: integer
+          example: 0
+        updated_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_by:
+          $ref: '#/components/schemas/case_response_updated_by_properties'
+        version:
+          type: string
+          example: WzUzMiwxXQ==
+    4xx_response:
+      type: object
+      title: Unsuccessful cases API response
+      properties:
+        error:
+          type: string
+          example: Unauthorized
+        message:
+          type: string
+        statusCode:
+          type: integer
+          example: 401
+    update_case_request:
+      title: Update case request
+      description: The update case API request body varies depending on the type of connector.
+      type: object
+      required:
+        - cases
+      properties:
+        cases:
+          type: array
+          description: An array containing one or more case objects.
+          items:
+            type: object
+            required:
+              - id
+              - version
+            properties:
+              assignees:
+                $ref: '#/components/schemas/assignees'
+              connector:
+                oneOf:
+                  - $ref: '#/components/schemas/connector_properties_none'
+                  - $ref: '#/components/schemas/connector_properties_cases_webhook'
+                  - $ref: '#/components/schemas/connector_properties_jira'
+                  - $ref: '#/components/schemas/connector_properties_resilient'
+                  - $ref: '#/components/schemas/connector_properties_servicenow'
+                  - $ref: '#/components/schemas/connector_properties_servicenow_sir'
+                  - $ref: '#/components/schemas/connector_properties_swimlane'
+              description:
+                description: An updated description for the case.
+                type: string
+              id:
+                description: The identifier for the case.
+                type: string
+              settings:
+                $ref: '#/components/schemas/settings'
+              severity:
+                $ref: '#/components/schemas/severity_property'
+              status:
+                $ref: '#/components/schemas/status'
+              tags:
+                description: The words and phrases that help categorize cases.
+                type: array
+                items:
+                  type: string
+              title:
+                description: A title for the case.
+                type: string
+              version:
+                description: The current version of the case. To determine this value, use the get case or find cases APIs.
+                type: string
+    searchFieldsType:
+      type: string
+      description: The fields to perform the `simple_query_string` parsed query against.
+      enum:
+        - closed_by.username
+        - closed_by.full_name
+        - closed_by.email
+        - closed_by.profile_uid
+        - created_by.username
+        - created_by.full_name
+        - created_by.email
+        - created_by.profile_uid
+        - description
+        - connector.name
+        - connector.type
+        - external_service.pushed_by.username
+        - external_service.pushed_by.full_name
+        - external_service.pushed_by.email
+        - external_service.pushed_by.profile_uid
+        - external_service.connector_name
+        - external_service.external_id
+        - external_service.external_title
+        - external_service.external_url
+        - title
+        - title.keyword
+        - updated_by.username
+        - updated_by.full_name
+        - updated_by.email
+        - updated_by.profile_uid
+  examples:
+    create_case_request:
+      summary: Create a security case that uses a Jira connector.
+      value:
+        description: A case description.
+        title: Case title 1
+        tags:
+          - tag-1
+        connector:
+          id: 131d4448-abe0-4789-939d-8ef60680b498
+          name: My connector
+          type: .jira
+          fields:
+            issueType: '10006'
+            priority: High
+            parent: null
+        settings:
+          syncAlerts: true
+        owner: cases
+    create_case_response:
+      summary: The create case API returns a JSON object that contains details about the case.
+      value:
+        comments: []
+        totalAlerts: 0
+        id: 66b9aa00-94fa-11ea-9f74-e7e108796192
+        version: WzUzMiwxXQ==
+        totalComment: 1
+        title: Case title 1
+        tags:
+          - tag 1
+        assignees: []
+        description: A case description.
+        settings:
+          syncAlerts: false
+        owner: cases
+        duration: null
+        severity: low
+        closed_at: null
+        closed_by: null
+        created_at: '2022-03-24T00:37:03.906Z'
+        created_by:
+          username: elastic
+          full_name: null
+          email: null
+        status: open
+        updated_at: null
+        updated_by: null
+        connector:
+          id: 131d4448-abe0-4789-939d-8ef60680b498
+          name: My connector
+          type: .jira
+          fields:
+            issueType: '10006'
+            parent: null
+            priority: High
+        external_service: null
+    update_case_request:
+      summary: Update the case description, tags, and connector.
+      value:
+        cases:
+          - id: a18b38a0-71b0-11ea-a0b2-c51ea50a58e2
+            version: WzIzLDFd
+            connector:
+              id: 131d4448-abe0-4789-939d-8ef60680b498
+              name: My connector
+              type: .jira
+              fields:
+                issueType: '10006'
+                priority: null
+                parent: null
+            description: A case description.
+            tags:
+              - tag-1
+            settings:
+              syncAlerts: true
+    update_case_response:
+      summary: This is an example response when the case description, tags, and connector were updated.
+      value:
+        - id: 66b9aa00-94fa-11ea-9f74-e7e108796192
+          version: WzU0OCwxXQ==
+          comments: []
+          totalComment: 0
+          totalAlerts: 0
+          title: Case title 1
+          tags:
+            - tag-1
+          settings:
+            syncAlerts: true
+          owner: cases
+          description: A case description.
+          duration: null
+          severity: low
+          closed_at: null
+          closed_by: null
+          created_at: '2022-05-13T09:16:17.416Z'
+          created_by:
+            email: null
+            full_name: null
+            username: elastic
+          status: open
+          updated_at: '2022-05-13T09:48:33.043Z'
+          updated_by:
+            email: null
+            full_name: null
+            username: elastic
+          assignees: []
+          connector:
+            id: 131d4448-abe0-4789-939d-8ef60680b498
+            name: My connector
+            type: .jira
+            fields:
+              issueType: '10006'
+              parent: null
+              priority: null
+          external_service:
+            external_title: IS-4
+            pushed_by:
+              full_name: null
+              email: null
+              username: elastic
+            external_url: https://hms.atlassian.net/browse/IS-4
+            pushed_at: '2022-05-13T09:20:40.672Z'
+            connector_id: 05da469f-1fde-4058-99a3-91e4807e2de8
+            external_id: '10003'
+            connector_name: Jira
+    find_case_response:
+      summary: Retrieve the first five cases with the `tag-1` tag, in ascending order by last update time.
+      value:
+        page: 1
+        per_page: 5
+        total: 1
+        cases:
+          - id: abed3a70-71bd-11ea-a0b2-c51ea50a58e2
+            version: WzExMCwxXQ==
+            comments: []
+            totalComment: 1
+            totalAlerts: 0
+            title: Case title
+            tags:
+              - tag-1
+            description: Case description
+            settings:
+              syncAlerts: true
+            owner: cases
+            duration: null
+            severity: low
+            closed_at: null
+            closed_by: null
+            created_at: '2022-05-12T00:16:36.371Z'
+            created_by:
+              email: null
+              full_name: null
+              username: elastic
+            status: open
+            updated_at: '2022-05-12T00:27:58.162Z'
+            updated_by:
+              email: null
+              full_name: null
+              username: elastic
+            assignees: []
+            connector:
+              id: none
+              name: none
+              type: .none
+              fields: null
+            external_service: null
+        count_open_cases: 1
+        count_in_progress_cases: 0
+        count_closed_cases: 0
+    get_case_response:
+      summary: Retrieves information about a case including its comments.
+      value:
+        id: 31cdada0-02c1-11ed-85f2-4f7c222ca2fa
+        version: WzM2LDFd
+        comments:
+          - id: 2134c1d0-02c2-11ed-85f2-4f7c222ca2fa
+            version: WzM3LDFd
+            type: user
+            owner: cases
+            comment: A new comment
+            created_at: '2022-07-13T15:40:32.335Z'
+            created_by:
+              email: null
+              full_name: null
+              username: elastic
+            pushed_at: null
+            pushed_by: null
+            updated_at: null
+            updated_by: null
+        totalComment: 1
+        totalAlerts: 0
+        title: Case title 1
+        tags:
+          - tag 1
+        settings:
+          syncAlerts: true
+        owner: cases
+        description: A case description
+        duration: null
+        severity: low
+        closed_at: null
+        closed_by: null
+        created_at: '2022-07-13T15:33:50.604Z'
+        created_by:
+          username: elastic
+          email: null
+          full_name: null
+        status: open
+        updated_at: '2022-07-13T15:40:32.335Z'
+        updated_by:
+          full_name: null
+          email: null
+          username: elastic
+        assignees:
+          - uid: u_mGBROF_q5bmFCATbLXAcCwKa0k8JvONAwSruelyKA5E_0
+        connector:
+          id: none
+          name: none
+          type: .none
+          fields: null
+        external_service: null
+security:
+  - basicAuth: []
+  - apiKeyAuth: []

--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -12,24 +12,16 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     }
   },
-  "servers": [
-    {
-      "url": "http://localhost:5601",
-      "description": "local"
-    }
-  ],
-  "security": [
-    {
-      "basicAuth": []
-    },
-    {
-      "apiKeyAuth": []
-    }
-  ],
   "tags": [
     {
       "name": "cases",
       "description": "Case APIs enable you to open and track issues."
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:5601",
+      "description": "local"
     }
   ],
   "paths": {
@@ -7141,5 +7133,13 @@
         ]
       }
     }
-  }
+  },
+  "security": [
+    {
+      "basicAuth": []
+    },
+    {
+      "apiKeyAuth": []
+    }
+  ]
 }

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -8,15 +8,12 @@ info:
   license:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
-servers:
-  - url: http://localhost:5601
-    description: local
-security:
-  - basicAuth: []
-  - apiKeyAuth: []
 tags:
   - name: cases
     description: Case APIs enable you to open and track issues.
+servers:
+  - url: http://localhost:5601
+    description: local
 paths:
   /api/cases:
     post:
@@ -4753,3 +4750,6 @@ components:
           isPreconfigured: false
           isDeprecated: false
           referencedByCount: 0
+security:
+  - basicAuth: []
+  - apiKeyAuth: []

--- a/x-pack/plugins/cases/docs/openapi/entrypoint-serverless.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint-serverless.yaml
@@ -1,0 +1,35 @@
+openapi: 3.0.1
+info:
+  title: Serverless Cases
+  description: OpenAPI schema for Serverless Cases endpoints
+  version: 'YYYY-MM-DD'
+  contact:
+    name: Cases Team
+  license:
+    name: Elastic License 2.0
+    url: https://www.elastic.co/licensing/elastic-license
+tags:
+  - name: cases
+    description: Case APIs enable you to open and track issues.
+servers:
+  - url: 'http://localhost:5601'
+    description: local
+paths:
+  '/api/cases':
+    $ref: 'paths/api@cases.yaml'
+  '/api/cases/_find':
+    $ref: 'paths/api@cases@_find.yaml'
+  '/api/cases/{caseId}':
+    $ref: 'paths/api@cases@{caseid}.yaml'
+components:
+  securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: ApiKey
+security:
+  - basicAuth: []
+  - apiKeyAuth: []


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/152382

This PR creates a bundled open API specification that contains a subset of case APIs likely to be public in serverless. For now, it re-uses the specifications from the classic context, but the amount of re-use possible will likely decrease as the functionality diverges. For example, if the responses differ we'll need to create serverless-specific response objects and examples.

I have assumed that the s/<space-id> paths aren't supported in serverless, but we can add those to the list if that assumption is incorrect.