### PR TITLE
[Security Solution] expandable flyout - move share alert and chat buttons up to improve header UI

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel.cy.ts
@@ -111,12 +111,12 @@ describe(
       expandDocumentDetailsExpandableFlyoutLeftSection();
       cy.get(DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON)
         .should('be.visible')
-        .and('have.text', 'Collapse alert details');
+        .and('have.text', 'Collapse details');
 
       collapseDocumentDetailsExpandableFlyoutLeftSection();
       cy.get(DOCUMENT_DETAILS_FLYOUT_EXPAND_DETAILS_BUTTON)
         .should('be.visible')
-        .and('have.text', 'Expand alert details');
+        .and('have.text', 'Expand details');
 
       cy.log('Verify the take action button is visible on all tabs');
 

--- a/x-pack/plugins/security_solution/public/flyout/right/components/header_title.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/header_title.tsx
@@ -10,6 +10,7 @@ import React, { memo } from 'react';
 import { NewChatById } from '@kbn/elastic-assistant';
 import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { isEmpty } from 'lodash';
+import { css } from '@emotion/react';
 import { DocumentStatus } from './status';
 import { useAssistant } from '../hooks/use_assistant';
 import {
@@ -37,38 +38,44 @@ export const HeaderTitle: FC = memo(() => {
     dataFormattedForFieldBrowser,
     isAlert,
   });
+  const showShareAlertButton = isAlert && alertUrl;
 
   return (
     <>
-      <EuiTitle size="s">
-        <EuiFlexGroup alignItems="center" justifyContent="spaceBetween">
-          <EuiFlexItem>
-            <h4 data-test-subj={FLYOUT_HEADER_TITLE_TEST_ID}>
-              {isAlert && !isEmpty(ruleName) ? ruleName : DOCUMENT_DETAILS}
-            </h4>
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiFlexGroup alignItems="center">
-              {isAlert && alertUrl && (
-                <EuiFlexItem>
-                  <ShareButton alertUrl={alertUrl} />
-                </EuiFlexItem>
-              )}
-              {showAssistant && (
-                <EuiFlexItem grow={false}>
-                  <NewChatById
-                    conversationId={
-                      isAlert ? ALERT_SUMMARY_CONVERSATION_ID : EVENT_SUMMARY_CONVERSATION_ID
-                    }
-                    promptContextId={promptContextId}
-                  />
-                </EuiFlexItem>
-              )}
-            </EuiFlexGroup>
-          </EuiFlexItem>
+      {(showShareAlertButton || showAssistant) && (
+        <EuiFlexGroup
+          direction="row"
+          justifyContent="flexEnd"
+          gutterSize="none"
+          css={css`
+            margin-top: -44px;
+            padding: 0 25px;
+          `}
+        >
+          {showAssistant && (
+            <EuiFlexItem grow={false}>
+              <NewChatById
+                conversationId={
+                  isAlert ? ALERT_SUMMARY_CONVERSATION_ID : EVENT_SUMMARY_CONVERSATION_ID
+                }
+                promptContextId={promptContextId}
+              />
+            </EuiFlexItem>
+          )}
+          {showShareAlertButton && (
+            <EuiFlexItem grow={false}>
+              <ShareButton alertUrl={alertUrl} />
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
+      )}
+      <EuiSpacer size="s" />
+      <EuiTitle size="s">
+        <h4 data-test-subj={FLYOUT_HEADER_TITLE_TEST_ID}>
+          {isAlert && !isEmpty(ruleName) ? ruleName : DOCUMENT_DETAILS}
+        </h4>
       </EuiTitle>
-      <EuiSpacer size="xs" />
+      <EuiSpacer size="s" />
       <EuiFlexGroup direction="row" gutterSize="m">
         <EuiFlexItem grow={false}>
           <DocumentStatus />
@@ -77,7 +84,7 @@ export const HeaderTitle: FC = memo(() => {
           {timestamp && <PreferenceFormattedDate value={new Date(timestamp)} />}
         </EuiFlexItem>
       </EuiFlexGroup>
-      <EuiSpacer size="xs" />
+      <EuiSpacer size="s" />
       <EuiFlexGroup direction="row" gutterSize="m">
         <EuiFlexItem grow={false}>
           <DocumentSeverity />

--- a/x-pack/plugins/security_solution/public/flyout/right/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/translations.ts
@@ -11,12 +11,12 @@ import { i18n } from '@kbn/i18n';
 
 export const EXPAND_DETAILS_BUTTON = i18n.translate(
   'xpack.securitySolution.flyout.documentDetails.expandDetailButton',
-  { defaultMessage: 'Expand alert details' }
+  { defaultMessage: 'Expand details' }
 );
 
 export const COLLAPSE_DETAILS_BUTTON = i18n.translate(
   'xpack.securitySolution.flyout.documentDetails.collapseDetailButton',
-  { defaultMessage: 'Collapse alert details' }
+  { defaultMessage: 'Collapse details' }
 );
 
 export const DOCUMENT_DETAILS = i18n.translate(

--- a/x-pack/plugins/security_solution/public/flyout/right/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/header.tsx
@@ -42,6 +42,7 @@ export const PanelHeader: VFC<PanelHeaderProps> = memo(
         `}
       >
         <div
+          // moving the buttons up in the header
           css={css`
             margin-top: -24px;
             margin-left: -8px;
@@ -49,7 +50,7 @@ export const PanelHeader: VFC<PanelHeaderProps> = memo(
         >
           <ExpandDetailButton />
         </div>
-        <EuiSpacer size="m" />
+        <EuiSpacer size="xs" />
         <HeaderTitle />
         <EuiSpacer size="m" />
         <EuiTabs


### PR DESCRIPTION
## Summary

This PR improves slightly the UI of the expandable flyout header:
- moves the `Share alert` and `Chat` buttons up in the very top section of the header, to leave a full width of space for the rule name
- put `Share alert` button on the right side to stay consistent with current flyout
- manages vertical spacing (via `EuiSpacer`) a bit better for better readability
- rename `Expand alert details` to `Expand details` (not reflected in the screenshot below)

Before
![Screenshot 2023-08-01 at 11 50 18 AM](https://github.com/elastic/kibana/assets/17276605/67a40ec9-f75f-4fbe-abb9-70c4ada91e54)

After
![Screenshot 2023-08-02 at 8 59 06 AM](https://github.com/elastic/kibana/assets/17276605/4835b936-7db4-40b4-844f-32ea0c82cd97)