### PR TITLE
[APM][Profiling] Adding feature flag to enable profiling integration

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -549,6 +549,10 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'observability:apmEnableProfilingIntegration': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
   'observability:apmEnableCriticalPath': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -150,6 +150,7 @@ export interface UsageStats {
   'observability:apmServiceInventoryOptimizedSorting': boolean;
   'observability:apmTraceExplorerTab': boolean;
   'observability:apmEnableCriticalPath': boolean;
+  'observability:apmEnableProfilingIntegration': boolean;
   'securitySolution:enableGroupedNav': boolean;
   'securitySolution:showRelatedIntegrations': boolean;
   'visualization:visualize:legacyGaugeChartsLibrary': boolean;

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -9870,6 +9870,12 @@
             "description": "Non-default value of setting."
           }
         },
+        "observability:apmEnableProfilingIntegration": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
         "observability:apmEnableCriticalPath": {
           "type": "boolean",
           "_meta": {

--- a/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
@@ -19,6 +19,7 @@ import {
   apmEnableServiceMetrics,
   apmEnableContinuousRollups,
   enableAgentExplorerView,
+  apmEnableProfilingIntegration,
 } from '@kbn/observability-plugin/common';
 import { isEmpty } from 'lodash';
 import React from 'react';
@@ -37,6 +38,7 @@ const apmSettingsKeys = [
   apmEnableServiceMetrics,
   apmEnableContinuousRollups,
   enableAgentExplorerView,
+  apmEnableProfilingIntegration,
 ];
 
 export function GeneralSettings() {

--- a/x-pack/plugins/apm/public/hooks/use_profiling_plugin.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_profiling_plugin.tsx
@@ -6,10 +6,15 @@
  */
 
 import { useEffect, useState } from 'react';
+import { apmEnableProfilingIntegration } from '@kbn/observability-plugin/common';
 import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
 
 export function useProfilingPlugin() {
-  const { plugins } = useApmPluginContext();
+  const { plugins, core } = useApmPluginContext();
+  const isProfilingIntegrationEnabled = core.uiSettings.get<boolean>(
+    apmEnableProfilingIntegration,
+    false
+  );
   const [isProfilingPluginInitialized, setIsProfilingPluginInitialized] =
     useState<boolean | undefined>();
 
@@ -28,8 +33,10 @@ export function useProfilingPlugin() {
 
   return {
     isProfilingPluginInitialized,
-    profilingLocators: isProfilingPluginInitialized
-      ? plugins.profiling?.locators
-      : undefined,
+    profilingLocators:
+      isProfilingIntegrationEnabled && isProfilingPluginInitialized
+        ? plugins.profiling?.locators
+        : undefined,
+    isProfilingIntegrationEnabled,
   };
 }

--- a/x-pack/plugins/observability/common/index.ts
+++ b/x-pack/plugins/observability/common/index.ts
@@ -40,6 +40,7 @@ export {
   apmEnableContinuousRollups,
   enableCriticalPath,
   syntheticsThrottlingEnabled,
+  apmEnableProfilingIntegration,
 } from './ui_settings_keys';
 
 export {

--- a/x-pack/plugins/observability/common/ui_settings_keys.ts
+++ b/x-pack/plugins/observability/common/ui_settings_keys.ts
@@ -26,3 +26,4 @@ export const apmEnableServiceMetrics = 'observability:apmEnableServiceMetrics';
 export const apmEnableContinuousRollups = 'observability:apmEnableContinuousRollups';
 export const syntheticsThrottlingEnabled = 'observability:syntheticsThrottlingEnabled';
 export const enableLegacyUptimeApp = 'observability:enableLegacyUptimeApp';
+export const apmEnableProfilingIntegration = 'observability:apmEnableProfilingIntegration';

--- a/x-pack/plugins/observability/server/ui_settings.ts
+++ b/x-pack/plugins/observability/server/ui_settings.ts
@@ -29,6 +29,7 @@ import {
   enableInfrastructureHostsView,
   syntheticsThrottlingEnabled,
   enableLegacyUptimeApp,
+  apmEnableProfilingIntegration,
 } from '../common/ui_settings_keys';
 
 const betaLabel = i18n.translate('xpack.observability.uiSettings.betaLabel', {
@@ -363,6 +364,15 @@ export const uiSettings: Record<string, UiSettings> = {
     }),
     schema: schema.boolean(),
     requiresPageReload: true,
+  },
+  [apmEnableProfilingIntegration]: {
+    category: [observabilityFeatureId],
+    name: i18n.translate('xpack.observability.apmEnableProfilingIntegration', {
+      defaultMessage: 'Enable Universal Profiling integration in APM',
+    }),
+    value: false,
+    schema: schema.boolean(),
+    requiresPageReload: false,
   },
 };
 


### PR DESCRIPTION
<img width="1493" alt="Screenshot 2023-08-14 at 3 11 13 PM" src="https://github.com/elastic/kibana/assets/55978943/6bafa1e3-7075-4779-92ae-35ab30436255">

When Profiling is initiated but feature flag is not enabled:
<img width="381" alt="Screenshot 2023-08-14 at 3 17 14 PM" src="https://github.com/elastic/kibana/assets/55978943/fb4821b9-2bcc-4a7d-bd77-b200e3d43892">

When Profiling is initiated and feature flag is enabled:
<img width="369" alt="Screenshot 2023-08-14 at 3 18 59 PM" src="https://github.com/elastic/kibana/assets/55978943/cf8ed7c6-77ee-48e7-bf82-7fc2a7101d6b">
