### PR TITLE
[Security Solution][Endpoint] CLI script load Roles and Users into Kibana

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/load_roles_and_users.js
+++ b/x-pack/plugins/security_solution/scripts/endpoint/load_roles_and_users.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+require('../../../../../src/setup_node_env');
+require('./roles_and_users').cli();

--- a/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/index.ts
@@ -9,7 +9,7 @@ import type { RunFn } from '@kbn/dev-cli-runner';
 import { run } from '@kbn/dev-cli-runner';
 import { createRuntimeServices } from '../common/stack_services';
 import type { RolesAndUsersType } from './load_roles_users';
-import { loadRolesAndUsers } from './load_roles_users';
+import { loadRolesAndUsers, SUPPORTED_ROLE_TYPES } from './load_roles_users';
 
 export const cli = () => {
   run(
@@ -36,7 +36,9 @@ export const cli = () => {
         --kibana            The url to Kibana (Default: http://127.0.0.1:5601)
         --elasticsearch     The url to Elasticsearch (Default: http://127.0.0.1:9200)
         --type              The type of roles/users to load. Valid values are:
-                            - serverless: loads roles and users used in the serverless projects
+                            ${Object.entries(SUPPORTED_ROLE_TYPES)
+                              .map(([type, description]) => `- ${type}: ${description}`)
+                              .join(' '.repeat(28))}
       `,
       },
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/index.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RunFn } from '@kbn/dev-cli-runner';
+import { run } from '@kbn/dev-cli-runner';
+import { createRuntimeServices } from '../common/stack_services';
+import type { RolesAndUsersType } from './load_roles_users';
+import { loadRolesAndUsers } from './load_roles_users';
+
+export const cli = () => {
+  run(
+    cliRunner,
+
+    // Options
+    {
+      description: `Load Roles and Users into Kibana`,
+      flags: {
+        string: ['kibana', 'elastic', 'username', 'password'],
+        default: {
+          kibana: 'http://127.0.0.1:5601',
+          elasticsearch: 'http://127.0.0.1:9200',
+          username: 'elastic',
+          password: 'changeme',
+          type: 'serverless',
+        },
+        help: `
+        --username          User name to be used for auth against elasticsearch and
+                            kibana (Default: elastic).
+                            **IMPORTANT:** if 'asSuperuser' option is not used, then the
+                            user defined here MUST have 'superuser' AND 'kibana_system' roles
+        --password          User name Password (Default: changeme)
+        --kibana            The url to Kibana (Default: http://127.0.0.1:5601)
+        --elasticsearch     The url to Elasticsearch (Default: http://127.0.0.1:9200)
+        --type              The type of roles/users to load. Valid values are:
+                            - serverless: loads roles and users used in the serverless projects
+      `,
+      },
+    }
+  );
+};
+
+const cliRunner: RunFn = async (cliContext) => {
+  const { kbnClient, log } = await createRuntimeServices({
+    username: cliContext.flags.username as string,
+    password: cliContext.flags.password as string,
+    kibanaUrl: cliContext.flags.kibana as string,
+    elasticsearchUrl: cliContext.flags.elasticsearch as string,
+    log: cliContext.log,
+  });
+  const type = (cliContext.flags.type as string).toLowerCase() as RolesAndUsersType;
+
+  await loadRolesAndUsers(kbnClient, log, type);
+};

--- a/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/load_roles_users.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/load_roles_users.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ToolingLog } from '@kbn/tooling-log';
+import type { KbnClient } from '@kbn/test';
+import { SecurityRoleAndUserLoader } from '../../../../../test_serverless/shared/lib';
+
+const VALID_TYPES = ['serverless'] as const;
+
+export type RolesAndUsersType = typeof VALID_TYPES[number];
+
+export const loadRolesAndUsers = async (
+  kbnClient: KbnClient,
+  logger: ToolingLog,
+  type: RolesAndUsersType
+) => {
+  if (type === 'serverless') {
+    const silentLogger = new ToolingLog({
+      writeTo: process.stdout,
+      level: 'silent',
+    });
+
+    const roleAndUserLoader = new SecurityRoleAndUserLoader(kbnClient, silentLogger);
+
+    const loadedRoles = await roleAndUserLoader.loadAll();
+
+    logger.info(`DONE.
+The following roles were loaded:
+${JSON.stringify(loadedRoles, null, 2)}
+    `);
+  } else {
+    throw new Error(`Unknown type [${type}]. Valid values are: ${VALID_TYPES.join(', ')}`);
+  }
+};

--- a/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/load_roles_users.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/roles_and_users/load_roles_users.ts
@@ -9,9 +9,15 @@ import { ToolingLog } from '@kbn/tooling-log';
 import type { KbnClient } from '@kbn/test';
 import { SecurityRoleAndUserLoader } from '../../../../../test_serverless/shared/lib';
 
-const VALID_TYPES = ['serverless'] as const;
+export const SUPPORTED_ROLE_TYPES = {
+  serverless: 'loads roles and users used in the serverless projects',
+} as const;
 
-export type RolesAndUsersType = typeof VALID_TYPES[number];
+const VALID_TYPES = Object.keys(SUPPORTED_ROLE_TYPES) as ReadonlyArray<
+  keyof typeof SUPPORTED_ROLE_TYPES
+>;
+
+export type RolesAndUsersType = keyof typeof SUPPORTED_ROLE_TYPES;
 
 export const loadRolesAndUsers = async (
   kbnClient: KbnClient,

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/role_loader.ts
@@ -67,6 +67,16 @@ export class RoleAndUserLoader<R extends Record<string, Role> = Record<string, R
     };
   }
 
+  async loadAll(): Promise<Record<keyof R, LoadedRoleAndUser>> {
+    const response = {} as Record<keyof R, LoadedRoleAndUser>;
+
+    for (const roleName of Object.keys(this.roles) as Array<keyof R>) {
+      response[roleName] = await this.load(roleName);
+    }
+
+    return response;
+  }
+
   private async createRole(role: Role): Promise<void> {
     const { name: roleName, ...roleDefinition } = role;
 


### PR DESCRIPTION
# ON HOLD 🛑 

I thought it was going to be an easy one, but having we can't import form the serverless testing dir into security solution. Will eventually come back to this and see if there is an alternative (I have already tried a) moving the roles/users library to `security_solution/common` and `security_solution/scripts/*` with no success).

Anyone is free to pick this up and fix it if needed.

_______


## Summary

- Added `loadAll()` to the Serverless Role and User loader
- Adds new script (`x-pack/plugins/security_solution/scripts/endpoint/load_roles_and_users.js`) that creates Security Solution users and roles in kibana.
    - Currently, it defaults to the set of roles defined for serverless, however, the script is setup to be able to support other sets of Roles if necessary (there is a `--type` option that currently defaults to `serverless`


## Usage

### Show help

```shell
node x-pack/plugins/security_solution/scripts/endpoint/load_roles_and_users.js --help

  node load_roles_and_users.js

  Load Roles and Users into Kibana

  Options:
    --username          User name to be used for auth against elasticsearch and
                        kibana (Default: elastic)
    --password          User name Password (Default: changeme)
    --kibana            The url to Kibana (Default: http://127.0.0.1:5601)
    --elasticsearch     The url to Elasticsearch (Default: http://127.0.0.1:9200)
    --type              The type of roles/users to load. Valid values are:
                        - serverless: loads roles and users used in the serverless projects
    --verbose, -v      Log verbosely
    --debug            Log debug messages (less than verbose)
    --quiet            Only log errors
    --silent           Don't log anything
    --help             Show this message

```

### Run with default arguments:

```shell
node x-pack/plugins/security_solution/scripts/endpoint/load_roles_and_users.js
 info DONE.
      The following roles were loaded:
      {
        "t1_analyst": {
          "role": "t1_analyst",
          "username": "t1_analyst",
          "password": "changeme"
        },
        "t2_analyst": {
          "role": "t2_analyst",
          "username": "t2_analyst",
          "password": "changeme"
        },
        "t3_analyst": {
          "role": "t3_analyst",
          "username": "t3_analyst",
          "password": "changeme"
        },
        "threat_intelligence_analyst": {
          "role": "threat_intelligence_analyst",
          "username": "threat_intelligence_analyst",
          "password": "changeme"
        },
        "rule_author": {
          "role": "rule_author",
          "username": "rule_author",
          "password": "changeme"
        },
        "soc_manager": {
          "role": "soc_manager",
          "username": "soc_manager",
          "password": "changeme"
        },
        "detections_admin": {
          "role": "detections_admin",
          "username": "detections_admin",
          "password": "changeme"
        },
        "platform_engineer": {
          "role": "platform_engineer",
          "username": "platform_engineer",
          "password": "changeme"
        },
        "endpoint_operations_analyst": {
          "role": "endpoint_operations_analyst",
          "username": "endpoint_operations_analyst",
          "password": "changeme"
        },
        "endpoint_policy_manager": {
          "role": "endpoint_policy_manager",
          "username": "endpoint_policy_manager",
          "password": "changeme"
        }
      }
          

```



