### PR TITLE
[ML] Hides paging controls in anomaly swim lane if only one page is available 

### DIFF
--- a/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
+++ b/x-pack/plugins/ml/public/application/explorer/swimlane_container.tsx
@@ -244,6 +244,7 @@ export const SwimlaneContainer: FC<SwimlaneProps> = ({
   const isPaginationVisible =
     (showSwimlane || isLoading) &&
     swimlaneLimit !== undefined &&
+    swimlaneLimit > (perPage ?? 5) &&
     onPaginationChange &&
     fromPage &&
     perPage;


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/151586

Hides pagination controls in the Anomaly Swim Lane if there are fewer results than pagination size. 

<img width="832" alt="image" src="https://github.com/elastic/kibana/assets/5236598/0aacfa16-ef15-4e43-9fe3-01657bbbd5b5">




