### PR TITLE
[8.9] [Synthetics] Pass monitor.id to `run_once`. (#163799)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.test.tsx
@@ -96,6 +96,19 @@ describe('format', () => {
     };
   });
 
+  it('leaves un-nested fields as is', () => {
+    const projectSourceContent = 'UUUUUUUIJLVIK';
+    formValues['source.project.content'] = projectSourceContent;
+    formValues['ssl.verification_mode'] = 'full';
+    formValues.type = 'browser';
+    expect(format(formValues)).toEqual(
+      expect.objectContaining({
+        ['source.project.content']: projectSourceContent,
+        ['ssl.verification_mode']: 'full',
+      })
+    );
+  });
+
   it.each([[true], [false]])('correctly formats form fields to monitor type', (enabled) => {
     formValues.enabled = enabled;
     expect(format(formValues)).toEqual({

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/formatter.ts
@@ -15,7 +15,7 @@ export const formatter = (fields: Record<string, any>) => {
   Object.keys(defaults).map((key) => {
     /* split key names on dot to handle dot notation fields,
      * which are changed to nested fields by react-hook-form */
-    monitorFields[key] = get(fields, key.split('.')) ?? defaults[key as ConfigKey];
+    monitorFields[key] = get(fields, key.split('.')) ?? fields[key] ?? defaults[key as ConfigKey];
   });
   return monitorFields as MonitorFields;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Synthetics] Pass monitor.id to `run_once`. (#163799)](https://github.com/elastic/kibana/pull/163799)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Abdul Wahab Zahid","email":"awahab07@yahoo.com"},"sourceCommit":{"committedDate":"2023-08-14T17:26:25Z","message":"[Synthetics] Pass monitor.id to `run_once`. (#163799)\n\nFixes #163655 \r\n\r\n## Summary\r\n\r\nFixes the issue where run once wasn't forwarding monitor.id.","sha":"6aa5d499d23d71e615660ae2dc481214ab5b0f1b","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","Team:uptime","release_note:skip","v8.9.0","v8.10.0","v8.9.2"],"number":163799,"url":"https://github.com/elastic/kibana/pull/163799","mergeCommit":{"message":"[Synthetics] Pass monitor.id to `run_once`. (#163799)\n\nFixes #163655 \r\n\r\n## Summary\r\n\r\nFixes the issue where run once wasn't forwarding monitor.id.","sha":"6aa5d499d23d71e615660ae2dc481214ab5b0f1b"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163799","number":163799,"mergeCommit":{"message":"[Synthetics] Pass monitor.id to `run_once`. (#163799)\n\nFixes #163655 \r\n\r\n## Summary\r\n\r\nFixes the issue where run once wasn't forwarding monitor.id.","sha":"6aa5d499d23d71e615660ae2dc481214ab5b0f1b"}}]}] BACKPORT-->