### PR TITLE
[Cloud Security] Removed beta tag from vuln findings tab

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -7,16 +7,12 @@
 import React from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import {
-  EuiBetaBadge,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiSpacer,
   EuiTab,
   EuiTabs,
   EuiTitle,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { css } from '@emotion/react';
 import { Redirect, useHistory, useLocation, matchPath } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
 import { Configurations } from '../configurations';
@@ -113,29 +109,10 @@ export const Findings = () => {
               onClick={navigateToVulnerabilitiesTab}
               isSelected={isVulnerabilitiesTabSelected(location.pathname)}
             >
-              <EuiFlexGroup responsive={false} alignItems="center" direction="row" gutterSize="s">
-                <EuiFlexItem grow={false}>
                   <FormattedMessage
                     id="xpack.csp.findings.tabs.vulnerabilities"
                     defaultMessage="Vulnerabilities"
                   />
-                </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiBetaBadge
-                    css={css`
-                      display: block;
-                    `}
-                    label="Beta"
-                    tooltipContent={
-                      <FormattedMessage
-                        id="xpack.csp.findings.betaLabel"
-                        defaultMessage="This functionality is in beta and is subject to change. The design and code is less mature than official generally available features and is being provided as-is with no warranties. Beta features are not subject to the support service level agreement of official generally available features."
-                      />
-                    }
-                    tooltipPosition="bottom"
-                  />
-                </EuiFlexItem>
-              </EuiFlexGroup>
             </EuiTab>
             <EuiTab
               key="configurations"

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -6,12 +6,7 @@
  */
 import React from 'react';
 import useLocalStorage from 'react-use/lib/useLocalStorage';
-import {
-  EuiSpacer,
-  EuiTab,
-  EuiTabs,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiSpacer, EuiTab, EuiTabs, EuiTitle } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { Redirect, useHistory, useLocation, matchPath } from 'react-router-dom';
 import { Routes, Route } from '@kbn/shared-ux-router';
@@ -109,10 +104,10 @@ export const Findings = () => {
               onClick={navigateToVulnerabilitiesTab}
               isSelected={isVulnerabilitiesTabSelected(location.pathname)}
             >
-                  <FormattedMessage
-                    id="xpack.csp.findings.tabs.vulnerabilities"
-                    defaultMessage="Vulnerabilities"
-                  />
+              <FormattedMessage
+                id="xpack.csp.findings.tabs.vulnerabilities"
+                defaultMessage="Vulnerabilities"
+              />
             </EuiTab>
             <EuiTab
               key="configurations"

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -11463,7 +11463,6 @@
     "xpack.csp.emptyState.title": "没有任何结果匹配您的搜索条件",
     "xpack.csp.expandColumnDescriptionLabel": "展开",
     "xpack.csp.expandColumnNameLabel": "展开",
-    "xpack.csp.findings.betaLabel": "此功能为公测版，可能会进行更改。设计和代码相对于正式发行版功能还不够成熟，将按原样提供，且不提供任何保证。公测版功能不受正式发行版功能的支持服务水平协议约束。",
     "xpack.csp.findings.distributionBar.totalFailedLabel": "失败的结果",
     "xpack.csp.findings.distributionBar.totalPassedLabel": "通过的结果",
     "xpack.csp.findings.errorCallout.pageSearchErrorTitle": "检索搜索结果时遇到问题",


### PR DESCRIPTION
## Summary

Removed beta tag from vuln findings tab

![image](https://github.com/elastic/kibana/assets/51442161/ca532ebf-acfb-4a07-b751-357c9bc5575c)
