### PR TITLE
[8.9] [Discover] Make share links and search session info shorter for ad-hoc data views (#161180)

### DIFF
--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -26,6 +26,29 @@ Object {
 }
 `;
 
+exports[`IndexPattern toMinimalSpec can exclude fields 1`] = `
+Object {
+  "allowNoIndex": false,
+  "fieldAttrs": undefined,
+  "fieldFormats": Object {},
+  "id": "test-pattern",
+  "name": "Name",
+  "runtimeFieldMap": Object {
+    "runtime_field": Object {
+      "script": Object {
+        "source": "emit('hello world')",
+      },
+      "type": "keyword",
+    },
+  },
+  "sourceFilters": Array [],
+  "timeFieldName": "time",
+  "title": "title",
+  "type": "index-pattern",
+  "version": "2",
+}
+`;
+
 exports[`IndexPattern toSpec can optionally exclude fields 1`] = `
 Object {
   "allowNoIndex": false,

--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -478,4 +478,111 @@ describe('IndexPattern', () => {
       expect(dataView1.sourceFilters).not.toBe(dataView2.sourceFilters);
     });
   });
+
+  describe('toMinimalSpec', () => {
+    test('can exclude fields', () => {
+      expect(indexPattern.toMinimalSpec()).toMatchSnapshot();
+    });
+
+    test('can omit counts', () => {
+      const fieldsMap = {
+        test1: {
+          name: 'test1',
+          type: 'keyword',
+          aggregatable: true,
+          searchable: true,
+          readFromDocValues: false,
+        },
+        test2: {
+          name: 'test2',
+          type: 'keyword',
+          aggregatable: true,
+          searchable: true,
+          readFromDocValues: false,
+        },
+        test3: {
+          name: 'test3',
+          type: 'keyword',
+          aggregatable: true,
+          searchable: true,
+          readFromDocValues: false,
+        },
+      };
+      expect(
+        create('test', {
+          id: 'test',
+          title: 'test*',
+          fields: fieldsMap,
+          fieldAttrs: undefined,
+        }).toMinimalSpec().fieldAttrs
+      ).toBeUndefined();
+      expect(
+        create('test', {
+          id: 'test',
+          title: 'test*',
+          fields: fieldsMap,
+          fieldAttrs: {
+            test1: {
+              count: 11,
+            },
+            test2: {
+              count: 12,
+            },
+          },
+        }).toMinimalSpec().fieldAttrs
+      ).toBeUndefined();
+
+      expect(
+        create('test', {
+          id: 'test',
+          title: 'test*',
+          fields: fieldsMap,
+          fieldAttrs: {
+            test1: {
+              count: 11,
+              customLabel: 'test11',
+            },
+            test2: {
+              count: 12,
+            },
+          },
+        }).toMinimalSpec().fieldAttrs
+      ).toMatchInlineSnapshot(`
+        Object {
+          "test1": Object {
+            "customLabel": "test11",
+          },
+        }
+      `);
+
+      expect(
+        create('test', {
+          id: 'test',
+          title: 'test*',
+          fields: fieldsMap,
+          fieldAttrs: {
+            test1: {
+              count: 11,
+              customLabel: 'test11',
+            },
+            test2: {
+              customLabel: 'test12',
+            },
+            test3: {
+              count: 30,
+            },
+          },
+        }).toMinimalSpec().fieldAttrs
+      ).toMatchInlineSnapshot(`
+        Object {
+          "test1": Object {
+            "customLabel": "test11",
+          },
+          "test2": Object {
+            "customLabel": "test12",
+          },
+        }
+      `);
+    });
+  });
 });

