### PR TITLE
[Logs+] Enabled refresh interval with 10s after the onboarding flow w…

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/utils.ts
+++ b/x-pack/plugins/observability_onboarding/public/components/app/utils.ts
@@ -9,7 +9,11 @@ import type { DataViewSpec } from '@kbn/data-views-plugin/common';
 import { DiscoverAppLocatorParams } from '@kbn/discover-plugin/common';
 import { Filter, FilterStateStore } from '@kbn/es-query';
 
-type DiscoverPropertiesToPick = 'dataViewId' | 'dataViewSpec' | 'filters';
+type DiscoverPropertiesToPick =
+  | 'dataViewId'
+  | 'dataViewSpec'
+  | 'filters'
+  | 'refreshInterval';
 
 type DiscoverNavigationParams = Pick<
   DiscoverAppLocatorParams,
@@ -50,6 +54,10 @@ const getDefaultDatasetFilter = (datasets: string[]): Filter[] => [
 export const getDiscoverNavigationParams = (
   datasets: string[]
 ): DiscoverNavigationParams => ({
+  refreshInterval: {
+    pause: false,
+    value: 10000,
+  },
   dataViewId: defaultLogsDataViewId,
   dataViewSpec: defaultLogsDataView,
   filters: getDefaultDatasetFilter(datasets),


### PR DESCRIPTION
closes [#163718](https://github.com/elastic/kibana/issues/163718)


## 📝  Summary

This PR enables auto refresh with 10s after clicking the `Explore logs` button at the end of the logs onboarding flow

## ✅  Testing

1. Navigate to the onboarding flow `/app/observabilityOnboarding/`
2. Choose either System logs or Stream log files
3. Go through the onboarding wizard
4. Click the Explore logs button at the end
5. Observe the refresh interval being set to 10s and enabled

## 🎥 Demo



https://github.com/elastic/kibana/assets/11225826/e1feef09-09e9-4287-a8a3-e8eca7f4badf




