### PR TITLE
[Security Solution][Serverless] Add HTTP header 'x-elastic-internal-product' to e2e Role/User loader

### DIFF
--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
@@ -26,7 +26,7 @@ const ignoreHttp409Error = (error: AxiosError) => {
 };
 
 const DEFAULT_HEADERS = Object.freeze({
-  'x-elastic-internal-product': 'kibana',
+  'x-elastic-internal-product': 'security-solution',
 });
 
 export interface LoadedRoleAndUser {

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
@@ -25,6 +25,10 @@ const ignoreHttp409Error = (error: AxiosError) => {
   throw error;
 };
 
+const DEFAULT_HEADERS = Object.freeze({
+  'x-elastic-internal-product': 'kibana',
+});
+
 export interface LoadedRoleAndUser {
   role: string;
   username: string;
@@ -75,6 +79,9 @@ export class RoleAndUserLoader<R extends Record<string, Role> = Record<string, R
       .request({
         method: 'PUT',
         path: `/api/security/role/${roleName}`,
+        headers: {
+          ...DEFAULT_HEADERS,
+        },
         body: roleDefinition,
       })
       .catch(ignoreHttp409Error)
@@ -104,6 +111,9 @@ export class RoleAndUserLoader<R extends Record<string, Role> = Record<string, R
       .request({
         method: 'POST',
         path: `/internal/security/users/${username}`,
+        headers: {
+          ...DEFAULT_HEADERS,
+        },
         body: user,
       })
       .catch(ignoreHttp409Error)


### PR DESCRIPTION
## Summary

- Adds http header `x-elastic-internal-product` to the calls made form the Role/User loader to create the roles in cypress tests

