### PR TITLE
[Search Relevance] Prepopulate ingest pipeline name using index name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -226,9 +226,7 @@ export const ConfigurePipeline: React.FC = () => {
                             defaultMessage:
                               'Pipeline names are unique within a deployment and can only contain letters, numbers, underscores, and hyphens. This will create a pipeline named {pipelineName}.',
                             values: {
-                              pipelineName: `ml-inference-${
-                                pipelineName.length > 0 ? pipelineName : indexName
-                              }`,
+                              pipelineName: `ml-inference-${pipelineName}`,
                             },
                           }
                         )}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -32,6 +32,8 @@ import { docLinks } from '../../../../../shared/doc_links';
 
 import { IndexViewLogic } from '../../index_view_logic';
 
+import { IndexNameLogic } from '../../index_name_logic';
+
 import { InferenceConfiguration } from './inference_config';
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
 import { MlModelSelectOption } from './model_select_option';
@@ -65,6 +67,7 @@ export const ConfigurePipeline: React.FC = () => {
   const { selectExistingPipeline, setInferencePipelineConfiguration } =
     useActions(MLInferenceLogic);
   const { ingestionMethod } = useValues(IndexViewLogic);
+  const { indexName } = useValues(IndexNameLogic);
 
   const { existingPipeline, modelID, pipelineName } = configuration;
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
@@ -216,7 +219,7 @@ export const ConfigurePipeline: React.FC = () => {
                               'Pipeline names are unique within a deployment and can only contain letters, numbers, underscores, and hyphens. This will create a pipeline named {pipelineName}.',
                             values: {
                               pipelineName: `ml-inference-${
-                                pipelineName.length > 0 ? pipelineName : '<name>'
+                                pipelineName.length > 0 ? pipelineName : indexName
                               }`,
                             },
                           }
@@ -232,13 +235,7 @@ export const ConfigurePipeline: React.FC = () => {
                     disabled={inputsDisabled}
                     fullWidth
                     prepend="ml-inference-"
-                    placeholder={i18n.translate(
-                      'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.namePlaceholder',
-                      {
-                        defaultMessage: 'Enter a unique name for this pipeline',
-                      }
-                    )}
-                    value={pipelineName}
+                    value={pipelineName || indexName}
                     onChange={(e) =>
                       setInferencePipelineConfiguration({
                         ...configuration,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -74,7 +74,7 @@ export const ConfigurePipeline: React.FC = () => {
   useEffect(() => {
     setInferencePipelineConfiguration({
       ...configuration,
-      pipelineName: pipelineName ? pipelineName : indexName,
+      pipelineName: pipelineName || indexName,
     })
   }, [])
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -30,9 +30,8 @@ import { i18n } from '@kbn/i18n';
 
 import { docLinks } from '../../../../../shared/doc_links';
 
-import { IndexViewLogic } from '../../index_view_logic';
-
 import { IndexNameLogic } from '../../index_name_logic';
+import { IndexViewLogic } from '../../index_view_logic';
 
 import { InferenceConfiguration } from './inference_config';
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
@@ -75,8 +74,8 @@ export const ConfigurePipeline: React.FC = () => {
     setInferencePipelineConfiguration({
       ...configuration,
       pipelineName: pipelineName || indexName,
-    })
-  }, [])
+    });
+  }, []);
 
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -241,6 +241,12 @@ export const ConfigurePipeline: React.FC = () => {
                     disabled={inputsDisabled}
                     fullWidth
                     prepend="ml-inference-"
+                    placeholder={i18n.translate(
+                      'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.namePlaceholder',
+                      {
+                        defaultMessage: 'Enter a unique name for this pipeline',
+                      }
+                    )}
                     value={pipelineName}
                     onChange={(e) =>
                       setInferencePipelineConfiguration({

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { useValues, useActions } from 'kea';
 
@@ -70,6 +70,14 @@ export const ConfigurePipeline: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
 
   const { existingPipeline, modelID, pipelineName } = configuration;
+
+  useEffect(() => {
+    setInferencePipelineConfiguration({
+      ...configuration,
+      pipelineName: pipelineName ? pipelineName : indexName,
+    })
+  }, [])
+
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
 
   const modelOptions: Array<EuiSuperSelectOption<string>> = [
@@ -235,7 +243,7 @@ export const ConfigurePipeline: React.FC = () => {
                     disabled={inputsDisabled}
                     fullWidth
                     prepend="ml-inference-"
-                    value={pipelineName || indexName}
+                    value={pipelineName}
                     onChange={(e) =>
                       setInferencePipelineConfiguration({
                         ...configuration,

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13576,6 +13576,7 @@
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.model.redactedValue": "此模型在 Kibana 工作区不可用",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.modelLabel": "选择已训练 ML 模型",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.nameLabel": "名称",
+    "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.namePlaceholder": "为此管道输入唯一名称",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.pipelineNameExistsError": "名称已由其他管道使用。",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.title": "创建或选择管道",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.titleSelectTrainedModel": "选择已训练 ML 模型",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13576,7 +13576,6 @@
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.model.redactedValue": "此模型在 Kibana 工作区不可用",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.modelLabel": "选择已训练 ML 模型",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.nameLabel": "名称",
-    "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.namePlaceholder": "为此管道输入唯一名称",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.pipelineNameExistsError": "名称已由其他管道使用。",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.title": "创建或选择管道",
     "xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.titleSelectTrainedModel": "选择已训练 ML 模型",


### PR DESCRIPTION
This PR addresses the enhancement mentioned in this issue: https://github.com/elastic/enterprise-search-team/issues/5038

With the changes in this PR, whenever a user attempts to add an inference pipeline, the pipeline name will be prepopulated with the index name.

<img width="1631" alt="Screenshot 2023-08-02 at 3 53 15 PM" src="https://github.com/elastic/kibana/assets/132922331/2e92df5d-79af-4c18-bf7e-ed27cb759957">
<img width="978" alt="Screenshot 2023-08-02 at 3 54 48 PM" src="https://github.com/elastic/kibana/assets/132922331/5e190fcf-e3eb-4feb-8679-847396c1699d">
