### PR TITLE
fix agent cfg path on macOS for standalone agent installer 

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
+++ b/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
@@ -30,6 +30,7 @@ OS="$(uname)"
 ARCH="$(uname -m)"
 os=linux
 arch=x86_64
+cfg=/opt/Elastic/Agent/elastic-agent.yml
 if [ "${OS}" == "Linux" ]; then
   if [ "${ARCH}" == "aarch64" ]; then
     arch=arm64
@@ -39,6 +40,7 @@ elif [ "${OS}" == "Darwin" ]; then
   if [ "${ARCH}" == "arm64" ]; then
     arch=aarch64
   fi
+  cfg=/Library/Elastic/Agent/elastic-agent.yml
 else
   fail "this script is only supported on linux and macOS"
 fi
@@ -126,7 +128,7 @@ ELASTIC_AGENT_STATE="$(elastic-agent status | grep -m1 State | sed 's/State: //'
 ELASTIC_AGENT_MESSAGE="$(elastic-agent status | grep -m1 Message | sed 's/Message: //')"
 if [ "${ELASTIC_AGENT_STATE}" = "HEALTHY" ] && [ "${ELASTIC_AGENT_MESSAGE}" = "Running" ]; then
   echo "Elastic Agent running"
-  echo "Download and save configuration to /opt/Elastic/Agent/elastic-agent.yml"
+  echo "Download and save configuration to ${cfg}"
   updateStepProgress "ea-status" "complete"
 else
   updateStepProgress "ea-status" "warning" "Expected agent status HEALTHY / Running but got ${ELASTIC_AGENT_STATE} / ${ELASTIC_AGENT_MESSAGE}"
@@ -141,7 +143,7 @@ downloadElasticAgentConfig() {
     --header "Content-Type: application/json" \
     --header "kbn-xsrf: true" \
     --no-progress-meter \
-    --output /opt/Elastic/Agent/elastic-agent.yml
+    --output ${cfg}
 
   if [ "$?" -eq 0 ]; then
     echo "Downloaded elastic-agent.yml"
@@ -156,5 +158,5 @@ if [ "${AUTO_DOWNLOAD_CONFIG}" == "autoDownloadConfig=1" ]; then
   downloadElasticAgentConfig
   echo "Done with standalone Elastic Agent setup for custom logs. Look for streaming logs to arrive in Kibana"
 else
-  echo "Done with standalone Elastic Agent setup for custom logs. Make sure to add your configuration to /opt/Elastic/Agent/elastic-agent.yml, then look for streaming logs to arrive in Kibana"
+  echo "Done with standalone Elastic Agent setup for custom logs. Make sure to add your configuration to ${cfg}, then look for streaming logs to arrive in Kibana"
 fi


### PR DESCRIPTION
## Summary

Fix for https://github.com/elastic/kibana/issues/159184#issuecomment-1653288889

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
