### PR TITLE
[Migrations] Unskip migration integration tests after fixing

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/multiple_kibana_nodes.test.ts
@@ -106,8 +106,7 @@ async function createRoot({ logFileName }: CreateRootConfig) {
 // suite is very long, the 10mins default can cause timeouts
 jest.setTimeout(15 * 60 * 1000);
 
-// FLAKY: https://github.com/elastic/kibana/issues/156117
-describe.skip('migration v2', () => {
+describe('migration v2', () => {
   let esServer: TestElasticsearchUtils;
   let rootA: Root;
   let rootB: Root;


### PR DESCRIPTION
## Summary

Resolves #156117.

This PR just enables back the tests as they should have been fixed in #158182.


<!--ONMERGE {"backportTargets":["8.8","8.9"]} ONMERGE-->