### PR TITLE
[Security Solution] move tier into source.metadata

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/endpoint/services/metering_service.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/services/metering_service.ts
@@ -113,13 +113,15 @@ export class EndpointMeteringService {
       creation_timestamp: timestampStr,
       usage: {
         type: 'security_solution_endpoint',
-        sub_type: this.tier,
         period_seconds: SAMPLE_PERIOD_SECONDS,
         quantity: 1,
       },
       source: {
         id: taskId,
         instance_group_id: projectId,
+        metadata: {
+          tier: this.tier,
+        },
       },
     };
   }

--- a/x-pack/plugins/security_solution_serverless/server/types.ts
+++ b/x-pack/plugins/security_solution_serverless/server/types.ts
@@ -19,6 +19,8 @@ import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { SecuritySolutionEssPluginSetup } from '@kbn/security-solution-ess/server';
 import type { MlPluginSetup } from '@kbn/ml-plugin/server';
 
+import type { ProductTier } from '../common/product';
+
 import type { ServerlessSecurityConfig } from './config';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -63,6 +65,11 @@ export interface UsageMetrics {
 export interface UsageSource {
   id: string;
   instance_group_id: string;
+  metadata?: UsageSourceMetadata;
+}
+
+export interface UsageSourceMetadata {
+  tier?: ProductTier;
 }
 
 export interface SecurityUsageReportingTaskSetupContract {


### PR DESCRIPTION
## Summary

Per discussions with billing team, tier should be standardized into `source.metadata.tier`.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
