### PR TITLE
[Watcher] Disable watcher using contextRef

### DIFF
--- a/x-pack/plugins/watcher/server/index.ts
+++ b/x-pack/plugins/watcher/server/index.ts
@@ -14,6 +14,13 @@ export const plugin = (ctx: PluginInitializerContext) => new WatcherServerPlugin
 
 export const config = {
   schema: schema.object({
-    enabled: schema.boolean({ defaultValue: true }),
+    enabled: schema.conditional(
+      schema.contextRef('serverless'),
+      true,
+      // Watcher is disabled in serverless; refer to the serverless.yml file as the source of truth
+      // We take this approach in order to have a central place (serverless.yml) to view disabled plugins across Kibana
+      schema.boolean({ defaultValue: true }),
+      schema.never()
+    ),
   }),
 };

--- a/x-pack/test_serverless/functional/test_suites/common/management.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management.ts
@@ -50,6 +50,10 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
           appName: 'License Management',
           url: 'stack/license_management',
         },
+        {
+          appName: 'Watcher',
+          url: 'insightsAndAlerting/watcher',
+        },
       ];
 
       DISABLED_PLUGINS.forEach(({ appName, url }) => {


### PR DESCRIPTION
Follow-up to https://github.com/elastic/kibana/pull/160671.

This PR leverages the [schema.contextRef('serverless') check](https://www.elastic.co/guide/en/kibana/master/configuration-service.html#validating-your-configuration-based-on-context-references) to prevent the watcher config from leaking to self-managed. 