### PR TITLE
[Security Solution] add serverless flag to endpoint policies

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -16,7 +16,8 @@ export const policyFactory = (
   cloud = false,
   licenseUid = '',
   clusterUuid = '',
-  clusterName = ''
+  clusterName = '',
+  serverless = false
 ): PolicyConfig => {
   return {
     meta: {
@@ -25,6 +26,7 @@ export const policyFactory = (
       cluster_uuid: clusterUuid,
       cluster_name: clusterName,
       cloud,
+      serverless,
     },
     windows: {
       events: {

--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
@@ -192,7 +192,14 @@ describe('Policy Config helpers', () => {
 // This constant makes sure that if the type `PolicyConfig` is ever modified,
 // the logic for disabling protections is also modified due to type check.
 export const eventsOnlyPolicy = (): PolicyConfig => ({
-  meta: { license: '', cloud: false, license_uid: '', cluster_name: '', cluster_uuid: '' },
+  meta: {
+    license: '',
+    cloud: false,
+    license_uid: '',
+    cluster_name: '',
+    cluster_uuid: '',
+    serverless: false,
+  },
   windows: {
     events: {
       credential_access: true,

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -945,6 +945,8 @@ export interface PolicyConfig {
     license_uid: string;
     cluster_uuid: string;
     cluster_name: string;
+    serverless: boolean;
+    heartbeatinterval?: number;
   };
   windows: {
     advanced?: {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
@@ -275,6 +275,7 @@ describe('policy details: ', () => {
                     license_uid: '',
                     cluster_name: '',
                     cluster_uuid: '',
+                    serverless: false,
                   },
                   windows: {
                     events: {

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.test.ts
@@ -109,7 +109,8 @@ describe('ingest_integration tests ', () => {
       cloud = cloudService.isCloudEnabled,
       licenseUuid = 'updated-uid',
       clusterUuid = '',
-      clusterName = ''
+      clusterName = '',
+      isServerlessEnabled = cloudService.isServerlessEnabled
     ) => ({
       type: 'endpoint',
       enabled: true,
@@ -118,7 +119,14 @@ describe('ingest_integration tests ', () => {
         integration_config: {},
         policy: {
           value: disableProtections(
-            policyFactory(license, cloud, licenseUuid, clusterUuid, clusterName)
+            policyFactory(
+              license,
+              cloud,
+              licenseUuid,
+              clusterUuid,
+              clusterName,
+              isServerlessEnabled
+            )
           ),
         },
         artifact_manifest: { value: manifest },
@@ -527,6 +535,7 @@ describe('ingest_integration tests ', () => {
     beforeEach(() => {
       licenseEmitter.next(Platinum); // set license level to platinum
     });
+
     it('updates successfully when meta fields differ from services', async () => {
       const mockPolicy = policyFactory();
       mockPolicy.meta.cloud = true; // cloud mock will return true
@@ -534,6 +543,7 @@ describe('ingest_integration tests ', () => {
       mockPolicy.meta.cluster_name = 'updated-name';
       mockPolicy.meta.cluster_uuid = 'updated-uuid';
       mockPolicy.meta.license_uid = 'updated-uid';
+      mockPolicy.meta.serverless = false;
       const logger = loggingSystemMock.create().get('ingest_integration.test');
       const callback = getPackagePolicyUpdateCallback(
         logger,
@@ -552,6 +562,7 @@ describe('ingest_integration tests ', () => {
       policyConfig.inputs[0]!.config!.policy.value.meta.cluster_name = 'original-name';
       policyConfig.inputs[0]!.config!.policy.value.meta.cluster_uuid = 'original-uuid';
       policyConfig.inputs[0]!.config!.policy.value.meta.license_uid = 'original-uid';
+      policyConfig.inputs[0]!.config!.policy.value.meta.serverless = true;
       const updatedPolicyConfig = await callback(
         policyConfig,
         soClient,
@@ -569,6 +580,7 @@ describe('ingest_integration tests ', () => {
       mockPolicy.meta.cluster_name = 'updated-name';
       mockPolicy.meta.cluster_uuid = 'updated-uuid';
       mockPolicy.meta.license_uid = 'updated-uid';
+      mockPolicy.meta.serverless = false;
       const logger = loggingSystemMock.create().get('ingest_integration.test');
       const callback = getPackagePolicyUpdateCallback(
         logger,
@@ -586,6 +598,7 @@ describe('ingest_integration tests ', () => {
       policyConfig.inputs[0]!.config!.policy.value.meta.cluster_name = 'updated-name';
       policyConfig.inputs[0]!.config!.policy.value.meta.cluster_uuid = 'updated-uuid';
       policyConfig.inputs[0]!.config!.policy.value.meta.license_uid = 'updated-uid';
+      policyConfig.inputs[0]!.config!.policy.value.meta.serverless = false;
       const updatedPolicyConfig = await callback(
         policyConfig,
         soClient,

--- a/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/fleet_integration.ts
@@ -57,14 +57,16 @@ const shouldUpdateMetaValues = (
   currentCloudInfo: boolean,
   currentClusterName: string,
   currentClusterUUID: string,
-  currentLicenseUID: string
+  currentLicenseUID: string,
+  currentIsServerlessEnabled: boolean
 ) => {
   return (
     endpointPackagePolicy.meta.license !== currentLicenseType ||
     endpointPackagePolicy.meta.cloud !== currentCloudInfo ||
     endpointPackagePolicy.meta.cluster_name !== currentClusterName ||
     endpointPackagePolicy.meta.cluster_uuid !== currentClusterUUID ||
-    endpointPackagePolicy.meta.license_uid !== currentLicenseUID
+    endpointPackagePolicy.meta.license_uid !== currentLicenseUID ||
+    endpointPackagePolicy.meta.serverless !== currentIsServerlessEnabled
   );
 };
 
@@ -221,7 +223,8 @@ export const getPackagePolicyUpdateCallback = (
         cloud?.isCloudEnabled,
         esClientInfo.cluster_name,
         esClientInfo.cluster_uuid,
-        licenseService.getLicenseUID()
+        licenseService.getLicenseUID(),
+        cloud?.isServerlessEnabled
       )
     ) {
       newEndpointPackagePolicy.meta.license = licenseService.getLicenseType();
@@ -229,6 +232,7 @@ export const getPackagePolicyUpdateCallback = (
       newEndpointPackagePolicy.meta.cluster_name = esClientInfo.cluster_name;
       newEndpointPackagePolicy.meta.cluster_uuid = esClientInfo.cluster_uuid;
       newEndpointPackagePolicy.meta.license_uid = licenseService.getLicenseUID();
+      newEndpointPackagePolicy.meta.serverless = cloud?.isServerlessEnabled;
 
       endpointIntegrationData.inputs[0].config.policy.value = newEndpointPackagePolicy;
     }

--- a/x-pack/plugins/security_solution/server/fleet_integration/handlers/create_default_policy.ts
+++ b/x-pack/plugins/security_solution/server/fleet_integration/handlers/create_default_policy.ts
@@ -49,6 +49,7 @@ export const createDefaultPolicy = (
     ? esClientInfo.cluster_uuid
     : factoryPolicy.meta.cluster_uuid;
   factoryPolicy.meta.license_uid = licenseService.getLicenseUID();
+  factoryPolicy.meta.serverless = cloud.isServerlessEnabled || false;
 
   let defaultPolicyPerType: PolicyConfig =
     config?.type === 'cloud'

--- a/x-pack/plugins/security_solution_serverless/kibana.jsonc
+++ b/x-pack/plugins/security_solution_serverless/kibana.jsonc
@@ -19,7 +19,8 @@
       "securitySolution",
       "serverless",
       "taskManager",
-      "cloud"
+      "cloud",
+      "fleet"
     ],
     "optionalPlugins": [
       "securitySolutionEss"

--- a/x-pack/plugins/security_solution_serverless/server/endpoint/services/index.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/services/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { endpointMeteringService } from './metering_service';
+export { setEndpointPackagePolicyServerlessFlag } from './set_package_policy_flag';

--- a/x-pack/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { cloneDeep } from 'lodash';
+
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+import { elasticsearchServiceMock, savedObjectsClientMock } from '@kbn/core/server/mocks';
+import type { ElasticsearchClientMock } from '@kbn/core/server/mocks';
+import {
+  FLEET_ENDPOINT_PACKAGE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
+} from '@kbn/fleet-plugin/common';
+import type { PackagePolicy } from '@kbn/fleet-plugin/common';
+import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import { createPackagePolicyServiceMock } from '@kbn/fleet-plugin/server/mocks';
+import { policyFactory } from '@kbn/security-solution-plugin/common/endpoint/models/policy_config';
+
+import { setEndpointPackagePolicyServerlessFlag } from './set_package_policy_flag';
+
+describe('setEndpointPackagePolicyServerlessFlag', () => {
+  let esClientMock: ElasticsearchClientMock;
+  let soClientMock: jest.Mocked<SavedObjectsClientContract>;
+  let packagePolicyServiceMock: jest.Mocked<PackagePolicyClient>;
+
+  function generatePackagePolicy(policy = policyFactory()): PackagePolicy {
+    return {
+      inputs: [
+        {
+          config: {
+            policy: {
+              value: policy,
+            },
+          },
+        },
+      ],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any as PackagePolicy;
+  }
+
+  beforeEach(() => {
+    esClientMock = elasticsearchServiceMock.createClusterClient().asInternalUser;
+    soClientMock = savedObjectsClientMock.create();
+    packagePolicyServiceMock = createPackagePolicyServiceMock();
+  });
+
+  it('updates serverless flag for endpoint policies', async () => {
+    const packagePolicy1 = generatePackagePolicy();
+    const packagePolicy2 = generatePackagePolicy();
+    packagePolicyServiceMock.list.mockResolvedValue({
+      items: [packagePolicy1, packagePolicy2],
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+      total: 2,
+    });
+    packagePolicyServiceMock.bulkCreate.mockImplementation();
+
+    await setEndpointPackagePolicyServerlessFlag(
+      soClientMock,
+      esClientMock,
+      packagePolicyServiceMock
+    );
+
+    const expectedPolicy1 = cloneDeep(packagePolicy1);
+    expectedPolicy1!.inputs[0]!.config!.policy.value.meta.serverless = true;
+    const expectedPolicy2 = cloneDeep(packagePolicy2);
+    expectedPolicy2!.inputs[0]!.config!.policy.value.meta.serverless = true;
+    const expectedPolicies = [expectedPolicy1, expectedPolicy2];
+    expect(packagePolicyServiceMock.list).toBeCalledWith(soClientMock, {
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${FLEET_ENDPOINT_PACKAGE}`,
+    });
+    expect(packagePolicyServiceMock.bulkUpdate).toBeCalledWith(
+      soClientMock,
+      esClientMock,
+      expectedPolicies
+    );
+  });
+
+  it('batches properly when over perPage', async () => {
+    packagePolicyServiceMock.list
+      .mockResolvedValueOnce({
+        items: [],
+        page: 1,
+        perPage: SO_SEARCH_LIMIT,
+        total: SO_SEARCH_LIMIT,
+      })
+      .mockResolvedValueOnce({
+        items: [],
+        page: 2,
+        perPage: SO_SEARCH_LIMIT,
+        total: 1,
+      });
+    packagePolicyServiceMock.bulkCreate.mockImplementation();
+
+    await setEndpointPackagePolicyServerlessFlag(
+      soClientMock,
+      esClientMock,
+      packagePolicyServiceMock
+    );
+
+    expect(packagePolicyServiceMock.list).toHaveBeenNthCalledWith(1, soClientMock, {
+      page: 1,
+      perPage: SO_SEARCH_LIMIT,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${FLEET_ENDPOINT_PACKAGE}`,
+    });
+    expect(packagePolicyServiceMock.list).toHaveBeenNthCalledWith(2, soClientMock, {
+      page: 2,
+      perPage: SO_SEARCH_LIMIT,
+      kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${FLEET_ENDPOINT_PACKAGE}`,
+    });
+  });
+});

--- a/x-pack/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/services/set_package_policy_flag.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract, ElasticsearchClient } from '@kbn/core/server';
+import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import type { ListResult, PackagePolicy } from '@kbn/fleet-plugin/common';
+import {
+  FLEET_ENDPOINT_PACKAGE,
+  PACKAGE_POLICY_SAVED_OBJECT_TYPE,
+  SO_SEARCH_LIMIT,
+} from '@kbn/fleet-plugin/common';
+
+// set all endpoint policies serverless flag to true
+// required so that endpoint will write heartbeats
+export async function setEndpointPackagePolicyServerlessFlag(
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  packagePolicyService: PackagePolicyClient
+): Promise<void> {
+  const perPage: number = SO_SEARCH_LIMIT;
+  let page: number = 1;
+  let endpointPackagesResult: ListResult<PackagePolicy> | undefined;
+
+  while (page === 1 || endpointPackagesResult?.total === perPage) {
+    endpointPackagesResult = await getEndpointPackagePolicyBatch(
+      soClient,
+      packagePolicyService,
+      page,
+      perPage
+    );
+    await processBatch(endpointPackagesResult, soClient, esClient, packagePolicyService);
+    page++;
+  }
+}
+
+function getEndpointPackagePolicyBatch(
+  soClient: SavedObjectsClientContract,
+  packagePolicyService: PackagePolicyClient,
+  page: number,
+  perPage: number
+): Promise<ListResult<PackagePolicy>> {
+  return packagePolicyService.list(soClient, {
+    page,
+    perPage,
+    kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${FLEET_ENDPOINT_PACKAGE}`,
+  });
+}
+
+async function processBatch(
+  endpointPackagesResult: ListResult<PackagePolicy>,
+  soClient: SavedObjectsClientContract,
+  esClient: ElasticsearchClient,
+  packagePolicyService: PackagePolicyClient
+): Promise<void> {
+  if (!endpointPackagesResult.total) {
+    return;
+  }
+
+  const updatedEndpointPackages = endpointPackagesResult.items.map((endpointPackage) => ({
+    ...endpointPackage,
+    inputs: endpointPackage.inputs.map((input) => {
+      const config = input?.config || {};
+      const policy = config.policy || {};
+      const policyValue = policy?.value || {};
+      const meta = policyValue?.meta || {};
+      return {
+        ...input,
+        config: {
+          ...config,
+          policy: {
+            ...policy,
+            value: {
+              ...policyValue,
+              meta: {
+                ...meta,
+                serverless: true,
+              },
+            },
+          },
+        },
+      };
+    }),
+  }));
+  await packagePolicyService.bulkUpdate(soClient, esClient, updatedEndpointPackages);
+}

--- a/x-pack/plugins/security_solution_serverless/server/types.ts
+++ b/x-pack/plugins/security_solution_serverless/server/types.ts
@@ -18,6 +18,7 @@ import type {
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { SecuritySolutionEssPluginSetup } from '@kbn/security-solution-ess/server';
 import type { MlPluginSetup } from '@kbn/ml-plugin/server';
+import type { FleetStartContract } from '@kbn/fleet-plugin/server';
 
 import type { ProductTier } from '../common/product';
 
@@ -43,6 +44,7 @@ export interface SecuritySolutionServerlessPluginStartDeps {
   securitySolution: SecuritySolutionPluginStart;
   features: PluginStartContract;
   taskManager: TaskManagerStartContract;
+  fleet: FleetStartContract;
 }
 
 export interface UsageRecord {

--- a/x-pack/plugins/security_solution_serverless/tsconfig.json
+++ b/x-pack/plugins/security_solution_serverless/tsconfig.json
@@ -35,6 +35,7 @@
     "@kbn/kibana-utils-plugin",
     "@kbn/task-manager-plugin",
     "@kbn/cloud-plugin",
-    "@kbn/cloud-security-posture-plugin"
+    "@kbn/cloud-security-posture-plugin",
+    "@kbn/fleet-plugin"
   ]
 }


### PR DESCRIPTION
## Summary

endpoint only sends heartbeats used for metering when the serverless flag is set to true in the package policy. this PR adds the ability to automatically configure endpoint package policy serverless flag to true when running in serverless:
* sets endpoint integration policy's `policy.meta.serverless` to `true` on serverless security solution plugin start
* automatically sets `policy.meta.serverless` during endpoint package policy create/update

will look into additional failure handling / retry logic in follow up.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
