### PR TITLE
Temporarily avoid proxy-cache for hashes, the cache is polluted blocking downloads

### DIFF
--- a/src/dev/build/tasks/nodejs/node_shasums.ts
+++ b/src/dev/build/tasks/nodejs/node_shasums.ts
@@ -10,7 +10,7 @@ import { ToolingLog } from '@kbn/tooling-log';
 import { downloadToString } from '../../lib/download';
 
 export async function getNodeShasums(log: ToolingLog, nodeVersion: string) {
-  const url = `https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/dist/v${nodeVersion}/SHASUMS256.txt`;
+  const url = `https://storage.googleapis.com/kibana-custom-node-artifacts/node-glibc-217/dist/v${nodeVersion}/SHASUMS256.txt`;
 
   log.debug('Downloading shasum values for node version', nodeVersion, 'from', url);
 


### PR DESCRIPTION
## Summary
Our builds started failing not long after the Node.js bump was merged. Somehow the SHASUMS256.txt is arriving in a wrong version through the cache.

Temporarily go directly to the bucket, skipping the proxy-cache's copied paths.