### PR TITLE
[Chore] Fix Osquery tests dsn issue.

### DIFF
--- a/x-pack/plugins/security_solution/scripts/start_cypress_parallel.js
+++ b/x-pack/plugins/security_solution/scripts/start_cypress_parallel.js
@@ -6,4 +6,5 @@
  */
 
 require('../../../../src/setup_node_env');
+process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ''} --dns-result-order=ipv4first`;
 require('./run_cypress/parallel').cli();


### PR DESCRIPTION
This seems to be a better approach to fix Cypress tests than https://github.com/elastic/kibana/pull/163420 

@jbudz I know you added `require('dns').setDefaultResultOrder('ipv4first');` but it doesn't seem to work in Cypress, so this PR adds a workaround. 