### PR TITLE
[ResponseOps][Alerting] Unskips alerting serverless tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/helpers/alerting_api_helper.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/helpers/alerting_api_helper.ts
@@ -110,7 +110,7 @@ export async function createEsQueryRule({
       name,
       rule_type_id: ruleTypeId,
       actions,
-      ...(notifyWhen ? { notify_when: notifyWhen, throttle: '1m' } : {}),
+      ...(notifyWhen ? { notify_when: notifyWhen, throttle: '5m' } : {}),
     });
   return body;
 }
@@ -173,11 +173,11 @@ export async function runRule({
   supertest: SuperTest<Test>;
   ruleId: string;
 }) {
-  const { body } = await supertest
+  const response = await supertest
     .post(`/internal/alerting/rule/${ruleId}/_run_soon`)
     .set('kbn-xsrf', 'foo')
     .set('x-elastic-internal-origin', 'foo');
-  return body;
+  return response;
 }
 
 export async function muteRule({

--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/helpers/alerting_wait_for_helpers.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/helpers/alerting_wait_for_helpers.ts
@@ -252,15 +252,15 @@ export async function waitForDisabled({
   );
 }
 
-export async function waitForEventLog({
+export async function waitForExecutionEventLog({
   esClient,
-  provider,
   filter,
+  ruleId,
   num = 1,
 }: {
   esClient: Client;
-  provider: string;
   filter: Date;
+  ruleId: string;
   num?: number;
 }): Promise<SearchResponse> {
   return pRetry(
@@ -273,8 +273,15 @@ export async function waitForEventLog({
               filter: [
                 {
                   term: {
+                    'rule.id': {
+                      value: ruleId,
+                    },
+                  },
+                },
+                {
+                  term: {
                     'event.provider': {
-                      value: provider,
+                      value: 'alerting',
                     },
                   },
                 },
@@ -324,10 +331,10 @@ export async function waitForNumRuleRuns({
         if (resp.status !== 204) {
           throw new Error(`Expected ${resp.status} to equal 204`);
         }
-        await waitForEventLog({
+        await waitForExecutionEventLog({
           esClient,
-          provider: 'alerting',
           filter: testStart,
+          ruleId,
           num: i + 1,
         });
         await waitForAllTasksIdle({ esClient, filter: testStart });

--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
@@ -27,6 +27,7 @@ import {
   waitForDisabled,
   waitForDocumentInIndex,
   waitForEventLog,
+  waitForNumRuleRuns,
 } from './helpers/alerting_wait_for_helpers';
 
 export default function ({ getService }: FtrProviderContext) {
@@ -34,7 +35,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esClient = getService('es');
   const esDeleteAllIndices = getService('esDeleteAllIndices');
 
-  describe.skip('Alerting rules', () => {
+  describe('Alerting rules', () => {
     const RULE_TYPE_ID = '.es-query';
     const ALERT_ACTION_INDEX = 'alert-action-es-query';
     let actionId: string;
@@ -351,7 +352,7 @@ export default function ({ getService }: FtrProviderContext) {
         consumer: 'alerts',
         name: 'always fire',
         ruleTypeId: RULE_TYPE_ID,
-        schedule: { interval: '5s' },
+        schedule: { interval: '1m' },
         notifyWhen: 'onThrottleInterval',
         params: {
           size: 100,
@@ -389,13 +390,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(ruleId).not.to.be(undefined);
 
       // Wait until alerts ran at least 3 times before disabling the alert and waiting for tasks to finish
-      const eventLogResp = await waitForEventLog({
-        esClient,
-        provider: 'alerting',
-        filter: testStart,
-        num: 3,
-      });
-      expect(eventLogResp.hits.hits.length >= 3).to.be(true);
+      await waitForNumRuleRuns({ supertest, numOfRuns: 3, ruleId, esClient, testStart });
 
       await disableRule({
         supertest,
@@ -431,7 +426,7 @@ export default function ({ getService }: FtrProviderContext) {
         consumer: 'alerts',
         name: 'always fire',
         ruleTypeId: RULE_TYPE_ID,
-        schedule: { interval: '5s' },
+        schedule: { interval: '1m' },
         params: {
           size: 100,
           thresholdComparator: '>',
@@ -463,7 +458,7 @@ export default function ({ getService }: FtrProviderContext) {
             },
             frequency: {
               notify_when: 'onThrottleInterval',
-              throttle: '1m',
+              throttle: '5m',
               summary: false,
             },
           },
@@ -473,13 +468,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(ruleId).not.to.be(undefined);
 
       // Wait until alerts ran at least 3 times before disabling the alert and waiting for tasks to finish
-      const eventLogResp = await waitForEventLog({
-        esClient,
-        provider: 'alerting',
-        filter: testStart,
-        num: 3,
-      });
-      expect(eventLogResp.hits.hits.length >= 3).to.be(true);
+      await waitForNumRuleRuns({ supertest, numOfRuns: 3, ruleId, esClient, testStart });
 
       await disableRule({
         supertest,
@@ -661,7 +650,6 @@ export default function ({ getService }: FtrProviderContext) {
         consumer: 'alerts',
         name: 'always fire',
         ruleTypeId: RULE_TYPE_ID,
-        schedule: { interval: '5s' },
         params: {
           size: 100,
           thresholdComparator: '>',
@@ -714,13 +702,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       // Wait until alerts schedule actions twice to ensure actions had a chance to skip
       // execution once before disabling the alert and waiting for tasks to finish
-      const eventLogResp = await waitForEventLog({
-        esClient,
-        provider: 'alerting',
-        filter: testStart,
-        num: 2,
-      });
-      expect(eventLogResp.hits.hits.length >= 2).to.be(true);
+      await waitForNumRuleRuns({ supertest, numOfRuns: 2, ruleId, esClient, testStart });
 
       await disableRule({
         supertest,
@@ -758,7 +740,6 @@ export default function ({ getService }: FtrProviderContext) {
         consumer: 'alerts',
         name: 'always fire',
         ruleTypeId: RULE_TYPE_ID,
-        schedule: { interval: '5s' },
         params: {
           size: 100,
           thresholdComparator: '>',
@@ -812,13 +793,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       // Wait until alerts schedule actions twice to ensure actions had a chance to skip
       // execution once before disabling the alert and waiting for tasks to finish
-      const eventLogResp = await waitForEventLog({
-        esClient,
-        provider: 'alerting',
-        filter: testStart,
-        num: 2,
-      });
-      expect(eventLogResp.hits.hits.length >= 2).to.be(true);
+      await waitForNumRuleRuns({ supertest, numOfRuns: 2, ruleId, esClient, testStart });
 
       await disableRule({
         supertest,

--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
@@ -26,7 +26,7 @@ import {
   waitForAllTasksIdle,
   waitForDisabled,
   waitForDocumentInIndex,
-  waitForEventLog,
+  waitForExecutionEventLog,
   waitForNumRuleRuns,
 } from './helpers/alerting_wait_for_helpers';
 
@@ -149,10 +149,10 @@ export default function ({ getService }: FtrProviderContext) {
         tags: '',
       });
 
-      const eventLogResp = await waitForEventLog({
+      const eventLogResp = await waitForExecutionEventLog({
         esClient,
-        provider: 'alerting',
         filter: testStart,
+        ruleId,
       });
       expect(eventLogResp.hits.hits.length).to.be(1);
 
@@ -605,10 +605,10 @@ export default function ({ getService }: FtrProviderContext) {
         ruleId,
       });
 
-      const eventLogResp = await waitForEventLog({
+      const eventLogResp = await waitForExecutionEventLog({
         esClient,
-        provider: 'alerting',
         filter: testStart,
+        ruleId,
         num: 2,
       });
       expect(eventLogResp.hits.hits.length).to.be(2);


### PR DESCRIPTION
Related to https://github.com/elastic/response-ops-team/issues/124

## Summary

Fixes tests that had an interval less than 1m
