### PR TITLE
[Synthetics] Fix auto-expand feature for failed step detail

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.test.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Matcher, SelectorMatcherOptions, within } from '@testing-library/react';
+import React from 'react';
+import { render, WrappedHelper } from '../../../utils/testing';
+import { JourneyStep } from '../../../../../../common/runtime_types';
+import { BrowserStepsList } from './browser_steps_list';
+
+describe('<BrowserStepsList />', () => {
+  let steps: JourneyStep[] = [];
+
+  it('renders step data and pre-expands when using pre-fetched data', () => {
+    const { getByText } = render(
+      <BrowserStepsList steps={steps} loading={false} showStepNumber={true} />
+    );
+
+    assertErrorIsExpanded(getByText);
+  });
+
+  it('renders step data and pre-expands after loading completes', () => {
+    const { rerender, getByText } = render(
+      <BrowserStepsList steps={[]} loading={true} showStepNumber={true} />
+    );
+
+    expect(getByText('Loading steps...'));
+
+    rerender(
+      <WrappedHelper>
+        <BrowserStepsList steps={steps} loading={false} showStepNumber={true} />
+      </WrappedHelper>
+    );
+
+    assertErrorIsExpanded(getByText);
+  });
+
+  function assertErrorIsExpanded(
+    getByText: (id: Matcher, options?: SelectorMatcherOptions) => HTMLElement
+  ) {
+    const passNode = getByText('pass');
+    const passRow = passNode.closest('tr');
+    expect(passRow).not.toBeNull();
+    const passUtils = within(passRow!);
+    expect(passUtils.getByLabelText('Expand'));
+
+    const failNode = getByText('fail');
+    const failRow = failNode.closest('tr');
+    expect(failRow).not.toBeNull();
+    const failUtils = within(failRow!);
+    expect(failUtils.getByLabelText('Collapse'));
+  }
+
+  beforeEach(() => {
+    steps = [
+      {
+        _id: 'ulfZrIkBgED7L_98fYgN',
+        synthetics: {
+          package_version: '1.0.0',
+          journey: {
+            name: 'inline',
+            id: 'inline',
+          },
+          payload: {
+            source: "() => page.goto('https://elastic.co')",
+            url: 'https://elastic.co/',
+            status: 'succeeded',
+          },
+          index: 12,
+          step: {
+            duration: {
+              us: 9836995,
+            },
+            name: 'pass',
+            index: 1,
+            status: 'succeeded',
+          },
+          type: 'step/end',
+          isFullScreenshot: false,
+          isScreenshotRef: true,
+        },
+        monitor: {
+          name: 'fail 2nd',
+          id: '86dbbb01-b087-46b2-81f4-dfa5b1714f91',
+          timespan: {
+            lt: '2023-07-31T16:58:00.731Z',
+            gte: '2023-07-31T16:48:00.731Z',
+          },
+          check_group: 'fbe02469-2fc1-11ee-8782-fabe9948d28f',
+          type: 'browser',
+        },
+        observer: {
+          geo: {
+            name: 'North America - US Central',
+            location: '41.8780, 93.0977',
+          },
+          name: 'us_central',
+        },
+        '@timestamp': '2023-07-31T16:48:00.729Z',
+        config_id: '86dbbb01-b087-46b2-81f4-dfa5b1714f91',
+      },
+      {
+        _id: 'u1fZrIkBgED7L_98fYgN',
+        synthetics: {
+          package_version: '1.0.0',
+          journey: {
+            name: 'inline',
+            id: 'inline',
+          },
+          payload: {
+            source: "() => {throw Error('fail now plz')}",
+            url: 'https://www.elastic.co/',
+            status: 'failed',
+          },
+          index: 13,
+          step: {
+            duration: {
+              us: 413593,
+            },
+            name: 'fail',
+            index: 2,
+            status: 'failed',
+          },
+          error: {
+            stack:
+              'Error: fail now plz\n    at Step.eval [as callback] (eval at loadInlineScript (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/loader.ts:86:20), <anonymous>:4:27)\n    at Runner.runStep (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/core/runner.ts:212:18)\n    at Runner.runSteps (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/core/runner.ts:262:16)\n    at Runner.runJourney (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/core/runner.ts:352:27)\n    at Runner.run (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/core/runner.ts:445:11)\n    at Command.<anonymous> (/usr/share/heartbeat/.node/node/lib/node_modules/@elastic/synthetics/src/cli.ts:136:23)',
+            name: 'Error',
+            message: 'fail now plz',
+          },
+          type: 'step/end',
+          isFullScreenshot: false,
+          isScreenshotRef: true,
+        },
+        monitor: {
+          name: 'fail 2nd',
+          timespan: {
+            lt: '2023-07-31T16:58:01.144Z',
+            gte: '2023-07-31T16:48:01.144Z',
+          },
+          check_group: 'fbe02469-2fc1-11ee-8782-fabe9948d28f',
+          id: '86dbbb01-b087-46b2-81f4-dfa5b1714f91',
+          type: 'browser',
+        },
+        error: {
+          message: 'error executing step: fail now plz',
+        },
+        observer: {
+          geo: {
+            name: 'North America - US Central',
+            location: '41.8780, 93.0977',
+          },
+          name: 'us_central',
+        },
+        '@timestamp': '2023-07-31T16:48:01.143Z',
+        config_id: '86dbbb01-b087-46b2-81f4-dfa5b1714f91',
+      },
+    ];
+  });
+});

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
@@ -88,7 +88,7 @@ export const BrowserStepsList = ({
   testNowMode = false,
 }: Props) => {
   const { euiTheme } = useEuiTheme();
-  const stepEnds: JourneyStep[] = steps?.filter(isStepEnd);
+  const stepEnds: JourneyStep[] = steps.filter(isStepEnd);
   const [expandedMap, setExpandedMap] = useState<Record<string, ReactElement>>({});
   const [stepIds, setStepIds] = useState<string>(mapStepIds(stepEnds));
   const isTabletOrGreater = useIsWithinMinBreakpoint('s');
@@ -101,7 +101,7 @@ export const BrowserStepsList = ({
     const latestIds = mapStepIds(stepEnds);
     if (latestIds !== stepIds) {
       setStepIds(latestIds);
-      const failedStep = stepEnds?.find((step) => step.synthetics.step?.status === 'failed');
+      const failedStep = stepEnds.find((step) => step.synthetics.step?.status === 'failed');
       if (failedStep && showExpand && !expandedMap[failedStep._id]) {
         setExpandedMap(
           Object.assign(expandedMap, {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/monitor_test_result/browser_steps_list.tsx
@@ -59,6 +59,23 @@ export function isStepEnd(step: JourneyStep) {
   return step.synthetics?.type === 'step/end';
 }
 
+function toExpandedMapItem(step: JourneyStep, stepsList: JourneyStep[], testNowMode: boolean) {
+  if (testNowMode) {
+    return (
+      <EuiFlexGroup>
+        <EuiFlexItem>
+          <StepTabs step={step} loading={false} stepsList={stepsList} />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+  return <></>;
+}
+
+function mapStepIds(steps: JourneyStep[]) {
+  return steps.map(({ _id }) => _id).toString();
+}
+
 export const BrowserStepsList = ({
   steps,
   error,
@@ -71,44 +88,44 @@ export const BrowserStepsList = ({
   testNowMode = false,
 }: Props) => {
   const { euiTheme } = useEuiTheme();
-  const stepEnds: JourneyStep[] = steps.filter(isStepEnd);
-  const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<
-    Record<string, ReactElement>
-  >({});
+  const stepEnds: JourneyStep[] = steps?.filter(isStepEnd);
+  const [expandedMap, setExpandedMap] = useState<Record<string, ReactElement>>({});
+  const [stepIds, setStepIds] = useState<string>(mapStepIds(stepEnds));
   const isTabletOrGreater = useIsWithinMinBreakpoint('s');
+
+  useEffect(() => {
+    /**
+     * This effect will only take action when the set of steps changes. We create a "default" state,
+     * where we can pre-expand the failed step the first time we render a new set of steps.
+     */
+    const latestIds = mapStepIds(stepEnds);
+    if (latestIds !== stepIds) {
+      setStepIds(latestIds);
+      const failedStep = stepEnds?.find((step) => step.synthetics.step?.status === 'failed');
+      if (failedStep && showExpand && !expandedMap[failedStep._id]) {
+        setExpandedMap(
+          Object.assign(expandedMap, {
+            [failedStep._id]: toExpandedMapItem(failedStep, steps, testNowMode),
+          })
+        );
+      }
+    }
+  }, [expandedMap, showExpand, stepEnds, stepIds, steps, testNowMode]);
 
   const toggleDetails = useCallback(
     (item: JourneyStep) => {
-      setItemIdToExpandedRowMap((prevState) => {
-        const itemIdToExpandedRowMapValues = { ...prevState };
-        if (itemIdToExpandedRowMapValues[item._id]) {
-          delete itemIdToExpandedRowMapValues[item._id];
+      setExpandedMap((prevState) => {
+        const expandedMapValues = { ...prevState };
+        if (expandedMapValues[item._id]) {
+          delete expandedMapValues[item._id];
         } else {
-          if (testNowMode) {
-            itemIdToExpandedRowMapValues[item._id] = (
-              <EuiFlexGroup>
-                <EuiFlexItem>
-                  <StepTabs step={item} loading={false} stepsList={steps} />
-                </EuiFlexItem>
-              </EuiFlexGroup>
-            );
-          } else {
-            itemIdToExpandedRowMapValues[item._id] = <></>;
-          }
+          expandedMapValues[item._id] = toExpandedMapItem(item, steps, testNowMode);
         }
-        return itemIdToExpandedRowMapValues;
+        return expandedMapValues;
       });
     },
     [steps, testNowMode]
   );
-
-  const failedStep = stepEnds?.find((step) => step.synthetics.step?.status === 'failed');
-
-  useEffect(() => {
-    if (failedStep && showExpand) {
-      toggleDetails(failedStep);
-    }
-  }, [failedStep, showExpand, toggleDetails]);
 
   const columns: Array<EuiBasicTableColumn<JourneyStep>> = [
     ...(showExpand
@@ -120,8 +137,8 @@ export const BrowserStepsList = ({
             render: (item: JourneyStep) => (
               <EuiButtonIcon
                 onClick={() => toggleDetails(item)}
-                aria-label={itemIdToExpandedRowMap[item._id] ? 'Collapse' : 'Expand'}
-                iconType={itemIdToExpandedRowMap[item._id] ? 'arrowDown' : 'arrowRight'}
+                aria-label={expandedMap[item._id] ? 'Collapse' : 'Expand'}
+                iconType={expandedMap[item._id] ? 'arrowDown' : 'arrowRight'}
               />
             ),
           },
@@ -166,7 +183,7 @@ export const BrowserStepsList = ({
             stepsLoading={loading}
             showStepNumber={showStepNumber}
             showLastSuccessful={showLastSuccessful}
-            isExpanded={Boolean(itemIdToExpandedRowMap[step._id])}
+            isExpanded={Boolean(expandedMap[step._id])}
             isTestNowMode={testNowMode}
             euiTheme={euiTheme}
           />
@@ -204,7 +221,7 @@ export const BrowserStepsList = ({
           testNowMode={testNowMode}
           step={item}
           pingStatus={pingStatus}
-          isExpanded={Boolean(itemIdToExpandedRowMap[item._id]) && !testNowMode}
+          isExpanded={Boolean(expandedMap[item._id]) && !testNowMode}
         />
       ),
       mobileOptions: {
@@ -217,10 +234,7 @@ export const BrowserStepsList = ({
             field: 'synthetics.step.status',
             name: LAST_SUCCESSFUL,
             render: (pingStatus: string, item: JourneyStep) => (
-              <ResultDetailsSuccessful
-                step={item}
-                isExpanded={Boolean(itemIdToExpandedRowMap[item._id])}
-              />
+              <ResultDetailsSuccessful step={item} isExpanded={Boolean(expandedMap[item._id])} />
             ),
             mobileOptions: {
               show: false,
@@ -261,7 +275,7 @@ export const BrowserStepsList = ({
       <EuiBasicTable
         css={{ overflowX: isTabletOrGreater ? 'auto' : undefined }}
         cellProps={(row) => {
-          if (itemIdToExpandedRowMap[row._id]) {
+          if (expandedMap[row._id]) {
             return {
               style: { verticalAlign: 'top' },
             };
@@ -285,7 +299,7 @@ export const BrowserStepsList = ({
         }
         tableLayout={'auto'}
         itemId="_id"
-        itemIdToExpandedRowMap={testNowMode ? itemIdToExpandedRowMap : undefined}
+        itemIdToExpandedRowMap={testNowMode ? expandedMap : undefined}
       />
     </>
   );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/fetch_effect.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/utils/fetch_effect.ts
@@ -102,7 +102,7 @@ export function fetchEffectFactory<T, R, S, F>(
         }
 
         if (typeof onSuccess === 'function') {
-          onSuccess?.(response as R);
+          onSuccess(response as R);
         } else if (onSuccess && typeof onSuccess === 'string') {
           kibanaService.core.notifications.toasts.addSuccess(onSuccess);
         }


### PR DESCRIPTION
## Summary

Resolves #162237.

You can see this happening in the video in the attached issue. There are also repro instructions there.

## Testing this PR

Follow the repro steps in the original ticket (create multistep journey with a failure as the final step).

This component is also re-used in multiple places.
- **Monitor Detail page:** Ensure that the monitor detail page does not auto-expand the error on the most recent run.
- **Journey Detail page:** Ensure that the error step does auto-expand when refreshing the page. Also ensure it expands when drilling in from the detail page (i.e. click a journey on the _Last 10 Runs_ view to load the journey details).
- **Test Now mode:** Run your monitor manually and make sure when you open up a location's results the error step is pre-expanded.

Additionally, check these things:

- Observe that you can safely toggle expansion on all steps, including the final failed step
- Contrast this with main, where the feature is not working


### Example

![20230728165129](https://github.com/elastic/kibana/assets/18429259/38525d2b-2611-4447-9b49-6776077f7d15)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
