### PR TITLE
[8.9] [TSVB] Unskip tsdb tests (#163471)

### DIFF
--- a/test/functional/apps/visualize/group6/_tsvb_tsdb_basic.ts
+++ b/test/functional/apps/visualize/group6/_tsvb_tsdb_basic.ts
@@ -17,8 +17,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const testSubjects = getService('testSubjects');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/163454
-  describe.skip('visual builder tsdb check', function describeIndexTests() {
+  describe('visual builder tsdb check', function describeIndexTests() {
     before(async () => {
       log.info(`loading sample TSDB index...`);
       await esArchiver.load('test/functional/fixtures/es_archiver/kibana_sample_data_logs_tsdb');
@@ -61,16 +60,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       const isFieldForAggregationValid = await visualBuilder.checkFieldForAggregationValidity();
       expect(isFieldForAggregationValid).to.be(true);
       expect(await testSubjects.exists('visualization-error-text')).to.be(false);
-    });
-
-    it('should show an error when using an unsupported tsdb field type', async () => {
-      await visualBuilder.selectAggType('Average');
-      await visualBuilder.setFieldForAggregation('bytes_counter');
-      // this is still returning true
-      const isFieldForAggregationValid = await visualBuilder.checkFieldForAggregationValidity();
-      expect(isFieldForAggregationValid).to.be(true);
-      // but an error should appear in visualization
-      expect(await testSubjects.exists('visualization-error-text')).to.be(true);
     });
   });
 }


### PR DESCRIPTION
# Backport

Closes https://github.com/elastic/kibana/issues/163454

This will backport the following commits from `main` to `8.9`:
 - [[TSVB] Unskip tsdb tests (#163471)](https://github.com/elastic/kibana/pull/163471)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2023-08-09T11:16:02Z","message":"[TSVB] Unskip tsdb tests (#163471)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/163454\r\n\r\nNow ES doesnt error out for average aggregation in counter fields. So we\r\ncan remove the test for this scenario","sha":"4fc9906c17206a67426e743984d8d628f7b14321","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:TSVB","Team:Visualizations","failed-test","release_note:skip","backport:skip","v8.10.0"],"number":163471,"url":"https://github.com/elastic/kibana/pull/163471","mergeCommit":{"message":"[TSVB] Unskip tsdb tests (#163471)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/163454\r\n\r\nNow ES doesnt error out for average aggregation in counter fields. So we\r\ncan remove the test for this scenario","sha":"4fc9906c17206a67426e743984d8d628f7b14321"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163471","number":163471,"mergeCommit":{"message":"[TSVB] Unskip tsdb tests (#163471)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/163454\r\n\r\nNow ES doesnt error out for average aggregation in counter fields. So we\r\ncan remove the test for this scenario","sha":"4fc9906c17206a67426e743984d8d628f7b14321"}}]}] BACKPORT-->