### PR TITLE
[Serverless] Chrome UI fixes

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
@@ -16,6 +16,8 @@ import {
   EuiIcon,
   EuiLoadingSpinner,
   htmlIdGenerator,
+  useEuiTheme,
+  EuiThemeComputed,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { InternalApplicationStart } from '@kbn/core-application-browser-internal';
@@ -46,12 +48,12 @@ import { ScreenReaderRouteAnnouncements, SkipToMainContent } from '../header/scr
 import { AppMenuBar } from './app_menu';
 import { ProjectNavigation } from './navigation';
 
-const headerCss = {
+const getHeaderCss = ({ size }: EuiThemeComputed) => ({
   logo: {
     container: css`
       display: inline-block;
       min-width: 56px; /* 56 = 40 + 8 + 8 */
-      padding: 0 8px;
+      padding: 0 ${size.s};
       cursor: pointer;
     `,
     logo: css`
@@ -68,10 +70,12 @@ const headerCss = {
     toggleNavButton: css`
       border-right: 1px solid #d3dae6;
       margin-left: -1px;
-      padding-right: 4px;
+      padding-right: ${size.xs};
     `,
   },
-};
+});
+
+type HeaderCss = ReturnType<typeof getHeaderCss>;
 
 const headerStrings = {
   logo: {
@@ -115,16 +119,17 @@ export interface Props {
 const LOCAL_STORAGE_IS_OPEN_KEY = 'PROJECT_NAVIGATION_OPEN' as const;
 const LOADING_DEBOUNCE_TIME = 80;
 
-const Logo = (
-  props: Pick<Props, 'application' | 'homeHref$' | 'loadingCount$' | 'prependBasePath'>
-) => {
+type LogoProps = Pick<Props, 'application' | 'homeHref$' | 'loadingCount$' | 'prependBasePath'> & {
+  logoCss: HeaderCss['logo'];
+};
+
+const Logo = (props: LogoProps) => {
   const loadingCount = useObservable(
     props.loadingCount$.pipe(debounceTime(LOADING_DEBOUNCE_TIME)),
     0
   );
 
   const homeHref = useObservable(props.homeHref$, '/app/home');
-  const { logo } = headerCss;
 
   let fullHref: string | undefined;
   if (homeHref) {
@@ -142,18 +147,18 @@ const Logo = (
   );
 
   return (
-    <span css={logo.container} data-test-subj="nav-header-logo">
+    <span css={props.logoCss.container} data-test-subj="nav-header-logo">
       {loadingCount === 0 ? (
         <EuiHeaderLogo
           iconType="logoElastic"
           onClick={navigateHome}
           href={fullHref}
-          css={logo}
+          css={props.logoCss}
           data-test-subj="globalLoadingIndicator-hidden"
           aria-label={headerStrings.logo.ariaLabel}
         />
       ) : (
-        <a onClick={navigateHome} href={fullHref} css={logo.spinner}>
+        <a onClick={navigateHome} href={fullHref} css={props.logoCss.spinner}>
           <EuiLoadingSpinner
             size="l"
             aria-hidden={false}
@@ -179,6 +184,9 @@ export const ProjectHeader = ({
   const toggleCollapsibleNavRef = createRef<HTMLButtonElement & { euiAnimate: () => void }>();
   const headerActionMenuMounter = useHeaderActionMenuMounter(observables.actionMenu$);
   const projectsUrl = useObservable(observables.projectsUrl$);
+  const { euiTheme } = useEuiTheme();
+  const headerCss = getHeaderCss(euiTheme);
+  const { logo: logoCss } = headerCss;
 
   return (
     <>
@@ -229,6 +237,7 @@ export const ProjectHeader = ({
                   application={application}
                   homeHref$={observables.homeHref$}
                   loadingCount$={observables.loadingCount$}
+                  logoCss={logoCss}
                 />
               </EuiHeaderSectionItem>
 

--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
@@ -68,6 +68,7 @@ const headerCss = {
     toggleNavButton: css`
       border-right: 1px solid #d3dae6;
       margin-left: -1px;
+      padding-right: 4px;
     `,
   },
 };

--- a/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.test.tsx
@@ -25,11 +25,13 @@ jest.mock('../../dashboard_listing/dashboard_listing', () => {
 });
 
 import { DashboardAppNoDataPage } from '../no_data/dashboard_app_no_data';
+const mockIsDashboardAppInNoDataState = jest.fn().mockResolvedValue(false);
 jest.mock('../no_data/dashboard_app_no_data', () => {
   const originalModule = jest.requireActual('../no_data/dashboard_app_no_data');
   return {
     __esModule: true,
     ...originalModule,
+    isDashboardAppInNoDataState: () => mockIsDashboardAppInNoDataState(),
     DashboardAppNoDataPage: jest.fn().mockReturnValue(null),
   };
 });
@@ -53,6 +55,7 @@ function mountWith({ props: incomingProps }: { props?: DashboardListingPageProps
 }
 
 test('renders analytics no data page when the user has no data view', async () => {
+  mockIsDashboardAppInNoDataState.mockResolvedValueOnce(true);
   pluginServices.getServices().data.dataViews.hasData.hasUserDataView = jest
     .fn()
     .mockResolvedValue(false);

--- a/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.tsx
@@ -42,12 +42,12 @@ export const DashboardListingPage = ({
     dashboardContentManagement: { findDashboards },
   } = pluginServices.getServices();
 
-  const [showNoDataPage, setShowNoDataPage] = useState<boolean>(false);
+  const [showNoDataPage, setShowNoDataPage] = useState<boolean | undefined>();
   useEffect(() => {
     let isMounted = true;
     (async () => {
       const isInNoDataState = await isDashboardAppInNoDataState();
-      if (isInNoDataState && isMounted) setShowNoDataPage(true);
+      setShowNoDataPage(isInNoDataState && isMounted);
     })();
     return () => {
       isMounted = false;
@@ -91,6 +91,10 @@ export const DashboardListingPage = ({
   }, [title, redirectTo, query, kbnUrlStateStorage, findDashboards]);
 
   const titleFilter = title ? `${title}` : '';
+
+  if (showNoDataPage === undefined) {
+    return null;
+  }
 
   return (
     <>

--- a/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
+++ b/x-pack/plugins/global_search_bar/public/components/search_bar.tsx
@@ -268,7 +268,7 @@ export const SearchBar: FC<SearchBarProps> = (opts) => {
 
   if (chromeStyle === 'project' && !isVisible) {
     return (
-      <EuiButtonIcon
+      <EuiHeaderSectionItemButton
         aria-label={i18nStrings.showSearchAriaText}
         buttonRef={visibilityButtonRef}
         color="text"


### PR DESCRIPTION
In this PR I fixed a few Chrome UI bugs. See the linked issue for details.

## Notes

### No space

I could not reproduce the issue. I see it centered on the screen

<img width="1385" alt="Screenshot 2023-08-14 at 11 54 41" src="https://github.com/elastic/kibana/assets/2854616/98a20a8f-b44c-42b0-a40b-4a28f7f22537">

### Navigation items repeat

I didn't fix that. This would be a requirement for the @elastic/platform-deployment-management team to provide a way to not render the header bar. Not entirely sure how that would be implemented, maybe a query params but then the user could potentially remove it from the URL. Maybe then through local storage?
There is also the problem that "Grok debugger" and "Painless lab" are not in the side nav and would be lost if we were to hide the full header bar in dev tools. Do we want to open an issue to track this work? cc @alisonelizabeth 

### No spacing around text

This occurs because we set `flush: left` to align the buttons on the left. If we remove that prop then there is space around the text but the buttons don't align with the drop down titles. That looks worst IMO so I decided to leave it as is.

### Sample data dropdown shows Canvas app

This has been fixed in https://github.com/elastic/kibana/pull/163740

Fixes https://github.com/elastic/kibana/issues/163701