### PR TITLE
fix(slo): index settings auto expand replicas

### DIFF
--- a/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
@@ -11,6 +11,7 @@ export const getSLOSettingsTemplate = (name: string) => ({
   name,
   template: {
     settings: {
+      auto_expand_replicas: '0-1',
       hidden: true,
     },
   },

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_settings_template.ts
@@ -11,7 +11,7 @@ export const getSLOSettingsTemplate = (name: string) => ({
   name,
   template: {
     settings: {
-      auto_expand_replicas: '0-1',
+      auto_expand_replicas: '0-all',
       hidden: true,
     },
   },

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_summary_settings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_summary_settings_template.ts
@@ -11,6 +11,7 @@ export const getSLOSummarySettingsTemplate = (name: string) => ({
   name,
   template: {
     settings: {
+      auto_expand_replicas: '0-1',
       hidden: true,
     },
   },

--- a/x-pack/plugins/observability/server/assets/component_templates/slo_summary_settings_template.ts
+++ b/x-pack/plugins/observability/server/assets/component_templates/slo_summary_settings_template.ts
@@ -11,7 +11,7 @@ export const getSLOSummarySettingsTemplate = (name: string) => ({
   name,
   template: {
     settings: {
-      auto_expand_replicas: '0-1',
+      auto_expand_replicas: '0-all',
       hidden: true,
     },
   },


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/163230

This PR sets the auto_expand_replicas index settings to `0-all` so the SLO index health becomes green on a 1 node cluster.