### PR TITLE
Fix rules functional test by replacing uptime rule with metric threshold

### DIFF
--- a/x-pack/test/observability_functional/apps/observability/pages/rules_page.ts
+++ b/x-pack/test/observability_functional/apps/observability/pages/rules_page.ts
@@ -85,24 +85,30 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     describe('Rules table', () => {
-      let uptimeRuleId: string;
+      let metricThresholdRuleId: string;
       let logThresholdRuleId: string;
       before(async () => {
-        const uptimeRule = {
+        const metricThresholdRule = {
           params: {
-            search: '',
-            numTimes: 5,
-            timerangeUnit: 'm',
-            timerangeCount: 15,
-            shouldCheckStatus: true,
-            shouldCheckAvailability: true,
-            availability: { range: 30, rangeUnit: 'd', threshold: '99' },
+            criteria: [
+              {
+                aggType: 'avg',
+                comparator: '>',
+                threshold: [0.5],
+                timeSize: 5,
+                timeUnit: 'm',
+                metric: 'system.cpu.user.pct',
+              },
+            ],
+            sourceId: 'default',
+            alertOnNoData: true,
+            alertOnGroupDisappear: true,
           },
-          consumer: 'alerts',
+          consumer: 'infrastructure',
+          tags: ['infrastructure'],
+          name: 'metric-threshold',
           schedule: { interval: '1m' },
-          tags: [],
-          name: 'uptime',
-          rule_type_id: 'xpack.uptime.alerts.monitorStatus',
+          rule_type_id: 'metrics.alert.threshold',
           notify_when: 'onActionGroupChange',
           actions: [],
         };
@@ -125,12 +131,12 @@ export default ({ getService }: FtrProviderContext) => {
           notify_when: 'onActionGroupChange',
           actions: [],
         };
-        uptimeRuleId = await createRule(uptimeRule);
+        metricThresholdRuleId = await createRule(metricThresholdRule);
         logThresholdRuleId = await createRule(logThresholdRule);
         await observability.alerts.common.navigateToRulesPage();
       });
       after(async () => {
-        await deleteRuleById(uptimeRuleId);
+        await deleteRuleById(metricThresholdRuleId);
         await deleteRuleById(logThresholdRuleId);
       });
 
@@ -142,7 +148,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(rows.length).to.be(2);
         expect(rows[0].name).to.contain('error-log');
         expect(rows[0].enabled).to.be('Enabled');
-        expect(rows[1].name).to.contain('uptime');
+        expect(rows[1].name).to.contain('metric-threshold');
         expect(rows[1].enabled).to.be('Enabled');
       });
 


### PR DESCRIPTION
Fixes #163427

## Summary

Fix rules functional test by replacing uptime rule with a metric threshold as uptime is now replaced with synthetics (Why understand and solve an issue if we can remove it altogether?! :D)

Flaky test runner [100]: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2859
