### PR TITLE
[Fleet] Remove unneeded deprecation from openapi specs

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -5406,7 +5406,6 @@
         "name": "kuery",
         "in": "query",
         "required": false,
-        "deprecated": true,
         "schema": {
           "type": "string"
         }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -3363,7 +3363,6 @@ components:
       name: kuery
       in: query
       required: false
-      deprecated: true
       schema:
         type: string
     show_inactive:

--- a/x-pack/plugins/fleet/common/openapi/components/parameters/kuery.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/parameters/kuery.yaml
@@ -1,6 +1,5 @@
 name: kuery
 in: query
 required: false
-deprecated: true
 schema:
   type: string


### PR DESCRIPTION
## Summary
In https://github.com/elastic/kibana/pull/161064 the deprecation of the parameter `kuery` was removed but I forgot to update the openapi specs. Here I'm fixing it.


### Checklist
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials


