### PR TITLE
[regression] ReactDOM.render calls need Render context in deprecated component

### DIFF
--- a/packages/react/kibana_context/render/render_provider.tsx
+++ b/packages/react/kibana_context/render/render_provider.tsx
@@ -8,18 +8,13 @@
 
 import React, { FC } from 'react';
 
-import { EuiErrorBoundary } from '@elastic/eui';
-import type { I18nStart } from '@kbn/core-i18n-browser';
 import {
-  KibanaThemeProvider,
-  type KibanaThemeProviderProps,
-} from '@kbn/react-kibana-context-theme';
+  KibanaRootContextProvider,
+  type KibanaRootContextProviderProps,
+} from '@kbn/react-kibana-context-root';
 
 /** Props for the KibanaContextProvider */
-export interface KibanaRenderContextProviderProps extends KibanaThemeProviderProps {
-  /** The `I18nStart` API from `CoreStart`. */
-  i18n: I18nStart;
-}
+export type KibanaRenderContextProviderProps = Omit<KibanaRootContextProviderProps, 'globalStyles'>;
 
 /**
  * The `KibanaRenderContextProvider` provides the necessary context for an out-of-current
@@ -27,14 +22,11 @@ export interface KibanaRenderContextProviderProps extends KibanaThemeProviderPro
  */
 export const KibanaRenderContextProvider: FC<KibanaRenderContextProviderProps> = ({
   children,
-  i18n,
   ...props
 }) => {
   return (
-    <i18n.Context>
-      <KibanaThemeProvider {...props}>
-        <EuiErrorBoundary>{children}</EuiErrorBoundary>
-      </KibanaThemeProvider>
-    </i18n.Context>
+    <KibanaRootContextProvider globalStyles={false} {...props}>
+      {children}
+    </KibanaRootContextProvider>
   );
 };

--- a/packages/react/kibana_context/render/tsconfig.json
+++ b/packages/react/kibana_context/render/tsconfig.json
@@ -16,7 +16,6 @@
     "target/**/*"
   ],
   "kbn_references": [
-    "@kbn/core-i18n-browser",
-    "@kbn/react-kibana-context-theme",
+    "@kbn/react-kibana-context-root",
   ]
 }

--- a/packages/react/kibana_context/root/root_provider.tsx
+++ b/packages/react/kibana_context/root/root_provider.tsx
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { EuiErrorBoundary } from '@elastic/eui';
 import { I18nStart } from '@kbn/core-i18n-browser';
 import React, { FC } from 'react';
 
@@ -13,10 +14,13 @@ import { KibanaEuiProvider, type KibanaEuiProviderProps } from './eui_provider';
 
 /** Props for the KibanaRootContextProvider */
 export interface KibanaRootContextProviderProps extends KibanaEuiProviderProps {
+  // TODO: clintandrewhall - this should *not* be optional, but must be for now to avoid breaking
+  // components using `KibanaThemeProvider` as a rendering context.
   /** The `I18nStart` API from `CoreStart`. */
-  i18n: I18nStart;
+  i18n?: I18nStart;
 }
 
+const EmptyContext = ({ children }: { children: React.ReactNode }) => <>{children}</>;
 /**
  * The `KibanaRootContextProvider` provides the necessary context at the root of Kibana, including
  * initialization and the theme and i18n contexts.  This context should only be used _once_, and
@@ -35,8 +39,14 @@ export const KibanaRootContextProvider: FC<KibanaRootContextProviderProps> = ({
   children,
   i18n,
   ...props
-}) => (
-  <KibanaEuiProvider {...props}>
-    <i18n.Context>{children}</i18n.Context>
-  </KibanaEuiProvider>
-);
+}) => {
+  const I18nContext = i18n ? i18n.Context : EmptyContext;
+
+  return (
+    <KibanaEuiProvider {...props}>
+      <I18nContext>
+        <EuiErrorBoundary>{children}</EuiErrorBoundary>
+      </I18nContext>
+    </KibanaEuiProvider>
+  );
+};

--- a/src/plugins/kibana_react/public/theme.tsx
+++ b/src/plugins/kibana_react/public/theme.tsx
@@ -8,10 +8,10 @@
 
 import React from 'react';
 import {
-  KibanaThemeProvider as KbnThemeProvider,
   KibanaThemeProviderProps as KbnThemeProviderProps,
   wrapWithTheme as kbnWrapWithTheme,
 } from '@kbn/react-kibana-context-theme';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
 /** @deprecated Use `KibanaThemeProviderProps` from `@kbn/react-kibana-context-theme`  */
 export type KibanaThemeProviderProps = Pick<KbnThemeProviderProps, 'children' | 'modify'> &
@@ -19,9 +19,9 @@ export type KibanaThemeProviderProps = Pick<KbnThemeProviderProps, 'children' | 
 
 /** @deprecated Use `KibanaThemeProvider` from `@kbn/react-kibana-context-theme`  */
 export const KibanaThemeProvider = ({ children, theme$, modify }: KibanaThemeProviderProps) => (
-  <KbnThemeProvider theme={{ theme$ }} {...modify}>
+  <KibanaRenderContextProvider theme={{ theme$ }} {...modify}>
     {children}
-  </KbnThemeProvider>
+  </KibanaRenderContextProvider>
 );
 
 type Theme = KbnThemeProviderProps['theme']['theme$'];

