### PR TITLE
[Cases] Add max alerts per case to docs

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -5471,7 +5471,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "maxItems": 1000
           }
         ],
         "x-technical-preview": true,
@@ -5488,7 +5489,8 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "maxItems": 1000
           }
         ],
         "x-technical-preview": true

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -3532,6 +3532,7 @@ components:
         - type: array
           items:
             type: string
+          maxItems: 1000
       x-technical-preview: true
       example: 6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42
     alert_indices:
@@ -3543,6 +3544,7 @@ components:
         - type: array
           items:
             type: string
+          maxItems: 1000
       x-technical-preview: true
     rule:
       title: Alerting rule

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
@@ -11,5 +11,6 @@ oneOf:
   - type: array
     items:
       type: string
+    maxItems: 1000
 x-technical-preview: true
 example: 6b24c4dc44bc720cfc92797f3d61fff952f2b2627db1fb4f8cc49f4530c4ff42

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
@@ -12,4 +12,5 @@ oneOf:
   - type: array
     items:
       type: string
+    maxItems: 1000
 x-technical-preview: true


### PR DESCRIPTION
## Summary

Added docs for total alerts per case guardrails as per https://github.com/elastic/kibana/issues/146945

| Description  | Limit | Done? | Documented? | UI?
| ------------- | ---- | :---: | ---- | :----: |
| Total alerts per case   |  1.000  | :white_check_mark: | Yes | N/A |


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->