### PR TITLE
[Security Solution] Migrate rules management API to versioned router

### DIFF
--- a/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/osquery/cypress/tasks/api_fixtures.ts
@@ -223,6 +223,9 @@ export const loadRule = (includeResponseActions = false) =>
         : {}),
     } as RuleCreateProps,
     url: `/api/detection_engine/rules`,
+    headers: {
+      'Elastic-Api-Version': API_VERSIONS.public.v1,
+    },
   }).then((response) => response.body);
 
 export const cleanupRule = (id: string) => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.test.ts
@@ -37,7 +37,6 @@ import {
   fetchRulesSnoozeSettings,
 } from './api';
 
-const abortCtrl = new AbortController();
 const mockKibanaServices = KibanaServices.get as jest.Mock;
 jest.mock('../../../common/lib/kibana');
 
@@ -53,12 +52,14 @@ describe('Detections Rules API', () => {
 
     test('POSTs rule', async () => {
       const payload = getCreateRulesSchemaMock();
-      await createRule({ rule: payload, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules', {
-        body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","rule_id":"rule-1"}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      await createRule({ rule: payload });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules',
+        expect.objectContaining({
+          body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","rule_id":"rule-1"}',
+          method: 'POST',
+        })
+      );
     });
   });
 
@@ -70,12 +71,14 @@ describe('Detections Rules API', () => {
 
     test('PUTs rule', async () => {
       const payload = getUpdateRulesSchemaMock();
-      await updateRule({ rule: payload, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules', {
-        body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","id":"04128c15-0d1b-4716-a4c5-46997ac7f3bd"}',
-        method: 'PUT',
-        signal: abortCtrl.signal,
-      });
+      await updateRule({ rule: payload });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules',
+        expect.objectContaining({
+          body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","id":"04128c15-0d1b-4716-a4c5-46997ac7f3bd"}',
+          method: 'PUT',
+        })
+      );
     });
   });
 
@@ -87,12 +90,14 @@ describe('Detections Rules API', () => {
 
     test('PATCHs rule', async () => {
       const payload = getPatchRulesSchemaMock();
-      await patchRule({ ruleProperties: payload, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules', {
-        body: JSON.stringify(payload),
-        method: 'PATCH',
-        signal: abortCtrl.signal,
-      });
+      await patchRule({ ruleProperties: payload });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules',
+        expect.objectContaining({
+          body: JSON.stringify(payload),
+          method: 'PATCH',
+        })
+      );
     });
   });
 
@@ -106,13 +111,14 @@ describe('Detections Rules API', () => {
       const payload = getCreateRulesSchemaMock();
       await previewRule({
         rule: { ...payload, invocationCount: 1, timeframeEnd: '2015-03-12 05:17:10' },
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/preview', {
-        body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","rule_id":"rule-1","invocationCount":1,"timeframeEnd":"2015-03-12 05:17:10"}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/preview',
+        expect.objectContaining({
+          body: '{"description":"Detecting root and admin users","name":"Query with a rule id","query":"user.name: root or user.name: admin","severity":"high","type":"query","risk_score":55,"language":"kuery","rule_id":"rule-1","invocationCount":1,"timeframeEnd":"2015-03-12 05:17:10"}',
+          method: 'POST',
+        })
+      );
     });
   });
 
