### PR TITLE
remove deprecated components, improve spacing and title

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -382,7 +382,7 @@ src/plugins/expression_reveal_image @elastic/kibana-presentation
 src/plugins/expression_shape @elastic/kibana-presentation
 src/plugins/chart_expressions/expression_tagcloud @elastic/kibana-visualizations
 src/plugins/chart_expressions/expression_xy @elastic/kibana-visualizations
-examples/expressions_explorer @elastic/kibana-app-services
+examples/expressions_explorer @elastic/kibana-visualizations
 src/plugins/expressions @elastic/kibana-visualizations
 packages/kbn-failed-test-reporter-cli @elastic/kibana-operations @elastic/appex-qa
 x-pack/test/plugin_api_integration/plugins/feature_usage_test @elastic/kibana-security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -382,7 +382,7 @@ src/plugins/expression_reveal_image @elastic/kibana-presentation
 src/plugins/expression_shape @elastic/kibana-presentation
 src/plugins/chart_expressions/expression_tagcloud @elastic/kibana-visualizations
 src/plugins/chart_expressions/expression_xy @elastic/kibana-visualizations
-examples/expressions_explorer @elastic/kibana-visualizations
+examples/expressions_explorer @elastic/kibana-app-services
 src/plugins/expressions @elastic/kibana-visualizations
 packages/kbn-failed-test-reporter-cli @elastic/kibana-operations @elastic/appex-qa
 x-pack/test/plugin_api_integration/plugins/feature_usage_test @elastic/kibana-security

--- a/examples/expressions_explorer/public/actions_and_expressions.tsx
+++ b/examples/expressions_explorer/public/actions_and_expressions.tsx
@@ -11,13 +11,14 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPageBody,
-  EuiPageContent_Deprecated as EuiPageContent,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageTemplate,
+  EuiPageSection,
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiPanel,
   EuiText,
   EuiTitle,
