### PR TITLE
[regression] Handle deprecated KibanaThemeProvider uses to include KibanaRenderContextProvider

### DIFF
--- a/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
@@ -51,7 +51,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -70,7 +70,7 @@ Array [
                         />
                       </EuiFlyout>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -78,7 +78,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -97,7 +97,7 @@ Array [
                       />
                     </EuiFlyout>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -130,7 +130,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -149,7 +149,7 @@ Array [
                         />
                       </EuiFlyout>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -157,7 +157,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -176,7 +176,7 @@ Array [
                       />
                     </EuiFlyout>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },

--- a/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
@@ -51,14 +51,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiFlyout
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiFlyout>,
+                  "children": <EuiErrorBoundary>
+                    <EuiFlyout
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiFlyout>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -66,14 +68,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiFlyout
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiFlyout>,
+                "value": <EuiErrorBoundary>
+                  <EuiFlyout
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiFlyout>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -106,14 +110,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiFlyout
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiFlyout>,
+                  "children": <EuiErrorBoundary>
+                    <EuiFlyout
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiFlyout>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -121,14 +127,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiFlyout
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiFlyout>,
+                "value": <EuiErrorBoundary>
+                  <EuiFlyout
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiFlyout>
+                </EuiErrorBoundary>,
               },
             ],
           },

--- a/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/flyout/__snapshots__/flyout_service.test.tsx.snap
@@ -51,26 +51,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiFlyout
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiFlyout
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiFlyout>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiFlyout>,
                 },
                 Object {},
               ],
@@ -78,26 +66,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiFlyout
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiFlyout
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiFlyout>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiFlyout>,
               },
             ],
           },
@@ -130,26 +106,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiFlyout
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiFlyout
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiFlyout>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiFlyout>,
                 },
                 Object {},
               ],
@@ -157,26 +121,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiFlyout
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiFlyout
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiFlyout>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiFlyout>,
               },
             ],
           },

--- a/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
@@ -18,14 +18,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -33,14 +35,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -159,20 +163,56 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
+                },
+                Object {},
+              ],
+              Array [
+                Object {
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
+                },
+                Object {},
+              ],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": <EuiErrorBoundary>
+                  <EuiModal
                     onClose={[Function]}
                   >
                     <MountWrapper
                       className="kbnOverlayMountWrapper"
                       mount={[Function]}
                     />
-                  </EuiModal>,
-                },
-                Object {},
-              ],
-              Array [
-                Object {
-                  "children": <EuiConfirmModal
+                  </EuiModal>
+                </EuiErrorBoundary>,
+              },
+              Object {
+                "type": "return",
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
                     cancelButtonText="Cancel"
                     confirmButtonText="Confirm"
                     onCancel={[Function]}
@@ -182,36 +222,8 @@ Array [
                       className="kbnOverlayMountWrapper"
                       mount={[Function]}
                     />
-                  </EuiConfirmModal>,
-                },
-                Object {},
-              ],
-            ],
-            "results": Array [
-              Object {
-                "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
-              },
-              Object {
-                "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiConfirmModal>,
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -323,43 +335,49 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    Some message
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      Some message
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -367,39 +385,45 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  Some message
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    Some message
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -432,43 +456,49 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    Some message
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      Some message
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -476,39 +506,45 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  Some message
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    Some message
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -546,43 +582,49 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    Some message
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      Some message
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -590,39 +632,45 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  Some message
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    Some message
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -655,43 +703,49 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <EuiConfirmModal
-                    cancelButtonText="Cancel"
-                    confirmButtonText="Confirm"
-                    onCancel={[Function]}
-                    onConfirm={[Function]}
-                  >
-                    Some message
-                  </EuiConfirmModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiConfirmModal
+                      cancelButtonText="Cancel"
+                      confirmButtonText="Confirm"
+                      onCancel={[Function]}
+                      onConfirm={[Function]}
+                    >
+                      Some message
+                    </EuiConfirmModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -699,39 +753,45 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
               Object {
                 "type": "return",
-                "value": <EuiConfirmModal
-                  cancelButtonText="Cancel"
-                  confirmButtonText="Confirm"
-                  onCancel={[Function]}
-                  onConfirm={[Function]}
-                >
-                  Some message
-                </EuiConfirmModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
+                  >
+                    Some message
+                  </EuiConfirmModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -831,14 +891,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -846,14 +908,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -886,14 +950,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -901,14 +967,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -946,14 +1014,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -961,14 +1031,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
             ],
           },
@@ -1001,14 +1073,16 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <EuiModal
-                    onClose={[Function]}
-                  >
-                    <MountWrapper
-                      className="kbnOverlayMountWrapper"
-                      mount={[Function]}
-                    />
-                  </EuiModal>,
+                  "children": <EuiErrorBoundary>
+                    <EuiModal
+                      onClose={[Function]}
+                    >
+                      <MountWrapper
+                        className="kbnOverlayMountWrapper"
+                        mount={[Function]}
+                      />
+                    </EuiModal>
+                  </EuiErrorBoundary>,
                 },
                 Object {},
               ],
