### PR TITLE
[Saved Search] [Embeddable] Fix extra fetch in saved search embeddable when custom title is used

### DIFF
--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.test.ts
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.test.ts
@@ -321,12 +321,11 @@ describe('saved search embeddable', () => {
     expect(search).toHaveBeenCalledTimes(1);
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/162997
-  it.skip('should not reload when the input title doesnt change', async () => {
+  it('should not reload when the input title doesnt change', async () => {
     const search = jest.fn().mockReturnValue(getSearchResponse(1));
     const { embeddable } = createEmbeddable({ searchMock: search, customTitle: 'custom title' });
-    await waitOneTick();
     embeddable.reload = jest.fn();
+    await waitOneTick();
     embeddable.render(mountpoint);
     // wait for data fetching
     await waitOneTick();
@@ -340,8 +339,8 @@ describe('saved search embeddable', () => {
   it('should reload when a different input title is set', async () => {
     const search = jest.fn().mockReturnValue(getSearchResponse(1));
     const { embeddable } = createEmbeddable({ searchMock: search, customTitle: 'custom title' });
-    await waitOneTick();
     embeddable.reload = jest.fn();
+    await waitOneTick();
     embeddable.render(mountpoint);
 
     await waitOneTick();
@@ -355,8 +354,8 @@ describe('saved search embeddable', () => {
   it('should not reload and fetch when a input title matches the saved search title', async () => {
     const search = jest.fn().mockReturnValue(getSearchResponse(1));
     const { embeddable } = createEmbeddable({ searchMock: search });
-    await waitOneTick();
     embeddable.reload = jest.fn();
+    await waitOneTick();
     embeddable.render(mountpoint);
     await waitOneTick();
     embeddable.updateOutput({ title: 'saved search' });

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
@@ -165,6 +165,10 @@ export class SavedSearchEmbeddable
     });
   }
 
+  private getCurrentTitle() {
+    return this.input.hidePanelTitles ? '' : this.input.title ?? this.savedSearch?.title ?? '';
+  }
+
   private async initializeSavedSearch(input: SearchInput) {
     try {
       const unwrapResult = await this.attributeService.unwrapAttributes(input);
@@ -178,7 +182,7 @@ export class SavedSearchEmbeddable
         unwrapResult
       );
 
-      this.panelTitle = this.savedSearch.title ?? '';
+      this.panelTitle = this.getCurrentTitle();
 
       await this.initializeOutput();
 
@@ -201,7 +205,7 @@ export class SavedSearchEmbeddable
     const dataView = savedSearch.searchSource.getField('index');
     const indexPatterns = dataView ? [dataView] : [];
     const input = this.getInput();
-    const title = input.hidePanelTitles ? '' : input.title ?? savedSearch.title;
+    const title = this.getCurrentTitle();
     const description = input.hidePanelTitles ? '' : input.description ?? savedSearch.description;
     const savedObjectId = (input as SearchByReferenceInput).savedObjectId;
     const locatorParams = getDiscoverLocatorParams({ input, savedSearch });


### PR DESCRIPTION
## Summary

This PR fixes an issue where using a custom title in the saved search embeddable creates a race condition that could result in an extra fetch being triggered. I've also created a separate PR with the same changes that runs the flaky tests 100x each to confirm this fix resolves the flakiness: #164088.

Resolves #162997.
Resolves #164125.

### Checklist

- [ ] ~Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [ ] ~[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials~
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] ~Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~
- [ ] ~Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~
- [ ] ~If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [ ] ~This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~
- [ ] ~This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->