### PR TITLE
Skip Serverless Observability Tests / serverless observability UI navigation active sidenav section is auto opened on load

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
@@ -69,7 +69,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await expectNoPageReload();
     });
 
-    it('active sidenav section is auto opened on load', async () => {
+    // FLAKY/BUG?: https://github.com/elastic/kibana/issues/162781
+    it.skip('active sidenav section is auto opened on load', async () => {
       await svlCommonNavigation.sidenav.openSection('project_settings_project_nav');
       await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'management' });
       await browser.refresh();


### PR DESCRIPTION
## Summary

skip https://github.com/elastic/kibana/issues/162781

