### PR TITLE
[Cases] Validate max user actions on update comment.

### DIFF
--- a/x-pack/plugins/cases/server/client/attachments/update.ts
+++ b/x-pack/plugins/cases/server/client/attachments/update.ts
@@ -7,6 +7,7 @@
 
 import Boom from '@hapi/boom';
 
+import { validateMaxUserActions } from '../../../common/utils/validators';
 import { AttachmentPatchRequestRt } from '../../../common/types/api';
 import { CaseCommentModel } from '../../common/models';
 import { createCaseError } from '../../common/error';
@@ -29,7 +30,7 @@ export async function update(
   clientArgs: CasesClientArgs
 ): Promise<Case> {
   const {
-    services: { attachmentService },
+    services: { attachmentService, userActionService },
     logger,
     authorization,
     externalReferenceAttachmentTypeRegistry,
@@ -41,6 +42,11 @@ export async function update(
       version: queryCommentVersion,
       ...queryRestAttributes
     } = decodeWithExcessOrThrow(AttachmentPatchRequestRt)(queryParams);
+    await validateMaxUserActions({
+      caseId: caseID,
+      userActionService,
+      userActionsToAdd: 1,
+    });
 
     decodeCommentRequest(queryRestAttributes, externalReferenceAttachmentTypeRegistry);
 


### PR DESCRIPTION
## Summary

Updating a comment in a case creates a user action. We want to validate that updating a comment will not make the total user actions of a case exceed 10000.

## Release Notes

Updating a case comment is now included in the 10000 user actions restriction.