### PR TITLE
Revert "Enable API protection in serverless"

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -51,7 +51,7 @@ xpack.security.ui.roleManagementEnabled: false
 xpack.security.ui.roleMappingManagementEnabled: false
 
 # Enforce restring access to internal APIs see https://github.com/elastic/kibana/issues/151940
-server.restrictInternalApis: true
+# server.restrictInternalApis: true
 # Telemetry enabled by default and not disableable via UI
 telemetry.optIn: true
 telemetry.allowChangingOptInStatus: false


### PR DESCRIPTION
Reverts elastic/kibana#162149

Fleet API are not mark public as yet, and that commit break serverless for us, we have a task in our current sprint to correctly mark Fleet APIs public or not. 

Can we revert that commit while it's done? cc @juliaElastic 