### PR TITLE
[Infra UI] Fix flyout-related tests

### DIFF
--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -155,8 +155,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       return !!currentUrl.match(path);
     });
 
-  // Failing: See https://github.com/elastic/kibana/issues/162672
-  describe.skip('Hosts View', function () {
+  const waitForPageToLoad = async () =>
+    await retry.waitFor(
+      'wait for table and KPI charts to load',
+      async () =>
+        (await pageObjects.infraHostsView.isHostTableLoading()) &&
+        (await pageObjects.infraHostsView.isKPIChartsLoaded())
+    );
+
+  describe('Hosts View', function () {
     before(async () => {
       await Promise.all([
         esArchiver.load('x-pack/test/functional/es_archives/infra/alerts'),
@@ -247,189 +254,243 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     });
 
-    describe('#Single host Flyout', () => {
+    describe('#Single Host Flyout', () => {
       before(async () => {
         await setHostViewEnabled(true);
         await pageObjects.common.navigateToApp(HOSTS_VIEW_PATH);
         await pageObjects.header.waitUntilLoadingHasFinished();
-        await pageObjects.timePicker.setAbsoluteRange(
-          START_HOST_PROCESSES_DATE.format(timepickerFormat),
-          END_HOST_PROCESSES_DATE.format(timepickerFormat)
-        );
-        await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
       });
 
-      after(async () => {
-        await retry.try(async () => {
-          await pageObjects.infraHostsView.clickCloseFlyoutButton();
-        });
-      });
-
-      describe('Overview Tab', () => {
+      describe('Tabs', () => {
         before(async () => {
-          await pageObjects.infraHostsView.clickOverviewFlyoutTab();
+          await pageObjects.timePicker.setAbsoluteRange(
+            START_HOST_PROCESSES_DATE.format(timepickerFormat),
+            END_HOST_PROCESSES_DATE.format(timepickerFormat)
+          );
+
+          await waitForPageToLoad();
+
+          await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
         });
 
-        [
-          { metric: 'cpuUsage', value: '13.9%' },
-          { metric: 'normalizedLoad1m', value: '18.8%' },
-          { metric: 'memoryUsage', value: '94.9%' },
-          { metric: 'diskSpaceUsage', value: 'N/A' },
-        ].forEach(({ metric, value }) => {
-          it(`${metric} tile should show ${value}`, async () => {
-            await retry.try(async () => {
-              const tileValue = await pageObjects.infraHostsView.getAssetDetailsKPITileValue(
-                metric
-              );
-              expect(tileValue).to.eql(value);
+        after(async () => {
+          await retry.try(async () => {
+            await pageObjects.infraHostsView.clickCloseFlyoutButton();
+          });
+        });
+
+        describe('Overview Tab', () => {
+          before(async () => {
+            await pageObjects.infraHostsView.clickOverviewFlyoutTab();
+          });
+
+          [
+            { metric: 'cpuUsage', value: '13.9%' },
+            { metric: 'normalizedLoad1m', value: '18.8%' },
+            { metric: 'memoryUsage', value: '94.9%' },
+            { metric: 'diskSpaceUsage', value: 'N/A' },
+          ].forEach(({ metric, value }) => {
+            it(`${metric} tile should show ${value}`, async () => {
+              await retry.try(async () => {
+                const tileValue = await pageObjects.infraHostsView.getAssetDetailsKPITileValue(
+                  metric
+                );
+                expect(tileValue).to.eql(value);
+              });
             });
           });
+
+          it('should render 8 charts in the Metrics section', async () => {
+            const hosts = await pageObjects.infraHostsView.getAssetDetailsMetricsCharts();
+            expect(hosts.length).to.equal(8);
+          });
+
+          it('should navigate to metadata tab', async () => {
+            await pageObjects.infraHostsView.clickShowAllMetadataOverviewTab();
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            await pageObjects.infraHostsView.metadataTableExist();
+            await pageObjects.infraHostsView.clickOverviewFlyoutTab();
+          });
+
+          it('should show alerts', async () => {
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            await pageObjects.infraHostsView.overviewAlertsTitleExist();
+          });
+
+          it('should open alerts flyout', async () => {
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            await pageObjects.infraHostsView.clickOverviewOpenAlertsFlyout();
+            // There are 2 flyouts open (asset details and alerts)
+            // so we need a stricter selector
+            // to be sure that we are closing the alerts flyout
+            const closeAlertFlyout = await find.byCssSelector(
+              '[aria-labelledby="flyoutRuleAddTitle"] > [data-test-subj="euiFlyoutCloseButton"]'
+            );
+            await closeAlertFlyout.click();
+          });
+
+          it('should navigate to alerts', async () => {
+            await pageObjects.infraHostsView.clickOverviewLinkToAlerts();
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            const url = parse(await browser.getCurrentUrl());
+
+            const query = decodeURIComponent(url.query ?? '');
+
+            const alertsQuery =
+              "_a=(kuery:'host.name:\"Jennys-MBP.fritz.box\"',rangeFrom:'2023-03-28T18:20:00.000Z',rangeTo:'2023-03-28T18:21:00.000Z',status:all)";
+
+            expect(url.pathname).to.eql('/app/observability/alerts');
+            expect(query).to.contain(alertsQuery);
+
+            await returnTo(HOSTS_VIEW_PATH);
+          });
         });
 
-        it('should render 8 charts in the Metrics section', async () => {
-          const hosts = await pageObjects.infraHostsView.getAssetDetailsMetricsCharts();
-          expect(hosts.length).to.equal(8);
+        describe('Metadata Tab', () => {
+          before(async () => {
+            await pageObjects.infraHostsView.clickMetadataFlyoutTab();
+          });
+
+          it('should render metadata tab, add and remove filter', async () => {
+            await pageObjects.infraHostsView.metadataTableExist();
+
+            // Add Pin
+            await pageObjects.infraHostsView.clickAddMetadataPin();
+            expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(true);
+
+            // Persist pin after refresh
+            await browser.refresh();
+            await retry.try(async () => {
+              await pageObjects.infraHome.waitForLoading();
+              const removePinExist = await pageObjects.infraHostsView.getRemovePinExist();
+              expect(removePinExist).to.be(true);
+            });
+
+            // Remove Pin
+            await pageObjects.infraHostsView.clickRemoveMetadataPin();
+            expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(false);
+
+            await pageObjects.infraHostsView.clickAddMetadataFilter();
+            await pageObjects.header.waitUntilLoadingHasFinished();
+
+            // Add Filter
+            const addedFilter = await pageObjects.infraHostsView.getAppliedFilter();
+            expect(addedFilter).to.contain('host.architecture: arm64');
+            const removeFilterExists = await pageObjects.infraHostsView.getRemoveFilterExist();
+            expect(removeFilterExists).to.be(true);
+
+            // Remove filter
+            await pageObjects.infraHostsView.clickRemoveMetadataFilter();
+            await pageObjects.header.waitUntilLoadingHasFinished();
+            const removeFilterShouldNotExist =
+              await pageObjects.infraHostsView.getRemoveFilterExist();
+            expect(removeFilterShouldNotExist).to.be(false);
+          });
+
+          it('should render metadata tab, pin and unpin table row', async () => {
+            // Add Pin
+            await pageObjects.infraHostsView.clickAddMetadataPin();
+            expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(true);
+
+            // Persist pin after refresh
+            await browser.refresh();
+            await retry.try(async () => {
+              await pageObjects.infraHome.waitForLoading();
+              const removePinExist = await pageObjects.infraHostsView.getRemovePinExist();
+              expect(removePinExist).to.be(true);
+            });
+
+            // Remove Pin
+            await pageObjects.infraHostsView.clickRemoveMetadataPin();
+            expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(false);
+          });
         });
 
-        it('should navigate to metadata tab', async () => {
-          await pageObjects.infraHostsView.clickShowAllMetadataOverviewTab();
-          await pageObjects.header.waitUntilLoadingHasFinished();
-          await pageObjects.infraHostsView.metadataTableExist();
-          await pageObjects.infraHostsView.clickOverviewFlyoutTab();
+        describe('Processes Tab', () => {
+          before(async () => {
+            await pageObjects.infraHostsView.clickProcessesFlyoutTab();
+          });
+          it('should render processes tab and with Total Value summary', async () => {
+            const processesTotalValue =
+              await pageObjects.infraHostsView.getProcessesTabContentTotalValue();
+            const processValue = await processesTotalValue.getVisibleText();
+            expect(processValue).to.eql('313');
+          });
+
+          it('should expand processes table row', async () => {
+            await pageObjects.infraHostsView.getProcessesTable();
+            await pageObjects.infraHostsView.getProcessesTableBody();
+            await pageObjects.infraHostsView.clickProcessesTableExpandButton();
+          });
         });
 
-        it('should show alerts', async () => {
-          await pageObjects.header.waitUntilLoadingHasFinished();
-          await pageObjects.infraHostsView.overviewAlertsTitleExist();
+        describe('Logs Tab', () => {
+          before(async () => {
+            await pageObjects.infraHostsView.clickLogsFlyoutTab();
+          });
+          it('should render logs tab', async () => {
+            await testSubjects.existOrFail('infraAssetDetailsLogsTabContent');
+          });
         });
 
-        it('should open alerts flyout', async () => {
-          await pageObjects.header.waitUntilLoadingHasFinished();
-          await pageObjects.infraHostsView.clickOverviewOpenAlertsFlyout();
-          // There are 2 flyouts open (asset details and alerts)
-          // so we need a stricter selector
-          // to be sure that we are closing the alerts flyout
-          const closeAlertFlyout = await find.byCssSelector(
-            '[aria-labelledby="flyoutRuleAddTitle"] > [data-test-subj="euiFlyoutCloseButton"]'
+        describe('Flyout links', () => {
+          it('should navigate to APM services after click', async () => {
+            await pageObjects.infraHostsView.clickFlyoutApmServicesLink();
+            const url = parse(await browser.getCurrentUrl());
+            const query = decodeURIComponent(url.query ?? '');
+            const kuery = 'kuery=host.hostname:"Jennys-MBP.fritz.box"';
+
+            expect(url.pathname).to.eql('/app/apm/services');
+            expect(query).to.contain(kuery);
+
+            await returnTo(HOSTS_VIEW_PATH);
+          });
+        });
+      });
+
+      describe('Host with alerts', () => {
+        before(async () => {
+          await pageObjects.timePicker.setAbsoluteRange(
+            START_DATE.format(timepickerFormat),
+            END_DATE.format(timepickerFormat)
           );
-          await closeAlertFlyout.click();
+          await pageObjects.infraHostsView.clickHostCheckbox('demo-stack-mysql-01', '-');
+          await pageObjects.infraHostsView.clickSelectedHostsButton();
+          await pageObjects.infraHostsView.clickSelectedHostsAddFilterButton();
+
+          await waitForPageToLoad();
+
+          await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
         });
 
-        it('should navigate to alerts', async () => {
-          await pageObjects.infraHostsView.clickOverviewLinkToAlerts();
-          await pageObjects.header.waitUntilLoadingHasFinished();
-          const url = parse(await browser.getCurrentUrl());
-
-          const query = decodeURIComponent(url.query ?? '');
-
-          const alertsQuery =
-            "_a=(kuery:'host.name:\"Jennys-MBP.fritz.box\"',rangeFrom:'2023-03-28T18:20:00.000Z',rangeTo:'2023-03-28T18:21:00.000Z',status:all)";
-
-          expect(url.pathname).to.eql('/app/observability/alerts');
-          expect(query).to.contain(alertsQuery);
-
-          await returnTo(HOSTS_VIEW_PATH);
-        });
-      });
-
-      describe('Metadata Tab', () => {
-        before(async () => {
-          await pageObjects.infraHostsView.clickMetadataFlyoutTab();
-        });
-
-        it('should render metadata tab, add and remove filter', async () => {
-          await pageObjects.infraHostsView.metadataTableExist();
-
-          // Add Pin
-          await pageObjects.infraHostsView.clickAddMetadataPin();
-          expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(true);
-
-          // Persist pin after refresh
-          await browser.refresh();
+        after(async () => {
           await retry.try(async () => {
-            await pageObjects.infraHome.waitForLoading();
-            const removePinExist = await pageObjects.infraHostsView.getRemovePinExist();
-            expect(removePinExist).to.be(true);
+            await pageObjects.infraHostsView.clickCloseFlyoutButton();
+          });
+        });
+
+        it('should render alerts count for a host inside a flyout', async () => {
+          await pageObjects.infraHostsView.clickOverviewFlyoutTab();
+
+          retry.tryForTime(30 * 1000, async () => {
+            await observability.components.alertSummaryWidget.getFullSizeComponentSelectorOrFail();
           });
 
-          // Remove Pin
-          await pageObjects.infraHostsView.clickRemoveMetadataPin();
-          expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(false);
+          const activeAlertsCount =
+            await observability.components.alertSummaryWidget.getActiveAlertCount();
+          const totalAlertsCount =
+            await observability.components.alertSummaryWidget.getTotalAlertCount();
 
-          await pageObjects.infraHostsView.clickAddMetadataFilter();
-          await pageObjects.header.waitUntilLoadingHasFinished();
-
-          // Add Filter
-          const addedFilter = await pageObjects.infraHostsView.getAppliedFilter();
-          expect(addedFilter).to.contain('host.architecture: arm64');
-          const removeFilterExists = await pageObjects.infraHostsView.getRemoveFilterExist();
-          expect(removeFilterExists).to.be(true);
-
-          // Remove filter
-          await pageObjects.infraHostsView.clickRemoveMetadataFilter();
-          await pageObjects.header.waitUntilLoadingHasFinished();
-          const removeFilterShouldNotExist =
-            await pageObjects.infraHostsView.getRemoveFilterExist();
-          expect(removeFilterShouldNotExist).to.be(false);
+          expect(activeAlertsCount.trim()).to.equal('2');
+          expect(totalAlertsCount.trim()).to.equal('3');
         });
 
-        it('should render metadata tab, pin and unpin table row', async () => {
-          // Add Pin
-          await pageObjects.infraHostsView.clickAddMetadataPin();
-          expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(true);
-
-          // Persist pin after refresh
-          await browser.refresh();
-          await retry.try(async () => {
-            await pageObjects.infraHome.waitForLoading();
-            const removePinExist = await pageObjects.infraHostsView.getRemovePinExist();
-            expect(removePinExist).to.be(true);
-          });
-
-          // Remove Pin
-          await pageObjects.infraHostsView.clickRemoveMetadataPin();
-          expect(await pageObjects.infraHostsView.getRemovePinExist()).to.be(false);
-        });
-      });
-
-      describe('Processes Tab', () => {
-        before(async () => {
+        it('should render "N/A" when processes summary is not available in flyout', async () => {
           await pageObjects.infraHostsView.clickProcessesFlyoutTab();
-        });
-        it('should render processes tab and with Total Value summary', async () => {
           const processesTotalValue =
             await pageObjects.infraHostsView.getProcessesTabContentTotalValue();
           const processValue = await processesTotalValue.getVisibleText();
-          expect(processValue).to.eql('313');
-        });
-
-        it('should expand processes table row', async () => {
-          await pageObjects.infraHostsView.getProcessesTable();
-          await pageObjects.infraHostsView.getProcessesTableBody();
-          await pageObjects.infraHostsView.clickProcessesTableExpandButton();
-        });
-      });
-
-      describe('Logs Tab', () => {
-        before(async () => {
-          await pageObjects.infraHostsView.clickLogsFlyoutTab();
-        });
-        it('should render logs tab', async () => {
-          await testSubjects.existOrFail('infraAssetDetailsLogsTabContent');
-        });
-      });
-
-      describe('Flyout links', () => {
-        it('should navigate to APM services after click', async () => {
-          await pageObjects.infraHostsView.clickFlyoutApmServicesLink();
-          const url = parse(await browser.getCurrentUrl());
-          const query = decodeURIComponent(url.query ?? '');
-          const kuery = 'kuery=host.hostname:"Jennys-MBP.fritz.box"';
-
-          expect(url.pathname).to.eql('/app/apm/services');
-          expect(query).to.contain(kuery);
-
-          await returnTo(HOSTS_VIEW_PATH);
+          expect(processValue).to.eql('N/A');
         });
       });
     });
@@ -444,12 +505,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           END_DATE.format(timepickerFormat)
         );
 
-        await retry.waitFor(
-          'wait for table and KPI charts to load',
-          async () =>
-            (await pageObjects.infraHostsView.isHostTableLoading()) &&
-            (await pageObjects.infraHostsView.isKPIChartsLoaded())
-        );
+        await waitForPageToLoad();
       });
 
       it('should render the correct page title', async () => {
@@ -509,37 +565,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         });
       });
 
-      it('should render alerts count for a host inside a flyout', async () => {
-        await pageObjects.infraHostsView.clickHostCheckbox('demo-stack-mysql-01', '-');
-        await pageObjects.infraHostsView.clickSelectedHostsButton();
-        await pageObjects.infraHostsView.clickSelectedHostsAddFilterButton();
-        await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-
-        const activeAlertsCount = await pageObjects.infraHostsView.getActiveAlertsCountText();
-        const totalAlertsCount = await pageObjects.infraHostsView.getTotalAlertsCountText();
-
-        expect(activeAlertsCount).to.equal('2 ');
-        expect(totalAlertsCount).to.equal('3');
-
-        const deleteFilterButton = await find.byCssSelector(
-          `[title="Delete host.name: demo-stack-mysql-01"]`
-        );
-        await deleteFilterButton.click();
-
-        await pageObjects.infraHostsView.clickCloseFlyoutButton();
-      });
-
-      it('should render "N/A" when processes summary is not available in flyout', async () => {
-        await pageObjects.infraHostsView.clickTableOpenFlyoutButton();
-        await pageObjects.infraHostsView.clickProcessesFlyoutTab();
-        const processesTotalValue =
-          await pageObjects.infraHostsView.getProcessesTabContentTotalValue();
-        const processValue = await processesTotalValue.getVisibleText();
-        expect(processValue).to.eql('N/A');
-        await pageObjects.infraHostsView.clickCloseFlyoutButton();
-      });
-
-      describe('KPI tiles', () => {
+      describe('KPIs', () => {
         [
           { metric: 'hostsCount', value: '6' },
           { metric: 'cpuUsage', value: '0.8%' },
@@ -673,12 +699,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         before(async () => {
           await browser.scrollTop();
           await pageObjects.infraHostsView.submitQuery(query);
-          await retry.waitFor(
-            'wait for table and KPI charts to load',
-            async () =>
-              (await pageObjects.infraHostsView.isHostTableLoading()) &&
-              (await pageObjects.infraHostsView.isKPIChartsLoaded())
-          );
+          await await waitForPageToLoad();
         });
 
         after(async () => {

--- a/x-pack/test/functional/page_objects/infra_hosts_view.ts
+++ b/x-pack/test/functional/page_objects/infra_hosts_view.ts
@@ -215,18 +215,6 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
       return testSubjects.exists('assetDetailsAlertsTitle');
     },
 
-    async getActiveAlertsCountText() {
-      const container = await testSubjects.find('activeAlertCount');
-      const containerText = await container.getVisibleText();
-      return containerText;
-    },
-
-    async getTotalAlertsCountText() {
-      const container = await testSubjects.find('totalAlertCount');
-      const containerText = await container.getVisibleText();
-      return containerText;
-    },
-
     async getAssetDetailsMetricsCharts() {
       const container = await testSubjects.find('assetDetailsMetricsChartGrid');
       return container.findAllByCssSelector('[data-test-subj*="assetDetailsMetricsChart"]');


### PR DESCRIPTION
closes [#162672](https://github.com/elastic/kibana/issues/162672)
## Summary

This PR fixes the `should render alerts count for a host inside a flyout`. It also moves all flyout-related tests to the `#Single Host Flyout` test.


### How to test

```bash
yarn test:ftr:server --config x-pack/test/functional/apps/infra/config.ts
```

```bash
yarn test:ftr:runner --config x-pack/test/functional/apps/infra/config.ts --include x-pack/test/functional/apps/infra/hosts_view.ts
```


https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2830