### PR TITLE
[APM] Remove EuiPageTemplate from failure prompt

### DIFF
--- a/x-pack/plugins/apm/public/components/app/infra_overview/infra_tabs/failure_prompt.tsx
+++ b/x-pack/plugins/apm/public/components/app/infra_overview/infra_tabs/failure_prompt.tsx
@@ -5,42 +5,32 @@
  * 2.0.
  */
 
-import {
-  EuiEmptyPrompt,
-  EuiPageTemplate_Deprecated as EuiPageTemplate,
-} from '@elastic/eui';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
 
 export function FailurePrompt() {
   return (
-    <EuiPageTemplate
-      pageContentProps={{
-        color: 'transparent',
-      }}
-      template="centeredBody"
-    >
-      <EuiEmptyPrompt
-        color="danger"
-        iconType="warning"
-        layout="vertical"
-        title={
-          <h2>
-            {i18n.translate('xpack.apm.infraTabs.failurePromptTitle', {
-              defaultMessage: 'Unable to load your infrastructure data',
-            })}
-          </h2>
-        }
-        titleSize="m"
-        body={
-          <p>
-            {i18n.translate('xpack.apm.infraTabs.failurePromptDescription', {
-              defaultMessage:
-                'There was a problem loading the Infrastructure tab and your data. You can contact your administrator for help.',
-            })}
-          </p>
-        }
-      />
-    </EuiPageTemplate>
+    <EuiEmptyPrompt
+      color="danger"
+      iconType="warning"
+      layout="vertical"
+      title={
+        <h2>
+          {i18n.translate('xpack.apm.infraTabs.failurePromptTitle', {
+            defaultMessage: 'Unable to load your infrastructure data',
+          })}
+        </h2>
+      }
+      titleSize="m"
+      body={
+        <p>
+          {i18n.translate('xpack.apm.infraTabs.failurePromptDescription', {
+            defaultMessage:
+              'There was a problem loading the Infrastructure tab and your data. You can contact your administrator for help.',
+          })}
+        </p>
+      }
+    />
   );
 }


### PR DESCRIPTION
Removes `EuiPageTemplate_Deprecated` from the failure prompt in infra tab which is displayed if the fetch request for the infra attributes fails.

### Before
<img width="1508" alt="image" src="https://github.com/elastic/kibana/assets/5831975/b1a51640-8c65-4f55-bfa2-6878357cd6ba">

### After
<img width="1521" alt="image" src="https://github.com/elastic/kibana/assets/5831975/b502b68e-28ca-44b8-a293-4173ae4eadbb">

### No data screen
<img width="1523" alt="image" src="https://github.com/elastic/kibana/assets/5831975/510102a2-89d9-4114-b5f7-92c2e536be31">

Closes https://github.com/elastic/kibana/issues/161415