### PR TITLE
[SecuritySolution] Dashboard listing layout fix

### DIFF
--- a/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.test.tsx
@@ -18,6 +18,7 @@ import { DashboardContextProvider } from '../../context/dashboard_context';
 import { act } from 'react-dom/test-utils';
 import type { NavigationLink } from '../../../common/links/types';
 import { DashboardListingTable } from '@kbn/dashboard-plugin/public';
+import { DASHBOARDS_PAGE_SECTION_CUSTOM } from './translations';
 
 jest.mock('../../../common/containers/tags/api');
 jest.mock('../../../common/lib/kibana');
@@ -94,6 +95,12 @@ describe('Dashboards landing', () => {
   });
 
   describe('Dashboards default links', () => {
+    it('should render custom dashboard listing title', async () => {
+      await renderDashboardLanding();
+
+      expect(screen.queryByText(DASHBOARDS_PAGE_SECTION_CUSTOM)).toBeInTheDocument();
+    });
+
     it('should render items', async () => {
       await renderDashboardLanding();
 

--- a/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
@@ -134,19 +134,18 @@ export const DashboardsLandingPage = () => {
 
       {canReadDashboard && securityTagsExist && initialFilter ? (
         <>
+          <EuiTitle size="xxxs">
+            <h2>{i18n.DASHBOARDS_PAGE_SECTION_CUSTOM}</h2>
+          </EuiTitle>
+          <EuiHorizontalRule margin="s" />
+          <EuiSpacer size="m" />
           <DashboardListingTable
             disableCreateDashboardButton={loadingCreateDashboardUrl}
             getDashboardUrl={getSecuritySolutionDashboardUrl}
             goToDashboard={goToDashboard}
             initialFilter={initialFilter}
             urlStateEnabled={false}
-          >
-            <EuiTitle size="xxxs">
-              <h2>{i18n.DASHBOARDS_PAGE_SECTION_CUSTOM}</h2>
-            </EuiTitle>
-            <EuiHorizontalRule margin="s" />
-            <EuiSpacer size="m" />
-          </DashboardListingTable>
+          />
         </>
       ) : (
         <EuiEmptyPrompt icon={<EuiLoadingSpinner size="l" />} />

--- a/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
@@ -134,6 +134,7 @@ export const DashboardsLandingPage = () => {
 
       {canReadDashboard && securityTagsExist && initialFilter ? (
         <>
+          <EuiSpacer size="m" />
           <EuiTitle size="xxxs">
             <h2>{i18n.DASHBOARDS_PAGE_SECTION_CUSTOM}</h2>
           </EuiTitle>


### PR DESCRIPTION
## Summary

Before: `Custom` was missing:
![new-dashboard-table](https://github.com/elastic/kibana/assets/6295984/4bec452d-4365-443c-af47-12edfeb0eb5a)

After:
<img width="2538" alt="Screenshot 2023-08-03 at 16 29 55" src="https://github.com/elastic/kibana/assets/6295984/d2af10e6-1df1-4e48-99c8-d1238c438f7b">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

