### PR TITLE
Add Fleet pgpKeyPath as container env var

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -287,6 +287,7 @@ kibana_vars=(
     xpack.fleet.agents.kibana.host
     xpack.fleet.agents.tlsCheckDisabled
     xpack.fleet.packages
+    xpack.fleet.packageVerification.gpgKeyPath
     xpack.fleet.registryProxyUrl
     xpack.fleet.registryUrl
     xpack.graph.canEditDrillDownUrls


### PR DESCRIPTION
## Summary

Adds the `xpack.fleet.packageVerification.gpgKeyPath` config setting as an env var available in Kibana's container.


<!--ONMERGE {"backportTargets":["8.9"]} ONMERGE-->