### PR TITLE
[7.17] Bump types/tar to ^6.1.5 (#162833) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -627,7 +627,7 @@
     "@types/styled-components": "^5.1.0",
     "@types/supertest": "^2.0.5",
     "@types/tapable": "^1.0.6",
-    "@types/tar": "^4.0.5",
+    "@types/tar": "^6.1.5",
     "@types/tar-fs": "^1.16.1",
     "@types/tempy": "^0.2.0",
     "@types/testing-library__jest-dom": "5.14.5",

--- a/x-pack/plugins/fleet/server/services/epm/archive/extract.ts
+++ b/x-pack/plugins/fleet/server/services/epm/archive/extract.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { finished } from 'stream/promises';
+
 import tar from 'tar';
 import yauzl from 'yauzl';
 
@@ -16,19 +18,20 @@ export async function untarBuffer(
   buffer: Buffer,
   filter = (entry: ArchiveEntry): boolean => true,
   onEntry = (entry: ArchiveEntry): void => {}
-): Promise<unknown> {
+) {
   const deflatedStream = bufferToStream(buffer);
   // use tar.list vs .extract to avoid writing to disk
-  const inflateStream = tar.list().on('entry', (entry: tar.FileStat) => {
-    const path = entry.header.path || '';
+  const inflateStream = tar.list().on('entry', (entry) => {
+    const path = entry.path || '';
     if (!filter({ path })) return;
-    streamToBuffer(entry).then((entryBuffer) => onEntry({ buffer: entryBuffer, path }));
+    streamToBuffer(entry as unknown as NodeJS.ReadableStream).then((entryBuffer) =>
+      onEntry({ buffer: entryBuffer, path })
+    );
   });
 
-  return new Promise((resolve, reject) => {
-    inflateStream.on('end', resolve).on('error', reject);
-    deflatedStream.pipe(inflateStream);
-  });
+  deflatedStream.pipe(inflateStream);
+
+  await finished(inflateStream);
 }
 
 export async function unzipBuffer(

--- a/yarn.lock
+++ b/yarn.lock
@@ -6311,13 +6311,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/minipass@*":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@types/minipass/-/minipass-2.2.0.tgz#51ad404e8eb1fa961f75ec61205796807b6f9651"
-  integrity sha512-wuzZksN4w4kyfoOv/dlpov4NOunwutLA/q7uc00xU02ZyUY+aoM5PWIXEKBMnm0NHd4a+N71BMjq+x7+2Af1fg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/mocha@^9.1.0":
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-9.1.0.tgz#baf17ab2cca3fcce2d322ebc30454bff487efad5"
@@ -6855,13 +6848,13 @@
   dependencies:
     "@types/node" "*"
 
-"@types/tar@^4.0.5":
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-4.0.5.tgz#5f953f183e36a15c6ce3f336568f6051b7b183f3"
-  integrity sha512-cgwPhNEabHaZcYIy5xeMtux2EmYBitfqEceBUi2t5+ETy4dW6kswt6WX4+HqLeiiKOo42EXbGiDmVJ2x+vi37Q==
+"@types/tar@^6.1.5":
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.5.tgz#90ccb3b6a35430e7427410d50eed564e85feaaff"
+  integrity sha512-qm2I/RlZij5RofuY7vohTpYNaYcrSQlN2MyjucQc7ZweDwaEWkdN/EeNh6e9zjK6uEm6PwjdMXkcj05BxZdX1Q==
   dependencies:
-    "@types/minipass" "*"
     "@types/node" "*"
+    minipass "^4.0.0"
 
 "@types/tempy@^0.2.0":
   version "0.2.0"
@@ -20325,9 +20318,16 @@ minipass-sized@^1.0.3:
     minipass "^3.0.0"
 
 minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3, minipass@^3.1.6:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.2.1.tgz#12ac0ab289be638db0ad8887b28413b773355c13"
-  integrity sha512-v5cqJP4WxUVXYXhOOdPiOZEDoF7omSpLivw2GMCL1v/j+xh886bPXKh6SzyA6sa45e4NRQ46IRBEkAazvb6I6A==
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.0.0.tgz#7cebb0f9fa7d56f0c5b17853cbe28838a8dbbd3b"
+  integrity sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==
   dependencies:
     yallist "^4.0.0"
 


### PR DESCRIPTION
Backports #162833
Partially backports https://github.com/elastic/kibana/pull/144012 via `x-pack/plugins/fleet/server/services/epm/archive/extract.ts`
Needed for https://github.com/elastic/kibana/pull/162722