### PR TITLE
[8.9][Security Solution] Skip flaky CTI test

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
@@ -48,7 +48,8 @@ describe('CTI Enrichment', () => {
     goToRuleDetails();
   });
 
-  it('Displays enrichment matched.* fields on the timeline', () => {
+  // Skipped: https://github.com/elastic/kibana/issues/162818
+  it.skip('Displays enrichment matched.* fields on the timeline', () => {
     const expectedFields = {
       'threat.enrichments.matched.atomic': indicatorRuleMatchingDoc.atomic,
       'threat.enrichments.matched.type': indicatorRuleMatchingDoc.matchedType,


### PR DESCRIPTION
## Summary

Skip the CTI test on `8.9` that was skipped in this PR: https://github.com/elastic/kibana/pull/162787

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
