### PR TITLE
[Cloud Security] Findings Onboarding "not-installed" FTR tests

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -24,7 +24,11 @@ import { CSPM_POLICY_TEMPLATE, KSPM_POLICY_TEMPLATE } from '../../common/constan
 import { FullSizeCenteredPage } from './full_size_centered_page';
 import { useCspBenchmarkIntegrations } from '../pages/benchmarks/use_csp_benchmark_integrations';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
-import { NO_FINDINGS_STATUS_TEST_SUBJ } from './test_subjects';
+import {
+  CSPM_NOT_INSTALLED_ACTION_SUBJ,
+  KSPM_NOT_INSTALLED_ACTION_SUBJ,
+  NO_FINDINGS_STATUS_TEST_SUBJ,
+} from './test_subjects';
 import { CloudPosturePage, PACKAGE_NOT_INSTALLED_TEST_SUBJECT } from './cloud_posture_page';
 import { useCspSetupStatusApi } from '../common/api/use_setup_status_api';
 import type { IndexDetails, PostureTypes } from '../../common/types';
@@ -220,7 +224,12 @@ const ConfigurationFindingsInstalledEmptyPrompt = ({
       actions={
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButton color="primary" fill href={cspmIntegrationLink}>
+            <EuiButton
+              color="primary"
+              fill
+              href={cspmIntegrationLink}
+              data-test-subj={CSPM_NOT_INSTALLED_ACTION_SUBJ}
+            >
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.packageNotInstalledRenderer.addCspmIntegrationButtonTitle"
                 defaultMessage="Add CSPM Integration"
@@ -228,7 +237,12 @@ const ConfigurationFindingsInstalledEmptyPrompt = ({
             </EuiButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton color="primary" fill href={kspmIntegrationLink}>
+            <EuiButton
+              color="primary"
+              fill
+              href={kspmIntegrationLink}
+              data-test-subj={KSPM_NOT_INSTALLED_ACTION_SUBJ}
+            >
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.packageNotInstalledRenderer.addKspmIntegrationButtonTitle"
                 defaultMessage="Add KSPM Integration"

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -26,7 +26,10 @@ import { FullSizeCenteredPage } from './full_size_centered_page';
 import { CloudPosturePage } from './cloud_posture_page';
 import { useCspSetupStatusApi } from '../common/api/use_setup_status_api';
 import type { IndexDetails } from '../../common/types';
-import { NO_VULNERABILITIES_STATUS_TEST_SUBJ, NOT_INSTALLED_ACTION_SUBJ } from './test_subjects';
+import {
+  NO_VULNERABILITIES_STATUS_TEST_SUBJ,
+  CNVM_NOT_INSTALLED_ACTION_SUBJ,
+} from './test_subjects';
 import noDataIllustration from '../assets/illustrations/no_data_illustration.svg';
 import { useCspIntegrationLink } from '../common/navigation/use_csp_integration_link';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
@@ -93,7 +96,7 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
               color="primary"
               fill
               href={vulnMgmtIntegrationLink}
-              data-test-subj={NOT_INSTALLED_ACTION_SUBJ}
+              data-test-subj={CNVM_NOT_INSTALLED_ACTION_SUBJ}
             >
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.addVulMngtIntegrationButtonTitle"

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -26,7 +26,7 @@ import { FullSizeCenteredPage } from './full_size_centered_page';
 import { CloudPosturePage } from './cloud_posture_page';
 import { useCspSetupStatusApi } from '../common/api/use_setup_status_api';
 import type { IndexDetails } from '../../common/types';
-import { NO_VULNERABILITIES_STATUS_TEST_SUBJ } from './test_subjects';
+import { NO_VULNERABILITIES_STATUS_TEST_SUBJ, NOT_INSTALLED_ACTION_SUBJ } from './test_subjects';
 import noDataIllustration from '../assets/illustrations/no_data_illustration.svg';
 import { useCspIntegrationLink } from '../common/navigation/use_csp_integration_link';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
@@ -89,7 +89,12 @@ const CnvmIntegrationNotInstalledEmptyPrompt = ({
       actions={
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
-            <EuiButton color="primary" fill href={vulnMgmtIntegrationLink}>
+            <EuiButton
+              color="primary"
+              fill
+              href={vulnMgmtIntegrationLink}
+              data-test-subj={NOT_INSTALLED_ACTION_SUBJ}
+            >
               <FormattedMessage
                 id="xpack.csp.cloudPosturePage.vulnerabilitiesInstalledEmptyPrompt.addVulMngtIntegrationButtonTitle"
                 defaultMessage="Install Cloud Native Vulnerability Management"

--- a/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
@@ -29,6 +29,7 @@ export const NO_VULNERABILITIES_STATUS_TEST_SUBJ = {
   NO_VULNERABILITIES: 'no-vulnerabilities-vuln-mgmt-found',
   INDEX_TIMEOUT: 'vulnerabilities-timeout',
 };
+export const NOT_INSTALLED_ACTION_SUBJ = 'not-installed-action';
 
 export const VULNERABILITIES_CONTAINER_TEST_SUBJ = 'vulnerabilities_container';
 

--- a/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
+++ b/x-pack/plugins/cloud_security_posture/public/components/test_subjects.ts
@@ -29,7 +29,9 @@ export const NO_VULNERABILITIES_STATUS_TEST_SUBJ = {
   NO_VULNERABILITIES: 'no-vulnerabilities-vuln-mgmt-found',
   INDEX_TIMEOUT: 'vulnerabilities-timeout',
 };
-export const NOT_INSTALLED_ACTION_SUBJ = 'not-installed-action';
+export const CNVM_NOT_INSTALLED_ACTION_SUBJ = 'cnvm-not-installed-action';
+export const CSPM_NOT_INSTALLED_ACTION_SUBJ = 'cspm-not-installed-action';
+export const KSPM_NOT_INSTALLED_ACTION_SUBJ = 'kspm-not-installed-action';
 
 export const VULNERABILITIES_CONTAINER_TEST_SUBJ = 'vulnerabilities_container';
 

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -92,9 +92,7 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     },
 
     async navigateToAction(actionTestSubject: string) {
-      const element = await this.getElement();
-      const button = await element.findByCssSelector(`[data-test-subj="${actionTestSubject}"]`);
-      await button.click();
+      await testSubjects.click(actionTestSubject);
     },
   });
 

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -86,14 +86,14 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
       testSubjects.click(type === 'failed' ? 'distribution_bar_failed' : 'distribution_bar_passed'),
   };
 
-  const createNoInstalledObject = (notInstalledSubject: string) => ({
+  const createNotInstalledObject = (notInstalledSubject: string) => ({
     getElement() {
       return testSubjects.find(notInstalledSubject);
     },
 
-    async navigateToAction() {
+    async navigateToAction(actionTestSubject: string) {
       const element = await this.getElement();
-      const button = await element.findByCssSelector('[data-test-subj="not-installed-action"');
+      const button = await element.findByCssSelector(`[data-test-subj="${actionTestSubject}"]`);
       await button.click();
     },
   });
@@ -215,6 +215,14 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     );
   };
 
+  const navigateToMisconfigurations = async () => {
+    await PageObjects.common.navigateToUrl(
+      'securitySolution', // Defined in Security Solution plugin
+      'cloud_security_posture/findings/configurations',
+      { shouldUseHashForSubUrl: false }
+    );
+  };
+
   const latestFindingsTable = createTableObject('latest_findings_table');
   const resourceFindingsTable = createTableObject('resource_findings_table');
   const findingsByResourceTable = {
@@ -230,15 +238,18 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
       await link.click();
     },
   };
-  const notInstalledVulnerabilities = createNoInstalledObject('cnvm-integration-not-installed');
+  const notInstalledVulnerabilities = createNotInstalledObject('cnvm-integration-not-installed');
+  const notInstalledCSP = createNotInstalledObject('cloud_posture_page_package_not_installed');
 
   return {
     navigateToLatestFindingsPage,
     navigateToVulnerabilities,
+    navigateToMisconfigurations,
     latestFindingsTable,
     resourceFindingsTable,
     findingsByResourceTable,
     notInstalledVulnerabilities,
+    notInstalledCSP,
     index,
     waitForPluginInitialized,
     distributionBar,

--- a/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
+++ b/x-pack/test/cloud_security_posture_functional/page_objects/findings_page.ts
@@ -86,6 +86,18 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
       testSubjects.click(type === 'failed' ? 'distribution_bar_failed' : 'distribution_bar_passed'),
   };
 
+  const createNoInstalledObject = (notInstalledSubject: string) => ({
+    getElement() {
+      return testSubjects.find(notInstalledSubject);
+    },
+
+    async navigateToAction() {
+      const element = await this.getElement();
+      const button = await element.findByCssSelector('[data-test-subj="not-installed-action"');
+      await button.click();
+    },
+  });
+
   const createTableObject = (tableTestSubject: string) => ({
     getElement() {
       return testSubjects.find(tableTestSubject);
@@ -195,6 +207,14 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
     );
   };
 
+  const navigateToVulnerabilities = async () => {
+    await PageObjects.common.navigateToUrl(
+      'securitySolution', // Defined in Security Solution plugin
+      'cloud_security_posture/findings/vulnerabilities',
+      { shouldUseHashForSubUrl: false }
+    );
+  };
+
   const latestFindingsTable = createTableObject('latest_findings_table');
   const resourceFindingsTable = createTableObject('resource_findings_table');
   const findingsByResourceTable = {
@@ -210,12 +230,15 @@ export function FindingsPageProvider({ getService, getPageObjects }: FtrProvider
       await link.click();
     },
   };
+  const notInstalledVulnerabilities = createNoInstalledObject('cnvm-integration-not-installed');
 
   return {
     navigateToLatestFindingsPage,
+    navigateToVulnerabilities,
     latestFindingsTable,
     resourceFindingsTable,
     findingsByResourceTable,
+    notInstalledVulnerabilities,
     index,
     waitForPluginInitialized,
     distributionBar,

--- a/x-pack/test/cloud_security_posture_functional/pages/compliance_dashboard.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/compliance_dashboard.ts
@@ -32,7 +32,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     },
   ];
 
-  describe('Cloud Posture Dashboard Page', () => {
+  describe('Cloud Posture Dashboard Page', function () {
+    this.tags(['cloud_security_posture_compliance_dashboard']);
     let cspDashboard: typeof pageObjects.cloudPostureDashboard;
     let dashboard: typeof pageObjects.cloudPostureDashboard.dashboard;
 

--- a/x-pack/test/cloud_security_posture_functional/pages/findings.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings.ts
@@ -95,7 +95,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   const benchMarkName = data[0].rule.benchmark.name;
 
-  describe('Findings Page', () => {
+  describe('Findings Page', function () {
+    this.tags(['cloud_security_posture_findings']);
     let findings: typeof pageObjects.findings;
     let latestFindingsTable: typeof findings.latestFindingsTable;
     let findingsByResourceTable: typeof findings.findingsByResourceTable;

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
@@ -17,7 +17,7 @@ export default ({ getPageObjects }: FtrProviderContext) => {
     let findings: typeof PageObjects.findings;
     let noFindingsVulnerabilities: typeof findings.notInstalledVulnerabilities;
 
-    it('shows `not-installed` state for vulnerabilities and navigates to the CNVM integration installation page when clicking on the `No integrations installed` prompt action button - `install CNVM`', async () => {
+    it('clicking on the `No integrations installed` prompt action button - `install CNVM`: navigates to the CNVM integration installation page', async () => {
       findings = PageObjects.findings;
       noFindingsVulnerabilities = findings.notInstalledVulnerabilities;
 

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../ftr_provider_context';
+
+// eslint-disable-next-line import/no-default-export
+export default ({ getPageObjects }: FtrProviderContext) => {
+  const PageObjects = getPageObjects(['common', 'findings', 'header']);
+
+  describe('Findings Page onboarding', function () {
+    this.tags(['cloud_security_posture_findings_onboarding']);
+    let findings: typeof PageObjects.findings;
+    let noFindingsVulnerabilities: typeof findings.notInstalledVulnerabilities;
+
+    it('shows `not-installed` state for vulnerabilities and navigates to the CNVM integration installation page when clicking on the `No integrations installed` prompt action button - `install CNVM`', async () => {
+      findings = PageObjects.findings;
+      noFindingsVulnerabilities = findings.notInstalledVulnerabilities;
+
+      await findings.waitForPluginInitialized();
+
+      await findings.navigateToVulnerabilities();
+      const element = await noFindingsVulnerabilities.getElement();
+      expect(element).to.not.be(null);
+
+      await noFindingsVulnerabilities.navigateToAction();
+      await PageObjects.common.waitUntilUrlIncludes('integrations/cloud_security_posture');
+    });
+  });
+};

--- a/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/findings_onboarding.ts
@@ -15,20 +15,45 @@ export default ({ getPageObjects }: FtrProviderContext) => {
   describe('Findings Page onboarding', function () {
     this.tags(['cloud_security_posture_findings_onboarding']);
     let findings: typeof PageObjects.findings;
-    let noFindingsVulnerabilities: typeof findings.notInstalledVulnerabilities;
+    let notInstalledVulnerabilities: typeof findings.notInstalledVulnerabilities;
+    let notInstalledCSP: typeof findings.notInstalledCSP;
 
-    it('clicking on the `No integrations installed` prompt action button - `install CNVM`: navigates to the CNVM integration installation page', async () => {
+    beforeEach(async () => {
       findings = PageObjects.findings;
-      noFindingsVulnerabilities = findings.notInstalledVulnerabilities;
+      notInstalledVulnerabilities = findings.notInstalledVulnerabilities;
+      notInstalledCSP = findings.notInstalledCSP;
 
       await findings.waitForPluginInitialized();
+    });
 
+    it('clicking on the `No integrations installed` prompt action button - `install CNVM`: navigates to the CNVM integration installation page', async () => {
       await findings.navigateToVulnerabilities();
-      const element = await noFindingsVulnerabilities.getElement();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      const element = await notInstalledVulnerabilities.getElement();
       expect(element).to.not.be(null);
 
-      await noFindingsVulnerabilities.navigateToAction();
-      await PageObjects.common.waitUntilUrlIncludes('integrations/cloud_security_posture');
+      await notInstalledVulnerabilities.navigateToAction('cnvm-not-installed-action');
+      await PageObjects.common.waitUntilUrlIncludes('add-integration/vuln_mgmt');
+    });
+
+    it('clicking on the `No integrations installed` prompt action button - `install cloud posture intergation`: navigates to the CSPM integration installation page', async () => {
+      await findings.navigateToMisconfigurations();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      const element = await notInstalledCSP.getElement();
+      expect(element).to.not.be(null);
+
+      await notInstalledCSP.navigateToAction('cspm-not-installed-action');
+      await PageObjects.common.waitUntilUrlIncludes('add-integration/cspm');
+    });
+
+    it('clicking on the `No integrations installed` prompt action button - `install kubernetes posture intergation`: navigates to the KSPM integration installation page', async () => {
+      await findings.navigateToMisconfigurations();
+      await PageObjects.header.waitUntilLoadingHasFinished();
+      const element = await notInstalledCSP.getElement();
+      expect(element).to.not.be(null);
+
+      await notInstalledCSP.navigateToAction('kspm-not-installed-action');
+      await PageObjects.common.waitUntilUrlIncludes('add-integration/kspm');
     });
   });
 };

--- a/x-pack/test/cloud_security_posture_functional/pages/index.ts
+++ b/x-pack/test/cloud_security_posture_functional/pages/index.ts
@@ -10,6 +10,7 @@ import { FtrProviderContext } from '../ftr_provider_context';
 // eslint-disable-next-line import/no-default-export
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Cloud Security Posture', function () {
+    loadTestFile(require.resolve('./findings_onboarding'));
     loadTestFile(require.resolve('./findings'));
     loadTestFile(require.resolve('./compliance_dashboard'));
   });


### PR DESCRIPTION
## Summary

This PR adds FTR tests for "not-installed" states of Findings page

Contributes to:
- https://github.com/elastic/kibana/issues/155657

## How to test
run in separate terminals
```
yarn test:ftr:server --config x-pack/test/cloud_security_posture_functional/config.ts
```
and 
```
yarn test:ftr:runner --include-tag=cloud_security_posture_findings_onboarding --config x-pack/test/cloud_security_posture_functional/config.ts
```