+  EuiSpacer,
 } from '@elastic/eui';
 import { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
@@ -55,8 +56,8 @@ export function ActionsExpressionsExample({ expressions, actions }: Props) {
           </EuiTitle>
         </EuiPageHeaderSection>
       </EuiPageHeader>
-      <EuiPageContent data-test-subj="expressionsActionsTest">
-        <EuiPageContentBody>
+      <EuiPageTemplate.Section data-test-subj="expressionsActionsTest">
+        <EuiPageSection>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiText>
@@ -66,6 +67,8 @@ export function ActionsExpressionsExample({ expressions, actions }: Props) {
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
+
+          <EuiSpacer />
 
           <EuiFlexGroup gutterSize="l">
             <EuiFlexItem>
@@ -86,8 +89,8 @@ export function ActionsExpressionsExample({ expressions, actions }: Props) {
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiPageContentBody>
-      </EuiPageContent>
+        </EuiPageSection>
+      </EuiPageTemplate.Section>
     </EuiPageBody>
   );
 }

--- a/examples/expressions_explorer/public/actions_and_expressions2.tsx
+++ b/examples/expressions_explorer/public/actions_and_expressions2.tsx
@@ -11,13 +11,14 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPageBody,
-  EuiPageContent_Deprecated as EuiPageContent,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageTemplate,
+  EuiPageSection,
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiPanel,
   EuiText,
   EuiTitle,
+  EuiSpacer,
 } from '@elastic/eui';
 import { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { UiActionsStart } from '@kbn/ui-actions-plugin/public';
@@ -54,8 +55,8 @@ export function ActionsExpressionsExample2({ expressions, actions }: Props) {
           </EuiTitle>
         </EuiPageHeaderSection>
       </EuiPageHeader>
-      <EuiPageContent>
-        <EuiPageContentBody data-test-subj="expressionsVariablesTest">
+      <EuiPageTemplate.Section>
+        <EuiPageSection data-test-subj="expressionsVariablesTest">
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiText>
@@ -64,6 +65,8 @@ export function ActionsExpressionsExample2({ expressions, actions }: Props) {
               </EuiText>
             </EuiFlexItem>
           </EuiFlexGroup>
+
+          <EuiSpacer />
 
           <EuiFlexGroup gutterSize="l">
             <EuiFlexItem>
@@ -86,8 +89,8 @@ export function ActionsExpressionsExample2({ expressions, actions }: Props) {
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiPageContentBody>
-      </EuiPageContent>
+        </EuiPageSection>
+      </EuiPageTemplate.Section>
     </EuiPageBody>
   );
 }

--- a/examples/expressions_explorer/public/app.tsx
+++ b/examples/expressions_explorer/public/app.tsx
@@ -12,8 +12,8 @@ import {
   EuiPage,
   EuiPageHeader,
   EuiPageBody,
-  EuiPageContent_Deprecated as EuiPageContent,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageTemplate,
+  EuiPageSection,
   EuiSpacer,
   EuiText,
   EuiLink,
@@ -55,9 +55,11 @@ const ExpressionsExplorer = ({
     <KibanaReactContextProvider>
       <EuiPage>
         <EuiPageBody>
-          <EuiPageHeader>Expressions Explorer</EuiPageHeader>
-          <EuiPageContent>
-            <EuiPageContentBody>
+          <EuiPageSection>
+            <EuiPageHeader pageTitle="Expressions Explorer" />
+          </EuiPageSection>
+          <EuiPageTemplate.Section>
+            <EuiPageSection>
               <EuiText>
                 <p>
                   There are a couple of ways to run the expressions. Below some of the options are
@@ -87,8 +89,8 @@ const ExpressionsExplorer = ({
               <EuiSpacer />
 
               <ActionsExpressionsExample2 expressions={expressions} actions={actions} />
-            </EuiPageContentBody>
-          </EuiPageContent>
+            </EuiPageSection>
+          </EuiPageTemplate.Section>
         </EuiPageBody>
       </EuiPage>
     </KibanaReactContextProvider>

--- a/examples/expressions_explorer/public/render_expressions.tsx
+++ b/examples/expressions_explorer/public/render_expressions.tsx
@@ -11,14 +11,15 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPageBody,
-  EuiPageContent_Deprecated as EuiPageContent,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageTemplate,
+  EuiPageSection,
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiPanel,
   EuiText,
   EuiTitle,
   EuiButton,
+  EuiSpacer,
 } from '@elastic/eui';
 import { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { Start as InspectorStart } from '@kbn/inspector-plugin/public';
@@ -49,8 +50,8 @@ export function RenderExpressionsExample({ expressions, inspector }: Props) {
           </EuiTitle>
         </EuiPageHeaderSection>
       </EuiPageHeader>
-      <EuiPageContent>
-        <EuiPageContentBody>
+      <EuiPageTemplate.Section>
+        <EuiPageSection>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiText>
@@ -68,6 +69,8 @@ export function RenderExpressionsExample({ expressions, inspector }: Props) {
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
+
+          <EuiSpacer />
 
           <EuiFlexGroup gutterSize="l">
             <EuiFlexItem>
@@ -90,8 +93,8 @@ export function RenderExpressionsExample({ expressions, inspector }: Props) {
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiPageContentBody>
-      </EuiPageContent>
+        </EuiPageSection>
+      </EuiPageTemplate.Section>
     </EuiPageBody>
   );
 }

--- a/examples/expressions_explorer/public/run_expressions.tsx
+++ b/examples/expressions_explorer/public/run_expressions.tsx
@@ -13,14 +13,15 @@ import {
   EuiFlexItem,
   EuiFlexGroup,
   EuiPageBody,
-  EuiPageContent_Deprecated as EuiPageContent,
-  EuiPageContentBody_Deprecated as EuiPageContentBody,
+  EuiPageTemplate,
+  EuiPageSection,
   EuiPageHeader,
   EuiPageHeaderSection,
   EuiPanel,
   EuiText,
   EuiTitle,
   EuiButton,
+  EuiSpacer,
 } from '@elastic/eui';
 import { ExpressionsStart } from '@kbn/expressions-plugin/public';
 import { Adapters, Start as InspectorStart } from '@kbn/inspector-plugin/public';
@@ -64,8 +65,8 @@ export function RunExpressionsExample({ expressions, inspector }: Props) {
           </EuiTitle>
         </EuiPageHeaderSection>
       </EuiPageHeader>
-      <EuiPageContent>
-        <EuiPageContentBody>
+      <EuiPageTemplate.Section>
+        <EuiPageSection>
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiText>
@@ -83,6 +84,8 @@ export function RunExpressionsExample({ expressions, inspector }: Props) {
               </EuiButton>
             </EuiFlexItem>
           </EuiFlexGroup>
+
+          <EuiSpacer />
 
           <EuiFlexGroup gutterSize="l">
             <EuiFlexItem>
@@ -104,8 +107,8 @@ export function RunExpressionsExample({ expressions, inspector }: Props) {
               </EuiPanel>
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiPageContentBody>
-      </EuiPageContent>
+        </EuiPageSection>
+      </EuiPageTemplate.Section>
     </EuiPageBody>
   );
 }


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/elastic/kibana/issues/161425

New look:

<img width="1645" alt="image" src="https://github.com/elastic/kibana/assets/82822460/9da0ae4a-9f6e-4744-80c1-9a13b6d23d1c">
