### PR TITLE
[Security Solution][Endpoint] Update `t3_analyst` role to ensure it only has `read` access to Policy Details

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/complete_with_endpoint_roles.cy.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/complete_with_endpoint_roles.cy.ts
@@ -13,7 +13,6 @@ import {
   EndpointArtifactPageId,
   ensureArtifactPageAuthzAccess,
   ensureEndpointListPageAuthzAccess,
-  ensurePolicyDetailsPageAuthzAccess,
   ensurePolicyListPageAuthzAccess,
   getArtifactListEmptyStateAddButton,
   getEndpointManagementPageList,
@@ -33,6 +32,7 @@ import {
   getConsoleHelpPanelResponseActionTestSubj,
   openConsoleHelpPanel,
 } from '../../../screens/endpoint_management/response_console';
+import { ensurePolicyDetailsPageAuthzAccess } from '../../../screens/endpoint_management/policy_details';
 
 describe(
   'User Roles for Security Complete PLI with Endpoint Complete addon',

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/complete_with_endpoint_roles.cy.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/complete_with_endpoint_roles.cy.ts
@@ -13,6 +13,8 @@ import {
   EndpointArtifactPageId,
   ensureArtifactPageAuthzAccess,
   ensureEndpointListPageAuthzAccess,
+  ensurePolicyDetailsPageAuthzAccess,
+  ensurePolicyListPageAuthzAccess,
   getArtifactListEmptyStateAddButton,
   getEndpointManagementPageList,
   getEndpointManagementPageMap,
@@ -130,6 +132,11 @@ describe(
 
       it('should have access to Endpoint list page', () => {
         ensureEndpointListPageAuthzAccess('all', true);
+      });
+
+      it('should have read access to Endpoint Policy Management', () => {
+        ensurePolicyListPageAuthzAccess('read', true);
+        ensurePolicyDetailsPageAuthzAccess(loadedEndpoints.integrationPolicies[0].id, 'read', true);
       });
 
       for (const { title, id } of artifactPagesFullAccess) {

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/essentials_with_endpoint.roles.cy.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/essentials_with_endpoint.roles.cy.ts
@@ -16,6 +16,7 @@ import {
   ensureArtifactPageAuthzAccess,
   ensureEndpointListPageAuthzAccess,
   ensurePolicyListPageAuthzAccess,
+  ensurePolicyDetailsPageAuthzAccess,
 } from '../../../screens/endpoint_management';
 import {
   ensurePermissionDeniedScreen,
@@ -98,6 +99,7 @@ describe(
 
       it('should have read access to Endpoint Policy Management', () => {
         ensurePolicyListPageAuthzAccess('read', true);
+        ensurePolicyDetailsPageAuthzAccess(loadedEndpoints.integrationPolicies[0].id, 'read', true);
       });
 
       for (const { title, id } of artifactPagesFullAccess) {
@@ -173,6 +175,7 @@ describe(
 
       it('should have access to policy management', () => {
         ensurePolicyListPageAuthzAccess('all', true);
+        ensurePolicyDetailsPageAuthzAccess(loadedEndpoints.integrationPolicies[0].id, 'all', true);
       });
 
       it(`should NOT have access to Host Isolation Exceptions`, () => {

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/essentials_with_endpoint.roles.cy.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/e2e/endpoint_management/roles/essentials_with_endpoint.roles.cy.ts
@@ -16,7 +16,6 @@ import {
   ensureArtifactPageAuthzAccess,
   ensureEndpointListPageAuthzAccess,
   ensurePolicyListPageAuthzAccess,
-  ensurePolicyDetailsPageAuthzAccess,
 } from '../../../screens/endpoint_management';
 import {
   ensurePermissionDeniedScreen,
@@ -24,6 +23,7 @@ import {
   visitFleetAgentList,
 } from '../../../screens';
 import { ServerlessRoleName } from '../../../../../../../shared/lib';
+import { ensurePolicyDetailsPageAuthzAccess } from '../../../screens/endpoint_management/policy_details';
 
 describe(
   'Roles for Security Essential PLI with Endpoint Essentials addon',

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_details.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_details.ts
@@ -6,7 +6,29 @@
  */
 
 import { APP_POLICIES_PATH } from '@kbn/security-solution-plugin/common/constants';
+import { UserAuthzAccessLevel } from './types';
+import { getNoPrivilegesPage } from './common';
 
 export const visitPolicyDetails = (policyId: string): Cypress.Chainable => {
   return cy.visit(`${APP_POLICIES_PATH}/${policyId}`);
+};
+
+export const ensurePolicyDetailsPageAuthzAccess = (
+  policyId: string,
+  accessLevel: UserAuthzAccessLevel,
+  visitPage: boolean = false
+): Cypress.Chainable => {
+  if (visitPage) {
+    visitPolicyDetails(policyId);
+  }
+
+  if (accessLevel === 'none') {
+    return getNoPrivilegesPage().should('exist');
+  }
+
+  if (accessLevel === 'read') {
+    return cy.getByTestSubj('policyDetailsSaveButton').should('not.exist');
+  }
+
+  return cy.getByTestSubj('policyDetailsSaveButton').should('exist');
 };

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_list.ts
@@ -17,10 +17,6 @@ export const visitPolicyList = (): Cypress.Chainable => {
   return cy.visit(pageById.policyList);
 };
 
-export const visitPolicyDetails = (policyId: string): Cypress.Chainable => {
-  return cy.visit(pageById.policyList + `/${policyId}`);
-};
-
 export const ensurePolicyListPageAuthzAccess = (
   accessLevel: UserAuthzAccessLevel,
   visitPage: boolean = false
@@ -35,24 +31,4 @@ export const ensurePolicyListPageAuthzAccess = (
 
   // Read and All currently are the same
   return getNoPrivilegesPage().should('not.exist');
-};
-
-export const ensurePolicyDetailsPageAuthzAccess = (
-  policyId: string,
-  accessLevel: UserAuthzAccessLevel,
-  visitPage: boolean = false
-): Cypress.Chainable => {
-  if (visitPage) {
-    visitPolicyDetails(policyId);
-  }
-
-  if (accessLevel === 'none') {
-    return getNoPrivilegesPage().should('exist');
-  }
-
-  if (accessLevel === 'read') {
-    return cy.getByTestSubj('policyDetailsSaveButton').should('not.exist');
-  }
-
-  return cy.getByTestSubj('policyDetailsSaveButton').should('exist');
 };

--- a/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/cypress/screens/endpoint_management/policy_list.ts
@@ -17,6 +17,10 @@ export const visitPolicyList = (): Cypress.Chainable => {
   return cy.visit(pageById.policyList);
 };
 
+export const visitPolicyDetails = (policyId: string): Cypress.Chainable => {
+  return cy.visit(pageById.policyList + `/${policyId}`);
+};
+
 export const ensurePolicyListPageAuthzAccess = (
   accessLevel: UserAuthzAccessLevel,
   visitPage: boolean = false
@@ -31,4 +35,24 @@ export const ensurePolicyListPageAuthzAccess = (
 
   // Read and All currently are the same
   return getNoPrivilegesPage().should('not.exist');
+};
+
+export const ensurePolicyDetailsPageAuthzAccess = (
+  policyId: string,
+  accessLevel: UserAuthzAccessLevel,
+  visitPage: boolean = false
+): Cypress.Chainable => {
+  if (visitPage) {
+    visitPolicyDetails(policyId);
+  }
+
+  if (accessLevel === 'none') {
+    return getNoPrivilegesPage().should('exist');
+  }
+
+  if (accessLevel === 'read') {
+    return cy.getByTestSubj('policyDetailsSaveButton').should('not.exist');
+  }
+
+  return cy.getByTestSubj('policyDetailsSaveButton').should('exist');
 };

--- a/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
+++ b/x-pack/test_serverless/shared/lib/security/kibana_roles/project_controller_security_roles.yml
@@ -165,7 +165,7 @@ t3_analyst:
         - event_filters_all
         - host_isolation_exceptions_all
         - blocklist_all
-        - policy_management_all # Elastic Defend Policy Management
+        - policy_management_read # Elastic Defend Policy Management
         - host_isolation_all
         - process_operations_all
         - actions_log_management_all # Response actions history


### PR DESCRIPTION
## Summary

- Updates the roles YAML file (used in testing) to match update done to project-controller for serverless
- adds additional tests to validate `t3_analyst` role in serverless


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


