### PR TITLE
[Serverless] Add deployment URL

### DIFF
--- a/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
+++ b/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
@@ -45,7 +45,7 @@ export type AppDeepLinkId =
   | ObservabilityLink;
 
 /** @public */
-export type CloudLinkId = 'userAndRoles' | 'performance' | 'billingAndSub';
+export type CloudLinkId = 'userAndRoles' | 'performance' | 'billingAndSub' | 'deployment';
 
 export type GetIsActiveFn = (params: {
   /** The current path name including the basePath + hash value but **without** any query params */

--- a/packages/shared-ux/chrome/navigation/src/cloud_links.tsx
+++ b/packages/shared-ux/chrome/navigation/src/cloud_links.tsx
@@ -17,7 +17,7 @@ export type CloudLinks = {
 };
 
 export const getCloudLinks = (cloud: CloudStart): CloudLinks => {
-  const { billingUrl, performanceUrl, usersAndRolesUrl } = cloud;
+  const { billingUrl, deploymentUrl, performanceUrl, usersAndRolesUrl } = cloud;
 
   const links: CloudLinks = {};
 
@@ -51,6 +51,18 @@ export const getCloudLinks = (cloud: CloudStart): CloudLinks => {
         defaultMessage: 'Billing and subscription',
       }),
       href: billingUrl,
+    };
+  }
+
+  if (deploymentUrl) {
+    links.deployment = {
+      title: i18n.translate(
+        'sharedUXPackages.chrome.sideNavigation.cloudLinks.deploymentLinkText',
+        {
+          defaultMessage: 'Project',
+        }
+      ),
+      href: deploymentUrl,
     };
   }
 

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -135,6 +135,13 @@ const navigationTree: NavigationTreeDefinition = {
               }),
             },
             {
+              id: 'cloudLinkDeployment',
+              cloudLink: 'deployment',
+              title: i18n.translate('xpack.serverlessSearch.nav.performance', {
+                defaultMessage: 'Performance',
+              }),
+            },
+            {
               id: 'cloudLinkUserAndRoles',
               cloudLink: 'userAndRoles',
             },


### PR DESCRIPTION
## Summary

This adds a link to the concrete project in Serverless ES3. We can't link to performance directly because that has been descoped for now. 