### PR TITLE
[OAS] Create runtime field API

### DIFF
--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -332,6 +332,46 @@
               }
             }
           }
+        }
+      },
+      "put": {
+        "summary": "Create or update an existing runtime field.",
+        "operationId": "updateRuntimeField",
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data_view_id": {
+                    "description": "The ID of the data view.",
+                    "type": "string",
+                    "required": true
+                  },
+                  "space_id": {
+                    "description": "An identifier for the space. If space_id is not provided in the URL, the default space is used.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              },
+              "examples": {
+                "updateRuntimeFieldRequest": {
+                  "$ref": "#/components/examples/create_runtime_field_request"
+                }
+              }
+            }
+          }
         },
         "responses": {
           "200": {

--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -293,6 +293,80 @@
         }
       ]
     },
+    "/api/data_views/data_view/{viewId}/runtime_field": {
+      "post": {
+        "summary": "Creates a runtime field.",
+        "operationId": "createRuntimeField",
+        "description": "This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "tags": [
+          "data views"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/kbn_xsrf"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data_view_id": {
+                    "description": "The ID of the data view.",
+                    "type": "string",
+                    "required": true
+                  },
+                  "space_id": {
+                    "description": "An identifier for the space. If space_id is not provided in the URL, the default space is used.",
+                    "type": "string",
+                    "required": false
+                  }
+                }
+              },
+              "examples": {
+                "createRuntimeFieldRequest": {
+                  "$ref": "#/components/examples/create_runtime_field_request"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/create_runtime_field_response"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/400_response"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "https://localhost:5601"
+          }
+        ]
+      },
+      "servers": [
+        {
+          "url": "https://localhost:5601"
+        }
+      ]
+    },
     "/api/data_views/data_view/{viewId}/runtime_field/{fieldName}": {
       "get": {
         "summary": "Retrieves a runtime field.",
@@ -1690,6 +1764,18 @@
           "refresh_fields": true
         }
       },
+      "create_runtime_field_request": {
+        "summary": "Create a runtime field.",
+        "value": {
+          "name": "runtimeFoo",
+          "runtimeField": {
+            "type": "long",
+            "script": {
+              "source": "emit(doc[\"foo\"].value)"
+            }
+          }
+        }
+      },
       "get_runtime_field_response": {
         "summary": "The get runtime field API returns a JSON object that contains information about the runtime field (`hour_of_day`) and the data view (`d3d7af60-4c81-11e8-b3d7-01146121b73d`).",
         "value": {
@@ -2610,6 +2696,17 @@
             "description": "Reloads the data view fields after the data view is updated.",
             "default": false
           }
+        }
+      },
+      "create_runtime_field_response": {
+        "summary": "The API returns created runtime field object array and updated data view object.",
+        "value": {
+          "data_view": {
+            "...": null
+          },
+          "fields": [
+            "..."
+          ]
         }
       }
     }

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -202,6 +202,33 @@ paths:
             examples:
               createRuntimeFieldRequest:
                 $ref: '#/components/examples/create_runtime_field_request'
+    put:
+      summary: Create or update an existing runtime field.
+      operationId: updateRuntimeField
+      description: |
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data_view_id:
+                  description: The ID of the data view.
+                  type: string
+                  required: true
+                space_id:
+                  description: An identifier for the space. If space_id is not provided in the URL, the default space is used.
+                  type: string
+                  required: false
+            examples:
+              updateRuntimeFieldRequest:
+                $ref: '#/components/examples/create_runtime_field_request'
       responses:
         '200':
           description: Indicates a successful call.

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -174,6 +174,51 @@ paths:
         - url: https://localhost:5601
     servers:
       - url: https://localhost:5601
+  /api/data_views/data_view/{viewId}/runtime_field:
+    post:
+      summary: Creates a runtime field.
+      operationId: createRuntimeField
+      description: |
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      tags:
+        - data views
+      parameters:
+        - $ref: '#/components/parameters/kbn_xsrf'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data_view_id:
+                  description: The ID of the data view.
+                  type: string
+                  required: true
+                space_id:
+                  description: An identifier for the space. If space_id is not provided in the URL, the default space is used.
+                  type: string
+                  required: false
+            examples:
+              createRuntimeFieldRequest:
+                $ref: '#/components/examples/create_runtime_field_request'
+      responses:
+        '200':
+          description: Indicates a successful call.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/create_runtime_field_response'
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/400_response'
+      servers:
+        - url: https://localhost:5601
+    servers:
+      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
     get:
       summary: Retrieves a runtime field.
