### PR TITLE
[Infra UI] Add timeout to fix flaky tests

### DIFF
--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -21,8 +21,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
 
-  // Failing: See https://github.com/elastic/kibana/issues/157711
-  describe.skip('Home page', function () {
+  describe('Home page', function () {
     this.tags('includeFirefox');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
@@ -225,8 +224,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/157740
-    describe.skip('Saved Views', () => {
+    describe('Saved Views', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
         await pageObjects.infraHome.goToMetricExplorer();

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -339,7 +339,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await testSubjects.click('infrastructure-alerts-and-rules');
       await testSubjects.click('inventory-alerts-menu-option');
       await testSubjects.click('inventory-alerts-create-rule');
-      await testSubjects.missingOrFail('inventory-alerts-create-rule');
+      await testSubjects.missingOrFail('inventory-alerts-create-rule', { timeout: 30000 });
       await testSubjects.find('euiFlyoutCloseButton');
     },
 
@@ -347,7 +347,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await testSubjects.click('infrastructure-alerts-and-rules');
       await testSubjects.click('metrics-threshold-alerts-menu-option');
       await testSubjects.click('metrics-threshold-alerts-create-rule');
-      await testSubjects.missingOrFail('metrics-threshold-alerts-create-rule');
+      await testSubjects.missingOrFail('metrics-threshold-alerts-create-rule', { timeout: 30000 });
       await testSubjects.find('euiFlyoutCloseButton');
     },
 

--- a/x-pack/test/functional/page_objects/infra_saved_views.ts
+++ b/x-pack/test/functional/page_objects/infra_saved_views.ts
@@ -54,7 +54,7 @@ export function InfraSavedViewsProvider({ getService }: FtrProviderContext) {
     async createNewSavedView(name: string) {
       await testSubjects.setValue('savedViewName', name);
       await testSubjects.click('createSavedViewButton');
-
+      await testSubjects.missingOrFail('createSavedViewButton', { timeout: 20000 });
       await retry.tryForTime(10 * 1000, async () => {
         await testSubjects.missingOrFail('savedViews-upsertModal');
       });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/157711
Closes https://github.com/elastic/kibana/issues/157740

## Summary

Fixes for the flaky tests: I ran the tests 200 and after that 50 times and with the fix they are not flaky anymore. The fix was setting a timeout because the element was still present when the test checked for it.

