### PR TITLE
[Infra UI] Implement Telemetry on 'Show' buttons within Inventory

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_inventory_switcher.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_inventory_switcher.tsx
@@ -86,6 +86,7 @@ export const WaffleInventorySwitcher: React.FC = () => {
             {
               name: 'AWS',
               panel: 'awsPanel',
+              'data-test-subj': 'goToAWS-open',
             },
           ],
         },
@@ -96,18 +97,22 @@ export const WaffleInventorySwitcher: React.FC = () => {
             {
               name: getDisplayNameForType('awsEC2'),
               onClick: goToAwsEC2,
+              'data-test-subj': 'goToAWS-EC2',
             },
             {
               name: getDisplayNameForType('awsS3'),
               onClick: goToAwsS3,
+              'data-test-subj': 'goToAWS-S3',
             },
             {
               name: getDisplayNameForType('awsRDS'),
               onClick: goToAwsRDS,
+              'data-test-subj': 'goToAWS-RDS',
             },
             {
               name: getDisplayNameForType('awsSQS'),
               onClick: goToAwsSQS,
+              'data-test-subj': 'goToAWS-SQS',
             },
           ],
         },


### PR DESCRIPTION
## Summary

This PR adds telemetry for AWS buttons in the Inventory show menu.

## Testing
1. Go to inventory page
2. Open show drop down and check is all mentioned `data-test-subj` are present
  - data-test-subj="goToAWS-open"
     
![image](https://github.com/elastic/kibana/assets/14139027/d13439f0-712b-401b-869d-fb73f97e1f81)

  - data-test-subj="goToAWS-EC2"
  - data-test-subj="goToAWS-S3"
  - data-test-subj="goToAWS-RDS"
  - data-test-subj="goToAWS-SQS"
 
![image](https://github.com/elastic/kibana/assets/14139027/0fca9d28-7c41-47b4-a025-17cdb8b5fac0)

Check in the Network tab the `kibana-browser` request after clicking on the button:
<img width="1006" alt="image" src="https://github.com/elastic/kibana/assets/14139027/027d44a4-5d97-4340-ae59-62ddb266634e">