@@ -1253,6 +1298,14 @@ components:
           allowNoIndex: false
           name: Kibana Sample Data eCommerce
         refresh_fields: true
+    create_runtime_field_request:
+      summary: Create a runtime field.
+      value:
+        name: runtimeFoo
+        runtimeField:
+          type: long
+          script:
+            source: emit(doc["foo"].value)
     get_runtime_field_response:
       summary: The get runtime field API returns a JSON object that contains information about the runtime field (`hour_of_day`) and the data view (`d3d7af60-4c81-11e8-b3d7-01146121b73d`).
       value:
@@ -1967,3 +2020,10 @@ components:
           type: boolean
           description: Reloads the data view fields after the data view is updated.
           default: false
+    create_runtime_field_response:
+      summary: The API returns created runtime field object array and updated data view object.
+      value:
+        data_view:
+          ...: null
+        fields:
+          - ...

--- a/src/plugins/data_views/docs/openapi/components/examples/create_runtime_field_request.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/create_runtime_field_request.yaml
@@ -1,0 +1,11 @@
+summary: Create a runtime field.
+value:
+  {
+  "name": "runtimeFoo",
+  "runtimeField": {
+     "type": "long",
+     "script": {
+        "source": 'emit(doc["foo"].value)'
+      }
+    }
+  }

--- a/src/plugins/data_views/docs/openapi/components/examples/create_runtime_field_response.yaml
+++ b/src/plugins/data_views/docs/openapi/components/examples/create_runtime_field_response.yaml
@@ -1,0 +1,6 @@
+summary: The API returns created runtime field object array and updated data view object.
+value: 
+ {
+    "data_view": {...},
+    "fields": [...]
+ }

--- a/src/plugins/data_views/docs/openapi/entrypoint.yaml
+++ b/src/plugins/data_views/docs/openapi/entrypoint.yaml
@@ -24,8 +24,8 @@ paths:
     $ref: 'paths/api@data_views@data_view@{viewid}.yaml'
 #  '/api/data_views/data_view/{viewId}/fields':
 #    $ref: 'paths/api@data_views@data_view@{viewid}@fields.yaml'
-#  '/api/data_views/data_view/{viewId}/runtime_field':
-#    $ref: 'paths/api@data_views@data_view@{viewid}@runtime_field.yaml'
+  '/api/data_views/data_view/{viewId}/runtime_field':
+   $ref: 'paths/api@data_views@data_view@{viewid}@runtime_field.yaml'
   '/api/data_views/data_view/{viewId}/runtime_field/{fieldName}':
     $ref: 'paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml'
   '/api/data_views/default':

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
@@ -25,6 +25,34 @@ post:
         examples:
           createRuntimeFieldRequest:
             $ref: '../components/examples/create_runtime_field_request.yaml'
+
+put:
+  summary: Create or update an existing runtime field.
+  operationId: updateRuntimeField 
+  description: >
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data_view_id:
+              description: The ID of the data view.
+              type: string
+              required: true
+            space_id:
+              description: An identifier for the space. If space_id is not provided in the URL, the default space is used.
+              type: string
+              required: false
+        examples:
+          updateRuntimeFieldRequest:
+            $ref: '../components/examples/create_runtime_field_request.yaml'
   responses:
     '200':
       description: Indicates a successful call.

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
@@ -1,0 +1,45 @@
+post:
+  summary: Creates a runtime field.
+  operationId: createRuntimeField 
+  description: >
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  tags:
+    - data views
+  parameters:
+    - $ref: '../components/headers/kbn_xsrf.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            data_view_id:
+              description: The ID of the data view.
+              type: string
+              required: true
+            space_id:
+              description: An identifier for the space. If space_id is not provided in the URL, the default space is used.
+              type: string
+              required: false
+        examples:
+          createRuntimeFieldRequest:
+            $ref: '../components/examples/create_runtime_field_request.yaml'
+  responses:
+    '200':
+      description: Indicates a successful call.
+      content:
+        application/json:
+          schema:
+            $ref: '../components/examples/create_runtime_field_response.yaml'
+    '400':
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/400_response.yaml'
+  servers:
+    - url: https://localhost:5601
+
+servers:
+  - url: https://localhost:5601


### PR DESCRIPTION
This PR drafts openAPI specifications for:

- [Create runtime field API](https://www.elastic.co/guide/en/kibana/master/data-views-runtime-field-api-create.html).
- [Upsert runtime field API](https://www.elastic.co/guide/en/kibana/master/data-views-runtime-field-api-upsert.html)

Relates to https://github.com/elastic/kibana/issues/137240
