### PR TITLE
[Cloud Security] AWS Organization form

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.test.tsx
@@ -6,7 +6,11 @@
  */
 import React from 'react';
 import { render } from '@testing-library/react';
-import { CspPolicyTemplateForm } from './policy_template_form';
+import {
+  CspPolicyTemplateForm,
+  AWS_ORGANIZATION_ACCOUNT,
+  AWS_SINGLE_ACCOUNT,
+} from './policy_template_form';
 import { TestProvider } from '../../test/test_provider';
 import {
   getMockPackageInfoCspmAWS,
@@ -712,10 +716,10 @@ describe('<CspPolicyTemplateForm />', () => {
   });
 
   describe('AWS Credentials input fields', () => {
-    it(`renders ${CLOUDBEAT_AWS} Account Type field`, () => {
+    it(`renders ${CLOUDBEAT_AWS} Account Type field, AWS Organization is enabled for supported versions`, () => {
       let policy = getMockPolicyAWS();
       policy = getPosturePolicy(policy, CLOUDBEAT_AWS, {
-        'aws.account_type': { value: 'single_account' },
+        'aws.account_type': { value: AWS_ORGANIZATION_ACCOUNT },
       });
 
       const { getByLabelText } = render(
@@ -724,13 +728,14 @@ describe('<CspPolicyTemplateForm />', () => {
 
       expect(getByLabelText('Single Account')).toBeInTheDocument();
       expect(getByLabelText('AWS Organization')).toBeInTheDocument();
+      expect(getByLabelText('AWS Organization')).toBeEnabled();
     });
 
     it(`${CLOUDBEAT_AWS} form displays upgrade message for unsupported versions and aws organization option is disabled`, () => {
       let policy = getMockPolicyAWS();
       policy = getPosturePolicy(policy, CLOUDBEAT_AWS, {
         'aws.credentials.type': { value: 'cloud_formation' },
-        'aws.account_type': { value: 'single_account' },
+        'aws.account_type': { value: AWS_SINGLE_ACCOUNT },
       });
 
       const { getByText, getByLabelText } = render(
@@ -743,13 +748,14 @@ describe('<CspPolicyTemplateForm />', () => {
         )
       ).toBeInTheDocument();
       expect(getByLabelText('AWS Organization')).toBeDisabled();
+      expect(getByLabelText('Single Account')).toBeEnabled();
     });
 
     it(`${CLOUDBEAT_AWS} form do not displays upgrade message for supported versions and aws organization option is enabled`, () => {
       let policy = getMockPolicyAWS();
       policy = getPosturePolicy(policy, CLOUDBEAT_AWS, {
         'aws.credentials.type': { value: 'cloud_formation' },
-        'aws.account_type': { value: 'single_account' },
+        'aws.account_type': { value: AWS_ORGANIZATION_ACCOUNT },
       });
 
       const { queryByText, getByLabelText } = render(

--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -79,8 +79,8 @@ interface IntegrationInfoFieldsProps {
   onChange(field: string, value: string): void;
 }
 
-const SINGLE_ACCOUNT = 'single_account';
-const ORGANIZATION_ACCOUNT = 'organization_account';
+const SINGLE_ACCOUNT = 'single-account';
+const ORGANIZATION_ACCOUNT = 'organization-account';
 type AwsAccountType = typeof SINGLE_ACCOUNT | typeof ORGANIZATION_ACCOUNT;
 
 const getAwsAccountTypeOptions = (isAwsOrgDisabled: boolean): CspRadioGroupProps['options'] => [


### PR DESCRIPTION
Resolves #161345

## Summary

https://github.com/elastic/kibana/assets/51442161/557ec0ae-fcfc-4d92-97ca-3e2027227f6c

- [x] Add the AWS Organization form
- [x] Instructions documentation link should lead [here](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-whatis-howdoesitwork.html) for now
- [ ] ~CTA Button should switch to `Save & Launch CloudFormation` according to the to the Figma~
- [x] After saving, open the Launch CloudFormation Modal introduced in [[CloudSecurity][Fleet] Add CloudFormation install method to CSPM](https://github.com/elastic/kibana/pull/159994#top)
- [x] Configure the Add Agent flyout to support this installation method, as shown in [[CloudSecurity][Fleet] Add CloudFormation install method to CSPM](https://github.com/elastic/kibana/pull/159994#top)
- [x] Validate the functionality of both forms
- [x] Add unit tests
- [x] Update the [RTC](https://docs.google.com/spreadsheets/d/1-uqDi7z9GdVob2rHK8EHcrcIqhBGUcR0K5MqMQiLQho/edit#gid=1133699557) - Add requirements
- [x] Create a followup task to design automated tests