### PR TITLE
[Synthetics] Fix 404 not found monitor view

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -59,7 +59,7 @@ export const getSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
 
         const encryptedSavedObjectsClient = encryptedSavedObjects.getClient();
 
-        return getSyntheticsMonitor({
+        return await getSyntheticsMonitor({
           monitorId,
           encryptedSavedObjectsClient,
           savedObjectsClient,


### PR DESCRIPTION
## Summary

### Before
<img width="1499" alt="image" src="https://github.com/elastic/kibana/assets/3505601/4b29f521-97ce-44e6-9512-06f4787bd5c1">

### After

<img width="1713" alt="image" src="https://github.com/elastic/kibana/assets/3505601/b8050398-1ac4-469a-aa74-a9446a5ada41">



<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->