### PR TITLE
[7.17] add BlueOak-1.0.0 to the list of allowed licences (#155018)

### DIFF
--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -66,6 +66,7 @@ export const LICENSE_ALLOWED = [
   'WTFPL',
   'Nuclide software',
   'Python-2.0',
+  'BlueOak-1.0.0',
 ];
 
 // The following list only applies to licenses that


### PR DESCRIPTION
Backports #155018
Needed for https://github.com/elastic/kibana/pull/162722