### PR TITLE
[Infrastructure UI] remove deprecated SavedObjectReference type

### DIFF
--- a/x-pack/plugins/infra/public/common/visualizations/lens/utils.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/utils.ts
@@ -10,7 +10,7 @@ import {
   TermsIndexPatternColumn,
 } from '@kbn/lens-plugin/public';
 import type { DataView, DataViewSpec } from '@kbn/data-views-plugin/public';
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 
 export const DEFAULT_LAYER_ID = 'layer';
 export const DEFAULT_AD_HOC_DATA_VIEW_ID = 'infra_lens_ad_hoc_default';

--- a/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/metric_layer.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/metric_layer.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type {
   FormulaPublicApi,

--- a/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/xy_data_layer.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/xy_data_layer.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type {
   FormulaPublicApi,

--- a/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/xy_reference_lines_layer.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/layers/xy_reference_lines_layer.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type {
   FormBasedPersistedState,

--- a/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/metric_chart.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/metric_chart.ts
@@ -6,7 +6,7 @@
  */
 
 import type { FormBasedPersistedState, MetricVisualizationState } from '@kbn/lens-plugin/public';
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataView } from '@kbn/data-views-plugin/public';
 import { DEFAULT_LAYER_ID } from '../utils';
 

--- a/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/xy_chart.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/lens/visualization_types/xy_chart.ts
@@ -7,7 +7,7 @@
 
 import type { FormBasedPersistedState, XYLayerConfig, XYState } from '@kbn/lens-plugin/public';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import { DEFAULT_LAYER_ID } from '../utils';
 import type { Chart, ChartConfig, ChartLayer } from '../../types';
 

--- a/x-pack/plugins/infra/public/common/visualizations/types.ts
+++ b/x-pack/plugins/infra/public/common/visualizations/types.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type {
   FormBasedPersistedState,

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_references_manager.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_references_manager.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import { Comparator, RuleParams } from '../../../../common/alerting/logs/log_threshold';
 import { extractReferences, injectReferences } from './log_threshold_references_manager';
 

--- a/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_references_manager.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/log_threshold/log_threshold_references_manager.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { SavedObjectReference } from '@kbn/core-saved-objects-common';
+import type { SavedObjectReference } from '@kbn/core/server';
 import { logViewReferenceRT } from '@kbn/logs-shared-plugin/common';
 import { logViewSavedObjectName } from '@kbn/logs-shared-plugin/server';
 import { RuleParams, ruleParamsRT } from '../../../../common/alerting/logs/log_threshold';

--- a/x-pack/plugins/infra/tsconfig.json
+++ b/x-pack/plugins/infra/tsconfig.json
@@ -49,7 +49,6 @@
     "@kbn/ui-actions-plugin",
     "@kbn/charts-plugin",
     "@kbn/lens-plugin",
-    "@kbn/core-saved-objects-common",
     "@kbn/core-analytics-server",
     "@kbn/analytics-client",
     "@kbn/shared-ux-router",


### PR DESCRIPTION
## Summary

Remove `SavedObjectReference` type from `@kbn/core-saved-objects-common` in favor of `@kbn/core/server`

Closes https://github.com/elastic/kibana/issues/162725