### PR TITLE
Flaky test: Detection rule telemetry #162407

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -6,13 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import type { DetectionMetrics } from '@kbn/security-solution-plugin/server/usage/detections/types';
 import type {
   ThreatMatchRuleCreateProps,
   ThresholdRuleCreateProps,
 } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { getInitialDetectionMetrics } from '@kbn/security-solution-plugin/server/usage/detections/get_initial_usage';
-import { getInitialEventLogUsage } from '@kbn/security-solution-plugin/server/usage/detections/rules/get_initial_usage';
 import { ELASTIC_SECURITY_RULE_ID } from '@kbn/security-solution-plugin/common';
 import { RulesTypeUsage } from '@kbn/security-solution-plugin/server/usage/detections/rules/types';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
@@ -74,32 +72,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -110,38 +102,28 @@ export default ({ getService }: FtrProviderContext) => {
         await waitForSignalsToBePresent(supertest, log, 4, [id]);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -153,30 +135,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              notifications_disabled: 1,
+              disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              notifications_disabled: 1,
+              disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -190,32 +162,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -227,26 +189,21 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-              },
+
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -260,32 +217,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                query: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            query: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.query,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
     });
@@ -296,32 +243,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -332,38 +273,28 @@ export default ({ getService }: FtrProviderContext) => {
         await waitForSignalsToBePresent(supertest, log, 4, [id]);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -375,30 +306,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              notifications_disabled: 1,
+              disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              notifications_disabled: 1,
+              disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -412,32 +333,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -476,32 +387,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial (see detection_rule_status.ts for more in-depth testing of this structure)
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
     });
@@ -518,32 +419,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -560,38 +455,28 @@ export default ({ getService }: FtrProviderContext) => {
         await waitForSignalsToBePresent(supertest, log, 4, [id]);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -609,30 +494,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              notifications_disabled: 1,
+              disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              notifications_disabled: 1,
+              disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -652,32 +527,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -695,30 +560,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -738,32 +593,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threshold: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threshold: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threshold,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
     });
@@ -775,33 +620,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -810,37 +648,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  enabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              enabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -852,31 +679,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              notifications_disabled: 1,
+              disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              notifications_disabled: 1,
+              disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -888,31 +704,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  enabled: 1,
-                  notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              enabled: 1,
+              notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -924,31 +729,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -960,31 +754,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                machine_learning: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage
-                    .machine_learning,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            machine_learning: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.machine_learning,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
     });
@@ -995,32 +778,26 @@ export default ({ getService }: FtrProviderContext) => {
         await createRule(supertest, log, rule);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -1046,38 +823,28 @@ export default ({ getService }: FtrProviderContext) => {
         await waitForSignalsToBePresent(supertest, log, 4, [id]);
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 0,
-                  notifications_disabled: 0,
-                  legacy_notifications_disabled: 0,
-                  legacy_notifications_enabled: 0,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 0,
+              notifications_disabled: 0,
+              legacy_notifications_disabled: 0,
+              legacy_notifications_enabled: 0,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -1089,30 +856,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  notifications_disabled: 1,
-                  disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              notifications_disabled: 1,
+              disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              notifications_disabled: 1,
+              disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -1141,32 +898,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  enabled: 1,
-                  alerts: 4,
-                  notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              enabled: 1,
+              alerts: 4,
+              notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -1178,30 +925,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 
@@ -1230,32 +967,22 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-
-          // remove "detection_rule_status" from the test by resetting it to initial
-          stats.detection_rules.detection_rule_status = getInitialEventLogUsage();
-
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                threat_match: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  alerts: 4,
-                  enabled: 1,
-                  legacy_notifications_enabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            threat_match: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.threat_match,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              alerts: 4,
+              enabled: 1,
+              legacy_notifications_enabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
     });

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -14,6 +14,7 @@ import type {
 import { getInitialDetectionMetrics } from '@kbn/security-solution-plugin/server/usage/detections/get_initial_usage';
 import { getInitialEventLogUsage } from '@kbn/security-solution-plugin/server/usage/detections/rules/get_initial_usage';
 import { ELASTIC_SECURITY_RULE_ID } from '@kbn/security-solution-plugin/common';
+import { RulesTypeUsage } from '@kbn/security-solution-plugin/server/usage/detections/rules/types';
 import type { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
   createLegacyRuleAction,
@@ -289,8 +290,8 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/156088
-    describe.skip('"eql" rule type', () => {
+    // github.com/elastic/kibana/issues/156088
+    describe('"eql" rule type', () => {
       it('should show "notifications_enabled", "notifications_disabled" "legacy_notifications_enabled", "legacy_notifications_disabled", all to be "0" for "disabled"/"in-active" rule that does not have any actions', async () => {
         const rule = getEqlRuleForSignalTesting(['telemetry'], 'rule-1', false);
         await createRule(supertest, log, rule);
@@ -449,26 +450,20 @@ export default ({ getService }: FtrProviderContext) => {
 
         await retry.try(async () => {
           const stats = await getStats(supertest, log);
-          const expected: DetectionMetrics = {
-            ...getInitialDetectionMetrics(),
-            detection_rules: {
-              ...getInitialDetectionMetrics().detection_rules,
-              detection_rule_usage: {
-                ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
-                eql: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-                custom_total: {
-                  ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
-                  disabled: 1,
-                  legacy_notifications_disabled: 1,
-                },
-              },
+          const expected: RulesTypeUsage = {
+            ...getInitialDetectionMetrics().detection_rules.detection_rule_usage,
+            eql: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.eql,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
+            },
+            custom_total: {
+              ...getInitialDetectionMetrics().detection_rules.detection_rule_usage.custom_total,
+              disabled: 1,
+              legacy_notifications_disabled: 1,
             },
           };
-          expect(stats).to.eql(expected);
+          expect(stats.detection_rules.detection_rule_usage).to.eql(expected);
         });
       });
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/usage_collector/detection_rules.ts
@@ -290,7 +290,6 @@ export default ({ getService }: FtrProviderContext) => {
       });
     });
 
-    // github.com/elastic/kibana/issues/156088
     describe('"eql" rule type', () => {
       it('should show "notifications_enabled", "notifications_disabled" "legacy_notifications_enabled", "legacy_notifications_disabled", all to be "0" for "disabled"/"in-active" rule that does not have any actions', async () => {
         const rule = getEqlRuleForSignalTesting(['telemetry'], 'rule-1', false);


### PR DESCRIPTION
## Summary

Original ticket: https://github.com/elastic/kibana/issues/156088

It looks like flakiness happens due to another rule from previous test case being scheduled by alerting framework and running even after we deleted it (since we called delete rule after it was scheduled). That rule scheduled earlier produces some unexpected artifacts in metrics, specifically `stats.detection_rules.detection_rule_status` where occasionally see

<img width="1255" alt="Screenshot 2023-07-25 at 15 13 29" src="https://github.com/elastic/kibana/assets/2700761/5d1cc334-25b5-4bf2-8822-c9858a0b72bf">

Since, in this test case the rule is disabled, we should not see this data.

As a fix, we decided to test against specific metrics attributes `stats.detection_rules.detection_rule_usage` which we expect being updated.


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->