### PR TITLE
[Security Solution] Reduce Rules Management e2e flakiness

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_authorization.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_authorization.cy.ts
@@ -14,7 +14,6 @@ import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { tag } from '../../../tags';
 
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
-import { waitForRulesTableToBeLoaded } from '../../../tasks/alerts_detection_rules';
 import { createAndInstallMockedPrebuiltRules } from '../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState, deleteAlertsAndRules } from '../../../tasks/common';
 import { login, waitForPageWithoutDateRange } from '../../../tasks/login';
@@ -66,7 +65,6 @@ describe(
       resetRulesTableState();
       deleteAlertsAndRules();
       cy.task('esArchiverResetKibana');
-      waitForRulesTableToBeLoaded();
       createAndInstallMockedPrebuiltRules({ rules: [OUTDATED_RULE_1, OUTDATED_RULE_2] });
     });
 
@@ -83,7 +81,6 @@ describe(
         // Now login with read-only user in preparation for test
         createAndInstallMockedPrebuiltRules({ rules: [RULE_1, RULE_2], installToKibana: false });
         loadPageAsReadOnlyUser(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToBeLoaded();
       });
 
       it('should not be able to install prebuilt rules', () => {
@@ -111,7 +108,6 @@ describe(
         });
         // Now login with read-only user in preparation for test
         loadPageAsReadOnlyUser(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToBeLoaded();
       });
 
       it('should not be able to upgrade prebuilt rules', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
@@ -8,7 +8,6 @@
 import { tag } from '../../../tags';
 
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
-import { waitForRulesTableToBeLoaded } from '../../../tasks/alerts_detection_rules';
 import { createAndInstallMockedPrebuiltRules } from '../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState, deleteAlertsAndRules, reload } from '../../../tasks/common';
 import { login, visitWithoutDateRange } from '../../../tasks/login';
@@ -50,7 +49,6 @@ describe(
       });
       beforeEach(() => {
         createAndInstallMockedPrebuiltRules({ rules: [RULE_1, RULE_2], installToKibana: false });
-        waitForRulesTableToBeLoaded();
       });
 
       it('installing prebuilt rules one by one', () => {
@@ -114,7 +112,6 @@ describe(
           rules: [UPDATED_RULE_1, UPDATED_RULE_2],
           installToKibana: false,
         });
-        waitForRulesTableToBeLoaded();
         reload();
       });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
@@ -10,8 +10,7 @@ import { tag } from '../../../tags';
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
 import { createAndInstallMockedPrebuiltRules } from '../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState, deleteAlertsAndRules, reload } from '../../../tasks/common';
