### PR TITLE
[Security Solution] expandable flyout - prevalence data is calculated from 30d to now

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -70,7 +70,7 @@ describe(
       );
       cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_DOC_COUNT_CELL).should(
         'contain.text',
-        2
+        0
       );
       cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_HOST_PREVALENCE_CELL).should(
         'contain.text',

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
@@ -37,7 +37,6 @@ import { EventKind } from '../../shared/hooks/use_fetch_field_value_pair_by_even
 
 interface PrevalenceDetailsTableCell {
   highlightedField: { name: string; values: string[] };
-  scopeId: string;
 }
 
 export const PREVALENCE_TAB_ID = 'prevalence-details';
@@ -60,7 +59,6 @@ const columns: Array<EuiBasicTableColumn<unknown>> = [
     render: (data: PrevalenceDetailsTableCell) => (
       <PrevalenceDetailsCountCell
         highlightedField={data.highlightedField}
-        scopeId={data.scopeId}
         type={{
           eventKind: EventKind.signal,
           include: true,
@@ -75,7 +73,6 @@ const columns: Array<EuiBasicTableColumn<unknown>> = [
     render: (data: PrevalenceDetailsTableCell) => (
       <PrevalenceDetailsCountCell
         highlightedField={data.highlightedField}
-        scopeId={data.scopeId}
         type={{
           eventKind: EventKind.signal,
           exclude: true,
@@ -90,7 +87,6 @@ const columns: Array<EuiBasicTableColumn<unknown>> = [
     render: (data: PrevalenceDetailsTableCell) => (
       <PrevalenceDetailsPrevalenceCell
         highlightedField={data.highlightedField}
-        scopeId={data.scopeId}
         aggregationField={'host.name'}
       />
     ),
@@ -102,7 +98,6 @@ const columns: Array<EuiBasicTableColumn<unknown>> = [
     render: (data: PrevalenceDetailsTableCell) => (
       <PrevalenceDetailsPrevalenceCell
         highlightedField={data.highlightedField}
-        scopeId={data.scopeId}
         aggregationField={'user.name'}
       />
     ),
@@ -129,7 +124,6 @@ export const PrevalenceDetails: React.FC = () => {
         name: summaryRow.description.data.field,
         values: summaryRow.description.values || [],
       },
-      scopeId,
     });
 
     return (summaryRows || []).map((summaryRow) => {

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_count_cell.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_count_cell.test.tsx
@@ -24,7 +24,6 @@ const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const scopeId = 'scopeId';
 const type = {
   eventKind: EventKind.signal,
   include: true,
@@ -39,11 +38,7 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     });
 
     const { getByTestId } = render(
-      <PrevalenceDetailsCountCell
-        highlightedField={highlightedField}
-        scopeId={scopeId}
-        type={type}
-      />
+      <PrevalenceDetailsCountCell highlightedField={highlightedField} type={type} />
     );
 
     expect(getByTestId(PREVALENCE_DETAILS_COUNT_CELL_LOADING_TEST_ID)).toBeInTheDocument();
@@ -57,11 +52,7 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     });
 
     const { getByTestId } = render(
-      <PrevalenceDetailsCountCell
-        highlightedField={highlightedField}
-        scopeId={scopeId}
-        type={type}
-      />
+      <PrevalenceDetailsCountCell highlightedField={highlightedField} type={type} />
     );
 
     expect(getByTestId(PREVALENCE_DETAILS_COUNT_CELL_ERROR_TEST_ID)).toBeInTheDocument();
@@ -75,11 +66,7 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     });
 
     const { getByTestId } = render(
-      <PrevalenceDetailsCountCell
-        highlightedField={highlightedField}
-        scopeId={scopeId}
-        type={type}
-      />
+      <PrevalenceDetailsCountCell highlightedField={highlightedField} type={type} />
     );
 
     expect(getByTestId(PREVALENCE_DETAILS_COUNT_CELL_VALUE_TEST_ID)).toBeInTheDocument();
@@ -94,11 +81,7 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     });
 
     const { getByTestId } = render(
-      <PrevalenceDetailsCountCell
-        highlightedField={highlightedField}
-        scopeId={scopeId}
-        type={type}
-      />
+      <PrevalenceDetailsCountCell highlightedField={highlightedField} type={type} />
     );
 
     expect(getByTestId(PREVALENCE_DETAILS_COUNT_CELL_VALUE_TEST_ID)).toBeInTheDocument();

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_count_cell.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_count_cell.tsx
@@ -15,17 +15,12 @@ import {
 } from './test_ids';
 import type { EventType } from '../../shared/hooks/use_fetch_field_value_pair_by_event_type';
 import { useFetchFieldValuePairByEventType } from '../../shared/hooks/use_fetch_field_value_pair_by_event_type';
-import { TimelineId } from '../../../../common/types';
 
 export interface PrevalenceDetailsCountCellProps {
   /**
    * The highlighted field name and values
    * */
   highlightedField: { name: string; values: string[] };
-  /**
-   * The scope id
-   */
-  scopeId: string;
   /**
    * Limit the search to include or exclude a specific value for the event.kind field
    * (alert, asset, enrichment, event, metric, state, pipeline_error, signal)
@@ -41,12 +36,10 @@ export interface PrevalenceDetailsCountCellProps {
  */
 export const PrevalenceDetailsCountCell: VFC<PrevalenceDetailsCountCellProps> = ({
   highlightedField,
-  scopeId,
   type,
 }) => {
   const { loading, error, count } = useFetchFieldValuePairByEventType({
     highlightedField,
-    isActiveTimelines: scopeId === TimelineId.active,
     type,
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_prevalence_cell.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_prevalence_cell.test.tsx
@@ -23,7 +23,6 @@ const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const scopeId = 'scopeId';
 const aggregationField = 'aggregationField';
 
 describe('PrevalenceDetailsAlertCountCell', () => {
@@ -42,7 +41,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );
@@ -65,7 +63,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );
@@ -88,7 +85,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );
@@ -111,7 +107,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );
@@ -134,7 +129,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );
@@ -157,7 +151,6 @@ describe('PrevalenceDetailsAlertCountCell', () => {
     const { getByTestId } = render(
       <PrevalenceDetailsPrevalenceCell
         highlightedField={highlightedField}
-        scopeId={scopeId}
         aggregationField={aggregationField}
       />
     );

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_prevalence_cell.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details_prevalence_cell.tsx
@@ -14,7 +14,6 @@ import {
   PREVALENCE_DETAILS_PREVALENCE_CELL_VALUE_TEST_ID,
 } from './test_ids';
 import { useFetchFieldValuePairWithAggregation } from '../../shared/hooks/use_fetch_field_value_pair_with_aggregation';
-import { TimelineId } from '../../../../common/types';
 import { useFetchUniqueByField } from '../../shared/hooks/use_fetch_unique_by_field';
 
 export interface PrevalenceDetailsPrevalenceCellProps {
@@ -22,10 +21,6 @@ export interface PrevalenceDetailsPrevalenceCellProps {
    * The highlighted field name and values
    * */
   highlightedField: { name: string; values: string[] };
-  /**
-   * The scope id
-   */
-  scopeId: string;
   /**
    * The aggregation field
    */
@@ -38,7 +33,6 @@ export interface PrevalenceDetailsPrevalenceCellProps {
  */
 export const PrevalenceDetailsPrevalenceCell: VFC<PrevalenceDetailsPrevalenceCellProps> = ({
   highlightedField,
-  scopeId,
   aggregationField,
 }) => {
   const {
@@ -47,7 +41,6 @@ export const PrevalenceDetailsPrevalenceCell: VFC<PrevalenceDetailsPrevalenceCel
     count: aggregationCount,
   } = useFetchFieldValuePairWithAggregation({
     highlightedField,
-    isActiveTimelines: scopeId === TimelineId.active,
     aggregationField,
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
@@ -26,7 +26,6 @@ const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const scopeId = 'scopeId';
 const callbackIfNull = jest.fn();
 
 const panelContextValue = {
@@ -61,7 +60,6 @@ describe('<PrevalenceOverview />', () => {
       prevalenceRows: [
         <PrevalenceOverviewRow
           highlightedField={highlightedField}
-          scopeId={scopeId}
           callbackIfNull={callbackIfNull}
           data-test-subj={'test'}
         />,
@@ -106,7 +104,6 @@ describe('<PrevalenceOverview />', () => {
       prevalenceRows: [
         <PrevalenceOverviewRow
           highlightedField={highlightedField}
-          scopeId={scopeId}
           callbackIfNull={callbackIfNull}
           data-test-subj={'test'}
         />,

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview_row.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview_row.test.tsx
@@ -18,7 +18,6 @@ const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const scopeId = 'scopeId';
 const dataTestSubj = 'test';
 const iconDataTestSubj = 'testIcon';
 const valueDataTestSubj = 'testValue';
@@ -41,7 +40,6 @@ describe('<PrevalenceOverviewRow />', () => {
     const { getByTestId, getAllByText, queryByTestId } = render(
       <PrevalenceOverviewRow
         highlightedField={highlightedField}
-        scopeId={scopeId}
         callbackIfNull={() => {}}
         data-test-subj={dataTestSubj}
       />
@@ -71,7 +69,6 @@ describe('<PrevalenceOverviewRow />', () => {
     const { queryAllByAltText } = render(
       <PrevalenceOverviewRow
         highlightedField={highlightedField}
-        scopeId={scopeId}
         callbackIfNull={callbackIfNull}
         data-test-subj={dataTestSubj}
       />
@@ -97,7 +94,6 @@ describe('<PrevalenceOverviewRow />', () => {
     const { queryAllByAltText } = render(
       <PrevalenceOverviewRow
         highlightedField={highlightedField}
-        scopeId={scopeId}
         callbackIfNull={callbackIfNull}
         data-test-subj={dataTestSubj}
       />
@@ -122,7 +118,6 @@ describe('<PrevalenceOverviewRow />', () => {
     const { getByTestId } = render(
       <PrevalenceOverviewRow
         highlightedField={highlightedField}
-        scopeId={scopeId}
         callbackIfNull={() => {}}
         data-test-subj={dataTestSubj}
       />

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview_row.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview_row.tsx
@@ -11,7 +11,6 @@ import { PREVALENCE_ROW_UNCOMMON } from './translations';
 import { useFetchFieldValuePairWithAggregation } from '../../shared/hooks/use_fetch_field_value_pair_with_aggregation';
 import { useFetchUniqueByField } from '../../shared/hooks/use_fetch_unique_by_field';
 import { InsightsSummaryRow } from './insights_summary_row';
-import { TimelineId } from '../../../../common/types';
 
 const HOST_FIELD = 'host.name';
 const PERCENTAGE_THRESHOLD = 0.1; // we show the prevalence if its value is below 10%
@@ -21,10 +20,6 @@ export interface PrevalenceOverviewRowProps {
    * The highlighted field name and values
    * */
   highlightedField: { name: string; values: string[] };
-  /**
-   * Maintain backwards compatibility // TODO remove when possible
-   */
-  scopeId: string;
   /**
    * This is a solution to allow the parent component to NOT render if all its row children are null
    */
@@ -42,19 +37,15 @@ export interface PrevalenceOverviewRowProps {
  */
 export const PrevalenceOverviewRow: VFC<PrevalenceOverviewRowProps> = ({
   highlightedField,
-  scopeId,
   callbackIfNull,
   'data-test-subj': dataTestSubj,
 }) => {
-  const isActiveTimelines = scopeId === TimelineId.active;
-
   const {
     loading: hostsLoading,
     error: hostsError,
     count: hostsCount,
   } = useFetchFieldValuePairWithAggregation({
     highlightedField,
-    isActiveTimelines,
     aggregationField: HOST_FIELD,
   });
 

--- a/x-pack/plugins/security_solution/public/flyout/right/hooks/use_prevalence.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/hooks/use_prevalence.tsx
@@ -79,14 +79,13 @@ export const usePrevalence = ({
         return (
           <PrevalenceOverviewRow
             highlightedField={highlightedField}
-            scopeId={scopeId}
             callbackIfNull={() => setCount((prevCount) => prevCount + 1)}
             data-test-subj={INSIGHTS_PREVALENCE_TEST_ID}
             key={row.description.data.field}
           />
         );
       }),
-    [summaryRows, scopeId]
+    [summaryRows]
   );
 
   return {

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_by_event_type.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_by_event_type.test.ts
@@ -9,8 +9,6 @@ import { useQuery } from '@tanstack/react-query';
 import type { RenderHookResult } from '@testing-library/react-hooks';
 import { renderHook } from '@testing-library/react-hooks';
 import { useKibana } from '../../../common/lib/kibana';
-import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
 import type {
   UseFetchFieldValuePairByEventTypeParams,
   UseFetchFieldValuePairByEventTypeResult,
@@ -22,14 +20,11 @@ import {
 
 jest.mock('@tanstack/react-query');
 jest.mock('../../../common/lib/kibana');
-jest.mock('../../../common/hooks/use_selector');
-jest.mock('../../../common/containers/use_global_time');
 
 const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const isActiveTimelines = true;
 const type = {
   eventKind: EventKind.alert,
   include: true,
@@ -45,8 +40,6 @@ describe('useFetchFieldValuePairByEventType', () => {
       data: { search: jest.fn() },
     },
   });
-  jest.mocked(useDeepEqualSelector).mockReturnValue({ to: '', from: '' });
-  (useGlobalTime as jest.Mock).mockReturnValue({ to: '', from: '' });
 
   it('should return loading true while data is being fetched', () => {
     (useQuery as jest.Mock).mockReturnValue({
@@ -55,9 +48,7 @@ describe('useFetchFieldValuePairByEventType', () => {
       data: 0,
     });
 
-    hookResult = renderHook(() =>
-      useFetchFieldValuePairByEventType({ highlightedField, isActiveTimelines, type })
-    );
+    hookResult = renderHook(() => useFetchFieldValuePairByEventType({ highlightedField, type }));
 
     expect(hookResult.result.current.loading).toBeTruthy();
     expect(hookResult.result.current.error).toBeFalsy();
@@ -71,9 +62,7 @@ describe('useFetchFieldValuePairByEventType', () => {
       data: 0,
     });
 
-    hookResult = renderHook(() =>
-      useFetchFieldValuePairByEventType({ highlightedField, isActiveTimelines, type })
-    );
+    hookResult = renderHook(() => useFetchFieldValuePairByEventType({ highlightedField, type }));
 
     expect(hookResult.result.current.loading).toBeFalsy();
     expect(hookResult.result.current.error).toBeTruthy();
@@ -87,9 +76,7 @@ describe('useFetchFieldValuePairByEventType', () => {
       data: 1,
     });
 
-    hookResult = renderHook(() =>
-      useFetchFieldValuePairByEventType({ highlightedField, isActiveTimelines, type })
-    );
+    hookResult = renderHook(() => useFetchFieldValuePairByEventType({ highlightedField, type }));
 
     expect(hookResult.result.current.loading).toBeFalsy();
     expect(hookResult.result.current.error).toBeFalsy();

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_by_event_type.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_by_event_type.ts
@@ -10,12 +10,11 @@ import type { IEsSearchRequest } from '@kbn/data-plugin/public';
 import { useQuery } from '@tanstack/react-query';
 import { createFetchData } from '../utils/fetch_data';
 import { useKibana } from '../../../common/lib/kibana';
-import { inputsSelectors } from '../../../common/store';
-import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
 import type { RawResponse } from '../utils/fetch_data';
 
 const QUERY_KEY = 'FetchFieldValuePairByEventType';
+const DEFAULT_FROM = 'now-30d';
+const DEFAULT_TO = 'now';
 
 export enum EventKind {
   alert = 'alert',
@@ -39,10 +38,6 @@ export interface UseFetchFieldValuePairByEventTypeParams {
    * The highlighted field name and values
    * */
   highlightedField: { name: string; values: string[] };
-  /**
-   * True is the current timeline is active ('timeline-1')
-   */
-  isActiveTimelines: boolean;
   /**
    * Limit the search to include or exclude a specific value for the event.kind field
    * (alert, asset, enrichment, event, metric, state, pipeline_error, signal)
@@ -70,7 +65,6 @@ export interface UseFetchFieldValuePairByEventTypeResult {
  */
 export const useFetchFieldValuePairByEventType = ({
   highlightedField,
-  isActiveTimelines,
   type,
 }: UseFetchFieldValuePairByEventTypeParams): UseFetchFieldValuePairByEventTypeResult => {
   const {
@@ -79,11 +73,7 @@ export const useFetchFieldValuePairByEventType = ({
     },
   } = useKibana();
 
-  const timelineTime = useDeepEqualSelector((state) =>
-    inputsSelectors.timelineTimeRangeSelector(state)
-  );
-  const globalTime = useGlobalTime();
-  const { to, from } = isActiveTimelines ? timelineTime : globalTime;
+  const { from, to } = { from: DEFAULT_FROM, to: DEFAULT_TO };
 
   const { name, values } = highlightedField;
 

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_with_aggregation.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_with_aggregation.test.ts
@@ -14,19 +14,14 @@ import type {
   UseFetchFieldValuePairWithAggregationResult,
 } from './use_fetch_field_value_pair_with_aggregation';
 import { useFetchFieldValuePairWithAggregation } from './use_fetch_field_value_pair_with_aggregation';
-import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
 
 jest.mock('@tanstack/react-query');
 jest.mock('../../../common/lib/kibana');
-jest.mock('../../../common/hooks/use_selector');
-jest.mock('../../../common/containers/use_global_time');
 
 const highlightedField = {
   name: 'field',
   values: ['values'],
 };
-const isActiveTimelines = true;
 const aggregationField = 'aggregationField';
 
 describe('useFetchFieldValuePairWithAggregation', () => {
@@ -39,8 +34,6 @@ describe('useFetchFieldValuePairWithAggregation', () => {
       data: { search: jest.fn() },
     },
   });
-  jest.mocked(useDeepEqualSelector).mockReturnValue({ to: '', from: '' });
-  (useGlobalTime as jest.Mock).mockReturnValue({ to: '', from: '' });
 
   it('should return loading true while data is being fetched', () => {
     (useQuery as jest.Mock).mockReturnValue({
@@ -52,7 +45,6 @@ describe('useFetchFieldValuePairWithAggregation', () => {
     hookResult = renderHook(() =>
       useFetchFieldValuePairWithAggregation({
         highlightedField,
-        isActiveTimelines,
         aggregationField,
       })
     );
@@ -72,7 +64,6 @@ describe('useFetchFieldValuePairWithAggregation', () => {
     hookResult = renderHook(() =>
       useFetchFieldValuePairWithAggregation({
         highlightedField,
-        isActiveTimelines,
         aggregationField,
       })
     );
@@ -92,7 +83,6 @@ describe('useFetchFieldValuePairWithAggregation', () => {
     hookResult = renderHook(() =>
       useFetchFieldValuePairWithAggregation({
         highlightedField,
-        isActiveTimelines,
         aggregationField,
       })
     );

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_with_aggregation.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_field_value_pair_with_aggregation.ts
@@ -12,21 +12,16 @@ import { buildAggregationSearchRequest } from '../utils/build_requests';
 import type { RawAggregatedDataResponse } from '../utils/fetch_data';
 import { AGG_KEY, createFetchData } from '../utils/fetch_data';
 import { useKibana } from '../../../common/lib/kibana';
-import { inputsSelectors } from '../../../common/store';
-import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
-import { useGlobalTime } from '../../../common/containers/use_global_time';
 
 const QUERY_KEY = 'useFetchFieldValuePairWithAggregation';
+const DEFAULT_FROM = 'now-30d';
+const DEFAULT_TO = 'now';
 
 export interface UseFetchFieldValuePairWithAggregationParams {
   /**
    * The highlighted field name and values
    * */
   highlightedField: { name: string; values: string[] };
-  /**
-   *
-   */
-  isActiveTimelines: boolean;
   /**
    * Field to aggregate value by
    */
@@ -55,7 +50,6 @@ export interface UseFetchFieldValuePairWithAggregationResult {
  */
 export const useFetchFieldValuePairWithAggregation = ({
   highlightedField,
-  isActiveTimelines,
   aggregationField,
 }: UseFetchFieldValuePairWithAggregationParams): UseFetchFieldValuePairWithAggregationResult => {
   const {
@@ -64,12 +58,7 @@ export const useFetchFieldValuePairWithAggregation = ({
     },
   } = useKibana();
 
-  const timelineTime = useDeepEqualSelector((state) =>
-    inputsSelectors.timelineTimeRangeSelector(state)
-  );
-  const globalTime = useGlobalTime();
-  const { to, from } = isActiveTimelines ? timelineTime : globalTime;
-
+  const { from, to } = { from: DEFAULT_FROM, to: DEFAULT_TO };
   const { name, values } = highlightedField;
 
   const searchRequest = buildSearchRequest(name, values, from, to, aggregationField);


### PR DESCRIPTION
## Summary

This previous PRs added the prevalence [summary](https://github.com/elastic/kibana/pull/158038) and the prevalence [detail](https://github.com/elastic/kibana/pull/158606) components to the expandable flyout right and left sections respectively.

This PR modifies the way the data is queried: instead of fetching some prevalence data. It was previously using a dynamic from/to time interval that was retrieved from timeline if timeline is active, or from the KQL bar. We're now retrieving prevalence information for the last 30 days (similar to the threat intelligence data). Changes have been made to the following hooks:
- `useFetchFieldValuePairByEventType` that retrieves all the unique hosts in the environment that have the field/value pair
- `useFetchFieldValuePairWithAggregation` that retrieves all the unique documents for the aggregationField in the environment that have the field/value pair

This PR shouldn't introduce any visual changes.

A follow up PR will add a datetime picker to the left section, to allow users to select a specific time range for the prevalence table.

https://github.com/elastic/security-team/issues/7014

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios