### PR TITLE
[Logs UI] Adapt test to ES highlighting changes and unskip

### DIFF
--- a/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/log_entry_highlights.ts
@@ -45,8 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(() => esArchiver.unload('x-pack/test/functional/es_archives/infra/simple_logs'));
 
     describe('/log_entries/highlights', () => {
-      // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/163486
-      describe.skip('with the default source', () => {
+      describe('with the default source', () => {
         before(() => kibanaServer.savedObjects.cleanStandardList());
         after(() => kibanaServer.savedObjects.cleanStandardList());
 
@@ -120,7 +119,7 @@ export default function ({ getService }: FtrProviderContext) {
           entries.forEach((entry) => {
             entry.columns.forEach((column) => {
               if ('message' in column && 'highlights' in column.message[0]) {
-                expect(column.message[0].highlights).to.eql(['message', 'of', 'document', '0']);
+                expect(column.message[0].highlights).to.eql(['message of document 0']);
               }
             });
           });


### PR DESCRIPTION
## :memo: Summary

In https://github.com/elastic/elasticsearch/pull/96068 Elasticsearch changed the default behavior of the highlighting without announcing it as a breaking change. This adapts the test expectations to match the new behavior, because the feature still just works.

closes https://github.com/elastic/kibana/issues/163486