### PR TITLE
Replace locahost with 127.0.0.1 in synthrace default config

### DIFF
--- a/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
+++ b/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts
@@ -80,8 +80,8 @@ async function getKibanaUrl({ target, logger }: { target: string; logger: Logger
 export async function getServiceUrls({ logger, target, kibana }: RunOptions & { logger: Logger }) {
   if (!target) {
     // assume things are running locally
-    kibana = kibana || 'http://localhost:5601';
-    target = 'http://localhost:9200';
+    kibana = kibana || 'http://127.0.0.1:5601';
+    target = 'http://127.0.0.1:9200';
   }
 
   if (!target) {


### PR DESCRIPTION
## Summary

To fix the following error when running `node scripts/synthtrace simple_trace.ts --local --live`:

```
Error: Could not connect to Kibana: request to http://elastic:changeme@localhost:5601/ failed, reason: connect ECONNREFUSED ::1:5601
    at getKibanaUrl (/kibana/packages/kbn-apm-synthtrace/src/cli/utils/get_service_urls.ts:76:11)
```