### PR TITLE
[Logs onboarding] Troubleshooting section

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/wizard/install_elastic_agent.tsx
@@ -10,6 +10,7 @@ import {
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -36,6 +37,7 @@ import {
 import { ApiKeyBanner } from './api_key_banner';
 import { BackButton } from './back_button';
 import { getDiscoverNavigationParams } from '../../utils';
+import { TroubleshootingLink } from '../../../shared/troubleshooting_link';
 
 export function InstallElasticAgent() {
   const {
@@ -348,6 +350,8 @@ export function InstallElasticAgent() {
           appendedSteps={[getCheckLogsStep()]}
         />
       </StepPanelContent>
+      <EuiHorizontalRule />
+      <TroubleshootingLink />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/app/system_logs/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/system_logs/install_elastic_agent.tsx
@@ -9,6 +9,7 @@ import {
   EuiButton,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiHorizontalRule,
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
@@ -36,6 +37,7 @@ import {
 } from '../../shared/step_panel';
 import { ApiKeyBanner } from '../custom_logs/wizard/api_key_banner';
 import { getDiscoverNavigationParams } from '../utils';
+import { TroubleshootingLink } from '../../shared/troubleshooting_link';
 
 export function InstallElasticAgent() {
   const {
@@ -286,6 +288,8 @@ export function InstallElasticAgent() {
           appendedSteps={[getCheckLogsStep()]}
         />
       </StepPanelContent>
+      <EuiHorizontalRule />
+      <TroubleshootingLink />
     </StepPanel>
   );
 }

--- a/x-pack/plugins/observability_onboarding/public/components/shared/troubleshooting_link.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/shared/troubleshooting_link.tsx
@@ -6,15 +6,12 @@
  */
 
 import React from 'react';
-import {
-  EuiButtonEmpty,
-  EuiFlexGroup,
-} from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 export function TroubleshootingLink() {
   return (
-    <EuiFlexGroup alignItems='center' justifyContent='center'>
+    <EuiFlexGroup alignItems="center" justifyContent="center">
       <EuiButtonEmpty
         iconType="help"
         color="primary"

--- a/x-pack/plugins/observability_onboarding/public/components/shared/troubleshooting_link.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/shared/troubleshooting_link.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import {
+  EuiButtonEmpty,
+  EuiFlexGroup,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export function TroubleshootingLink() {
+  return (
+    <EuiFlexGroup alignItems='center' justifyContent='center'>
+      <EuiButtonEmpty
+        iconType="help"
+        color="primary"
+        href="https://www.elastic.co/guide/en/observability/current/logs-troubleshooting.html"
+        target="_blank"
+      >
+        {i18n.translate(
+          'xpack.observability_onboarding.installElasticAgent.troubleshooting',
+          { defaultMessage: 'Troubleshooting' }
+        )}
+      </EuiButtonEmpty>
+    </EuiFlexGroup>
+  );
+}


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/158908.

### Changes
- `TroubleshootingLink` component was created and added to installElasticAgent step.

#### before change
<img width="2056" alt="image" src="https://github.com/elastic/kibana/assets/1313018/eaae761b-14c4-4da0-971f-3a1fc0c592be">


#### after change
<img width="2060" alt="image" src="https://github.com/elastic/kibana/assets/1313018/8f07eb15-ab97-431a-9a0b-2af9a3a83295">
