### PR TITLE
[Dashboard Navigation] Design cleanup

### DIFF
--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_editor.scss
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_editor.scss
@@ -49,9 +49,11 @@
   }
 
   &.linkError {
-    background-color: tint($euiColorWarning, 95%);
     border: 1px solid transparentize($euiColorWarningText, .7);
-    color: $euiColorWarningText;
+
+    .navEmbeddableLinkText {
+      color: $euiColorWarningText;
+    }
 
     .navEmbeddableLinkText--noLabel {
       font-style: italic;
@@ -70,4 +72,8 @@
       visibility: visible;
     }
   }
+}
+
+.navEmbeddableDroppableLinksArea {
+  margin: 0 (-$euiSizeXS);
 }

--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor.tsx
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor.tsx
@@ -175,7 +175,10 @@ const NavigationEmbeddablePanelEditor = ({
               <EuiFormRow label={NavEmbeddableStrings.editor.panelEditor.getLinksTitle()}>
                 <div>
                   <EuiDragDropContext onDragEnd={onDragEnd}>
-                    <EuiDroppable droppableId="navEmbeddableDroppableLinksArea">
+                    <EuiDroppable
+                      className="navEmbeddableDroppableLinksArea"
+                      droppableId="navEmbeddableDroppableLinksArea"
+                    >
                       {orderedLinks.map((link, idx) => (
                         <EuiDraggable
                           spacing="m"
@@ -198,7 +201,12 @@ const NavigationEmbeddablePanelEditor = ({
                       ))}
                     </EuiDroppable>
                   </EuiDragDropContext>
-                  <EuiButtonEmpty size="s" iconType="plusInCircle" onClick={() => addOrEditLink()}>
+                  <EuiButtonEmpty
+                    flush="left"
+                    size="s"
+                    iconType="plusInCircle"
+                    onClick={() => addOrEditLink()}
+                  >
                     {NavEmbeddableStrings.editor.getAddButtonLabel()}
                   </EuiButtonEmpty>
                 </div>

--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_link.tsx
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_link.tsx
@@ -121,6 +121,7 @@ export const NavigationEmbeddablePanelEditorLink = ({
     <EuiPanel
       hasBorder
       hasShadow={false}
+      color={dashboardError ? 'warning' : 'plain'}
       className={`navEmbeddableLinkPanel ${dashboardError ? 'linkError' : ''}`}
     >
       <EuiFlexGroup gutterSize="s" responsive={false} wrap={false} alignItems="center">

--- a/src/plugins/navigation_embeddable/public/components/navigation_embeddable_component.scss
+++ b/src/plugins/navigation_embeddable/public/components/navigation_embeddable_component.scss
@@ -1,5 +1,4 @@
 .navEmbeddableComponent {
-  font-weight: $euiFontWeightRegular;
 
   .navigationLink {
     max-width: fit-content; // added this so that the error tooltip shows up **right beside** the link label
@@ -18,22 +17,22 @@
       border-radius: 0;
       .euiListGroupItem__text {
         cursor: default;
-        font-weight: $euiFontWeightSemiBold;
         color: $euiColorPrimary;
       }
     }
   }
 
   .verticalLayoutWrapper {
+    gap: $euiSizeXS;
     .navigationLink {
-      .euiListGroupItem__text {
-        line-height: 1.2rem;
-        min-block-size: 1.2rem;
-        padding-block: $euiSizeXS;
-      }
-
       &.navigationLinkCurrent {
-        box-shadow: $euiColorPrimary 2px 0 0 inset;
+        &::before {
+          content: "";
+          position: absolute;
+          width: 0.5 * $euiSizeXS;
+          height: 75%;
+          background-color: $euiColorPrimary;
+        }
       }
     }
   }
@@ -47,7 +46,7 @@
 
     .navigationLink {
       &.navigationLinkCurrent {
-        box-shadow: $euiColorPrimary 0 -2px 0 inset;
+        box-shadow: $euiColorPrimary 0 (-0.5 * $euiSizeXS) 0 inset;
 
         .euiListGroupItem__text {
           padding-inline: 0;


### PR DESCRIPTION
## Summary

- Clean up the styles to try to use native EUI props and variables wherever possible.
- Refine the blue line in the vertical layout that indicates the active link
- Adjust spacing in the form

<img width="662" alt="image" src="https://github.com/elastic/kibana/assets/4016496/a2d166e6-665e-4515-95ee-12df108619a3">

<img width="662" alt="image" src="https://github.com/elastic/kibana/assets/4016496/8ee1d480-538c-4432-98b5-580fe8b34650">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
