### PR TITLE
[7.17] fix(NA): yarn env vars for node_modules mirrors (#163549)

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -62,4 +62,12 @@ yarn_install(
   symlink_node_modules = True,
   quiet = False,
   frozen_lockfile = False,
+  environment = {
+    "GECKODRIVER_CDNURL": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache",
+    "CHROMEDRIVER_CDNURL": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache",
+    "CHROMEDRIVER_CDNBINARIESURL": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache",
+    "SASS_BINARY_SITE": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass",
+    "RE2_DOWNLOAD_MIRROR": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2",
+    "CYPRESS_DOWNLOAD_MIRROR": "https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/cypress",
+  }
 )

--- a/src/dev/ci_setup/setup_env.sh
+++ b/src/dev/ci_setup/setup_env.sh
@@ -128,10 +128,10 @@ export PATH="$PATH:$yarnGlobalDir"
 
 # use a proxy to fetch chromedriver/geckodriver asset
 export GECKODRIVER_CDNURL="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache"
-export CHROMEDRIVER_LEGACY_CDNURL="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache"
 export CHROMEDRIVER_CDNURL="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache"
 export CHROMEDRIVER_CDNBINARIESURL="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache"
 export RE2_DOWNLOAD_MIRROR="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache"
+export SASS_BINARY_SITE="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-sass"
 export CYPRESS_DOWNLOAD_MIRROR="https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/cypress"
 
 export CHECKS_REPORTER_ACTIVE=false


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [fix(NA): yarn env vars for node_modules mirrors (#163549)](https://github.com/elastic/kibana/pull/163549)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tiago Costa","email":"tiago.costa@elastic.co"},"sourceCommit":{"committedDate":"2023-08-10T14:35:34Z","message":"fix(NA): yarn env vars for node_modules mirrors (#163549)\n\nThis PR fixes the setup we have for the node_module mirrors vars that\r\nare overriding and pointing into our middle cache. The previous\r\nconfiguration was not working as intended as the env vars set globally\r\non CI never ended up in the bazel managed yarn install.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"17936ffd21d4b4b274d2cda90902764ed0d4ae07","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","Team:Operations","release_note:skip","backport:all-open","v8.10.0","v8.9.1"],"number":163549,"url":"https://github.com/elastic/kibana/pull/163549","mergeCommit":{"message":"fix(NA): yarn env vars for node_modules mirrors (#163549)\n\nThis PR fixes the setup we have for the node_module mirrors vars that\r\nare overriding and pointing into our middle cache. The previous\r\nconfiguration was not working as intended as the env vars set globally\r\non CI never ended up in the bazel managed yarn install.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"17936ffd21d4b4b274d2cda90902764ed0d4ae07"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163549","number":163549,"mergeCommit":{"message":"fix(NA): yarn env vars for node_modules mirrors (#163549)\n\nThis PR fixes the setup we have for the node_module mirrors vars that\r\nare overriding and pointing into our middle cache. The previous\r\nconfiguration was not working as intended as the env vars set globally\r\non CI never ended up in the bazel managed yarn install.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"17936ffd21d4b4b274d2cda90902764ed0d4ae07"}},{"branch":"8.9","label":"v8.9.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/163617","number":163617,"state":"MERGED","mergeCommit":{"sha":"fc94811899834fe1e8bbe1b27456c57ad08be211","message":"[8.9] fix(NA): yarn env vars for node_modules mirrors (#163549) (#163617)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.9`:\n- [fix(NA): yarn env vars for node_modules mirrors\n(#163549)](https://github.com/elastic/kibana/pull/163549)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Tiago\nCosta\",\"email\":\"tiago.costa@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2023-08-10T14:35:34Z\",\"message\":\"fix(NA):\nyarn env vars for node_modules mirrors (#163549)\\n\\nThis PR fixes the\nsetup we have for the node_module mirrors vars that\\r\\nare overriding\nand pointing into our middle cache. The previous\\r\\nconfiguration was\nnot working as intended as the env vars set globally\\r\\non CI never\nended up in the bazel managed yarn install.\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"17936ffd21d4b4b274d2cda90902764ed0d4ae07\",\"branchLabelMapping\":{\"^v8.10.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"chore\",\"Team:Operations\",\"release_note:skip\",\"backport:all-open\",\"v8.10.0\"],\"number\":163549,\"url\":\"https://github.com/elastic/kibana/pull/163549\",\"mergeCommit\":{\"message\":\"fix(NA):\nyarn env vars for node_modules mirrors (#163549)\\n\\nThis PR fixes the\nsetup we have for the node_module mirrors vars that\\r\\nare overriding\nand pointing into our middle cache. The previous\\r\\nconfiguration was\nnot working as intended as the env vars set globally\\r\\non CI never\nended up in the bazel managed yarn install.\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"17936ffd21d4b4b274d2cda90902764ed0d4ae07\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.10.0\",\"labelRegex\":\"^v8.10.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/163549\",\"number\":163549,\"mergeCommit\":{\"message\":\"fix(NA):\nyarn env vars for node_modules mirrors (#163549)\\n\\nThis PR fixes the\nsetup we have for the node_module mirrors vars that\\r\\nare overriding\nand pointing into our middle cache. The previous\\r\\nconfiguration was\nnot working as intended as the env vars set globally\\r\\non CI never\nended up in the bazel managed yarn install.\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"17936ffd21d4b4b274d2cda90902764ed0d4ae07\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>"}}]}] BACKPORT-->