### PR TITLE
[8.9] fix(NA): apply ipv4 first dns result order for worker threads (#163484)

### DIFF
--- a/src/setup_node_env/dns_ipv4_first.js
+++ b/src/setup_node_env/dns_ipv4_first.js
@@ -6,11 +6,8 @@
  * Side Public License, v 1.
  */
 
-// development env setup includes babel/register after the env is initialized
-require('./setup_env');
+// enables Node 16 default DNS lookup behavior for the current thread
+require('dns').setDefaultResultOrder('ipv4first');
 
-// restore < Node 16 default DNS lookup behavior
-require('./dns_ipv4_first');
-
-require('@kbn/babel-register').install();
-require('./polyfill');
+// overrides current process node options, so it can be restored in worker threads too
+process.env.NODE_OPTIONS = `${process.env.NODE_OPTIONS || ''} --dns-result-order=ipv4first`;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [fix(NA): apply ipv4 first dns result order for worker threads (#163484)](https://github.com/elastic/kibana/pull/163484)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2023-08-09T15:49:57Z","message":"fix(NA): apply ipv4 first dns result order for worker threads (#163484)\n\nThis PR is a follow up of https://github.com/elastic/kibana/pull/163025\r\nas we discover the initial fix doesn't apply correctly to working\r\nthreads during development.","sha":"f4856f74784cf5ca2094f2f54a6d86f2aff3335a","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v8.10.0"],"number":163484,"url":"https://github.com/elastic/kibana/pull/163484","mergeCommit":{"message":"fix(NA): apply ipv4 first dns result order for worker threads (#163484)\n\nThis PR is a follow up of https://github.com/elastic/kibana/pull/163025\r\nas we discover the initial fix doesn't apply correctly to working\r\nthreads during development.","sha":"f4856f74784cf5ca2094f2f54a6d86f2aff3335a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163484","number":163484,"mergeCommit":{"message":"fix(NA): apply ipv4 first dns result order for worker threads (#163484)\n\nThis PR is a follow up of https://github.com/elastic/kibana/pull/163025\r\nas we discover the initial fix doesn't apply correctly to working\r\nthreads during development.","sha":"f4856f74784cf5ca2094f2f54a6d86f2aff3335a"}}]}] BACKPORT-->