### PR TITLE
Refresh `.security-tokens` index in tests before simulating "missing refresh token" scenario.

### DIFF
--- a/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -431,8 +431,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/163456
-    describe.skip('API access with missing access token document or expired refresh token.', () => {
+    describe('API access with missing access token document or expired refresh token.', () => {
       let sessionCookie: Cookie;
 
       beforeEach(async () => {
@@ -446,6 +445,9 @@ export default function ({ getService }: FtrProviderContext) {
 
         sessionCookie = parseCookie(cookies[0])!;
         checkCookieIsSet(sessionCookie);
+
+        // Let's make sure that created tokens are available for search.
+        await getService('es').indices.refresh({ index: '.security-tokens' });
 
         // Let's delete tokens from `.security-tokens` index directly to simulate the case when
         // Elasticsearch automatically removes access/refresh token document from the index after

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
@@ -621,6 +621,9 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       it('should properly set cookie and start new OIDC handshake', async function () {
+        // Let's make sure that created tokens are available for search.
+        await getService('es').indices.refresh({ index: '.security-tokens' });
+
         // Let's delete tokens from `.security-tokens` index directly to simulate the case when
         // Elasticsearch automatically removes access/refresh token document from the index
         // after some period of time.

--- a/x-pack/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/test/security_api_integration/tests/saml/saml_login.ts
@@ -593,8 +593,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
     });
 
-    // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/163455
-    describe.skip('API access with missing access token document.', () => {
+    describe('API access with missing access token document.', () => {
       let sessionCookie: Cookie;
 
       beforeEach(async () => {
@@ -614,6 +613,9 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(302);
 
         sessionCookie = parseCookie(samlAuthenticationResponse.headers['set-cookie'][0])!;
+
+        // Let's make sure that created tokens are available for search.
+        await getService('es').indices.refresh({ index: '.security-tokens' });
 
         // Let's delete tokens from `.security` index directly to simulate the case when
         // Elasticsearch automatically removes access/refresh token document from the index
@@ -700,6 +702,9 @@ export default function ({ getService }: FtrProviderContext) {
         [
           'when access token document is missing',
           async () => {
+            // Let's make sure that created tokens are available for search.
+            await getService('es').indices.refresh({ index: '.security-tokens' });
+
             const esResponse = await getService('es').deleteByQuery({
               index: '.security-tokens',
               body: { query: { match: { doc_type: 'token' } } },

--- a/x-pack/test/security_api_integration/tests/token/session.ts
+++ b/x-pack/test/security_api_integration/tests/token/session.ts
@@ -189,6 +189,9 @@ export default function ({ getService }: FtrProviderContext) {
       beforeEach(async () => (sessionCookie = await createSessionCookie()));
 
       it('should clear cookie and redirect to login', async function () {
+        // Let's make sure that created tokens are available for search.
+        await getService('es').indices.refresh({ index: '.security-tokens' });
+
         // Let's delete tokens from `.security` index directly to simulate the case when
         // Elasticsearch automatically removes access/refresh token document from the index
         // after some period of time.


### PR DESCRIPTION
## Summary

Elasticsearch no longer refreshes `.security-tokens` index after token is created, and we need to respect that in the tests that simulate "expired refresh token" scenario.

Checked locally with:
```bash
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.10.0/archives/20230808-202136_29386737/manifest.json"
```

__Caused by: https://github.com/elastic/elasticsearch/pull/98102__

__Fixes: https://github.com/elastic/kibana/issues/163455__
__Fixes: https://github.com/elastic/kibana/issues/163456__