### PR TITLE
[APM] Fix custom links warning

### DIFF
--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.tsx
@@ -79,11 +79,13 @@ export function TransactionActionMenu({ transaction, isLoading }: Props) {
 
   return (
     <>
-      <CustomLinkFlyout
-        transaction={transaction}
-        isOpen={isCreateEditFlyoutOpen}
-        onClose={() => setIsCreateEditFlyoutOpen(false)}
-      />
+      {hasGoldLicense && (
+        <CustomLinkFlyout
+          transaction={transaction}
+          isOpen={isCreateEditFlyoutOpen}
+          onClose={() => setIsCreateEditFlyoutOpen(false)}
+        />
+      )}
 
       <ActionMenu
         id="transactionActionMenu"


### PR DESCRIPTION
Originally fixed in https://github.com/elastic/kibana/pull/83836


**Problem**

When running in basic mode and navigates to the transactions details page a toast is display with the warning:

>To create custom links, you must be subscribed to an Elastic Gold license or above. With it, you'll have the ability to create custom links to improve your workflow when analyzing your services.

This is caused by a request to `GET internal/apm/settings/custom_links`. This PR ensures that only when users have a valid license custom links will be attempted loaded


<img width="1705" alt="image" src="https://github.com/elastic/kibana/assets/209966/60c59c87-9837-4fbb-8172-5a4add121db0">
