### PR TITLE
[Infra UI] Fix filter popovers not being closed on trigger button click

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_inventory_switcher.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_inventory_switcher.tsx
@@ -31,7 +31,7 @@ export const WaffleInventorySwitcher: React.FC = () => {
   } = useWaffleOptionsContext();
   const [isOpen, setIsOpen] = useState(false);
   const closePopover = useCallback(() => setIsOpen(false), []);
-  const openPopover = useCallback(() => setIsOpen(true), []);
+  const togglePopover = useCallback(() => setIsOpen((currentIsOpen) => !currentIsOpen), []);
   const goToNodeType = useCallback(
     (targetNodeType: InventoryItemType) => {
       closePopover();
@@ -127,7 +127,7 @@ export const WaffleInventorySwitcher: React.FC = () => {
   const button = (
     <DropdownButton
       data-test-subj={'openInventorySwitcher'}
-      onClick={openPopover}
+      onClick={togglePopover}
       label={i18n.translate('xpack.infra.waffle.showLabel', { defaultMessage: 'Show' })}
       showKubernetesInfo={true}
     >

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/waffle_sort_controls.tsx
@@ -25,20 +25,15 @@ const LABELS = {
 export const WaffleSortControls = ({ sort, onChange }: Props) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const showPopover = useCallback(() => {
-    setIsOpen(true);
-  }, [setIsOpen]);
-
-  const closePopover = useCallback(() => {
-    setIsOpen(false);
-  }, [setIsOpen]);
+  const togglePopover = useCallback(() => setIsOpen((currentIsOpen) => !currentIsOpen), []);
+  const closePopover = useCallback(() => setIsOpen(false), []);
 
   const label = LABELS[sort.by];
 
   const button = (
     <DropdownButton
       label={i18n.translate('xpack.infra.waffle.sortLabel', { defaultMessage: 'Sort by' })}
-      onClick={showPopover}
+      onClick={togglePopover}
       data-test-subj={'waffleSortByDropdown'}
     >
       {label}

--- a/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_context_menu.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metrics_explorer/components/chart_context_menu.tsx
@@ -181,7 +181,7 @@ export const MetricsExplorerChartContextMenu: React.FC<Props> = ({
   ];
 
   const handleClose = () => setPopoverState(false);
-  const handleOpen = () => setPopoverState(true);
+  const togglePopover = () => setPopoverState((currentIsOpen) => !currentIsOpen);
   const actionAriaLabel = i18n.translate('xpack.infra.metricsExplorer.actionsLabel.aria', {
     defaultMessage: 'Actions for {grouping}',
     values: { grouping: series.id },
@@ -193,7 +193,7 @@ export const MetricsExplorerChartContextMenu: React.FC<Props> = ({
     <EuiButtonEmpty
       data-test-subj="infraMetricsExplorerChartContextMenuButton"
       contentProps={{ 'aria-label': actionAriaLabel }}
-      onClick={handleOpen}
+      onClick={togglePopover}
       size="s"
       iconType="arrowDown"
       iconSide="right"

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -197,6 +197,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.openTimeline();
         await pageObjects.infraHome.closeTimeline();
       });
+
+      it('toggles the inventory switcher', async () => {
+        await pageObjects.infraHome.toggleInventorySwitcher();
+      });
     });
 
     describe('alerts flyouts', () => {

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -171,9 +171,16 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       return timelineSelectorsVisible.every((visible) => !visible);
     },
 
-    async openInvenotrySwitcher() {
+    async openInventorySwitcher() {
       await testSubjects.click('openInventorySwitcher');
-      return await testSubjects.find('goToHost');
+      return await testSubjects.find('goToHost1');
+    },
+
+    async toggleInventorySwitcher() {
+      await testSubjects.click('openInventorySwitcher');
+      await testSubjects.find('goToHost');
+      await testSubjects.click('openInventorySwitcher');
+      return await testSubjects.missingOrFail('goToHost');
     },
 
     async goToHost() {


### PR DESCRIPTION
Fixes #96534 

## Summary

Fixes the bug with some popovers are not closed if their trigger buttons are clicked

*Bug demos from the original issue*
Inventory:
![](https://user-images.githubusercontent.com/4104278/113987390-a222e900-984e-11eb-872b-f12f5abe4540.gif)
Metrics Explorer
![](https://user-images.githubusercontent.com/4104278/113988929-3b9eca80-9850-11eb-859a-c639b89af8a5.gif)

### How to test

* Checkout the branch locally
* Goto "Inventory" section
* Click on "Hosts" filter
* Make sure popover opens
* Click on "Hosts" again
* Make sure the popover closes
* Check the same for "Sort by" filter
* Check the same for chart "Actions"  in "Metrics Explorer"

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->