### PR TITLE
[Security Solution][Serverless] Remove esArchive data load from Cypress test runner

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/runner.ts
@@ -14,9 +14,6 @@ export async function SecuritySolutionCypressTestRunner(
   envVars?: Record<string, string>
 ) {
   const config = getService('config');
-  const esArchiver = getService('esArchiver');
-
-  await esArchiver.load('x-pack/test/security_solution_cypress/es_archives/auditbeat');
 
   return {
     FORCE_COLOR: '1',


### PR DESCRIPTION
## Summary

- Remove esArchive load from Cypress runner (data should be loaded by individual tests and not globally across all tests)


