### PR TITLE
Update "Gen AI Streaming Response Example" to make use of `@kbn/ml-response-stream`.

### DIFF
--- a/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
+++ b/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
@@ -181,18 +181,9 @@ export const StreamingResponse = ({
   );
 };
 
-function streamReducer(state: string, action: Chunk | Chunk[] | 'RESET') {
-  if (action === 'RESET') {
-    return '';
-  }
-
-  return `${state}${getMessageFromChunks(Array.isArray(action) ? action : [action])}`;
-}
-
-function getMessageFromChunks(chunks: Chunk[]) {
-  let message = '';
-  chunks.forEach((chunk) => {
-    message += chunk.choices[0]?.delta.content ?? '';
-  });
-  return message;
+function streamReducer(state: string, action: Chunk | Chunk[]) {
+  return `${state}${[action]
+    .flat()
+    .map((chunk) => chunk.choices[0]?.delta.content ?? '')
+    .join('')}`;
 }

--- a/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
+++ b/x-pack/examples/gen_ai_streaming_response_example/public/components/streaming_response.tsx
@@ -5,8 +5,9 @@
  * 2.0.
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
+  EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiAccordion,
@@ -20,8 +21,7 @@ import {
 import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { CoreStart } from '@kbn/core/public';
-import { concatMap, delay, Observable, of } from 'rxjs';
-import useObservable from 'react-use/lib/useObservable';
+import { useFetchStream } from '@kbn/ml-response-stream/client';
 
 export interface StreamingResponseProps {
   http: CoreStart['http'];
@@ -79,113 +79,40 @@ export const StreamingResponse = ({
   const { euiTheme } = useEuiTheme();
   const [hasOpened, setHasOpened] = useState(false);
 
-  const response$ = useMemo(() => {
-    return hasOpened
-      ? new Observable<PromptObservableState>((observer) => {
-          observer.next({ chunks: [], loading: true });
+  const { dispatch, errors, start, cancel, data, isRunning } = useFetchStream(
+    http,
+    `/internal/examples/execute_gen_ai_connector`,
+    undefined,
+    {
+      connector_id: selectedConnectorId,
+      prompt,
+    },
+    { reducer: streamReducer, initialState: '' }
+  );
 
-          http
-            .post(`/internal/examples/execute_gen_ai_connector`, {
-              body: JSON.stringify({
-                connector_id: selectedConnectorId,
-                prompt,
-              }),
-              asResponse: true,
-              rawResponse: true,
-            })
-            .then((response) => {
-              const status = response.response?.status;
+  useEffect(() => {
+    if (hasOpened && !isRunning && errors.length === 0 && data === '') {
+      start();
+    }
+  }, [data, errors, hasOpened, isRunning, start]);
 
-              if (!status || status >= 400) {
-                throw new Error(response.response?.statusText || 'Unexpected error');
-              }
+  function refreshHandler() {
+    if (isRunning) {
+      cancel();
+    }
+    dispatch('RESET');
+    start();
+  }
 
-              const reader = response.response.body?.getReader();
-
-              if (!reader) {
-                throw new Error('Could not get reader from response');
-              }
-
-              const decoder = new TextDecoder();
-
-              const chunks: Chunk[] = [];
-
-              let prev: string = '';
-
-              function read() {
-                reader!.read().then(({ done, value }: { done: boolean; value?: Uint8Array }) => {
-                  try {
-                    if (done) {
-                      observer.next({
-                        chunks,
-                        message: getMessageFromChunks(chunks),
-                        loading: false,
-                      });
-                      observer.complete();
-                      return;
-                    }
-
-                    let lines: string[] = (prev + decoder.decode(value)).split('\n');
-
-                    const lastLine: string = lines[lines.length - 1];
-
-                    const isPartialChunk: boolean = !!lastLine && lastLine !== 'data: [DONE]';
-
-                    if (isPartialChunk) {
-                      prev = lastLine;
-                      lines.pop();
-                    } else {
-                      prev = '';
-                    }
-
-                    lines = lines
-                      .map((str) => str.substr(6))
-                      .filter((str) => !!str && str !== '[DONE]');
-
-                    const nextChunks: Chunk[] = lines.map((line) => JSON.parse(line));
-
-                    nextChunks.forEach((chunk) => {
-                      chunks.push(chunk);
-                      observer.next({
-                        chunks,
-                        message: getMessageFromChunks(chunks),
-                        loading: true,
-                      });
-                    });
-                  } catch (err) {
-                    observer.error(err);
-                    return;
-                  }
-                  read();
-                });
-              }
-
-              read();
-
-              return () => {
-                reader.cancel();
-              };
-            })
-            .catch((err) => {
-              observer.next({ chunks: [], error: err.message, loading: false });
-            });
-        }).pipe(concatMap((value) => of(value).pipe(delay(50))))
-      : new Observable<PromptObservableState>(() => {});
-  }, [http, hasOpened, prompt, selectedConnectorId]);
-
-  const response = useObservable(response$);
-
-  useEffect(() => {}, [response$]);
-
-  let content = response?.message ?? '';
+  let content = data;
 
   let state: 'init' | 'loading' | 'streaming' | 'error' | 'complete' = 'init';
 
-  if (response?.loading) {
+  if (isRunning) {
     state = content ? 'streaming' : 'loading';
-  } else if (response && 'error' in response && response.error) {
+  } else if (errors.length > 0) {
     state = 'error';
-    content = response.error;
+    content = errors.join('\n');
   } else if (content) {
     state = 'complete';
   }
@@ -259,10 +186,31 @@ export const StreamingResponse = ({
       >
         <EuiSpacer size="s" />
         {inner}
+        {hasOpened && !isRunning && (
+          <>
+            <EuiSpacer size="s" />
+            <EuiButton onClick={refreshHandler} size="s" iconType={'refresh'}>
+              {i18n.translate(
+                'genAiStreamingResponseExample.app.component.streamingResponseRefresh',
+                {
+                  defaultMessage: 'Refresh',
+                }
+              )}
+            </EuiButton>
+          </>
+        )}
       </EuiAccordion>
     </EuiPanel>
   );
 };
+
+function streamReducer(state: string, action: Chunk | Chunk[] | 'RESET') {
+  if (action === 'RESET') {
+    return '';
+  }
+
+  return `${state}${getMessageFromChunks(Array.isArray(action) ? action : [action])}`;
+}
 
 function getMessageFromChunks(chunks: Chunk[]) {
   let message = '';

--- a/x-pack/examples/gen_ai_streaming_response_example/tsconfig.json
+++ b/x-pack/examples/gen_ai_streaming_response_example/tsconfig.json
@@ -25,5 +25,6 @@
     "@kbn/charts-plugin",
     "@kbn/data-plugin",
     "@kbn/actions-plugin",
+    "@kbn/ml-response-stream",
   ]
 }


### PR DESCRIPTION
## Summary

Follow up to #161676.

Since we added support for handling SSE-streams returned by OpenAI APIs to `@kbn/ml-response-stream` in #162335, this updates the "Gen AI Streaming Response" developer example to make use of the custom hook `useFetchStream()` from `@kbn/ml-response-stream` instead of its inline code to process the stream on the client.

It also improves the refresh behaviour: Previously, once a prompt was entered and the accordion opened, every keystroke in the prompt textarea would cause a new request to the AI endpoint. This update adds a `Refresh prompt` to only do a new request on this user action. Support for cancelling requests when unmounting the `StreamingResponse` component was also added.

![gen-ai-streaming-0001](https://github.com/elastic/kibana/assets/230104/af81d3ac-cc03-4550-9aa5-8685c15304cd)

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
