### PR TITLE
[ResponseOps][Alerting] Flaky test x-pack/plugins/event_log/server/es

### DIFF
--- a/x-pack/plugins/event_log/server/es/init.test.ts
+++ b/x-pack/plugins/event_log/server/es/init.test.ts
@@ -455,8 +455,7 @@ describe('parseIndexAliases', () => {
   });
 });
 
-// FLAKY: https://github.com/elastic/kibana/issues/156061
-describe.skip('retries', () => {
+describe('retries', () => {
   let esContext = contextMock.create();
   // set up context APIs to return defaults indicating already created
   beforeEach(() => {
@@ -474,7 +473,7 @@ describe.skip('retries', () => {
 
     const timeStart = performance.now();
     await initializeEs(esContext);
-    const timeElapsed = performance.now() - timeStart;
+    const timeElapsed = Math.ceil(performance.now() - timeStart);
 
     expect(timeElapsed).toBeGreaterThanOrEqual(MOCK_RETRY_DELAY);
 


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/156061

## Summary

Fixes flaky test by adding ceil(). When it fails the time elapsed is close to the `MOCK_RETRY_DELAY` of 20 (like 19.7), so rounding up helps with the flakiness

