### PR TITLE
Add appex-qa as codeowner for FTR serverless base config files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -997,6 +997,7 @@ x-pack/plugins/infra/server/lib/alerting @elastic/actionable-observability
 /x-pack/performance @elastic/appex-qa
 /packages/kbn-test/src/functional_test_runner @elastic/appex-qa
 /packages/kbn-performance-testing-dataset-extractor @elastic/appex-qa
+/x-pack/test_serverless/**/*config.base.ts @elastic/appex-qa
 
 # Core
 /config/ @elastic/kibana-core


### PR DESCRIPTION
## Summary

This way Appex-QA can keep track on config changes and make sure  folks aware that some changes might not work for real MKI-hosted projects.