### PR TITLE
[Synthetics] Refactor usage of alerting apis

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -30,6 +30,8 @@ export enum SYNTHETICS_API_URLS {
   PRIVATE_LOCATIONS_MONITORS = `/internal/synthetics/private_locations/monitors`,
   SYNC_GLOBAL_PARAMS = `/internal/synthetics/sync_global_params`,
   ENABLE_DEFAULT_ALERTING = `/internal/synthetics/enable_default_alerting`,
+  GET_ACTIONS_CONNECTORS = `/internal/synthetics/get_actions_connectors`,
+  GET_CONNECTOR_TYPES = `/internal/synthetics/get_connector_types`,
   JOURNEY = `/internal/synthetics/journey/{checkGroup}`,
   SYNTHETICS_SUCCESSFUL_CHECK = `/internal/synthetics/synthetics/check/success`,
   JOURNEY_SCREENSHOT_BLOCKS = `/internal/synthetics/journey/screenshot/block`,

--- a/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
+++ b/x-pack/plugins/synthetics/common/constants/synthetics/rest_api.ts
@@ -49,9 +49,4 @@ export enum SYNTHETICS_API_URLS {
   SYNTHETICS_MONITORS_PROJECT_DELETE = '/api/synthetics/project/{projectName}/monitors/_bulk_delete',
 
   DYNAMIC_SETTINGS = `/internal/uptime/dynamic_settings`,
-  RULE_CONNECTORS = '/api/actions/connectors',
-  CREATE_RULE = '/api/alerting/rule',
-  DELETE_RULE = '/api/alerting/rule/',
-  RULES_FIND = '/api/alerting/rules/_find',
-  CONNECTOR_TYPES = '/api/actions/connector_types',
 }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/settings/api.ts
@@ -8,7 +8,6 @@
 import {
   ActionConnector as RawActionConnector,
   ActionType,
-  AsApiContract,
 } from '@kbn/triggers-actions-ui-plugin/public';
 import { apiService } from '../../../../utils/api_service';
 import {
@@ -51,51 +50,13 @@ export const fetchLocationMonitors = async (): Promise<LocationMonitor[]> => {
 export type ActionConnector = Omit<RawActionConnector, 'secrets'>;
 
 export const fetchConnectors = async (): Promise<ActionConnector[]> => {
-  const response = (await apiService.get(SYNTHETICS_API_URLS.RULE_CONNECTORS)) as Array<
-    AsApiContract<ActionConnector>
-  >;
-  return response.map(
-    ({
-      connector_type_id: actionTypeId,
-      referenced_by_count: referencedByCount,
-      is_preconfigured: isPreconfigured,
-      is_deprecated: isDeprecated,
-      is_missing_secrets: isMissingSecrets,
-      is_system_action: isSystemAction,
-      ...res
-    }) => ({
-      ...res,
-      actionTypeId,
-      referencedByCount,
-      isDeprecated,
-      isPreconfigured,
-      isMissingSecrets,
-      isSystemAction,
-    })
-  );
+  return await apiService.get(SYNTHETICS_API_URLS.GET_ACTIONS_CONNECTORS);
 };
 
 export const fetchActionTypes = async (): Promise<ActionType[]> => {
-  const response = (await apiService.get(SYNTHETICS_API_URLS.CONNECTOR_TYPES, {
+  return await apiService.get(SYNTHETICS_API_URLS.GET_CONNECTOR_TYPES, {
     feature_id: 'uptime',
-  })) as Array<AsApiContract<ActionType>>;
-  return response.map<ActionType>(
-    ({
-      enabled_in_config: enabledInConfig,
-      enabled_in_license: enabledInLicense,
-      minimum_license_required: minimumLicenseRequired,
-      supported_feature_ids: supportedFeatureIds,
-      is_system_action_type: isSystemActionType,
-      ...res
-    }: AsApiContract<ActionType>) => ({
-      ...res,
-      enabledInConfig,
-      enabledInLicense,
-      minimumLicenseRequired,
-      supportedFeatureIds,
-      isSystemActionType,
-    })
-  );
+  });
 };
 
 export const syncGlobalParamsAPI = async (): Promise<boolean> => {

--- a/x-pack/plugins/synthetics/server/lib.ts
+++ b/x-pack/plugins/synthetics/server/lib.ts
@@ -170,7 +170,7 @@ export class UptimeEsClient {
     const showInspectData =
       (isInspectorEnabled || this.isDev) && path !== SYNTHETICS_API_URLS.DYNAMIC_SETTINGS;
 
-    if (showInspectData) {
+    if (showInspectData && this.inspectableEsQueries.length > 0) {
       return { _inspect: this.inspectableEsQueries };
     }
     return {};

--- a/x-pack/plugins/synthetics/server/routes/default_alerts/get_action_connectors.ts
+++ b/x-pack/plugins/synthetics/server/routes/default_alerts/get_action_connectors.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SyntheticsRestApiRouteFactory } from '../types';
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+
+export const getActionConnectorsRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.GET_ACTIONS_CONNECTORS,
+  validate: {},
+  handler: async ({ context, server, savedObjectsClient }): Promise<any> => {
+    const actionsClient = (await context.actions)?.getActionsClient();
+
+    return actionsClient.getAll();
+  },
+});

--- a/x-pack/plugins/synthetics/server/routes/default_alerts/get_connector_types.ts
+++ b/x-pack/plugins/synthetics/server/routes/default_alerts/get_connector_types.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SyntheticsRestApiRouteFactory } from '../types';
+import { SYNTHETICS_API_URLS } from '../../../common/constants';
+
+export const getConnectorTypesRoute: SyntheticsRestApiRouteFactory = () => ({
+  method: 'GET',
+  path: SYNTHETICS_API_URLS.GET_CONNECTOR_TYPES,
+  validate: {},
+  handler: async ({ context, server, savedObjectsClient }): Promise<any> => {
+    const actionsClient = (await context.actions)?.getActionsClient();
+
+    return actionsClient.listTypes({ featureId: 'uptime' });
+  },
+});

--- a/x-pack/plugins/synthetics/server/routes/index.ts
+++ b/x-pack/plugins/synthetics/server/routes/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { getConnectorTypesRoute } from './default_alerts/get_connector_types';
+import { getActionConnectorsRoute } from './default_alerts/get_action_connectors';
 import { SyntheticsRestApiRouteFactory } from './types';
 import { getSyntheticsCertsRoute } from './certs/get_certificates';
 import { getAgentPoliciesRoute } from './settings/private_locations/get_agent_policies';
@@ -100,4 +102,6 @@ export const syntheticsAppRestApiRoutes: SyntheticsRestApiRouteFactory[] = [
   inspectSyntheticsMonitorRoute,
   getAgentPoliciesRoute,
   getSyntheticsCertsRoute,
+  getActionConnectorsRoute,
+  getConnectorTypesRoute,
 ];

--- a/x-pack/plugins/synthetics/server/synthetics_route_wrapper.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_route_wrapper.ts
@@ -6,6 +6,7 @@
  */
 import { KibanaResponse } from '@kbn/core-http-router-server-internal';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
+import { isEmpty } from 'lodash';
 import { isTestUser, UptimeEsClient } from './lib';
 import { checkIndicesReadPrivileges } from './synthetics_service/authentication/check_has_privilege';
 import { SYNTHETICS_INDEX_PATTERN } from '../common/constants';
@@ -57,6 +58,23 @@ export const syntheticsRouteWrapper: SyntheticsRouteWrapper = (
       });
       if (res instanceof KibanaResponse) {
         return res;
+      }
+
+      const inspectData = await uptimeEsClient.getInspectData(uptimeRoute.path);
+
+      if (Array.isArray(res)) {
+        if (isEmpty(inspectData)) {
+          return response.ok({
+            body: res,
+          });
+        } else {
+          return response.ok({
+            body: {
+              result: res,
+              ...inspectData,
+            },
+          });
+        }
       }
 
       return response.ok({


### PR DESCRIPTION
## Summary

Refactor usage of alerting apis, we shouldn't be calling API's directly in our code, it's hard to maintain that. Created new routes internally to fetch connectors needed in synthetics App