### PR TITLE
Enable prefer-object-has-own ESLint rule

### DIFF
--- a/packages/kbn-ace/src/ace/modes/x_json/worker/x_json.ace.worker.js
+++ b/packages/kbn-ace/src/ace/modes/x_json/worker/x_json.ace.worker.js
@@ -899,7 +899,7 @@
       if ("{" === ch) {
         if (next("{"), white(), "}" === ch) return next("}"), object;
         for (; ch;) {
-          if (key = string(), white(), next(":"), Object.hasOwnProperty.call(object, key) && error('Duplicate key "' + key + '"'), object[key] = value(), white(), "}" === ch) return next("}"), object;
+          if (key = string(), white(), next(":"), Object.hasOwn(object, key) && error('Duplicate key "' + key + '"'), object[key] = value(), white(), "}" === ch) return next("}"), object;
           next(","), white()
         }
       }
@@ -924,7 +924,7 @@
       return text = source, at = 0, ch = " ", result = value(), white(), ch && error("Syntax error"), "function" == typeof reviver ? function walk(holder, key) {
         var k, v, value = holder[key];
         if (value && "object" == typeof value)
-          for (k in value) Object.hasOwnProperty.call(value, k) && (v = walk(value, k), void 0 !== v ? value[k] = v : delete value[k]);
+          for (k in value) Object.hasOwn(value, k) && (v = walk(value, k), void 0 !== v ? value[k] = v : delete value[k]);
         return reviver.call(holder, key, value)
       }({
         "": result

--- a/packages/kbn-eslint-config/javascript.js
+++ b/packages/kbn-eslint-config/javascript.js
@@ -77,6 +77,7 @@ module.exports = {
         'no-with': 'error',
         'one-var': [ 'error', 'never' ],
         'prefer-const': 'error',
+        'prefer-object-has-own': 'error',
         strict: [ 'error', 'never' ],
         'valid-typeof': 'error',
         yoda: 'off',

--- a/packages/kbn-eslint-config/typescript.js
+++ b/packages/kbn-eslint-config/typescript.js
@@ -235,6 +235,7 @@ module.exports = {
           'object-shorthand': 'error',
           'one-var': [ 'error', 'never' ],
           'prefer-const': 'error',
+          'prefer-object-has-own': 'error',
           'prefer-rest-params': 'error',
           'radix': 'error',
           'spaced-comment': ["error", "always", {

--- a/packages/kbn-expect/expect.js
+++ b/packages/kbn-expect/expect.js
@@ -389,7 +389,7 @@ Assertion.prototype.length = function (n, msg) {
 Assertion.prototype.property = function (name, val) {
   if (this.flags.own) {
     this.assert(
-        Object.prototype.hasOwnProperty.call(this.obj, name)
+        Object.hasOwn(this.obj, name)
       , function(){ return 'expected ' + i(this.obj) + ' to have own property ' + i(name) }
       , function(){ return 'expected ' + i(this.obj) + ' to not have own property ' + i(name) });
     return this;
@@ -833,7 +833,7 @@ function keys (obj) {
   var keys = [];
 
   for (var i in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, i)) {
+    if (Object.hasOwn(obj, i)) {
       keys.push(i);
     }
   }

--- a/packages/kbn-handlebars/src/spec/index.regressions.test.ts
+++ b/packages/kbn-handlebars/src/spec/index.regressions.test.ts
@@ -231,7 +231,7 @@ describe('Regressions', () => {
           // It's valid to execute a block against an undefined context, but
           // helpers can not do so, so we expect to have an empty object here;
           for (const name in this) {
-            if (Object.prototype.hasOwnProperty.call(this, name)) {
+            if (Object.hasOwn(this, name)) {
               return 'found';
             }
           }

--- a/packages/kbn-handlebars/src/visitor.ts
+++ b/packages/kbn-handlebars/src/visitor.ts
@@ -112,7 +112,7 @@ export class ElasticHandlebarsVisitor extends Handlebars.Visitor {
         if (result == null) {
           return result;
         }
-        if (Object.prototype.hasOwnProperty.call(parent, propertyName)) {
+        if (Object.hasOwn(parent, propertyName)) {
           return result;
         }
 

--- a/packages/kbn-managed-vscode-config/src/update_vscode_config.ts
+++ b/packages/kbn-managed-vscode-config/src/update_vscode_config.ts
@@ -141,7 +141,7 @@ const mergeManagedProperties = (
     if (
       isBasicObjectProp(prop) &&
       isManaged(prop) &&
-      !Object.prototype.hasOwnProperty.call(managedValue, prop.key.value)
+      !Object.hasOwn(managedValue, prop.key.value)
     ) {
       remove(properties, prop);
     }

--- a/packages/kbn-monaco/src/xjson/grammar.ts
+++ b/packages/kbn-monaco/src/xjson/grammar.ts
@@ -165,7 +165,7 @@ export const createParser = () => {
             ((key = string()),
             white(),
             next(':'),
-            Object.hasOwnProperty.call(object, key!) &&
+            Object.hasOwn(object, key!) &&
               warning('Duplicate key "' + key + '"', latchKeyStart),
             (object[key!] = value()),
             white(),

--- a/packages/kbn-safer-lodash-set/test/fp_patch_test.js
+++ b/packages/kbn-safer-lodash-set/test/fp_patch_test.js
@@ -190,7 +190,7 @@ setFunctions.forEach(([testPermutations, set, testName]) => {
         t.notStrictEqual(arr, result);
         t.ok(Array.isArray(result));
         Object.keys(expected).forEach((key) => {
-          t.ok(Object.prototype.hasOwnProperty.call(result, key));
+          t.ok(Object.hasOwn(result, key));
           t.deepEqual(result[key], expected[key]);
         });
       });

--- a/packages/kbn-safer-lodash-set/test/patch_test.js
+++ b/packages/kbn-safer-lodash-set/test/patch_test.js
@@ -115,7 +115,7 @@ setAndSetWithFunctions.forEach(([set, testName]) => {
       const arr = [];
       set(arr, path, 'foo');
       Object.keys(expected).forEach((key) => {
-        t.ok(Object.prototype.hasOwnProperty.call(arr, key));
+        t.ok(Object.hasOwn(arr, key));
         t.deepEqual(arr[key], expected[key]);
       });
       t.end();

--- a/packages/kbn-std/src/ensure_no_unsafe_properties.ts
+++ b/packages/kbn-std/src/ensure_no_unsafe_properties.ts
@@ -11,12 +11,6 @@ interface StackItem {
   previousKey: string | null;
 }
 
-// we have to do Object.prototype.hasOwnProperty because when you create an object using
-// Object.create(null), and I assume other methods, you get an object without a prototype,
-// so you can't use current.hasOwnProperty
-const hasOwnProperty = (obj: any, property: string) =>
-  Object.prototype.hasOwnProperty.call(obj, property);
-
 const isObject = (obj: any) => typeof obj === 'object' && obj !== null;
 
 // we're using a stack instead of recursion so we aren't limited by the call stack
@@ -40,11 +34,11 @@ export function ensureNoUnsafeProperties(obj: any) {
       continue;
     }
 
-    if (hasOwnProperty(value, '__proto__')) {
+    if (Object.hasOwn(value, '__proto__')) {
       throw new Error(`'__proto__' is an invalid key`);
     }
 
-    if (hasOwnProperty(value, 'prototype') && previousKey === 'constructor') {
+    if (Object.hasOwn(value, 'prototype') && previousKey === 'constructor') {
       throw new Error(`'constructor.prototype' is an invalid key`);
     }
 

--- a/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
+++ b/src/plugins/console/public/application/models/legacy_core_editor/mode/worker/worker.js
@@ -2162,7 +2162,7 @@ ace.define(
             key = string();
             white();
             next(':');
-            if (Object.hasOwnProperty.call(object, key)) {
+            if (Object.hasOwn(object, key)) {
               error('Duplicate key "' + key + '"');
             }
             object[key] = value();
@@ -2283,7 +2283,7 @@ ace.define(
             value = holder[key];
           if (value && typeof value === 'object') {
             for (k in value) {
-              if (Object.hasOwnProperty.call(value, k)) {
+              if (Object.hasOwn(value, k)) {
                 v = walk(value, k);
                 if (v !== undefined) {
                   value[k] = v;

--- a/src/plugins/data/public/utils/shallow_equal.ts
+++ b/src/plugins/data/public/utils/shallow_equal.ts
@@ -24,7 +24,7 @@ export function shallowEqual(objA: unknown, objB: unknown): boolean {
 
   for (let i = 0; i < keysA.length; i++) {
     if (
-      !Object.prototype.hasOwnProperty.call(objB, keysA[i]) ||
+      !Object.hasOwn(objB, keysA[i]) ||
       // @ts-ignore
       !Object.is(objA[keysA[i]], objB[keysA[i]])
     ) {

--- a/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
+++ b/src/plugins/es_ui_shared/static/forms/hook_form_lib/hooks/use_field.ts
@@ -479,7 +479,7 @@ export const useField = <T, FormType = FormData, I = T>(
 
   const onChange: FieldHook<T, I>['onChange'] = useCallback(
     (event) => {
-      const newValue = {}.hasOwnProperty.call(event!.target, 'checked')
+      const newValue = Object.hasOwn(event!.target, 'checked')
         ? event.target.checked
         : event.target.value;
 
@@ -494,8 +494,7 @@ export const useField = <T, FormType = FormData, I = T>(
         const isSameErrorCode = errorCode && error.code === errorCode;
         const isSamevalidationType =
           error.validationType === validationType ||
-          (validationType === VALIDATION_TYPES.FIELD &&
-            !{}.hasOwnProperty.call(error, 'validationType'));
+          (validationType === VALIDATION_TYPES.FIELD && !Object.hasOwn(error, 'validationType'));
 
         if (isSameErrorCode || (typeof errorCode === 'undefined' && isSamevalidationType)) {
           return messages

--- a/src/plugins/unified_search/public/utils/shallow_equal.ts
+++ b/src/plugins/unified_search/public/utils/shallow_equal.ts
@@ -24,7 +24,7 @@ export function shallowEqual(objA: unknown, objB: unknown): boolean {
 
   for (let i = 0; i < keysA.length; i++) {
     if (
-      !Object.prototype.hasOwnProperty.call(objB, keysA[i]) ||
+      !Object.hasOwn(objB, keysA[i]) ||
       // @ts-ignore
       !Object.is(objA[keysA[i]], objB[keysA[i]])
     ) {

--- a/x-pack/packages/ml/is_populated_object/src/is_populated_object.ts
+++ b/x-pack/packages/ml/is_populated_object/src/is_populated_object.ts
@@ -30,7 +30,6 @@ export const isPopulatedObject = <U extends string = string, T extends unknown =
     typeof arg === 'object' &&
     arg !== null &&
     Object.keys(arg).length > 0 &&
-    (requiredAttributes.length === 0 ||
-      requiredAttributes.every((d) => ({}.hasOwnProperty.call(arg, d))))
+    (requiredAttributes.length === 0 || requiredAttributes.every((d) => Object.hasOwn(arg, d)))
   );
 };

--- a/x-pack/packages/ml/url_state/src/url_state.tsx
+++ b/x-pack/packages/ml/url_state/src/url_state.tsx
@@ -112,7 +112,7 @@ export const UrlStateProvider: FC = ({ children }) => {
       const urlState = parseUrlState(prevSearchString);
       const parsedQueryString = parse(prevSearchString, { sort: false });
 
-      if (!Object.prototype.hasOwnProperty.call(urlState, accessor)) {
+      if (!Object.hasOwn(urlState, accessor)) {
         urlState[accessor] = {};
       }
 

--- a/x-pack/plugins/alerting/server/saved_objects/migrations/7.11/index.ts
+++ b/x-pack/plugins/alerting/server/saved_objects/migrations/7.11/index.ts
@@ -19,7 +19,7 @@ export const isAnyActionSupportIncidents = (doc: SavedObjectUnsanitizedDoc<RawRu
 
 function isEmptyObject(obj: {}) {
   for (const attr in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, attr)) {
+    if (Object.hasOwn(obj, attr)) {
       return false;
     }
   }

--- a/x-pack/plugins/cases/public/components/user_actions/status.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/status.tsx
@@ -15,8 +15,7 @@ import { createCommonUpdateUserActionBuilder } from './common';
 import { statuses } from '../status';
 import * as i18n from './translations';
 
-const isStatusValid = (status: string): status is CaseStatuses =>
-  Object.prototype.hasOwnProperty.call(statuses, status);
+const isStatusValid = (status: string): status is CaseStatuses => Object.hasOwn(statuses, status);
 
 const getLabelTitle = (userAction: SnakeToCamelCase<StatusUserAction>) => {
   const status = userAction.payload.status ?? '';

--- a/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
+++ b/x-pack/plugins/data_visualizer/public/application/index_data_visualizer/index_data_visualizer.tsx
@@ -201,7 +201,7 @@ export const DataVisualizerStateContextProvider: FC<DataVisualizerStateContextPr
       const urlState = parseUrlState(prevSearchString);
       const parsedQueryString = parse(prevSearchString, { sort: false });
 
-      if (!Object.prototype.hasOwnProperty.call(urlState, accessor)) {
+      if (!Object.hasOwn(urlState, accessor)) {
         urlState[accessor] = {};
       }
 

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/curations/curation/results/utils.ts
@@ -43,7 +43,7 @@ export const convertToResultFormat = (document: CurationResult): SearchResult =>
   // Convert `key: 'value'` into `key: { raw: 'value' }`
   const result = Object.entries(document).reduce((acc, [key, value]) => {
     acc[key] =
-      isNestedObject(value) || Object.prototype.hasOwnProperty.call(value, 'raw')
+      isNestedObject(value) || (typeof value === 'object' && Object.hasOwn(value, 'raw'))
         ? value
         : { raw: value };
     return acc;

--- a/x-pack/plugins/index_management/common/lib/utils.ts
+++ b/x-pack/plugins/index_management/common/lib/utils.ts
@@ -15,7 +15,7 @@ import { TemplateDeserialized, LegacyTemplateSerialized, TemplateSerialized } fr
 export const isLegacyTemplate = (
   template: TemplateDeserialized | LegacyTemplateSerialized | TemplateSerialized
 ): boolean => {
-  return {}.hasOwnProperty.call(template, 'template') ? false : true;
+  return Object.hasOwn(template, 'template') ? false : true;
 };
 
 export const getTemplateParameter = (

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/analyzer_parameter.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/analyzer_parameter.tsx
@@ -38,14 +38,11 @@ const ANALYZER_OPTIONS_WITHOUT_DEFAULT = (
 ).filter(({ value }) => value !== INDEX_DEFAULT);
 
 const getCustomAnalyzers = (indexSettings: IndexSettings): SelectOption[] | undefined => {
-  const settings: IndexSettingsInterface = {}.hasOwnProperty.call(indexSettings, 'index')
+  const settings: IndexSettingsInterface = Object.hasOwn(indexSettings, 'index')
     ? (indexSettings as { index: IndexSettingsInterface }).index
     : (indexSettings as IndexSettingsInterface);
 
-  if (
-    !{}.hasOwnProperty.call(settings, 'analysis') ||
-    !{}.hasOwnProperty.call(settings.analysis!, 'analyzer')
-  ) {
+  if (!Object.hasOwn(settings, 'analysis') || !Object.hasOwn(settings.analysis!, 'analyzer')) {
     return undefined;
   }
 

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/analyzer_parameter_selects.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/components/document_fields/field_parameters/analyzer_parameter_selects.tsx
@@ -28,7 +28,7 @@ const areOptionsSuperSelect = (options: Options): boolean => {
     return false;
   }
   // `Select` options have a "text" property, `SuperSelect` options don't have it.
-  return {}.hasOwnProperty.call(options[0], 'text') === false;
+  return Object.hasOwn(options[0], 'text') === false;
 };
 
 interface Props {

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/data_types_definition.tsx
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/constants/data_types_definition.tsx
@@ -990,7 +990,7 @@ export const MAIN_DATA_TYPE_DEFINITION: {
  */
 export const SUB_TYPE_MAP_TO_MAIN = Object.entries(MAIN_DATA_TYPE_DEFINITION).reduce(
   (acc, [type, definition]) => {
-    if ({}.hasOwnProperty.call(definition, 'subTypes')) {
+    if (Object.hasOwn(definition, 'subTypes')) {
       definition.subTypes!.types.forEach((subType) => {
         acc[subType] = type;
       });

--- a/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/serializers.ts
+++ b/x-pack/plugins/index_management/public/application/components/mappings_editor/lib/serializers.ts
@@ -50,7 +50,7 @@ export const fieldSerializer: SerializerFunc<Field> = (field: Field) => {
   const updatedField: Field = Boolean(otherTypeJson) ? { ...otherTypeJson, ...rest } : { ...rest };
 
   // If a subType is present, use it as an Elasticsearch datatype
-  if ({}.hasOwnProperty.call(updatedField, 'subType')) {
+  if (Object.hasOwn(updatedField, 'subType')) {
     updatedField.type = updatedField.subType as DataType;
     delete updatedField.subType;
   }
@@ -77,8 +77,7 @@ export const fieldDeserializer: SerializerFunc<Field> = (field: Field): Field =>
      */
     field.otherTypeJson = otherTypeJson;
   } else {
-    (field as any).useSameAnalyzerForSearch =
-      {}.hasOwnProperty.call(field, 'search_analyzer') === false;
+    (field as any).useSameAnalyzerForSearch = Object.hasOwn(field, 'search_analyzer') === false;
   }
 
   return runParametersDeserializers(field);

--- a/x-pack/plugins/infra/public/pages/link_to/redirect_to_inventory.tsx
+++ b/x-pack/plugins/infra/public/pages/link_to/redirect_to_inventory.tsx
@@ -33,7 +33,7 @@ function parseQueryString(search: string): Record<string, string> {
 
   // Force all values into string. If they are empty don't create the keys
   for (const key in obj) {
-    if (Object.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       if (!obj[key]) {
         delete obj[key];
       }

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/common.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/analytics_list/common.ts
@@ -50,9 +50,9 @@ export function isDataFrameAnalyticsStats(arg: any): arg is DataFrameAnalyticsSt
   return (
     typeof arg === 'object' &&
     arg !== null &&
-    {}.hasOwnProperty.call(arg, 'state') &&
+    Object.hasOwn(arg, 'state') &&
     Object.values(DATA_FRAME_TASK_STATE).includes(arg.state) &&
-    {}.hasOwnProperty.call(arg, 'progress') &&
+    Object.hasOwn(arg, 'progress') &&
     Array.isArray(arg.progress)
   );
 }

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/services/analytics_service/get_analytics.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/services/analytics_service/get_analytics.ts
@@ -32,8 +32,8 @@ export const isGetDataFrameAnalyticsStatsResponseOk = (
   arg: any
 ): arg is GetDataFrameAnalyticsStatsResponseOk => {
   return (
-    {}.hasOwnProperty.call(arg, 'count') &&
-    {}.hasOwnProperty.call(arg, 'data_frame_analytics') &&
+    Object.hasOwn(arg, 'count') &&
+    Object.hasOwn(arg, 'data_frame_analytics') &&
     Array.isArray(arg.data_frame_analytics)
   );
 };

--- a/x-pack/plugins/monitoring/server/lib/elasticsearch_settings/cluster.ts
+++ b/x-pack/plugins/monitoring/server/lib/elasticsearch_settings/cluster.ts
@@ -16,7 +16,7 @@ export function handleResponse(
 ): ClusterSettingsReasonResponse {
   let source: keyof ClusterGetSettingsResponse;
   for (source in response) {
-    if (Object.prototype.hasOwnProperty.call(response, source)) {
+    if (Object.hasOwn(response, source)) {
       const monitoringSettings = get(response[source], 'xpack.monitoring');
       if (monitoringSettings !== undefined) {
         const check = findReason(

--- a/x-pack/plugins/security/server/deprecations/privilege_deprecations.ts
+++ b/x-pack/plugins/security/server/deprecations/privilege_deprecations.ts
@@ -106,7 +106,7 @@ export const getPrivilegeDeprecationsService = ({
     }
     return {
       roles: kibanaRoles.filter((role) =>
-        role.kibana.find((privilege) => Object.hasOwnProperty.call(privilege.feature, featureId))
+        role.kibana.find((privilege) => Object.hasOwn(privilege.feature, featureId))
       ),
     };
   };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_links.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_links.ts
@@ -7,7 +7,7 @@
 
 import { uniq } from 'lodash/fp';
 
-const lazySuricataLibConfiguration = () => {
+const lazySuricataLibConfiguration = (): Promise<{ db: Record<string, string[]> }> => {
   /**
    * The specially formatted comment in the `import` expression causes the corresponding webpack chunk to be named. This aids us in debugging chunk size issues.
    * See https://webpack.js.org/api/module-methods/#magic-comments
@@ -18,12 +18,9 @@ const lazySuricataLibConfiguration = () => {
   );
 };
 
-const has = <T>(obj: T, key: string | number | symbol): key is keyof T =>
-  Object.prototype.hasOwnProperty.call(obj, key);
-
 export const getLinksFromSignature = async (id: number): Promise<string[]> => {
   const db = (await lazySuricataLibConfiguration()).db;
-  const refs = has(db, id) ? db[id] : null;
+  const refs = Object.hasOwn(db, id) ? db[id] : null;
   if (refs != null) {
     return uniq(refs);
   } else {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_migrations.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/logic/rule_actions/legacy_migrations.ts
@@ -31,7 +31,7 @@ import {
  */
 function isEmptyObject(obj: {}) {
   for (const attr in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, attr)) {
+    if (Object.hasOwn(obj, attr)) {
       return false;
     }
   }

--- a/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/jira/jira_params.tsx
@@ -104,10 +104,10 @@ const JiraParamsFields: React.FunctionComponent<ActionParamsProps<JiraActionPara
     () =>
       fields != null
         ? {
-            hasLabels: Object.prototype.hasOwnProperty.call(fields, 'labels'),
-            hasDescription: Object.prototype.hasOwnProperty.call(fields, 'description'),
-            hasPriority: Object.prototype.hasOwnProperty.call(fields, 'priority'),
-            hasParent: Object.prototype.hasOwnProperty.call(fields, 'parent'),
+            hasLabels: Object.hasOwn(fields, 'labels'),
+            hasDescription: Object.hasOwn(fields, 'description'),
+            hasPriority: Object.hasOwn(fields, 'priority'),
+            hasParent: Object.hasOwn(fields, 'parent'),
           }
         : { hasLabels: false, hasDescription: false, hasPriority: false, hasParent: false },
     [fields]

--- a/x-pack/plugins/transform/common/api_schemas/type_guards.ts
+++ b/x-pack/plugins/transform/common/api_schemas/type_guards.ts
@@ -86,7 +86,7 @@ type SearchResponseWithAggregations = Required<Pick<estypes.SearchResponse, 'agg
 export const isEsSearchResponseWithAggregations = (
   arg: unknown
 ): arg is SearchResponseWithAggregations => {
-  return isEsSearchResponse(arg) && {}.hasOwnProperty.call(arg, 'aggregations');
+  return isEsSearchResponse(arg) && Object.hasOwn(arg, 'aggregations');
 };
 
 export const isFieldHistogramsResponseSchema = (


### PR DESCRIPTION
~Depends on #162309~

This PR enables the [`prefer-object-has-own`](https://eslint.org/docs/latest/rules/prefer-object-has-own) ESLint rule for all TypeScript and JavaScript files.

This means that we now require the use of [`Object.hasOwn`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) instead of `Object.prototype.hasOwnProperty.call` and other more insecure variants. Note that `Object.hasOwn` requires that Node.js and browsers support ES2022. But as far as I know the minimum browser requirement for Kibana should support that.