### PR TITLE
[Files] Make download route public

### DIFF
--- a/src/plugins/files/server/routes/file_kind/download.ts
+++ b/src/plugins/files/server/routes/file_kind/download.ts
@@ -59,7 +59,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
         validate: { ...rt },
         options: {
           tags: fileKind.http.download.tags,
-          access: 'public',
+          access: 'public', // the endpoint is used by <img src=""/> and should work without any special headers
         },
       },
       handler

--- a/src/plugins/files/server/routes/file_kind/download.ts
+++ b/src/plugins/files/server/routes/file_kind/download.ts
@@ -59,6 +59,7 @@ export function register(fileKindRouter: FileKindRouter, fileKind: FileKind) {
         validate: { ...rt },
         options: {
           tags: fileKind.http.download.tags,
+          access: 'public',
         },
       },
       handler


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/163364 in serverless
Similar to https://github.com/elastic/kibana/pull/162707/, the the endpoint is used by `<img src=""/>` and should work without any special headers

