### PR TITLE
[SLO] Add support to burn rate visualization for group by

### DIFF
--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -182,14 +182,19 @@ const getSLOBurnRatesResponseSchema = t.type({
 
 const getSLOBurnRatesParamsSchema = t.type({
   path: t.type({ id: t.string }),
-  body: t.type({
-    windows: t.array(
-      t.type({
-        name: t.string,
-        duration: durationType,
-      })
-    ),
-  }),
+  body: t.intersection([
+    t.type({
+      windows: t.array(
+        t.type({
+          name: t.string,
+          duration: durationType,
+        })
+      ),
+    }),
+    t.partial({
+      instanceId: t.string,
+    }),
+  ]),
 });
 
 const getSLOInstancesParamsSchema = t.type({

--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -182,19 +182,15 @@ const getSLOBurnRatesResponseSchema = t.type({
 
 const getSLOBurnRatesParamsSchema = t.type({
   path: t.type({ id: t.string }),
-  body: t.intersection([
-    t.type({
-      windows: t.array(
-        t.type({
-          name: t.string,
-          duration: durationType,
-        })
-      ),
-    }),
-    t.partial({
-      instanceId: t.string,
-    }),
-  ]),
+  body: t.type({
+    instanceId: allOrAnyString,
+    windows: t.array(
+      t.type({
+        name: t.string,
+        duration: durationType,
+      })
+    ),
+  }),
 });
 
 const getSLOInstancesParamsSchema = t.type({

--- a/x-pack/plugins/observability/public/hooks/slo/query_key_factory.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/query_key_factory.ts
@@ -33,7 +33,8 @@ export const sloKeys = {
   historicalSummaries: () => [...sloKeys.all, 'historicalSummary'] as const,
   historicalSummary: (sloIds: string[]) => [...sloKeys.historicalSummaries(), sloIds] as const,
   globalDiagnosis: () => [...sloKeys.all, 'globalDiagnosis'] as const,
-  burnRates: (sloId: string) => [...sloKeys.all, 'burnRates', sloId] as const,
+  burnRates: (sloId: string, instanceId: string | undefined) =>
+    [...sloKeys.all, 'burnRates', sloId, instanceId] as const,
   preview: (indicator?: Indicator) => [...sloKeys.all, 'preview', indicator] as const,
 };
 

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_burn_rates.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_burn_rates.ts
@@ -10,7 +10,7 @@ import {
   RefetchQueryFilters,
   useQuery,
 } from '@tanstack/react-query';
-import { GetSLOBurnRatesResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
+import { ALL_VALUE, GetSLOBurnRatesResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
 
@@ -48,7 +48,7 @@ export function useFetchSloBurnRates({
           const response = await http.post<GetSLOBurnRatesResponse>(
             `/internal/observability/slos/${slo.id}/_burn_rates`,
             {
-              body: JSON.stringify({ windows, instanceId: slo.instanceId }),
+              body: JSON.stringify({ windows, instanceId: slo.instanceId ?? ALL_VALUE }),
               signal,
             }
           );

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_burn_rates.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_burn_rates.ts
@@ -10,7 +10,7 @@ import {
   RefetchQueryFilters,
   useQuery,
 } from '@tanstack/react-query';
-import { GetSLOBurnRatesResponse } from '@kbn/slo-schema';
+import { GetSLOBurnRatesResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
 
@@ -29,26 +29,26 @@ export interface UseFetchSloBurnRatesResponse {
 const LONG_REFETCH_INTERVAL = 1000 * 60; // 1 minute
 
 interface UseFetchSloBurnRatesParams {
-  sloId: string;
+  slo: SLOWithSummaryResponse;
   windows: Array<{ name: string; duration: string }>;
   shouldRefetch?: boolean;
 }
 
 export function useFetchSloBurnRates({
-  sloId,
+  slo,
   windows,
   shouldRefetch,
 }: UseFetchSloBurnRatesParams): UseFetchSloBurnRatesResponse {
   const { http } = useKibana().services;
   const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
     {
-      queryKey: sloKeys.burnRates(sloId),
+      queryKey: sloKeys.burnRates(slo.id, slo.instanceId),
       queryFn: async ({ signal }) => {
         try {
           const response = await http.post<GetSLOBurnRatesResponse>(
-            `/internal/observability/slos/${sloId}/_burn_rates`,
+            `/internal/observability/slos/${slo.id}/_burn_rates`,
             {
-              body: JSON.stringify({ windows }),
+              body: JSON.stringify({ windows, instanceId: slo.instanceId }),
               signal,
             }
           );

--- a/x-pack/plugins/observability/public/pages/slo_details/components/burn_rates.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/burn_rates.tsx
@@ -55,7 +55,7 @@ function getSliAndBurnRate(name: string, burnRates: GetSLOBurnRatesResponse['bur
 
 export function BurnRates({ slo, isAutoRefreshing }: Props) {
   const { isLoading, data } = useFetchSloBurnRates({
-    sloId: slo.id,
+    slo,
     shouldRefetch: isAutoRefreshing,
     windows: WINDOWS,
   });

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
@@ -19,6 +19,7 @@ import { LocatorPublic } from '@kbn/share-plugin/common';
 
 import { memoize, last, upperCase } from 'lodash';
 import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
+import { ALL_VALUE } from '@kbn/slo-schema';
 import { AlertsLocatorParams, getAlertUrl } from '../../../../common';
 import { SLO_ID_FIELD, SLO_REVISION_FIELD } from '../../../../common/field_names/slo';
 import { Duration, SLO, toDurationUnit } from '../../../domain/models';
@@ -53,7 +54,7 @@ async function evaluateWindow(slo: SLO, summaryClient: DefaultSLIClient, windowD
     toDurationUnit(windowDef.shortWindow.unit)
   );
 
-  const sliData = await summaryClient.fetchSLIDataFrom(slo, undefined, [
+  const sliData = await summaryClient.fetchSLIDataFrom(slo, ALL_VALUE, [
     { name: LONG_WINDOW, duration: longWindowDuration.add(slo.settings.syncDelay) },
     { name: SHORT_WINDOW, duration: shortWindowDuration.add(slo.settings.syncDelay) },
   ]);

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/executor.ts
@@ -53,7 +53,7 @@ async function evaluateWindow(slo: SLO, summaryClient: DefaultSLIClient, windowD
     toDurationUnit(windowDef.shortWindow.unit)
   );
 
-  const sliData = await summaryClient.fetchSLIDataFrom(slo, [
+  const sliData = await summaryClient.fetchSLIDataFrom(slo, undefined, [
     { name: LONG_WINDOW, duration: longWindowDuration.add(slo.settings.syncDelay) },
     { name: SHORT_WINDOW, duration: shortWindowDuration.add(slo.settings.syncDelay) },
   ]);

--- a/x-pack/plugins/observability/server/routes/slo/route.ts
+++ b/x-pack/plugins/observability/server/routes/slo/route.ts
@@ -350,10 +350,15 @@ const getSloBurnRates = createObservabilityServerRoute({
 
     const esClient = (await context.core).elasticsearch.client.asCurrentUser;
     const soClient = (await context.core).savedObjects.client;
-    const burnRates = await getBurnRates(params.path.id, params.body.windows, {
-      soClient,
-      esClient,
-    });
+    const burnRates = await getBurnRates(
+      params.path.id,
+      params.body.instanceId,
+      params.body.windows,
+      {
+        soClient,
+        esClient,
+      }
+    );
     return { burnRates };
   },
 });

--- a/x-pack/plugins/observability/server/services/slo/get_burn_rates.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_burn_rates.ts
@@ -24,7 +24,7 @@ interface LookbackWindow {
 
 export async function getBurnRates(
   sloId: string,
-  instanceId: string | undefined,
+  instanceId: string,
   windows: LookbackWindow[],
   services: Services
 ) {

--- a/x-pack/plugins/observability/server/services/slo/get_burn_rates.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_burn_rates.ts
@@ -22,14 +22,19 @@ interface LookbackWindow {
   duration: Duration;
 }
 
-export async function getBurnRates(sloId: string, windows: LookbackWindow[], services: Services) {
+export async function getBurnRates(
+  sloId: string,
+  instanceId: string | undefined,
+  windows: LookbackWindow[],
+  services: Services
+) {
   const { soClient, esClient } = services;
 
   const repository = new KibanaSavedObjectsSLORepository(soClient);
   const sliClient = new DefaultSLIClient(esClient);
   const slo = await repository.findById(sloId);
 
-  const sliData = await sliClient.fetchSLIDataFrom(slo, windows);
+  const sliData = await sliClient.fetchSLIDataFrom(slo, instanceId, windows);
   return Object.keys(sliData).map((key) => {
     return {
       name: key,

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -87,7 +87,7 @@ describe('SummaryClient', () => {
         });
         const summaryClient = new DefaultSLIClient(esClientMock);
 
-        const result = await summaryClient.fetchSLIDataFrom(slo, lookbackWindows);
+        const result = await summaryClient.fetchSLIDataFrom(slo, undefined, lookbackWindows);
 
         expect(esClientMock?.search?.mock?.lastCall?.[0]).toMatchObject({
           aggs: {
@@ -177,7 +177,7 @@ describe('SummaryClient', () => {
         });
         const summaryClient = new DefaultSLIClient(esClientMock);
 
-        const result = await summaryClient.fetchSLIDataFrom(slo, lookbackWindows);
+        const result = await summaryClient.fetchSLIDataFrom(slo, undefined, lookbackWindows);
 
         expect(esClientMock?.search?.mock?.lastCall?.[0]).toMatchObject({
           aggs: {

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -7,6 +7,7 @@
 
 import { ElasticsearchClientMock, elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import moment from 'moment';
+import { ALL_VALUE } from '@kbn/slo-schema';
 
 import { Duration, DurationUnit } from '../../domain/models';
 import { createSLO } from './fixtures/slo';
@@ -87,7 +88,7 @@ describe('SummaryClient', () => {
         });
         const summaryClient = new DefaultSLIClient(esClientMock);
 
-        const result = await summaryClient.fetchSLIDataFrom(slo, undefined, lookbackWindows);
+        const result = await summaryClient.fetchSLIDataFrom(slo, ALL_VALUE, lookbackWindows);
 
         expect(esClientMock?.search?.mock?.lastCall?.[0]).toMatchObject({
           aggs: {
@@ -177,7 +178,7 @@ describe('SummaryClient', () => {
         });
         const summaryClient = new DefaultSLIClient(esClientMock);
 
-        const result = await summaryClient.fetchSLIDataFrom(slo, undefined, lookbackWindows);
+        const result = await summaryClient.fetchSLIDataFrom(slo, ALL_VALUE, lookbackWindows);
 
         expect(esClientMock?.search?.mock?.lastCall?.[0]).toMatchObject({
           aggs: {

--- a/x-pack/plugins/observability/server/services/slo/sli_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.ts
@@ -29,7 +29,7 @@ import { InternalQueryError } from '../../errors';
 export interface SLIClient {
   fetchSLIDataFrom(
     slo: SLO,
-    instanceId: string | undefined,
+    instanceId: string,
     lookbackWindows: LookbackWindow[]
   ): Promise<Record<WindowName, IndicatorData>>;
 }
@@ -48,7 +48,7 @@ export class DefaultSLIClient implements SLIClient {
 
   async fetchSLIDataFrom(
     slo: SLO,
-    instanceId: string | undefined,
+    instanceId: string,
     lookbackWindows: LookbackWindow[]
   ): Promise<Record<WindowName, IndicatorData>> {
     const sortedLookbackWindows = [...lookbackWindows].sort((a, b) =>

--- a/x-pack/plugins/observability/server/services/slo/sli_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.ts
@@ -11,11 +11,9 @@ import {
   AggregationsSumAggregate,
   AggregationsValueCountAggregate,
   MsearchMultisearchBody,
-  QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient } from '@kbn/core/server';
 import {
-  ALL_VALUE,
   occurrencesBudgetingMethodSchema,
   timeslicesBudgetingMethodSchema,
   toMomentUnitOfTime,
@@ -86,25 +84,20 @@ function commonQuery(
   instanceId: string | undefined,
   dateRange: DateRange
 ): Pick<MsearchMultisearchBody, 'size' | 'query'> {
-  const filter: QueryDslQueryContainer[] = [
-    { term: { 'slo.id': slo.id } },
-    { term: { 'slo.revision': slo.revision } },
-    {
-      range: {
-        '@timestamp': { gte: dateRange.from.toISOString(), lt: dateRange.to.toISOString() },
-      },
-    },
-  ];
-
-  if (instanceId && instanceId !== ALL_VALUE) {
-    filter.push({ term: { 'slo.instanceId': instanceId } });
-  }
-
   return {
     size: 0,
     query: {
       bool: {
-        filter,
+        filter: [
+          { term: { 'slo.id': slo.id } },
+          { term: { 'slo.revision': slo.revision } },
+          { term: { 'slo.instanceId': instanceId } },
+          {
+            range: {
+              '@timestamp': { gte: dateRange.from.toISOString(), lt: dateRange.to.toISOString() },
+            },
+          },
+        ],
       },
     },
   };

--- a/x-pack/plugins/observability/server/services/slo/sli_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.ts
@@ -11,9 +11,11 @@ import {
   AggregationsSumAggregate,
   AggregationsValueCountAggregate,
   MsearchMultisearchBody,
+  QueryDslQueryContainer,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ElasticsearchClient } from '@kbn/core/server';
 import {
+  ALL_VALUE,
   occurrencesBudgetingMethodSchema,
   timeslicesBudgetingMethodSchema,
   toMomentUnitOfTime,
@@ -27,6 +29,7 @@ import { InternalQueryError } from '../../errors';
 export interface SLIClient {
   fetchSLIDataFrom(
     slo: SLO,
+    instanceId: string | undefined,
     lookbackWindows: LookbackWindow[]
   ): Promise<Record<WindowName, IndicatorData>>;
 }
@@ -45,6 +48,7 @@ export class DefaultSLIClient implements SLIClient {
 
   async fetchSLIDataFrom(
     slo: SLO,
+    instanceId: string | undefined,
     lookbackWindows: LookbackWindow[]
   ): Promise<Record<WindowName, IndicatorData>> {
     const sortedLookbackWindows = [...lookbackWindows].sort((a, b) =>
@@ -55,7 +59,7 @@ export class DefaultSLIClient implements SLIClient {
 
     if (occurrencesBudgetingMethodSchema.is(slo.budgetingMethod)) {
       const result = await this.esClient.search<unknown, EsAggregations>({
-        ...commonQuery(slo, longestDateRange),
+        ...commonQuery(slo, instanceId, longestDateRange),
         index: SLO_DESTINATION_INDEX_PATTERN,
         aggs: toLookbackWindowsAggregationsQuery(sortedLookbackWindows),
       });
@@ -65,7 +69,7 @@ export class DefaultSLIClient implements SLIClient {
 
     if (timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)) {
       const result = await this.esClient.search<unknown, EsAggregations>({
-        ...commonQuery(slo, longestDateRange),
+        ...commonQuery(slo, instanceId, longestDateRange),
         index: SLO_DESTINATION_INDEX_PATTERN,
         aggs: toLookbackWindowsSlicedAggregationsQuery(slo, sortedLookbackWindows),
       });
@@ -79,21 +83,28 @@ export class DefaultSLIClient implements SLIClient {
 
 function commonQuery(
   slo: SLO,
+  instanceId: string | undefined,
   dateRange: DateRange
 ): Pick<MsearchMultisearchBody, 'size' | 'query'> {
+  const filter: QueryDslQueryContainer[] = [
+    { term: { 'slo.id': slo.id } },
+    { term: { 'slo.revision': slo.revision } },
+    {
+      range: {
+        '@timestamp': { gte: dateRange.from.toISOString(), lt: dateRange.to.toISOString() },
+      },
+    },
+  ];
+
+  if (instanceId && instanceId !== ALL_VALUE) {
+    filter.push({ term: { 'slo.instanceId': instanceId } });
+  }
+
   return {
     size: 0,
     query: {
       bool: {
-        filter: [
-          { term: { 'slo.id': slo.id } },
-          { term: { 'slo.revision': slo.revision } },
-          {
-            range: {
-              '@timestamp': { gte: dateRange.from.toISOString(), lt: dateRange.to.toISOString() },
-            },
-          },
-        ],
+        filter,
       },
     },
   };


### PR DESCRIPTION
## Summary

This PR fixes #163121  by adding support for the `instanceId` the burn rate endpoint. This also updates the burn rate visualization to send the `instanceId` as an optional attribute to the post body JSON object.

```JSON
POST /internal/observability/slos/6bad8fe0-323b-11ee-ac4c-37263913b2b5/_burn_rates
{
    "windows": [
        {
            "name": "CRITICAL_LONG",
            "duration": "1h"
        },
        {
            "name": "CRITICAL_SHORT",
            "duration": "5m"
        },
        {
            "name": "HIGH_LONG",
            "duration": "6h"
        },
        {
            "name": "HIGH_SHORT",
            "duration": "30m"
        },
        {
            "name": "MEDIUM_LONG",
            "duration": "24h"
        },
        {
            "name": "MEDIUM_SHORT",
            "duration": "120m"
        },
        {
            "name": "LOW_LONG",
            "duration": "72h"
        },
        {
            "name": "LOW_SHORT",
            "duration": "360m"
        }
    ],
    "instanceId": "you-got.mail"
}
```