--- a/src/plugins/discover/public/__mocks__/data_view.ts
+++ b/src/plugins/discover/public/__mocks__/data_view.ts
@@ -110,6 +110,7 @@ export const buildDataViewMock = ({
     isTimeNanosBased: () => false,
     isPersisted: () => true,
     toSpec: () => ({}),
+    toMinimalSpec: () => ({}),
     getTimeField: () => {
       return dataViewFields.find((field) => field.name === timeFieldName);
     },

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -146,7 +146,7 @@ export const getTopNavLinks = ({
         ...(savedSearch.id ? { savedSearchId: savedSearch.id } : {}),
         ...(dataView?.isPersisted()
           ? { dataViewId: dataView?.id }
-          : { dataViewSpec: dataView?.toSpec() }),
+          : { dataViewSpec: dataView?.toMinimalSpec() }),
         filters,
         timeRange,
         refreshInterval,

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -522,7 +522,7 @@ describe('Test discover state actions', () => {
       timeFieldName: 'mock-time-field-name',
     };
     const dataViewsCreateMock = discoverServiceMock.dataViews.create as jest.Mock;
-    dataViewsCreateMock.mockImplementation(() => ({
+    dataViewsCreateMock.mockImplementationOnce(() => ({
       ...dataViewMock,
       ...dataViewSpecMock,
       isPersisted: () => false,

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -541,6 +541,6 @@ function createUrlGeneratorState({
     viewMode: appState.viewMode,
     hideAggregatedPreview: appState.hideAggregatedPreview,
     breakdownField: appState.breakdownField,
-    dataViewSpec: !dataView?.isPersisted() ? dataView?.toSpec(false) : undefined,
+    dataViewSpec: !dataView?.isPersisted() ? dataView?.toMinimalSpec() : undefined,
   };
 }

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_search_source_query.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { omit, pickBy, mapValues } from 'lodash';
 import { buildRangeFilter, Filter } from '@kbn/es-query';
 import {
   DataView,
@@ -221,19 +220,5 @@ function updateFilterReferences(filters: Filter[], fromDataView: string, toDataV
 export function getSmallerDataViewSpec(
   dataView: DataView
 ): DiscoverAppLocatorParams['dataViewSpec'] {
-  const dataViewSpec = dataView.toSpec(false);
-
-  if (dataViewSpec.fieldAttrs) {
-    // remove `count` props
-    dataViewSpec.fieldAttrs = pickBy(
-      mapValues(dataViewSpec.fieldAttrs, (fieldAttrs) => omit(fieldAttrs, 'count')),
-      (trimmedFieldAttrs) => Object.keys(trimmedFieldAttrs).length > 0
-    );
-
-    if (Object.keys(dataViewSpec.fieldAttrs).length === 0) {
-      dataViewSpec.fieldAttrs = undefined;
-    }
-  }
-
-  return dataViewSpec;
+  return dataView.toMinimalSpec();
 }

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type.test.ts
@@ -14,6 +14,8 @@ import {
   AlertInstanceMock,
 } from '@kbn/alerting-plugin/server/mocks';
 import { loggingSystemMock } from '@kbn/core/server/mocks';
+import type { DataViewSpec } from '@kbn/data-views-plugin/common';
+import { createStubDataView } from '@kbn/data-views-plugin/common/data_view.stub';
 import { getRuleType } from './rule_type';
 import { EsQueryRuleParams, EsQueryRuleState } from './rule_type_params';
 import { ActionContext } from './action_context';
@@ -512,32 +514,31 @@ describe('ruleType', () => {
   });
 
   describe('search source query', () => {
-    const dataViewMock = {
-      id: 'test-id',
-      title: 'test-title',
-      timeFieldName: 'time-field',
-      fields: [
-        {
-          name: 'message',
-          type: 'string',
-          displayName: 'message',
-          scripted: false,
-          filterable: false,
-          aggregatable: false,
+    const dataViewMock = createStubDataView({
+      spec: {
+        id: 'test-id',
+        title: 'test-title',
+        timeFieldName: 'time-field',
+        fields: {
+          message: {
+            name: 'message',
+            type: 'string',
+            scripted: false,
+            searchable: false,
+            aggregatable: false,
+            readFromDocValues: false,
+          },
+          timestamp: {
+            name: 'timestamp',
+            type: 'date',
+            scripted: false,
+            searchable: true,
+            aggregatable: false,
+            readFromDocValues: false,
+          },
         },
-        {
-          name: 'timestamp',
-          type: 'date',
-          displayName: 'timestamp',
-          scripted: false,
-          filterable: false,
-          aggregatable: false,
-        },
-      ],
-      toSpec: () => {
-        return { id: 'test-id', title: 'test-title', timeFieldName: 'time-field' };
       },
-    };
+    });
     const defaultParams: OnlySearchSourceRuleParams = {
       size: 100,
       timeWindowSize: 5,
@@ -583,9 +584,9 @@ describe('ruleType', () => {
       const searchResult: ESSearchResponse<unknown, {}> = generateResults([]);
       const ruleServices: RuleExecutorServicesMock = alertsMock.createRuleExecutorServices();
 
-      (ruleServices.dataViews.create as jest.Mock).mockResolvedValueOnce({
-        toSpec: () => dataViewMock.toSpec(),
-      });
+      (ruleServices.dataViews.create as jest.Mock).mockImplementationOnce((spec: DataViewSpec) =>
+        createStubDataView({ spec })
+      );
       (searchSourceInstanceMock.getField as jest.Mock).mockImplementation((name: string) => {
         if (name === 'index') {
           return dataViewMock;
@@ -620,9 +621,9 @@ describe('ruleType', () => {
       const params = { ...defaultParams, thresholdComparator: Comparator.GT_OR_EQ, threshold: [3] };
       const ruleServices: RuleExecutorServicesMock = alertsMock.createRuleExecutorServices();
 
-      (ruleServices.dataViews.create as jest.Mock).mockResolvedValueOnce({
-        toSpec: () => dataViewMock.toSpec(),
-      });
+      (ruleServices.dataViews.create as jest.Mock).mockImplementationOnce((spec: DataViewSpec) =>
+        createStubDataView({ spec })
+      );
       (searchSourceInstanceMock.getField as jest.Mock).mockImplementation((name: string) => {
         if (name === 'index') {
           return dataViewMock;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Discover] Make share links and search session info shorter for ad-hoc data views (#161180)](https://github.com/elastic/kibana/pull/161180)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2023-07-25T19:49:13Z","message":"[Discover] Make share links and search session info shorter for ad-hoc data views (#161180)\n\n- Closes https://github.com/elastic/kibana/issues/160993\r\n\r\n## Summary\r\n\r\nThis PR introduces `dataView.toMinimalSpec()` which is used now in 3\r\ncases:\r\n- when constructing an alert link\r\n- when constructing a share URL for ad-hoc data views\r\n- when constructing search session info for ad-hoc data views\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8b42e0f79b1dfd6ce81b9f89846eee4d9df21b75","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:prev-minor","v8.10.0"],"number":161180,"url":"https://github.com/elastic/kibana/pull/161180","mergeCommit":{"message":"[Discover] Make share links and search session info shorter for ad-hoc data views (#161180)\n\n- Closes https://github.com/elastic/kibana/issues/160993\r\n\r\n## Summary\r\n\r\nThis PR introduces `dataView.toMinimalSpec()` which is used now in 3\r\ncases:\r\n- when constructing an alert link\r\n- when constructing a share URL for ad-hoc data views\r\n- when constructing search session info for ad-hoc data views\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8b42e0f79b1dfd6ce81b9f89846eee4d9df21b75"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161180","number":161180,"mergeCommit":{"message":"[Discover] Make share links and search session info shorter for ad-hoc data views (#161180)\n\n- Closes https://github.com/elastic/kibana/issues/160993\r\n\r\n## Summary\r\n\r\nThis PR introduces `dataView.toMinimalSpec()` which is used now in 3\r\ncases:\r\n- when constructing an alert link\r\n- when constructing a share URL for ad-hoc data views\r\n- when constructing search session info for ad-hoc data views\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"8b42e0f79b1dfd6ce81b9f89846eee4d9df21b75"}}]}] BACKPORT-->