### PR TITLE
[8.8] [Reporting] Allow custom roles to use image reporting in dashboard (#163873)

### DIFF
--- a/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
+++ b/x-pack/plugins/reporting/public/share_context_menu/register_pdf_png_reporting.tsx
@@ -82,7 +82,6 @@ export const reportingScreenshotShareProvider = ({
     let capabilityHasDashboardScreenshotReporting = false;
     let capabilityHasVisualizeScreenshotReporting = false;
     if (usesUiCapabilities) {
-      // TODO: add abstractions in ExportTypeRegistry to use here?
       capabilityHasDashboardScreenshotReporting =
         application.capabilities.dashboard?.generateScreenshot === true;
       capabilityHasVisualizeScreenshotReporting =
@@ -106,7 +105,11 @@ export const reportingScreenshotShareProvider = ({
       return [];
     }
 
-    if (isSupportedType && !capabilityHasVisualizeScreenshotReporting) {
+    if (
+      isSupportedType &&
+      !capabilityHasVisualizeScreenshotReporting &&
+      !capabilityHasDashboardScreenshotReporting
+    ) {
       return [];
     }
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Reporting] Allow custom roles to use image reporting in dashboard (#163873)](https://github.com/elastic/kibana/pull/163873)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rachel Shen","email":"rshen@elastic.co"},"sourceCommit":{"committedDate":"2023-08-15T19:42:06Z","message":"[Reporting] Allow custom roles to use image reporting in dashboard (#163873)\n\n## Summary\r\n\r\nThis PR fixes a bug mentioned in\r\nhttps://github.com/elastic/sdh-kibana/issues/4016 from\r\nhttps://github.com/elastic/kibana/pull/153429 where users with custom\r\nroles should allow them the ability to generate reports (with\r\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug doesn't\r\narise for users with all privileges.\r\n\r\n- set xpack.reporting.roles.enabled false in the kibana.yml \r\n- load sample data \r\n- create a custom role where the index (whatever sample data index you\r\nwant) has the read and view_index_metadata privilege.\r\n- Add the Kibana privilege for all spaces Analytics > Dashboard >\r\nGenerate PDF or PNG Reports and Download Csv reports from Saved Search\r\npanels. Create the global privilege and then the role.\r\n- Apply that role to a new user and log in using that user. \r\n\r\n\r\n## Before \r\n\r\nYou can see in the console that usesUiCapabilitie in\r\nregister_pdf_png_reporting.tsx is true\r\n\r\n<img width=\"1458\" alt=\"Screenshot 2023-08-14 at 12 34 38 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\">\r\n\r\n\r\n## After\r\n<img width=\"1343\" alt=\"Screenshot 2023-08-14 at 2 18 30 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"54d11a964c1ed86268cb1a5aca24674895ffdf13","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Feature:Reporting","Team:SharedUX","backport:all-open","v8.10.0","v8.9.1"],"number":163873,"url":"https://github.com/elastic/kibana/pull/163873","mergeCommit":{"message":"[Reporting] Allow custom roles to use image reporting in dashboard (#163873)\n\n## Summary\r\n\r\nThis PR fixes a bug mentioned in\r\nhttps://github.com/elastic/sdh-kibana/issues/4016 from\r\nhttps://github.com/elastic/kibana/pull/153429 where users with custom\r\nroles should allow them the ability to generate reports (with\r\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug doesn't\r\narise for users with all privileges.\r\n\r\n- set xpack.reporting.roles.enabled false in the kibana.yml \r\n- load sample data \r\n- create a custom role where the index (whatever sample data index you\r\nwant) has the read and view_index_metadata privilege.\r\n- Add the Kibana privilege for all spaces Analytics > Dashboard >\r\nGenerate PDF or PNG Reports and Download Csv reports from Saved Search\r\npanels. Create the global privilege and then the role.\r\n- Apply that role to a new user and log in using that user. \r\n\r\n\r\n## Before \r\n\r\nYou can see in the console that usesUiCapabilitie in\r\nregister_pdf_png_reporting.tsx is true\r\n\r\n<img width=\"1458\" alt=\"Screenshot 2023-08-14 at 12 34 38 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\">\r\n\r\n\r\n## After\r\n<img width=\"1343\" alt=\"Screenshot 2023-08-14 at 2 18 30 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"54d11a964c1ed86268cb1a5aca24674895ffdf13"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163873","number":163873,"mergeCommit":{"message":"[Reporting] Allow custom roles to use image reporting in dashboard (#163873)\n\n## Summary\r\n\r\nThis PR fixes a bug mentioned in\r\nhttps://github.com/elastic/sdh-kibana/issues/4016 from\r\nhttps://github.com/elastic/kibana/pull/153429 where users with custom\r\nroles should allow them the ability to generate reports (with\r\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug doesn't\r\narise for users with all privileges.\r\n\r\n- set xpack.reporting.roles.enabled false in the kibana.yml \r\n- load sample data \r\n- create a custom role where the index (whatever sample data index you\r\nwant) has the read and view_index_metadata privilege.\r\n- Add the Kibana privilege for all spaces Analytics > Dashboard >\r\nGenerate PDF or PNG Reports and Download Csv reports from Saved Search\r\npanels. Create the global privilege and then the role.\r\n- Apply that role to a new user and log in using that user. \r\n\r\n\r\n## Before \r\n\r\nYou can see in the console that usesUiCapabilitie in\r\nregister_pdf_png_reporting.tsx is true\r\n\r\n<img width=\"1458\" alt=\"Screenshot 2023-08-14 at 12 34 38 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\">\r\n\r\n\r\n## After\r\n<img width=\"1343\" alt=\"Screenshot 2023-08-14 at 2 18 30 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"54d11a964c1ed86268cb1a5aca24674895ffdf13"}},{"branch":"8.9","label":"v8.9.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/163972","number":163972,"state":"MERGED","mergeCommit":{"sha":"0a17923f65b4c8d97666ab5fcb131c767d45d5a4","message":"[8.9] [Reporting] Allow custom roles to use image reporting in dashboard (#163873) (#163972)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.9`:\n- [[Reporting] Allow custom roles to use image reporting in dashboard\n(#163873)](https://github.com/elastic/kibana/pull/163873)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Rachel\nShen\",\"email\":\"rshen@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2023-08-15T19:42:06Z\",\"message\":\"[Reporting]\nAllow custom roles to use image reporting in dashboard (#163873)\\n\\n##\nSummary\\r\\n\\r\\nThis PR fixes a bug mentioned\nin\\r\\nhttps://github.com/elastic/sdh-kibana/issues/4016\nfrom\\r\\nhttps://github.com/elastic/kibana/pull/153429 where users with\ncustom\\r\\nroles should allow them the ability to generate reports\n(with\\r\\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug\ndoesn't\\r\\narise for users with all privileges.\\r\\n\\r\\n- set\nxpack.reporting.roles.enabled false in the kibana.yml \\r\\n- load sample\ndata \\r\\n- create a custom role where the index (whatever sample data\nindex you\\r\\nwant) has the read and view_index_metadata privilege.\\r\\n-\nAdd the Kibana privilege for all spaces Analytics > Dashboard\n>\\r\\nGenerate PDF or PNG Reports and Download Csv reports from Saved\nSearch\\r\\npanels. Create the global privilege and then the role.\\r\\n-\nApply that role to a new user and log in using that user. \\r\\n\\r\\n\\r\\n##\nBefore \\r\\n\\r\\nYou can see in the console that usesUiCapabilitie\nin\\r\\nregister_pdf_png_reporting.tsx is true\\r\\n\\r\\n<img width=\\\"1458\\\"\nalt=\\\"Screenshot 2023-08-14 at 12 34 38\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\\\">\\r\\n\\r\\n\\r\\n##\nAfter\\r\\n<img width=\\\"1343\\\" alt=\\\"Screenshot 2023-08-14 at 2 18 30\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\\\">\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"54d11a964c1ed86268cb1a5aca24674895ffdf13\",\"branchLabelMapping\":{\"^v8.10.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"bug\",\"release_note:fix\",\"Feature:Reporting\",\"Team:SharedUX\",\"backport:all-open\",\"v8.10.0\"],\"number\":163873,\"url\":\"https://github.com/elastic/kibana/pull/163873\",\"mergeCommit\":{\"message\":\"[Reporting]\nAllow custom roles to use image reporting in dashboard (#163873)\\n\\n##\nSummary\\r\\n\\r\\nThis PR fixes a bug mentioned\nin\\r\\nhttps://github.com/elastic/sdh-kibana/issues/4016\nfrom\\r\\nhttps://github.com/elastic/kibana/pull/153429 where users with\ncustom\\r\\nroles should allow them the ability to generate reports\n(with\\r\\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug\ndoesn't\\r\\narise for users with all privileges.\\r\\n\\r\\n- set\nxpack.reporting.roles.enabled false in the kibana.yml \\r\\n- load sample\ndata \\r\\n- create a custom role where the index (whatever sample data\nindex you\\r\\nwant) has the read and view_index_metadata privilege.\\r\\n-\nAdd the Kibana privilege for all spaces Analytics > Dashboard\n>\\r\\nGenerate PDF or PNG Reports and Download Csv reports from Saved\nSearch\\r\\npanels. Create the global privilege and then the role.\\r\\n-\nApply that role to a new user and log in using that user. \\r\\n\\r\\n\\r\\n##\nBefore \\r\\n\\r\\nYou can see in the console that usesUiCapabilitie\nin\\r\\nregister_pdf_png_reporting.tsx is true\\r\\n\\r\\n<img width=\\\"1458\\\"\nalt=\\\"Screenshot 2023-08-14 at 12 34 38\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\\\">\\r\\n\\r\\n\\r\\n##\nAfter\\r\\n<img width=\\\"1343\\\" alt=\\\"Screenshot 2023-08-14 at 2 18 30\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\\\">\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"54d11a964c1ed86268cb1a5aca24674895ffdf13\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[],\"targetPullRequestStates\":[{\"branch\":\"main\",\"label\":\"v8.10.0\",\"labelRegex\":\"^v8.10.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/163873\",\"number\":163873,\"mergeCommit\":{\"message\":\"[Reporting]\nAllow custom roles to use image reporting in dashboard (#163873)\\n\\n##\nSummary\\r\\n\\r\\nThis PR fixes a bug mentioned\nin\\r\\nhttps://github.com/elastic/sdh-kibana/issues/4016\nfrom\\r\\nhttps://github.com/elastic/kibana/pull/153429 where users with\ncustom\\r\\nroles should allow them the ability to generate reports\n(with\\r\\n`xpack.reporting.roles.enabled: false`) in Dashboard. This bug\ndoesn't\\r\\narise for users with all privileges.\\r\\n\\r\\n- set\nxpack.reporting.roles.enabled false in the kibana.yml \\r\\n- load sample\ndata \\r\\n- create a custom role where the index (whatever sample data\nindex you\\r\\nwant) has the read and view_index_metadata privilege.\\r\\n-\nAdd the Kibana privilege for all spaces Analytics > Dashboard\n>\\r\\nGenerate PDF or PNG Reports and Download Csv reports from Saved\nSearch\\r\\npanels. Create the global privilege and then the role.\\r\\n-\nApply that role to a new user and log in using that user. \\r\\n\\r\\n\\r\\n##\nBefore \\r\\n\\r\\nYou can see in the console that usesUiCapabilitie\nin\\r\\nregister_pdf_png_reporting.tsx is true\\r\\n\\r\\n<img width=\\\"1458\\\"\nalt=\\\"Screenshot 2023-08-14 at 12 34 38\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/f6b567fa-3fbd-4039-aa64-fd28bb4534fb\\\">\\r\\n\\r\\n\\r\\n##\nAfter\\r\\n<img width=\\\"1343\\\" alt=\\\"Screenshot 2023-08-14 at 2 18 30\nPM\\\"\\r\\nsrc=\\\"https://github.com/elastic/kibana/assets/20343860/1e4ade9e-332c-4431-954a-38e8a16d4131\\\">\\r\\n\\r\\n\\r\\n###\nChecklist\\r\\n\\r\\nDelete any items that are not applicable to this\nPR.\\r\\n\\r\\n- [ ] Any text added follows [EUI's\nwriting\\r\\nguidelines](https://elastic.github.io/eui/#/guidelines/writing),\nuses\\r\\nsentence case text and includes\n[i18n\\r\\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\\r\\n-\n[\n]\\r\\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\\r\\nwas\nadded for features that require explanation or tutorials\\r\\n- [ ] [Unit\nor\nfunctional\\r\\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\\r\\nwere\nupdated or added to match the most common scenarios\\r\\n- [ ] Any UI\ntouched in this PR is usable by keyboard only (learn more\\r\\nabout\n[keyboard accessibility](https://webaim.org/techniques/keyboard/))\\r\\n-\n[ ] Any UI touched in this PR does not create any new axe\nfailures\\r\\n(run axe in\nbrowser:\\r\\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\\r\\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\\r\\n-\n[ ] If a plugin configuration key changed, check if it needs to\nbe\\r\\nallowlisted in the cloud and added to the\n[docker\\r\\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\\r\\n-\n[ ] This renders correctly on smaller devices using a\nresponsive\\r\\nlayout. (You can test this [in\nyour\\r\\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\\r\\n-\n[ ] This was checked for\n[cross-browser\\r\\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nkibanamachine\n<42973632+kibanamachine@users.noreply.github.com>\",\"sha\":\"54d11a964c1ed86268cb1a5aca24674895ffdf13\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Rachel Shen <rshen@elastic.co>"}}]}] BACKPORT-->