@@ -1016,14 +1090,16 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <EuiModal
-                  onClose={[Function]}
-                >
-                  <MountWrapper
-                    className="kbnOverlayMountWrapper"
-                    mount={[Function]}
-                  />
-                </EuiModal>,
+                "value": <EuiErrorBoundary>
+                  <EuiModal
+                    onClose={[Function]}
+                  >
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>
+                </EuiErrorBoundary>,
               },
             ],
           },

--- a/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
@@ -18,7 +18,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -37,7 +37,7 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -45,7 +45,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -64,7 +64,7 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -183,7 +183,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -202,13 +202,13 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -230,7 +230,7 @@ Array [
                         />
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -238,7 +238,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -257,11 +257,11 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -283,7 +283,7 @@ Array [
                       />
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -395,7 +395,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -414,13 +414,13 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -442,13 +442,13 @@ Array [
                         />
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -467,7 +467,7 @@ Array [
                         Some message
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -475,7 +475,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -494,11 +494,11 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -520,11 +520,11 @@ Array [
                       />
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -543,7 +543,7 @@ Array [
                       Some message
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -576,7 +576,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -595,13 +595,13 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -623,13 +623,13 @@ Array [
                         />
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -648,7 +648,7 @@ Array [
                         Some message
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -656,7 +656,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -675,11 +675,11 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -701,11 +701,11 @@ Array [
                       />
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -724,7 +724,7 @@ Array [
                       Some message
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -762,7 +762,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -781,13 +781,13 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -809,13 +809,13 @@ Array [
                         />
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -834,7 +834,7 @@ Array [
                         Some message
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -842,7 +842,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -861,11 +861,11 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -887,11 +887,11 @@ Array [
                       />
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -910,7 +910,7 @@ Array [
                       Some message
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -943,7 +943,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -962,13 +962,13 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -990,13 +990,13 @@ Array [
                         />
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -1015,7 +1015,7 @@ Array [
                         Some message
                       </EuiConfirmModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -1023,7 +1023,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1042,11 +1042,11 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1068,11 +1068,11 @@ Array [
                       />
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1091,7 +1091,7 @@ Array [
                       Some message
                     </EuiConfirmModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -1191,7 +1191,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -1210,7 +1210,7 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -1218,7 +1218,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1237,7 +1237,7 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -1270,7 +1270,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -1289,7 +1289,7 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -1297,7 +1297,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1316,7 +1316,7 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -1354,7 +1354,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -1373,7 +1373,7 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -1381,7 +1381,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1400,7 +1400,7 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },
@@ -1433,7 +1433,7 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProvider
+                  "children": <KibanaThemeProviderCheck
                     theme={
                       Object {
                         "theme$": Observable {
@@ -1452,7 +1452,7 @@ Array [
                         />
                       </EuiModal>
                     </EuiErrorBoundary>
-                  </KibanaThemeProvider>,
+                  </KibanaThemeProviderCheck>,
                 },
                 Object {},
               ],
@@ -1460,7 +1460,7 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProvider
+                "value": <KibanaThemeProviderCheck
                   theme={
                     Object {
                       "theme$": Observable {
@@ -1479,7 +1479,7 @@ Array [
                       />
                     </EuiModal>
                   </EuiErrorBoundary>
-                </KibanaThemeProvider>,
+                </KibanaThemeProviderCheck>,
               },
             ],
           },

--- a/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
+++ b/packages/core/overlays/core-overlays-browser-internal/src/modal/__snapshots__/modal_service.test.tsx.snap
@@ -18,26 +18,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
@@ -45,26 +33,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
             ],
           },
@@ -183,54 +159,30 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
@@ -238,52 +190,28 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiConfirmModal>,
               },
             ],
           },
@@ -395,79 +323,43 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        Some message
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    Some message
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
@@ -475,75 +367,39 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiConfirmModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      Some message
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  Some message
+                </EuiConfirmModal>,
               },
             ],
           },
@@ -576,79 +432,43 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        Some message
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    Some message
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
@@ -656,75 +476,39 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiConfirmModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      Some message
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  Some message
+                </EuiConfirmModal>,
               },
             ],
           },
@@ -762,79 +546,43 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        Some message
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    Some message
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
@@ -842,75 +590,39 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiConfirmModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      Some message
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  Some message
+                </EuiConfirmModal>,
               },
             ],
           },
@@ -943,79 +655,43 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiConfirmModal
+                    cancelButtonText="Cancel"
+                    confirmButtonText="Confirm"
+                    onCancel={[Function]}
+                    onConfirm={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiConfirmModal
-                        cancelButtonText="Cancel"
-                        confirmButtonText="Confirm"
-                        onCancel={[Function]}
-                        onConfirm={[Function]}
-                      >
-                        Some message
-                      </EuiConfirmModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    Some message
+                  </EuiConfirmModal>,
                 },
                 Object {},
               ],
@@ -1023,75 +699,39 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiConfirmModal>,
               },
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiConfirmModal
+                  cancelButtonText="Cancel"
+                  confirmButtonText="Confirm"
+                  onCancel={[Function]}
+                  onConfirm={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiConfirmModal
-                      cancelButtonText="Cancel"
-                      confirmButtonText="Confirm"
-                      onCancel={[Function]}
-                      onConfirm={[Function]}
-                    >
-                      Some message
-                    </EuiConfirmModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  Some message
+                </EuiConfirmModal>,
               },
             ],
           },
@@ -1191,26 +831,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
@@ -1218,26 +846,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
             ],
           },