--- a/src/plugins/kibana_react/tsconfig.json
+++ b/src/plugins/kibana_react/tsconfig.json
@@ -23,6 +23,7 @@
     "@kbn/core-theme-browser",
     "@kbn/react-kibana-context-common",
     "@kbn/react-kibana-context-styled",
+    "@kbn/react-kibana-context-render",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/kibana_utils/public/theme/kibana_theme_provider.tsx
+++ b/src/plugins/kibana_utils/public/theme/kibana_theme_provider.tsx
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
 
 import { EuiProviderProps } from '@elastic/eui';
 import { CoreTheme } from '@kbn/core-theme-browser';
-import { KibanaThemeProvider as KbnThemeProvider } from '@kbn/react-kibana-context-theme';
+import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 
 export interface KibanaThemeProviderProps {
   theme$: Observable<CoreTheme>;
@@ -20,5 +20,7 @@ export interface KibanaThemeProviderProps {
 
 /** @deprecated use `KibanaThemeProvider` from `@kbn/react-kibana-context-theme */
 export const KibanaThemeProvider: FC<KibanaThemeProviderProps> = ({ theme$, modify, children }) => (
-  <KbnThemeProvider {...{ theme: { theme$ }, modify }}>{children}</KbnThemeProvider>
+  <KibanaRenderContextProvider {...{ theme: { theme$ }, modify }}>
+    {children}
+  </KibanaRenderContextProvider>
 );

--- a/src/plugins/kibana_utils/tsconfig.json
+++ b/src/plugins/kibana_utils/tsconfig.json
@@ -21,8 +21,8 @@
     "@kbn/rison",
     "@kbn/crypto-browser",
     "@kbn/core-notifications-browser-mocks",
-    "@kbn/react-kibana-context-theme",
     "@kbn/core-theme-browser",
+    "@kbn/react-kibana-context-render",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
> This is an alternative to #163103, and includes a fix @cee-chen and I discussed.

## Summary

There's currently a regression when using the deprecated `KibanaThemeProvider` from `kibana_react` and `kibana_utils`.

>Unfortunately, #161914 regressed #162365 in that many plugins and their Emotion styles (including EUI emotion styles) are now missing a cache and are being appended to to the end of the document `<head>` as opposed to within `<meta name="emotion">`.
>
>What appears to be happening is many plugins are using a parent `<KibanaThemeProvider>` but **not** a parent `<KibanaRootContextProvider>` (not sure if this work is TBD or in progress). This means that a parent `<EuiProvider>`, (which determines the cache insertion of child Emotion styled components) is missing, which is causing several CSS specificity bugs, e.g. around datagrid.

The design for context use moving forward would be that we would use the **`Root`** context once, the `Render` context for out-of-band renders, and the `Theme` provider when adjusting the theme.

The mistake I made was deprecating the existing `KibanaThemeProvider` and mapping it directly to the new Theme context.  My plan was to follow up and update all of the `ReactDOM.render` calls to use the Render provider, and believed my deprecation to be passive.  It was, but not in all cases.

Until we can update all of our `ReactDOM.render` calls to use the correct context, we need to have the deprecated provider use the _Render_ context.  This will return us to the status quo until applications can make the change.

This PR also fixes an oversight where the Render provider still needs to utilize the `EuiProvider`, just not with the global styles.  @cee-chen and I had several conversations clarifying which contexts were needed in each case, and it wasn't until we saw this issue that we realized we hadn't clarified enough.  :-)

The good news is that @cee-chen and EUI are going to be working on their documentation and provider APIs to make the distinction easier.  Even better news is, with these contexts, we can abstract any updates away from Kibana code.  So all-in-all, we're still in a better position than when we started.

## Next steps
- [ ] Update all calls to `ReactDOM.render` to use the `KibanaRenderContextProvider`.
- [ ] Remove all superfluous contexts from those calls.

## QA

### Previous/broken behavior

- In your browser devtools inspector, open the document `<head>`
- Under `<meta name="emotion">`, you'll only see a couple hundred style nodes:
    <img width="477" alt="" src="https://github.com/elastic/kibana/assets/549407/a00be725-11ca-41d7-a317-64bc4e102cb6">
    <img width="494" alt="" src="https://github.com/elastic/kibana/assets/549407/cb62d91b-2fb0-4890-ba02-cc0740a94e21">
- If you scroll to the bottom of  `<head>`, you should see a _lot_ of `<style data-emotion="css">` nodes:
    <img width="450" alt="" src="https://github.com/elastic/kibana/assets/549407/45584e4c-5de5-4653-91cc-a411af3760bb">

### Fixed behavior in this PR

- In your browser devtools inspector, open the document `<head>`
- Under `<meta name="emotion">`, you should now see well over thousands of styles
    <img width="477" alt="" src="https://github.com/elastic/kibana/assets/549407/a00be725-11ca-41d7-a317-64bc4e102cb6">
    <img width="498" alt="" src="https://github.com/elastic/kibana/assets/549407/372de83e-bcea-4b6c-958c-1d6d041666bb">
- You should no longer see many `<style data-emotion="css">` with **EUI** styles at the end of the head (there's a lot of `<script>` tags instead). There's still a few, but they appear to not be EUI styles (e.g. it's a plugin's random Emotion styles that they're using without a cache set up).
