### PR TITLE
Re-enable security related tests related to the concurrent access token refresh.

### DIFF
--- a/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -381,8 +381,7 @@ export default function ({ getService }: FtrProviderContext) {
         expect(nonAjaxResponse.headers['www-authenticate']).to.be(undefined);
       });
 
-      // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/162581
-      describe.skip('post-authentication stage', () => {
+      describe('post-authentication stage', () => {
         for (const client of ['start-contract', 'request-context', 'custom']) {
           it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
             this.timeout(60000);

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
@@ -542,8 +542,7 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
       });
 
-      // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/162583
-      describe.skip('post-authentication stage', () => {
+      describe('post-authentication stage', () => {
         for (const client of ['start-contract', 'request-context', 'custom']) {
           it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
             this.timeout(60000);

--- a/x-pack/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/test/security_api_integration/tests/saml/saml_login.ts
@@ -443,8 +443,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/162584
-    describe.skip('API access with expired access token.', () => {
+    describe('API access with expired access token.', () => {
       let sessionCookie: Cookie;
 
       beforeEach(async function () {

--- a/x-pack/test/security_api_integration/tests/token/session.ts
+++ b/x-pack/test/security_api_integration/tests/token/session.ts
@@ -132,8 +132,7 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(200);
       });
 
-      // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/162586
-      describe.skip('post-authentication stage', () => {
+      describe('post-authentication stage', () => {
         for (const client of ['start-contract', 'request-context', 'custom']) {
           it(`expired access token should be automatically refreshed by the ${client} client`, async function () {
             this.timeout(60000);


### PR DESCRIPTION
## Summary

Since https://github.com/elastic/elasticsearch/pull/98011 is merged, we can re-enable our tests as soon as ES snapshot is promoted.

I run a few of these tests locally against Elasticsearch built from source and they were passing.

__Fixes: https://github.com/elastic/kibana/issues/162581__
__Fixes: https://github.com/elastic/kibana/issues/162583__
__Fixes: https://github.com/elastic/kibana/issues/162584__
__Fixes: https://github.com/elastic/kibana/issues/162586__

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->