### PR TITLE
Fixes TCP server's host for Firefox WebDriver to IPv4 loopback address

### DIFF
--- a/test/functional/services/remote/create_stdout_stream.ts
+++ b/test/functional/services/remote/create_stdout_stream.ts
@@ -53,7 +53,7 @@ export async function createStdoutSocket() {
     )
   ).toPromise();
 
-  server.listen(0);
+  server.listen(0, '127.0.0.1');
   cleanup$.subscribe(() => {
     server.close();
   });


### PR DESCRIPTION
Closes #163281

## Summary

This PR forces TCP server to listen on `127.0.0.1`, which helps to avoid `EADDRNOTAVAIL` error on IPv6 during Firefox WebDriver's initialization.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)