### PR TITLE
[Fleet] Add agents per OS telemetry

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
@@ -125,11 +125,14 @@ export const getAgentData = async (
           },
           os: {
             multi_terms: {
-              terms: [{ 
-                field: 'local_metadata.os.name.keyword' 
-              }, {
-                field: 'local_metadata.os.version.keyword' 
-              }],
+              terms: [
+                {
+                  field: 'local_metadata.os.name.keyword',
+                },
+                {
+                  field: 'local_metadata.os.version.keyword',
+                },
+              ],
             },
           },
         },

--- a/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
@@ -71,7 +71,8 @@ export interface AgentData {
   };
   agents_per_policy: number[];
   agents_per_os: Array<{
-    os: string;
+    name: string;
+    version: string;
     count: number;
   }>;
 }
@@ -123,7 +124,13 @@ export const getAgentData = async (
             terms: { field: 'policy_id' },
           },
           os: {
-            terms: { field: 'local_metadata.os.full.keyword' },
+            multi_terms: {
+              terms: [{ 
+                field: 'local_metadata.os.name.keyword' 
+              }, {
+                field: 'local_metadata.os.version.keyword' 
+              }],
+            },
           },
         },
       },
@@ -175,7 +182,8 @@ export const getAgentData = async (
     );
 
     const agentsPerOS = ((response?.aggregations?.os as any).buckets ?? []).map((bucket: any) => ({
-      os: bucket.key,
+      name: bucket.key[0],
+      version: bucket.key[1],
       count: bucket.doc_count,
     }));
 

--- a/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
+++ b/x-pack/plugins/fleet/server/collectors/agent_collectors.ts
@@ -70,12 +70,10 @@ export interface AgentData {
     degraded: number;
   };
   agents_per_policy: number[];
-  agents_per_os: Array<
-    {
-      os: string;
-      count: number;
-    }
-  >;
+  agents_per_os: Array<{
+    os: string;
+    count: number;
+  }>;
 }
 
 const DEFAULT_AGENT_DATA = {
@@ -125,8 +123,8 @@ export const getAgentData = async (
             terms: { field: 'policy_id' },
           },
           os: {
-            terms: { field: 'local_metadata.os.full.keyword' }
-          }
+            terms: { field: 'local_metadata.os.full.keyword' },
+          },
         },
       },
       { signal: abortController.signal }
@@ -176,12 +174,10 @@ export const getAgentData = async (
       (bucket: any) => bucket.doc_count
     );
 
