### PR TITLE
fix(NA): source classifier to indentify xml as static files

### DIFF
--- a/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
@@ -154,6 +154,7 @@ export class RepoSourceClassifier {
     const pkgInfo = path.getPkgInfo();
     if (!pkgInfo) {
       // TODO: consider if static, test or mock and tooling should only be checked before triggering non-package
+      // GH ISSUE: https://github.com/elastic/kibana/issues/164110
       return 'non-package';
     }
 

--- a/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
@@ -13,7 +13,9 @@ import { RANDOM_TEST_FILE_NAMES, TEST_DIR, TEST_TAG } from './config';
 import { RepoPath } from './repo_path';
 
 const STATIC_EXTS = new Set(
-  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl|xml'.split('|').map((e) => `.${e}`)
+  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl|xml'
+    .split('|')
+    .map((e) => `.${e}`)
 );
 
 export class RepoSourceClassifier {

--- a/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
+++ b/packages/kbn-repo-source-classifier/src/repo_source_classifier.ts
@@ -13,7 +13,7 @@ import { RANDOM_TEST_FILE_NAMES, TEST_DIR, TEST_TAG } from './config';
 import { RepoPath } from './repo_path';
 
 const STATIC_EXTS = new Set(
-  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl'.split('|').map((e) => `.${e}`)
+  'json|woff|woff2|ttf|eot|svg|ico|png|jpg|gif|jpeg|html|md|txt|tmpl|xml'.split('|').map((e) => `.${e}`)
 );
 
 export class RepoSourceClassifier {
@@ -153,6 +153,7 @@ export class RepoSourceClassifier {
 
     const pkgInfo = path.getPkgInfo();
     if (!pkgInfo) {
+      // TODO: consider if static, test or mock and tooling should only be checked before triggering non-package
       return 'non-package';
     }
 


### PR DESCRIPTION
This PR fixes a bug in the source classifier as it is currently not identifying xml as a static file.

As part of this I've also identified a TODO in the source classifier related with the evaluating order.

<!--ONMERGE {"backportTargets":["7.17","8.10","8.9"]} ONMERGE-->