### PR TITLE
[Flaky test #116048] Unskip tests

### DIFF
--- a/x-pack/test/functional/apps/saved_objects_management/feature_controls/saved_objects_management_security.ts
+++ b/x-pack/test/functional/apps/saved_objects_management/feature_controls/saved_objects_management_security.ts
@@ -245,9 +245,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // From https://github.com/elastic/kibana/issues/59588 edit view became read-only json view
       // test description changed from "edit" to "inspect"
       // Skipping the test to allow code owners to delete or modify the test.
-      //
-      // FLAKY: https://github.com/elastic/kibana/issues/116048
-      describe.skip('inspect visualization', () => {
+      describe('inspect visualization', () => {
         before(async () => {
           await PageObjects.settings.navigateTo();
           await PageObjects.settings.clickKibanaSavedObjects();


### PR DESCRIPTION
## Summary

Resolves #116048.

Unskipping should suffice because, according to https://github.com/elastic/kibana/issues/116048#issuecomment-1663764373, the underlying issue has been fixed.

✅ Flaky-test runner (400x): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2852

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->