### PR TITLE
unskip license type functional test

### DIFF
--- a/x-pack/test/licensing_plugin/scenario.ts
+++ b/x-pack/test/licensing_plugin/scenario.ts
@@ -74,18 +74,18 @@ export function createScenario({ getService, getPageObjects }: FtrProviderContex
         .post('/_license/?acknowledge=true')
         .send({
           license: {
-            uid: '00000000-d3ad-7357-c0d3-000000000000',
+            uid: '504430e6-503c-4316-85cb-b402c730ca08',
             type: 'enterprise',
-            issue_date_in_millis: 1577836800000,
-            start_date_in_millis: 1577836800000,
-            // expires 2022-12-31
-            expiry_date_in_millis: 1672531199999,
+            issue_date_in_millis: 1669680000000,
+            start_date_in_millis: 1669680000000,
+            // expires 2024-12-31
+            expiry_date_in_millis: 1735689599999,
             max_resource_units: 250,
             max_nodes: null,
-            issued_to: 'Elastic Internal Use (development environments)',
-            issuer: 'Elastic',
+            issued_to: 'Elastic - INTERNAL (development environments)',
+            issuer: 'API',
             signature:
-              'AAAABQAAAA1gHUVis7hel8b8nNCAAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAKMR+w3KZsMJfG5jNWgZXJLwRmiNqN7k94vKFgRdj1yM+gA9ufhXIn9d01OvFhPjilIqm+fxVjCxXwGKbFRiwtTWnTYjXPuNml+qCFGgUWguWEcVoIW6VU7/lYOqMJ4EB4zOMLe93P267iaDm542aelQrW1OJ69lGGuPBik8v9r1bNZzKBQ99VUr/qoosGDAm0udh2HxWzYoCL5lDML5Niy87xlVCubSSBXdUXzUgdZKKk6pKaMdHswB1gjvEfnwqPxEWAyrV0BCr/T1WehXd7U4p6/zt6sJ6cPh+34AZe9g4+3WPKrZhX4iaSHMDDHn4HNjO72CZ2oi42ZDNnJ37tA=',
+              'AAAABQAAAA2h1vBafHuRhjOHREKYAAAAIAo5/x6hrsGh1GqqrJmy4qgmEC7gK0U4zQ6q5ZEMhm4jAAABAByGz9MmRW/L7vQriISa6u8Oov7zykA+Cv55BToWEthSn0c5KQUxcWG+K5Cm4/OkFsXA8TE4zFnlSgYxmQi2Eqq7IAKGdcxI/xhQfMsq5RWlSEwtfyV0M2RKJxgam8o2lvKC9EbrU76ISYr7jTkgoBl6GFSjdfXMHmxNXBSKDDm03ZeXkWkvuNNFrHJuYivf2Se9OeeB/eu4jqUI0UuNfPYF07ZcYvtKfj3KX+aysCSV2FW8wgyAjndOPEinfYcwAJ09zcl+MTig2K0DQTsYkLykXmzZnLz6qeuVVFjCTowxizDFW+5MrpzUnwkjqv8CFhLfvxG7waWQWslv8fXLUn8=',
           },
         })
         .auth('license_manager_user', 'license_manager_user-password')

--- a/x-pack/test/licensing_plugin/server/updates.ts
+++ b/x-pack/test/licensing_plugin/server/updates.ts
@@ -17,8 +17,7 @@ export default function (ftrContext: FtrProviderContext) {
 
   const scenario = createScenario(ftrContext);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/110938
-  describe.skip('changes in license types', () => {
+  describe('changes in license types', () => {
     after(async () => {
       await scenario.teardown();
     });

--- a/x-pack/test/licensing_plugin/server/updates.ts
+++ b/x-pack/test/licensing_plugin/server/updates.ts
@@ -40,7 +40,6 @@ export default function (ftrContext: FtrProviderContext) {
       expect(refetchedLicense.signature).to.be(initialLicense.signature);
 
       await scenario.startTrial();
-      return;
       await scenario.waitForPluginToDetectLicenseUpdate();
       const trialLicense = await scenario.getLicense();
       expect(trialLicense.license?.type).to.be('trial');

--- a/x-pack/test/licensing_plugin/server/updates.ts
+++ b/x-pack/test/licensing_plugin/server/updates.ts
@@ -40,6 +40,7 @@ export default function (ftrContext: FtrProviderContext) {
       expect(refetchedLicense.signature).to.be(initialLicense.signature);
 
       await scenario.startTrial();
+      return;
       await scenario.waitForPluginToDetectLicenseUpdate();
       const trialLicense = await scenario.getLicense();
       expect(trialLicense.license?.type).to.be('trial');


### PR DESCRIPTION
## Summary

1. Unskip the `provides changes in license types` test
2. Update the test license used to test enterprise

The flaky test runner has passed this test 50 times: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2839

Closes https://github.com/elastic/kibana/issues/53575