@@ -123,17 +129,19 @@ describe('Detections Rules API', () => {
     });
 
     test('check parameter url, query without any options', async () => {
-      await fetchRules({ signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      await fetchRules({});
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, query with a filter', async () => {
@@ -148,21 +156,22 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter:
-            '(alert.attributes.name: "hello world" OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(alert.attributes.name: "hello world" OR alert.attributes.params.index: "hello world" OR alert.attributes.params.threat.tactic.id: "hello world" OR alert.attributes.params.threat.tactic.name: "hello world" OR alert.attributes.params.threat.technique.id: "hello world" OR alert.attributes.params.threat.technique.name: "hello world" OR alert.attributes.params.threat.technique.subtechnique.id: "hello world" OR alert.attributes.params.threat.technique.subtechnique.name: "hello world")',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, query with a filter get escaped correctly', async () => {
@@ -177,21 +186,22 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter:
-            '(alert.attributes.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.index: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.tactic.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.tactic.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" \\OR \\(foo\\:bar\\)")',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(alert.attributes.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.index: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.tactic.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.tactic.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.name: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.subtechnique.id: "\\" \\OR \\(foo\\:bar\\)" OR alert.attributes.params.threat.technique.subtechnique.name: "\\" \\OR \\(foo\\:bar\\)")',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, query with showCustomRules', async () => {
@@ -206,20 +216,21 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter: 'alert.attributes.params.immutable: false',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter: 'alert.attributes.params.immutable: false',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, query with showElasticRules', async () => {
@@ -234,20 +245,21 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter: 'alert.attributes.params.immutable: true',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter: 'alert.attributes.params.immutable: true',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, query with tags', async () => {
@@ -262,20 +274,21 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter: 'alert.attributes.tags:("hello" AND "world")',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter: 'alert.attributes.tags:("hello" AND "world")',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('check parameter url, passed sort field is snake case', async () => {
@@ -290,20 +303,21 @@ describe('Detections Rules API', () => {
           field: 'updatedAt',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter: 'alert.attributes.tags:("hello" AND "world")',
-          page: 1,
-          per_page: 20,
-          sort_field: 'updatedAt',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter: 'alert.attributes.tags:("hello" AND "world")',
+            page: 1,
+            per_page: 20,
+            sort_field: 'updatedAt',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('query with tags KQL parses without errors when tags contain characters such as left parenthesis (', async () => {
@@ -314,7 +328,6 @@ describe('Detections Rules API', () => {
           showElasticRules: true,
           tags: ['('],
         },
-        signal: abortCtrl.signal,
       });
       const [
         [
@@ -339,7 +352,6 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
       const [
         [
@@ -364,7 +376,6 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
       const [
         [
@@ -389,24 +400,25 @@ describe('Detections Rules API', () => {
           field: 'enabled',
           order: 'desc',
         },
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_find', {
-        method: 'GET',
-        query: {
-          filter:
-            '(alert.attributes.name: "ruleName" OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
-          page: 1,
-          per_page: 20,
-          sort_field: 'enabled',
-          sort_order: 'desc',
-        },
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_find',
+        expect.objectContaining({
+          method: 'GET',
+          query: {
+            filter:
+              '(alert.attributes.name: "ruleName" OR alert.attributes.params.index: "ruleName" OR alert.attributes.params.threat.tactic.id: "ruleName" OR alert.attributes.params.threat.tactic.name: "ruleName" OR alert.attributes.params.threat.technique.id: "ruleName" OR alert.attributes.params.threat.technique.name: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.id: "ruleName" OR alert.attributes.params.threat.technique.subtechnique.name: "ruleName") AND alert.attributes.tags:("hello" AND "world")',
+            page: 1,
+            per_page: 20,
+            sort_field: 'enabled',
+            sort_order: 'desc',
+          },
+        })
+      );
     });
 
     test('happy path', async () => {
-      const rulesResp = await fetchRules({ signal: abortCtrl.signal });
+      const rulesResp = await fetchRules({});
       expect(rulesResp).toEqual(rulesMock);
     });
   });
@@ -418,18 +430,20 @@ describe('Detections Rules API', () => {
     });
 
     test('check parameter url, query', async () => {
-      await fetchRuleById({ id: 'mySuperRuleId', signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules', {
-        query: {
-          id: 'mySuperRuleId',
-        },
-        method: 'GET',
-        signal: abortCtrl.signal,
-      });
+      await fetchRuleById({ id: 'mySuperRuleId' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules',
+        expect.objectContaining({
+          query: {
+            id: 'mySuperRuleId',
+          },
+          method: 'GET',
+        })
+      );
     });
 
     test('happy path', async () => {
-      const ruleResp = await fetchRuleById({ id: 'mySuperRuleId', signal: abortCtrl.signal });
+      const ruleResp = await fetchRuleById({ id: 'mySuperRuleId' });
       expect(ruleResp).toEqual(getRulesSchemaMock());
     });
   });
@@ -455,37 +469,41 @@ describe('Detections Rules API', () => {
     });
 
     test('check parameter url, body and query when importing rules', async () => {
-      await importRules({ fileToImport, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_import', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: formData,
-        headers: {
-          'Content-Type': undefined,
-        },
-        query: {
-          overwrite: false,
-          overwrite_action_connectors: false,
-          overwrite_exceptions: false,
-        },
-      });
+      await importRules({ fileToImport });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_import',
+        expect.objectContaining({
+          method: 'POST',
+          body: formData,
+          headers: {
+            'Content-Type': undefined,
+          },
+          query: {
+            overwrite: false,
+            overwrite_action_connectors: false,
+            overwrite_exceptions: false,
+          },
+        })
+      );
     });
 
     test('check parameter url, body and query when importing rules with overwrite', async () => {
-      await importRules({ fileToImport, overwrite: true, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_import', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: formData,
-        headers: {
-          'Content-Type': undefined,
-        },
-        query: {
-          overwrite: true,
-          overwrite_exceptions: false,
-          overwrite_action_connectors: false,
-        },
-      });
+      await importRules({ fileToImport, overwrite: true });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_import',
+        expect.objectContaining({
+          method: 'POST',
+          body: formData,
+          headers: {
+            'Content-Type': undefined,
+          },
+          query: {
+            overwrite: true,
+            overwrite_exceptions: false,
+            overwrite_action_connectors: false,
+          },
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -502,7 +520,7 @@ describe('Detections Rules API', () => {
         action_connectors_errors: [],
         action_connectors_warnings: [],
       });
-      const resp = await importRules({ fileToImport, signal: abortCtrl.signal });
+      const resp = await importRules({ fileToImport });
       expect(resp).toEqual({
         success: true,
         success_count: 33,
@@ -537,51 +555,54 @@ describe('Detections Rules API', () => {
     test('check parameter url, body and query when exporting rules', async () => {
       await exportRules({
         ids: ['mySuperRuleId', 'mySuperRuleId_II'],
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_export', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
-        query: {
-          exclude_export_details: false,
-          file_name: 'rules_export.ndjson',
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_export',
+        expect.objectContaining({
+          method: 'POST',
+          body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
+          query: {
+            exclude_export_details: false,
+            file_name: 'rules_export.ndjson',
+          },
+        })
+      );
     });
 
     test('check parameter url, body and query when exporting rules with excludeExportDetails', async () => {
       await exportRules({
         excludeExportDetails: true,
         ids: ['mySuperRuleId', 'mySuperRuleId_II'],
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_export', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
-        query: {
-          exclude_export_details: true,
-          file_name: 'rules_export.ndjson',
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_export',
+        expect.objectContaining({
+          method: 'POST',
+          body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
+          query: {
+            exclude_export_details: true,
+            file_name: 'rules_export.ndjson',
+          },
+        })
+      );
     });
 
     test('check parameter url, body and query when exporting rules with fileName', async () => {
       await exportRules({
         filename: 'myFileName.ndjson',
         ids: ['mySuperRuleId', 'mySuperRuleId_II'],
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_export', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
-        query: {
-          exclude_export_details: false,
-          file_name: 'myFileName.ndjson',
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_export',
+        expect.objectContaining({
+          method: 'POST',
+          body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
+          query: {
+            exclude_export_details: false,
+            file_name: 'myFileName.ndjson',
+          },
+        })
+      );
     });
 
     test('check parameter url, body and query when exporting rules with all options', async () => {
@@ -589,23 +610,23 @@ describe('Detections Rules API', () => {
         excludeExportDetails: true,
         filename: 'myFileName.ndjson',
         ids: ['mySuperRuleId', 'mySuperRuleId_II'],
-        signal: abortCtrl.signal,
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_export', {
-        signal: abortCtrl.signal,
-        method: 'POST',
-        body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
-        query: {
-          exclude_export_details: true,
-          file_name: 'myFileName.ndjson',
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_export',
+        expect.objectContaining({
+          method: 'POST',
+          body: '{"objects":[{"rule_id":"mySuperRuleId"},{"rule_id":"mySuperRuleId_II"}]}',
+          query: {
+            exclude_export_details: true,
+            file_name: 'myFileName.ndjson',
+          },
+        })
+      );
     });
 
     test('happy path', async () => {
       const resp = await exportRules({
         ids: ['mySuperRuleId', 'mySuperRuleId_II'],
-        signal: abortCtrl.signal,
       });
       expect(resp).toEqual(blob);
     });
@@ -623,14 +644,16 @@ describe('Detections Rules API', () => {
       fetchMock.mockResolvedValue(prePackagedRulesStatus);
     });
     test('check parameter url when fetching tags', async () => {
-      await getPrePackagedRulesStatus({ signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/prepackaged/_status', {
-        signal: abortCtrl.signal,
-        method: 'GET',
-      });
+      await getPrePackagedRulesStatus({});
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/prepackaged/_status',
+        expect.objectContaining({
+          method: 'GET',
+        })
+      );
     });
     test('happy path', async () => {
-      const resp = await getPrePackagedRulesStatus({ signal: abortCtrl.signal });
+      const resp = await getPrePackagedRulesStatus({});
       expect(resp).toEqual(prePackagedRulesStatus);
     });
   });
@@ -654,16 +677,18 @@ describe('Detections Rules API', () => {
           namespaceType: 'single',
         },
       ];
-      await findRuleExceptionReferences({ lists: payload, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith(DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL, {
-        query: {
-          ids: '123,456',
-          list_ids: 'list_id_1,list_id_2',
-          namespace_types: 'single,single',
-        },
-        method: 'GET',
-        signal: abortCtrl.signal,
-      });
+      await findRuleExceptionReferences({ lists: payload });
+      expect(fetchMock).toHaveBeenCalledWith(
+        DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL,
+        expect.objectContaining({
+          query: {
+            ids: '123,456',
+            list_ids: 'list_id_1,list_id_2',
+            namespace_types: 'single,single',
+          },
+          method: 'GET',
+        })
+      );
     });
   });
 
@@ -678,16 +703,19 @@ describe('Detections Rules API', () => {
     test('passes a query', async () => {
       await performBulkAction({ bulkAction: { type: BulkActionType.enable, query: 'some query' } });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_bulk_action', {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'enable',
-          query: 'some query',
-        }),
-        query: {
-          dry_run: false,
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_bulk_action',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'enable',
+            query: 'some query',
+          }),
+          query: {
+            dry_run: false,
+          },
+        })
+      );
     });
 
     test('passes ids', async () => {
@@ -695,16 +723,19 @@ describe('Detections Rules API', () => {
         bulkAction: { type: BulkActionType.disable, ids: ['ruleId1', 'ruleId2'] },
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_bulk_action', {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'disable',
-          ids: ['ruleId1', 'ruleId2'],
-        }),
-        query: {
-          dry_run: false,
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_bulk_action',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'disable',
+            ids: ['ruleId1', 'ruleId2'],
+          }),
+          query: {
+            dry_run: false,
+          },
+        })
+      );
     });
 
     test('passes edit payload', async () => {
@@ -718,17 +749,20 @@ describe('Detections Rules API', () => {
         },
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_bulk_action', {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'edit',
-          ids: ['ruleId1'],
-          edit: [{ type: 'add_index_patterns', value: ['some-index-pattern'] }],
-        }),
-        query: {
-          dry_run: false,
-        },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_bulk_action',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'edit',
+            ids: ['ruleId1'],
+            edit: [{ type: 'add_index_patterns', value: ['some-index-pattern'] }],
+          }),
+          query: {
+            dry_run: false,
+          },
+        })
+      );
     });
 
     test('executes dry run', async () => {
@@ -737,14 +771,17 @@ describe('Detections Rules API', () => {
         dryRun: true,
       });
 
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/rules/_bulk_action', {
-        method: 'POST',
-        body: JSON.stringify({
-          action: 'disable',
-          query: 'some query',
-        }),
-        query: { dry_run: true },
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/rules/_bulk_action',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({
+            action: 'disable',
+            query: 'some query',
+          }),
+          query: { dry_run: true },
+        })
+      );
     });
 
     test('returns result', async () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -94,6 +94,7 @@ import type {
 export const createRule = async ({ rule, signal }: CreateRulesProps): Promise<RuleResponse> =>
   KibanaServices.get().http.fetch<RuleResponse>(DETECTION_ENGINE_RULES_URL, {
     method: 'POST',
+    version: '2023-10-31',
     body: JSON.stringify(rule),
     signal,
   });
@@ -114,6 +115,7 @@ export const createRule = async ({ rule, signal }: CreateRulesProps): Promise<Ru
 export const updateRule = async ({ rule, signal }: UpdateRulesProps): Promise<Rule> =>
   KibanaServices.get().http.fetch<Rule>(DETECTION_ENGINE_RULES_URL, {
     method: 'PUT',
+    version: '2023-10-31',
     body: JSON.stringify(rule),
     signal,
   });
@@ -135,6 +137,7 @@ export const patchRule = async ({
 }: PatchRuleProps): Promise<RuleResponse> =>
   KibanaServices.get().http.fetch<RuleResponse>(DETECTION_ENGINE_RULES_URL, {
     method: 'PATCH',
+    version: '2023-10-31',
     body: JSON.stringify(ruleProperties),
     signal,
   });
@@ -192,6 +195,7 @@ export const fetchRules = async ({
 
   return KibanaServices.get().http.fetch<FetchRulesResponse>(DETECTION_ENGINE_RULES_URL_FIND, {
     method: 'GET',
+    version: '2023-10-31',
     query,
     signal,
   });
@@ -213,6 +217,7 @@ export const fetchRules = async ({
 export const fetchRuleById = async ({ id, signal }: FetchRuleProps): Promise<Rule> =>
   KibanaServices.get().http.fetch<Rule>(DETECTION_ENGINE_RULES_URL, {
     method: 'GET',
+    version: '2023-10-31',
     query: { id },
     signal,
   });
@@ -267,6 +272,7 @@ export const fetchCoverageOverview = async ({
 }: FetchCoverageOverviewProps): Promise<CoverageOverviewResponse> =>
   KibanaServices.get().http.fetch<CoverageOverviewResponse>(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL, {
     method: 'POST',
+    version: '1',
     body: JSON.stringify({
       filter,
     }),
@@ -369,6 +375,7 @@ export async function performBulkAction({
 
   return KibanaServices.get().http.fetch<BulkActionResponse>(DETECTION_ENGINE_RULES_BULK_ACTION, {
     method: 'POST',
+    version: '2023-10-31',
     body: JSON.stringify(params),
     query: { dry_run: dryRun },
   });
@@ -392,6 +399,7 @@ export async function bulkExportRules(queryOrIds: QueryOrIds): Promise<BulkExpor
 
   return KibanaServices.get().http.fetch<BulkExportResponse>(DETECTION_ENGINE_RULES_BULK_ACTION, {
     method: 'POST',
+    version: '2023-10-31',
     body: JSON.stringify(params),
   });
 }
@@ -426,6 +434,7 @@ export const importRules = async ({
     `${DETECTION_ENGINE_RULES_URL}/_import`,
     {
       method: 'POST',
+      version: '2023-10-31',
       headers: { 'Content-Type': undefined },
       query: {
         overwrite,
@@ -461,6 +470,7 @@ export const exportRules = async ({
 
   return KibanaServices.get().http.fetch<Blob>(`${DETECTION_ENGINE_RULES_URL}/_export`, {
     method: 'POST',
+    version: '2023-10-31',
     body,
     query: {
       exclude_export_details: excludeExportDetails,
@@ -484,6 +494,7 @@ export const fetchRuleManagementFilters = async ({
 }): Promise<GetRuleManagementFiltersResponse> =>
   KibanaServices.get().http.fetch<GetRuleManagementFiltersResponse>(RULE_MANAGEMENT_FILTERS_URL, {
     method: 'GET',
+    version: '1',
     signal,
   });
 
@@ -497,10 +508,11 @@ export const fetchRuleManagementFilters = async ({
 export const getPrePackagedRulesStatus = async ({
   signal,
 }: {
-  signal: AbortSignal | undefined;
+  signal?: AbortSignal;
 }): Promise<PrePackagedRulesStatusResponse> =>
   KibanaServices.get().http.fetch<PrePackagedRulesStatusResponse>(PREBUILT_RULES_STATUS_URL, {
     method: 'GET',
+    version: '2023-10-31',
     signal,
   });
 
@@ -642,6 +654,7 @@ export const getPrebuiltRulesStatus = async ({
     GET_PREBUILT_RULES_STATUS_URL,
     {
       method: 'GET',
+      version: '1',
       signal,
     }
   );
@@ -660,6 +673,7 @@ export const reviewRuleUpgrade = async ({
 }): Promise<ReviewRuleUpgradeResponseBody> =>
   KibanaServices.get().http.fetch(REVIEW_RULE_UPGRADE_URL, {
     method: 'POST',
+    version: '1',
     signal,
   });
 
@@ -677,12 +691,14 @@ export const reviewRuleInstall = async ({
 }): Promise<ReviewRuleInstallationResponseBody> =>
   KibanaServices.get().http.fetch(REVIEW_RULE_INSTALLATION_URL, {
     method: 'POST',
+    version: '1',
     signal,
   });
 
 export const performInstallAllRules = async (): Promise<PerformRuleInstallationResponseBody> =>
   KibanaServices.get().http.fetch(PERFORM_RULE_INSTALLATION_URL, {
     method: 'POST',
+    version: '1',
     body: JSON.stringify({
       mode: 'ALL_RULES',
     }),
@@ -693,6 +709,7 @@ export const performInstallSpecificRules = async (
 ): Promise<PerformRuleInstallationResponseBody> =>
   KibanaServices.get().http.fetch(PERFORM_RULE_INSTALLATION_URL, {
     method: 'POST',
+    version: '1',
     body: JSON.stringify({
       mode: 'SPECIFIC_RULES',
       rules,
@@ -702,6 +719,7 @@ export const performInstallSpecificRules = async (
 export const performUpgradeAllRules = async (): Promise<PerformRuleUpgradeResponseBody> =>
   KibanaServices.get().http.fetch(PERFORM_RULE_UPGRADE_URL, {
     method: 'POST',
+    version: '1',
     body: JSON.stringify({
       mode: 'ALL_RULES',
       pick_version: 'TARGET',
@@ -713,6 +731,7 @@ export const performUpgradeSpecificRules = async (
 ): Promise<PerformRuleUpgradeResponseBody> =>
   KibanaServices.get().http.fetch(PERFORM_RULE_UPGRADE_URL, {
     method: 'POST',
+    version: '1',
     body: JSON.stringify({
       mode: 'SPECIFIC_RULES',
       rules,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/types.ts
@@ -290,7 +290,7 @@ export interface ImportDataProps {
   overwrite?: boolean;
   overwriteExceptions?: boolean;
   overwriteActionConnectors?: boolean;
-  signal: AbortSignal;
+  signal?: AbortSignal;
 }
 
 export interface ImportRulesResponseError {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/api/api_client.test.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/api/api_client.test.ts
@@ -25,8 +25,6 @@ describe('Rule Monitoring API Client', () => {
   const mockKibanaServices = KibanaServices.get as jest.Mock;
   mockKibanaServices.mockReturnValue({ http: { fetch: fetchMock } });
 
-  const signal = new AbortController().signal;
-
   describe('setupDetectionEngineHealthApi', () => {
     const responseMock = {};
 
@@ -38,9 +36,12 @@ describe('Rule Monitoring API Client', () => {
     it('calls API with correct parameters', async () => {
       await api.setupDetectionEngineHealthApi();
 
-      expect(fetchMock).toHaveBeenCalledWith('/internal/detection_engine/health/_setup', {
-        method: 'POST',
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/internal/detection_engine/health/_setup',
+        expect.objectContaining({
+          method: 'POST',
+        })
+      );
     });
   });
 
@@ -60,15 +61,14 @@ describe('Rule Monitoring API Client', () => {
     });
 
     it('calls API correctly with only rule id specified', async () => {
-      await api.fetchRuleExecutionEvents({ ruleId: '42', signal });
+      await api.fetchRuleExecutionEvents({ ruleId: '42' });
 
       expect(fetchMock).toHaveBeenCalledWith(
         '/internal/detection_engine/rules/42/execution/events',
-        {
+        expect.objectContaining({
           method: 'GET',
           query: {},
-          signal,
-        }
+        })
       );
     });
 
@@ -80,12 +80,11 @@ describe('Rule Monitoring API Client', () => {
         sortOrder: 'asc',
         page: 42,
         perPage: 146,
-        signal,
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
         '/internal/detection_engine/rules/42/execution/events',
-        {
+        expect.objectContaining({
           method: 'GET',
           query: {
             event_types: 'message',
@@ -94,8 +93,7 @@ describe('Rule Monitoring API Client', () => {
             page: 42,
             per_page: 146,
           },
-          signal,
-        }
+        })
       );
     });
   });
@@ -118,12 +116,11 @@ describe('Rule Monitoring API Client', () => {
         end: '2001-01-02T17:00:00.000Z',
         queryText: '',
         statusFilters: [],
-        signal,
       });
 
       expect(fetchMock).toHaveBeenCalledWith(
         '/internal/detection_engine/rules/42/execution/results',
-        {
+        expect.objectContaining({
           method: 'GET',
           query: {
             end: '2001-01-02T17:00:00.000Z',
@@ -135,8 +132,7 @@ describe('Rule Monitoring API Client', () => {
             start: '2001-01-01T17:00:00.000Z',
             status_filters: '',
           },
-          signal,
-        }
+        })
       );
     });
 
@@ -147,7 +143,6 @@ describe('Rule Monitoring API Client', () => {
         end: 'now',
         queryText: '',
         statusFilters: [],
-        signal,
       });
       expect(response).toEqual(responseMock);
     });

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/api/api_client.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_monitoring/api/api_client.ts
@@ -28,6 +28,7 @@ import type {
 export const api: IRuleMonitoringApiClient = {
   setupDetectionEngineHealthApi: async (): Promise<void> => {
     await http().fetch(SETUP_HEALTH_URL, {
+      version: '1',
       method: 'POST',
     });
   },
@@ -41,6 +42,7 @@ export const api: IRuleMonitoringApiClient = {
 
     return http().fetch<GetRuleExecutionEventsResponse>(url, {
       method: 'GET',
+      version: '1',
       query: {
         event_types: eventTypes?.join(','),
         log_levels: logLevels?.join(','),
@@ -74,6 +76,7 @@ export const api: IRuleMonitoringApiClient = {
 
     return http().fetch<GetRuleExecutionResultsResponse>(url, {
       method: 'GET',
+      version: '1',
       query: {
         start: startDate?.utc().toISOString(),
         end: endDate?.utc().toISOString(),

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/add_alerts_to_case.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/add_alerts_to_case.ts
@@ -36,6 +36,9 @@ export const addAlertsToCase = ({
     method: 'GET',
     url: DETECTION_ENGINE_RULES_URL,
     qs: { rule_id: ELASTIC_SECURITY_RULE_ID },
+    headers: {
+      'elastic-api-version': '2023-10-31',
+    },
   }).then((ruleResponse) => {
     const endpointRuleDocId = ruleResponse.body.id;
 

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/alerts.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/alerts.ts
@@ -71,6 +71,9 @@ export const fetchEndpointSecurityDetectionRule = (): Cypress.Chainable<Rule> =>
     qs: {
       rule_id: ELASTIC_SECURITY_RULE_ID,
     },
+    headers: {
+      'elastic-api-version': '2023-10-31',
+    },
   }).then(({ body }) => {
     return body;
   });
@@ -87,6 +90,9 @@ export const stopStartEndpointDetectionsRule = (): Cypress.Chainable<Rule> => {
           action: 'disable',
           ids: [endpointRule.id],
         },
+        headers: {
+          'elastic-api-version': '2023-10-31',
+        },
       }).then(() => {
         return endpointRule;
       });
@@ -101,6 +107,9 @@ export const stopStartEndpointDetectionsRule = (): Cypress.Chainable<Rule> => {
         body: {
           action: 'enable',
           ids: [endpointRule.id],
+        },
+        headers: {
+          'elastic-api-version': '2023-10-31',
         },
       }).then(() => endpointRule);
     })

--- a/x-pack/plugins/security_solution/public/management/cypress/tasks/api_fixtures.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/tasks/api_fixtures.ts
@@ -13,7 +13,13 @@ export const generateRandomStringName = (length: number) =>
   Array.from({ length }, () => Math.random().toString(36).substring(2));
 
 export const cleanupRule = (id: string) => {
-  request({ method: 'DELETE', url: `/api/detection_engine/rules?id=${id}` });
+  request({
+    method: 'DELETE',
+    url: `/api/detection_engine/rules?id=${id}`,
+    headers: {
+      'elastic-api-version': '2023-10-31',
+    },
+  });
 };
 
 export const loadRule = (body = {}, includeResponseActions = true) =>
@@ -66,6 +72,9 @@ export const loadRule = (body = {}, includeResponseActions = true) =>
             ],
           }
         : {}),
+    },
+    headers: {
+      'elastic-api-version': '2023-10-31',
     },
   }).then((response) => response.body);
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.ts
@@ -31,75 +31,81 @@ export const getPrebuiltRulesAndTimelinesStatusRoute = (
   router: SecuritySolutionPluginRouter,
   security: SetupPlugins['security']
 ) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'public',
       path: PREBUILT_RULES_STATUS_URL,
-      validate: false,
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
-      const ctx = await context.resolve(['core', 'alerting']);
-      const savedObjectsClient = ctx.core.savedObjects.client;
-      const rulesClient = ctx.alerting.getRulesClient();
-      const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
+        const ctx = await context.resolve(['core', 'alerting']);
+        const savedObjectsClient = ctx.core.savedObjects.client;
+        const rulesClient = ctx.alerting.getRulesClient();
+        const ruleAssetsClient = createPrebuiltRuleAssetsClient(savedObjectsClient);
 
-      try {
-        const latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();
+        try {
+          const latestPrebuiltRules = await ruleAssetsClient.fetchLatestAssets();
 
-        const customRules = await findRules({
-          rulesClient,
-          perPage: 1,
-          page: 1,
-          sortField: 'enabled',
-          sortOrder: 'desc',
-          filter: 'alert.attributes.params.immutable: false',
-          fields: undefined,
-        });
+          const customRules = await findRules({
+            rulesClient,
+            perPage: 1,
+            page: 1,
+            sortField: 'enabled',
+            sortOrder: 'desc',
+            filter: 'alert.attributes.params.immutable: false',
+            fields: undefined,
+          });
 
-        const installedPrebuiltRules = rulesToMap(
-          await getExistingPrepackagedRules({ rulesClient })
-        );
+          const installedPrebuiltRules = rulesToMap(
+            await getExistingPrepackagedRules({ rulesClient })
+          );
 
-        const rulesToInstall = getRulesToInstall(latestPrebuiltRules, installedPrebuiltRules);
-        const rulesToUpdate = getRulesToUpdate(latestPrebuiltRules, installedPrebuiltRules);
+          const rulesToInstall = getRulesToInstall(latestPrebuiltRules, installedPrebuiltRules);
+          const rulesToUpdate = getRulesToUpdate(latestPrebuiltRules, installedPrebuiltRules);
 
-        const frameworkRequest = await buildFrameworkRequest(context, security, request);
-        const prebuiltTimelineStatus = await checkTimelinesStatus(frameworkRequest);
-        const [validatedPrebuiltTimelineStatus] = validate(
-          prebuiltTimelineStatus,
-          checkTimelineStatusRt
-        );
+          const frameworkRequest = await buildFrameworkRequest(context, security, request);
+          const prebuiltTimelineStatus = await checkTimelinesStatus(frameworkRequest);
+          const [validatedPrebuiltTimelineStatus] = validate(
+            prebuiltTimelineStatus,
+            checkTimelineStatusRt
+          );
 
-        const responseBody: GetPrebuiltRulesAndTimelinesStatusResponse = {
-          rules_custom_installed: customRules.total,
-          rules_installed: installedPrebuiltRules.size,
-          rules_not_installed: rulesToInstall.length,
-          rules_not_updated: rulesToUpdate.length,
-          timelines_installed: validatedPrebuiltTimelineStatus?.prepackagedTimelines.length ?? 0,
-          timelines_not_installed: validatedPrebuiltTimelineStatus?.timelinesToInstall.length ?? 0,
-          timelines_not_updated: validatedPrebuiltTimelineStatus?.timelinesToUpdate.length ?? 0,
-        };
+          const responseBody: GetPrebuiltRulesAndTimelinesStatusResponse = {
+            rules_custom_installed: customRules.total,
+            rules_installed: installedPrebuiltRules.size,
+            rules_not_installed: rulesToInstall.length,
+            rules_not_updated: rulesToUpdate.length,
+            timelines_installed: validatedPrebuiltTimelineStatus?.prepackagedTimelines.length ?? 0,
+            timelines_not_installed:
+              validatedPrebuiltTimelineStatus?.timelinesToInstall.length ?? 0,
+            timelines_not_updated: validatedPrebuiltTimelineStatus?.timelinesToUpdate.length ?? 0,
+          };
 
-        const [validatedBody, validationError] = validate(
-          responseBody,
-          GetPrebuiltRulesAndTimelinesStatusResponse
-        );
+          const [validatedBody, validationError] = validate(
+            responseBody,
+            GetPrebuiltRulesAndTimelinesStatusResponse
+          );
 
-        if (validationError != null) {
-          return siemResponse.error({ statusCode: 500, body: validationError });
-        } else {
-          return response.ok({ body: validatedBody ?? {} });
+          if (validationError != null) {
+            return siemResponse.error({ statusCode: 500, body: validationError });
+          } else {
+            return response.ok({ body: validatedBody ?? {} });
+          }
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/get_prebuilt_rules_status_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/get_prebuilt_rules_status/get_prebuilt_rules_status_route.ts
@@ -16,48 +16,53 @@ import { fetchRuleVersionsTriad } from '../../logic/rule_versions/fetch_rule_ver
 import { getVersionBuckets } from '../../model/rule_versions/get_version_buckets';
 
 export const getPrebuiltRulesStatusRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: GET_PREBUILT_RULES_STATUS_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {},
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['core', 'alerting']);
-        const soClient = ctx.core.savedObjects.client;
-        const rulesClient = ctx.alerting.getRulesClient();
-        const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
-        const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
+        try {
+          const ctx = await context.resolve(['core', 'alerting']);
+          const soClient = ctx.core.savedObjects.client;
+          const rulesClient = ctx.alerting.getRulesClient();
+          const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
+          const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
 
-        const ruleVersionsMap = await fetchRuleVersionsTriad({
-          ruleAssetsClient,
-          ruleObjectsClient,
-        });
-        const { currentRules, installableRules, upgradeableRules, totalAvailableRules } =
-          getVersionBuckets(ruleVersionsMap);
+          const ruleVersionsMap = await fetchRuleVersionsTriad({
+            ruleAssetsClient,
+            ruleObjectsClient,
+          });
+          const { currentRules, installableRules, upgradeableRules, totalAvailableRules } =
+            getVersionBuckets(ruleVersionsMap);
 
-        const body: GetPrebuiltRulesStatusResponseBody = {
-          stats: {
-            num_prebuilt_rules_installed: currentRules.length,
-            num_prebuilt_rules_to_install: installableRules.length,
-            num_prebuilt_rules_to_upgrade: upgradeableRules.length,
-            num_prebuilt_rules_total_in_package: totalAvailableRules.length,
-          },
-        };
+          const body: GetPrebuiltRulesStatusResponseBody = {
+            stats: {
+              num_prebuilt_rules_installed: currentRules.length,
+              num_prebuilt_rules_to_install: installableRules.length,
+              num_prebuilt_rules_to_upgrade: upgradeableRules.length,
+              num_prebuilt_rules_total_in_package: totalAvailableRules.length,
+            },
+          };
 
-        return response.ok({ body });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/perform_rule_upgrade/perform_rule_upgrade_route.ts
@@ -32,158 +32,165 @@ import type { PrebuiltRuleAsset } from '../../model/rule_assets/prebuilt_rule_as
 import { getVersionBuckets } from '../../model/rule_versions/get_version_buckets';
 
 export const performRuleUpgradeRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: PERFORM_RULE_UPGRADE_URL,
-      validate: {
-        body: buildRouteValidation(PerformRuleUpgradeRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidation(PerformRuleUpgradeRequestBody),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['core', 'alerting', 'securitySolution']);
-        const soClient = ctx.core.savedObjects.client;
-        const rulesClient = ctx.alerting.getRulesClient();
-        const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
-        const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
+        try {
+          const ctx = await context.resolve(['core', 'alerting', 'securitySolution']);
+          const soClient = ctx.core.savedObjects.client;
+          const rulesClient = ctx.alerting.getRulesClient();
+          const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
+          const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
 
-        const { mode, pick_version: globalPickVersion = PickVersionValues.TARGET } = request.body;
+          const { mode, pick_version: globalPickVersion = PickVersionValues.TARGET } = request.body;
 
-        const fetchErrors: Array<PromisePoolError<{ rule_id: string }>> = [];
-        const targetRules: PrebuiltRuleAsset[] = [];
-        const skippedRules: SkippedRuleUpgrade[] = [];
+          const fetchErrors: Array<PromisePoolError<{ rule_id: string }>> = [];
+          const targetRules: PrebuiltRuleAsset[] = [];
+          const skippedRules: SkippedRuleUpgrade[] = [];
 
-        const versionSpecifiers = mode === 'ALL_RULES' ? undefined : request.body.rules;
-        const versionSpecifiersMap = new Map(
-          versionSpecifiers?.map((rule) => [rule.rule_id, rule])
-        );
-        const ruleVersionsMap = await fetchRuleVersionsTriad({
-          ruleAssetsClient,
-          ruleObjectsClient,
-          versionSpecifiers,
-        });
-        const versionBuckets = getVersionBuckets(ruleVersionsMap);
-        const { currentRules } = versionBuckets;
-        // The upgradeable rules list is mutable; we can remove rules from it because of version mismatch
-        let upgradeableRules = versionBuckets.upgradeableRules;
-
-        // Perform all the checks we can before we start the upgrade process
-        if (mode === 'SPECIFIC_RULES') {
-          const installedRuleIds = new Set(currentRules.map((rule) => rule.rule_id));
-          const upgradeableRuleIds = new Set(
-            upgradeableRules.map(({ current }) => current.rule_id)
+          const versionSpecifiers = mode === 'ALL_RULES' ? undefined : request.body.rules;
+          const versionSpecifiersMap = new Map(
+            versionSpecifiers?.map((rule) => [rule.rule_id, rule])
           );
-          request.body.rules.forEach((rule) => {
-            // Check that the requested rule was found
-            if (!installedRuleIds.has(rule.rule_id)) {
-              fetchErrors.push({
-                error: new Error(
-                  `Rule with ID "${rule.rule_id}" and version "${rule.version}" not found`
-                ),
-                item: rule,
-              });
-              return;
-            }
-
-            // Check that the requested rule is upgradeable
-            if (!upgradeableRuleIds.has(rule.rule_id)) {
-              skippedRules.push({
-                rule_id: rule.rule_id,
-                reason: SkipRuleUpgradeReason.RULE_UP_TO_DATE,
-              });
-              return;
-            }
-
-            // Check that rule revisions match (no update slipped in since the user reviewed the list)
-            const currentRevision = ruleVersionsMap.get(rule.rule_id)?.current?.revision;
-            if (rule.revision !== currentRevision) {
-              fetchErrors.push({
-                error: new Error(
-                  `Revision mismatch for rule ID ${rule.rule_id}: expected ${rule.revision}, got ${currentRevision}`
-                ),
-                item: rule,
-              });
-              // Remove the rule from the list of upgradeable rules
-              upgradeableRules = upgradeableRules.filter(
-                ({ current }) => current.rule_id !== rule.rule_id
-              );
-            }
+          const ruleVersionsMap = await fetchRuleVersionsTriad({
+            ruleAssetsClient,
+            ruleObjectsClient,
+            versionSpecifiers,
           });
-        }
+          const versionBuckets = getVersionBuckets(ruleVersionsMap);
+          const { currentRules } = versionBuckets;
+          // The upgradeable rules list is mutable; we can remove rules from it because of version mismatch
+          let upgradeableRules = versionBuckets.upgradeableRules;
 
-        // Construct the list of target rule versions
-        upgradeableRules.forEach(({ current, target }) => {
-          const rulePickVersion =
-            versionSpecifiersMap?.get(current.rule_id)?.pick_version ?? globalPickVersion;
-          switch (rulePickVersion) {
-            case PickVersionValues.BASE:
-              const baseVersion = ruleVersionsMap.get(current.rule_id)?.base;
-              if (baseVersion) {
-                targetRules.push({ ...baseVersion, version: target.version });
-              } else {
+          // Perform all the checks we can before we start the upgrade process
+          if (mode === 'SPECIFIC_RULES') {
+            const installedRuleIds = new Set(currentRules.map((rule) => rule.rule_id));
+            const upgradeableRuleIds = new Set(
+              upgradeableRules.map(({ current }) => current.rule_id)
+            );
+            request.body.rules.forEach((rule) => {
+              // Check that the requested rule was found
+              if (!installedRuleIds.has(rule.rule_id)) {
                 fetchErrors.push({
-                  error: new Error(`Could not find base version for rule ${current.rule_id}`),
-                  item: current,
+                  error: new Error(
+                    `Rule with ID "${rule.rule_id}" and version "${rule.version}" not found`
+                  ),
+                  item: rule,
                 });
+                return;
               }
-              break;
-            case PickVersionValues.CURRENT:
-              targetRules.push({ ...current, version: target.version });
-              break;
-            case PickVersionValues.TARGET:
-              targetRules.push(target);
-              break;
-            default:
-              assertUnreachable(rulePickVersion);
+
+              // Check that the requested rule is upgradeable
+              if (!upgradeableRuleIds.has(rule.rule_id)) {
+                skippedRules.push({
+                  rule_id: rule.rule_id,
+                  reason: SkipRuleUpgradeReason.RULE_UP_TO_DATE,
+                });
+                return;
+              }
+
+              // Check that rule revisions match (no update slipped in since the user reviewed the list)
+              const currentRevision = ruleVersionsMap.get(rule.rule_id)?.current?.revision;
+              if (rule.revision !== currentRevision) {
+                fetchErrors.push({
+                  error: new Error(
+                    `Revision mismatch for rule ID ${rule.rule_id}: expected ${rule.revision}, got ${currentRevision}`
+                  ),
+                  item: rule,
+                });
+                // Remove the rule from the list of upgradeable rules
+                upgradeableRules = upgradeableRules.filter(
+                  ({ current }) => current.rule_id !== rule.rule_id
+                );
+              }
+            });
           }
-        });
 
-        // Perform the upgrade
-        const { results: updatedRules, errors: installationErrors } = await upgradePrebuiltRules(
-          rulesClient,
-          targetRules
-        );
-        const ruleErrors = [...fetchErrors, ...installationErrors];
+          // Construct the list of target rule versions
+          upgradeableRules.forEach(({ current, target }) => {
+            const rulePickVersion =
+              versionSpecifiersMap?.get(current.rule_id)?.pick_version ?? globalPickVersion;
+            switch (rulePickVersion) {
+              case PickVersionValues.BASE:
+                const baseVersion = ruleVersionsMap.get(current.rule_id)?.base;
+                if (baseVersion) {
+                  targetRules.push({ ...baseVersion, version: target.version });
+                } else {
+                  fetchErrors.push({
+                    error: new Error(`Could not find base version for rule ${current.rule_id}`),
+                    item: current,
+                  });
+                }
+                break;
+              case PickVersionValues.CURRENT:
+                targetRules.push({ ...current, version: target.version });
+                break;
+              case PickVersionValues.TARGET:
+                targetRules.push(target);
+                break;
+              default:
+                assertUnreachable(rulePickVersion);
+            }
+          });
 
-        const { error: timelineInstallationError } = await performTimelinesInstallation(
-          ctx.securitySolution
-        );
+          // Perform the upgrade
+          const { results: updatedRules, errors: installationErrors } = await upgradePrebuiltRules(
+            rulesClient,
+            targetRules
+          );
+          const ruleErrors = [...fetchErrors, ...installationErrors];
 
-        const allErrors = aggregatePrebuiltRuleErrors(ruleErrors);
-        if (timelineInstallationError) {
-          allErrors.push({
-            message: timelineInstallationError,
-            rules: [],
+          const { error: timelineInstallationError } = await performTimelinesInstallation(
+            ctx.securitySolution
+          );
+
+          const allErrors = aggregatePrebuiltRuleErrors(ruleErrors);
+          if (timelineInstallationError) {
+            allErrors.push({
+              message: timelineInstallationError,
+              rules: [],
+            });
+          }
+
+          const body: PerformRuleUpgradeResponseBody = {
+            summary: {
+              total: updatedRules.length + skippedRules.length + ruleErrors.length,
+              skipped: skippedRules.length,
+              succeeded: updatedRules.length,
+              failed: ruleErrors.length,
+            },
+            results: {
+              updated: updatedRules.map(({ result }) => internalRuleToAPIResponse(result)),
+              skipped: skippedRules,
+            },
+            errors: allErrors,
+          };
+
+          return response.ok({ body });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-
-        const body: PerformRuleUpgradeResponseBody = {
-          summary: {
-            total: updatedRules.length + skippedRules.length + ruleErrors.length,
-            skipped: skippedRules.length,
-            succeeded: updatedRules.length,
-            failed: ruleErrors.length,
-          },
-          results: {
-            updated: updatedRules.map(({ result }) => internalRuleToAPIResponse(result)),
-            skipped: skippedRules,
-          },
-          errors: allErrors,
-        };
-
-        return response.ok({ body });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/review_rule_upgrade/review_rule_upgrade_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/api/review_rule_upgrade/review_rule_upgrade_route.ts
@@ -25,51 +25,56 @@ import { fetchRuleVersionsTriad } from '../../logic/rule_versions/fetch_rule_ver
 import { getVersionBuckets } from '../../model/rule_versions/get_version_buckets';
 
 export const reviewRuleUpgradeRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: REVIEW_RULE_UPGRADE_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {},
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['core', 'alerting']);
-        const soClient = ctx.core.savedObjects.client;
-        const rulesClient = ctx.alerting.getRulesClient();
-        const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
-        const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
+        try {
+          const ctx = await context.resolve(['core', 'alerting']);
+          const soClient = ctx.core.savedObjects.client;
+          const rulesClient = ctx.alerting.getRulesClient();
+          const ruleAssetsClient = createPrebuiltRuleAssetsClient(soClient);
+          const ruleObjectsClient = createPrebuiltRuleObjectsClient(rulesClient);
 
-        const ruleVersionsMap = await fetchRuleVersionsTriad({
-          ruleAssetsClient,
-          ruleObjectsClient,
-        });
-        const { upgradeableRules } = getVersionBuckets(ruleVersionsMap);
+          const ruleVersionsMap = await fetchRuleVersionsTriad({
+            ruleAssetsClient,
+            ruleObjectsClient,
+          });
+          const { upgradeableRules } = getVersionBuckets(ruleVersionsMap);
 
-        const ruleDiffCalculationResults = upgradeableRules.map(({ current }) => {
-          const ruleVersions = ruleVersionsMap.get(current.rule_id);
-          invariant(ruleVersions != null, 'ruleVersions not found');
-          return calculateRuleDiff(ruleVersions);
-        });
+          const ruleDiffCalculationResults = upgradeableRules.map(({ current }) => {
+            const ruleVersions = ruleVersionsMap.get(current.rule_id);
+            invariant(ruleVersions != null, 'ruleVersions not found');
+            return calculateRuleDiff(ruleVersions);
+          });
 
-        const body: ReviewRuleUpgradeResponseBody = {
-          stats: calculateRuleStats(ruleDiffCalculationResults),
-          rules: calculateRuleInfos(ruleDiffCalculationResults),
-        };
+          const body: ReviewRuleUpgradeResponseBody = {
+            stats: calculateRuleStats(ruleDiffCalculationResults),
+            rules: calculateRuleInfos(ruleDiffCalculationResults),
+          };
 
-        return response.ok({ body });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };
 
 const calculateRuleStats = (results: CalculateRuleDiffResult[]): RuleUpgradeStatsForReview => {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/server.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/__mocks__/server.ts
@@ -12,28 +12,48 @@ import { responseMock as responseFactoryMock } from './response_factory';
 import { requestMock } from '.';
 import { responseAdapter } from './test_adapters';
 import type { SecuritySolutionRequestHandlerContext } from '../../../../types';
+import type { RegisteredVersionedRoute } from '@kbn/core-http-router-server-mocks';
 
 interface Route {
-  config: RouteConfig<unknown, unknown, unknown, 'get' | 'post' | 'delete' | 'patch' | 'put'>;
+  validate: RouteConfig<
+    unknown,
+    unknown,
+    unknown,
+    'get' | 'post' | 'delete' | 'patch' | 'put'
+  >['validate'];
   handler: RequestHandler;
 }
 
-const getRoute = (routerMock: MockServer['router']): Route => {
-  const routeCalls = [
-    ...routerMock.get.mock.calls,
-    ...routerMock.post.mock.calls,
-    ...routerMock.put.mock.calls,
-    ...routerMock.patch.mock.calls,
-    ...routerMock.delete.mock.calls,
-  ];
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
 
-  const [route] = routeCalls;
-  if (!route) {
-    throw new Error('No route registered!');
+const getClassicRoute = (routerMock: MockServer['router']): Route | undefined => {
+  const method = HTTP_METHODS.find((m) => routerMock[m].mock.calls.length > 0);
+  if (!method) {
+    return undefined;
   }
 
-  const [config, handler] = route;
-  return { config, handler };
+  const [config, handler] = routerMock[method].mock.calls[0];
+  return { validate: config.validate, handler };
+};
+
+const getVersionedRoute = (router: MockServer['router']): Route => {
+  const method = HTTP_METHODS.find((m) => router.versioned[m].mock.calls.length > 0);
+  if (!method) {
+    throw new Error('No route registered!');
+  }
+  const config = router.versioned[method].mock.calls[0][0];
+  const routePath = config.path;
+
+  const route: RegisteredVersionedRoute = router.versioned.getRoute(method, routePath);
+  const firstVersion = Object.values(route.versions)[0];
+
+  return {
+    validate:
+      firstVersion.config.validate === false
+        ? false
+        : firstVersion.config.validate.request || false,
+    handler: firstVersion.handler,
+  };
 };
 
 const buildResultMock = () => ({ ok: jest.fn((x) => x), badRequest: jest.fn((x) => x) });
@@ -66,7 +86,7 @@ class MockServer {
   }
 
   private getRoute(): Route {
-    return getRoute(this.router);
+    return getClassicRoute(this.router) ?? getVersionedRoute(this.router);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -75,7 +95,7 @@ class MockServer {
   }
 
   private validateRequest(request: KibanaRequest): KibanaRequest {
-    const validations = this.getRoute().config.validate;
+    const validations = this.getRoute().validate;
     if (!validations) {
       return request;
     }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_actions/route.ts
@@ -233,310 +233,317 @@ export const performBulkActionRoute = (
   ml: SetupPlugins['ml'],
   logger: Logger
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_BULK_ACTION,
-      validate: {
-        body: buildRouteValidation(PerformBulkActionRequestBody),
-        query: buildRouteValidation(PerformBulkActionRequestQuery),
-      },
       options: {
         tags: ['access:securitySolution', routeLimitedConcurrencyTag(MAX_ROUTE_CONCURRENCY)],
         timeout: {
           idleSocket: moment.duration(15, 'minutes').asMilliseconds(),
         },
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<PerformBulkActionResponse>> => {
-      const { body } = request;
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation(PerformBulkActionRequestBody),
+            query: buildRouteValidation(PerformBulkActionRequestQuery),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<PerformBulkActionResponse>> => {
+        const { body } = request;
+        const siemResponse = buildSiemResponse(response);
 
-      if (body?.ids && body.ids.length > RULES_TABLE_MAX_PAGE_SIZE) {
-        return siemResponse.error({
-          body: `More than ${RULES_TABLE_MAX_PAGE_SIZE} ids sent for bulk edit action.`,
-          statusCode: 400,
-        });
-      }
-
-      if (body?.ids && body.query !== undefined) {
-        return siemResponse.error({
-          body: `Both query and ids are sent. Define either ids or query in request payload.`,
-          statusCode: 400,
-        });
-      }
-
-      const isDryRun = request.query.dry_run === 'true';
-
-      // dry run is not supported for export, as it doesn't change ES state and has different response format(exported JSON file)
-      if (isDryRun && body.action === BulkActionType.export) {
-        return siemResponse.error({
-          body: `Export action doesn't support dry_run mode`,
-          statusCode: 400,
-        });
-      }
-
-      const abortController = new AbortController();
-
-      // subscribing to completed$, because it handles both cases when request was completed and aborted.
-      // when route is finished by timeout, aborted$ is not getting fired
-      request.events.completed$.subscribe(() => abortController.abort());
-      try {
-        const ctx = await context.resolve([
-          'core',
-          'securitySolution',
-          'alerting',
-          'licensing',
-          'lists',
-          'actions',
-        ]);
-
-        const rulesClient = ctx.alerting.getRulesClient();
-        const exceptionsClient = ctx.lists?.getExceptionListClient();
-        const savedObjectsClient = ctx.core.savedObjects.client;
-        const actionsClient = (await ctx.actions)?.getActionsClient();
-
-        const { getExporter, getClient } = (await ctx.core).savedObjects;
-        const client = getClient({ includedHiddenTypes: ['action'] });
-
-        const exporter = getExporter(client);
-
-        const mlAuthz = buildMlAuthz({
-          license: ctx.licensing.license,
-          ml,
-          request,
-          savedObjectsClient,
-        });
-
-        const query = body.query !== '' ? body.query : undefined;
-
-        // handling this action before switch statement as bulkEditRules fetch rules within
-        // rulesClient method, hence there is no need to use fetchRulesByQueryOrIds utility
-        if (body.action === BulkActionType.edit && !isDryRun) {
-          const { rules, errors, skipped } = await bulkEditRules({
-            rulesClient,
-            filter: query,
-            ids: body.ids,
-            actions: body.edit,
-            mlAuthz,
+        if (body?.ids && body.ids.length > RULES_TABLE_MAX_PAGE_SIZE) {
+          return siemResponse.error({
+            body: `More than ${RULES_TABLE_MAX_PAGE_SIZE} ids sent for bulk edit action.`,
+            statusCode: 400,
           });
+        }
+
+        if (body?.ids && body.query !== undefined) {
+          return siemResponse.error({
+            body: `Both query and ids are sent. Define either ids or query in request payload.`,
+            statusCode: 400,
+          });
+        }
+
+        const isDryRun = request.query.dry_run === 'true';
+
+        // dry run is not supported for export, as it doesn't change ES state and has different response format(exported JSON file)
+        if (isDryRun && body.action === BulkActionType.export) {
+          return siemResponse.error({
+            body: `Export action doesn't support dry_run mode`,
+            statusCode: 400,
+          });
+        }
+
+        const abortController = new AbortController();
+
+        // subscribing to completed$, because it handles both cases when request was completed and aborted.
+        // when route is finished by timeout, aborted$ is not getting fired
+        request.events.completed$.subscribe(() => abortController.abort());
+        try {
+          const ctx = await context.resolve([
+            'core',
+            'securitySolution',
+            'alerting',
+            'licensing',
+            'lists',
+            'actions',
+          ]);
+
+          const rulesClient = ctx.alerting.getRulesClient();
+          const exceptionsClient = ctx.lists?.getExceptionListClient();
+          const savedObjectsClient = ctx.core.savedObjects.client;
+          const actionsClient = (await ctx.actions)?.getActionsClient();
+
+          const { getExporter, getClient } = (await ctx.core).savedObjects;
+          const client = getClient({ includedHiddenTypes: ['action'] });
+
+          const exporter = getExporter(client);
+
+          const mlAuthz = buildMlAuthz({
+            license: ctx.licensing.license,
+            ml,
+            request,
+            savedObjectsClient,
+          });
+
+          const query = body.query !== '' ? body.query : undefined;
+
+          // handling this action before switch statement as bulkEditRules fetch rules within
+          // rulesClient method, hence there is no need to use fetchRulesByQueryOrIds utility
+          if (body.action === BulkActionType.edit && !isDryRun) {
+            const { rules, errors, skipped } = await bulkEditRules({
+              rulesClient,
+              filter: query,
+              ids: body.ids,
+              actions: body.edit,
+              mlAuthz,
+            });
+
+            return buildBulkResponse(response, {
+              updated: rules,
+              skipped,
+              errors,
+            });
+          }
+
+          const fetchRulesOutcome = await fetchRulesByQueryOrIds({
+            rulesClient,
+            query,
+            ids: body.ids,
+            abortSignal: abortController.signal,
+          });
+
+          const rules = fetchRulesOutcome.results.map(({ result }) => result);
+          let bulkActionOutcome: PromisePoolOutcome<RuleAlertType, RuleAlertType | null>;
+          let updated: RuleAlertType[] = [];
+          let created: RuleAlertType[] = [];
+          let deleted: RuleAlertType[] = [];
+
+          switch (body.action) {
+            case BulkActionType.enable:
+              bulkActionOutcome = await initPromisePool({
+                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+                items: rules,
+                executor: async (rule) => {
+                  await validateBulkEnableRule({ mlAuthz, rule });
+
+                  // during dry run only validation is getting performed and rule is not saved in ES, thus return early
+                  if (isDryRun) {
+                    return rule;
+                  }
+
+                  if (!rule.enabled) {
+                    await rulesClient.enable({ id: rule.id });
+                  }
+
+                  return {
+                    ...rule,
+                    enabled: true,
+                  };
+                },
+                abortSignal: abortController.signal,
+              });
+              updated = bulkActionOutcome.results
+                .map(({ result }) => result)
+                .filter((rule): rule is RuleAlertType => rule !== null);
+              break;
+            case BulkActionType.disable:
+              bulkActionOutcome = await initPromisePool({
+                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+                items: rules,
+                executor: async (rule) => {
+                  await validateBulkDisableRule({ mlAuthz, rule });
+
+                  // during dry run only validation is getting performed and rule is not saved in ES, thus return early
+                  if (isDryRun) {
+                    return rule;
+                  }
+
+                  if (rule.enabled) {
+                    await rulesClient.disable({ id: rule.id });
+                  }
+
+                  return {
+                    ...rule,
+                    enabled: false,
+                  };
+                },
+                abortSignal: abortController.signal,
+              });
+              updated = bulkActionOutcome.results
+                .map(({ result }) => result)
+                .filter((rule): rule is RuleAlertType => rule !== null);
+              break;
+
+            case BulkActionType.delete:
+              bulkActionOutcome = await initPromisePool({
+                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+                items: rules,
+                executor: async (rule) => {
+                  // during dry run return early for delete, as no validations needed for this action
+                  if (isDryRun) {
+                    return null;
+                  }
+
+                  await deleteRules({
+                    ruleId: rule.id,
+                    rulesClient,
+                  });
+
+                  return null;
+                },
+                abortSignal: abortController.signal,
+              });
+              deleted = bulkActionOutcome.results
+                .map(({ item }) => item)
+                .filter((rule): rule is RuleAlertType => rule !== null);
+              break;
+
+            case BulkActionType.duplicate:
+              bulkActionOutcome = await initPromisePool({
+                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+                items: rules,
+                executor: async (rule) => {
+                  await validateBulkDuplicateRule({ mlAuthz, rule });
+
+                  // during dry run only validation is getting performed and rule is not saved in ES, thus return early
+                  if (isDryRun) {
+                    return rule;
+                  }
+
+                  let shouldDuplicateExceptions = true;
+                  let shouldDuplicateExpiredExceptions = true;
+                  if (body.duplicate !== undefined) {
+                    shouldDuplicateExceptions = body.duplicate.include_exceptions;
+                    shouldDuplicateExpiredExceptions = body.duplicate.include_expired_exceptions;
+                  }
+
+                  const duplicateRuleToCreate = await duplicateRule({
+                    rule,
+                  });
+
+                  const createdRule = await rulesClient.create({
+                    data: duplicateRuleToCreate,
+                  });
+
+                  // we try to create exceptions after rule created, and then update rule
+                  const exceptions = shouldDuplicateExceptions
+                    ? await duplicateExceptions({
+                        ruleId: rule.params.ruleId,
+                        exceptionLists: rule.params.exceptionsList,
+                        includeExpiredExceptions: shouldDuplicateExpiredExceptions,
+                        exceptionsClient,
+                      })
+                    : [];
+
+                  const updatedRule = await rulesClient.update({
+                    id: createdRule.id,
+                    data: {
+                      ...duplicateRuleToCreate,
+                      params: {
+                        ...duplicateRuleToCreate.params,
+                        exceptionsList: exceptions,
+                      },
+                    },
+                    shouldIncrementRevision: () => false,
+                  });
+
+                  // TODO: figureout why types can't return just updatedRule
+                  return { ...createdRule, ...updatedRule };
+                },
+                abortSignal: abortController.signal,
+              });
+              created = bulkActionOutcome.results
+                .map(({ result }) => result)
+                .filter((rule): rule is RuleAlertType => rule !== null);
+              break;
+
+            case BulkActionType.export:
+              const exported = await getExportByObjectIds(
+                rulesClient,
+                exceptionsClient,
+                savedObjectsClient,
+                rules.map(({ params }) => ({ rule_id: params.ruleId })),
+                logger,
+                exporter,
+                request,
+                actionsClient
+              );
+
+              const responseBody = `${exported.rulesNdjson}${exported.exceptionLists}${exported.actionConnectors}${exported.exportDetails}`;
+
+              return response.ok({
+                headers: {
+                  'Content-Disposition': `attachment; filename="rules_export.ndjson"`,
+                  'Content-Type': 'application/ndjson',
+                },
+                body: responseBody,
+              });
+
+            // will be processed only when isDryRun === true
+            // during dry run only validation is getting performed and rule is not saved in ES
+            case BulkActionType.edit:
+              bulkActionOutcome = await initPromisePool({
+                concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
+                items: rules,
+                executor: async (rule) => {
+                  await dryRunValidateBulkEditRule({ mlAuthz, rule, edit: body.edit });
+
+                  return rule;
+                },
+                abortSignal: abortController.signal,
+              });
+              updated = bulkActionOutcome.results
+                .map(({ result }) => result)
+                .filter((rule): rule is RuleAlertType => rule !== null);
+          }
+
+          if (abortController.signal.aborted === true) {
+            throw new AbortError('Bulk action was aborted');
+          }
 
           return buildBulkResponse(response, {
-            updated: rules,
-            skipped,
-            errors,
+            updated,
+            deleted,
+            created,
+            errors: [...fetchRulesOutcome.errors, ...bulkActionOutcome.errors],
+            isDryRun,
+          });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-
-        const fetchRulesOutcome = await fetchRulesByQueryOrIds({
-          rulesClient,
-          query,
-          ids: body.ids,
-          abortSignal: abortController.signal,
-        });
-
-        const rules = fetchRulesOutcome.results.map(({ result }) => result);
-        let bulkActionOutcome: PromisePoolOutcome<RuleAlertType, RuleAlertType | null>;
-        let updated: RuleAlertType[] = [];
-        let created: RuleAlertType[] = [];
-        let deleted: RuleAlertType[] = [];
-
-        switch (body.action) {
-          case BulkActionType.enable:
-            bulkActionOutcome = await initPromisePool({
-              concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-              items: rules,
-              executor: async (rule) => {
-                await validateBulkEnableRule({ mlAuthz, rule });
-
-                // during dry run only validation is getting performed and rule is not saved in ES, thus return early
-                if (isDryRun) {
-                  return rule;
-                }
-
-                if (!rule.enabled) {
-                  await rulesClient.enable({ id: rule.id });
-                }
-
-                return {
-                  ...rule,
-                  enabled: true,
-                };
-              },
-              abortSignal: abortController.signal,
-            });
-            updated = bulkActionOutcome.results
-              .map(({ result }) => result)
-              .filter((rule): rule is RuleAlertType => rule !== null);
-            break;
-          case BulkActionType.disable:
-            bulkActionOutcome = await initPromisePool({
-              concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-              items: rules,
-              executor: async (rule) => {
-                await validateBulkDisableRule({ mlAuthz, rule });
-
-                // during dry run only validation is getting performed and rule is not saved in ES, thus return early
-                if (isDryRun) {
-                  return rule;
-                }
-
-                if (rule.enabled) {
-                  await rulesClient.disable({ id: rule.id });
-                }
-
-                return {
-                  ...rule,
-                  enabled: false,
-                };
-              },
-              abortSignal: abortController.signal,
-            });
-            updated = bulkActionOutcome.results
-              .map(({ result }) => result)
-              .filter((rule): rule is RuleAlertType => rule !== null);
-            break;
-
-          case BulkActionType.delete:
-            bulkActionOutcome = await initPromisePool({
-              concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-              items: rules,
-              executor: async (rule) => {
-                // during dry run return early for delete, as no validations needed for this action
-                if (isDryRun) {
-                  return null;
-                }
-
-                await deleteRules({
-                  ruleId: rule.id,
-                  rulesClient,
-                });
-
-                return null;
-              },
-              abortSignal: abortController.signal,
-            });
-            deleted = bulkActionOutcome.results
-              .map(({ item }) => item)
-              .filter((rule): rule is RuleAlertType => rule !== null);
-            break;
-
-          case BulkActionType.duplicate:
-            bulkActionOutcome = await initPromisePool({
-              concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-              items: rules,
-              executor: async (rule) => {
-                await validateBulkDuplicateRule({ mlAuthz, rule });
-
-                // during dry run only validation is getting performed and rule is not saved in ES, thus return early
-                if (isDryRun) {
-                  return rule;
-                }
-
-                let shouldDuplicateExceptions = true;
-                let shouldDuplicateExpiredExceptions = true;
-                if (body.duplicate !== undefined) {
-                  shouldDuplicateExceptions = body.duplicate.include_exceptions;
-                  shouldDuplicateExpiredExceptions = body.duplicate.include_expired_exceptions;
-                }
-
-                const duplicateRuleToCreate = await duplicateRule({
-                  rule,
-                });
-
-                const createdRule = await rulesClient.create({
-                  data: duplicateRuleToCreate,
-                });
-
-                // we try to create exceptions after rule created, and then update rule
-                const exceptions = shouldDuplicateExceptions
-                  ? await duplicateExceptions({
-                      ruleId: rule.params.ruleId,
-                      exceptionLists: rule.params.exceptionsList,
-                      includeExpiredExceptions: shouldDuplicateExpiredExceptions,
-                      exceptionsClient,
-                    })
-                  : [];
-
-                const updatedRule = await rulesClient.update({
-                  id: createdRule.id,
-                  data: {
-                    ...duplicateRuleToCreate,
-                    params: {
-                      ...duplicateRuleToCreate.params,
-                      exceptionsList: exceptions,
-                    },
-                  },
-                  shouldIncrementRevision: () => false,
-                });
-
-                // TODO: figureout why types can't return just updatedRule
-                return { ...createdRule, ...updatedRule };
-              },
-              abortSignal: abortController.signal,
-            });
-            created = bulkActionOutcome.results
-              .map(({ result }) => result)
-              .filter((rule): rule is RuleAlertType => rule !== null);
-            break;
-
-          case BulkActionType.export:
-            const exported = await getExportByObjectIds(
-              rulesClient,
-              exceptionsClient,
-              savedObjectsClient,
-              rules.map(({ params }) => ({ rule_id: params.ruleId })),
-              logger,
-              exporter,
-              request,
-              actionsClient
-            );
-
-            const responseBody = `${exported.rulesNdjson}${exported.exceptionLists}${exported.actionConnectors}${exported.exportDetails}`;
-
-            return response.ok({
-              headers: {
-                'Content-Disposition': `attachment; filename="rules_export.ndjson"`,
-                'Content-Type': 'application/ndjson',
-              },
-              body: responseBody,
-            });
-
-          // will be processed only when isDryRun === true
-          // during dry run only validation is getting performed and rule is not saved in ES
-          case BulkActionType.edit:
-            bulkActionOutcome = await initPromisePool({
-              concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
-              items: rules,
-              executor: async (rule) => {
-                await dryRunValidateBulkEditRule({ mlAuthz, rule, edit: body.edit });
-
-                return rule;
-              },
-              abortSignal: abortController.signal,
-            });
-            updated = bulkActionOutcome.results
-              .map(({ result }) => result)
-              .filter((rule): rule is RuleAlertType => rule !== null);
-        }
-
-        if (abortController.signal.aborted === true) {
-          throw new AbortError('Bulk action was aborted');
-        }
-
-        return buildBulkResponse(response, {
-          updated,
-          deleted,
-          created,
-          errors: [...fetchRulesOutcome.errors, ...bulkActionOutcome.errors],
-          isDryRun,
-        });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_delete_rules/route.ts
@@ -5,34 +5,31 @@
  * 2.0.
  */
 
-import type { RouteConfig, RequestHandler, Logger, IKibanaResponse } from '@kbn/core/server';
+import type { VersionedRouteConfig } from '@kbn/core-http-server';
+import type { IKibanaResponse, Logger, RequestHandler } from '@kbn/core/server';
 import { validate } from '@kbn/securitysolution-io-ts-utils';
-
-import { DETECTION_ENGINE_RULES_BULK_DELETE } from '../../../../../../../common/constants';
 import {
+  BulkCrudRulesResponse,
   BulkDeleteRulesRequestBody,
   validateQueryRuleByIds,
-  BulkCrudRulesResponse,
 } from '../../../../../../../common/api/detection_engine/rule_management';
-
-import { buildRouteValidation } from '../../../../../../utils/build_validation/route_validation';
+import { DETECTION_ENGINE_RULES_BULK_DELETE } from '../../../../../../../common/constants';
 import type {
   SecuritySolutionPluginRouter,
   SecuritySolutionRequestHandlerContext,
 } from '../../../../../../types';
-
-import { getIdBulkError } from '../../../utils/utils';
-import { transformValidateBulkError } from '../../../utils/validate';
+import { buildRouteValidation } from '../../../../../../utils/build_validation/route_validation';
 import {
-  transformBulkError,
   buildSiemResponse,
   createBulkErrorObject,
+  transformBulkError,
 } from '../../../../routes/utils';
 import { deleteRules } from '../../../logic/crud/delete_rules';
 import { readRules } from '../../../logic/crud/read_rules';
+import { getIdBulkError } from '../../../utils/utils';
+import { transformValidateBulkError } from '../../../utils/validate';
 import { getDeprecatedBulkEndpointHeader, logDeprecatedBulkEndpoint } from '../../deprecation';
 
-type Config = RouteConfig<unknown, unknown, BulkDeleteRulesRequestBody, 'delete' | 'post'>;
 type Handler = RequestHandler<
   unknown,
   unknown,
@@ -45,15 +42,6 @@ type Handler = RequestHandler<
  * @deprecated since version 8.2.0. Use the detection_engine/rules/_bulk_action API instead
  */
 export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
-  const config: Config = {
-    validate: {
-      body: buildRouteValidation(BulkDeleteRulesRequestBody),
-    },
-    path: DETECTION_ENGINE_RULES_BULK_DELETE,
-    options: {
-      tags: ['access:securitySolution'],
-    },
-  };
   const handler: Handler = async (
     context,
     request,
@@ -112,6 +100,21 @@ export const bulkDeleteRulesRoute = (router: SecuritySolutionPluginRouter, logge
     }
   };
 
-  router.delete(config, handler);
-  router.post(config, handler);
+  const routeConfig: VersionedRouteConfig<'post' | 'delete'> = {
+    access: 'public',
+    path: DETECTION_ENGINE_RULES_BULK_DELETE,
+    options: {
+      tags: ['access:securitySolution'],
+    },
+  };
+  const versionConfig = {
+    version: '2023-10-31',
+    validate: {
+      request: {
+        body: buildRouteValidation(BulkDeleteRulesRequestBody),
+      },
+    },
+  };
+  router.versioned.delete(routeConfig).addVersion(versionConfig, handler);
+  router.versioned.post(routeConfig).addVersion(versionConfig, handler);
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/bulk_patch_rules/route.ts
@@ -36,95 +36,102 @@ export const bulkPatchRulesRoute = (
   ml: SetupPlugins['ml'],
   logger: Logger
 ) => {
-  router.patch(
-    {
+  router.versioned
+    .patch({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_BULK_UPDATE,
-      validate: {
-        body: buildRouteValidationNonExact(BulkPatchRulesRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<BulkCrudRulesResponse>> => {
-      logDeprecatedBulkEndpoint(logger, DETECTION_ENGINE_RULES_BULK_UPDATE);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidationNonExact(BulkPatchRulesRequestBody),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<BulkCrudRulesResponse>> => {
+        logDeprecatedBulkEndpoint(logger, DETECTION_ENGINE_RULES_BULK_UPDATE);
 
-      const siemResponse = buildSiemResponse(response);
+        const siemResponse = buildSiemResponse(response);
 
-      const ctx = await context.resolve(['core', 'securitySolution', 'alerting', 'licensing']);
+        const ctx = await context.resolve(['core', 'securitySolution', 'alerting', 'licensing']);
 
-      const rulesClient = ctx.alerting.getRulesClient();
-      const savedObjectsClient = ctx.core.savedObjects.client;
+        const rulesClient = ctx.alerting.getRulesClient();
+        const savedObjectsClient = ctx.core.savedObjects.client;
 
-      const mlAuthz = buildMlAuthz({
-        license: ctx.licensing.license,
-        ml,
-        request,
-        savedObjectsClient,
-      });
-
-      const rules = await Promise.all(
-        request.body.map(async (payloadRule) => {
-          const idOrRuleIdOrUnknown = payloadRule.id ?? payloadRule.rule_id ?? '(unknown id)';
-
-          try {
-            if (payloadRule.type) {
-              // reject an unauthorized "promotion" to ML
-              throwAuthzError(await mlAuthz.validateRuleType(payloadRule.type));
-            }
-
-            const existingRule = await readRules({
-              rulesClient,
-              ruleId: payloadRule.rule_id,
-              id: payloadRule.id,
-            });
-            if (existingRule?.params.type) {
-              // reject an unauthorized modification of an ML rule
-              throwAuthzError(await mlAuthz.validateRuleType(existingRule?.params.type));
-            }
-
-            validateRulesWithDuplicatedDefaultExceptionsList({
-              allRules: request.body,
-              exceptionsList: payloadRule.exceptions_list,
-              ruleId: idOrRuleIdOrUnknown,
-            });
-
-            await validateRuleDefaultExceptionList({
-              exceptionsList: payloadRule.exceptions_list,
-              rulesClient,
-              ruleRuleId: payloadRule.rule_id,
-              ruleId: payloadRule.id,
-            });
-
-            const rule = await patchRules({
-              existingRule,
-              rulesClient,
-              nextParams: payloadRule,
-            });
-            if (rule != null && rule.enabled != null && rule.name != null) {
-              return transformValidateBulkError(rule.id, rule);
-            } else {
-              return getIdBulkError({ id: payloadRule.id, ruleId: payloadRule.rule_id });
-            }
-          } catch (err) {
-            return transformBulkError(idOrRuleIdOrUnknown, err);
-          }
-        })
-      );
-
-      const [validated, errors] = validate(rules, BulkCrudRulesResponse);
-      if (errors != null) {
-        return siemResponse.error({
-          statusCode: 500,
-          body: errors,
-          headers: getDeprecatedBulkEndpointHeader(DETECTION_ENGINE_RULES_BULK_UPDATE),
+        const mlAuthz = buildMlAuthz({
+          license: ctx.licensing.license,
+          ml,
+          request,
+          savedObjectsClient,
         });
-      } else {
-        return response.ok({
-          body: validated ?? {},
-          headers: getDeprecatedBulkEndpointHeader(DETECTION_ENGINE_RULES_BULK_UPDATE),
-        });
+
+        const rules = await Promise.all(
+          request.body.map(async (payloadRule) => {
+            const idOrRuleIdOrUnknown = payloadRule.id ?? payloadRule.rule_id ?? '(unknown id)';
+
+            try {
+              if (payloadRule.type) {
+                // reject an unauthorized "promotion" to ML
+                throwAuthzError(await mlAuthz.validateRuleType(payloadRule.type));
+              }
+
+              const existingRule = await readRules({
+                rulesClient,
+                ruleId: payloadRule.rule_id,
+                id: payloadRule.id,
+              });
+              if (existingRule?.params.type) {
+                // reject an unauthorized modification of an ML rule
+                throwAuthzError(await mlAuthz.validateRuleType(existingRule?.params.type));
+              }
+
+              validateRulesWithDuplicatedDefaultExceptionsList({
+                allRules: request.body,
+                exceptionsList: payloadRule.exceptions_list,
+                ruleId: idOrRuleIdOrUnknown,
+              });
+
+              await validateRuleDefaultExceptionList({
+                exceptionsList: payloadRule.exceptions_list,
+                rulesClient,
+                ruleRuleId: payloadRule.rule_id,
+                ruleId: payloadRule.id,
+              });
+
+              const rule = await patchRules({
+                existingRule,
+                rulesClient,
+                nextParams: payloadRule,
+              });
+              if (rule != null && rule.enabled != null && rule.name != null) {
+                return transformValidateBulkError(rule.id, rule);
+              } else {
+                return getIdBulkError({ id: payloadRule.id, ruleId: payloadRule.rule_id });
+              }
+            } catch (err) {
+              return transformBulkError(idOrRuleIdOrUnknown, err);
+            }
+          })
+        );
+
+        const [validated, errors] = validate(rules, BulkCrudRulesResponse);
+        if (errors != null) {
+          return siemResponse.error({
+            statusCode: 500,
+            body: errors,
+            headers: getDeprecatedBulkEndpointHeader(DETECTION_ENGINE_RULES_BULK_UPDATE),
+          });
+        } else {
+          return response.ok({
+            body: validated ?? {},
+            headers: getDeprecatedBulkEndpointHeader(DETECTION_ENGINE_RULES_BULK_UPDATE),
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/create_rule/route.ts
@@ -29,91 +29,99 @@ export const createRuleRoute = (
   router: SecuritySolutionPluginRouter,
   ml: SetupPlugins['ml']
 ): void => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_URL,
-      validate: {
-        body: buildRouteValidation(CreateRuleRequestBody),
-      },
+
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<CreateRuleResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = validateCreateRuleProps(request.body);
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation(CreateRuleRequestBody),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<CreateRuleResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = validateCreateRuleProps(request.body);
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
+        }
 
-      try {
-        const ctx = await context.resolve([
-          'core',
-          'securitySolution',
-          'licensing',
-          'alerting',
-          'lists',
-        ]);
+        try {
+          const ctx = await context.resolve([
+            'core',
+            'securitySolution',
+            'licensing',
+            'alerting',
+            'lists',
+          ]);
 
-        const rulesClient = ctx.alerting.getRulesClient();
-        const savedObjectsClient = ctx.core.savedObjects.client;
-        const exceptionsClient = ctx.lists?.getExceptionListClient();
+          const rulesClient = ctx.alerting.getRulesClient();
+          const savedObjectsClient = ctx.core.savedObjects.client;
+          const exceptionsClient = ctx.lists?.getExceptionListClient();
 
-        if (request.body.rule_id != null) {
-          const rule = await readRules({
-            rulesClient,
-            ruleId: request.body.rule_id,
-            id: undefined,
-          });
-          if (rule != null) {
-            return siemResponse.error({
-              statusCode: 409,
-              body: `rule_id: "${request.body.rule_id}" already exists`,
+          if (request.body.rule_id != null) {
+            const rule = await readRules({
+              rulesClient,
+              ruleId: request.body.rule_id,
+              id: undefined,
             });
+            if (rule != null) {
+              return siemResponse.error({
+                statusCode: 409,
+                body: `rule_id: "${request.body.rule_id}" already exists`,
+              });
+            }
           }
+
+          const mlAuthz = buildMlAuthz({
+            license: ctx.licensing.license,
+            ml,
+            request,
+            savedObjectsClient,
+          });
+          throwAuthzError(await mlAuthz.validateRuleType(request.body.type));
+
+          // This will create the endpoint list if it does not exist yet
+          await exceptionsClient?.createEndpointList();
+          checkDefaultRuleExceptionListReferences({
+            exceptionLists: request.body.exceptions_list,
+          });
+
+          await validateRuleDefaultExceptionList({
+            exceptionsList: request.body.exceptions_list,
+            rulesClient,
+            ruleRuleId: undefined,
+            ruleId: undefined,
+          });
+
+          await validateResponseActionsPermissions(ctx.securitySolution, request.body);
+
+          const createdRule = await createRules({
+            rulesClient,
+            params: request.body,
+          });
+
+          const [validated, errors] = transformValidate(createdRule);
+          if (errors != null) {
+            return siemResponse.error({ statusCode: 500, body: errors });
+          } else {
+            return response.ok({ body: validated });
+          }
+        } catch (err) {
+          const error = transformError(err as Error);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-
-        const mlAuthz = buildMlAuthz({
-          license: ctx.licensing.license,
-          ml,
-          request,
-          savedObjectsClient,
-        });
-        throwAuthzError(await mlAuthz.validateRuleType(request.body.type));
-
-        // This will create the endpoint list if it does not exist yet
-        await exceptionsClient?.createEndpointList();
-        checkDefaultRuleExceptionListReferences({
-          exceptionLists: request.body.exceptions_list,
-        });
-
-        await validateRuleDefaultExceptionList({
-          exceptionsList: request.body.exceptions_list,
-          rulesClient,
-          ruleRuleId: undefined,
-          ruleId: undefined,
-        });
-
-        await validateResponseActionsPermissions(ctx.securitySolution, request.body);
-
-        const createdRule = await createRules({
-          rulesClient,
-          params: request.body,
-        });
-
-        const [validated, errors] = transformValidate(createdRule);
-        if (errors != null) {
-          return siemResponse.error({ statusCode: 500, body: errors });
-        } else {
-          return response.ok({ body: validated });
-        }
-      } catch (err) {
-        const error = transformError(err as Error);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/export_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/export_rules/route.ts
@@ -27,90 +27,97 @@ export const exportRulesRoute = (
   config: ConfigType,
   logger: Logger
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'public',
       path: `${DETECTION_ENGINE_RULES_URL}/_export`,
-      validate: {
-        query: buildRouteValidation(ExportRulesRequestQuery),
-        body: buildRouteValidation(ExportRulesRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
-      const rulesClient = (await context.alerting).getRulesClient();
-      const exceptionsClient = (await context.lists)?.getExceptionListClient();
-      const actionsClient = (await context.actions)?.getActionsClient();
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: buildRouteValidation(ExportRulesRequestQuery),
+            body: buildRouteValidation(ExportRulesRequestBody),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
+        const rulesClient = (await context.alerting).getRulesClient();
+        const exceptionsClient = (await context.lists)?.getExceptionListClient();
+        const actionsClient = (await context.actions)?.getActionsClient();
 
-      const {
-        getExporter,
-        getClient,
-        client: savedObjectsClient,
-      } = (await context.core).savedObjects;
+        const {
+          getExporter,
+          getClient,
+          client: savedObjectsClient,
+        } = (await context.core).savedObjects;
 
-      const client = getClient({ includedHiddenTypes: ['action'] });
-      const actionsExporter = getExporter(client);
-      try {
-        const exportSizeLimit = config.maxRuleImportExportSize;
-        if (request.body?.objects != null && request.body.objects.length > exportSizeLimit) {
-          return siemResponse.error({
-            statusCode: 400,
-            body: `Can't export more than ${exportSizeLimit} rules`,
-          });
-        } else {
-          const nonPackagedRulesCount = await getNonPackagedRulesCount({
-            rulesClient,
-          });
-          if (nonPackagedRulesCount > exportSizeLimit) {
+        const client = getClient({ includedHiddenTypes: ['action'] });
+        const actionsExporter = getExporter(client);
+        try {
+          const exportSizeLimit = config.maxRuleImportExportSize;
+          if (request.body?.objects != null && request.body.objects.length > exportSizeLimit) {
             return siemResponse.error({
               statusCode: 400,
               body: `Can't export more than ${exportSizeLimit} rules`,
             });
+          } else {
+            const nonPackagedRulesCount = await getNonPackagedRulesCount({
+              rulesClient,
+            });
+            if (nonPackagedRulesCount > exportSizeLimit) {
+              return siemResponse.error({
+                statusCode: 400,
+                body: `Can't export more than ${exportSizeLimit} rules`,
+              });
+            }
           }
+
+          const exportedRulesAndReferences =
+            request.body?.objects != null
+              ? await getExportByObjectIds(
+                  rulesClient,
+                  exceptionsClient,
+                  savedObjectsClient,
+                  request.body.objects,
+                  logger,
+                  actionsExporter,
+                  request,
+                  actionsClient
+                )
+              : await getExportAll(
+                  rulesClient,
+                  exceptionsClient,
+                  savedObjectsClient,
+                  logger,
+                  actionsExporter,
+                  request,
+                  actionsClient
+                );
+
+          const responseBody = request.query.exclude_export_details
+            ? exportedRulesAndReferences.rulesNdjson
+            : `${exportedRulesAndReferences.rulesNdjson}${exportedRulesAndReferences.exceptionLists}${exportedRulesAndReferences.actionConnectors}${exportedRulesAndReferences.exportDetails}`;
+
+          return response.ok({
+            headers: {
+              'Content-Disposition': `attachment; filename="${request.query.file_name}"`,
+              'Content-Type': 'application/ndjson',
+            },
+            body: responseBody,
+          });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-
-        const exportedRulesAndReferences =
-          request.body?.objects != null
-            ? await getExportByObjectIds(
-                rulesClient,
-                exceptionsClient,
-                savedObjectsClient,
-                request.body.objects,
-                logger,
-                actionsExporter,
-                request,
-                actionsClient
-              )
-            : await getExportAll(
-                rulesClient,
-                exceptionsClient,
-                savedObjectsClient,
-                logger,
-                actionsExporter,
-                request,
-                actionsClient
-              );
-
-        const responseBody = request.query.exclude_export_details
-          ? exportedRulesAndReferences.rulesNdjson
-          : `${exportedRulesAndReferences.rulesNdjson}${exportedRulesAndReferences.exceptionLists}${exportedRulesAndReferences.actionConnectors}${exportedRulesAndReferences.exportDetails}`;
-
-        return response.ok({
-          headers: {
-            'Content-Disposition': `attachment; filename="${request.query.file_name}"`,
-            'Content-Type': 'application/ndjson',
-          },
-          body: responseBody,
-        });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/filters/route.ts
@@ -52,48 +52,53 @@ async function fetchRulesCount(rulesClient: RulesClient): Promise<RulesCount> {
 }
 
 export const getRuleManagementFilters = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: RULE_MANAGEMENT_FILTERS_URL,
-      validate: false,
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, _, response): Promise<IKibanaResponse<GetRuleManagementFiltersResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const ctx = await context.resolve(['alerting']);
-      const rulesClient = ctx.alerting.getRulesClient();
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: false,
+      },
+      async (context, _, response): Promise<IKibanaResponse<GetRuleManagementFiltersResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const ctx = await context.resolve(['alerting']);
+        const rulesClient = ctx.alerting.getRulesClient();
 
-      try {
-        const [{ prebuilt: prebuiltRulesCount, custom: customRulesCount }, tags] =
-          await Promise.all([fetchRulesCount(rulesClient), readTags({ rulesClient })]);
-        const responseBody: GetRuleManagementFiltersResponse = {
-          rules_summary: {
-            custom_count: customRulesCount,
-            prebuilt_installed_count: prebuiltRulesCount,
-          },
-          aggregated_fields: {
-            tags,
-          },
-        };
-        const [validatedBody, validationError] = validate(
-          responseBody,
-          GetRuleManagementFiltersResponse
-        );
+        try {
+          const [{ prebuilt: prebuiltRulesCount, custom: customRulesCount }, tags] =
+            await Promise.all([fetchRulesCount(rulesClient), readTags({ rulesClient })]);
+          const responseBody: GetRuleManagementFiltersResponse = {
+            rules_summary: {
+              custom_count: customRulesCount,
+              prebuilt_installed_count: prebuiltRulesCount,
+            },
+            aggregated_fields: {
+              tags,
+            },
+          };
+          const [validatedBody, validationError] = validate(
+            responseBody,
+            GetRuleManagementFiltersResponse
+          );
 
-        if (validationError != null) {
-          return siemResponse.error({ statusCode: 500, body: validationError });
-        } else {
-          return response.ok({ body: validatedBody });
+          if (validationError != null) {
+            return siemResponse.error({ statusCode: 500, body: validationError });
+          } else {
+            return response.ok({ body: validatedBody });
+          }
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/find_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/find_rules/route.ts
@@ -22,52 +22,59 @@ import { buildRouteValidation } from '../../../../../../utils/build_validation/r
 import { transformFindAlerts } from '../../../utils/utils';
 
 export const findRulesRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_URL_FIND,
-      validate: {
-        query: buildRouteValidation(FindRulesRequestQuery),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<FindRulesResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: buildRouteValidation(FindRulesRequestQuery),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<FindRulesResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      const validationErrors = validateFindRulesRequestQuery(request.query);
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
-
-      try {
-        const { query } = request;
-        const ctx = await context.resolve(['core', 'securitySolution', 'alerting']);
-        const rulesClient = ctx.alerting.getRulesClient();
-
-        const rules = await findRules({
-          rulesClient,
-          perPage: query.per_page,
-          page: query.page,
-          sortField: query.sort_field,
-          sortOrder: query.sort_order,
-          filter: query.filter,
-          fields: query.fields,
-        });
-
-        const transformed = transformFindAlerts(rules);
-        if (transformed == null) {
-          return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
-        } else {
-          return response.ok({ body: transformed ?? {} });
+        const validationErrors = validateFindRulesRequestQuery(request.query);
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+
+        try {
+          const { query } = request;
+          const ctx = await context.resolve(['core', 'securitySolution', 'alerting']);
+          const rulesClient = ctx.alerting.getRulesClient();
+
+          const rules = await findRules({
+            rulesClient,
+            perPage: query.per_page,
+            page: query.page,
+            sortField: query.sort_field,
+            sortOrder: query.sort_order,
+            filter: query.filter,
+            fields: query.fields,
+          });
+
+          const transformed = transformFindAlerts(rules);
+          if (transformed == null) {
+            return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
+          } else {
+            return response.ok({ body: transformed ?? {} });
+          }
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/import_rules/route.ts
@@ -47,15 +47,10 @@ export const importRulesRoute = (
   config: ConfigType,
   ml: SetupPlugins['ml']
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'public',
       path: `${DETECTION_ENGINE_RULES_URL}/_import`,
-      validate: {
-        query: buildRouteValidation<typeof ImportRulesRequestQuery, ImportRulesRequestQueryDecoded>(
-          ImportRulesRequestQuery
-        ),
-        body: schema.any(), // validation on file object is accomplished later in the handler.
-      },
       options: {
         tags: ['access:securitySolution'],
         body: {
@@ -63,150 +58,163 @@ export const importRulesRoute = (
           output: 'stream',
         },
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<ImportRulesResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: buildRouteValidation<
+              typeof ImportRulesRequestQuery,
+              ImportRulesRequestQueryDecoded
+            >(ImportRulesRequestQuery),
+            body: schema.any(), // validation on file object is accomplished later in the handler.
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<ImportRulesResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve([
-          'core',
-          'securitySolution',
-          'alerting',
-          'actions',
-          'lists',
-          'licensing',
-        ]);
+        try {
+          const ctx = await context.resolve([
+            'core',
+            'securitySolution',
+            'alerting',
+            'actions',
+            'lists',
+            'licensing',
+          ]);
 
-        const rulesClient = ctx.alerting.getRulesClient();
-        const actionsClient = ctx.actions.getActionsClient();
-        const actionSOClient = ctx.core.savedObjects.getClient({
-          includedHiddenTypes: ['action'],
-        });
-        const actionsImporter = ctx.core.savedObjects.getImporter(actionSOClient);
+          const rulesClient = ctx.alerting.getRulesClient();
+          const actionsClient = ctx.actions.getActionsClient();
+          const actionSOClient = ctx.core.savedObjects.getClient({
+            includedHiddenTypes: ['action'],
+          });
+          const actionsImporter = ctx.core.savedObjects.getImporter(actionSOClient);
 
-        const savedObjectsClient = ctx.core.savedObjects.client;
-        const exceptionsClient = ctx.lists?.getExceptionListClient();
+          const savedObjectsClient = ctx.core.savedObjects.client;
+          const exceptionsClient = ctx.lists?.getExceptionListClient();
 
-        const mlAuthz = buildMlAuthz({
-          license: ctx.licensing.license,
-          ml,
-          request,
-          savedObjectsClient,
-        });
+          const mlAuthz = buildMlAuthz({
+            license: ctx.licensing.license,
+            ml,
+            request,
+            savedObjectsClient,
+          });
 
-        const { filename } = (request.body.file as HapiReadableStream).hapi;
-        const fileExtension = extname(filename).toLowerCase();
-        if (fileExtension !== '.ndjson') {
+          const { filename } = (request.body.file as HapiReadableStream).hapi;
+          const fileExtension = extname(filename).toLowerCase();
+          if (fileExtension !== '.ndjson') {
+            return siemResponse.error({
+              statusCode: 400,
+              body: `Invalid file extension ${fileExtension}`,
+            });
+          }
+
+          const objectLimit = config.maxRuleImportExportSize;
+
+          // parse file to separate out exceptions from rules
+          const readAllStream = createRulesAndExceptionsStreamFromNdJson(objectLimit);
+          const [{ exceptions, rules, actionConnectors }] = await createPromiseFromStreams<
+            RuleExceptionsPromiseFromStreams[]
+          >([request.body.file as HapiReadableStream, ...readAllStream]);
+
+          // import exceptions, includes validation
+          const {
+            errors: exceptionsErrors,
+            successCount: exceptionsSuccessCount,
+            success: exceptionsSuccess,
+          } = await importRuleExceptions({
+            exceptions,
+            exceptionsClient,
+            overwrite: request.query.overwrite_exceptions,
+            maxExceptionsImportSize: objectLimit,
+          });
+          // report on duplicate rules
+          const [duplicateIdErrors, parsedObjectsWithoutDuplicateErrors] =
+            getTupleDuplicateErrorsAndUniqueRules(rules, request.query.overwrite);
+
+          const migratedParsedObjectsWithoutDuplicateErrors = await migrateLegacyActionsIds(
+            parsedObjectsWithoutDuplicateErrors,
+            actionSOClient
+          );
+
+          // import actions-connectors
+          const {
+            successCount: actionConnectorSuccessCount,
+            success: actionConnectorSuccess,
+            warnings: actionConnectorWarnings,
+            errors: actionConnectorErrors,
+            rulesWithMigratedActions,
+          } = await importRuleActionConnectors({
+            actionConnectors,
+            actionsClient,
+            actionsImporter,
+            rules: migratedParsedObjectsWithoutDuplicateErrors,
+            overwrite: request.query.overwrite_action_connectors,
+          });
+
+          // rulesWithMigratedActions: Is returned only in case connectors were exported from different namespace and the
+          // original rules actions' ids were replaced with new destinationIds
+          const parsedRules = actionConnectorErrors.length
+            ? []
+            : rulesWithMigratedActions || migratedParsedObjectsWithoutDuplicateErrors;
+
+          // gather all exception lists that the imported rules reference
+          const foundReferencedExceptionLists = await getReferencedExceptionLists({
+            rules: parsedRules,
+            savedObjectsClient,
+          });
+
+          const chunkParseObjects = chunk(CHUNK_PARSED_OBJECT_SIZE, parsedRules);
+
+          const importRuleResponse: ImportRuleResponse[] = await importRulesHelper({
+            ruleChunks: chunkParseObjects,
+            rulesResponseAcc: [...actionConnectorErrors, ...duplicateIdErrors],
+            mlAuthz,
+            overwriteRules: request.query.overwrite,
+            rulesClient,
+            savedObjectsClient,
+            exceptionsClient,
+            spaceId: ctx.securitySolution.getSpaceId(),
+            existingLists: foundReferencedExceptionLists,
+            allowMissingConnectorSecrets: !!actionConnectors.length,
+          });
+          const errorsResp = importRuleResponse.filter((resp) => isBulkError(resp)) as BulkError[];
+          const successes = importRuleResponse.filter((resp) => {
+            if (isImportRegular(resp)) {
+              return resp.status_code === 200;
+            } else {
+              return false;
+            }
+          });
+          const importRules: ImportRulesResponse = {
+            success: errorsResp.length === 0,
+            success_count: successes.length,
+            rules_count: rules.length,
+            errors: errorsResp,
+            exceptions_errors: exceptionsErrors,
+            exceptions_success: exceptionsSuccess,
+            exceptions_success_count: exceptionsSuccessCount,
+            action_connectors_success: actionConnectorSuccess,
+            action_connectors_success_count: actionConnectorSuccessCount,
+            action_connectors_errors: actionConnectorErrors,
+            action_connectors_warnings: actionConnectorWarnings,
+          };
+
+          const [validated, errors] = validate(importRules, ImportRulesResponse);
+          if (errors != null) {
+            return siemResponse.error({ statusCode: 500, body: errors });
+          } else {
+            return response.ok({ body: validated ?? {} });
+          }
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
-            statusCode: 400,
-            body: `Invalid file extension ${fileExtension}`,
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-
-        const objectLimit = config.maxRuleImportExportSize;
-
-        // parse file to separate out exceptions from rules
-        const readAllStream = createRulesAndExceptionsStreamFromNdJson(objectLimit);
-        const [{ exceptions, rules, actionConnectors }] = await createPromiseFromStreams<
-          RuleExceptionsPromiseFromStreams[]
-        >([request.body.file as HapiReadableStream, ...readAllStream]);
-
-        // import exceptions, includes validation
-        const {
-          errors: exceptionsErrors,
-          successCount: exceptionsSuccessCount,
-          success: exceptionsSuccess,
-        } = await importRuleExceptions({
-          exceptions,
-          exceptionsClient,
-          overwrite: request.query.overwrite_exceptions,
-          maxExceptionsImportSize: objectLimit,
-        });
-        // report on duplicate rules
-        const [duplicateIdErrors, parsedObjectsWithoutDuplicateErrors] =
-          getTupleDuplicateErrorsAndUniqueRules(rules, request.query.overwrite);
-
-        const migratedParsedObjectsWithoutDuplicateErrors = await migrateLegacyActionsIds(
-          parsedObjectsWithoutDuplicateErrors,
-          actionSOClient
-        );
-
-        // import actions-connectors
-        const {
-          successCount: actionConnectorSuccessCount,
-          success: actionConnectorSuccess,
-          warnings: actionConnectorWarnings,
-          errors: actionConnectorErrors,
-          rulesWithMigratedActions,
-        } = await importRuleActionConnectors({
-          actionConnectors,
-          actionsClient,
-          actionsImporter,
-          rules: migratedParsedObjectsWithoutDuplicateErrors,
-          overwrite: request.query.overwrite_action_connectors,
-        });
-
-        // rulesWithMigratedActions: Is returned only in case connectors were exported from different namespace and the
-        // original rules actions' ids were replaced with new destinationIds
-        const parsedRules = actionConnectorErrors.length
-          ? []
-          : rulesWithMigratedActions || migratedParsedObjectsWithoutDuplicateErrors;
-
-        // gather all exception lists that the imported rules reference
-        const foundReferencedExceptionLists = await getReferencedExceptionLists({
-          rules: parsedRules,
-          savedObjectsClient,
-        });
-
-        const chunkParseObjects = chunk(CHUNK_PARSED_OBJECT_SIZE, parsedRules);
-
-        const importRuleResponse: ImportRuleResponse[] = await importRulesHelper({
-          ruleChunks: chunkParseObjects,
-          rulesResponseAcc: [...actionConnectorErrors, ...duplicateIdErrors],
-          mlAuthz,
-          overwriteRules: request.query.overwrite,
-          rulesClient,
-          savedObjectsClient,
-          exceptionsClient,
-          spaceId: ctx.securitySolution.getSpaceId(),
-          existingLists: foundReferencedExceptionLists,
-          allowMissingConnectorSecrets: !!actionConnectors.length,
-        });
-        const errorsResp = importRuleResponse.filter((resp) => isBulkError(resp)) as BulkError[];
-        const successes = importRuleResponse.filter((resp) => {
-          if (isImportRegular(resp)) {
-            return resp.status_code === 200;
-          } else {
-            return false;
-          }
-        });
-        const importRules: ImportRulesResponse = {
-          success: errorsResp.length === 0,
-          success_count: successes.length,
-          rules_count: rules.length,
-          errors: errorsResp,
-          exceptions_errors: exceptionsErrors,
-          exceptions_success: exceptionsSuccess,
-          exceptions_success_count: exceptionsSuccessCount,
-          action_connectors_success: actionConnectorSuccess,
-          action_connectors_success_count: actionConnectorSuccessCount,
-          action_connectors_errors: actionConnectorErrors,
-          action_connectors_warnings: actionConnectorWarnings,
-        };
-
-        const [validated, errors] = validate(importRules, ImportRulesResponse);
-        if (errors != null) {
-          return siemResponse.error({ statusCode: 500, body: errors });
-        } else {
-          return response.ok({ body: validated ?? {} });
-        }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/read_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/read_rule/route.ts
@@ -20,55 +20,62 @@ import { readRules } from '../../../logic/crud/read_rules';
 import { getIdError, transform } from '../../../utils/utils';
 
 export const readRuleRoute = (router: SecuritySolutionPluginRouter, logger: Logger) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_URL,
-      validate: {
-        query: buildRouteValidation(ReadRuleRequestQuery),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<ReadRuleResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = validateQueryRuleByIds(request.query);
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            query: buildRouteValidation(ReadRuleRequestQuery),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<ReadRuleResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = validateQueryRuleByIds(request.query);
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
+        }
 
-      const { id, rule_id: ruleId } = request.query;
+        const { id, rule_id: ruleId } = request.query;
 
-      try {
-        const rulesClient = (await context.alerting).getRulesClient();
+        try {
+          const rulesClient = (await context.alerting).getRulesClient();
 
-        // TODO: https://github.com/elastic/kibana/issues/125642 Reuse fetchRuleById
-        const rule = await readRules({
-          id,
-          rulesClient,
-          ruleId,
-        });
-        if (rule != null) {
-          const transformed = transform(rule);
-          if (transformed == null) {
-            return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
+          // TODO: https://github.com/elastic/kibana/issues/125642 Reuse fetchRuleById
+          const rule = await readRules({
+            id,
+            rulesClient,
+            ruleId,
+          });
+          if (rule != null) {
+            const transformed = transform(rule);
+            if (transformed == null) {
+              return siemResponse.error({ statusCode: 500, body: 'Internal error transforming' });
+            } else {
+              return response.ok({ body: transformed ?? {} });
+            }
           } else {
-            return response.ok({ body: transformed ?? {} });
+            const error = getIdError({ id, ruleId });
+            return siemResponse.error({
+              body: error.message,
+              statusCode: error.statusCode,
+            });
           }
-        } else {
-          const error = getIdError({ id, ruleId });
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
             body: error.message,
             statusCode: error.statusCode,
           });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/update_rule/route.ts
@@ -27,80 +27,91 @@ import { getIdError } from '../../../utils/utils';
 import { transformValidate, validateResponseActionsPermissions } from '../../../utils/validate';
 
 export const updateRuleRoute = (router: SecuritySolutionPluginRouter, ml: SetupPlugins['ml']) => {
-  router.put(
-    {
+  router.versioned
+    .put({
+      access: 'public',
       path: DETECTION_ENGINE_RULES_URL,
-      validate: {
-        body: buildRouteValidation(UpdateRuleRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<UpdateRuleResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = validateUpdateRuleProps(request.body);
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
-      try {
-        const ctx = await context.resolve(['core', 'securitySolution', 'alerting', 'licensing']);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation(UpdateRuleRequestBody),
+          },
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<UpdateRuleResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = validateUpdateRuleProps(request.body);
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
+        }
+        try {
+          const ctx = await context.resolve(['core', 'securitySolution', 'alerting', 'licensing']);
 
-        const rulesClient = ctx.alerting.getRulesClient();
-        const savedObjectsClient = ctx.core.savedObjects.client;
+          const rulesClient = ctx.alerting.getRulesClient();
+          const savedObjectsClient = ctx.core.savedObjects.client;
 
-        const mlAuthz = buildMlAuthz({
-          license: ctx.licensing.license,
-          ml,
-          request,
-          savedObjectsClient,
-        });
-        throwAuthzError(await mlAuthz.validateRuleType(request.body.type));
+          const mlAuthz = buildMlAuthz({
+            license: ctx.licensing.license,
+            ml,
+            request,
+            savedObjectsClient,
+          });
+          throwAuthzError(await mlAuthz.validateRuleType(request.body.type));
 
-        checkDefaultRuleExceptionListReferences({ exceptionLists: request.body.exceptions_list });
+          checkDefaultRuleExceptionListReferences({ exceptionLists: request.body.exceptions_list });
 
-        await validateRuleDefaultExceptionList({
-          exceptionsList: request.body.exceptions_list,
-          rulesClient,
-          ruleRuleId: request.body.rule_id,
-          ruleId: request.body.id,
-        });
+          await validateRuleDefaultExceptionList({
+            exceptionsList: request.body.exceptions_list,
+            rulesClient,
+            ruleRuleId: request.body.rule_id,
+            ruleId: request.body.id,
+          });
 
-        const existingRule = await readRules({
-          rulesClient,
-          ruleId: request.body.rule_id,
-          id: request.body.id,
-        });
+          const existingRule = await readRules({
+            rulesClient,
+            ruleId: request.body.rule_id,
+            id: request.body.id,
+          });
 
-        await validateResponseActionsPermissions(ctx.securitySolution, request.body, existingRule);
+          await validateResponseActionsPermissions(
+            ctx.securitySolution,
+            request.body,
+            existingRule
+          );
 
-        const rule = await updateRules({
-          rulesClient,
-          existingRule,
-          ruleUpdate: request.body,
-        });
+          const rule = await updateRules({
+            rulesClient,
+            existingRule,
+            ruleUpdate: request.body,
+          });
 
-        if (rule != null) {
-          const [validated, errors] = transformValidate(rule);
-          if (errors != null) {
-            return siemResponse.error({ statusCode: 500, body: errors });
+          if (rule != null) {
+            const [validated, errors] = transformValidate(rule);
+            if (errors != null) {
+              return siemResponse.error({ statusCode: 500, body: errors });
+            } else {
+              return response.ok({ body: validated ?? {} });
+            }
           } else {
-            return response.ok({ body: validated ?? {} });
+            const error = getIdError({ id: request.body.id, ruleId: request.body.rule_id });
+            return siemResponse.error({
+              body: error.message,
+              statusCode: error.statusCode,
+            });
           }
-        } else {
-          const error = getIdError({ id: request.body.id, ruleId: request.body.rule_id });
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
             body: error.message,
             statusCode: error.statusCode,
           });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/tags/read_tags/route.ts
@@ -14,34 +14,39 @@ import { buildSiemResponse } from '../../../../routes/utils';
 import { readTags } from './read_tags';
 
 export const readTagsRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'public',
       path: DETECTION_ENGINE_TAGS_URL,
-      validate: false,
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<ReadTagsResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const rulesClient = (await context.alerting)?.getRulesClient();
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, request, response): Promise<IKibanaResponse<ReadTagsResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const rulesClient = (await context.alerting)?.getRulesClient();
 
-      if (!rulesClient) {
-        return siemResponse.error({ statusCode: 404 });
-      }
+        if (!rulesClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
-      try {
-        const tags = await readTags({
-          rulesClient,
-        });
-        return response.ok({ body: tags });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+        try {
+          const tags = await readTags({
+            rulesClient,
+          });
+          return response.ok({ body: tags });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_cluster_health/get_cluster_health_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_cluster_health/get_cluster_health_route.ts
@@ -32,51 +32,61 @@ import { validateGetClusterHealthRequest } from './get_cluster_health_request';
  *   (the same stats are calculated over each of the discreet sub-intervals of the whole interval)
  */
 export const getClusterHealthRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: GET_CLUSTER_HEALTH_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response) => {
-      return handleClusterHealthRequest({
-        response,
-        resolveParameters: () => validateGetClusterHealthRequest({}),
-        resolveDependencies: async () => {
-          const ctx = await context.resolve(['securitySolution']);
-          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
-          return { healthClient };
-        },
-      });
-    }
-  );
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {},
+      },
+      async (context, request, response) => {
+        return handleClusterHealthRequest({
+          response,
+          resolveParameters: () => validateGetClusterHealthRequest({}),
+          resolveDependencies: async () => {
+            const ctx = await context.resolve(['securitySolution']);
+            const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+            return { healthClient };
+          },
+        });
+      }
+    );
 
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: GET_CLUSTER_HEALTH_URL,
-      validate: {
-        body: buildRouteValidation(GetClusterHealthRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<GetClusterHealthResponse>> => {
-      return handleClusterHealthRequest({
-        response,
-        resolveParameters: () => validateGetClusterHealthRequest(request.body),
-        resolveDependencies: async () => {
-          const ctx = await context.resolve(['securitySolution']);
-          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
-          return { healthClient };
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidation(GetClusterHealthRequestBody),
+          },
         },
-      });
-    }
-  );
+      },
+      async (context, request, response): Promise<IKibanaResponse<GetClusterHealthResponse>> => {
+        return handleClusterHealthRequest({
+          response,
+          resolveParameters: () => validateGetClusterHealthRequest(request.body),
+          resolveDependencies: async () => {
+            const ctx = await context.resolve(['securitySolution']);
+            const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+            return { healthClient };
+          },
+        });
+      }
+    );
 };
 
 interface ClusterHealthRouteDependencies {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_rule_health/get_rule_health_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_rule_health/get_rule_health_route.ts
@@ -29,46 +29,52 @@ import { validateGetRuleHealthRequest } from './get_rule_health_request';
  *   (the same stats are calculated over each of the discreet sub-intervals of the whole interval)
  */
 export const getRuleHealthRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: GET_RULE_HEALTH_URL,
-      validate: {
-        body: buildRouteValidation(GetRuleHealthRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<GetRuleHealthResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-
-      try {
-        const params = validateGetRuleHealthRequest(request.body);
-
-        const ctx = await context.resolve(['securitySolution']);
-        const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
-
-        const ruleHealthParameters = { interval: params.interval, rule_id: params.ruleId };
-        const ruleHealth = await healthClient.calculateRuleHealth(ruleHealthParameters);
-
-        const responseBody: GetRuleHealthResponse = {
-          timings: calculateHealthTimings(params.requestReceivedAt),
-          parameters: ruleHealthParameters,
-          health: {
-            ...ruleHealth,
-            debug: params.debug ? ruleHealth.debug : undefined,
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidation(GetRuleHealthRequestBody),
           },
-        };
+        },
+      },
+      async (context, request, response): Promise<IKibanaResponse<GetRuleHealthResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-        return response.ok({ body: responseBody });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+        try {
+          const params = validateGetRuleHealthRequest(request.body);
+
+          const ctx = await context.resolve(['securitySolution']);
+          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+
+          const ruleHealthParameters = { interval: params.interval, rule_id: params.ruleId };
+          const ruleHealth = await healthClient.calculateRuleHealth(ruleHealthParameters);
+
+          const responseBody: GetRuleHealthResponse = {
+            timings: calculateHealthTimings(params.requestReceivedAt),
+            parameters: ruleHealthParameters,
+            health: {
+              ...ruleHealth,
+              debug: params.debug ? ruleHealth.debug : undefined,
+            },
+          };
+
+          return response.ok({ body: responseBody });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_space_health/get_space_health_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/get_space_health/get_space_health_route.ts
@@ -32,51 +32,61 @@ import { validateGetSpaceHealthRequest } from './get_space_health_request';
  *   (the same stats are calculated over each of the discreet sub-intervals of the whole interval)
  */
 export const getSpaceHealthRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: GET_SPACE_HEALTH_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<GetSpaceHealthResponse>> => {
-      return handleSpaceHealthRequest({
-        response,
-        resolveParameters: () => validateGetSpaceHealthRequest({}),
-        resolveDependencies: async () => {
-          const ctx = await context.resolve(['securitySolution']);
-          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
-          return { healthClient };
-        },
-      });
-    }
-  );
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {},
+      },
+      async (context, request, response): Promise<IKibanaResponse<GetSpaceHealthResponse>> => {
+        return handleSpaceHealthRequest({
+          response,
+          resolveParameters: () => validateGetSpaceHealthRequest({}),
+          resolveDependencies: async () => {
+            const ctx = await context.resolve(['securitySolution']);
+            const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+            return { healthClient };
+          },
+        });
+      }
+    );
 
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: GET_SPACE_HEALTH_URL,
-      validate: {
-        body: buildRouteValidation(GetSpaceHealthRequestBody),
-      },
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response) => {
-      return handleSpaceHealthRequest({
-        response,
-        resolveParameters: () => validateGetSpaceHealthRequest(request.body),
-        resolveDependencies: async () => {
-          const ctx = await context.resolve(['securitySolution']);
-          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
-          return { healthClient };
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            body: buildRouteValidation(GetSpaceHealthRequestBody),
+          },
         },
-      });
-    }
-  );
+      },
+      async (context, request, response) => {
+        return handleSpaceHealthRequest({
+          response,
+          resolveParameters: () => validateGetSpaceHealthRequest(request.body),
+          resolveDependencies: async () => {
+            const ctx = await context.resolve(['securitySolution']);
+            const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+            return { healthClient };
+          },
+        });
+      }
+    );
 };
 
 interface SpaceHealthRouteDependencies {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/setup/setup_health_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/detection_engine_health/setup/setup_health_route.ts
@@ -18,32 +18,36 @@ import { buildSiemResponse } from '../../../../routes/utils';
  * and can do any other setup work.
  */
 export const setupHealthRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
+      access: 'internal',
       path: SETUP_HEALTH_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
-        access: 'public', // must be public to enable "system" users to collect data
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<SetupHealthResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {},
+      },
+      async (context, request, response): Promise<IKibanaResponse<SetupHealthResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['securitySolution']);
-        const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
+        try {
+          const ctx = await context.resolve(['securitySolution']);
+          const healthClient = ctx.securitySolution.getDetectionEngineHealthClient();
 
-        await healthClient.installAssetsForMonitoringHealth();
+          await healthClient.installAssetsForMonitoringHealth();
 
-        return response.ok({ body: {} });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body: {} });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/rule_execution_logs/get_rule_execution_events/get_rule_execution_events_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/api/rule_execution_logs/get_rule_execution_events/get_rule_execution_events_route.ts
@@ -23,45 +23,52 @@ import {
  * Accepts rule's saved object ID (`rule.id`) and options for filtering, sorting and pagination.
  */
 export const getRuleExecutionEventsRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: GET_RULE_EXECUTION_EVENTS_URL,
-      validate: {
-        params: buildRouteValidation(GetRuleExecutionEventsRequestParams),
-        query: buildRouteValidation(GetRuleExecutionEventsRequestQuery),
-      },
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (
-      context,
-      request,
-      response
-    ): Promise<IKibanaResponse<GetRuleExecutionEventsResponse>> => {
-      const { params, query } = request;
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            params: buildRouteValidation(GetRuleExecutionEventsRequestParams),
+            query: buildRouteValidation(GetRuleExecutionEventsRequestQuery),
+          },
+        },
+      },
+      async (
+        context,
+        request,
+        response
+      ): Promise<IKibanaResponse<GetRuleExecutionEventsResponse>> => {
+        const { params, query } = request;
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['securitySolution']);
-        const executionLog = ctx.securitySolution.getRuleExecutionLog();
-        const executionEventsResponse = await executionLog.getExecutionEvents({
-          ruleId: params.ruleId,
-          eventTypes: query.event_types,
-          logLevels: query.log_levels,
-          sortOrder: query.sort_order,
-          page: query.page,
-          perPage: query.per_page,
-        });
+        try {
+          const ctx = await context.resolve(['securitySolution']);
+          const executionLog = ctx.securitySolution.getRuleExecutionLog();
+          const executionEventsResponse = await executionLog.getExecutionEvents({
+            ruleId: params.ruleId,
+            eventTypes: query.event_types,
+            logLevels: query.log_levels,
+            sortOrder: query.sort_order,
+            page: query.page,
+            perPage: query.per_page,
+          });
 
-        return response.ok({ body: executionEventsResponse });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body: executionEventsResponse });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/test/detection_engine_api_integration/basic/tests/coverage_overview.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/coverage_overview.ts
@@ -37,6 +37,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '1')
           .send({})
           .expect(200);
 
@@ -56,6 +57,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '1')
           .send({})
           .expect(200);
 
@@ -81,6 +83,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '1')
           .send({})
           .expect(200);
 
@@ -112,6 +115,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 search_term: 'TA002',
@@ -148,6 +152,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 search_term: 'T002',
@@ -184,6 +189,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 search_term: 'T002.002',
@@ -217,6 +223,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 search_term: 'rule-2',
@@ -249,6 +256,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 search_term: 'index-pattern-2',
@@ -283,6 +291,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 activity: ['disabled'],
@@ -319,6 +328,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 activity: ['enabled'],
@@ -357,6 +367,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 activity: ['enabled', 'disabled'],
@@ -406,6 +417,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(RULE_MANAGEMENT_COVERAGE_OVERVIEW_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               filter: {
                 source: ['custom'],

--- a/x-pack/test/detection_engine_api_integration/basic/tests/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/create_rules.ts
@@ -53,6 +53,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -109,6 +110,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(rule)
           .expect(200);
 
@@ -120,6 +122,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRuleWithoutRuleId())
           .expect(200);
 
@@ -131,6 +134,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleMlRule())
           .expect(403);
 
@@ -145,12 +149,14 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(409);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/create_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/create_rules_bulk.ts
@@ -51,6 +51,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
@@ -62,6 +63,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRuleWithoutRuleId()])
           .expect(200);
 
@@ -73,6 +75,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule(), getSimpleRule()])
           .expect(200);
 
@@ -91,12 +94,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'foo')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/delete_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/delete_rules.ts
@@ -46,6 +46,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedProperties(body);
@@ -59,6 +60,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=${bodyWithCreatedRule.rule_id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body);
@@ -72,6 +74,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=${bodyWithCreatedRule.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body);
@@ -82,6 +85,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=c1e1b359-7ac1-4e96-bc81-c683c092436f`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(404);
 
         expect(body).to.eql({
@@ -94,6 +98,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=fake_id`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(404);
 
         expect(body).to.eql({

--- a/x-pack/test/detection_engine_api_integration/basic/tests/delete_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/delete_rules_bulk.ts
@@ -46,6 +46,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1' }])
           .expect(200);
 
@@ -59,8 +60,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its rule_id
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -73,8 +75,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its id
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -84,8 +87,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the ruled_id does not exist when trying to delete a rule_id', async () => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: 'fake_id' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: 'fake_id' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -102,8 +106,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the id does not exist when trying to delete an id', async () => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -122,8 +127,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -158,6 +164,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1' }])
           .expect(200);
 
@@ -171,8 +178,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its rule_id
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -185,8 +193,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its id
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -196,8 +205,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the ruled_id does not exist when trying to delete a rule_id', async () => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: 'fake_id' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: 'fake_id' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -214,8 +224,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the id does not exist when trying to delete an id', async () => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -234,8 +245,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);

--- a/x-pack/test/detection_engine_api_integration/basic/tests/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/export_rules.ts
@@ -43,6 +43,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .expect('Content-Type', 'application/ndjson')
@@ -55,6 +56,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -71,6 +73,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -103,6 +106,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);

--- a/x-pack/test/detection_engine_api_integration/basic/tests/find_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/find_rules.ts
@@ -33,6 +33,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -51,6 +52,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -68,6 +70,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await supertest
         .post(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send(getComplexRule())
         .expect(200);
 
@@ -75,6 +78,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/import_rules.ts
@@ -41,6 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect('Content-Type', 'application/json; charset=utf-8')
           .expect(200);
@@ -50,6 +51,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.txt')
           .expect(400);
 
@@ -63,6 +65,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -85,11 +88,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -110,6 +115,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', fileNdJson, 'rules.ndjson')
           .expect(200);
 
@@ -129,6 +135,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', fileNdJson, 'rules.ndjson')
           .expect(200);
 
@@ -141,6 +148,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
@@ -168,6 +176,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(ruleIds, false), 'rules.ndjson')
           .expect(200);
 
@@ -208,6 +217,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(ruleIds, false), 'rules.ndjson')
           .expect(500);
 
@@ -221,6 +231,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -251,6 +262,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -273,12 +285,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -309,12 +323,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -337,6 +353,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -347,11 +364,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ndjson, 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -369,12 +388,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -405,12 +426,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -452,27 +475,32 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
         const { body: bodyOfRule1 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule2 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-2`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule3 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-3`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/patch_rules.ts
@@ -45,6 +45,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', name: 'some other name' })
           .expect(200);
 
@@ -62,6 +63,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', type: 'machine_learning' })
           .expect(403);
 
@@ -81,6 +83,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: createRuleBody.rule_id, name: 'some other name' })
           .expect(200);
 
@@ -98,6 +101,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ id: createdBody.id, name: 'some other name' })
           .expect(200);
 
@@ -115,6 +119,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', enabled: false })
           .expect(200);
 
@@ -132,6 +137,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', severity: 'low', enabled: false })
           .expect(200);
 
@@ -151,6 +157,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', timeline_title: 'some title', timeline_id: 'some id' })
           .expect(200);
 
@@ -158,6 +165,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', name: 'some other name' })
           .expect(200);
 
@@ -175,6 +183,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' })
           .expect(404);
 
@@ -188,6 +197,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'fake_id', name: 'some other name' })
           .expect(404);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/patch_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/patch_rules_bulk.ts
@@ -45,6 +45,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', name: 'some other name' }])
           .expect(200);
 
@@ -63,6 +64,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { rule_id: 'rule-1', name: 'some other name' },
             { rule_id: 'rule-2', name: 'some other name' },
@@ -90,6 +92,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: createRuleBody.id, name: 'some other name' }])
           .expect(200);
 
@@ -108,6 +111,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { id: createRule1.id, name: 'some other name' },
             { id: createRule2.id, name: 'some other name' },
@@ -135,6 +139,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: createdBody.id, name: 'some other name' }])
           .expect(200);
 
@@ -152,6 +157,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', enabled: false }])
           .expect(200);
 
@@ -169,6 +175,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', severity: 'low', enabled: false }])
           .expect(200);
 
@@ -188,6 +195,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', timeline_title: 'some title', timeline_id: 'some id' }])
           .expect(200);
 
@@ -195,6 +203,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', name: 'some other name' }])
           .expect(200);
 
@@ -212,6 +221,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' }])
           .expect(200);
 
@@ -230,6 +240,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'fake_id', name: 'some other name' }])
           .expect(200);
 
@@ -248,6 +259,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { rule_id: 'rule-1', name: 'some other name' },
             { rule_id: 'fake_id', name: 'some other name' },
@@ -278,6 +290,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { id: createdBody.id, name: 'some other name' },
             { id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' },

--- a/x-pack/test/detection_engine_api_integration/basic/tests/read_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/read_rules.ts
@@ -45,6 +45,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -58,6 +59,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -71,6 +73,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${createRuleBody.rule_id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -82,6 +85,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=c1e1b359-7ac1-4e96-bc81-c683c092436f`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(404);
 
@@ -95,6 +99,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=fake_id`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(404);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/update_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/update_rules.ts
@@ -52,6 +52,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -74,6 +75,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(403);
 
@@ -97,6 +99,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -119,6 +122,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -140,6 +144,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -163,6 +168,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate)
           .expect(200);
 
@@ -173,6 +179,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate2)
           .expect(200);
 
@@ -192,6 +199,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(404);
 
@@ -209,6 +217,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(404);
 

--- a/x-pack/test/detection_engine_api_integration/basic/tests/update_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/update_rules_bulk.ts
@@ -52,6 +52,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule])
           .expect(200);
 
@@ -69,6 +70,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRuleUpdate('rule-2'))
           .expect(200);
 
@@ -82,6 +84,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -111,6 +114,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -139,6 +143,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -168,6 +173,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -189,6 +195,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -212,6 +219,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -222,6 +230,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate2])
           .expect(200);
 
@@ -241,6 +250,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -263,6 +273,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -289,6 +300,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate, ruleUpdate2])
           .expect(200);
 
@@ -326,6 +338,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([rule1, rule2])
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/check_privileges.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/check_privileges.ts
@@ -76,6 +76,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .get(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .query({ id })
             .expect(200);
 
@@ -114,6 +115,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .get(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .query({ id })
             .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_new_terms.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_new_terms.ts
@@ -33,6 +33,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .post(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send(rule);
 
       expect(response.status).to.equal(400);
@@ -50,6 +51,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .post(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send(rule);
 
       expect(response.status).to.equal(400);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rule_exceptions.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rule_exceptions.ts
@@ -67,6 +67,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: items } = await supertest
         .post(`${DETECTION_ENGINE_RULES_URL}/${rule.id}/exceptions`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({
           items: [getRuleExceptionItemMock()],
         })
@@ -122,6 +123,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: items } = await supertest
         .post(`${DETECTION_ENGINE_RULES_URL}/${rule.id}/exceptions`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({
           items: [getRuleExceptionItemMock()],
         })
@@ -195,6 +197,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: items } = await supertest
         .post(`${DETECTION_ENGINE_RULES_URL}/${rule.id}/exceptions`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({
           items: [getRuleExceptionItemMock()],
         })
@@ -231,6 +234,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body } = await supertest
         .post(`${DETECTION_ENGINE_RULES_URL}/4656dc92-5832-11ea-8e2d-0242ac130003/exceptions`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({
           items: [getRuleExceptionItemMock()],
         })

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rules.ts
@@ -85,6 +85,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(savedQueryRule)
             .expect(200);
 
@@ -97,6 +98,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRule())
             .expect(200);
 
@@ -131,6 +133,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(200);
 
@@ -142,6 +145,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(simpleRule)
             .expect(200);
 
@@ -154,6 +158,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: rule } = await supertest
             .get(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .query({ id: body.id })
             .expect(200);
 
@@ -172,6 +177,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(200);
 
@@ -227,6 +233,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(200);
 
@@ -238,6 +245,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRuleWithoutRuleId())
             .expect(200);
 
@@ -253,6 +261,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(legacyMlRule)
             .expect(200);
 
@@ -264,6 +273,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleMlRule())
             .expect(200);
 
@@ -275,12 +285,14 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRule())
             .expect(200);
 
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRule())
             .expect(409);
 
@@ -321,6 +333,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(500);
 
@@ -353,12 +366,14 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: ruleWithException } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(200);
 
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ ...rule, rule_id: 'rule-2' })
             .expect(409);
 
@@ -391,12 +406,14 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(200);
 
           await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ ...rule, rule_id: 'rule-2' })
             .expect(200);
         });
@@ -418,6 +435,7 @@ export default ({ getService }: FtrProviderContext) => {
             .post(DETECTION_ENGINE_RULES_URL)
             .auth(role, 'changeme')
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRule())
             .expect(403);
         });
@@ -429,6 +447,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(400);
 
@@ -444,6 +463,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               ...rule,
               threshold: {
@@ -464,6 +484,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               ...rule,
               threshold: {
@@ -485,6 +506,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               ...rule,
               threshold: {
@@ -532,6 +554,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(200);
         const bodyId = body.id;
@@ -546,6 +569,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body: rule } = await supertest
           .get(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .query({ id: bodyId })
           .expect(200);
 
@@ -564,6 +588,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(200);
         const bodyId = body.id;
@@ -578,6 +603,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body: rule } = await supertest
           .get(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .query({ id: bodyId })
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/create_rules_bulk.ts
@@ -55,6 +55,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { header } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
@@ -86,6 +87,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
@@ -120,6 +122,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([rule])
           .expect(200);
 
@@ -130,6 +133,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRuleWithoutRuleId()])
           .expect(200);
 
@@ -141,6 +145,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule(), getSimpleRule()])
           .expect(200);
 
@@ -159,12 +164,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'foo')
+          .set('elastic-api-version', '2023-10-31')
           .send([getSimpleRule()])
           .expect(200);
 
@@ -179,10 +186,11 @@ export default ({ getService }: FtrProviderContext): void => {
         ]);
       });
 
-      it('should return a 200 ok but have a 409 conflict if we attempt to create the rule, which use existing attached rule defult list', async () => {
+      it('should return a 200 ok but have a 409 conflict if we attempt to create the rule, which use existing attached rule default list', async () => {
         const { body: ruleWithException } = await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             ...getSimpleRuleWithoutRuleId(),
             exceptions_list: [
@@ -199,6 +207,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               ...getSimpleRule(),
@@ -229,6 +238,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_CREATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               ...getSimpleRule(),
@@ -296,6 +306,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_BULK_CREATE)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send([rule])
             .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/delete_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/delete_rules.ts
@@ -51,6 +51,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedProperties(body);
@@ -64,6 +65,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=${bodyWithCreatedRule.rule_id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body);
@@ -77,6 +79,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=${bodyWithCreatedRule.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body);
@@ -87,6 +90,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=c1e1b359-7ac1-4e96-bc81-c683c092436f`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(404);
 
         expect(body).to.eql({
@@ -99,6 +103,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=fake_id`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(404);
 
         expect(body).to.eql({
@@ -164,6 +169,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         // ensure the actions contains the response
@@ -208,6 +214,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .delete(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         // Test to ensure that we have exactly 0 legacy actions by querying the Alerting client REST API directly

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/delete_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/delete_rules_bulk.ts
@@ -41,6 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { header } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1' }])
           .expect(200);
 
@@ -67,6 +68,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1' }])
           .expect(200);
 
@@ -80,8 +82,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its rule_id
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -94,8 +97,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its id
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -105,8 +109,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the ruled_id does not exist when trying to delete a rule_id', async () => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: 'fake_id' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: 'fake_id' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -123,8 +128,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the id does not exist when trying to delete an id', async () => {
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -143,8 +149,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -179,6 +186,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1' }])
           .expect(200);
 
@@ -194,6 +202,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
           .send([{ rule_id: bodyWithCreatedRule.rule_id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -206,8 +215,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete that rule by its id
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -217,8 +227,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the ruled_id does not exist when trying to delete a rule_id', async () => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ rule_id: 'fake_id' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ rule_id: 'fake_id' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -235,8 +246,9 @@ export default ({ getService }: FtrProviderContext): void => {
       it('should return an error if the id does not exist when trying to delete an id', async () => {
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         expect(body).to.eql([
@@ -255,8 +267,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const { body } = await supertest
           .post(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: bodyWithCreatedRule.id }, { id: 'c4e80a0d-e20f-4efc-84c1-08112da5a612' }])
           .expect(200);
 
         const bodyToCompare = removeServerGeneratedPropertiesIncludingRuleId(body[0]);
@@ -292,8 +305,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete the rule with the legacy action
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: createRuleBody.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: createRuleBody.id }])
           .expect(200);
 
         // ensure we only get one body back
@@ -341,8 +355,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // delete 2 rules where both have legacy actions
         const { body } = await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: createRuleBody1.id }, { id: createRuleBody2.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: createRuleBody1.id }, { id: createRuleBody2.id }])
           .expect(200);
 
         // ensure we only get two bodies back
@@ -402,8 +417,9 @@ export default ({ getService }: FtrProviderContext): void => {
         // bulk delete the rule
         await supertest
           .delete(DETECTION_ENGINE_RULES_BULK_DELETE)
-          .send([{ id: createRuleBody.id }])
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send([{ id: createRuleBody.id }])
           .expect(200);
 
         // Test to ensure that we have exactly 0 legacy actions by querying the Alerting client REST API directly

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
@@ -46,6 +46,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .expect('Content-Type', 'application/ndjson')
@@ -66,6 +67,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             objects: [{ rule_id: 'rule-1' }],
           })
@@ -98,6 +100,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -115,6 +118,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -147,6 +151,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -200,6 +205,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -256,6 +262,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -314,6 +321,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -375,6 +383,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -441,6 +450,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200)
             .parse(binaryToString);
@@ -518,6 +528,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200)
             .parse(binaryToString);
@@ -636,6 +647,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200)
             .parse(binaryToString);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rules.ts
@@ -34,6 +34,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -52,6 +53,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -69,6 +71,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await supertest
         .post(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send(getComplexRule())
         .expect(200);
 
@@ -76,6 +79,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -114,6 +118,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -164,6 +169,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send()
         .expect(200);
 
@@ -228,6 +234,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/get_rule_management_filters.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/get_rule_management_filters.ts
@@ -28,6 +28,8 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body } = await supertest
         .get(RULE_MANAGEMENT_FILTERS_URL)
         .set('kbn-xsrf', 'true')
+        .set('x-elastic-internal-origin', 'Kibana')
+        .set('elastic-api-version', '1')
         .send()
         .expect(200);
 
@@ -50,6 +52,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(rule)
           .expect(200);
       });
@@ -58,6 +61,8 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .get(RULE_MANAGEMENT_FILTERS_URL)
           .set('kbn-xsrf', 'true')
+          .set('x-elastic-internal-origin', 'Kibana')
+          .set('elastic-api-version', '1')
           .send()
           .expect(200);
 
@@ -69,6 +74,8 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .get(RULE_MANAGEMENT_FILTERS_URL)
           .set('kbn-xsrf', 'true')
+          .set('x-elastic-internal-origin', 'Kibana')
+          .set('elastic-api-version', '1')
           .send()
           .expect(200);
 
@@ -86,6 +93,8 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .get(RULE_MANAGEMENT_FILTERS_URL)
           .set('kbn-xsrf', 'true')
+          .set('x-elastic-internal-origin', 'Kibana')
+          .set('elastic-api-version', '1')
           .send()
           .expect(200);
 
@@ -97,6 +106,8 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .get(RULE_MANAGEMENT_FILTERS_URL)
           .set('kbn-xsrf', 'true')
+          .set('x-elastic-internal-origin', 'Kibana')
+          .set('elastic-api-version', '1')
           .send()
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/get_rule_execution_results.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/get_rule_execution_results.ts
@@ -63,6 +63,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .get(getRuleExecutionResultsUrl('1'))
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({ start, end });
 
       expect(response.status).to.eql(404);
@@ -85,6 +86,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .get(getRuleExecutionResultsUrl(id))
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({ start, end });
 
       expect(response.status).to.eql(200);
@@ -111,6 +113,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .get(getRuleExecutionResultsUrl(id))
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({ start, end });
 
       expect(response.status).to.eql(200);
@@ -158,6 +161,7 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .get(getRuleExecutionResultsUrl(id))
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({ start, end });
 
       expect(response.status).to.eql(200);
@@ -229,6 +233,8 @@ export default ({ getService }: FtrProviderContext) => {
       const response = await supertest
         .get(getRuleExecutionResultsUrl(id))
         .set('kbn-xsrf', 'true')
+        .set('x-elastic-internal-origin', 'Kibana')
+        .set('elastic-api-version', '1')
         .query({ start, end, status_filters: 'failed,succeeded' });
 
       // Verify the most recent execution was one of the failedRanAfterDisabled executions, which have a duration of 3ms and are made up of 2 docs per execution,

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/import_export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/import_export_rules.ts
@@ -110,6 +110,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -117,6 +118,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
           .expect(200);
 
@@ -187,6 +189,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -194,6 +197,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
           .expect(200);
 
@@ -273,6 +277,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200)
           .parse(binaryToString);
@@ -280,6 +285,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
           .expect(200);
 
@@ -349,6 +355,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_export`)
+          .set('elastic-api-version', '2023-10-31')
           .set('kbn-xsrf', 'true')
           .send()
           .expect(200)
@@ -357,6 +364,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true&overwrite_exceptions=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', Buffer.from(body), 'rules.ndjson')
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/import_rules.ts
@@ -207,6 +207,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -265,6 +266,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach(
             'file',
             Buffer.from(toNdJsonString([simpleRule, ruleWithConnector])),
@@ -344,6 +346,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach(
             'file',
             Buffer.from(toNdJsonString([simpleRule, ruleWithConnector])),
@@ -390,6 +393,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(rule as RuleCreateProps), 'rules.ndjson')
           .expect(200);
 
@@ -414,6 +418,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(rule), 'rules.ndjson')
           .expect(200);
 
@@ -438,6 +443,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(rule), 'rules.ndjson')
           .expect(200);
 
@@ -467,6 +473,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(rule), 'rules.ndjson')
           .expect(200);
 
@@ -494,6 +501,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect('Content-Type', 'application/json; charset=utf-8')
           .expect(200);
@@ -503,6 +511,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.txt')
           .expect(400);
 
@@ -516,6 +525,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -538,11 +548,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -557,6 +569,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
@@ -579,6 +592,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -609,6 +623,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -631,12 +646,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -667,12 +684,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -695,6 +714,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -705,11 +725,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ndjson, 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -754,6 +776,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ndjson, 'rules.ndjson')
           .expect(200);
 
@@ -766,12 +789,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -802,12 +827,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -850,27 +877,32 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
         const { body: bodyOfRule1 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule2 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-2`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule3 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-3`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -900,6 +932,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
 
@@ -967,6 +1000,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach(
             'file',
             Buffer.from(toNdJsonString([simpleRule, ruleWithConnector])),
@@ -1018,6 +1052,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
         expect(body).to.eql({
@@ -1112,6 +1147,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', buffer, 'rules.ndjson')
           .expect(200);
 
@@ -1189,6 +1225,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', buffer, 'rules.ndjson')
           .expect(200);
 
@@ -1251,6 +1288,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body.success).to.eql(true);
@@ -1266,6 +1304,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
 
@@ -1292,6 +1331,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body).to.eql({
@@ -1316,6 +1356,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body.success).to.equal(false);
@@ -1335,6 +1376,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body.success).to.equal(false);
@@ -1360,6 +1402,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body).to.eql({
@@ -1387,6 +1430,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body.success).to.equal(true);
@@ -1406,6 +1450,7 @@ export default ({ getService }: FtrProviderContext): void => {
             const { body } = await supertest
               .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
               .set('kbn-xsrf', 'true')
+              .set('elastic-api-version', '2023-10-31')
               .attach('file', buffer, 'rules.ndjson')
               .expect(200);
             expect(body.success).to.equal(false);
@@ -1436,6 +1481,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1466,6 +1512,7 @@ export default ({ getService }: FtrProviderContext): void => {
           await supertest
             .delete(`${EXCEPTION_LIST_ITEM_URL}?item_id=${'test_item_id'}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .expect(200);
         });
 
@@ -1475,6 +1522,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1535,11 +1583,13 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
             .expect(200);
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
 
@@ -1597,6 +1647,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1643,6 +1694,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
           const bodyToCompare = removeServerGeneratedProperties(ruleResponse);
@@ -1700,6 +1752,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1757,6 +1810,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
           const bodyToCompare = removeServerGeneratedProperties(ruleResponse);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/legacy_actions_migrations.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/legacy_actions_migrations.ts
@@ -61,6 +61,7 @@ export default ({ getService }: FtrProviderContext) => {
       await supertest
         .patch(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({ rule_id: ruleId, enabled: false })
         .expect(200);
 
@@ -98,6 +99,7 @@ export default ({ getService }: FtrProviderContext) => {
       await supertest
         .patch(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({ rule_id: ruleId, enabled: false })
         .expect(200);
 
@@ -171,6 +173,7 @@ export default ({ getService }: FtrProviderContext) => {
       await supertest
         .patch(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({ rule_id: ruleId, enabled: false })
         .expect(200);
 
@@ -245,6 +248,7 @@ export default ({ getService }: FtrProviderContext) => {
       await supertest
         .patch(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({ rule_id: ruleId, enabled: false })
         .expect(200);
 
@@ -304,6 +308,7 @@ export default ({ getService }: FtrProviderContext) => {
       await supertest
         .patch(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send({ rule_id: ruleId, enabled: false })
         .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules.ts
@@ -63,6 +63,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', name: 'some other name' })
           .expect(200);
 
@@ -80,6 +81,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', machine_learning_job_id: 'some_job_id' })
           .expect(200);
 
@@ -95,6 +97,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', name: 'some other name' })
           .expect(200);
 
@@ -114,6 +117,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: createRuleBody.rule_id, name: 'some other name' })
           .expect(200);
 
@@ -131,6 +135,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ id: createdBody.id, name: 'some other name' })
           .expect(200);
 
@@ -148,6 +153,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', enabled: false })
           .expect(200);
 
@@ -165,6 +171,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', severity: 'low', enabled: false })
           .expect(200);
 
@@ -184,6 +191,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', timeline_title: 'some title', timeline_id: 'some id' })
           .expect(200);
 
@@ -191,6 +199,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'rule-1', name: 'some other name' })
           .expect(200);
 
@@ -211,6 +220,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: 'rule-1',
             exceptions_list: [
@@ -228,6 +238,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: 'rule-1',
             exceptions_list: [
@@ -253,6 +264,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: 'rule-1',
             exceptions_list: [
@@ -295,6 +307,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: 'rule-2',
             exceptions_list: [
@@ -331,6 +344,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             id: createdBody.id,
             exceptions_list: [
@@ -375,6 +389,7 @@ export default ({ getService }: FtrProviderContext) => {
         const patchResponse = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ id: rule.id, enabled: false })
           .expect(200);
 
@@ -405,6 +420,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' })
           .expect(404);
 
@@ -418,6 +434,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: 'fake_id', name: 'some other name' })
           .expect(404);
 
@@ -442,6 +459,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rulePatch)
             .expect(200);
 
@@ -459,6 +477,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body: patchedRule } = await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({ rule_id: ruleId, throttle, actions })
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/patch_rules_bulk.ts
@@ -43,6 +43,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { header } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', name: 'some other name' }])
           .expect(200);
 
@@ -69,6 +70,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', name: 'some other name' }])
           .expect(200);
 
@@ -87,6 +89,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { rule_id: 'rule-1', name: 'some other name' },
             { rule_id: 'rule-2', name: 'some other name' },
@@ -114,6 +117,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: createRuleBody.id, name: 'some other name' }])
           .expect(200);
 
@@ -132,6 +136,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { id: createRule1.id, name: 'some other name' },
             { id: createRule2.id, name: 'some other name' },
@@ -183,6 +188,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { id: rule1.id, enabled: false },
             { id: rule2.id, enabled: false },
@@ -222,6 +228,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: createdBody.id, name: 'some other name' }])
           .expect(200);
 
@@ -239,6 +246,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', enabled: false }])
           .expect(200);
 
@@ -256,6 +264,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', severity: 'low', enabled: false }])
           .expect(200);
 
@@ -275,6 +284,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', timeline_title: 'some title', timeline_id: 'some id' }])
           .expect(200);
 
@@ -282,6 +292,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'rule-1', name: 'some other name' }])
           .expect(200);
 
@@ -299,6 +310,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' }])
           .expect(200);
 
@@ -317,6 +329,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([{ rule_id: 'fake_id', name: 'some other name' }])
           .expect(200);
 
@@ -335,6 +348,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { rule_id: 'rule-1', name: 'some other name' },
             { rule_id: 'fake_id', name: 'some other name' },
@@ -365,6 +379,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             { id: createdBody.id, name: 'some other name' },
             { id: '5096dec6-b6b9-4d8d-8f93-6c2602079d9d', name: 'some other name' },
@@ -405,6 +420,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               rule_id: 'rule-1',
@@ -438,6 +454,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .patch(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               rule_id: 'rule-1',

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/perform_bulk_action.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/perform_bulk_action.ts
@@ -48,16 +48,24 @@ export default ({ getService }: FtrProviderContext): void => {
   const esArchiver = getService('esArchiver');
 
   const postBulkAction = () =>
-    supertest.post(DETECTION_ENGINE_RULES_BULK_ACTION).set('kbn-xsrf', 'true');
+    supertest
+      .post(DETECTION_ENGINE_RULES_BULK_ACTION)
+      .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31');
+
   const fetchRule = (ruleId: string) =>
-    supertest.get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`).set('kbn-xsrf', 'true');
+    supertest
+      .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
+      .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31');
 
   const fetchPrebuiltRule = async () => {
     const { body: findBody } = await supertest
       .get(
         `${DETECTION_ENGINE_RULES_URL}/_find?per_page=1&filter=alert.attributes.params.immutable: true`
       )
-      .set('kbn-xsrf', 'true');
+      .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31');
 
     return findBody.data[0];
   };
@@ -436,6 +444,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body: rulesResponse } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .expect(200);
 
       expect(rulesResponse.total).to.eql(2);
@@ -541,6 +550,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body: rulesResponse } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .expect(200);
 
       expect(rulesResponse.total).to.eql(2);
@@ -645,6 +655,7 @@ export default ({ getService }: FtrProviderContext): void => {
       // Check that the updates have been persisted
       const { body: rulesResponse } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
+        .set('elastic-api-version', '2023-10-31')
         .set('kbn-xsrf', 'true')
         .expect(200);
 
@@ -692,6 +703,7 @@ export default ({ getService }: FtrProviderContext): void => {
       const { body: rulesResponse } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .expect(200);
 
       expect(rulesResponse.total).to.eql(2);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/perform_bulk_action_dry_run.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/perform_bulk_action_dry_run.ts
@@ -34,13 +34,20 @@ export default ({ getService }: FtrProviderContext): void => {
     supertest
       .post(DETECTION_ENGINE_RULES_BULK_ACTION)
       .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31')
       .query({ dry_run: true });
 
   const fetchRule = (ruleId: string) =>
-    supertest.get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`).set('kbn-xsrf', 'true');
+    supertest
+      .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
+      .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31');
 
   const findRules = () =>
-    supertest.get(`${DETECTION_ENGINE_RULES_URL}/_find`).set('kbn-xsrf', 'true');
+    supertest
+      .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
+      .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31');
 
   describe('perform_bulk_action dry_run', () => {
     beforeEach(async () => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/read_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/read_rules.ts
@@ -46,6 +46,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -59,6 +60,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -72,6 +74,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${createRuleBody.rule_id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -83,6 +86,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=c1e1b359-7ac1-4e96-bc81-c683c092436f`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(404);
 
@@ -96,6 +100,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=fake_id`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(404);
 
@@ -130,6 +135,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -174,6 +180,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRule())
           .expect(200);
 
@@ -232,6 +239,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?id=${createRuleBody.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(getSimpleRule())
             .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/resolve_read_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/resolve_read_rules.ts
@@ -41,7 +41,11 @@ export default ({ getService }: FtrProviderContext) => {
       it('should create a "migrated" rule where querying for the new SO _id will resolve the new object and not return the outcome field when outcome === exactMatch', async () => {
         // link to the new URL with migrated SO id 74f3e6d7-b7bb-477d-ac28-92ee22728e6e
         const URL = `/s/${spaceId}${DETECTION_ENGINE_RULES_URL}?id=90e3ca0e-71f7-513a-b60a-ac678efd8887`;
-        const readRulesAliasMatchRes = await supertest.get(URL).set('kbn-xsrf', 'true').send();
+        const readRulesAliasMatchRes = await supertest
+          .get(URL)
+          .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
+          .send();
         expect(readRulesAliasMatchRes.body.outcome).to.eql('aliasMatch');
         expect(readRulesAliasMatchRes.body.alias_purpose).to.eql('savedObjectConversion');
 
@@ -51,6 +55,7 @@ export default ({ getService }: FtrProviderContext) => {
         const readRulesExactMatchRes = await supertest
           .get(exactMatchURL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send();
         expect(readRulesExactMatchRes.body.outcome).to.eql(undefined);
       });
@@ -149,6 +154,7 @@ export default ({ getService }: FtrProviderContext) => {
         const readRulesConflictRes = await supertest
           .get(conflictURL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
         expect(readRulesConflictRes.body.outcome).to.eql('conflict');

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/throttle.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/throttle.ts
@@ -322,6 +322,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ rule_id: rule.rule_id, name: 'some other name' })
             .expect(200);
           const readRule = await getRule(supertest, log, rule.rule_id);
@@ -342,6 +343,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ rule_id: rule.rule_id, name: 'some other name' })
             .expect(200);
           const {
@@ -366,6 +368,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ rule_id: rule.rule_id, actions: [] })
             .expect(200);
           const readRule = await getRule(supertest, log, rule.rule_id);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules.ts
@@ -72,6 +72,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -94,6 +95,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -117,6 +119,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -141,6 +144,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -190,6 +194,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -245,6 +250,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -285,6 +291,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -306,6 +313,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(updatedRule)
           .expect(200);
 
@@ -329,6 +337,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate)
           .expect(200);
 
@@ -339,6 +348,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate2)
           .expect(200);
 
@@ -358,6 +368,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(404);
 
@@ -375,6 +386,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(simpleRule)
           .expect(404);
 
@@ -412,6 +424,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate)
           .expect(200);
 
@@ -444,6 +457,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(ruleUpdate)
           .expect(500);
 
@@ -470,6 +484,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             ...getSimpleRule('rule-2'),
             exceptions_list: [
@@ -511,6 +526,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             ...updatedRule,
             exceptions_list: [
@@ -539,6 +555,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(400);
 
@@ -563,6 +580,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(400);
 
@@ -586,6 +604,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(400);
 
@@ -615,6 +634,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .post(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(rule)
             .expect(400);
 
@@ -634,6 +654,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: outputRule } = await supertest
             .put(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(savedQueryRule)
             .expect(200);
 
@@ -649,6 +670,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: outputRule } = await supertest
             .put(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(savedQueryRule)
             .expect(200);
 
@@ -664,6 +686,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: outputRule } = await supertest
             .put(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(queryRule)
             .expect(200);
 
@@ -688,6 +711,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body: updatedRule } = await supertest
             .put(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(ruleToUpdate)
             .expect(200);
 
@@ -857,6 +881,7 @@ export default ({ getService }: FtrProviderContext) => {
           const { body } = await supertest
             .put(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send(ruleUpdate)
             .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules_bulk.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/update_rules_bulk.ts
@@ -59,6 +59,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { header } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule])
           .expect(200);
 
@@ -88,6 +89,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule])
           .expect(200);
 
@@ -105,6 +107,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .post(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send(getSimpleRuleUpdate('rule-2'))
           .expect(200);
 
@@ -118,6 +121,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -182,6 +186,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body }: { body: RuleResponse[] } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -249,6 +254,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body }: { body: RuleResponse[] } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -274,6 +280,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -302,6 +309,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1, updatedRule2])
           .expect(200);
 
@@ -331,6 +339,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -352,6 +361,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([updatedRule1])
           .expect(200);
 
@@ -375,6 +385,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -385,6 +396,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate2])
           .expect(200);
 
@@ -404,6 +416,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -426,6 +439,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate])
           .expect(200);
 
@@ -452,6 +466,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleUpdate, ruleUpdate2])
           .expect(200);
 
@@ -489,6 +504,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([rule1, rule2])
           .expect(200);
 
@@ -529,6 +545,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               ...rule1,
@@ -568,6 +585,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([
             {
               ...rule1,
@@ -629,6 +647,7 @@ export default ({ getService }: FtrProviderContext) => {
         const { body } = await supertest
           .put(DETECTION_ENGINE_RULES_BULK_UPDATE)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send([ruleToUpdate])
           .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group3/exceptions_workflows.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group3/exceptions_workflows.ts
@@ -185,6 +185,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ rule_id: ELASTIC_SECURITY_RULE_ID, exceptions_list: [] })
             .expect(200);
 
@@ -209,6 +210,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ELASTIC_SECURITY_RULE_ID,
               exceptions_list: [
@@ -238,6 +240,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({ rule_id: ELASTIC_SECURITY_RULE_ID, exceptions_list: [] })
             .expect(200);
 
@@ -267,6 +270,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ELASTIC_SECURITY_RULE_ID,
               exceptions_list: [
@@ -330,6 +334,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ELASTIC_SECURITY_RULE_ID,
               exceptions_list: [
@@ -386,6 +391,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ruleId,
               exceptions_list: [
@@ -430,6 +436,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ELASTIC_SECURITY_RULE_ID,
               exceptions_list: [
@@ -470,6 +477,7 @@ export default ({ getService }: FtrProviderContext) => {
           await supertest
             .patch(DETECTION_ENGINE_RULES_URL)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .send({
               rule_id: ELASTIC_SECURITY_RULE_ID,
               exceptions_list: [

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/task_based/detection_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group4/telemetry/task_based/detection_rules.ts
@@ -374,6 +374,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -432,6 +433,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -508,6 +510,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -584,6 +587,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -660,6 +664,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -736,6 +741,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [
@@ -836,6 +842,7 @@ export default ({ getService }: FtrProviderContext) => {
         await supertest
           .patch(DETECTION_ENGINE_RULES_URL)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .send({
             rule_id: ELASTIC_SECURITY_RULE_ID,
             exceptions_list: [

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/tests/import_rules.ts
@@ -123,6 +123,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -162,6 +163,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
 
@@ -201,6 +203,7 @@ export default ({ getService }: FtrProviderContext): void => {
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .auth(ROLES.hunter_no_actions, 'changeme')
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
         expect(body).to.eql({
@@ -248,6 +251,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect('Content-Type', 'application/json; charset=utf-8')
           .expect(200);
@@ -257,6 +261,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.txt')
           .expect(400);
 
@@ -270,6 +275,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -292,11 +298,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -311,6 +319,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
@@ -333,6 +342,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -363,6 +373,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -385,12 +396,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -421,12 +434,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -449,6 +464,7 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
@@ -459,11 +475,13 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import?overwrite=true`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ndjson, 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -481,12 +499,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -517,12 +537,14 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
@@ -565,27 +587,32 @@ export default ({ getService }: FtrProviderContext): void => {
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2']), 'rules.ndjson')
           .expect(200);
 
         await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', getSimpleRuleAsNdjson(['rule-1', 'rule-2', 'rule-3']), 'rules.ndjson')
           .expect(200);
 
         const { body: bodyOfRule1 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule2 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-2`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
         const { body: bodyOfRule3 } = await supertest
           .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-3`)
+          .set('elastic-api-version', '2023-10-31')
           .send()
           .expect(200);
 
@@ -615,6 +642,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
 
@@ -670,6 +698,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
           .expect(200);
         expect(body).to.eql({
@@ -725,6 +754,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', buffer, 'rules.ndjson')
           .expect(200);
 
@@ -781,6 +811,7 @@ export default ({ getService }: FtrProviderContext): void => {
         const { body } = await supertest
           .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '2023-10-31')
           .attach('file', buffer, 'rules.ndjson')
           .expect(200);
 
@@ -830,6 +861,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', buffer, 'rules.ndjson')
             .expect(200);
           expect(body.success).to.eql(true);
@@ -846,6 +878,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', buffer, 'rules.ndjson')
             .expect(200);
           expect(body.success).to.equal(false);
@@ -866,6 +899,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', buffer, 'rules.ndjson')
             .expect(200);
           expect(body.success).to.equal(false);
@@ -884,6 +918,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', buffer, 'rules.ndjson')
             .expect(200);
           expect(body.success).to.equal(true);
@@ -903,6 +938,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`/s/${spaceId}${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', buffer, 'rules.ndjson')
             .expect(200);
           expect(body.success).to.equal(false);
@@ -924,6 +960,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -984,11 +1021,13 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach('file', ruleToNdjson(simpleRule), 'rules.ndjson')
             .expect(200);
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
 
@@ -1046,6 +1085,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1092,6 +1132,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
           const bodyToCompare = removeServerGeneratedProperties(ruleResponse);
@@ -1149,6 +1190,7 @@ export default ({ getService }: FtrProviderContext): void => {
           const { body } = await supertest
             .post(`${DETECTION_ENGINE_RULES_URL}/_import`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '2023-10-31')
             .attach(
               'file',
               Buffer.from(
@@ -1206,6 +1248,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
           const { body: ruleResponse } = await supertest
             .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=rule-1`)
+            .set('elastic-api-version', '2023-10-31')
             .send()
             .expect(200);
           const bodyToCompare = removeServerGeneratedProperties(ruleResponse);

--- a/x-pack/test/detection_engine_api_integration/utils/create_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_rule.ts
@@ -32,6 +32,7 @@ export const createRule = async (
   const response = await supertest
     .post(DETECTION_ENGINE_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send(rule);
   if (response.status === 409) {
     if (rule.rule_id != null) {
@@ -44,6 +45,7 @@ export const createRule = async (
       const secondResponseTry = await supertest
         .post(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send(rule);
       if (secondResponseTry.status !== 200) {
         throw new Error(

--- a/x-pack/test/detection_engine_api_integration/utils/create_rule_with_auth.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_rule_with_auth.ts
@@ -26,6 +26,7 @@ export const createRuleWithAuth = async (
   const { body } = await supertest
     .post(DETECTION_ENGINE_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .auth(auth.user, auth.pass)
     .send(rule);
   return body;

--- a/x-pack/test/detection_engine_api_integration/utils/create_rule_with_exception_entries.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_rule_with_exception_entries.ts
@@ -58,6 +58,7 @@ export const createRuleWithExceptionEntries = async (
   const response = await supertest
     .patch(DETECTION_ENGINE_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send({ rule_id: ruleResponse.rule_id, enabled: true });
 
   if (response.status !== 200) {

--- a/x-pack/test/detection_engine_api_integration/utils/delete_all_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/delete_all_rules.ts
@@ -27,11 +27,13 @@ export const deleteAllRules = async (
       await supertest
         .post(DETECTION_ENGINE_RULES_BULK_ACTION)
         .send({ action: 'delete', query: '' })
-        .set('kbn-xsrf', 'true');
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31');
 
       const { body: finalCheck } = await supertest
         .get(`${DETECTION_ENGINE_RULES_URL}/_find`)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .send();
       return {
         passed: finalCheck.data.length === 0,

--- a/x-pack/test/detection_engine_api_integration/utils/delete_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/delete_rule.ts
@@ -23,6 +23,7 @@ export const deleteRule = async (
   const response = await supertest
     .delete(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .expect(200);
 
   return response.body;

--- a/x-pack/test/detection_engine_api_integration/utils/find_immutable_rule_by_id.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/find_immutable_rule_by_id.ts
@@ -31,6 +31,7 @@ export const findImmutableRuleById = async (
       `${DETECTION_ENGINE_RULES_URL}/_find?filter=alert.attributes.params.immutable: true AND alert.attributes.params.ruleId: "${ruleId}"`
     )
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send();
   if (response.status !== 200) {
     log.error(

--- a/x-pack/test/detection_engine_api_integration/utils/get_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/get_rule.ts
@@ -24,7 +24,8 @@ export const getRule = async (
 ): Promise<RuleResponse> => {
   const response = await supertest
     .get(`${DETECTION_ENGINE_RULES_URL}?rule_id=${ruleId}`)
-    .set('kbn-xsrf', 'true');
+    .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31');
 
   if (response.status !== 200) {
     log.error(

--- a/x-pack/test/detection_engine_api_integration/utils/patch_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/patch_rule.ts
@@ -28,6 +28,7 @@ export const patchRule = async (
   const response = await supertest
     .patch(DETECTION_ENGINE_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send(patchedRule);
   if (response.status !== 200) {
     log.error(

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
@@ -23,6 +23,7 @@ export const getInstalledRules = async (
   const { body: rulesResponse } = await supertest
     .get(`${DETECTION_ENGINE_RULES_URL_FIND}?per_page=10000`)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_prebuilt_rules_and_timelines_status.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_prebuilt_rules_and_timelines_status.ts
@@ -23,6 +23,7 @@ export const getPrebuiltRulesAndTimelinesStatus = async (
   const response = await supertest
     .get(PREBUILT_RULES_STATUS_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_prebuilt_rules_status.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_prebuilt_rules_status.ts
@@ -22,6 +22,7 @@ export const getPrebuiltRulesStatus = async (
   const response = await supertest
     .get(GET_PREBUILT_RULES_STATUS_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
@@ -42,6 +42,7 @@ export const installPrebuiltRules = async (
   const response = await supertest
     .post(PERFORM_RULE_INSTALLATION_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send(payload)
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
@@ -36,6 +36,7 @@ export const installPrebuiltRulesAndTimelines = async (
   const response = await supertest
     .put(PREBUILT_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/review_install_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/review_install_prebuilt_rules.ts
@@ -21,6 +21,7 @@ export const reviewPrebuiltRulesToInstall = async (
   const response = await supertest
     .post(REVIEW_RULE_INSTALLATION_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/review_upgrade_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/review_upgrade_prebuilt_rules.ts
@@ -21,6 +21,7 @@ export const reviewPrebuiltRulesToUpgrade = async (
   const response = await supertest
     .post(REVIEW_RULE_UPGRADE_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send()
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/upgrade_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/upgrade_prebuilt_rules.ts
@@ -38,6 +38,7 @@ export const upgradePrebuiltRules = async (
   const response = await supertest
     .post(PERFORM_RULE_UPGRADE_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send(payload)
     .expect(200);
 

--- a/x-pack/test/detection_engine_api_integration/utils/update_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/update_rule.ts
@@ -28,6 +28,7 @@ export const updateRule = async (
   const response = await supertest
     .put(DETECTION_ENGINE_RULES_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
     .send(updatedRule);
   if (response.status !== 200) {
     log.error(

--- a/x-pack/test/detection_engine_api_integration/utils/wait_for_rule_status.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/wait_for_rule_status.ts
@@ -46,6 +46,7 @@ export const waitForRuleStatus = async (
       const response = await supertest
         .get(DETECTION_ENGINE_RULES_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
         .query(query)
         .expect(200);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -83,7 +83,7 @@ import {
   selectRulesByName,
 } from '../../../tasks/alerts_detection_rules';
 import { deleteSelectedRules } from '../../../tasks/rules_bulk_actions';
-import { createRule } from '../../../tasks/api_calls/rules';
+import { createRule, findAllRules } from '../../../tasks/api_calls/rules';
 import { createTimeline } from '../../../tasks/api_calls/timelines';
 import { deleteAlertsAndRules, deleteConnectors } from '../../../tasks/common';
 import { addEmailConnectorAndRuleAction } from '../../../tasks/common/rule_actions';
@@ -261,7 +261,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
           const initialNumberOfRules = rules.length;
           const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-          cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+          findAllRules().then(({ body }) => {
             const numberOfRules = body.data.length;
             expect(numberOfRules).to.eql(initialNumberOfRules);
           });
@@ -269,7 +269,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
           deleteFirstRule();
 
           getRulesManagementTableRows().should('have.length', expectedNumberOfRulesAfterDeletion);
-          cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+          findAllRules().then(({ body }) => {
             const numberOfRules = body.data.length;
             expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
           });
@@ -298,7 +298,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
             });
 
           getRulesManagementTableRows().should('have.length', expectedNumberOfRulesAfterDeletion);
-          cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+          findAllRules().then(({ body }) => {
             const numberOfRules = body.data.length;
             expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
           });
@@ -328,7 +328,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
           cy.waitFor('@deleteRule').then(() => {
             cy.get(RULES_MANAGEMENT_TABLE).should('exist');
             getRulesManagementTableRows().should('have.length', expectedNumberOfRulesAfterDeletion);
-            cy.request({ url: '/api/detection_engine/rules/_find' }).then(({ body }) => {
+            findAllRules().then(({ body }) => {
               const numberOfRules = body.data.length;
               expect(numberOfRules).to.eql(expectedNumberOfRulesAfterDeletion);
             });

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -14,7 +14,11 @@ export const getPrebuiltRulesStatus = () => {
   return cy.request<PrePackagedRulesStatusResponse>({
     method: 'GET',
     url: 'api/detection_engine/rules/prepackaged/_status',
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
   });
 };
 
@@ -34,7 +38,11 @@ export const installAllPrebuiltRulesRequest = () => {
   return cy.request({
     method: 'POST',
     url: 'internal/detection_engine/prebuilt_rules/installation/_perform',
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '1',
+    },
     body: {
       mode: 'ALL_RULES',
     },

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/rules.ts
@@ -18,6 +18,17 @@ import type { FetchRulesResponse } from '@kbn/security-solution-plugin/public/de
 import { internalAlertingSnoozeRule } from '../../urls/routes';
 import { rootRequest } from '../common';
 
+export const findAllRules = () => {
+  return rootRequest<FetchRulesResponse>({
+    url: DETECTION_ENGINE_RULES_URL_FIND,
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
+  });
+};
+
 export const createRule = (
   rule: RuleCreateProps
 ): Cypress.Chainable<Cypress.Response<RuleResponse>> => {
@@ -25,7 +36,11 @@ export const createRule = (
     method: 'POST',
     url: DETECTION_ENGINE_RULES_URL,
     body: rule,
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     failOnStatusCode: false,
   });
 };
@@ -54,7 +69,11 @@ export const deleteCustomRule = (ruleId = '1') => {
   rootRequest({
     method: 'DELETE',
     url: `api/detection_engine/rules?rule_id=${ruleId}`,
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     failOnStatusCode: false,
   });
 };
@@ -73,6 +92,7 @@ export const importRule = (ndjsonPath: string) => {
           'kbn-xsrf': 'cypress-creds',
           'content-type': 'multipart/form-data',
           'x-elastic-internal-origin': 'security-solution',
+          'elastic-api-version': '2023-10-31',
         },
         body: formdata,
       })
@@ -91,6 +111,7 @@ export const waitForRulesToFinishExecution = (ruleIds: string[], afterDate?: Dat
           'kbn-xsrf': 'cypress-creds',
           'content-type': 'multipart/form-data',
           'x-elastic-internal-origin': 'security-solution',
+          'elastic-api-version': '2023-10-31',
         },
       }).then((response) => {
         const areAllRulesFinished = ruleIds.every((ruleId) =>

--- a/x-pack/test/security_solution_cypress/cypress/tasks/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/common.ts
@@ -108,7 +108,11 @@ export const deleteAlertsAndRules = () => {
       action: 'delete',
     },
     failOnStatusCode: false,
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     timeout: 300000,
   });
 

--- a/x-pack/test/security_solution_ftr/services/detections/index.ts
+++ b/x-pack/test/security_solution_ftr/services/detections/index.ts
@@ -63,6 +63,7 @@ export class DetectionsTestService extends FtrService {
     return this.supertest
       .get(DETECTION_ENGINE_RULES_URL)
       .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31')
       .query({ rule_id: ELASTIC_SECURITY_RULE_ID })
       .send()
       .then(this.getHttpResponseFailureHandler())
@@ -82,6 +83,7 @@ export class DetectionsTestService extends FtrService {
     await this.supertest
       .post(DETECTION_ENGINE_RULES_BULK_ACTION)
       .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31')
       .send({
         action: 'disable',
         ids: [endpointSecurityRule.id],
@@ -95,6 +97,7 @@ export class DetectionsTestService extends FtrService {
     await this.supertest
       .post(DETECTION_ENGINE_RULES_BULK_ACTION)
       .set('kbn-xsrf', 'true')
+      .set('elastic-api-version', '2023-10-31')
       .send({
         action: 'enable',
         ids: [endpointSecurityRule.id],


### PR DESCRIPTION
**Resolves:** [elastic/security-team#6949](https://github.com/elastic/security-team/issues/6949)

## Summary

This PR migrates all HTTP Endpoints under the ownership of @elastic/security-detection-rule-management to the [versioned router](https://docs.elastic.dev/kibana-dev-docs/versioning-http-apis#use-the-versioned-router).

- Endpoints that are documented and start with `/api` were marked as `access: 'public'`. So in production, if accessed without the version header, they will be automatically resolved to the latest available version.
- Endpoints that start with `/internal` are now flagged as `access: 'internal'`, implying a special origin header is needed to access them in a Serverless environment. The version header (`'elastic-api-version': '1'`) should always be provided for these endpoints to work.

### Migrated endpoints:

- [x] Prebuilt Rules
- [x] Rule Management
- [x] Rule Monitoring
- [x] Health

For further reference, here's the [complete list of Security Solution APIs](https://docs.google.com/spreadsheets/d/1VCoJ74EkyGuj59VwWj_3v2ecB84pNCpzGqkYnS0SUKw/edit?pli=1#gid=0).