### PR TITLE
[Synthetics] Normalize monitor before mixing params.

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -370,7 +370,7 @@ export class SyntheticsMonitorClient {
       heartbeatConfigs.push(
         formatHeartbeatRequest(
           {
-            monitor: normalizeSecrets(monitor).attributes,
+            monitor: normalizedMonitor,
             configId: monitor.id,
           },
           paramsString

--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_monitor/synthetics_monitor_client.ts
@@ -361,8 +361,11 @@ export class SyntheticsMonitorClient {
     const heartbeatConfigs: HeartbeatConfig[] = [];
 
     for (const monitor of monitors) {
-      const attributes = monitor.attributes as unknown as MonitorFields;
-      const { str: paramsString } = mixParamsWithGlobalParams(paramsBySpace[spaceId], attributes);
+      const normalizedMonitor = normalizeSecrets(monitor).attributes as MonitorFields;
+      const { str: paramsString } = mixParamsWithGlobalParams(
+        paramsBySpace[spaceId],
+        normalizedMonitor
+      );
 
       heartbeatConfigs.push(
         formatHeartbeatRequest(


### PR DESCRIPTION
Fixes #163042 

## Summary

Normalize the monitor object before mixing global and project-wide params.

### Testing
To test, refer to the parent issue's "Steps to reproduce" section.


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->