### PR TITLE
Test failed test triage workflows

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -21,34 +21,6 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/functional/apm_cypress.sh
-    label: 'APM Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 120
-    parallelism: 4
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/profiling_cypress.sh
-    label: 'Profling Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 120
-    parallelism: 4
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
-
   - command: .buildkite/scripts/steps/functional/security_solution.sh
     label: 'Security Solution Tests'
     agents:
@@ -106,34 +78,3 @@ steps:
           limit: 1
     artifact_paths:
       - "target/kibana-security-solution/**/*"
-
-  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    label: 'Osquery Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    parallelism: 6
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1
-    artifact_paths:
-      - "target/kibana-osquery/**/*"
-
-  - command: .buildkite/scripts/steps/functional/synthetics_plugin.sh
-    label: 'Synthetics @elastic/synthetics Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 120
-    artifact_paths:
-      - 'x-pack/plugins/synthetics/e2e/.journeys/**/*'
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-        - exit_status: '*'
-          limit: 1

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
@@ -67,6 +67,8 @@ describe('Prebuilt rules', () => {
 
   describe('Alerts rules, prebuilt rules', () => {
     it('Loads prebuilt rules', () => {
+      // Explicitly fail this test.
+      expect(false).to.equal(true);
       // Check that the rules table contains rules
       cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW).should('have.length.gte', 1);
 

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
@@ -25,6 +25,8 @@ describe('Rules table: links', () => {
   });
 
   it('should render correct link for rule name - rules', () => {
+    // Explicitly fail this test
+    expect(true).toBe(false);
     cy.get(RULE_NAME).first().click();
     cy.url().should('contain', 'rules/id/');
   });

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_response/value_lists/value_lists.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_response/value_lists/value_lists.cy.ts
@@ -53,6 +53,8 @@ describe('value lists', () => {
       });
 
       it('creates a "keyword" list from an uploaded file', () => {
+        // explicitly fail this test
+        expect(false).toBe(true);
         const listName = 'value_list.txt';
         selectValueListType('keyword');
         selectValueListsFile(listName);

--- a/x-pack/plugins/security_solution/cypress/e2e/explore/cases/creation.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/explore/cases/creation.cy.ts
@@ -70,6 +70,8 @@ describe('Cases', () => {
   });
 
   it('Creates a new case with timeline and opens the timeline', function () {
+    // Explicitly fail this test
+    expect(true).toBe(false);
     loginWithUser({ username: 'elastic', password: 'changeme' });
     visitWithoutDateRange(CASES_URL);
     goToCreateNewCase();

--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/resolver.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/resolver.cy.ts
@@ -30,6 +30,8 @@ describe('Analyze events view for alerts', () => {
   });
 
   it('should render when button is clicked', () => {
+    // Explicitly fail this test
+    expect(true).toBe(false);
     openAnalyzerForFirstAlertInTimeline();
     cy.get(ANALYZER_NODE).first().should('be.visible');
   });

--- a/x-pack/plugins/security_solution/cypress/e2e/urls/not_found.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/urls/not_found.cy.ts
@@ -37,6 +37,9 @@ describe('Display not found page', () => {
   });
 
   it('navigates to the exceptions page with incorrect link', () => {
+    // Explicitly fail this test
+    expect(true).to.equal(false);
+
     visit(`${EXCEPTIONS_URL}/randomUrl`);
     cy.get(NOT_FOUND).should('exist');
   });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/response_console.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/endpoint/response_console.cy.ts
@@ -68,6 +68,8 @@ describe('Response console', () => {
     });
 
     it('should isolate host from response console', () => {
+      // Explicitly fail this test
+      expect(true).toBe(false);
       const command = 'isolate';
       waitForEndpointListPageToBeLoaded(createdHost.hostname);
       checkEndpointListForOnlyUnIsolatedHosts();


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
