### PR TITLE
[8.9] [Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#162839)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
@@ -33,7 +33,7 @@ describe('Exceptions viewer read only', () => {
   before(() => {
     cleanKibana();
     // create rule with exceptions
-    createExceptionList(exceptionList, exceptionList.list_id).then(response => {
+    createExceptionList(exceptionList, exceptionList.list_id).then((response) => {
       createRule(
         getNewRule({
           query: 'agent.name:*',

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
@@ -9,12 +9,11 @@ import { getExceptionList } from '../../../objects/exception';
 import { getNewRule } from '../../../objects/rule';
 import { ROLES } from '../../../../common/test';
 import { createRule } from '../../../tasks/api_calls/rules';
-import { esArchiverResetKibana } from '../../../tasks/es_archiver';
 import { login, visitWithoutDateRange } from '../../../tasks/login';
 import { goToExceptionsTab, goToAlertsTab } from '../../../tasks/rule_details';
 import { goToRuleDetails } from '../../../tasks/alerts_detection_rules';
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../../urls/navigation';
-import { deleteAlertsAndRules } from '../../../tasks/common';
+import { cleanKibana, deleteAlertsAndRules } from '../../../tasks/common';
 import {
   NO_EXCEPTIONS_EXIST_PROMPT,
   EXCEPTION_ITEM_VIEWER_CONTAINER,
@@ -32,9 +31,9 @@ describe('Exceptions viewer read only', () => {
   const exceptionList = getExceptionList();
 
   before(() => {
-    esArchiverResetKibana();
+    cleanKibana();
     // create rule with exceptions
-    createExceptionList(exceptionList, exceptionList.list_id).then((response) => {
+    createExceptionList(exceptionList, exceptionList.list_id).then(response => {
       createRule(
         getNewRule({
           query: 'agent.name:*',
@@ -57,6 +56,7 @@ describe('Exceptions viewer read only', () => {
     login(ROLES.reader);
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL, ROLES.reader);
     goToRuleDetails();
+    cy.url().should('contain', 'app/security/rules/id');
     goToExceptionsTab();
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#162839)](https://github.com/elastic/kibana/pull/162839)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Devin W. Hurley","email":"devin.hurley@elastic.co"},"sourceCommit":{"committedDate":"2023-08-12T03:35:20Z","message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#162839)\n\n## Summary\r\n\r\nRef: https://github.com/elastic/kibana/issues/162569\r\n\r\nThe test was trying to load the exceptions tab before the rule details\r\npage loaded. Now we wait for the rule tab to load before continuing.\r\nSomething I was unaware of was that `cy.url()` will [automatically\r\nretry](https://docs.cypress.io/api/commands/url#Assertions) until all\r\nchained assertions have passed, which I think can be an easy way to fix\r\nfuture flake issues where cypress tries to click on an element before\r\nthe new page loads.","sha":"7b3cc8f5735306d13113b0f75499f386fc0aec48","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["review","release_note:skip","Team:Detection Engine","v8.10.0","v8.9.2"],"number":162839,"url":"https://github.com/elastic/kibana/pull/162839","mergeCommit":{"message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#162839)\n\n## Summary\r\n\r\nRef: https://github.com/elastic/kibana/issues/162569\r\n\r\nThe test was trying to load the exceptions tab before the rule details\r\npage loaded. Now we wait for the rule tab to load before continuing.\r\nSomething I was unaware of was that `cy.url()` will [automatically\r\nretry](https://docs.cypress.io/api/commands/url#Assertions) until all\r\nchained assertions have passed, which I think can be an easy way to fix\r\nfuture flake issues where cypress tries to click on an element before\r\nthe new page loads.","sha":"7b3cc8f5735306d13113b0f75499f386fc0aec48"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/162839","number":162839,"mergeCommit":{"message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#162839)\n\n## Summary\r\n\r\nRef: https://github.com/elastic/kibana/issues/162569\r\n\r\nThe test was trying to load the exceptions tab before the rule details\r\npage loaded. Now we wait for the rule tab to load before continuing.\r\nSomething I was unaware of was that `cy.url()` will [automatically\r\nretry](https://docs.cypress.io/api/commands/url#Assertions) until all\r\nchained assertions have passed, which I think can be an easy way to fix\r\nfuture flake issues where cypress tries to click on an element before\r\nthe new page loads.","sha":"7b3cc8f5735306d13113b0f75499f386fc0aec48"}},{"branch":"8.9","label":"v8.9.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->