### PR TITLE
[Fix] add to clause to allow read only users the image reporting share menu

### DIFF
--- a/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
@@ -81,10 +81,12 @@ export const reportingScreenshotShareProvider = ({
 
     let capabilityHasDashboardScreenshotReporting = false;
     let capabilityHasVisualizeScreenshotReporting = false;
+    console.log({usesUiCapabilities})
     if (usesUiCapabilities) {
       // TODO: add abstractions in ExportTypeRegistry to use here?
       capabilityHasDashboardScreenshotReporting =
         application.capabilities.dashboard?.generateScreenshot === true;
+
       capabilityHasVisualizeScreenshotReporting =
         application.capabilities.visualize?.generateScreenshot === true;
     } else {
@@ -106,11 +108,12 @@ export const reportingScreenshotShareProvider = ({
       return [];
     }
 
-    if (isSupportedType && !capabilityHasVisualizeScreenshotReporting) {
+    if (isSupportedType && !capabilityHasVisualizeScreenshotReporting && !capabilityHasDashboardScreenshotReporting) {
       return [];
     }
 
     const { sharingData } = shareOpts as unknown as { sharingData: ReportingSharingData };
+    console.log({ sharingData })
     const shareActions = [];
 
     const pngPanelTitle = i18n.translate('xpack.reporting.shareContextMenu.pngReportsButtonLabel', {
@@ -195,6 +198,7 @@ export const reportingScreenshotShareProvider = ({
 
     shareActions.push(panelPng);
     shareActions.push(panelPdf);
+    console.log('shareActions', shareActions)
     return shareActions;
   };
 


### PR DESCRIPTION
## Summary

This PR https://github.com/elastic/kibana/pull/153429 inadvertently created a bug where users in Dashboard could not generate reports if they have custom roles that aren't all. 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

