### PR TITLE
Fixes serverless common API security response headers API tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/security_response_headers.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/security_response_headers.ts
@@ -25,7 +25,7 @@ export default function ({ getService }: FtrProviderContext) {
     it('API endpoint response contains default security headers', async () => {
       const { header } = await supertest
         .get(`/internal/security/me`)
-        .set(svlCommonApi.getCommonRequestHeader())
+        .set(svlCommonApi.getInternalRequestHeader())
         .expect(200);
 
       expect(header).toBeDefined();
@@ -40,9 +40,9 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('redirect endpoint response contains default security headers', async () => {
       const { header } = await supertest
-        .get(`/login`)
+        .get(`/logout`)
         .set(svlCommonApi.getCommonRequestHeader())
-        .expect(302);
+        .expect(200);
 
       expect(header).toBeDefined();
       expect(header['content-security-policy']).toEqual(defaultCSP);


### PR DESCRIPTION
Unblocks #162149

## Summary
Fixes serverless security response headers tests by using the internal request header. This PR also opts to use the `/logout` redirect endpoint in testing, as it is more relevant to serverless.