### PR TITLE
[Event annotations] add types to integration tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -829,7 +829,7 @@ packages/kbn-yarn-lock-validator @elastic/kibana-operations
 /x-pack/test/api_integration/apis/lens/ @elastic/kibana-visualizations
 /test/functional/apps/visualize/ @elastic/kibana-visualizations
 /x-pack/test/functional/apps/graph @elastic/kibana-visualizations
-/test/api_integraion/apis/event_annotations @elastic/kibana-visualizations
+/test/api_integration/apis/event_annotations @elastic/kibana-visualizations
 
 # Global Experience
 

--- a/src/plugins/event_annotation/common/index.ts
+++ b/src/plugins/event_annotation/common/index.ts
@@ -26,5 +26,11 @@ export type { EventAnnotationGroupArgs } from './event_annotation_group';
 export type { FetchEventAnnotationsArgs } from './fetch_event_annotations/types';
 export type { EventAnnotationArgs, EventAnnotationOutput } from './types';
 
-export type { EventAnnotationGroupSavedObjectAttributes } from './content_management';
+export type {
+  EventAnnotationGroupSavedObjectAttributes,
+  EventAnnotationGroupCreateIn,
+  EventAnnotationGroupUpdateIn,
+  EventAnnotationGroupSearchIn,
+} from './content_management';
+export { CONTENT_ID } from './content_management';
 export { ANNOTATIONS_LISTING_VIEW_ID } from './constants';

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -67,6 +67,7 @@
     "@kbn/enterprise-search-plugin",
     "@kbn/core-saved-objects-server",
     "@kbn/discover-plugin",
-    "@kbn/core-http-common"
+    "@kbn/core-http-common",
+    "@kbn/event-annotation-plugin"
   ]
 }


### PR DESCRIPTION
## Summary

Just improving the integration tests so that if a type changes, we'll know to update them.
