### PR TITLE
Set xpack.task_manager.requeue_invalid_tasks.enabled: true in Serverless

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -90,3 +90,6 @@ vis_type_timeseries.readOnly: true
 vis_type_vislib.readOnly: true
 vis_type_xy.readOnly: true
 input_control_vis.readOnly: true
+
+## TaskManager requeue invalid tasks, supports ZDT
+xpack.task_manager.requeue_invalid_tasks.enabled: true


### PR DESCRIPTION
Facilitates ZDT upgrades for task manager tasks, by preventing newer tasks from running on old Kibana nodes.

Enables the changes made by https://github.com/elastic/kibana/pull/158022 in Serverless.