### PR TITLE
[performance] don't unload esArchives after warmup phase

### DIFF
--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -19,12 +19,8 @@ if [ "$BUILDKITE_PIPELINE_SLUG" == "kibana-performance-data-set-extraction" ]; t
   node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --skip-warmup
 else
   # pipeline should use bare metal static worker
-  for i in {1..5};
-  do
-    echo "--- Running performance tests #$i"
-    node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path x-pack/performance/journeys/data_stress_test_lens.ts
-    sleep 120
-  done
+  echo "--- Running performance tests"
+  node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION"
 fi
 
 echo "--- Upload journey step screenshots"

--- a/.buildkite/scripts/steps/functional/performance_playwright.sh
+++ b/.buildkite/scripts/steps/functional/performance_playwright.sh
@@ -19,8 +19,12 @@ if [ "$BUILDKITE_PIPELINE_SLUG" == "kibana-performance-data-set-extraction" ]; t
   node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --skip-warmup
 else
   # pipeline should use bare metal static worker
-  echo "--- Running performance tests"
-  node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION"
+  for i in {1..5};
+  do
+    echo "--- Running performance tests #$i"
+    node scripts/run_performance.js --kibana-install-dir "$KIBANA_BUILD_LOCATION" --journey-path x-pack/performance/journeys/data_stress_test_lens.ts
+    sleep 120
+  done
 fi
 
 echo "--- Upload journey step screenshots"


### PR DESCRIPTION
## Summary

Currently we run each single user perf journey 2 times in a row: first run is a "warmup" and 2nd run is actually to collect metrics. We load SOs/ES data before each journey and unload on completion, meaning we reload ES data 2 times though we don't restart ES instance.

This PR change the behaviour to keep ES data on "warmup" completion and re-use these data during test phase.

