### PR TITLE
[Cloud Security] Do not filter vulnerabilities by CVE

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -123,5 +123,3 @@ export const VULNERABILITIES_SEVERITY: Record<VulnSeverity, VulnSeverity> = {
   CRITICAL: 'CRITICAL',
   UNKNOWN: 'UNKNOWN',
 };
-
-export const VULNERABILITIES_ENUMERATION = 'CVE';

--- a/x-pack/plugins/cloud_security_posture/common/utils/get_safe_vulnerabilities_query_filter.ts
+++ b/x-pack/plugins/cloud_security_posture/common/utils/get_safe_vulnerabilities_query_filter.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
-import { VULNERABILITIES_ENUMERATION, VULNERABILITIES_SEVERITY } from '../constants';
+import { VULNERABILITIES_SEVERITY } from '../constants';
 
 export const getSafeVulnerabilitiesQueryFilter = (query?: QueryDslQueryContainer) => ({
   ...query,
@@ -29,7 +29,6 @@ export const getSafeVulnerabilitiesQueryFilter = (query?: QueryDslQueryContainer
       { exists: { field: 'vulnerability.severity' } },
       { exists: { field: 'resource.id' } },
       { exists: { field: 'resource.name' } },
-      { match_phrase: { 'vulnerability.enumeration': VULNERABILITIES_ENUMERATION } },
     ],
   },
 });


### PR DESCRIPTION

## Summary

`{ match_phrase: { 'vulnerability.enumeration': 'CVE' } }` has been removed from the vulnerabilities filter so that documents from other sources are presented in CNVM features

fixes:
- https://github.com/elastic/security-team/issues/7287

## Screenshots
This is how CNVM features look like with GHSA data
<img width="1728" alt="Screenshot 2023-08-08 at 15 47 10" src="https://github.com/elastic/kibana/assets/478762/d945afb1-8469-4810-ab27-40b243b34e76">
<img width="1721" alt="Screenshot 2023-08-08 at 15 46 59" src="https://github.com/elastic/kibana/assets/478762/0f8a3ce0-ffb6-4cc5-99cc-5d6d31a75640">

