### PR TITLE
[DOCS] Remove breaking changes tags

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -57,8 +57,6 @@ For information about the {kib} 8.9.0 release, review the following information.
 Breaking changes can prevent your application from optimal operation and performance.
 Before you upgrade to 8.9.0, review the breaking changes, then mitigate the impact to your application.
 
-// tag::notable-breaking-changes[]
-
 [discrete]
 [[breaking-159118]]
 .Hide Uptime app if no data is available
@@ -77,9 +75,6 @@ For synthetic monitoring, we now recommend to use the new Synthetics app. For mo
 *Details* +
 Data from browser monitors and monitors of all types created within the Synthetics App or via the Elastic Synthetics Fleet Integration will no longer appear in Uptime. For more information, refer to {kibana-pull}159012[#159012]
 ====
-      
-
-// end::notable-breaking-changes[]
 
 [float]
 [[deprecations-8.9.0]]

--- a/docs/migration/migrate_8_0.asciidoc
+++ b/docs/migration/migrate_8_0.asciidoc
@@ -12,10 +12,6 @@ See also <<whats-new>> and <<release-notes>>.
 * <<breaking_80_index_pattern_changes>>
 * <<breaking_80_setting_changes>>
 
-//NOTE: The notable-breaking-changes tagged regions are re-used in the
-//Installation and Upgrade Guide
-
-// tag::notable-breaking-changes[]
 [float]
 [[breaking_80_index_pattern_changes]]
 === Index pattern changes
@@ -404,5 +400,3 @@ Configuration management tools and automation will need to be updated to use the
 *Details:* The deprecated `server.xsrf.whitelist` setting is no longer supported.
 
 *Impact:* Use {kibana-ref}/settings.html#settings-xsrf-allowlist[`server.xsrf.allowlist`] instead.
-
-// end::notable-breaking-changes[]


### PR DESCRIPTION
With https://github.com/elastic/stack-docs/pull/2495 merged, we no longer need tags to reuse breaking changes in the Stack Install/Upgrade guide.

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->