### PR TITLE
[Security Solution] Fix the rules coverage overview API contract

### DIFF
--- a/x-pack/plugins/security_solution/common/api/detection_engine/rule_management/coverage_overview/coverage_overview_route.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/rule_management/coverage_overview/coverage_overview_route.ts
@@ -9,24 +9,18 @@ import * as t from 'io-ts';
 import { enumeration, NonEmptyArray, NonEmptyString } from '@kbn/securitysolution-io-ts-types';
 
 /**
- * Rule activity (status) filter applicable to two groups of rules
- * - installed from a Fleet package, custom and customized which are installed but customized later on which
- *  can be either enabled or disabled
- * - available to be installed from a Fleet package rules
+ * Rule activity (status) filter, which now can filter enabled and disabled rules.
+ * Later we're going to support available rules as well (prebuilt rules that are not yet installed).
  */
 export enum CoverageOverviewRuleActivity {
   /**
-   * Enabled rules (installed from a Fleet package, custom or customized)
+   * Enabled rules (prebuilt and custom)
    */
   Enabled = 'enabled',
   /**
-   * Disabled rules (installed from a Fleet package, custom or customized)
+   * Disabled rules (prebuilt and custom)
    */
   Disabled = 'disabled',
-  /**
-   * Available to be installed from a Fleet package rules (Elastic prebuilt rules)
-   */
-  Available = 'available',
 }
 export const CoverageOverviewRuleActivitySchema = enumeration(
   'CoverageOverviewRuleActivity',
@@ -45,10 +39,6 @@ export enum CoverageOverviewRuleSource {
    * Rules created manually
    */
   Custom = 'custom',
-  /**
-   * Rules installed from a Fleet package but modified later on
-   */
-  Customized = 'customized',
 }
 export const CoverageOverviewRuleSourceSchema = enumeration(
   'CoverageOverviewRuleSource',

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_dashboard_model.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/coverage_overview/build_coverage_overview_dashboard_model.ts
@@ -115,10 +115,13 @@ function addRule(
       id: ruleId,
       name: ruleData.name,
     });
-  } else if (ruleData.activity === CoverageOverviewRuleActivity.Available) {
-    container.availableRules.push({
-      id: ruleId,
-      name: ruleData.name,
-    });
   }
+
+  // When we add support for available (not installed) rules to this feature, add the following here:
+  // else if (ruleData.activity === CoverageOverviewRuleActivity.Available) {
+  //   container.availableRules.push({
+  //     id: ruleId,
+  //     name: ruleData.name,
+  //   });
+  // }
 }

--- a/x-pack/test/detection_engine_api_integration/basic/tests/coverage_overview.ts
+++ b/x-pack/test/detection_engine_api_integration/basic/tests/coverage_overview.ts
@@ -342,9 +342,9 @@ export default ({ getService }: FtrProviderContext): void => {
           });
         });
 
-        it('returns response filtered by enabled and disabled rules equal to response if enabled and disabled are not set', async () => {
+        it('returns all rules if both enabled and disabled filters are specified in the request', async () => {
           const expectedRule1 = await createRule(supertest, log, {
-            ...getSimpleRule('rule-1'),
+            ...getSimpleRule('rule-1', false),
             name: 'Disabled rule',
             threat: generateThreatArray(1),
           });


### PR DESCRIPTION
**Epic:** https://github.com/elastic/security-team/issues/2905 (internal)

## Summary

In our API endpoints, we shouldn't expose parameters for features we don't support yet.

This PR:

- Removes the `CoverageOverviewRuleActivity.Available` and `CoverageOverviewRuleSource.Customized` enum values from the coverage endpoint's request schema.
- Does some additional cleanup.

We will add the removed parameters back when we add the corresponding enhancements to the feature.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->