### PR TITLE
[Security Solutions] Fix copy to Clipboard not working for the Non-ECS Field

### DIFF
--- a/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
+++ b/packages/kbn-cell-actions/src/actions/copy_to_clipboard/copy_to_clipboard.ts
@@ -9,6 +9,7 @@
 import copy from 'copy-to-clipboard';
 import { i18n } from '@kbn/i18n';
 import type { NotificationsStart } from '@kbn/core/public';
+import { isString } from 'lodash';
 import { COPY_CELL_ACTION_TYPE } from '../../constants';
 import { createCellActionFactory } from '../factory';
 
@@ -23,7 +24,7 @@ const COPY_TO_CLIPBOARD_SUCCESS = i18n.translate(
   }
 );
 
-const escapeValue = (value: string) => value.replace(/"/g, '\\"');
+const escapeValue = (value: string) => (isString(value) ? value.replace(/"/g, '\\"') : value);
 
 export const createCopyToClipboardActionFactory = createCellActionFactory(
   ({ notifications }: { notifications: NotificationsStart }) => ({


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/162784

## Summary

This PR is a quick fix for 8.9.1. The bug is [properly fixed](https://github.com/elastic/kibana/pull/160095) on 8.10.

## How to test it?
* Open kibana and generate alerts
* Open dev tools and add a new field to all alerts 
```
POST /.alerts-security.alerts-default/_update_by_query?wait_for_completion=true
{
  "query": {
    "match_all": {}
  },
"script": {   "source":"ctx._source.my_field=123",
"lang": "painless"
  }
}
```
* Create a runtime field of type number with the same name
* Check if copy to clipboard work on the new field
