### PR TITLE
[Security Solution] expandable flyout - add cell actions to severity and status component in header

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
@@ -14,6 +14,7 @@ import {
 } from './test_ids';
 import { DocumentSeverity } from './severity';
 import { mockGetFieldsData } from '../mocks/mock_context';
+import { TestProviders } from '../../../common/mock';
 
 describe('<DocumentSeverity />', () => {
   it('should render severity information', () => {
@@ -22,9 +23,11 @@ describe('<DocumentSeverity />', () => {
     } as unknown as RightPanelContext;
 
     const { getByTestId } = render(
-      <RightPanelContext.Provider value={contextValue}>
-        <DocumentSeverity />
-      </RightPanelContext.Provider>
+      <TestProviders>
+        <RightPanelContext.Provider value={contextValue}>
+          <DocumentSeverity />
+        </RightPanelContext.Provider>
+      </TestProviders>
     );
 
     expect(getByTestId(FLYOUT_HEADER_SEVERITY_TITLE_TEST_ID)).toBeInTheDocument();

--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
@@ -10,6 +10,9 @@ import React, { memo } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
+import { CellActionsMode } from '@kbn/cell-actions';
+import { SecurityCellActions } from '../../../common/components/cell_actions';
+import { SecurityCellActionsTrigger } from '../../../actions/constants';
 import { SEVERITY_TITLE } from './translations';
 import { useRightPanelContext } from '../context';
 import { SeverityBadge } from '../../../detections/components/rules/severity_badge';
@@ -46,7 +49,17 @@ export const DocumentSeverity: FC = memo(() => {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <SeverityBadge value={alertSeverity} />
+        <SecurityCellActions
+          data={{
+            field: ALERT_SEVERITY,
+            value: alertSeverity,
+          }}
+          mode={CellActionsMode.HOVER_RIGHT}
+          triggerId={SecurityCellActionsTrigger.DEFAULT}
+          visibleCellActions={6}
+        >
+          <SeverityBadge value={alertSeverity} />
+        </SecurityCellActions>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
@@ -9,6 +9,8 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import { find } from 'lodash/fp';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
+import { CellActionsMode } from '@kbn/cell-actions';
+import { SecurityCellActions } from '../../../common/components/cell_actions';
 import type {
   EnrichedFieldInfo,
   EnrichedFieldInfoWithValues,
@@ -17,6 +19,7 @@ import { SIGNAL_STATUS_FIELD_NAME } from '../../../timelines/components/timeline
 import { StatusPopoverButton } from '../../../common/components/event_details/overview/status_popover_button';
 import { useRightPanelContext } from '../context';
 import { getEnrichedFieldInfo } from '../../../common/components/event_details/helpers';
+import { SecurityCellActionsTrigger } from '../../../actions/constants';
 
 /**
  * Checks if the field info has data to convert EnrichedFieldInfo into EnrichedFieldInfoWithValues
@@ -52,13 +55,23 @@ export const DocumentStatus: FC = () => {
   if (!statusData || !hasData(statusData)) return null;
 
   return (
-    <StatusPopoverButton
-      eventId={eventId}
-      contextId={scopeId}
-      enrichedFieldInfo={statusData}
-      scopeId={scopeId}
-      handleOnEventClosed={closeFlyout}
-    />
+    <SecurityCellActions
+      data={{
+        field: SIGNAL_STATUS_FIELD_NAME,
+        value: statusData.values[0],
+      }}
+      mode={CellActionsMode.HOVER_RIGHT}
+      triggerId={SecurityCellActionsTrigger.DEFAULT}
+      visibleCellActions={6}
+    >
+      <StatusPopoverButton
+        eventId={eventId}
+        contextId={scopeId}
+        enrichedFieldInfo={statusData}
+        scopeId={scopeId}
+        handleOnEventClosed={closeFlyout}
+      />
+    </SecurityCellActions>
   );
 };
 


### PR DESCRIPTION
## Summary

The new expandable flyout was missing the cell actions functionality on the severity and status components in the header. The old flyout also had those actions on the rule name, but the new UI doesn't allow us to replicate it. A future PR will probably add the feature after review with UIUX.

Old flyout

https://github.com/elastic/kibana/assets/17276605/25b8505a-1790-49be-b086-08b08963b21a

New flyout

https://github.com/elastic/kibana/assets/17276605/08fce9b8-eee5-4596-8953-4ef0089ee24a

https://github.com/elastic/security-team/issues/6641

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios