### PR TITLE
[Security Solution] expandable flyout - inverse Visualizations and Investigation order and expand Investigation by default

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_overview_tab.cy.ts
@@ -147,7 +147,6 @@ describe('Alert details expandable flyout right panel overview tab', () => {
   describe('investigation section', () => {
     it('should display investigation section', () => {
       toggleOverviewTabAboutSection();
-      toggleOverviewTabInvestigationSection();
 
       cy.log('header and content');
 
@@ -206,6 +205,7 @@ describe('Alert details expandable flyout right panel overview tab', () => {
   describe('insights section', () => {
     it('should display entities section', () => {
       toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
       toggleOverviewTabInsightsSection();
 
       cy.log('header and content');
@@ -224,9 +224,9 @@ describe('Alert details expandable flyout right panel overview tab', () => {
       // cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_ENTITIES_CONTENT).should('be.visible');
     });
 
-    // TODO: skipping this due to flakiness
-    it.skip('should display threat intelligence section', () => {
+    it('should display threat intelligence section', () => {
       toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
       toggleOverviewTabInsightsSection();
 
       cy.log('header and content');
@@ -270,6 +270,7 @@ describe('Alert details expandable flyout right panel overview tab', () => {
       createNewCaseFromExpandableFlyout();
 
       toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
       toggleOverviewTabInsightsSection();
 
       cy.log('header and content');
@@ -311,6 +312,7 @@ describe('Alert details expandable flyout right panel overview tab', () => {
     //  we need to generate enough data to have at least one field with prevalence
     it.skip('should display prevalence section', () => {
       toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
       toggleOverviewTabInsightsSection();
 
       cy.log('header and content');
@@ -338,6 +340,7 @@ describe('Alert details expandable flyout right panel overview tab', () => {
   describe('response section', () => {
     it('should display empty message', () => {
       toggleOverviewTabAboutSection();
+      toggleOverviewTabInvestigationSection();
       toggleOverviewTabResponseSection();
 
       cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB_RESPONSE_SECTION_EMPTY_RESPONSE).should(

--- a/x-pack/plugins/security_solution/public/flyout/right/components/investigation_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/investigation_section.tsx
@@ -23,7 +23,7 @@ export interface DescriptionSectionProps {
 /**
  * Most top section of the overview tab. It contains the description, reason and mitre attack information (for a document of type alert).
  */
-export const InvestigationSection: VFC<DescriptionSectionProps> = ({ expanded = false }) => {
+export const InvestigationSection: VFC<DescriptionSectionProps> = ({ expanded = true }) => {
   return (
     <ExpandableSection
       expanded={expanded}

--- a/x-pack/plugins/security_solution/public/flyout/right/tabs/overview_tab.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/tabs/overview_tab.tsx
@@ -22,9 +22,9 @@ export const OverviewTab: FC = memo(() => {
     <>
       <AboutSection />
       <EuiHorizontalRule margin="l" />
-      <VisualizationsSection />
-      <EuiHorizontalRule margin="l" />
       <InvestigationSection />
+      <EuiHorizontalRule margin="l" />
+      <VisualizationsSection />
       <EuiHorizontalRule margin="l" />
       <InsightsSection />
       <EuiHorizontalRule margin="l" />


### PR DESCRIPTION
## Summary

To increase readability and usability of the new expandable flyout, it was decided to move the `Visualizations` section below the `Investigation` section in the right panel. Also the `Investigation` section is now expanded by default, similarly to the `About` section.

![Screenshot 2023-08-11 at 11 22 29 AM](https://github.com/elastic/kibana/assets/17276605/2c80735b-8cd1-40dc-ac99-42c67de7556e)

https://github.com/elastic/security-team/issues/6641

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios