### PR TITLE
[docs] Improve Node.js upgrade docs

### DIFF
--- a/docs/developer/advanced/upgrading-nodejs.asciidoc
+++ b/docs/developer/advanced/upgrading-nodejs.asciidoc
@@ -44,15 +44,21 @@ Use best judgement when backporting.
 
 ==== Node.js patch upgrades
 
-Typically, you want to backport Node.js *patch* upgrades to all supported release branches that run the same *major* Node.js version (which currently is all of them, but this might change in the future once Node.js v18 is released and becomes LTS):
+Typically, you want to backport Node.js *patch* upgrades to all supported release branches that run the same *major* Node.js version (which currently is all of them, but this might change in the future):
 
-  - If upgrading Node.js 16, and the current release is 8.1.x, the main PR should target `main` and be backported to `7.17` and `8.1`.
+  - If the current release is 8.1.x, the main PR should target `main` and be backported to `7.17` and `8.1` (GitHub tag example: `backport:all-open`).
 
 ==== Node.js minor upgrades
 
-Typically, you want to backport Node.js *minor* upgrades to the next minor {kib} release branch that runs the same *major* Node.js version:
+Typically, you want to backport Node.js *minor* upgrades to the previous major {kib} release branch (if it runs the same *major* Node.js version):
 
-  - If upgrading Node.js 16, and the current release is 8.1.x, the main PR should target `main` and be backported to `7.17`, while leaving the `8.1` branch as-is.
+  - If the current release is 8.1.x, the main PR should target `main` and be backported to `7.17`, while leaving the `8.1` branch as-is (GitHub tag example: `auto-backport` + `v7.17.13`).
+
+==== Node.js major upgrades
+
+Typically, you want to backport Node.js *major* upgrades to the previous major {kib} release branch:
+
+  - If the current release is 8.1.x, the main PR should target `main` and be backported to `7.17`, while leaving the `8.1` branch as-is (GitHub tag example: `auto-backport` + `v7.17.13`).
 
 === Upgrading installed Node.js version
 


### PR DESCRIPTION
- Remove references to major Node.js version numbers where possible (so we don't have to keep them in sync every time we upgrade the major)
- Add section about how to backport a major Node.js version upgrade
- Improve phrasing in some areas to make things clearer
- Add GitHub tag examples to backport section

<!--ONMERGE {"backportTargets":["7.17","8.9"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->