### PR TITLE
[APM] Update usage of apmAlertsClient

### DIFF
--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_service_summary/index.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_service_summary/index.ts
@@ -285,15 +285,18 @@ export async function getApmServiceSummary({
     }),
     apmAlertsClient.search({
       size: 100,
-      query: {
-        bool: {
-          filter: [
-            ...termQuery(ALERT_RULE_PRODUCER, 'apm'),
-            ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
-            ...rangeQuery(start, end),
-            ...termQuery(SERVICE_NAME, serviceName),
-            ...environmentQuery(environment),
-          ],
+      track_total_hits: false,
+      body: {
+        query: {
+          bool: {
+            filter: [
+              ...termQuery(ALERT_RULE_PRODUCER, 'apm'),
+              ...termQuery(ALERT_STATUS, ALERT_STATUS_ACTIVE),
+              ...rangeQuery(start, end),
+              ...termQuery(SERVICE_NAME, serviceName),
+              ...environmentQuery(environment),
+            ],
+          },
         },
       },
     }),


### PR DESCRIPTION
Type of `apmAlertsClient` was changed in another PR that got merged slightly before.