### PR TITLE
[CI][Security Solution] Bump security solution cypress parallelism

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution.yml
+++ b/.buildkite/pipelines/pull_request/security_solution.yml
@@ -1,6 +1,6 @@
 steps:
   - command: .buildkite/scripts/steps/functional/security_solution.sh
-    label: 'Security Solution Tests'
+    label: 'Security Solution Cypress Tests'
     agents:
       queue: n2-4-spot
     depends_on: build

--- a/.buildkite/pipelines/pull_request/security_solution.yml
+++ b/.buildkite/pipelines/pull_request/security_solution.yml
@@ -5,7 +5,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 7
+    parallelism: 8
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/scripts/steps/functional/security_solution.sh
+++ b/.buildkite/scripts/steps/functional/security_solution.sh
@@ -8,6 +8,6 @@ source .buildkite/scripts/steps/functional/common_cypress.sh
 export JOB=kibana-security-solution-chrome
 export KIBANA_INSTALL_DIR=${KIBANA_BUILD_LOCATION}
 
-echo "--- Security Solution tests (Chrome)"
+echo "--- Security Solution Cypress tests (Chrome)"
 
 yarn --cwd x-pack/plugins/security_solution cypress:run


### PR DESCRIPTION
## Summary

This accomplishes two things:
* increases the number of parallel jobs for the main Security Solution Cypress tests from 7 to 8, to (temporarily) address issues with these jobs exceeding their allotted time (60m)
* Updates the naming of this CI step to make it more descriptive/discoverable