### PR TITLE
[APM] Make service group saved objects exportable

### DIFF
--- a/x-pack/plugins/apm/server/saved_objects/apm_service_groups.ts
+++ b/x-pack/plugins/apm/server/saved_objects/apm_service_groups.ts
@@ -52,12 +52,16 @@ export const apmServiceGroups: SavedObjectsType = {
     },
   },
   management: {
-    importableAndExportable: false,
+    importableAndExportable: true,
     icon: 'apmApp',
-    getTitle: () =>
-      i18n.translate('xpack.apm.apmServiceGroups.title', {
-        defaultMessage: 'APM Service Groups',
-      }),
+    getTitle: (savedObject) =>
+      `${i18n.translate('xpack.apm.apmServiceGroups.title', {
+        defaultMessage: 'Service Group',
+      })}: ${savedObject.attributes.groupName}`,
+    getInAppUrl: (savedObject) => ({
+      path: `/app/apm/services?serviceGroup=${savedObject.id}`,
+      uiCapabilitiesPath: 'apm.show',
+    }),
   },
   modelVersions: {
     '1': {


### PR DESCRIPTION
- Makes the saved objects used by service groups exportable / importable
- Adds a link from the saved object to the service group page
- Renames the saved objects from `APM Service Groups` to `Service Group: ${service_group_name}`

### Before

https://github.com/elastic/kibana/assets/5831975/3f498078-07d8-45ed-af18-7821de9e221c

### After

https://github.com/elastic/kibana/assets/5831975/d37029ee-ae2f-4ba9-8588-10bac8ac3bfb



Closes https://github.com/elastic/kibana/issues/163576