### PR TITLE
[Rollup] Add a comment about api use by the data view plugin

### DIFF
--- a/x-pack/plugins/rollup/server/routes/api/indices/register_get_route.ts
+++ b/x-pack/plugins/rollup/server/routes/api/indices/register_get_route.ts
@@ -18,6 +18,7 @@ export const registerGetRoute = ({
 }: RouteDependencies) => {
   router.get(
     {
+      // this endpoint is used by the data views plugin, see https://github.com/elastic/kibana/issues/152708
       path: addBasePath('/indices'),
       validate: false,
     },


### PR DESCRIPTION
## Summary
Adds a comment that the API endpoint /rollup/indices is used by the data view plugin. 

With https://github.com/elastic/kibana/pull/162674 merged, the issue https://github.com/elastic/kibana/issues/152708 has been closed. The Data Discovery team is not planning any further work around rollup api use due to the feature being deprecated. I think adding a comment to the API code directly will help us remember this dependency for when we are going to edit or remove the endpoint. 