@@ -1270,26 +886,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
@@ -1297,26 +901,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
             ],
           },
@@ -1354,26 +946,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
@@ -1381,26 +961,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
             ],
           },
@@ -1433,26 +1001,14 @@ Array [
             "calls": Array [
               Array [
                 Object {
-                  "children": <KibanaThemeProviderCheck
-                    theme={
-                      Object {
-                        "theme$": Observable {
-                          "_subscribe": [Function],
-                        },
-                      }
-                    }
+                  "children": <EuiModal
+                    onClose={[Function]}
                   >
-                    <EuiErrorBoundary>
-                      <EuiModal
-                        onClose={[Function]}
-                      >
-                        <MountWrapper
-                          className="kbnOverlayMountWrapper"
-                          mount={[Function]}
-                        />
-                      </EuiModal>
-                    </EuiErrorBoundary>
-                  </KibanaThemeProviderCheck>,
+                    <MountWrapper
+                      className="kbnOverlayMountWrapper"
+                      mount={[Function]}
+                    />
+                  </EuiModal>,
                 },
                 Object {},
               ],
@@ -1460,26 +1016,14 @@ Array [
             "results": Array [
               Object {
                 "type": "return",
-                "value": <KibanaThemeProviderCheck
-                  theme={
-                    Object {
-                      "theme$": Observable {
-                        "_subscribe": [Function],
-                      },
-                    }
-                  }
+                "value": <EuiModal
+                  onClose={[Function]}
                 >
-                  <EuiErrorBoundary>
-                    <EuiModal
-                      onClose={[Function]}
-                    >
-                      <MountWrapper
-                        className="kbnOverlayMountWrapper"
-                        mount={[Function]}
-                      />
-                    </EuiModal>
-                  </EuiErrorBoundary>
-                </KibanaThemeProviderCheck>,
+                  <MountWrapper
+                    className="kbnOverlayMountWrapper"
+                    mount={[Function]}
+                  />
+                </EuiModal>,
               },
             ],
           },

--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -12,6 +12,7 @@ import {
   KibanaRootContextProvider,
   type KibanaRootContextProviderProps,
 } from '@kbn/react-kibana-context-root';
+import { EuiErrorBoundary } from '@elastic/eui';
 
 /** Props for the KibanaContextProvider */
 export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderProps, 'globalStyles'>;
@@ -26,7 +27,7 @@ export const KibanaRenderContextProvider: FC<KibanaRenderContextProviderProps> =
 }) => {
   return (
     <KibanaRootContextProvider globalStyles={false} {...props}>
-      {children}
+      <EuiErrorBoundary>{children}</EuiErrorBoundary>
     </KibanaRootContextProvider>
   );
 };

