### PR TITLE
[ML] `@kbn/ml-response-stream`: Fix race condition related to throttling.

### DIFF
--- a/x-pack/packages/ml/response_stream/client/use_fetch_stream.ts
+++ b/x-pack/packages/ml/response_stream/client/use_fetch_stream.ts
@@ -129,7 +129,10 @@ export function useFetchStream<B extends object, R extends Reducer<any, any>>(
 
   return {
     cancel,
-    data: dataThrottled,
+    // To avoid a race condition where the stream already ended but `useThrottle` would
+    // yet have to trigger another update within the throttling interval, we'll return
+    // the unthrottled data once the stream is complete.
+    data: isRunning ? dataThrottled : data,
     dispatch,
     errors,
     isCancelled,


### PR DESCRIPTION
## Summary

Part of #141194. Follow up to #162335.

Fixes a race condition in the case where a response stream finishes and sets `isRunning` to `false`, but `useThrottle` didn't trigger it's last update yet within the refresh rate. In the case of log rate analysis, `isRunning` could be set to `false` too early and the UI wouldn't consider later throttled updates (for example, setting `loaded=1` which would result in inconsistent UI state).

The fix in this case is to return the unthrottled raw data instead of the throttled one as soon as the stream finished.

The bug is a regression introduced in #162335 and does not affect any existing releases, so putting `release_note:skip` on this one.

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
