### PR TITLE
[Cases] Flaky test UserActions pagination

### DIFF
--- a/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/index.test.tsx
@@ -466,28 +466,6 @@ describe.skip(`UserActions`, () => {
       expect(screen.getAllByTestId('user-actions-list')).toHaveLength(1);
     });
 
-    it('shows more button visible when hasNext page is true', async () => {
-      useInfiniteFindCaseUserActionsMock.mockReturnValue({
-        ...defaultInfiniteUseFindCaseUserActions,
-        hasNextPage: true,
-      });
-      const props = {
-        ...defaultProps,
-        userActionsStats: {
-          total: 25,
-          totalComments: 10,
-          totalOtherActions: 15,
-        },
-      };
-
-      appMockRender.render(<UserActions {...props} />);
-
-      await waitForComponentToUpdate();
-
-      expect(screen.getAllByTestId('user-actions-list')).toHaveLength(2);
-      expect(screen.getByTestId('cases-show-more-user-actions')).toBeInTheDocument();
-    });
-
     it('call fetchNextPage on showMore button click', async () => {
       useInfiniteFindCaseUserActionsMock.mockReturnValue({
         ...defaultInfiniteUseFindCaseUserActions,


### PR DESCRIPTION
Fixes #156748

## Summary

[There is already a functional test that covers the same functionality.](https://github.com/elastic/kibana/blob/main/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts#L727)

| Old Test  | Scenario | Where it is covered now |
| -------------   |  -------------   | ------------- |
| hasNext  page is true |  there are 2 `user-actions-list`  | functional test creates 24 UAs, displays two columns initially |
| hasNext  page is true |  `cases-show-more-user-actions` in document  |  functional test creates 24 UAs clicks `cases-show-more-user-actions` |