### PR TITLE
[Synthetics] Adjust `from` date monitor pings query range.

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_range_from.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_range_from.ts
@@ -17,9 +17,10 @@ export const useMonitorRangeFrom = () => {
 
   return useMemo(() => {
     if (monitor?.created_at) {
-      const diff = moment(monitor?.created_at).diff(moment().subtract(30, 'day'), 'days');
-      if (diff > 0) {
-        return { to, from: monitor?.created_at, loading };
+      const monitorCreatedDaysAgo = moment().diff(monitor.created_at, 'days');
+      // Always look back at lest 3 days to account for reinstated project monitors.
+      if (monitorCreatedDaysAgo > 3 && monitorCreatedDaysAgo < 30) {
+        return { to, from: monitor.created_at, loading };
       }
     }
     return { to, from, loading };

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_range_from.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_range_from.ts
@@ -7,6 +7,9 @@
 
 import { useMemo } from 'react';
 import moment from 'moment';
+
+import { ConfigKey } from '../../../../../../common/constants/monitor_management';
+import { SourceType } from '../../../../../../common/runtime_types';
 import { useRefreshedRange } from '../../../hooks';
 import { useSelectedMonitor } from './use_selected_monitor';
 
@@ -18,11 +21,13 @@ export const useMonitorRangeFrom = () => {
   return useMemo(() => {
     if (monitor?.created_at) {
       const monitorCreatedDaysAgo = moment().diff(monitor.created_at, 'days');
+      const isProjectMonitor = monitor?.[ConfigKey.MONITOR_SOURCE_TYPE] === SourceType.PROJECT;
+
       // Always look back at lest 3 days to account for reinstated project monitors.
-      if (monitorCreatedDaysAgo > 3 && monitorCreatedDaysAgo < 30) {
+      if ((!isProjectMonitor || monitorCreatedDaysAgo > 3) && monitorCreatedDaysAgo < 30) {
         return { to, from: monitor.created_at, loading };
       }
     }
     return { to, from, loading };
-  }, [monitor?.created_at, to, from, loading]);
+  }, [monitor, to, from, loading]);
 };

--- a/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
@@ -14,8 +14,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
 
 export default function ({ getService }: FtrProviderContext) {
-  // FLAKY: https://github.com/elastic/kibana/issues/158408
-  describe.skip('EnableDefaultAlerting', function () {
+  describe('EnableDefaultAlerting', function () {
     this.tags('skipCloud');
 
     const supertest = getService('supertest');

--- a/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
+++ b/x-pack/test/api_integration/apis/synthetics/enable_default_alerting.ts
@@ -14,7 +14,8 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
 
 export default function ({ getService }: FtrProviderContext) {
-  describe('EnableDefaultAlerting', function () {
+  // FLAKY: https://github.com/elastic/kibana/issues/158408
+  describe.skip('EnableDefaultAlerting', function () {
     this.tags('skipCloud');
 
     const supertest = getService('supertest');


### PR DESCRIPTION
Fixes #162587 

## Summary

Fixes the `from` date which previously would point to current day for a restored project monitor (i.e. when monitor `created_at` is refreshed due to a re-push of a deleted project monitor).