### PR TITLE
[Lens] Improvement of the discard changes modal

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -188,14 +188,14 @@ export function App({
       ) {
         return actions.confirm(
           i18n.translate('xpack.lens.app.unsavedWorkMessage', {
-            defaultMessage: 'Leave Lens with unsaved work?',
+            defaultMessage: 'Leave with unsaved changes?',
           }),
           i18n.translate('xpack.lens.app.unsavedWorkTitle', {
             defaultMessage: 'Unsaved changes',
           }),
           undefined,
           i18n.translate('xpack.lens.app.unsavedWorkConfirmBtn', {
-            defaultMessage: 'Discard changes',
+            defaultMessage: 'Discard',
           }),
           'danger'
         );

--- a/x-pack/plugins/lens/public/app_plugin/app.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/app.tsx
@@ -195,7 +195,7 @@ export function App({
           }),
           undefined,
           i18n.translate('xpack.lens.app.unsavedWorkConfirmBtn', {
-            defaultMessage: 'Discard',
+            defaultMessage: 'Discard changes',
           }),
           'danger'
         );
@@ -676,16 +676,16 @@ export function App({
       {isGoBackToVizEditorModalVisible && (
         <EuiConfirmModal
           maxWidth={600}
-          title={i18n.translate('xpack.lens.app.goBackModalTitle', {
-            defaultMessage: 'Discard changes?',
+          title={i18n.translate('xpack.lens.app.unsavedWorkTitle', {
+            defaultMessage: 'Unsaved changes',
           })}
           onCancel={() => setIsGoBackToVizEditorModalVisible(false)}
           onConfirm={navigateToVizEditor}
           cancelButtonText={i18n.translate('xpack.lens.app.goBackModalCancelBtn', {
             defaultMessage: 'Cancel',
           })}
-          confirmButtonText={i18n.translate('xpack.lens.app.goBackModalTitle', {
-            defaultMessage: 'Discard changes?',
+          confirmButtonText={i18n.translate('xpack.lens.app.unsavedWorkConfirmBtn', {
+            defaultMessage: 'Discard changes',
           })}
           buttonColor="danger"
           defaultFocusedButton="confirm"
@@ -693,7 +693,7 @@ export function App({
         >
           {i18n.translate('xpack.lens.app.goBackModalMessage', {
             defaultMessage:
-              'The changes you have made here are not backwards compatible with your original {contextOriginatingApp} visualization. Are you sure you want to discard these unsaved changes and return to {contextOriginatingApp}?',
+              'Your changes here won’t work with your original {contextOriginatingApp} visualization. Leave with unsaved changes and return to {contextOriginatingApp}?',
             values: { contextOriginatingApp },
           })}
         </EuiConfirmModal>

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -20813,7 +20813,6 @@
     "xpack.lens.app.exploreDataInDiscoverDrilldown": "在 Discover 中打开",
     "xpack.lens.app.exploreDataInDiscoverDrilldown.newTabConfig": "在新选项卡中打开",
     "xpack.lens.app.goBackModalCancelBtn": "取消",
-    "xpack.lens.app.goBackModalTitle": "放弃更改？",
     "xpack.lens.app.inspect": "检查",
     "xpack.lens.app.inspectAriaLabel": "检查",
     "xpack.lens.app.replaceInCanvas": "在 Canvas 中替换",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/161493

Leaving the editor with unsaved changes
<img width="690" alt="image" src="https://github.com/elastic/kibana/assets/17003240/1587b8dc-83a1-4d89-993d-3150dea17836">

Go back to TSVB modal
<img width="742" alt="image" src="https://github.com/elastic/kibana/assets/17003240/a49667a1-927b-4aa8-aa1a-765a14ebd925">
