### PR TITLE
[TESTING][Detection Engine] Testing Prebuilt Security Rules v8.9.3-beta.1 Package - DO NOT MERGE 

### DIFF
--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -54,7 +54,7 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.cloud.id=test',
         `--home.disableWelcomeScreen=true`,
         // Specify which version of the detection-rules package to install
-        // `--xpack.securitySolution.prebuiltRulesPackageVersion=8.3.1`,
+        `--xpack.securitySolution.prebuiltRulesPackageVersion=8.9.3-beta.1`,
         // Set an inexistent directory as the Fleet bundled packages location
         // in order to force Fleet to reach out to the registry to download the
         // packages listed in fleet_packages.json


### PR DESCRIPTION
## Related Issue
* https://github.com/elastic/ia-trade-team/issues/144

## Summary
This PR is used to use the Kibana CI testing for the security solution Cypress tests. This PR is NOT MEANT to be merged. Once tests are successful, this PR will be closed.

Prerelease package: [v8.9.3-beta.1](https://epr.elastic.co/package/security_detection_engine/8.9.3-beta.1/)