### PR TITLE
[Security Solution] Fix Coverage Overview API activity filter

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/coverage_overview/handle_coverage_overview_request.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/coverage_overview/handle_coverage_overview_request.ts
@@ -33,16 +33,19 @@ export async function handleCoverageOverviewRequest({
   params: { filter },
   deps: { rulesClient },
 }: HandleCoverageOverviewRequestArgs): Promise<CoverageOverviewResponse> {
+  const activitySet = new Set(filter?.activity);
   const kqlFilter = filter
     ? convertRulesFilterToKQL({
         filter: filter.search_term,
         showCustomRules: filter.source?.includes(CoverageOverviewRuleSource.Custom) ?? false,
         showElasticRules: filter.source?.includes(CoverageOverviewRuleSource.Prebuilt) ?? false,
-        enabled: filter.activity?.includes(CoverageOverviewRuleActivity.Disabled)
-          ? false
-          : filter.activity?.includes(CoverageOverviewRuleActivity.Enabled)
-          ? true
-          : undefined,
+        enabled:
+          (activitySet.has(CoverageOverviewRuleActivity.Enabled) &&
+            activitySet.has(CoverageOverviewRuleActivity.Disabled)) ||
+          (!activitySet.has(CoverageOverviewRuleActivity.Enabled) &&
+            !activitySet.has(CoverageOverviewRuleActivity.Disabled))
+            ? undefined
+            : activitySet.has(CoverageOverviewRuleActivity.Enabled),
       })
     : undefined;
 


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/158246

## Summary

If activity filter contains both allowed values `enabled` and `disabled` simultaneously Coverage Overview endpoint returns the response filtered by the first value only.

This PR fixes wrong behavior os if `enabled` and `disabled` values are set simultaneously the response contains combined results for both `enabled` and `disabled` activity filter values.

For example a request like below

```sh
curl -X POST --user elastic:changeme -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' -d '{"filter":{"activity": ["enabled","disabled"]}}' http://localhost:5601/kbn/internal/detection_engine/rules/_coverage_overview --verbose
```

would produce the same response as the following request

```sh
curl -X POST --user elastic:changeme -H 'Content-Type: application/json' -H 'kbn-xsrf: 123' http://localhost:5601/kbn/internal/detection_engine/rules/_coverage_overview --verbose
```

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
