### PR TITLE
Disable serverless alerting tests that cause errors in main

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
@@ -34,7 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esClient = getService('es');
   const esDeleteAllIndices = getService('esDeleteAllIndices');
 
-  describe('Alerting rules', () => {
+  describe.skip('Alerting rules', () => {
     const RULE_TYPE_ID = '.es-query';
     const ALERT_ACTION_INDEX = 'alert-action-es-query';
     let actionId: string;


### PR DESCRIPTION
## Summary


https://elastic.slack.com/archives/C5UDAFZQU/p1692168189310379