### PR TITLE
[DOCS] Fix `event.values` URL template var desc

### DIFF
--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -659,7 +659,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute.
+| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.value.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys

--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -659,7 +659,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
+| An array of all cell values for the row on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys

--- a/docs/user/dashboard/make-dashboards-interactive.asciidoc
+++ b/docs/user/dashboard/make-dashboards-interactive.asciidoc
@@ -659,7 +659,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.value.[x]}}`, where `x` represents the column number.
+| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys

--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -244,7 +244,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.value.[x]}}`, where `x` represents the column number.
+| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys

--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -244,7 +244,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
+| An array of all cell values for the row on which the action will execute. To access a column value, use `{{event.values.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys

--- a/docs/user/dashboard/url-drilldown.asciidoc
+++ b/docs/user/dashboard/url-drilldown.asciidoc
@@ -244,7 +244,7 @@ Note:
 
 |
 | event.values
-| An array of all cell values for the raw on which the action will execute.
+| An array of all cell values for the raw on which the action will execute. To access a column value, use `{{event.value.[x]}}`, where `x` represents the column number.
 
 |
 | event.keys


### PR DESCRIPTION
## Summary

Updates the **Row click / event.values** [URL template variable](https://www.elastic.co/guide/en/kibana/current/create-drilldowns.html#url-template-variables) docs to include info about accessing column values.

<!--ONMERGE {"backportTargets":["8.3","8.4","8.5","8.6","8.7","8.8","8.9"]} ONMERGE-->