--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -8,18 +8,13 @@
 
 import React, { FC } from 'react';
 
-import { EuiErrorBoundary } from '@elastic/eui';
-import type { I18nStart } from '@kbn/core-i18n-browser';
 import {
-  KibanaThemeProvider,
-  type KibanaThemeProviderProps,
-} from '@kbn/react-kibana-context-theme';
+  KibanaRootContextProvider,
+  type KibanaRootContextProviderProps,
+} from '@kbn/react-kibana-context-root';
 
 /** Props for the KibanaContextProvider */
-export interface KibanaRenderContextProviderProps extends KibanaThemeProviderProps {
-  /** The `I18nStart` API from `CoreStart`. */
-  i18n: I18nStart;
-}
+export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderProps, 'globalStyles'>;
 
 /**
  * The `KibanaRenderContextProvider` provides the necessary context for an out-of-current
@@ -27,14 +22,11 @@ export interface KibanaRenderContextProviderProps extends KibanaThemeProviderPro
  */
 export const KibanaRenderContextProvider: FC<KibanaRenderContextProviderProps> = ({
   children,
-  i18n,
   ...props
 }) => {
   return (
-    <i18n.Context>
-      <KibanaThemeProvider {...props}>
-        <EuiErrorBoundary>{children}</EuiErrorBoundary>
-      </KibanaThemeProvider>
-    </i18n.Context>
+    <KibanaRootContextProvider globalStyles={false} {...props}>
+      {children}
+    </KibanaRootContextProvider>
   );
 };

--- a/packages/react/kibana_context/render/tsconfig.json
+++ b/packages/react/kibana_context/render/tsconfig.json
@@ -16,7 +16,6 @@
     "target/**/*"
   ],
   "kbn_references": [
-    "@kbn/core-i18n-browser",
-    "@kbn/react-kibana-context-theme",
+    "@kbn/react-kibana-context-root",
   ]
 }

