### PR TITLE
[files] make download URL `access: public`

### DIFF
--- a/src/plugins/files/server/routes/public_facing/download.ts
+++ b/src/plugins/files/server/routes/public_facing/download.ts
@@ -73,6 +73,7 @@ export function register(router: FilesRouter) {
       validate: { ...rt },
       options: {
         authRequired: false,
+        access: 'public',
       },
     },
     handler


### PR DESCRIPTION
This endpoint is used in `href`s and should continue to work without require any special headers.