### PR TITLE
[8.9] [Discover] Fix search sessions using temporary data views (#161029)

### DIFF
--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -187,18 +187,21 @@ describe('Test createSearchSessionRestorationDataProvider', () => {
   let mockSavedSearch: SavedSearch = {} as unknown as SavedSearch;
   const history = createBrowserHistory();
   const mockDataPlugin = dataPluginMock.createStartContract();
+  const discoverStateContainer = getDiscoverStateContainer({
+    services: discoverServiceMock,
+    history,
+  });
+  discoverStateContainer.appState.update({
+    index: savedSearchMock.searchSource.getField('index')!.id,
+  });
   const searchSessionInfoProvider = createSearchSessionRestorationDataProvider({
     data: mockDataPlugin,
-    appStateContainer: getDiscoverStateContainer({
-      savedSearch: savedSearchMock,
-      services: discoverServiceMock,
-      history,
-    }).appState,
+    appStateContainer: discoverStateContainer.appState,
     getSavedSearch: () => mockSavedSearch,
   });
 
   describe('session name', () => {
-    test('No saved search returns default name', async () => {
+    test('No persisted saved search returns default name', async () => {
       expect(await searchSessionInfoProvider.getName()).toBe('Discover');
     });
 
@@ -215,6 +218,7 @@ describe('Test createSearchSessionRestorationDataProvider', () => {
 
   describe('session state', () => {
     test('restoreState has sessionId and initialState has not', async () => {
+      mockSavedSearch = savedSearchMock;
       const searchSessionId = 'id';
       (mockDataPlugin.search.session.getSessionId as jest.Mock).mockImplementation(
         () => searchSessionId
@@ -225,6 +229,7 @@ describe('Test createSearchSessionRestorationDataProvider', () => {
     });
 
     test('restoreState has absoluteTimeRange', async () => {
+      mockSavedSearch = savedSearchMock;
       const relativeTime = 'relativeTime';
       const absoluteTime = 'absoluteTime';
       (mockDataPlugin.query.timefilter.timefilter.getTime as jest.Mock).mockImplementation(
@@ -239,12 +244,28 @@ describe('Test createSearchSessionRestorationDataProvider', () => {
     });
 
     test('restoreState has paused autoRefresh', async () => {
+      mockSavedSearch = savedSearchMock;
       const { initialState, restoreState } = await searchSessionInfoProvider.getLocatorData();
       expect(initialState.refreshInterval).toBe(undefined);
       expect(restoreState.refreshInterval).toEqual({
         pause: true,
         value: 0,
       });
+    });
+
+    test('restoreState has persisted data view', async () => {
+      mockSavedSearch = savedSearchMock;
+      const { initialState, restoreState } = await searchSessionInfoProvider.getLocatorData();
+      expect(initialState.dataViewSpec).toEqual(undefined);
+      expect(restoreState.dataViewSpec).toEqual(undefined);
+      expect(initialState.dataViewId).toEqual(savedSearchMock.searchSource.getField('index')?.id);
+    });
+
+    test('restoreState has temporary data view', async () => {
+      mockSavedSearch = savedSearchAdHoc;
+      const { initialState, restoreState } = await searchSessionInfoProvider.getLocatorData();
+      expect(initialState.dataViewSpec).toEqual({});
+      expect(restoreState.dataViewSpec).toEqual({});
     });
   });
 });

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -476,7 +476,7 @@ export function createSearchSessionRestorationDataProvider(deps: {
   data: DataPublicPluginStart;
   getSavedSearch: () => SavedSearch;
 }): SearchSessionInfoProvider {
-  const getSavedSearchId = () => deps.getSavedSearch().id;
+  const getSavedSearch = () => deps.getSavedSearch();
   return {
     getName: async () => {
       const savedSearch = deps.getSavedSearch();
@@ -492,12 +492,12 @@ export function createSearchSessionRestorationDataProvider(deps: {
         id: DISCOVER_APP_LOCATOR,
         initialState: createUrlGeneratorState({
           ...deps,
-          getSavedSearchId,
+          getSavedSearch,
           shouldRestoreSearchSession: false,
         }),
         restoreState: createUrlGeneratorState({
           ...deps,
-          getSavedSearchId,
+          getSavedSearch,
           shouldRestoreSearchSession: true,
         }),
       };
@@ -508,20 +508,21 @@ export function createSearchSessionRestorationDataProvider(deps: {
 function createUrlGeneratorState({
   appStateContainer,
   data,
-  getSavedSearchId,
+  getSavedSearch,
   shouldRestoreSearchSession,
 }: {
   appStateContainer: StateContainer<DiscoverAppState>;
   data: DataPublicPluginStart;
-  getSavedSearchId: () => string | undefined;
+  getSavedSearch: () => SavedSearch;
   shouldRestoreSearchSession: boolean;
 }): DiscoverAppLocatorParams {
   const appState = appStateContainer.get();
+  const dataView = getSavedSearch().searchSource.getField('index');
   return {
     filters: data.query.filterManager.getFilters(),
     dataViewId: appState.index,
     query: appState.query,
-    savedSearchId: getSavedSearchId(),
+    savedSearchId: getSavedSearch().id,
     timeRange: shouldRestoreSearchSession
       ? data.query.timefilter.timefilter.getAbsoluteTime()
       : data.query.timefilter.timefilter.getTime(),
@@ -540,5 +541,6 @@ function createUrlGeneratorState({
     viewMode: appState.viewMode,
     hideAggregatedPreview: appState.hideAggregatedPreview,
     breakdownField: appState.breakdownField,
+    dataViewSpec: !dataView?.isPersisted() ? dataView?.toSpec(false) : undefined,
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Discover] Fix search sessions using temporary data views (#161029)](https://github.com/elastic/kibana/pull/161029)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Matthias Wilhelm","email":"matthias.wilhelm@elastic.co"},"sourceCommit":{"committedDate":"2023-07-03T12:10:25Z","message":"[Discover] Fix search sessions using temporary data views (#161029)\n\nEnables search sessions in Discover to work correctly with temporary data view\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"25c6446711392fbc2a71b1a88a46edd9599a2c16","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:fix","backport:skip","Team:DataDiscovery","v8.10.0"],"number":161029,"url":"https://github.com/elastic/kibana/pull/161029","mergeCommit":{"message":"[Discover] Fix search sessions using temporary data views (#161029)\n\nEnables search sessions in Discover to work correctly with temporary data view\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"25c6446711392fbc2a71b1a88a46edd9599a2c16"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161029","number":161029,"mergeCommit":{"message":"[Discover] Fix search sessions using temporary data views (#161029)\n\nEnables search sessions in Discover to work correctly with temporary data view\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"25c6446711392fbc2a71b1a88a46edd9599a2c16"}}]}] BACKPORT-->