### PR TITLE
[Synthetics] Pass monitor.id to `run_once`.

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.test.tsx
@@ -96,6 +96,19 @@ describe('format', () => {
     };
   });
 
+  it('leaves un-nested fields as is', () => {
+    const projectSourceContent = 'UUUUUUUIJLVIK';
+    formValues['source.project.content'] = projectSourceContent;
+    formValues['ssl.verification_mode'] = 'full';
+    formValues.type = 'browser';
+    expect(format(formValues)).toEqual(
+      expect.objectContaining({
+        ['source.project.content']: projectSourceContent,
+        ['ssl.verification_mode']: 'full',
+      })
+    );
+  });
+
   it.each([[true], [false]])('correctly formats form fields to monitor type', (enabled) => {
     formValues.enabled = enabled;
     expect(format(formValues)).toEqual({

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
@@ -15,7 +15,7 @@ export const serializeNestedFormField = (fields: Record<string, any>) => {
   Object.keys(defaults).map((key) => {
     /* split key names on dot to handle dot notation fields,
      * which are changed to nested fields by react-hook-form */
-    monitorFields[key] = get(fields, key.split('.')) ?? defaults[key as ConfigKey];
+    monitorFields[key] = get(fields, key.split('.')) ?? fields[key] ?? defaults[key as ConfigKey];
   });
   return monitorFields as MonitorFields;
 };


### PR DESCRIPTION
Fixes #163655 

## Summary

Fixes the issue where run once wasn't forwarding monitor.id.

### How to test
1. Have one UI monitor with public and private location, preferably a browser monitor using params and one project monitor with a public and private location.
2. Test that "Run test" button on monitor Add/Edit works for an unsaved as well as saved UI monitor.
3. Test that "Run test" button on monitor Add/Edit works for a pushed project monitor.
4. Test that "Run test manually" on monitor details page works as expected.
5. Confirm that results for "Run test manually" do register in the run history where as preflight test results ("Run test" results) do not get listed in the history.
