### PR TITLE
[Security Solution] [Detections] refactors logic for manipulating signalHistory state to use a functional approach

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -38,6 +38,7 @@ import {
 import { withSecuritySpan } from '../../../../utils/with_security_span';
 import { buildThresholdSignalHistory } from './build_signal_history';
 import type { IRuleExecutionLogForExecutors } from '../../rule_monitoring';
+import { getSignalHistory } from './utils';
 
 export const thresholdExecutor = async ({
   inputIndex,
@@ -98,22 +99,10 @@ export const thresholdExecutor = async ({
           ruleDataReader,
         });
 
-    if (state.initialized) {
-      // Clean up any signal history that has fallen outside the window
-      const toDelete: string[] = [];
-      for (const [hash, entry] of Object.entries(signalHistory)) {
-        if (entry.lastSignalTimestamp < tuple.from.valueOf()) {
-          toDelete.push(hash);
-        }
-      }
-      for (const hash of toDelete) {
-        delete signalHistory[hash];
-      }
-    }
-
+    const validSignalHistory = getSignalHistory(state, signalHistory, tuple);
     // Eliminate dupes
     const bucketFilters = await getThresholdBucketFilters({
-      signalHistory,
+      signalHistory: validSignalHistory,
       aggregatableTimestampField,
     });
 
@@ -157,7 +146,7 @@ export const thresholdExecutor = async ({
       signalsIndex: ruleParams.outputIndex,
       startedAt,
       from: tuple.from.toDate(),
-      signalHistory,
+      signalHistory: validSignalHistory,
       bulkCreate,
       wrapHits,
       ruleExecutionLogger,
@@ -191,7 +180,7 @@ export const thresholdExecutor = async ({
         ...state,
         initialized: true,
         signalHistory: {
-          ...signalHistory,
+          ...validSignalHistory,
           ...newSignalHistory,
         },
       },

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/utils.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/utils.test.ts
@@ -5,18 +5,65 @@
  * 2.0.
  */
 
-import { calculateThresholdSignalUuid } from './utils';
+import dateMath from '@kbn/datemath';
 
-describe('calculateThresholdSignalUuid', () => {
-  it('should generate a uuid without key', () => {
-    const startedAt = new Date('2020-12-17T16:27:00Z');
-    const signalUuid = calculateThresholdSignalUuid('abcd', startedAt, ['agent.name']);
-    expect(signalUuid).toEqual('a4832768-a379-583a-b1a2-e2ce2ad9e6e9');
+import { getThresholdRuleParams } from '../../rule_schema/mocks';
+import { calculateThresholdSignalUuid, getSignalHistory, getThresholdTermsHash } from './utils';
+
+describe('threshold utils', () => {
+  describe('calcualteThresholdSignalUuid', () => {
+    it('should generate a uuid without key', () => {
+      const startedAt = new Date('2020-12-17T16:27:00Z');
+      const signalUuid = calculateThresholdSignalUuid('abcd', startedAt, ['agent.name']);
+      expect(signalUuid).toEqual('a4832768-a379-583a-b1a2-e2ce2ad9e6e9');
+    });
+
+    it('should generate a uuid with key', () => {
+      const startedAt = new Date('2019-11-18T13:32:00Z');
+      const signalUuid = calculateThresholdSignalUuid('abcd', startedAt, ['host.ip'], '1.2.3.4');
+      expect(signalUuid).toEqual('ee8870dc-45ff-5e6c-a2f9-80886651ce03');
+    });
   });
-
-  it('should generate a uuid with key', () => {
-    const startedAt = new Date('2019-11-18T13:32:00Z');
-    const signalUuid = calculateThresholdSignalUuid('abcd', startedAt, ['host.ip'], '1.2.3.4');
-    expect(signalUuid).toEqual('ee8870dc-45ff-5e6c-a2f9-80886651ce03');
+  describe('getSignalHistory', () => {
+    const params = getThresholdRuleParams();
+    const tuple = {
+      from: dateMath.parse(params.from)!,
+      to: dateMath.parse(params.to)!,
+      maxSignals: params.maxSignals,
+    };
+    it('should return terms which do not fall outside of the search interval tuple', () => {
+      const terms1 = [
+        {
+          field: 'host.name',
+          value: 'elastic-pc-1',
+        },
+      ];
+      const signalHistoryRecord1 = {
+        terms: terms1,
+        lastSignalTimestamp: tuple.from.valueOf() - 60 * 1000,
+      };
+      const terms2 = [
+        {
+          field: 'host.name',
+          value: 'elastic-pc-2',
+        },
+      ];
+      const signalHistoryRecord2 = {
+        terms: terms2,
+        lastSignalTimestamp: tuple.from.valueOf() + 60 * 1000,
+      };
+      const hashOne = `${getThresholdTermsHash(terms1)}`;
+      const hashTwo = `${getThresholdTermsHash(terms2)}`;
+      const state = {
+        initialized: true,
+        signalHistory: {
+          [hashOne]: signalHistoryRecord1,
+          [hashTwo]: signalHistoryRecord2,
+        },
+      };
+      const validSignalHistory = getSignalHistory(state, state.signalHistory, tuple);
+      expect(validSignalHistory[hashOne]).toBe(undefined);
+      expect(validSignalHistory[hashTwo]).toBe(state.signalHistory[hashTwo]);
+    });
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/utils.ts
@@ -11,6 +11,39 @@ import type {
   ThresholdNormalized,
   ThresholdWithCardinality,
 } from '../../../../../common/api/detection_engine/model/rule_schema';
+import type { RuleRangeTuple } from '../types';
+import type { ThresholdSignalHistory, ThresholdAlertState } from './types';
+
+/**
+ * Returns a new signal history based on what the previous
+ * threshold rule state had stored and what the current rule
+ * run tuple timestamp is.
+ *
+ * This is used to determine which terms buckets over
+ * which periods of time are to be used in the search after
+ *
+ * @param state ThresholdAlertState
+ * @param signalHistory ThresholdSignalHistory
+ * @param tuple RuleRangeTuple
+ * @returns ThresholdSignalHistory
+ */
+export const getSignalHistory = (
+  state: ThresholdAlertState,
+  signalHistory: ThresholdSignalHistory,
+  tuple: RuleRangeTuple
+): ThresholdSignalHistory => {
+  if (state.initialized) {
+    return Object.entries(signalHistory).reduce((acc, [hash, entry]) => {
+      if (entry.lastSignalTimestamp > tuple.from.valueOf()) {
+        acc[hash] = entry;
+        return acc;
+      } else {
+        return acc;
+      }
+    }, {} as ThresholdSignalHistory);
+  }
+  return signalHistory;
+};
 
 export const shouldFilterByCardinality = (
   threshold: ThresholdNormalized


### PR DESCRIPTION
## Summary

The logic for determining which buckets a threshold rule uses during rule execution was directly manipulated the const derived from the alerting state, iterated inefficiently, and used an extra array for determining which terms buckets to remove. This is a small refactor into a utils function with additional comments describing why this logic is needed and what it is needed for in relation to the execution of the threshold rule. Hopefully this provides some extra readability to others when parsing the threshold executor logic.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)