--- a/packages/react/kibana_context/root/eui_provider.tsx
+++ b/packages/react/kibana_context/root/eui_provider.tsx
@@ -48,7 +48,8 @@ utilitiesCache.compat = true;
 const cache = { default: emotionCache, global: globalCache, utility: utilitiesCache };
 
 /**
- * Prepares and returns a configured `EuiProvider` for use in Kibana roots.
+ * Prepares and returns a configured `EuiProvider` for use in Kibana roots.  In most cases, this utility context
+ * should not be used.  Instead, refer to `KibanaRootContextProvider` to set up the root of Kibana.
  */
 export const KibanaEuiProvider: FC<KibanaEuiProviderProps> = ({
   theme: { theme$ },

--- a/packages/react/kibana_context/root/index.ts
+++ b/packages/react/kibana_context/root/index.ts
@@ -7,3 +7,4 @@
  */
 
 export { KibanaRootContextProvider, type KibanaRootContextProviderProps } from './root_provider';
+export { KibanaEuiProvider, type KibanaEuiProviderProps } from './eui_provider';

--- a/packages/react/kibana_context/theme/theme_provider.tsx
+++ b/packages/react/kibana_context/theme/theme_provider.tsx
@@ -10,12 +10,13 @@ import React, { useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 
 import { EuiThemeProvider, EuiThemeProviderProps } from '@elastic/eui';
+
 // @ts-ignore EUI exports this component internally, but Kibana isn't picking it up its types
 import { useIsNestedEuiProvider } from '@elastic/eui/lib/components/provider/nested';
 // @ts-ignore EUI exports this component internally, but Kibana isn't picking it up its types
 import { emitEuiProviderWarning } from '@elastic/eui/lib/services/theme/warning';
 
-import { KibanaEuiProvider } from '@kbn/react-kibana-context-root/eui_provider';
+import { KibanaEuiProvider } from '@kbn/react-kibana-context-root';
 
 import {
   getColorMode,
@@ -46,7 +47,7 @@ export interface KibanaThemeProviderProps extends EuiProps {
  * TODO: Restore this to the main `KibanaThemeProvider` once all theme providers can be guaranteed
  * to have a parent `EuiProvider`
  */
-export const KibanaThemeProviderOnly = ({
+const KibanaThemeProviderOnly = ({
   theme: { theme$ },
   euiTheme: theme,
   children,
@@ -62,11 +63,11 @@ export const KibanaThemeProviderOnly = ({
  * Unfortunately, a lot of plugins are using `KibanaThemeProvider` without a parent
  * `EuiProvider` which provides very necessary setup (e.g. Emotion cache, breakpoints).
  *
- * If so, we need to render an EuiProvider first (but without global styles, since those
- * are already handled by `KibanaRootContextProvider`)
+ * If a render call is using the deprecated context, we need to render an EuiProvider first
+ * (but without global styles, since those are already handled by `KibanaRootContextProvider`)
  *
- * TODO: We can hopefully remove this and revert to only exporting the above component once
- * all plugins are on `KibanaRootContextProvider`?
+ * TODO: clintandrewhall - We can remove this and revert to only exporting the above component
+ * once all out-of-band renders are using `KibanaRenderContextProvider`.
  */
 const KibanaThemeProviderCheck = ({ theme, children, ...props }: KibanaThemeProviderProps) => {
   const hasEuiProvider = useIsNestedEuiProvider();
@@ -79,7 +80,7 @@ const KibanaThemeProviderCheck = ({ theme, children, ...props }: KibanaThemeProv
     );
   } else {
     emitEuiProviderWarning(
-      'Your plugin used an KibanaThemeProvider without a required parent KibanaRootContextProvider.'
+      'KibanaThemeProvider requires a parent KibanaRenderContextProvider.  Check your React tree and ensure that they are wrapped in a KibanaRenderContextProvider.'
     );
     return (
       <KibanaEuiProvider theme={theme} globalStyles={false}>

--- a/packages/react/kibana_context/theme/theme_provider.tsx
+++ b/packages/react/kibana_context/theme/theme_provider.tsx
@@ -9,11 +9,11 @@
 import React, { useMemo } from 'react';
 import useObservable from 'react-use/lib/useObservable';
 
-import {
-  CurrentEuiBreakpointProvider,
-  EuiThemeProvider,
-  EuiThemeProviderProps,
-} from '@elastic/eui';
+import { EuiThemeProvider, EuiThemeProviderProps } from '@elastic/eui';
+// @ts-ignore EUI exports this component internally, but Kibana isn't picking it up its types
+import { useIsNestedEuiProvider } from '@elastic/eui/lib/components/provider/nested';
+
+import { KibanaEuiProvider } from '@kbn/react-kibana-context-root/eui_provider';
 
 import {
   getColorMode,
@@ -40,8 +40,11 @@ export interface KibanaThemeProviderProps extends EuiProps {
 
 /**
  * A Kibana-specific theme provider that uses the Kibana theme service to customize the EUI theme.
+ *
+ * TODO: Restore this to the main `KibanaThemeProvider` once all theme providers can be guaranteed
+ * to have a parent `EuiProvider`
  */
-export const KibanaThemeProvider = ({
+export const KibanaThemeProviderOnly = ({
   theme: { theme$ },
   euiTheme: theme,
   children,
@@ -50,14 +53,36 @@ export const KibanaThemeProvider = ({
   const kibanaTheme = useObservable(theme$, defaultTheme);
   const colorMode = useMemo(() => getColorMode(kibanaTheme), [kibanaTheme]);
 
-  // We have to add a breakpoint provider, because the `EuiProvider` we were using-- instead
-  // of `EuiThemeProvider`-- adds a breakpoint.  Without it here now, several Kibana layouts
-  // break, particularly sidebars.
-  //
-  // We can investigate removing it later, but I'm adding it here for now.
-  return (
-    <EuiThemeProvider {...{ colorMode, theme, ...props }}>
-      <CurrentEuiBreakpointProvider>{children}</CurrentEuiBreakpointProvider>
-    </EuiThemeProvider>
+  return <EuiThemeProvider {...{ colorMode, theme, ...props }}>{children}</EuiThemeProvider>;
+};
+
+/**
+ * Unfortunately, a lot of plugins are using `KibanaThemeProvider` without a parent
+ * `EuiProvider` which provides very necessary setup (e.g. Emotion cache, breakpoints).
+ *
+ * If so, we need to render an EuiProvider first (but without global styles, since those
+ * are already handled by `KibanaRootContextProvider`)
+ *
+ * TODO: We can hopefully remove this and revert to only exporting the above component once
+ * all plugins are on `KibanaRootContextProvider`?
+ */
+const KibanaThemeProviderCheck = ({ theme, children, ...props }: KibanaThemeProviderProps) => {
+  const hasEuiProvider = useIsNestedEuiProvider();
+
+  return hasEuiProvider ? (
+    <KibanaThemeProviderOnly theme={theme} {...props}>
+      {children}
+    </KibanaThemeProviderOnly>
+  ) : (
+    <KibanaEuiProvider theme={theme} globalStyles={false}>
+      {children}
+    </KibanaEuiProvider>
   );
 };
+
+/**
+ * A Kibana-specific theme provider that uses the Kibana theme service to customize the EUI theme.
+ *
+ * If the theme provider is missing a parent EuiProvider, one will automatically be rendered instead.
+ */
+export const KibanaThemeProvider = KibanaThemeProviderCheck;

--- a/packages/react/kibana_context/theme/theme_provider.tsx
+++ b/packages/react/kibana_context/theme/theme_provider.tsx
@@ -12,6 +12,8 @@ import useObservable from 'react-use/lib/useObservable';
 import { EuiThemeProvider, EuiThemeProviderProps } from '@elastic/eui';
 // @ts-ignore EUI exports this component internally, but Kibana isn't picking it up its types
 import { useIsNestedEuiProvider } from '@elastic/eui/lib/components/provider/nested';
+// @ts-ignore EUI exports this component internally, but Kibana isn't picking it up its types
+import { emitEuiProviderWarning } from '@elastic/eui/lib/services/theme/warning';
 
 import { KibanaEuiProvider } from '@kbn/react-kibana-context-root/eui_provider';
 
@@ -69,15 +71,22 @@ export const KibanaThemeProviderOnly = ({
 const KibanaThemeProviderCheck = ({ theme, children, ...props }: KibanaThemeProviderProps) => {
   const hasEuiProvider = useIsNestedEuiProvider();
 
-  return hasEuiProvider ? (
-    <KibanaThemeProviderOnly theme={theme} {...props}>
-      {children}
-    </KibanaThemeProviderOnly>
-  ) : (
-    <KibanaEuiProvider theme={theme} globalStyles={false}>
-      {children}
-    </KibanaEuiProvider>
-  );
+  if (hasEuiProvider) {
+    return (
+      <KibanaThemeProviderOnly theme={theme} {...props}>
+        {children}
+      </KibanaThemeProviderOnly>
+    );
+  } else {
+    emitEuiProviderWarning(
+      'Your plugin used an KibanaThemeProvider without a required parent KibanaRootContextProvider.'
+    );
+    return (
+      <KibanaEuiProvider theme={theme} globalStyles={false}>
+        {children}
+      </KibanaEuiProvider>
+    );
+  }
 };
 
 /**

--- a/packages/react/kibana_context/theme/tsconfig.json
+++ b/packages/react/kibana_context/theme/tsconfig.json
@@ -18,5 +18,6 @@
   "kbn_references": [
     "@kbn/test-jest-helpers",
     "@kbn/react-kibana-context-common",
+    "@kbn/react-kibana-context-root",
   ]
 }


### PR DESCRIPTION
## Summary

Unfortunately, #161914 regressed #162365 in that many plugins and their Emotion styles (including EUI emotion styles) are now missing a cache and are being appended to to the end of the document `<head>` as opposed to within `<meta name="emotion">`.

What appears to be happening is many plugins are using a parent `<KibanaThemeProvider>` but **not** a parent `<KibanaRootContextProvider>` (not sure if this work is TBD or in progress). This means that a parent `<EuiProvider>`, (which determines the cache insertion of child Emotion styled components) is missing, which is causing several CSS specificity bugs, e.g. around datagrid.

As a somewhat-bandaid-y fix, I've bogarted EUI's nested provider context to check if the theme provider has a parent `EuiProvider`, and if it doesn't, to use `KibanaEuiProvider` instead of `KibanaThemeProvider`. This should set up the caches and context if needed, or otherwise simply use the original `KibanaThemeProvider` component.

### FYI

If you see an error like this, in console dev tools, that means an Emotion cache somewhere is improperly set up. All of EUI's and Kibana's default caches should have `.compat = true` set, which silences these errors.

![Screenshot 2023-08-03 at 8 40 06 AM](https://github.com/elastic/kibana/assets/549407/7057926e-4846-4cc5-9ead-9fcbb543cb11)

## QA

### Previous/broken behavior

- In your browser devtools inspector, open the document `<head>`
- Under `<meta name="emotion">`, you'll only see a couple hundred style nodes:
    <img width="477" alt="" src="https://github.com/elastic/kibana/assets/549407/a00be725-11ca-41d7-a317-64bc4e102cb6">
    <img width="494" alt="" src="https://github.com/elastic/kibana/assets/549407/cb62d91b-2fb0-4890-ba02-cc0740a94e21">
- If you scroll to the bottom of  `<head>`, you should see a _lot_ of `<style data-emotion="css">` nodes:
    <img width="450" alt="" src="https://github.com/elastic/kibana/assets/549407/45584e4c-5de5-4653-91cc-a411af3760bb">

### Fixed behavior in this PR

- In your browser devtools inspector, open the document `<head>`
- Under `<meta name="emotion">`, you should now see well over thousands of styles
    <img width="477" alt="" src="https://github.com/elastic/kibana/assets/549407/a00be725-11ca-41d7-a317-64bc4e102cb6">
    <img width="498" alt="" src="https://github.com/elastic/kibana/assets/549407/372de83e-bcea-4b6c-958c-1d6d041666bb">
- You should no longer see many `<style data-emotion="css">` with **EUI** styles at the end of the head (there's a lot of `<script>` tags instead). There's still a few, but they appear to not be EUI styles (e.g. it's a plugin's random Emotion styles that they're using without a cache set up).