-    const agentsPerOS = ((response?.aggregations?.os as any).buckets ?? []).map(
-      (bucket: any) => ({
-        os: bucket.key,
-        count: bucket.doc_count,
-      })
-    );
+    const agentsPerOS = ((response?.aggregations?.os as any).buckets ?? []).map((bucket: any) => ({
+      os: bucket.key,
+      count: bucket.doc_count,
+    }));
 
     return {
       agent_checkin_status: statuses,

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -391,11 +391,13 @@ describe('fleet usage telemetry', () => {
         agents_per_policy: [2],
         agents_per_os: [
           {
-            os: 'Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))',
+            name: 'Ubuntu',
+            version: '22.04.2 LTS (Jammy Jellyfish)',
             count: 1,
           },
           {
-            os: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
+            name: 'Ubuntu',
+            version: '20.04.5 LTS (Focal Fossa)',
             count: 1,
           },
         ],

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -395,12 +395,12 @@ describe('fleet usage telemetry', () => {
         agents_per_os: [
           {
             name: 'Ubuntu',
-            version: '22.04.2 LTS (Jammy Jellyfish)',
+            version: '20.04.5 LTS (Focal Fossa)',
             count: 1,
           },
           {
             name: 'Ubuntu',
-            version: '20.04.5 LTS (Focal Fossa)',
+            version: '22.04.2 LTS (Jammy Jellyfish)',
             count: 1,
           },
         ],

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -132,7 +132,7 @@ describe('fleet usage telemetry', () => {
           policy_id: 'policy1',
           local_metadata: {
             os: {
-              full: "Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))",
+              full: 'Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))',
             },
           },
         },
@@ -165,7 +165,7 @@ describe('fleet usage telemetry', () => {
           policy_id: 'policy1',
           local_metadata: {
             os: {
-              full: "Ubuntu focal(20.04.5 LTS (Focal Fossa))",
+              full: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
             },
           },
         },

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -130,6 +130,11 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2022-11-21T12:26:24Z',
           active: true,
           policy_id: 'policy1',
+          local_metadata: {
+            os: {
+              full: "Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))",
+            },
+          },
         },
         {
           create: {
@@ -158,6 +163,11 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2021-11-21T12:27:24Z',
           active: false,
           policy_id: 'policy1',
+          local_metadata: {
+            os: {
+              full: "Ubuntu focal(20.04.5 LTS (Focal Fossa))",
+            },
+          },
         },
       ],
       refresh: 'wait_for',
@@ -374,6 +384,16 @@ describe('fleet usage telemetry', () => {
         ],
         agent_checkin_status: { error: 1, degraded: 1 },
         agents_per_policy: [2],
+        agents_per_os: [
+          {
+            os: 'Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))',
+            count: 1,
+          },
+          {
+            os: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
+            count: 1,
+          },
+        ],
         fleet_server_config: {
           policies: [
             {

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -132,7 +132,8 @@ describe('fleet usage telemetry', () => {
           policy_id: 'policy1',
           local_metadata: {
             os: {
-              full: 'Ubuntu jammy(22.04.2 LTS (Jammy Jellyfish))',
+              name: 'Ubuntu',
+              version: '22.04.2 LTS (Jammy Jellyfish)',
             },
           },
         },
@@ -151,7 +152,8 @@ describe('fleet usage telemetry', () => {
           policy_id: 'policy1',
           local_metadata: {
             os: {
-              full: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
+              name: 'Ubuntu',
+              version: '20.04.5 LTS (Focal Fossa)',
             },
           },
         },
@@ -170,7 +172,8 @@ describe('fleet usage telemetry', () => {
           policy_id: 'policy1',
           local_metadata: {
             os: {
-              full: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
+              name: 'Ubuntu',
+              version: '20.04.5 LTS (Focal Fossa)',
             },
           },
         },

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -149,6 +149,11 @@ describe('fleet usage telemetry', () => {
           last_checkin: '2022-11-21T12:27:24Z',
           active: true,
           policy_id: 'policy1',
+          local_metadata: {
+            os: {
+              full: 'Ubuntu focal(20.04.5 LTS (Focal Fossa))',
+            },
+          },
         },
         {
           create: {

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
@@ -24,7 +24,7 @@ const FLEET_AGENTS_EVENT_TYPE = 'fleet_agents';
 
 export class FleetUsageSender {
   private taskManager?: TaskManagerStartContract;
-  private taskVersion = '1.1.0';
+  private taskVersion = '1.1.1';
   private taskType = 'Fleet-Usage-Sender';
   private wasStarted: boolean = false;
   private interval = '1h';

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -261,4 +261,20 @@ export const fleetUsagesSchema: RootSchema<any> = {
       _meta: { description: 'Top messages from fleet server error logs' },
     },
   },
+  agents_per_os: {
+    properties: {
+      os: {
+        type: 'keyword',
+        _meta: {
+          description: 'Agent OS enrolled to this kibana',
+        },
+      },
+      count: {
+        type: 'long',
+        _meta: {
+          description: 'Number of agents enrolled that use this OS',
+        },
+      },
+    },
+  },
 };

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -263,10 +263,16 @@ export const fleetUsagesSchema: RootSchema<any> = {
   },
   agents_per_os: {
     properties: {
-      os: {
+      name: {
         type: 'keyword',
         _meta: {
           description: 'Agent OS enrolled to this kibana',
+        },
+      },
+      version: {
+        type: 'keyword',
+        _meta: {
+          description: 'Agent OS version enrolled to this kibana',
         },
       },
       count: {


### PR DESCRIPTION
## Summary

Querying agent operating system to add to telemetry.

How to test locally:
- enroll a few different agents running on different operating system
- wait up to 1h to see the telemetry task triggered
- check debug logs to see that the agents per version telemetry contains the status information

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
