### PR TITLE
chore(NA): skip failing suite on osquery/cypress/e2e/all/alerts.cy.ts

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts.cy.ts
@@ -95,7 +95,7 @@ describe('Alert Event Details', () => {
     });
   });
 
-  describe('Response actions', () => {
+  describe.skip('Response actions', () => {
     let multiQueryPackId: string;
     let multiQueryPackName: string;
     let ruleId: string;


### PR DESCRIPTION
This PR intends to skip a failing suite to unblock the unsupported FTRs pipeline along the same lines of what was done at https://github.com/elastic/kibana/pull/163322