### PR TITLE
feat(slo): Make API public for serverless

### DIFF
--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -63,7 +63,7 @@ const isLicenseAtLeastPlatinum = async (context: ObservabilityRequestHandlerCont
 const createSLORoute = createObservabilityServerRoute({
   endpoint: 'POST /api/observability/slos 2023-10-31',
   options: {
-    tags: ['access:slo_write'],
+    tags: ['access:public', 'access:slo_write'],
   },
   params: createSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
@@ -90,7 +90,7 @@ const createSLORoute = createObservabilityServerRoute({
 const updateSLORoute = createObservabilityServerRoute({
   endpoint: 'PUT /api/observability/slos/{id} 2023-10-31',
   options: {
-    tags: ['access:slo_write'],
+    tags: ['access:public', 'access:slo_write'],
   },
   params: updateSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
@@ -116,7 +116,7 @@ const updateSLORoute = createObservabilityServerRoute({
 const deleteSLORoute = createObservabilityServerRoute({
   endpoint: 'DELETE /api/observability/slos/{id} 2023-10-31',
   options: {
-    tags: ['access:slo_write'],
+    tags: ['access:public', 'access:slo_write'],
   },
   params: deleteSLOParamsSchema,
   handler: async ({
@@ -148,7 +148,7 @@ const deleteSLORoute = createObservabilityServerRoute({
 const getSLORoute = createObservabilityServerRoute({
   endpoint: 'GET /api/observability/slos/{id} 2023-10-31',
   options: {
-    tags: ['access:slo_read'],
+    tags: ['access:public', 'access:slo_read'],
   },
   params: getSLOParamsSchema,
   handler: async ({ context, params }) => {
@@ -173,7 +173,7 @@ const getSLORoute = createObservabilityServerRoute({
 const enableSLORoute = createObservabilityServerRoute({
   endpoint: 'POST /api/observability/slos/{id}/enable 2023-10-31',
   options: {
-    tags: ['access:slo_write'],
+    tags: ['access:public', 'access:slo_write'],
   },
   params: manageSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
@@ -199,7 +199,7 @@ const enableSLORoute = createObservabilityServerRoute({
 const disableSLORoute = createObservabilityServerRoute({
   endpoint: 'POST /api/observability/slos/{id}/disable 2023-10-31',
   options: {
-    tags: ['access:slo_write'],
+    tags: ['access:public', 'access:slo_write'],
   },
   params: manageSLOParamsSchema,
   handler: async ({ context, params, logger }) => {
@@ -225,7 +225,7 @@ const disableSLORoute = createObservabilityServerRoute({
 const findSLORoute = createObservabilityServerRoute({
   endpoint: 'GET /api/observability/slos 2023-10-31',
   options: {
-    tags: ['access:slo_read'],
+    tags: ['access:public', 'access:slo_read'],
   },
   params: findSLOParamsSchema,
   handler: async ({ context, params }) => {


### PR DESCRIPTION
## Summary

This PR adds the required `access:public` tag into the public SLO APIs for serverless.