-import { login, visitWithoutDateRange } from '../../../tasks/login';
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../urls/navigation';
+import { login, visitSecurityDetectionRulesPage } from '../../../tasks/login';
 import {
   addElasticRulesButtonClick,
   assertRuleAvailableForInstallAndInstallOne,
@@ -35,7 +34,7 @@ describe(
       deleteAlertsAndRules();
       cy.task('esArchiverResetKibana');
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
     });
 
     describe('Installation of prebuilt rules - Should fail gracefully with toast error message when', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
@@ -25,8 +25,7 @@ import {
   createAndInstallMockedPrebuiltRules,
 } from '../../../tasks/api_calls/prebuilt_rules';
 import { resetRulesTableState, deleteAlertsAndRules, reload } from '../../../tasks/common';
-import { login, visitWithoutDateRange } from '../../../tasks/login';
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../urls/navigation';
+import { login, visitSecurityDetectionRulesPage } from '../../../tasks/login';
 import {
   addElasticRulesButtonClick,
   assertRuleAvailableForInstallAndInstallOne,
@@ -50,7 +49,7 @@ describe(
       deleteAlertsAndRules();
       cy.task('esArchiverResetKibana');
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
     });
 
     describe('Installation of prebuilt rules package via Fleet', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
@@ -20,7 +20,6 @@ import {
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
   TOASTER,
 } from '../../../screens/alerts_detection_rules';
-import { waitForRulesTableToBeLoaded } from '../../../tasks/alerts_detection_rules';
 import {
   getRuleAssets,
   createAndInstallMockedPrebuiltRules,
@@ -60,7 +59,6 @@ describe(
         cy.intercept('POST', '/api/fleet/epm/packages/security_detection_engine/*').as(
           'installPackage'
         );
-        waitForRulesTableToBeLoaded();
       });
 
       it('should install package from Fleet in the background', () => {
@@ -150,7 +148,6 @@ describe(
       });
       beforeEach(() => {
         createAndInstallMockedPrebuiltRules({ rules: [RULE_1, RULE_2], installToKibana: false });
-        waitForRulesTableToBeLoaded();
         cy.intercept('POST', '/internal/detection_engine/prebuilt_rules/installation/_perform').as(
           'installPrebuiltRules'
         );
@@ -232,7 +229,6 @@ describe(
           rules: [UPDATED_RULE_1, UPDATED_RULE_2],
           installToKibana: false,
         });
-        waitForRulesTableToBeLoaded();
         reload();
       });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
@@ -14,14 +14,13 @@ import {
   ADD_ELASTIC_RULES_BTN,
   RULES_EMPTY_PROMPT,
   RULES_MONITORING_TAB,
-  RULES_ROW,
-  RULES_MANAGEMENT_TABLE,
   RULE_SWITCH,
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
   INSTALL_ALL_RULES_BUTTON,
 } from '../../../screens/alerts_detection_rules';
 import {
   deleteFirstRule,
+  getRulesManagementTableRows,
   selectAllRules,
   selectRulesByName,
   waitForPrebuiltDetectionRulesToBeLoaded,
@@ -69,7 +68,7 @@ describe('Prebuilt rules', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('Alerts rules, prebuilt rules', () => {
     it('Loads prebuilt rules', () => {
       // Check that the rules table contains rules
-      cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW).should('have.length.gte', 1);
+      getRulesManagementTableRows().should('have.length.gte', 1);
 
       // Check the correct count of prebuilt rules is displayed
       getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
@@ -23,7 +23,7 @@ import {
 import {
   deleteFirstRule,
   selectAllRules,
-  selectNumberOfRules,
+  selectRulesByName,
   waitForPrebuiltDetectionRulesToBeLoaded,
   waitForRuleToUpdate,
 } from '../../../tasks/alerts_detection_rules';
@@ -111,8 +111,7 @@ describe('Prebuilt rules', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
       });
 
       it('Does not allow to delete one rule when more than one is selected', () => {
-        const numberOfRulesToBeSelected = 2;
-        selectNumberOfRules(numberOfRulesToBeSelected);
+        selectAllRules();
 
         cy.get(COLLAPSED_ACTION_BTN).each((collapsedItemActionBtn) => {
           cy.wrap(collapsedItemActionBtn).should('have.attr', 'disabled');
@@ -153,16 +152,16 @@ describe('Prebuilt rules', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
       it('Deletes and recovers more than one rule', () => {
         getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-          const numberOfRulesToBeSelected = 2;
+          const rulesToDelete = ['Test rule 1', 'Test rule 2'] as const;
           const expectedNumberOfRulesAfterDeletion = availablePrebuiltRulesCount - 2;
           const expectedNumberOfRulesAfterRecovering = availablePrebuiltRulesCount;
 
-          selectNumberOfRules(numberOfRulesToBeSelected);
+          selectRulesByName(rulesToDelete);
           deleteSelectedRules();
 
           cy.get(ADD_ELASTIC_RULES_BTN).should(
             'have.text',
-            `Add Elastic rules${numberOfRulesToBeSelected}`
+            `Add Elastic rules${rulesToDelete.length}`
           );
           cy.get(ELASTIC_RULES_BTN).should(
             'have.text',

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
@@ -9,10 +9,7 @@ import { tag } from '../../../tags';
 
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
 import { ADD_ELASTIC_RULES_BTN, RULES_UPDATES_TAB } from '../../../screens/alerts_detection_rules';
-import {
-  deleteFirstRule,
-  waitForRulesTableToBeLoaded,
-} from '../../../tasks/alerts_detection_rules';
+import { deleteFirstRule, waitForRulesTableToShow } from '../../../tasks/alerts_detection_rules';
 import {
   installAllPrebuiltRulesRequest,
   createAndInstallMockedPrebuiltRules,
@@ -46,7 +43,8 @@ describe(
     describe('No notifications', () => {
       it('should NOT display install or update notifications when no prebuilt assets and no rules are installed', () => {
         visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToBeLoaded();
+        waitForRulesTableToShow();
+
         // TODO: test plan asserts "should NOT see a CTA to install prebuilt rules"
         // but current behavior is to always show the CTA, even with no prebuilt rule assets installed
         // Update that behaviour and then update this test.
@@ -56,7 +54,6 @@ describe(
       it('should NOT display install or update notifications when latest rules are installed', () => {
         createAndInstallMockedPrebuiltRules({ rules: [RULE_1], installToKibana: true });
         visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToBeLoaded();
 
         /* Assert that there are no installation or update notifications */
         /* Add Elastic Rules button should not contain a number badge */
@@ -102,7 +99,6 @@ describe(
               installToKibana: false,
             });
             visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-            waitForRulesTableToBeLoaded();
           });
         });
 
@@ -140,7 +136,6 @@ describe(
             });
             createAndInstallMockedPrebuiltRules({ rules: [UPDATED_RULE], installToKibana: false });
             visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-            waitForRulesTableToBeLoaded();
             reload();
           });
         });
@@ -175,7 +170,6 @@ describe(
               installToKibana: false,
             });
             visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-            waitForRulesTableToBeLoaded();
           });
         });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
@@ -8,8 +8,12 @@
 import { tag } from '../../../tags';
 
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
-import { ADD_ELASTIC_RULES_BTN, RULES_UPDATES_TAB } from '../../../screens/alerts_detection_rules';
-import { deleteFirstRule, waitForRulesTableToShow } from '../../../tasks/alerts_detection_rules';
+import {
+  ADD_ELASTIC_RULES_BTN,
+  ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN,
+  RULES_UPDATES_TAB,
+} from '../../../screens/alerts_detection_rules';
+import { deleteFirstRule } from '../../../tasks/alerts_detection_rules';
 import {
   installAllPrebuiltRulesRequest,
   createAndInstallMockedPrebuiltRules,
@@ -43,7 +47,8 @@ describe(
     describe('No notifications', () => {
       it('should NOT display install or update notifications when no prebuilt assets and no rules are installed', () => {
         visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToShow();
+
+        cy.get(ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN).should('be.visible');
 
         // TODO: test plan asserts "should NOT see a CTA to install prebuilt rules"
         // but current behavior is to always show the CTA, even with no prebuilt rule assets installed

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
@@ -24,8 +24,7 @@ import {
   reload,
   deletePrebuiltRulesAssets,
 } from '../../../tasks/common';
-import { login, visitWithoutDateRange } from '../../../tasks/login';
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../urls/navigation';
+import { login, visitSecurityDetectionRulesPage } from '../../../tasks/login';
 
 const RULE_1 = createRuleAssetSavedObject({
   name: 'Test rule 1',
@@ -46,7 +45,7 @@ describe(
 
     describe('No notifications', () => {
       it('should NOT display install or update notifications when no prebuilt assets and no rules are installed', () => {
-        visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+        visitSecurityDetectionRulesPage();
 
         cy.get(ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN).should('be.visible');
 
@@ -58,7 +57,7 @@ describe(
 
       it('should NOT display install or update notifications when latest rules are installed', () => {
         createAndInstallMockedPrebuiltRules({ rules: [RULE_1], installToKibana: true });
-        visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+        visitSecurityDetectionRulesPage();
 
         /* Assert that there are no installation or update notifications */
         /* Add Elastic Rules button should not contain a number badge */
@@ -75,7 +74,7 @@ describe(
 
       describe('Rules installation notification when no rules have been installed', () => {
         beforeEach(() => {
-          visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+          visitSecurityDetectionRulesPage();
         });
 
         it('should notify user about prebuilt rules available for installation', () => {
@@ -103,7 +102,7 @@ describe(
               rules: [RULE_2, RULE_3],
               installToKibana: false,
             });
-            visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+            visitSecurityDetectionRulesPage();
           });
         });
 
@@ -140,7 +139,7 @@ describe(
               version: 2,
             });
             createAndInstallMockedPrebuiltRules({ rules: [UPDATED_RULE], installToKibana: false });
-            visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+            visitSecurityDetectionRulesPage();
             reload();
           });
         });
@@ -174,7 +173,7 @@ describe(
               rules: [RULE_2, UPDATED_RULE],
               installToKibana: false,
             });
-            visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+            visitSecurityDetectionRulesPage();
           });
         });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -78,7 +78,7 @@ import {
   deleteRuleFromDetailsPage,
   editFirstRule,
   goToRuleDetails,
-  selectNumberOfRules,
+  selectRulesByName,
 } from '../../../tasks/alerts_detection_rules';
 import { deleteSelectedRules } from '../../../tasks/rules_bulk_actions';
 import { createRule } from '../../../tasks/api_calls/rules';
@@ -242,9 +242,18 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
     context('Deletion', () => {
       beforeEach(() => {
         deleteAlertsAndRules();
-        createRule(getNewRule({ rule_id: 'rule1', enabled: true, max_signals: 500 }));
-        createRule(getNewOverrideRule({ rule_id: 'rule2', enabled: true, max_signals: 500 }));
-        createRule(getExistingRule({ rule_id: 'rule3', enabled: true }));
+        createRule(
+          getNewRule({ rule_id: 'rule1', name: 'New Rule Test', enabled: true, max_signals: 500 })
+        );
+        createRule(
+          getNewOverrideRule({
+            rule_id: 'rule2',
+            name: 'Override Rule',
+            enabled: true,
+            max_signals: 500,
+          })
+        );
+        createRule(getExistingRule({ rule_id: 'rule3', name: 'Rule 1', enabled: true }));
         login();
         visit(DETECTIONS_RULE_MANAGEMENT_URL);
       });
@@ -281,12 +290,13 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
         cy.get(RULES_MANAGEMENT_TABLE)
           .find(RULES_ROW)
           .then((rules) => {
+            const rulesToDelete = ['New Rule Test', 'Override Rule'] as const;
             const initialNumberOfRules = rules.length;
             const numberOfRulesToBeDeleted = 2;
             const expectedNumberOfRulesAfterDeletion =
               initialNumberOfRules - numberOfRulesToBeDeleted;
 
-            selectNumberOfRules(numberOfRulesToBeDeleted);
+            selectRulesByName(rulesToDelete);
             deleteSelectedRules();
 
             cy.get(RULES_MANAGEMENT_TABLE)

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -85,7 +85,7 @@ import {
 import { deleteSelectedRules } from '../../../tasks/rules_bulk_actions';
 import { createRule } from '../../../tasks/api_calls/rules';
 import { createTimeline } from '../../../tasks/api_calls/timelines';
-import { cleanKibana, deleteAlertsAndRules, deleteConnectors } from '../../../tasks/common';
+import { deleteAlertsAndRules, deleteConnectors } from '../../../tasks/common';
 import { addEmailConnectorAndRuleAction } from '../../../tasks/common/rule_actions';
 import {
   createAndEnableRule,
@@ -111,16 +111,12 @@ import {
   waitForTheRuleToBeExecuted,
 } from '../../../tasks/create_new_rule';
 import { saveEditedRule } from '../../../tasks/edit_rule';
-import { login, visit } from '../../../tasks/login';
+import { login, visit, visitSecurityDetectionRulesPage } from '../../../tasks/login';
 import { enablesRule, getDetails } from '../../../tasks/rule_details';
 
-import { RULE_CREATION, DETECTIONS_RULE_MANAGEMENT_URL } from '../../../urls/navigation';
+import { RULE_CREATION } from '../../../urls/navigation';
 
 describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
-  before(() => {
-    cleanKibana();
-  });
-
   beforeEach(() => {
     deleteAlertsAndRules();
   });
@@ -257,7 +253,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
         );
         createRule(getExistingRule({ rule_id: 'rule3', name: 'Rule 1', enabled: false }));
         login();
-        visit(DETECTIONS_RULE_MANAGEMENT_URL);
+        visitSecurityDetectionRulesPage();
       });
 
       it('Deletes one rule', () => {
@@ -354,7 +350,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
         deleteConnectors();
         createRule(getExistingRule({ rule_id: 'rule1', enabled: true }));
         login();
-        visit(DETECTIONS_RULE_MANAGEMENT_URL);
+        visitSecurityDetectionRulesPage();
       });
 
       it('Only modifies rule active status on enable/disable', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -79,7 +79,7 @@ import {
   expectManagementTableRules,
   getRulesManagementTableRows,
   goToRuleDetails,
-  goToRuleDetailsPageFor,
+  goToTheRuleDetailsOf,
   selectRulesByName,
 } from '../../../tasks/alerts_detection_rules';
 import { deleteSelectedRules } from '../../../tasks/rules_bulk_actions';
@@ -319,7 +319,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
           const initialNumberOfRules = rules.length;
           const expectedNumberOfRulesAfterDeletion = initialNumberOfRules - 1;
 
-          goToRuleDetailsPageFor('New Rule Test');
+          goToTheRuleDetailsOf('New Rule Test');
           cy.intercept('POST', '/api/detection_engine/rules/_bulk_delete').as('deleteRule');
 
           deleteRuleFromDetailsPage();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
@@ -15,8 +15,6 @@ import {
   CUSTOM_RULES_BTN,
   RISK_SCORE,
   RULE_NAME,
-  RULES_ROW,
-  RULES_MANAGEMENT_TABLE,
   RULE_SWITCH,
   SEVERITY,
 } from '../../../screens/alerts_detection_rules';
@@ -52,7 +50,10 @@ import {
   EDIT_RULE_SETTINGS_LINK,
 } from '../../../screens/rule_details';
 
-import { goToRuleDetails } from '../../../tasks/alerts_detection_rules';
+import {
+  getRulesManagementTableRows,
+  goToRuleDetails,
+} from '../../../tasks/alerts_detection_rules';
 import { postDataView } from '../../../tasks/common';
 import {
   createAndEnableRule,
@@ -100,7 +101,7 @@ describe('Custom query rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, ()
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 
-      cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW).should('have.length', expectedNumberOfRules);
+      getRulesManagementTableRows().should('have.length', expectedNumberOfRules);
       cy.get(RULE_NAME).should('have.text', rule.name);
       cy.get(RISK_SCORE).should('have.text', rule.risk_score);
       cy.get(SEVERITY).should('have.text', 'High');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
@@ -62,9 +62,9 @@ import {
   duplicateFirstRule,
   duplicateRuleFromMenu,
   goToRuleDetails,
-  selectNumberOfRules,
   checkDuplicatedRule,
   expectNumberOfRules,
+  selectAllRules,
 } from '../../../tasks/alerts_detection_rules';
 import { duplicateSelectedRulesWithExceptions } from '../../../tasks/rules_bulk_actions';
 import { createRule } from '../../../tasks/api_calls/rules';
@@ -555,7 +555,7 @@ describe('indicator match', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () =>
       });
 
       it("Allows the rule to be duplicated from the table's bulk actions", () => {
-        selectNumberOfRules(1);
+        selectAllRules();
         duplicateSelectedRulesWithExceptions();
         checkDuplicatedRule();
       });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
@@ -15,7 +15,6 @@ import {
   RULE_NAME,
 } from '../../../../screens/alerts_detection_rules';
 import { VALUE_LISTS_MODAL_ACTIVATOR } from '../../../../screens/lists';
-import { waitForRulesTableToBeLoaded } from '../../../../tasks/alerts_detection_rules';
 import { createRule } from '../../../../tasks/api_calls/rules';
 import { cleanKibana } from '../../../../tasks/common';
 import {
@@ -36,7 +35,6 @@ describe('All rules - read only', { tags: tag.ESS }, () => {
   beforeEach(() => {
     login(ROLES.reader);
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL, ROLES.reader);
-    waitForRulesTableToBeLoaded();
     cy.get(RULE_NAME).should('have.text', getNewRule().name);
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
@@ -29,7 +29,7 @@ import { SECURITY_DETECTIONS_RULES_URL } from '../../../../urls/navigation';
 describe('All rules - read only', { tags: tag.ESS }, () => {
   before(() => {
     cleanKibana();
-    createRule(getNewRule({ rule_id: '1' }));
+    createRule(getNewRule({ rule_id: '1', enabled: false }));
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/authorization/all_rules_read_only.cy.ts
@@ -23,8 +23,7 @@ import {
   waitForCallOutToBeShown,
   MISSING_PRIVILEGES_CALLOUT,
 } from '../../../../tasks/common/callouts';
-import { login, visitWithoutDateRange } from '../../../../tasks/login';
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../../urls/navigation';
+import { login, visitSecurityDetectionRulesPage } from '../../../../tasks/login';
 
 describe('All rules - read only', { tags: tag.ESS }, () => {
   before(() => {
@@ -34,7 +33,7 @@ describe('All rules - read only', { tags: tag.ESS }, () => {
 
   beforeEach(() => {
     login(ROLES.reader);
-    visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL, ROLES.reader);
+    visitSecurityDetectionRulesPage(ROLES.reader);
     cy.get(RULE_NAME).should('have.text', getNewRule().name);
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -9,8 +9,8 @@ import { tag } from '../../../../../tags';
 
 import {
   goToTheRuleDetailsOf,
-  selectNumberOfRules,
   expectManagementTableRules,
+  selectAllRules,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
   duplicateSelectedRulesWithoutExceptions,
@@ -104,14 +104,14 @@ describe('Detection rules, bulk duplicate', { tags: [tag.ESS, tag.SERVERLESS] },
   });
 
   it('Duplicates rules', () => {
-    selectNumberOfRules(1);
+    selectAllRules();
     duplicateSelectedRulesWithoutExceptions();
     expectManagementTableRules([`${RULE_NAME} [Duplicate]`]);
   });
 
   describe('With exceptions', () => {
     it('Duplicates rules with expired exceptions', () => {
-      selectNumberOfRules(1);
+      selectAllRules();
       duplicateSelectedRulesWithExceptions();
       expectManagementTableRules([`${RULE_NAME} [Duplicate]`]);
       goToTheRuleDetailsOf(`${RULE_NAME} [Duplicate]`);
@@ -122,7 +122,7 @@ describe('Detection rules, bulk duplicate', { tags: [tag.ESS, tag.SERVERLESS] },
     });
 
     it('Duplicates rules with exceptions, excluding expired exceptions', () => {
-      selectNumberOfRules(1);
+      selectAllRules();
       duplicateSelectedRulesWithNonExpiredExceptions();
       expectManagementTableRules([`${RULE_NAME} [Duplicate]`]);
       goToTheRuleDetailsOf(`${RULE_NAME} [Duplicate]`);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -65,40 +65,40 @@ describe('Detection rules, bulk duplicate', { tags: [tag.ESS, tag.SERVERLESS] },
     resetRulesTableState();
     deleteAlertsAndRules();
     cy.task('esArchiverResetKibana');
-    createRule(getNewRule({ name: RULE_NAME, ...defaultRuleData, rule_id: '1' })).then(
-      (response) => {
-        createRuleExceptionItem(response.body.id, [
-          {
-            description: 'Exception item for rule default exception list',
-            entries: [
-              {
-                field: 'user.name',
-                operator: 'included',
-                type: 'match',
-                value: 'some value',
-              },
-            ],
-            name: EXPIRED_EXCEPTION_ITEM_NAME,
-            type: 'simple',
-            expire_time: expiredDate,
-          },
-          {
-            description: 'Exception item for rule default exception list',
-            entries: [
-              {
-                field: 'user.name',
-                operator: 'included',
-                type: 'match',
-                value: 'some value',
-              },
-            ],
-            name: NON_EXPIRED_EXCEPTION_ITEM_NAME,
-            type: 'simple',
-            expire_time: futureDate,
-          },
-        ]);
-      }
-    );
+    createRule(
+      getNewRule({ name: RULE_NAME, ...defaultRuleData, rule_id: '1', enabled: false })
+    ).then((response) => {
+      createRuleExceptionItem(response.body.id, [
+        {
+          description: 'Exception item for rule default exception list',
+          entries: [
+            {
+              field: 'user.name',
+              operator: 'included',
+              type: 'match',
+              value: 'some value',
+            },
+          ],
+          name: EXPIRED_EXCEPTION_ITEM_NAME,
+          type: 'simple',
+          expire_time: expiredDate,
+        },
+        {
+          description: 'Exception item for rule default exception list',
+          entries: [
+            {
+              field: 'user.name',
+              operator: 'included',
+              type: 'match',
+              value: 'some value',
+            },
+          ],
+          name: NON_EXPIRED_EXCEPTION_ITEM_NAME,
+          type: 'simple',
+          expire_time: futureDate,
+        },
+      ]);
+    });
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -11,6 +11,7 @@ import {
   goToTheRuleDetailsOf,
   expectManagementTableRules,
   selectAllRules,
+  disableAutoRefresh,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
   duplicateSelectedRulesWithoutExceptions,
@@ -18,9 +19,8 @@ import {
   duplicateSelectedRulesWithNonExpiredExceptions,
 } from '../../../../../tasks/rules_bulk_actions';
 import { goToExceptionsTab, viewExpiredExceptionItems } from '../../../../../tasks/rule_details';
-import { login, visitWithoutDateRange } from '../../../../../tasks/login';
+import { login, visitSecurityDetectionRulesPage } from '../../../../../tasks/login';
 
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../../../urls/navigation';
 import { createRule } from '../../../../../tasks/api_calls/rules';
 import {
   cleanKibana,
@@ -100,7 +100,8 @@ describe('Detection rules, bulk duplicate', { tags: [tag.ESS, tag.SERVERLESS] },
       ]);
     });
 
-    visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+    visitSecurityDetectionRulesPage();
+    disableAutoRefresh();
   });
 
   it('Duplicates rules', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_duplicate_rules.cy.ts
@@ -8,7 +8,6 @@
 import { tag } from '../../../../../tags';
 
 import {
-  waitForRulesTableToBeLoaded,
   goToTheRuleDetailsOf,
   selectNumberOfRules,
   expectManagementTableRules,
@@ -102,8 +101,6 @@ describe('Detection rules, bulk duplicate', { tags: [tag.ESS, tag.SERVERLESS] },
     );
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-
-    waitForRulesTableToBeLoaded();
   });
 
   it('Duplicates rules', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -12,8 +12,6 @@ import {
   MODAL_CONFIRMATION_BODY,
   RULES_TAGS_POPOVER_BTN,
   MODAL_ERROR_BODY,
-  RULE_NAME as RULE_NAME_SELECTOR,
-  RULES_ROW,
 } from '../../../../../screens/alerts_detection_rules';
 
 import {
@@ -41,6 +39,7 @@ import {
   selectRulesByName,
   getRulesManagementTableRows,
   selectAllRulesOnPage,
+  getRuleRow,
 } from '../../../../../tasks/alerts_detection_rules';
 
 import {
@@ -249,12 +248,8 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
       testMultipleSelectedRulesLabel(rulesToUpdate.length);
       // check if first four(rulesCount) rules still selected and tags are updated
       for (const ruleName of rulesToUpdate) {
-        cy.contains(RULE_NAME_SELECTOR, ruleName)
-          .parents(RULES_ROW)
-          .find(EUI_CHECKBOX)
-          .should('be.checked');
-        cy.contains(RULE_NAME_SELECTOR, ruleName)
-          .parents(RULES_ROW)
+        getRuleRow(ruleName).find(EUI_CHECKBOX).should('be.checked');
+        getRuleRow(ruleName)
           .find(RULES_TAGS_POPOVER_BTN)
           .each(($el) => {
             testTagsBadge($el, prePopulatedTags.concat(['new-tag-1']));

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import { tag } from '../../../../../tags';
-
 import {
   MODAL_CONFIRMATION_BTN,
   MODAL_CONFIRMATION_BODY,
@@ -74,9 +72,10 @@ import {
   assertDefaultValuesAreAppliedToScheduleFields,
 } from '../../../../../tasks/rules_bulk_actions';
 
+import { createRuleAssetSavedObject } from '../../../../../helpers/rules';
+import { tag } from '../../../../../tags';
 import { hasIndexPatterns, getDetails } from '../../../../../tasks/rule_details';
 import { login, visitSecurityDetectionRulesPage } from '../../../../../tasks/login';
-
 import { createRule } from '../../../../../tasks/api_calls/rules';
 import { loadPrepackagedTimelineTemplates } from '../../../../../tasks/api_calls/timelines';
 import {
@@ -95,8 +94,8 @@ import {
 } from '../../../../../objects/rule';
 
 import {
+  createAndInstallMockedPrebuiltRules,
   getAvailablePrebuiltRulesCount,
-  excessivelyInstallAllPrebuiltRules,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setRowsPerPageTo, sortByTableColumn } from '../../../../../tasks/table_pagination';
 
@@ -161,6 +160,17 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
   });
 
   describe('Prerequisites', () => {
+    const PREBUILT_RULES = [
+      createRuleAssetSavedObject({
+        name: 'Prebuilt rule 1',
+        rule_id: 'rule_1',
+      }),
+      createRuleAssetSavedObject({
+        name: 'Prebuilt rule 2',
+        rule_id: 'rule_2',
+      }),
+    ];
+
     it('No rules selected', () => {
       openBulkActionsMenu();
 
@@ -171,7 +181,7 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
     });
 
     it('Only prebuilt rules selected', () => {
-      excessivelyInstallAllPrebuiltRules();
+      createAndInstallMockedPrebuiltRules({ rules: PREBUILT_RULES });
 
       // select Elastic(prebuilt) rules, check if we can't proceed further, as Elastic rules are not editable
       filterByElasticRules();
@@ -190,7 +200,7 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
     it('Prebuilt and custom rules selected: user proceeds with custom rules editing', () => {
       getRulesManagementTableRows().then((existedRulesRows) => {
-        excessivelyInstallAllPrebuiltRules();
+        createAndInstallMockedPrebuiltRules({ rules: PREBUILT_RULES });
 
         // modal window should show how many rules can be edit, how many not
         selectAllRules();
@@ -215,7 +225,7 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
     });
 
     it('Prebuilt and custom rules selected: user cancels action', () => {
-      excessivelyInstallAllPrebuiltRules();
+      createAndInstallMockedPrebuiltRules({ rules: PREBUILT_RULES });
 
       getRulesManagementTableRows().then((rows) => {
         // modal window should show how many rules can be edit, how many not

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -40,6 +40,7 @@ import {
   getRulesManagementTableRows,
   selectAllRulesOnPage,
   getRuleRow,
+  disableAutoRefresh,
 } from '../../../../../tasks/alerts_detection_rules';
 
 import {
@@ -74,9 +75,8 @@ import {
 } from '../../../../../tasks/rules_bulk_actions';
 
 import { hasIndexPatterns, getDetails } from '../../../../../tasks/rule_details';
-import { login, visitWithoutDateRange } from '../../../../../tasks/login';
+import { login, visitSecurityDetectionRulesPage } from '../../../../../tasks/login';
 
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../../../urls/navigation';
 import { createRule } from '../../../../../tasks/api_calls/rules';
 import { loadPrepackagedTimelineTemplates } from '../../../../../tasks/api_calls/timelines';
 import {
@@ -156,7 +156,8 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
       getNewTermsRule({ ...defaultRuleData, rule_id: '6', name: 'New Terms Rule', enabled: false })
     );
 
-    visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+    visitSecurityDetectionRulesPage();
+    disableAutoRefresh();
   });
 
   describe('Prerequisites', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -29,7 +29,6 @@ import { TIMELINE_TEMPLATE_DETAILS } from '../../../../../screens/rule_details';
 import { EUI_FILTER_SELECT_ITEM } from '../../../../../screens/common/controls';
 
 import {
-  waitForRulesTableToBeLoaded,
   selectAllRules,
   goToTheRuleDetailsOf,
   selectNumberOfRules,
@@ -141,8 +140,6 @@ describe('Detection rules, bulk edit', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
     createRule(getNewTermsRule({ ...defaultRuleData, rule_id: '6' }));
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-
-    waitForRulesTableToBeLoaded();
   });
 
   describe('Prerequisites', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -36,10 +36,10 @@ import {
   pickSummaryOfAlertsOption,
 } from '../../../../../tasks/common/rule_actions';
 import {
-  waitForRulesTableToBeLoaded,
   selectNumberOfRules,
   goToEditRuleActionsSettingsOf,
   disableAutoRefresh,
+  expectManagementTableRules,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
   waitForBulkEditActionToFinish,
@@ -106,15 +106,15 @@ describe(
           },
         ];
 
-        createRule(getNewRule({ name: ruleNameToAssert, rule_id: '1', max_signals: 500, actions }));
+        createRule(getNewRule({ rule_id: '1', name: ruleNameToAssert, max_signals: 500, actions }));
       });
 
-      createRule(getEqlRule({ rule_id: '2' }));
-      createRule(getMachineLearningRule({ rule_id: '3' }));
-      createRule(getNewThreatIndicatorRule({ rule_id: '4' }));
-      createRule(getNewThresholdRule({ rule_id: '5' }));
-      createRule(getNewTermsRule({ rule_id: '6' }));
-      createRule(getNewRule({ saved_id: 'mocked', rule_id: '7' }));
+      createRule(getEqlRule({ rule_id: '2', name: 'New EQL Rule' }));
+      createRule(getMachineLearningRule({ rule_id: '3', name: 'New ML Rule Test' }));
+      createRule(getNewThreatIndicatorRule({ rule_id: '4', name: 'Threat Indicator Rule Test' }));
+      createRule(getNewThresholdRule({ rule_id: '5', name: 'Threshold Rule' }));
+      createRule(getNewTermsRule({ rule_id: '6', name: 'New Terms Rule' }));
+      createRule(getNewRule({ saved_id: 'mocked', rule_id: '7', name: 'New Rule Test' }));
 
       createSlackConnector();
 
@@ -137,8 +137,17 @@ describe(
       it("User with no privileges can't add rule actions", () => {
         login(ROLES.hunter_no_actions);
         visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL, ROLES.hunter_no_actions);
+
+        expectManagementTableRules([
+          ruleNameToAssert,
+          'New EQL Rule',
+          'New ML Rule Test',
+          'Threat Indicator Rule Test',
+          'Threshold Rule',
+          'New Terms Rule',
+          'New Rule Test',
+        ]);
         waitForCallOutToBeShown(MISSING_PRIVILEGES_CALLOUT, 'primary');
-        waitForRulesTableToBeLoaded();
 
         selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
 
@@ -152,7 +161,16 @@ describe(
       beforeEach(() => {
         login();
         visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-        waitForRulesTableToBeLoaded();
+
+        expectManagementTableRules([
+          ruleNameToAssert,
+          'New EQL Rule',
+          'New ML Rule Test',
+          'Threat Indicator Rule Test',
+          'Threshold Rule',
+          'New Terms Rule',
+          'New Rule Test',
+        ]);
         disableAutoRefresh();
       });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -37,11 +37,11 @@ import {
 } from '../../../../../tasks/common/rule_actions';
 import {
   goToEditRuleActionsSettingsOf,
-  disableAutoRefresh,
   expectManagementTableRules,
   selectAllRules,
   selectRulesByName,
   getRulesManagementTableRows,
+  disableAutoRefresh,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
   waitForBulkEditActionToFinish,
@@ -50,9 +50,7 @@ import {
   openBulkEditRuleActionsForm,
   openBulkActionsMenu,
 } from '../../../../../tasks/rules_bulk_actions';
-import { login, visitWithoutDateRange } from '../../../../../tasks/login';
-
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../../../urls/navigation';
+import { login, visitSecurityDetectionRulesPage } from '../../../../../tasks/login';
 
 import { createRule } from '../../../../../tasks/api_calls/rules';
 import { createSlackConnector } from '../../../../../tasks/api_calls/connectors';
@@ -152,7 +150,7 @@ describe(
     context('Restricted action privileges', () => {
       it("User with no privileges can't add rule actions", () => {
         login(ROLES.hunter_no_actions);
-        visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL, ROLES.hunter_no_actions);
+        visitSecurityDetectionRulesPage(ROLES.hunter_no_actions);
 
         expectManagementTableRules([
           ruleNameToAssert,
@@ -178,7 +176,8 @@ describe(
     context('All actions privileges', () => {
       beforeEach(() => {
         login();
-        visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+        visitSecurityDetectionRulesPage();
+        disableAutoRefresh();
 
         expectManagementTableRules([
           ruleNameToAssert,
@@ -191,7 +190,6 @@ describe(
           'Test rule 1',
           'Test rule 2',
         ]);
-        disableAutoRefresh();
       });
 
       it('Add a rule action to rules (existing connector)', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -36,10 +36,11 @@ import {
   pickSummaryOfAlertsOption,
 } from '../../../../../tasks/common/rule_actions';
 import {
-  selectNumberOfRules,
   goToEditRuleActionsSettingsOf,
   disableAutoRefresh,
   expectManagementTableRules,
+  selectAllRules,
+  selectRulesByName,
 } from '../../../../../tasks/alerts_detection_rules';
 import {
   waitForBulkEditActionToFinish,
@@ -149,7 +150,7 @@ describe(
         ]);
         waitForCallOutToBeShown(MISSING_PRIVILEGES_CALLOUT, 'primary');
 
-        selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+        selectAllRules();
 
         openBulkActionsMenu();
 
@@ -183,7 +184,7 @@ describe(
         excessivelyInstallAllPrebuiltRules();
 
         // select both custom and prebuilt rules
-        selectNumberOfRules(expectedNumberOfRulesToBeEdited);
+        selectAllRules();
         openBulkEditRuleActionsForm();
 
         // ensure rule actions info callout displayed on the form
@@ -211,7 +212,7 @@ describe(
         excessivelyInstallAllPrebuiltRules();
 
         // select both custom and prebuilt rules
-        selectNumberOfRules(expectedNumberOfRulesToBeEdited);
+        selectAllRules();
         openBulkEditRuleActionsForm();
 
         addSlackRuleAction(expectedSlackMessage);
@@ -245,7 +246,15 @@ describe(
         const expectedEmail = 'test@example.com';
         const expectedSubject = 'Subject';
 
-        selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+        selectRulesByName([
+          ruleNameToAssert,
+          'New EQL Rule',
+          'New ML Rule Test',
+          'Threat Indicator Rule Test',
+          'Threshold Rule',
+          'New Terms Rule',
+          'New Rule Test',
+        ]);
         openBulkEditRuleActionsForm();
 
         addEmailConnectorAndRuleAction(expectedEmail, expectedSubject);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts
@@ -162,6 +162,8 @@ describe(
           'Threshold Rule',
           'New Terms Rule',
           'New Rule Test',
+          'Test rule 1',
+          'Test rule 2',
         ]);
         waitForCallOutToBeShown(MISSING_PRIVILEGES_CALLOUT, 'primary');
 
@@ -186,6 +188,8 @@ describe(
           'Threshold Rule',
           'New Terms Rule',
           'New Rule Test',
+          'Test rule 1',
+          'Test rule 2',
         ]);
         disableAutoRefresh();
       });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -19,6 +19,7 @@ import {
   goToTheRuleDetailsOf,
   expectManagementTableRules,
   selectAllRules,
+  getRulesManagementTableRows,
 } from '../../../../../tasks/alerts_detection_rules';
 
 import {
@@ -53,8 +54,6 @@ import {
 const DATA_VIEW_ID = 'auditbeat';
 
 const expectedIndexPatterns = ['index-1-*', 'index-2-*'];
-
-const expectedNumberOfCustomRulesToBeEdited = 6;
 
 describe(
   'Bulk editing index patterns of rules with a data view only',
@@ -134,100 +133,110 @@ describe(
     });
 
     it('Add index patterns to custom rules with configured data view: all rules are skipped', () => {
-      selectAllRules();
+      getRulesManagementTableRows().then((rows) => {
+        selectAllRules();
 
-      openBulkEditAddIndexPatternsForm();
-      typeIndexPatterns(expectedIndexPatterns);
-      submitBulkEditForm();
+        openBulkEditAddIndexPatternsForm();
+        typeIndexPatterns(expectedIndexPatterns);
+        submitBulkEditForm();
 
-      waitForBulkEditActionToFinish({
-        skippedCount: expectedNumberOfCustomRulesToBeEdited,
-        showDataViewsWarning: true,
+        waitForBulkEditActionToFinish({
+          skippedCount: rows.length,
+          showDataViewsWarning: true,
+        });
+
+        // check if rule still has data view and index patterns field does not exist
+        goToRuleDetails();
+        getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
+        assertDetailsNotExist(INDEX_PATTERNS_DETAILS);
       });
-
-      // check if rule still has data view and index patterns field does not exist
-      goToRuleDetails();
-      getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
-      assertDetailsNotExist(INDEX_PATTERNS_DETAILS);
     });
 
     it('Add index patterns to custom rules with configured data view when data view checkbox is checked: rules are updated', () => {
-      selectAllRules();
+      getRulesManagementTableRows().then((rows) => {
+        selectAllRules();
 
-      openBulkEditAddIndexPatternsForm();
-      typeIndexPatterns(expectedIndexPatterns);
+        openBulkEditAddIndexPatternsForm();
+        typeIndexPatterns(expectedIndexPatterns);
 
-      // click on data view overwrite checkbox, ensure warning is displayed
-      cy.get(RULES_BULK_EDIT_DATA_VIEWS_WARNING).should('not.exist');
-      checkOverwriteDataViewCheckbox();
-      cy.get(RULES_BULK_EDIT_DATA_VIEWS_WARNING).should('be.visible');
+        // click on data view overwrite checkbox, ensure warning is displayed
+        cy.get(RULES_BULK_EDIT_DATA_VIEWS_WARNING).should('not.exist');
+        checkOverwriteDataViewCheckbox();
+        cy.get(RULES_BULK_EDIT_DATA_VIEWS_WARNING).should('be.visible');
 
-      submitBulkEditForm();
+        submitBulkEditForm();
 
-      waitForBulkEditActionToFinish({ updatedCount: expectedNumberOfCustomRulesToBeEdited });
+        waitForBulkEditActionToFinish({ updatedCount: rows.length });
 
-      // check if rule has been updated with index patterns and data view does not exist
-      goToRuleDetails();
-      hasIndexPatterns(expectedIndexPatterns.join(''));
-      assertDetailsNotExist(DATA_VIEW_DETAILS);
+        // check if rule has been updated with index patterns and data view does not exist
+        goToRuleDetails();
+        hasIndexPatterns(expectedIndexPatterns.join(''));
+        assertDetailsNotExist(DATA_VIEW_DETAILS);
+      });
     });
 
     it('Overwrite index patterns in custom rules with configured data view when overwrite data view checkbox is NOT checked:: rules are skipped', () => {
-      selectAllRules();
+      getRulesManagementTableRows().then((rows) => {
+        selectAllRules();
 
-      openBulkEditAddIndexPatternsForm();
-      typeIndexPatterns(expectedIndexPatterns);
-      checkOverwriteIndexPatternsCheckbox();
-      submitBulkEditForm();
+        openBulkEditAddIndexPatternsForm();
+        typeIndexPatterns(expectedIndexPatterns);
+        checkOverwriteIndexPatternsCheckbox();
+        submitBulkEditForm();
 
-      waitForBulkEditActionToFinish({
-        skippedCount: expectedNumberOfCustomRulesToBeEdited,
-        showDataViewsWarning: true,
+        waitForBulkEditActionToFinish({
+          skippedCount: rows.length,
+          showDataViewsWarning: true,
+        });
+
+        // check if rule still has data view and index patterns field does not exist
+        goToRuleDetails();
+        getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
+        assertDetailsNotExist(INDEX_PATTERNS_DETAILS);
       });
-
-      // check if rule still has data view and index patterns field does not exist
-      goToRuleDetails();
-      getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
-      assertDetailsNotExist(INDEX_PATTERNS_DETAILS);
     });
 
     it('Overwrite index patterns in custom rules with configured data view when overwrite data view checkbox is checked: rules are updated', () => {
-      selectAllRules();
+      getRulesManagementTableRows().then((rows) => {
+        selectAllRules();
 
-      openBulkEditAddIndexPatternsForm();
-      typeIndexPatterns(expectedIndexPatterns);
-      checkOverwriteIndexPatternsCheckbox();
-      checkOverwriteDataViewCheckbox();
+        openBulkEditAddIndexPatternsForm();
+        typeIndexPatterns(expectedIndexPatterns);
+        checkOverwriteIndexPatternsCheckbox();
+        checkOverwriteDataViewCheckbox();
 
-      submitBulkEditForm();
+        submitBulkEditForm();
 
-      waitForBulkEditActionToFinish({ updatedCount: expectedNumberOfCustomRulesToBeEdited });
+        waitForBulkEditActionToFinish({ updatedCount: rows.length });
 
-      // check if rule has been overwritten with index patterns and data view does not exist
-      goToRuleDetails();
-      hasIndexPatterns(expectedIndexPatterns.join(''));
-      assertDetailsNotExist(DATA_VIEW_DETAILS);
+        // check if rule has been overwritten with index patterns and data view does not exist
+        goToRuleDetails();
+        hasIndexPatterns(expectedIndexPatterns.join(''));
+        assertDetailsNotExist(DATA_VIEW_DETAILS);
+      });
     });
 
     it('Delete index patterns in custom rules with configured data view: rules are skipped', () => {
-      selectAllRules();
+      getRulesManagementTableRows().then((rows) => {
+        selectAllRules();
 
-      openBulkEditDeleteIndexPatternsForm();
-      typeIndexPatterns(expectedIndexPatterns);
+        openBulkEditDeleteIndexPatternsForm();
+        typeIndexPatterns(expectedIndexPatterns);
 
-      // in delete form data view checkbox is absent
-      cy.get(RULES_BULK_EDIT_OVERWRITE_DATA_VIEW_CHECKBOX).should('not.exist');
+        // in delete form data view checkbox is absent
+        cy.get(RULES_BULK_EDIT_OVERWRITE_DATA_VIEW_CHECKBOX).should('not.exist');
 
-      submitBulkEditForm();
+        submitBulkEditForm();
 
-      waitForBulkEditActionToFinish({
-        skippedCount: expectedNumberOfCustomRulesToBeEdited,
-        showDataViewsWarning: true,
+        waitForBulkEditActionToFinish({
+          skippedCount: rows.length,
+          showDataViewsWarning: true,
+        });
+
+        // check if rule still has data view and index patterns field does not exist
+        goToRuleDetails();
+        getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
       });
-
-      // check if rule still has data view and index patterns field does not exist
-      goToRuleDetails();
-      getDetails(DATA_VIEW_DETAILS).contains(DATA_VIEW_ID);
     });
   }
 );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -15,10 +15,10 @@ import {
 import { DATA_VIEW_DETAILS, INDEX_PATTERNS_DETAILS } from '../../../../../screens/rule_details';
 
 import {
-  waitForRulesTableToBeLoaded,
   goToRuleDetails,
   selectNumberOfRules,
   goToTheRuleDetailsOf,
+  expectManagementTableRules,
 } from '../../../../../tasks/alerts_detection_rules';
 
 import {
@@ -71,27 +71,66 @@ describe(
 
       postDataView(DATA_VIEW_ID);
 
-      createRule(getNewRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '1' }));
-      createRule(getEqlRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '2' }));
       createRule(
-        getNewThreatIndicatorRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '3' })
+        getNewRule({
+          index: undefined,
+          data_view_id: DATA_VIEW_ID,
+          rule_id: '1',
+          name: 'New Rule Test 1',
+        })
       );
       createRule(
-        getNewThresholdRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '4' })
+        getEqlRule({
+          index: undefined,
+          data_view_id: DATA_VIEW_ID,
+          rule_id: '2',
+          name: 'New EQL Rule',
+        })
       );
-      createRule(getNewTermsRule({ index: undefined, data_view_id: DATA_VIEW_ID, rule_id: '5' }));
+      createRule(
+        getNewThreatIndicatorRule({
+          index: undefined,
+          data_view_id: DATA_VIEW_ID,
+          rule_id: '3',
+          name: 'Threat Indicator Rule Test',
+        })
+      );
+      createRule(
+        getNewThresholdRule({
+          index: undefined,
+          data_view_id: DATA_VIEW_ID,
+          rule_id: '4',
+          name: 'Threshold Rule',
+        })
+      );
+      createRule(
+        getNewTermsRule({
+          index: undefined,
+          data_view_id: DATA_VIEW_ID,
+          rule_id: '5',
+          name: 'New Terms Rule',
+        })
+      );
       createRule(
         getNewRule({
           index: undefined,
           data_view_id: DATA_VIEW_ID,
           saved_id: 'mocked',
           rule_id: '6',
+          name: 'New Rule Test 2',
         })
       );
 
       visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
-      waitForRulesTableToBeLoaded();
+      expectManagementTableRules([
+        'New Rule Test 1',
+        'New EQL Rule',
+        'Threat Indicator Rule Test',
+        'Threshold Rule',
+        'New Terms Rule',
+        'New Rule Test 2',
+      ]);
     });
 
     it('Add index patterns to custom rules with configured data view: all rules are skipped', () => {
@@ -214,7 +253,7 @@ describe('Bulk editing index patterns of rules with index patterns and rules wit
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
-    waitForRulesTableToBeLoaded();
+    expectManagementTableRules(['with dataview', 'no data view']);
   });
 
   it('Add index patterns to custom rules: one rule is updated, one rule is skipped', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -76,6 +76,7 @@ describe(
           data_view_id: DATA_VIEW_ID,
           rule_id: '1',
           name: 'New Rule Test 1',
+          enabled: false,
         })
       );
       createRule(
@@ -84,6 +85,7 @@ describe(
           data_view_id: DATA_VIEW_ID,
           rule_id: '2',
           name: 'New EQL Rule',
+          enabled: false,
         })
       );
       createRule(
@@ -92,6 +94,7 @@ describe(
           data_view_id: DATA_VIEW_ID,
           rule_id: '3',
           name: 'Threat Indicator Rule Test',
+          enabled: false,
         })
       );
       createRule(
@@ -100,6 +103,7 @@ describe(
           data_view_id: DATA_VIEW_ID,
           rule_id: '4',
           name: 'Threshold Rule',
+          enabled: false,
         })
       );
       createRule(
@@ -108,6 +112,7 @@ describe(
           data_view_id: DATA_VIEW_ID,
           rule_id: '5',
           name: 'New Terms Rule',
+          enabled: false,
         })
       );
       createRule(
@@ -117,6 +122,7 @@ describe(
           saved_id: 'mocked',
           rule_id: '6',
           name: 'New Rule Test 2',
+          enabled: false,
         })
       );
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_data_view.cy.ts
@@ -16,9 +16,9 @@ import { DATA_VIEW_DETAILS, INDEX_PATTERNS_DETAILS } from '../../../../../screen
 
 import {
   goToRuleDetails,
-  selectNumberOfRules,
   goToTheRuleDetailsOf,
   expectManagementTableRules,
+  selectAllRules,
 } from '../../../../../tasks/alerts_detection_rules';
 
 import {
@@ -134,7 +134,7 @@ describe(
     });
 
     it('Add index patterns to custom rules with configured data view: all rules are skipped', () => {
-      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      selectAllRules();
 
       openBulkEditAddIndexPatternsForm();
       typeIndexPatterns(expectedIndexPatterns);
@@ -152,7 +152,7 @@ describe(
     });
 
     it('Add index patterns to custom rules with configured data view when data view checkbox is checked: rules are updated', () => {
-      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      selectAllRules();
 
       openBulkEditAddIndexPatternsForm();
       typeIndexPatterns(expectedIndexPatterns);
@@ -173,7 +173,7 @@ describe(
     });
 
     it('Overwrite index patterns in custom rules with configured data view when overwrite data view checkbox is NOT checked:: rules are skipped', () => {
-      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      selectAllRules();
 
       openBulkEditAddIndexPatternsForm();
       typeIndexPatterns(expectedIndexPatterns);
@@ -192,7 +192,7 @@ describe(
     });
 
     it('Overwrite index patterns in custom rules with configured data view when overwrite data view checkbox is checked: rules are updated', () => {
-      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      selectAllRules();
 
       openBulkEditAddIndexPatternsForm();
       typeIndexPatterns(expectedIndexPatterns);
@@ -210,7 +210,7 @@ describe(
     });
 
     it('Delete index patterns in custom rules with configured data view: rules are skipped', () => {
-      selectNumberOfRules(expectedNumberOfCustomRulesToBeEdited);
+      selectAllRules();
 
       openBulkEditDeleteIndexPatternsForm();
       typeIndexPatterns(expectedIndexPatterns);
@@ -233,8 +233,6 @@ describe(
 );
 
 describe('Bulk editing index patterns of rules with index patterns and rules with a data view', () => {
-  const customRulesNumber = 2;
-
   before(() => {
     cleanKibana();
   });
@@ -257,7 +255,7 @@ describe('Bulk editing index patterns of rules with index patterns and rules wit
   });
 
   it('Add index patterns to custom rules: one rule is updated, one rule is skipped', () => {
-    selectNumberOfRules(customRulesNumber);
+    selectAllRules();
 
     openBulkEditAddIndexPatternsForm();
     typeIndexPatterns(expectedIndexPatterns);
@@ -276,7 +274,7 @@ describe('Bulk editing index patterns of rules with index patterns and rules wit
   });
 
   it('Add index patterns to custom rules when overwrite data view checkbox is checked: all rules are updated', () => {
-    selectNumberOfRules(customRulesNumber);
+    selectAllRules();
 
     openBulkEditAddIndexPatternsForm();
     typeIndexPatterns(expectedIndexPatterns);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -17,7 +17,6 @@ import {
 } from '../../../../../screens/alerts_detection_rules';
 import {
   filterByElasticRules,
-  selectNumberOfRules,
   selectAllRules,
   waitForRuleExecution,
   exportRule,
@@ -106,7 +105,7 @@ describe('Export rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
     createAndInstallMockedPrebuiltRules({ rules: prebuiltRules });
 
     filterByElasticRules();
-    selectNumberOfRules(prebuiltRules.length);
+    selectAllRules();
     bulkExportRules();
 
     cy.get(MODAL_CONFIRMATION_BODY).contains(

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -73,7 +73,7 @@ describe('Export rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
     // Prevent installation of whole prebuilt rules package, use mock prebuilt rules instead
     preventPrebuiltRulesPackageInstallation();
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
-    createRule(getNewRule({ name: 'Rule to export' })).as('ruleResponse');
+    createRule(getNewRule({ name: 'Rule to export', enabled: false })).as('ruleResponse');
   });
 
   it('exports a custom rule', function () {
@@ -159,6 +159,7 @@ describe('Export rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
               },
             ],
             rule_id: '2',
+            enabled: false,
           })
         )
       );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
@@ -11,13 +11,13 @@ import { tag } from '../../../../../tags';
 
 import { createRule, snoozeRule as snoozeRuleViaAPI } from '../../../../../tasks/api_calls/rules';
 import { cleanKibana, deleteAlertsAndRules, deleteConnectors } from '../../../../../tasks/common';
-import { login, visitWithoutDateRange } from '../../../../../tasks/login';
-import { getNewRule } from '../../../../../objects/rule';
 import {
-  ruleDetailsUrl,
-  ruleEditUrl,
-  SECURITY_DETECTIONS_RULES_URL,
-} from '../../../../../urls/navigation';
+  login,
+  visitSecurityDetectionRulesPage,
+  visitWithoutDateRange,
+} from '../../../../../tasks/login';
+import { getNewRule } from '../../../../../objects/rule';
+import { ruleDetailsUrl, ruleEditUrl } from '../../../../../urls/navigation';
 import { internalAlertingSnoozeRule } from '../../../../../urls/routes';
 import { RULES_MANAGEMENT_TABLE, RULE_NAME } from '../../../../../screens/alerts_detection_rules';
 import {
@@ -33,7 +33,11 @@ import {
   unsnoozeRuleInTable,
 } from '../../../../../tasks/rule_snoozing';
 import { createSlackConnector } from '../../../../../tasks/api_calls/connectors';
-import { duplicateFirstRule, importRules } from '../../../../../tasks/alerts_detection_rules';
+import {
+  disableAutoRefresh,
+  duplicateFirstRule,
+  importRules,
+} from '../../../../../tasks/alerts_detection_rules';
 import { goToActionsStepTab } from '../../../../../tasks/create_new_rule';
 import { goToRuleEditSettings } from '../../../../../tasks/rule_details';
 import { actionFormSelector } from '../../../../../screens/common/rule_actions';
@@ -57,7 +61,8 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   it('ensures the rule is snoozed on the rules management page, rule details page and rule editing page', () => {
     createRule(getNewRule({ name: 'Test on all pages', enabled: false }));
 
-    visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+    visitSecurityDetectionRulesPage();
+    disableAutoRefresh();
 
     snoozeRuleInTable({
       tableSelector: RULES_MANAGEMENT_TABLE,
@@ -81,7 +86,8 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     it('snoozes a rule without actions for 3 hours', () => {
       createRule(getNewRule({ name: 'Test rule without actions', enabled: false }));
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       snoozeRuleInTable({
         tableSelector: RULES_MANAGEMENT_TABLE,
@@ -100,7 +106,8 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     it('snoozes a rule with actions for 2 days', () => {
       createRuleWithActions({ name: 'Test rule with actions' }, createRule);
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       snoozeRuleInTable({
         tableSelector: RULES_MANAGEMENT_TABLE,
@@ -119,7 +126,8 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     it('unsnoozes a rule with actions', () => {
       createSnoozedRule(getNewRule({ name: 'Snoozed rule' }));
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       unsnoozeRuleInTable({
         tableSelector: RULES_MANAGEMENT_TABLE,
@@ -136,7 +144,8 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     it('ensures snooze settings persist after page reload', () => {
       createRule(getNewRule({ name: 'Test persistence', enabled: false }));
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       snoozeRuleInTable({
         tableSelector: RULES_MANAGEMENT_TABLE,
@@ -156,12 +165,14 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     it('ensures a duplicated rule is not snoozed', () => {
       createRule(getNewRule({ name: 'Test rule', enabled: false }));
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       duplicateFirstRule();
 
       // Make sure rules table is shown as it navigates to rule editing page after successful duplication
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       expectRuleUnsnoozedInTable({
         tableSelector: RULES_MANAGEMENT_TABLE,
@@ -197,7 +208,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     });
 
     it('ensures imported rules are unsnoozed', () => {
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
 
       importRules(RULES_TO_IMPORT_FILENAME);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/snoozing/rule_snoozing.cy.ts
@@ -55,7 +55,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   });
 
   it('ensures the rule is snoozed on the rules management page, rule details page and rule editing page', () => {
-    createRule(getNewRule({ name: 'Test on all pages' }));
+    createRule(getNewRule({ name: 'Test on all pages', enabled: false }));
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
@@ -79,7 +79,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   describe('Rules management table', () => {
     it('snoozes a rule without actions for 3 hours', () => {
-      createRule(getNewRule({ name: 'Test rule without actions' }));
+      createRule(getNewRule({ name: 'Test rule without actions', enabled: false }));
 
       visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
@@ -134,7 +134,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     });
 
     it('ensures snooze settings persist after page reload', () => {
-      createRule(getNewRule({ name: 'Test persistence' }));
+      createRule(getNewRule({ name: 'Test persistence', enabled: false }));
 
       visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
@@ -154,7 +154,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     });
 
     it('ensures a duplicated rule is not snoozed', () => {
-      createRule(getNewRule({ name: 'Test rule' }));
+      createRule(getNewRule({ name: 'Test rule', enabled: false }));
 
       visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
 
@@ -214,7 +214,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   describe('Handling errors', () => {
     it('shows an error if unable to load snooze settings', () => {
-      createRule(getNewRule({ name: 'Test rule' })).then(({ body: rule }) => {
+      createRule(getNewRule({ name: 'Test rule', enabled: false })).then(({ body: rule }) => {
         cy.intercept('GET', `${INTERNAL_ALERTING_API_FIND_RULES_PATH}*`, {
           statusCode: 500,
         });
@@ -228,7 +228,7 @@ describe('rule snoozing', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     });
 
     it('shows an error if unable to save snooze settings', () => {
-      createRule(getNewRule({ name: 'Test rule' })).then(({ body: rule }) => {
+      createRule(getNewRule({ name: 'Test rule', enabled: false })).then(({ body: rule }) => {
         cy.intercept('POST', internalAlertingSnoozeRule(rule.id), { forceNetworkError: true });
 
         visitWithoutDateRange(ruleDetailsUrl(rule.id));

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -16,13 +16,13 @@ import {
 import {
   selectAllRules,
   clearAllRuleSelection,
-  selectNumberOfRules,
   mockGlobalClock,
   disableAutoRefresh,
   expectAutoRefreshIsDisabled,
   expectAutoRefreshIsEnabled,
   expectAutoRefreshIsDeactivated,
   expectNumberOfRules,
+  selectRulesByName,
 } from '../../../../tasks/alerts_detection_rules';
 import { login, visit, visitWithoutDateRange } from '../../../../tasks/login';
 
@@ -68,7 +68,7 @@ describe('Rules table: auto-refresh', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS
 
     expectNumberOfRules(RULES_MANAGEMENT_TABLE, NUM_OF_TEST_RULES);
 
-    selectNumberOfRules(1);
+    selectRulesByName(['Test rule 1']);
 
     // mock 1 minute passing to make sure refresh is not conducted
     cy.get(RULES_TABLE_AUTOREFRESH_INDICATOR).should('not.exist');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -8,11 +8,11 @@
 import { tag } from '../../../../tags';
 
 import {
-  RULE_CHECKBOX,
   REFRESH_RULES_STATUS,
   RULES_TABLE_AUTOREFRESH_INDICATOR,
   RULES_MANAGEMENT_TABLE,
 } from '../../../../screens/alerts_detection_rules';
+import { EUI_CHECKBOX } from '../../../../screens/common/controls';
 import {
   selectAllRules,
   clearAllRuleSelection,
@@ -23,6 +23,7 @@ import {
   expectAutoRefreshIsDeactivated,
   expectNumberOfRules,
   selectRulesByName,
+  getRuleRow,
 } from '../../../../tasks/alerts_detection_rules';
 import { login, visit, visitWithoutDateRange } from '../../../../tasks/login';
 
@@ -40,7 +41,7 @@ describe('Rules table: auto-refresh', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS
     login();
 
     for (let i = 1; i <= NUM_OF_TEST_RULES; ++i) {
-      createRule(getNewRule({ name: `Test rule ${i}`, rule_id: `${i}` }));
+      createRule(getNewRule({ name: `Test rule ${i}`, rule_id: `${i}`, enabled: false }));
     }
   });
 
@@ -76,7 +77,7 @@ describe('Rules table: auto-refresh', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS
     cy.get(RULES_TABLE_AUTOREFRESH_INDICATOR).should('not.exist');
 
     // ensure rule is still selected
-    cy.get(RULE_CHECKBOX).first().should('be.checked');
+    getRuleRow('Test rule 1').find(EUI_CHECKBOX).should('be.checked');
 
     cy.get(REFRESH_RULES_STATUS).should('have.not.text', 'Updated now');
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -8,14 +8,12 @@
 import { tag } from '../../../../tags';
 
 import { cleanKibana, resetRulesTableState, deleteAlertsAndRules } from '../../../../tasks/common';
-import { login, visitWithoutDateRange } from '../../../../tasks/login';
+import { login, visitSecurityDetectionRulesPage } from '../../../../tasks/login';
 import {
   expectRulesWithExecutionStatus,
   filterByExecutionStatus,
   expectNumberOfRulesShownOnPage,
 } from '../../../../tasks/rule_filters';
-
-import { SECURITY_DETECTIONS_RULES_URL } from '../../../../urls/navigation';
 
 import { createRule, waitForRulesToFinishExecution } from '../../../../tasks/api_calls/rules';
 import {
@@ -23,7 +21,7 @@ import {
   createIndex,
   createDocument,
 } from '../../../../tasks/api_calls/elasticsearch';
-
+import { disableAutoRefresh } from '../../../../tasks/alerts_detection_rules';
 import { getNewRule } from '../../../../objects/rule';
 
 describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
@@ -82,7 +80,8 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
       waitForRulesToFinishExecution(['successful_rule', 'warning_rule', 'failed_rule'], new Date());
 
-      visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
+      visitSecurityDetectionRulesPage();
+      disableAutoRefresh();
 
       // Initial table state - before filtering by status
       expectNumberOfRulesShownOnPage(3);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -56,7 +56,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           name: 'Successful rule',
           rule_id: 'successful_rule',
           index: ['test_index'],
-          enabled: false,
+          enabled: true,
         })
       );
 
@@ -65,7 +65,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           name: 'Warning rule',
           rule_id: 'warning_rule',
           index: ['non_existent_index'],
-          enabled: false,
+          enabled: true,
         })
       );
 
@@ -76,7 +76,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           index: ['test_index'],
           // Setting a crazy large "Additional look-back time" to force a failure
           from: 'now-9007199254746990s',
-          enabled: false,
+          enabled: true,
         })
       );
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -17,8 +17,6 @@ import {
 
 import { SECURITY_DETECTIONS_RULES_URL } from '../../../../urls/navigation';
 
-import { waitForRulesTableToBeLoaded } from '../../../../tasks/alerts_detection_rules';
-
 import { createRule, waitForRulesToFinishExecution } from '../../../../tasks/api_calls/rules';
 import {
   deleteIndex,
@@ -82,8 +80,6 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
       waitForRulesToFinishExecution(['successful_rule', 'warning_rule', 'failed_rule'], new Date());
 
       visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
-
-      waitForRulesTableToBeLoaded();
 
       // Initial table state - before filtering by status
       expectNumberOfRulesShownOnPage(3);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -56,6 +56,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           name: 'Successful rule',
           rule_id: 'successful_rule',
           index: ['test_index'],
+          enabled: false,
         })
       );
 
@@ -64,6 +65,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           name: 'Warning rule',
           rule_id: 'warning_rule',
           index: ['non_existent_index'],
+          enabled: false,
         })
       );
 
@@ -74,6 +76,7 @@ describe('Rules table: filtering', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
           index: ['test_index'],
           // Setting a crazy large "Additional look-back time" to force a failure
           from: 'now-9007199254746990s',
+          enabled: false,
         })
       );
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
@@ -22,7 +22,7 @@ describe('Rules table: links', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    createRule(getNewRule({ rule_id: 'rule1' }));
+    createRule(getNewRule({ rule_id: 'rule1', enabled: false }));
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -15,7 +15,7 @@ import {
 } from '../../../../screens/alerts_detection_rules';
 import {
   selectRulesByName,
-  unselectNumberOfRules,
+  unselectRulesByName,
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../../../tasks/alerts_detection_rules';
 import {
@@ -55,7 +55,7 @@ describe('Rules table: selection', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
     cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
 
-    unselectNumberOfRules(2);
+    unselectRulesByName(['Test rule 1', 'Test rule 2']);
 
     cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -14,7 +14,7 @@ import {
   SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
 } from '../../../../screens/alerts_detection_rules';
 import {
-  selectNumberOfRules,
+  selectRulesByName,
   unselectNumberOfRules,
   waitForPrebuiltDetectionRulesToBeLoaded,
 } from '../../../../tasks/alerts_detection_rules';
@@ -51,7 +51,7 @@ describe('Rules table: selection', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   it('should correctly update the selection label when rules are individually selected and unselected', () => {
     waitForPrebuiltDetectionRulesToBeLoaded();
 
-    selectNumberOfRules(2);
+    selectRulesByName(['Test rule 1', 'Test rule 2']);
 
     cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -42,10 +42,10 @@ describe('Rules table: sorting', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
     login();
-    createRule(getNewRule({ rule_id: '1' }));
-    createRule(getExistingRule({ rule_id: '2' }));
-    createRule(getNewOverrideRule({ rule_id: '3' }));
-    createRule(getNewThresholdRule({ rule_id: '4' }));
+    createRule(getNewRule({ rule_id: '1', enabled: false }));
+    createRule(getExistingRule({ rule_id: '2', enabled: false }));
+    createRule(getNewOverrideRule({ rule_id: '3', enabled: false }));
+    createRule(getNewThresholdRule({ rule_id: '4', enabled: false }));
   });
 
   beforeEach(() => {
@@ -70,8 +70,8 @@ describe('Rules table: sorting', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   });
 
   it('Pagination updates page number and results', () => {
-    createRule(getNewRule({ name: 'Test a rule', rule_id: '5' }));
-    createRule(getNewRule({ name: 'Not same as first rule', rule_id: '6' }));
+    createRule(getNewRule({ name: 'Test a rule', rule_id: '5', enabled: false }));
+    createRule(getNewRule({ name: 'Not same as first rule', rule_id: '6', enabled: false }));
 
     visit(DETECTIONS_RULE_MANAGEMENT_URL);
     setRowsPerPageTo(5);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -14,9 +14,12 @@ import {
   SECOND_RULE,
   FOURTH_RULE,
   RULES_MANAGEMENT_TABLE,
-  RULES_ROW,
 } from '../../../../screens/alerts_detection_rules';
-import { enableRule, waitForRuleToUpdate } from '../../../../tasks/alerts_detection_rules';
+import {
+  enableRule,
+  getRulesManagementTableRows,
+  waitForRuleToUpdate,
+} from '../../../../tasks/alerts_detection_rules';
 import { login, visit } from '../../../../tasks/login';
 
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../../../urls/navigation';
@@ -82,7 +85,7 @@ describe('Rules table: sorting', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
       .then((ruleNameFirstPage) => {
         goToTablePage(2);
         // Check that the rules table shows at least one row
-        cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW).should('have.length.gte', 1);
+        getRulesManagementTableRows().should('have.length.gte', 1);
         // Check that the rules table doesn't show the rule from the first page
         cy.get(RULES_MANAGEMENT_TABLE).should('not.contain', ruleNameFirstPage);
       });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -16,11 +16,7 @@ import {
   RULES_MANAGEMENT_TABLE,
   RULES_ROW,
 } from '../../../../screens/alerts_detection_rules';
-import {
-  enableRule,
-  waitForRulesTableToBeLoaded,
-  waitForRuleToUpdate,
-} from '../../../../tasks/alerts_detection_rules';
+import { enableRule, waitForRuleToUpdate } from '../../../../tasks/alerts_detection_rules';
 import { login, visit } from '../../../../tasks/login';
 
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../../../urls/navigation';
@@ -55,7 +51,6 @@ describe('Rules table: sorting', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   it('Sorts by enabled rules', () => {
     visit(DETECTIONS_RULE_MANAGEMENT_URL);
-    waitForRulesTableToBeLoaded();
 
     enableRule(SECOND_RULE);
     waitForRuleToUpdate();
@@ -76,7 +71,6 @@ describe('Rules table: sorting', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     createRule(getNewRule({ name: 'Not same as first rule', rule_id: '6' }));
 
     visit(DETECTIONS_RULE_MANAGEMENT_URL);
-    waitForRulesTableToBeLoaded();
     setRowsPerPageTo(5);
 
     cy.get(RULES_MANAGEMENT_TABLE).find(TABLE_FIRST_PAGE).should('have.attr', 'aria-current');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
@@ -10,15 +10,10 @@ import { tag } from '../../../tags';
 import { getExceptionList } from '../../../objects/exception';
 import { getNewRule } from '../../../objects/rule';
 import { createRule } from '../../../tasks/api_calls/rules';
-import { login, visitWithoutDateRange } from '../../../tasks/login';
+import { login, visitSecurityDetectionRulesPage } from '../../../tasks/login';
 import { goToExceptionsTab, goToAlertsTab } from '../../../tasks/rule_details';
-import {
-  disableAutoRefresh,
-  goToRuleDetails,
-  waitForRulesTableToBeLoaded,
-} from '../../../tasks/alerts_detection_rules';
-import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../../urls/navigation';
-import { cleanKibana, deleteAlertsAndRules } from '../../../tasks/common';
+import { goToTheRuleDetailsOf } from '../../../tasks/alerts_detection_rules';
+import { deleteAlertsAndRules } from '../../../tasks/common';
 import {
   NO_EXCEPTIONS_EXIST_PROMPT,
   EXCEPTION_ITEM_VIEWER_CONTAINER,
@@ -35,12 +30,15 @@ import {
 describe('Exceptions viewer read only', { tags: tag.ESS }, () => {
   const exceptionList = getExceptionList();
 
-  before(() => {
-    cleanKibana();
+  beforeEach(() => {
+    deleteAlertsAndRules();
+    deleteExceptionList(exceptionList.list_id, exceptionList.namespace_type);
+
     // create rule with exceptions
     createExceptionList(exceptionList, exceptionList.list_id).then((response) => {
       createRule(
         getNewRule({
+          name: 'Test exceptions rule',
           query: 'agent.name:*',
           index: ['exceptions*'],
           exceptions_list: [
@@ -55,20 +53,11 @@ describe('Exceptions viewer read only', { tags: tag.ESS }, () => {
         })
       );
     });
-  });
 
-  beforeEach(() => {
     login(ROLES.reader);
-    visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL, ROLES.reader);
-    waitForRulesTableToBeLoaded();
-    disableAutoRefresh();
-    goToRuleDetails();
+    visitSecurityDetectionRulesPage(ROLES.reader);
+    goToTheRuleDetailsOf('Test exceptions rule');
     goToExceptionsTab();
-  });
-
-  after(() => {
-    deleteAlertsAndRules();
-    deleteExceptionList(exceptionList.list_id, exceptionList.namespace_type);
   });
 
   it('Cannot add an exception from empty viewer screen', () => {

--- a/x-pack/test/security_solution_cypress/cypress/screens/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/alerts_detection_rules.ts
@@ -63,9 +63,6 @@ export const UPGRADE_SELECTED_RULES_BUTTON = '[data-test-subj="upgradeSelectedRu
 
 export const GO_BACK_TO_RULES_TABLE_BUTTON = '[data-test-subj="addRulesGoBackToRulesTableBtn"]';
 
-export const RULES_TABLE_INITIAL_LOADING_INDICATOR =
-  '[data-test-subj="initialLoadingPanelAllRulesTable"]';
-
 export const RULES_TABLE_REFRESH_INDICATOR = '[data-test-subj="loading-spinner"]';
 
 export const RULES_TABLE_AUTOREFRESH_INDICATOR = '[data-test-subj="loadingRulesInfoProgress"]';

--- a/x-pack/test/security_solution_cypress/cypress/screens/common/page.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/common/page.ts
@@ -10,3 +10,5 @@ export const PAGE_TITLE = '[data-test-subj="header-page-title"]';
 export const NOT_FOUND = '[data-test-subj="notFoundPage"]';
 
 export const LOADING_SPINNER = '.euiLoadingSpinner';
+
+export const PAGE_CONTENT_SPINNER = `[data-test-subj="pageContainer"] ${LOADING_SPINNER}`;

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const ALL_ACTIONS = '[data-test-subj="rules-details-popover-button-icon"]';
+export const REST_ACTIONS_BUTTON = '[data-test-subj="rules-details-popover-button-icon"]';
 
 export const ABOUT_INVESTIGATION_NOTES = '[data-test-subj="stepAboutDetailsNoteContent"]';
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-export const REST_ACTIONS_BUTTON = '[data-test-subj="rules-details-popover-button-icon"]';
+export const POPOVER_ACTIONS_TRIGGER_BUTTON =
+  '[data-test-subj="rules-details-popover-button-icon"]';
 
 export const ABOUT_INVESTIGATION_NOTES = '[data-test-subj="stepAboutDetailsNoteContent"]';
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -179,16 +179,8 @@ export const filterByDisabledRules = () => {
   cy.get(DISABLED_RULES_BTN).click();
 };
 
-export const goToRuleDetailsPageFor = (ruleName: string) => {
-  cy.contains(RULE_NAME, ruleName).click();
-
-  cy.get(PAGE_CONTENT_SPINNER).should('be.visible');
-  cy.contains(RULE_NAME_HEADER, ruleName).should('be.visible');
-  cy.get(PAGE_CONTENT_SPINNER).should('not.exist');
-};
-
 /**
- * @deprecated use goToRuleDetailsPageFor
+ * @deprecated use goToTheRuleDetailsOf
  */
 export const goToRuleDetails = () => {
   cy.get(RULE_NAME).first().click();
@@ -196,6 +188,10 @@ export const goToRuleDetails = () => {
 
 export const goToTheRuleDetailsOf = (ruleName: string) => {
   cy.contains(RULE_NAME, ruleName).click();
+
+  cy.get(PAGE_CONTENT_SPINNER).should('be.visible');
+  cy.contains(RULE_NAME_HEADER, ruleName).should('be.visible');
+  cy.get(PAGE_CONTENT_SPINNER).should('not.exist');
 };
 
 export const openIntegrationsPopover = () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -11,7 +11,6 @@ import {
   CUSTOM_RULES_BTN,
   DELETE_RULE_ACTION_BTN,
   RULES_SELECTED_TAG,
-  RULES_TABLE_INITIAL_LOADING_INDICATOR,
   RULE_CHECKBOX,
   RULE_NAME,
   RULE_SWITCH,
@@ -264,21 +263,6 @@ export const confirmRulesDelete = () => {
 export const waitForRulesTableToShow = () => {
   // Wait up to 5 minutes for the table to show up as in CI containers this can be very slow
   cy.get(RULES_MANAGEMENT_TABLE, { timeout: 300000 }).should('exist');
-};
-
-/**
- * Because the Rule Management page is relatively slow, in order to avoid timeouts and flakiness,
- * we almost always want to wait until the Rules table is "loaded" before we do anything with it.
- *
- * This task can be needed for some tests that e.g. check the table load/refetch/pagination logic.
- * It waits for the table's own loading indicator to show up and disappear.
- *
- * NOTE: Normally, we should not rely on loading indicators in tests, because due to their
- * dynamic nature it's possible to introduce race conditions and flakiness.
- */
-export const waitForRulesTableToBeLoaded = () => {
-  // Wait up to 5 minutes for the rules to load as in CI containers this can be very slow
-  cy.get(RULES_TABLE_INITIAL_LOADING_INDICATOR, { timeout: 300000 }).should('not.exist');
 };
 
 export const waitForRulesTableToBeRefreshed = () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -54,6 +54,7 @@ import {
   ADD_ELASTIC_RULES_EMPTY_PROMPT_BTN,
   CONFIRM_DELETE_RULE_BTN,
   AUTO_REFRESH_POPOVER_TRIGGER_BUTTON,
+  SELECT_ALL_RULES_ON_PAGE_CHECKBOX,
 } from '../screens/alerts_detection_rules';
 import type { RULES_MONITORING_TABLE } from '../screens/alerts_detection_rules';
 import { EUI_CHECKBOX } from '../screens/common/controls';
@@ -63,6 +64,8 @@ import { LOADING_INDICATOR } from '../screens/security_header';
 
 import { goToRuleEditSettings } from './rule_details';
 import { goToActionsStepTab } from './create_new_rule';
+
+export const getRulesManagementTableRows = () => cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW);
 
 export const enableRule = (rulePosition: number) => {
   cy.get(RULE_SWITCH).eq(rulePosition).click();
@@ -211,6 +214,12 @@ export const selectAllRules = () => {
   cy.log('Select all rules');
   cy.get(SELECT_ALL_RULES_BTN).contains('Select all').click();
   cy.get(SELECT_ALL_RULES_BTN).contains('Clear');
+};
+
+export const selectAllRulesOnPage = () => {
+  cy.log('Select all rules on page');
+  cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).check();
+  cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).should('be.checked');
 };
 
 export const clearAllRuleSelection = () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -58,12 +58,13 @@ import {
 } from '../screens/alerts_detection_rules';
 import type { RULES_MONITORING_TABLE } from '../screens/alerts_detection_rules';
 import { EUI_CHECKBOX } from '../screens/common/controls';
-import { ALL_ACTIONS } from '../screens/rule_details';
+import { REST_ACTIONS_BUTTON, RULE_NAME_HEADER } from '../screens/rule_details';
 import { EDIT_SUBMIT_BUTTON } from '../screens/edit_rule';
 import { LOADING_INDICATOR } from '../screens/security_header';
 
 import { goToRuleEditSettings } from './rule_details';
 import { goToActionsStepTab } from './create_new_rule';
+import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 
 export const getRulesManagementTableRows = () => cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW);
 
@@ -94,7 +95,7 @@ export const duplicateFirstRule = () => {
  */
 export const duplicateRuleFromMenu = () => {
   cy.get(LOADING_INDICATOR).should('not.exist');
-  cy.get(ALL_ACTIONS).click({ force: true });
+  cy.get(REST_ACTIONS_BUTTON).click({ force: true });
   cy.get(DUPLICATE_RULE_MENU_PANEL_BTN).should('be.visible');
 
   // Because of a fade effect and fast clicking this can produce more than one click
@@ -120,15 +121,7 @@ export const deleteFirstRule = () => {
 };
 
 export const deleteRuleFromDetailsPage = () => {
-  cy.get(ALL_ACTIONS).should('be.visible');
-  // We cannot use cy.root().pipe($el) withing this function and instead have to use a cy.wait()
-  // for the click handler to be registered. If you see flake here because of click handler issues
-  // increase the cy.wait(). The reason we cannot use cypress pipe is because multiple clicks on ALL_ACTIONS
-  // causes the pop up to show and then the next click for it to hide. Multiple clicks can cause
-  // the DOM to queue up and once we detect that the element is visible it can then become invisible later
-  // eslint-disable-next-line cypress/no-unnecessary-waiting
-  cy.wait(1000);
-  cy.get(ALL_ACTIONS).click();
+  cy.get(REST_ACTIONS_BUTTON).click();
   cy.get(RULE_DETAILS_DELETE_BTN).click();
   cy.get(RULE_DETAILS_DELETE_BTN).should('not.exist');
   cy.get(CONFIRM_DELETE_RULE_BTN).click();
@@ -186,6 +179,17 @@ export const filterByDisabledRules = () => {
   cy.get(DISABLED_RULES_BTN).click();
 };
 
+export const goToRuleDetailsPageFor = (ruleName: string) => {
+  cy.contains(RULE_NAME, ruleName).click();
+
+  cy.get(PAGE_CONTENT_SPINNER).should('be.visible');
+  cy.contains(RULE_NAME_HEADER, ruleName).should('be.visible');
+  cy.get(PAGE_CONTENT_SPINNER).should('not.exist');
+};
+
+/**
+ * @deprecated use goToRuleDetailsPageFor
+ */
 export const goToRuleDetails = () => {
   cy.get(RULE_NAME).first().click();
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -196,17 +196,9 @@ export const openIntegrationsPopover = () => {
   cy.get(INTEGRATIONS_POPOVER).click();
 };
 
-/**
- * Selects the number of rules. Since there can be missing click handlers
- * when the page loads at first, we use a pipe and a trigger of click
- * on it and then check to ensure that it is checked before continuing
- * with the tests.
- * @param numberOfRules The number of rules to click/check
- */
-export const selectNumberOfRules = (numberOfRules: number) => {
-  for (let i = 0; i < numberOfRules; i++) {
-    cy.get(RULE_CHECKBOX).eq(i).check();
-    cy.get(RULE_CHECKBOX).eq(i).should('be.checked');
+export const selectRulesByName = (ruleNames: Readonly<string[]>) => {
+  for (const ruleName of ruleNames) {
+    selectRuleByName(ruleName);
   }
 };
 
@@ -506,4 +498,9 @@ export const goToEditRuleActionsSettingsOf = (name: string) => {
   // wait until first step loads completely. Otherwise cypress stuck at the first edit page
   cy.get(EDIT_SUBMIT_BUTTON).should('be.enabled');
   goToActionsStepTab();
+};
+
+const selectRuleByName = (ruleName: string) => {
+  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).check();
+  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('be.checked');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -61,10 +61,10 @@ import { EUI_CHECKBOX } from '../screens/common/controls';
 import { REST_ACTIONS_BUTTON, RULE_NAME_HEADER } from '../screens/rule_details';
 import { EDIT_SUBMIT_BUTTON } from '../screens/edit_rule';
 import { LOADING_INDICATOR } from '../screens/security_header';
+import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 
 import { goToRuleEditSettings } from './rule_details';
 import { goToActionsStepTab } from './create_new_rule';
-import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 
 export const getRulesManagementTableRows = () => cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW);
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -58,7 +58,7 @@ import {
 } from '../screens/alerts_detection_rules';
 import type { RULES_MONITORING_TABLE } from '../screens/alerts_detection_rules';
 import { EUI_CHECKBOX } from '../screens/common/controls';
-import { REST_ACTIONS_BUTTON, RULE_NAME_HEADER } from '../screens/rule_details';
+import { POPOVER_ACTIONS_TRIGGER_BUTTON, RULE_NAME_HEADER } from '../screens/rule_details';
 import { EDIT_SUBMIT_BUTTON } from '../screens/edit_rule';
 import { LOADING_INDICATOR } from '../screens/security_header';
 import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
@@ -95,7 +95,7 @@ export const duplicateFirstRule = () => {
  */
 export const duplicateRuleFromMenu = () => {
   cy.get(LOADING_INDICATOR).should('not.exist');
-  cy.get(REST_ACTIONS_BUTTON).click({ force: true });
+  cy.get(POPOVER_ACTIONS_TRIGGER_BUTTON).click({ force: true });
   cy.get(DUPLICATE_RULE_MENU_PANEL_BTN).should('be.visible');
 
   // Because of a fade effect and fast clicking this can produce more than one click
@@ -121,7 +121,7 @@ export const deleteFirstRule = () => {
 };
 
 export const deleteRuleFromDetailsPage = () => {
-  cy.get(REST_ACTIONS_BUTTON).click();
+  cy.get(POPOVER_ACTIONS_TRIGGER_BUTTON).click();
   cy.get(RULE_DETAILS_DELETE_BTN).click();
   cy.get(RULE_DETAILS_DELETE_BTN).should('not.exist');
   cy.get(CONFIRM_DELETE_RULE_BTN).click();

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -495,16 +495,18 @@ export const goToEditRuleActionsSettingsOf = (name: string) => {
   goToActionsStepTab();
 };
 
+export const getRuleRow = (ruleName: string) => cy.contains(RULE_NAME, ruleName).parents(RULES_ROW);
+
 const selectRuleByName = (ruleName: string) => {
   cy.log(`Select rule "${ruleName}"`);
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).check();
+  getRuleRow(ruleName).find(EUI_CHECKBOX).check();
   cy.log(`Make sure rule "${ruleName}" has been selected`);
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('be.checked');
+  getRuleRow(ruleName).find(EUI_CHECKBOX).should('be.checked');
 };
 
 const unselectRuleByName = (ruleName: string) => {
   cy.log(`Unselect rule "${ruleName}"`);
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).uncheck();
+  getRuleRow(ruleName).find(EUI_CHECKBOX).uncheck();
   cy.log(`Make sure rule "${ruleName}" has been unselected`);
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('not.be.checked');
+  getRuleRow(ruleName).find(EUI_CHECKBOX).should('not.be.checked');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -11,7 +11,6 @@ import {
   CUSTOM_RULES_BTN,
   DELETE_RULE_ACTION_BTN,
   RULES_SELECTED_TAG,
-  RULE_CHECKBOX,
   RULE_NAME,
   RULE_SWITCH,
   RULE_SWITCH_LOADER,
@@ -202,22 +201,9 @@ export const selectRulesByName = (ruleNames: Readonly<string[]>) => {
   }
 };
 
-export const unselectRuleByName = (ruleName: string) => {
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).uncheck();
-  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('not.be.checked');
-};
-
-/**
- * Unselects a passed number of rules. To use together with selectNumberOfRules
- * as this utility will expect and check the passed number of rules
- * to have been previously checked.
- * @param numberOfRules The number of rules to click/check
- */
-export const unselectNumberOfRules = (numberOfRules: number) => {
-  for (let i = 0; i < numberOfRules; i++) {
-    cy.get(RULE_CHECKBOX).eq(i).should('be.checked');
-    cy.get(RULE_CHECKBOX).eq(i).uncheck();
-    cy.get(RULE_CHECKBOX).eq(i).should('not.be.checked');
+export const unselectRulesByName = (ruleNames: Readonly<string[]>) => {
+  for (const ruleName of ruleNames) {
+    unselectRuleByName(ruleName);
   }
 };
 
@@ -501,6 +487,15 @@ export const goToEditRuleActionsSettingsOf = (name: string) => {
 };
 
 const selectRuleByName = (ruleName: string) => {
+  cy.log(`Select rule "${ruleName}"`);
   cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).check();
+  cy.log(`Make sure rule "${ruleName}" has been selected`);
   cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('be.checked');
+};
+
+const unselectRuleByName = (ruleName: string) => {
+  cy.log(`Unselect rule "${ruleName}"`);
+  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).uncheck();
+  cy.log(`Make sure rule "${ruleName}" has been unselected`);
+  cy.contains(RULE_NAME, ruleName).parents(RULES_ROW).find(EUI_CHECKBOX).should('not.be.checked');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/prebuilt_rules.ts
@@ -74,45 +74,6 @@ export const excessivelyInstallAllPrebuiltRules = () => {
   installAllPrebuiltRulesRequest();
 };
 
-export const waitUntilAllRuleAssetsCreated = (
-  rules: Array<typeof SAMPLE_PREBUILT_RULE>,
-  index = '.kibana_security_solution'
-) =>
-  cy.waitUntil(
-    () => {
-      return cy
-        .request({
-          method: 'GET',
-          url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_search`,
-          headers: {
-            'kbn-xsrf': 'cypress-creds',
-            'x-elastic-internal-origin': 'security-solution',
-            'Content-Type': 'application/json',
-          },
-          failOnStatusCode: false,
-          body: {
-            query: {
-              match: {
-                type: 'security-rule',
-              },
-            },
-          },
-        })
-        .then((response) => {
-          const areAllRulesCreated = rules.every((rule) =>
-            // Checking that all the expected rules are stored in ES
-            response.body.hits.hits.some(
-              (storedRule: { _source: typeof SAMPLE_PREBUILT_RULE }) =>
-                storedRule._source['security-rule'].rule_id === rule['security-rule'].rule_id
-            )
-          );
-
-          return areAllRulesCreated;
-        });
-    },
-    { interval: 500, timeout: 12000 }
-  );
-
 export const createNewRuleAsset = ({
   index = '.kibana_security_solution',
   rule = SAMPLE_PREBUILT_RULE,
@@ -122,7 +83,7 @@ export const createNewRuleAsset = ({
 }) => {
   const url = `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_doc/security-rule:${
     rule['security-rule'].rule_id
-  }`;
+  }?refresh`;
   cy.log('URL', url);
   cy.waitUntil(
     () => {
@@ -168,7 +129,7 @@ export const bulkCreateRuleAssets = ({
 
   cy.request({
     method: 'PUT',
-    url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_mapping`,
+    url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_mapping?refresh`,
     body: {
       dynamic: true,
     },
@@ -241,20 +202,16 @@ export const createAndInstallMockedPrebuiltRules = ({
   rules,
   installToKibana = true,
 }: {
-  rules?: Array<typeof SAMPLE_PREBUILT_RULE>;
+  rules: Array<typeof SAMPLE_PREBUILT_RULE>;
   installToKibana?: boolean;
 }) => {
   cy.log('Install prebuilt rules', rules?.length);
   preventPrebuiltRulesPackageInstallation();
   // TODO: use this bulk method once the issue with Cypress is fixed
   // bulkCreateRuleAssets({ rules });
-  rules?.forEach((rule) => {
+  rules.forEach((rule) => {
     createNewRuleAsset({ rule });
   });
-
-  if (rules?.length) {
-    waitUntilAllRuleAssetsCreated(rules);
-  }
 
   if (installToKibana) {
     return installAllPrebuiltRulesRequest();

--- a/x-pack/test/security_solution_cypress/cypress/tasks/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/common.ts
@@ -114,7 +114,7 @@ export const deleteAlertsAndRules = () => {
 
   rootRequest({
     method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`,
+    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
     body: {
       query: {
         bool: {
@@ -134,7 +134,7 @@ export const deleteAlertsAndRules = () => {
     method: 'POST',
     url: `${Cypress.env(
       'ELASTICSEARCH_URL'
-    )}/.lists-*,.items-*,.alerts-security.alerts-*/_delete_by_query?conflicts=proceed&scroll_size=10000`,
+    )}/.lists-*,.items-*,.alerts-security.alerts-*/_delete_by_query?conflicts=proceed&scroll_size=10000&refresh`,
     body: {
       query: {
         match_all: {},
@@ -147,7 +147,7 @@ export const deleteTimelines = () => {
   const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
   rootRequest({
     method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`,
+    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
     body: {
       query: {
         bool: {
@@ -177,7 +177,7 @@ export const deleteCases = () => {
   const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
   rootRequest({
     method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`,
+    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
     body: {
       query: {
         bool: {
@@ -198,7 +198,7 @@ export const deleteConnectors = () => {
   const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
   rootRequest({
     method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`,
+    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
     body: {
       query: {
         bool: {
@@ -219,7 +219,7 @@ export const deletePrebuiltRulesAssets = () => {
   const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
   rootRequest({
     method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed`,
+    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
     body: {
       query: {
         bool: {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/login.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/login.ts
@@ -12,7 +12,13 @@ import Url from 'url';
 
 import type { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '@kbn/security-solution-plugin/common/constants';
-import { hostDetailsUrl, LOGOUT_URL, userDetailsUrl } from '../urls/navigation';
+import {
+  hostDetailsUrl,
+  LOGOUT_URL,
+  SECURITY_DETECTIONS_RULES_URL,
+  userDetailsUrl,
+} from '../urls/navigation';
+import { resetRulesTableState } from './common';
 
 /**
  * Credentials in the `kibana.dev.yml` config file will be used to authenticate
@@ -391,6 +397,11 @@ export const visitHostDetailsPage = (hostName = 'suricata-iowa') => {
   visit(hostDetailsUrl(hostName));
   cy.get('[data-test-subj="loading-spinner"]').should('exist');
   cy.get('[data-test-subj="loading-spinner"]').should('not.exist');
+};
+
+export const visitSecurityDetectionRulesPage = (role?: ROLES) => {
+  resetRulesTableState(); // Clear persistent rules filter data before page loading
+  visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL, role);
 };
 
 export const visitUserDetailsPage = (userName = 'test') => {


### PR DESCRIPTION
**Relates to: https://github.com/elastic/kibana/issues/161507**
**Fixes: https://github.com/elastic/kibana/issues/163704**
**Fixes: https://github.com/elastic/kibana/issues/163182**
**Fixes: https://github.com/elastic/kibana/issues/163558**
**Fixes: https://github.com/elastic/kibana/issues/163974**
**Fixes: https://github.com/elastic/kibana/issues/153914**
**Fixes: https://github.com/elastic/kibana/issues/164079**
**Fixes: https://github.com/elastic/kibana/issues/164279**

## Summary

While working on fixing Rules Management flaky tests I've noticed similar fails in different tests. This PR addresses common pitfalls to reduce a number of reasons causing e2e tests flakiness and as a result reduce a number of flaky tests.

## Details

The common reasons causing e2e tests flakiness for the rules tables are

- Auto-refresh

Auto-refresh functionality is enabled by default and the table gets auto-refreshed every 60 seconds. If a test takes more than 60 seconds the table fetches updated rules. Having rules enabled by default and sorted by `Enabled` column makes the sorting order undetermined and as rules get updated due to execution ES return them in undetermined order. This update can happen between commands working on the same element and indexed access like `eq()` would access different elements. 

- Missing selectors

Some tests or helper functions have expectations for an element absence like `should('not.exist')` without checking an element is visible before like `should('be.visible')`. This way a referenced element may disappear from the codebase after refactoring and the expectation still fulfils.

- Checking for `should('not.visible')` while an element is removed from the DOM

It most applicable to popovers as it first animates to be hidden and then removed from the DOM. Cypress first need to find an element to check its visibility. Replacing `should('not.visible')` with `should('not.exist')` and taking into concern from the account previous bullet fixes the problem.

- Modifying ES data without refreshing (`_delete_by_query` in particular)

Due to high performance ES architecture data isn't updated instantly. Having such behavior in tests leads to undetermined state depending on a number of environmental factors. As UI doesn't always auto-refreshes to fetch the recent updates in short period of time test fail. `_delete_by_query` may take some time to update the data but it doesn't support `refresh=wait_for` as it stated in [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-delete-by-query.html#_refreshing_shards). Adding `?refresh=true` or just `?refresh` to `_delete_by_query` ES request urls fixes the problem.

### What was done to address mentioned reasons above?

- Auto-refresh functionality disabled in tests where it's not necessary.
- `enabled: false` field was added to rule creators to have disabled rules as the majority of tests don't need enabled rules.
- `waitForRulesTableToBeLoaded` was removed and replaced with `expectManagementTableRules` at some tests.
- `should('not.visible')` replaced with `should('not.exist')` in `deleteRuleFromDetailsPage()`
- `?refresh` added to `_delete_by_query` ES data update requests

The other changes get rid of global constants and improve readability.

## Flaky test runs

[All Cypress tests under `detection_response` folder (100 runs)](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2920) (value lists export is flaky but it's out of scope of this PR)

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->