### PR TITLE
[Synthetics] Test run logs in test run details page 

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/test_run_error_info.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/components/test_run_error_info.tsx
@@ -42,7 +42,7 @@ export const TestRunErrorInfo = ({
         </EuiCallOut>
       )}
       <EuiSpacer size="m" />
-      {isDownMonitor && (showErrorLogs || hasNoSteps) && (
+      {(showErrorLogs || hasNoSteps) && (
         <StdErrorLogs
           checkGroup={journeyDetails?.journey?.monitor.check_group}
           hideTitle={false}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -85,16 +85,14 @@ export const TestRunDetails = () => {
             </EuiPanel>
             <EuiSpacer size="m" />
             <TestRunSteps isLoading={stepsLoading} steps={stepsData?.steps ?? []} />
-            <>
-              <EuiSpacer size="m" />
-              <EuiPanel hasShadow={false} hasBorder>
-                <TestRunErrorInfo
-                  journeyDetails={stepsData?.details}
-                  showErrorTitle={false}
-                  showErrorLogs={true}
-                />
-              </EuiPanel>
-            </>
+            <EuiSpacer size="m" />
+            <EuiPanel hasShadow={false} hasBorder>
+              <TestRunErrorInfo
+                journeyDetails={stepsData?.details}
+                showErrorTitle={false}
+                showErrorLogs={true}
+              />
+            </EuiPanel>
           </EuiFlexItem>
           <EuiFlexItem css={{ flexBasis: '36%', minWidth: 'min-content' }}>
             <StepDurationPanel legendPosition="bottom" />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_run_details/test_run_details.tsx
@@ -85,6 +85,16 @@ export const TestRunDetails = () => {
             </EuiPanel>
             <EuiSpacer size="m" />
             <TestRunSteps isLoading={stepsLoading} steps={stepsData?.steps ?? []} />
+            <>
+              <EuiSpacer size="m" />
+              <EuiPanel hasShadow={false} hasBorder>
+                <TestRunErrorInfo
+                  journeyDetails={stepsData?.details}
+                  showErrorTitle={false}
+                  showErrorLogs={true}
+                />
+              </EuiPanel>
+            </>
           </EuiFlexItem>
           <EuiFlexItem css={{ flexBasis: '36%', minWidth: 'min-content' }}>
             <StepDurationPanel legendPosition="bottom" />


### PR DESCRIPTION
## Summary

Added test run logs table to test run details page, earlier it was only displayed in error details page !!

<img width="1720" alt="image" src="https://github.com/elastic/kibana/assets/3505601/a2c01af7-ec27-40d4-8402-47960dc097d6">


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->