### PR TITLE
[7.17] Bump require-in-the-middle from v6.0.0 to v7.2.0 (#163164)

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,7 +371,7 @@
     "regenerator-runtime": "^0.13.3",
     "remark-parse-no-trim": "^8.0.4",
     "remark-stringify": "^8.0.3",
-    "require-in-the-middle": "^6.0.0",
+    "require-in-the-middle": "^7.2.0",
     "reselect": "^4.0.0",
     "resize-observer-polyfill": "^1.5.1",
     "rison-node": "1.0.2",

--- a/src/setup_node_env/harden/child_process.js
+++ b/src/setup_node_env/harden/child_process.js
@@ -6,13 +6,13 @@
  * Side Public License, v 1.
  */
 
-var hook = require('require-in-the-middle');
+var ritm = require('require-in-the-middle');
 
 // Ensure, when spawning a new child process, that the `options` and the
 // `options.env` object passed to the child process function doesn't inherit
 // from `Object.prototype`. This protects against similar RCE vulnerabilities
 // as described in CVE-2019-7609
-hook(['child_process'], function (cp) {
+new ritm.Hook(['child_process'], function (cp) {
   // The `exec` function is currently just a wrapper around `execFile`. So for
   // now there's no need to patch it. If this changes in the future, our tests
   // will fail and we can uncomment the line below.

--- a/src/setup_node_env/harden/lodash_template.js
+++ b/src/setup_node_env/harden/lodash_template.js
@@ -6,26 +6,26 @@
  * Side Public License, v 1.
  */
 
-var hook = require('require-in-the-middle');
+var ritm = require('require-in-the-middle');
 var isIterateeCall = require('lodash/_isIterateeCall');
 
-hook(['lodash'], function (lodash) {
+new ritm.Hook(['lodash'], function (lodash) {
   // we use lodash.template here to harden third-party usage of this otherwise banned function.
   // eslint-disable-next-line no-restricted-properties
   lodash.template = createProxy(lodash.template);
   return lodash;
 });
 
-hook(['lodash/template'], function (template) {
+new ritm.Hook(['lodash/template'], function (template) {
   return createProxy(template);
 });
 
-hook(['lodash/fp'], function (fp) {
+new ritm.Hook(['lodash/fp'], function (fp) {
   fp.template = createFpProxy(fp.template);
   return fp;
 });
 
-hook(['lodash/fp/template'], function (template) {
+new ritm.Hook(['lodash/fp/template'], function (template) {
   return createFpProxy(template);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -24943,16 +24943,7 @@ require-from-string@^2.0.1, require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-require-in-the-middle@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-6.0.0.tgz#01cc6416286fb5e672d0fe031d996f8bc202509d"
-  integrity sha512-+dtWQ7l2lqQDxheaG3jjyN1QI37gEwvzACSgjYi4/C2y+ZTUMeRW8BIOm+9NBKvwaMBUSZfPXVOt1skB0vBkRw==
-  dependencies:
-    debug "^4.1.1"
-    module-details-from-path "^1.0.3"
-    resolve "^1.22.1"
-
-require-in-the-middle@^7.1.1:
+require-in-the-middle@^7.1.1, require-in-the-middle@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz#b539de8f00955444dc8aed95e17c69b0a4f10fcf"
   integrity sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Bump require-in-the-middle from v6.0.0 to v7.2.0 (#163164)](https://github.com/elastic/kibana/pull/163164)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Thomas Watson","email":"watson@elastic.co"},"sourceCommit":{"committedDate":"2023-08-04T21:27:17Z","message":"Bump require-in-the-middle from v6.0.0 to v7.2.0 (#163164)","sha":"872f011e77aa6b58272193cddd467e26fb516159","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","auto-backport","v7.17.13"],"number":163164,"url":"https://github.com/elastic/kibana/pull/163164","mergeCommit":{"message":"Bump require-in-the-middle from v6.0.0 to v7.2.0 (#163164)","sha":"872f011e77aa6b58272193cddd467e26fb516159"}},"sourceBranch":"main","suggestedTargetBranches":["7.17"],"targetPullRequestStates":[{"branch":"7.17","label":"v7.17.13","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->