### PR TITLE
[Lens] wait for active data before loading suggestions

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.scss
@@ -100,3 +100,7 @@
   align-items: center;
   justify-content: center;
 }
+
+.lnsSuggestionPanel__loadingState {
+  height: $lnsSuggestionHeight;
+}


### PR DESCRIPTION
## Summary

This PR is an experiment to improve the initial time-to-render in the Lens editor by waiting to render suggestions until the main chart's data is loaded. 

Currently, the initial suggestion render is interrupted by the arrival of the main visualization's data which triggers a re-render of the suggestions. This is one improvement we could consider.

Without waiting on suggestion rendering (how it is today)

https://github.com/elastic/kibana/assets/315764/d5f27f2f-d068-4808-8f74-a78fc167743b

With waiting on suggestion rendering (optional enhancement)

https://github.com/elastic/kibana/assets/315764/bd27dfd0-1363-40bf-bf5c-8a21859ddcd7

