### PR TITLE
[Fleet] add managed to imported saved object

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -320,6 +320,7 @@ export async function installKibanaSavedObjects({
         readStream: createListStream(toBeSavedObjects),
         createNewCopies: false,
         refresh: false,
+        managed: true,
       })
     );
 
@@ -371,6 +372,7 @@ export async function installKibanaSavedObjects({
         await savedObjectsImporter.resolveImportErrors({
           readStream: createListStream(toBeSavedObjects),
           createNewCopies: false,
+          managed: true,
           retries,
         });
 

--- a/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_remove_assets.ts
@@ -437,61 +437,75 @@ const expectAssetsInstalled = ({
       id: 'sample_dashboard',
     });
     expect(resDashboard.id).equal('sample_dashboard');
+    expect(resDashboard.managed).be(true);
     expect(resDashboard.references.map((ref: any) => ref.id).includes('sample_tag')).equal(true);
     const resDashboard2 = await kibanaServer.savedObjects.get({
       type: 'dashboard',
       id: 'sample_dashboard2',
     });
     expect(resDashboard2.id).equal('sample_dashboard2');
+    expect(resDashboard2.managed).be(true);
     const resVis = await kibanaServer.savedObjects.get({
       type: 'visualization',
       id: 'sample_visualization',
     });
+
     expect(resVis.id).equal('sample_visualization');
+    expect(resVis.managed).be(true);
     const resSearch = await kibanaServer.savedObjects.get({
       type: 'search',
       id: 'sample_search',
     });
     expect(resSearch.id).equal('sample_search');
+    expect(resSearch.managed).be(true);
     const resLens = await kibanaServer.savedObjects.get({
       type: 'lens',
       id: 'sample_lens',
     });
+
     expect(resLens.id).equal('sample_lens');
+    expect(resLens.managed).be(true);
     const resMlModule = await kibanaServer.savedObjects.get({
       type: 'ml-module',
       id: 'sample_ml_module',
     });
     expect(resMlModule.id).equal('sample_ml_module');
+    expect(resMlModule.managed).be(true);
     const resSecurityRule = await kibanaServer.savedObjects.get({
       type: 'security-rule',
       id: 'sample_security_rule',
     });
     expect(resSecurityRule.id).equal('sample_security_rule');
+    expect(resSecurityRule.managed).be(true);
     const resOsqueryPackAsset = await kibanaServer.savedObjects.get({
       type: 'osquery-pack-asset',
       id: 'sample_osquery_pack_asset',
     });
     expect(resOsqueryPackAsset.id).equal('sample_osquery_pack_asset');
+    expect(resOsqueryPackAsset.managed).be(true);
     const resOsquerySavedObject = await kibanaServer.savedObjects.get({
       type: 'osquery-saved-query',
       id: 'sample_osquery_saved_query',
     });
     expect(resOsquerySavedObject.id).equal('sample_osquery_saved_query');
+    expect(resOsquerySavedObject.managed).be(true);
     const resCloudSecurityPostureRuleTemplate = await kibanaServer.savedObjects.get({
       type: 'csp-rule-template',
       id: 'sample_csp_rule_template',
     });
     expect(resCloudSecurityPostureRuleTemplate.id).equal('sample_csp_rule_template');
+    expect(resCloudSecurityPostureRuleTemplate.managed).be(true);
     const resTag = await kibanaServer.savedObjects.get({
       type: 'tag',
       id: 'sample_tag',
     });
+    expect(resTag.managed).be(true);
     expect(resTag.id).equal('sample_tag');
     const resIndexPattern = await kibanaServer.savedObjects.get({
       type: 'index-pattern',
       id: 'test-*',
     });
+    expect(resIndexPattern.managed).be(true);
     expect(resIndexPattern.id).equal('test-*');
 
     let resInvalidTypeIndexPattern;


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/154655

To be able to have readonly SO in the future that PR add `managed: true` to imported saved object.


## Test

I updated existing API integration to verify that imported saved object have the property `managed:true`