### PR TITLE
[8.9] [ELSER] Remove missing type hints related to the inference config (#162602)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@elastic/apm-rum-react": "^1.4.2",
     "@elastic/charts": "59.0.0",
     "@elastic/datemath": "5.0.3",
-    "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.8.0-canary.2",
+    "@elastic/elasticsearch": "npm:@elastic/elasticsearch@8.9.0",
     "@elastic/ems-client": "8.4.0",
     "@elastic/eui": "82.1.0",
     "@elastic/filesaver": "1.1.2",

--- a/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
@@ -27,7 +27,7 @@ export interface FieldDescriptor {
   metadata_field?: boolean;
   fixedInterval?: string[];
   timeZone?: string[];
-  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge';
+  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge' | 'position';
   timeSeriesDimension?: boolean;
 }
 

--- a/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
+++ b/src/plugins/data_views/server/fetcher/index_patterns_fetcher.ts
@@ -27,7 +27,7 @@ export interface FieldDescriptor {
   metadata_field?: boolean;
   fixedInterval?: string[];
   timeZone?: string[];
-  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge' | 'position';
+  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge';
   timeSeriesDimension?: boolean;
 }
 

--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
@@ -122,12 +122,16 @@ export function readFieldCapsResponse(
         return agg;
       }
 
-      let timeSeriesMetricType: 'gauge' | 'counter' | undefined;
+      let timeSeriesMetricType: 'gauge' | 'counter' | 'position' | undefined;
       if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'gauge') {
         timeSeriesMetricType = 'gauge';
       }
       if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'counter') {
         timeSeriesMetricType = 'counter';
+      }
+
+      if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'position') {
+        timeSeriesMetricType = 'position';
       }
       const esType = types[0];
       const field = {

--- a/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
+++ b/src/plugins/data_views/server/fetcher/lib/field_capabilities/field_caps_response.ts
@@ -122,16 +122,12 @@ export function readFieldCapsResponse(
         return agg;
       }
 
-      let timeSeriesMetricType: 'gauge' | 'counter' | 'position' | undefined;
+      let timeSeriesMetricType: 'gauge' | 'counter' | undefined;
       if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'gauge') {
         timeSeriesMetricType = 'gauge';
       }
       if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'counter') {
         timeSeriesMetricType = 'counter';
-      }
-
-      if (timeSeriesMetricProp.length === 1 && timeSeriesMetricProp[0] === 'position') {
-        timeSeriesMetricType = 'position';
       }
       const esType = types[0];
       const field = {

--- a/src/plugins/data_views/server/rest_api_routes/route_types.ts
+++ b/src/plugins/data_views/server/rest_api_routes/route_types.ts
@@ -98,7 +98,7 @@ export type FieldSpecRestResponse = DataViewFieldBaseRestResponse & {
   fixedInterval?: string[];
   timeZone?: string[];
   timeSeriesDimension?: boolean;
-  timeSeriesMetric?: 'histogram' | 'summary' | 'gauge' | 'counter';
+  timeSeriesMetric?: 'histogram' | 'summary' | 'gauge' | 'counter' | 'position';
   shortDotsEnable?: boolean;
   isMapped?: boolean;
   parentName?: string;
@@ -162,6 +162,6 @@ export interface FieldDescriptorRestResponse {
   metadata_field?: boolean;
   fixedInterval?: string[];
   timeZone?: string[];
-  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge';
+  timeSeriesMetric?: 'histogram' | 'summary' | 'counter' | 'gauge' | 'position';
   timeSeriesDimension?: boolean;
 }

--- a/x-pack/plugins/enterprise_search/server/lib/analytics/fetch_analytics_collection.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/analytics/fetch_analytics_collection.ts
@@ -18,7 +18,7 @@ export const fetchAnalyticsCollections = async (
 ): Promise<AnalyticsCollection[]> => {
   try {
     const collections = await client.asCurrentUser.searchApplication.getBehavioralAnalytics({
-      name: query,
+      name: [query],
     });
 
     return Object.keys(collections).map((value) => {

--- a/x-pack/plugins/enterprise_search/server/lib/ml/start_ml_model_download.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/start_ml_model_download.ts
@@ -50,7 +50,6 @@ export const startMlModelDownload = async (
 
   // we're not downloaded yet - let's initiate that...
   const putRequest: MlPutTrainedModelRequest = {
-    // @ts-expect-error @elastic-elasticsearch inference_config can be optional
     body: {
       input: {
         field_names: ['text_field'],

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -98,7 +98,7 @@ export type IndexPatternField = FieldSpec & {
    * Map of fields which can be used, but may fail partially (ranked lower than others)
    */
   partiallyApplicableFunctions?: Partial<Record<string, boolean>>;
-  timeSeriesMetric?: 'histogram' | 'summary' | 'gauge' | 'counter';
+  timeSeriesMetric?: 'histogram' | 'summary' | 'gauge' | 'counter' | 'position';
   timeSeriesRollup?: boolean;
   meta?: boolean;
   runtime?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,12 +1524,12 @@
     "@elastic/transport" "^8.3.1"
     tslib "^2.4.0"
 
-"@elastic/elasticsearch@npm:@elastic/elasticsearch-canary@8.8.0-canary.2":
-  version "8.8.0-canary.2"
-  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch-canary/-/elasticsearch-canary-8.8.0-canary.2.tgz#10b5699541d644797b33c7e24058d2e55367d88d"
-  integrity sha512-UxH8YUxcsqHXGh4t2PjuL0q03XunF9vCLHPAs9r+fQcaPXpNbEuv9jbNGXv/9TLyeAKYEgcq9Xm0p0Nk/Mh0lQ==
+"@elastic/elasticsearch@npm:@elastic/elasticsearch@8.9.0":
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/@elastic/elasticsearch/-/elasticsearch-8.9.0.tgz#d132021c6c12e4171fe14371609a5c69b535edd4"
+  integrity sha512-UyolnzjOYTRL2966TYS3IoJP4tQbvak/pmYmbP3JdphD53RjkyVDdxMpTBv+2LcNBRrvYPTzxQbpRW/nGSXA9g==
   dependencies:
-    "@elastic/transport" "^8.3.1"
+    "@elastic/transport" "^8.3.2"
     tslib "^2.4.0"
 
 "@elastic/ems-client@8.4.0":
@@ -1721,6 +1721,18 @@
     secure-json-parse "^2.4.0"
     tslib "^2.4.0"
     undici "^5.5.1"
+
+"@elastic/transport@^8.3.2":
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/@elastic/transport/-/transport-8.3.2.tgz#295e91f43e3a60a839f998ac3090a83ddb441592"
+  integrity sha512-ZiBYRVPj6pwYW99fueyNU4notDf7ZPs7Ix+4T1btIJsKJmeaORIItIfs+0O7KV4vV+DcvyMhkY1FXQx7kQOODw==
+  dependencies:
+    debug "^4.3.4"
+    hpagent "^1.0.0"
+    ms "^2.1.3"
+    secure-json-parse "^2.4.0"
+    tslib "^2.4.0"
+    undici "^5.22.1"
 
 "@emotion/babel-plugin-jsx-pragmatic@^0.2.1":
   version "0.2.1"
@@ -27986,6 +27998,13 @@ undici@^5.11.0, undici@^5.5.1:
   version "5.20.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.20.0.tgz#6327462f5ce1d3646bcdac99da7317f455bcc263"
   integrity sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==
+  dependencies:
+    busboy "^1.6.0"
+
+undici@^5.22.1:
+  version "5.22.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.1.tgz#877d512effef2ac8be65e695f3586922e1a57d7b"
+  integrity sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==
   dependencies:
     busboy "^1.6.0"
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[ELSER] Remove missing type hints related to the inference config (#162602)](https://github.com/elastic/kibana/pull/162602)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Saikat Sarkar","email":"132922331+saikatsarkar056@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-07-31T14:26:34Z","message":"[ELSER] Remove missing type hints related to the inference config (#162602)\n\nThis pr is related to issue:\r\nhttps://github.com/elastic/enterprise-search-team/issues/4432\r\n\r\nThis change involves removing hints related to the inference_config\r\nattribute\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bf5c2703f9794767b8b004304f250f02d346a01c","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v8.10.0"],"number":162602,"url":"https://github.com/elastic/kibana/pull/162602","mergeCommit":{"message":"[ELSER] Remove missing type hints related to the inference config (#162602)\n\nThis pr is related to issue:\r\nhttps://github.com/elastic/enterprise-search-team/issues/4432\r\n\r\nThis change involves removing hints related to the inference_config\r\nattribute\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bf5c2703f9794767b8b004304f250f02d346a01c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/162602","number":162602,"mergeCommit":{"message":"[ELSER] Remove missing type hints related to the inference config (#162602)\n\nThis pr is related to issue:\r\nhttps://github.com/elastic/enterprise-search-team/issues/4432\r\n\r\nThis change involves removing hints related to the inference_config\r\nattribute\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"bf5c2703f9794767b8b004304f250f02d346a01c"}}]}] BACKPORT-->