### PR TITLE
[8.9] [Lens] Improve message for unsupported aggregation when using a TSDB counter field (#161481)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -715,6 +715,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       datastreamsILM: `${FLEET_DOCS}data-streams.html#data-streams-ilm`,
       datastreamsNamingScheme: `${FLEET_DOCS}data-streams.html#data-streams-naming-scheme`,
       datastreamsManualRollover: `${ELASTICSEARCH_DOCS}use-a-data-stream.html#manually-roll-over-a-data-stream`,
+      datastreamsTSDS: `${ELASTICSEARCH_DOCS}tsds.html`,
+      datastreamsTSDSMetrics: `${ELASTICSEARCH_DOCS}tsds.html#time-series-metric`,
       installElasticAgent: `${FLEET_DOCS}install-fleet-managed-elastic-agent.html`,
       installElasticAgentStandalone: `${FLEET_DOCS}install-standalone-elastic-agent.html`,
       upgradeElasticAgent: `${FLEET_DOCS}upgrade-elastic-agent.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -483,6 +483,8 @@ export interface DocLinks {
     datastreamsILM: string;
     datastreamsNamingScheme: string;
     datastreamsManualRollover: string;
+    datastreamsTSDS: string;
+    datastreamsTSDSMetrics: string;
     installElasticAgent: string;
     installElasticAgentStandalone: string;
     packageSignatures: string;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -788,9 +788,9 @@ export const VisualizationWrapper = ({
         executionContext={executionContext}
         renderMode="edit"
         renderError={(errorMessage?: string | null, error?: ExpressionRenderError | null) => {
-          const errorsFromRequest = getOriginalRequestErrorMessages(error);
+          const errorsFromRequest = getOriginalRequestErrorMessages(error || null, core.docLinks);
           const visibleErrorMessages = errorsFromRequest.length
-            ? errorsFromRequest
+            ? errorsFromRequest.map((e) => e.longMessage || e.shortMessage)
             : errorMessage
             ? [errorMessage]
             : [];
@@ -829,11 +829,15 @@ export const VisualizationWrapper = ({
                       </p>
 
                       {localState.expandError
-                        ? visibleErrorMessages.map((visibleErrorMessage) => (
-                            <p className="eui-textBreakWord" key={visibleErrorMessage}>
-                              {visibleErrorMessage}
-                            </p>
-                          ))
+                        ? visibleErrorMessages.map((visibleErrorMessage) =>
+                            typeof visibleErrorMessage === 'string' ? (
+                              <p className="eui-textBreakWord" key={visibleErrorMessage}>
+                                {visibleErrorMessage}
+                              </p>
+                            ) : (
+                              visibleErrorMessage
+                            )
+                          )
                         : null}
                     </>
                   }

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -964,6 +964,7 @@ export class Embeddable
                 this.logError('runtime');
               }}
               noPadding={this.visDisplayOptions.noPadding}
+              docLinks={this.deps.coreStart.docLinks}
             />
           </KibanaThemeProvider>
           <MessagesBadge

--- a/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
@@ -12,7 +12,7 @@ import {
   ReactExpressionRendererProps,
   ReactExpressionRendererType,
 } from '@kbn/expressions-plugin/public';
-import type { KibanaExecutionContext } from '@kbn/core/public';
+import type { CoreStart, KibanaExecutionContext } from '@kbn/core/public';
 import { ExecutionContextSearch } from '@kbn/data-plugin/public';
 import { DefaultInspectorAdapters, RenderMode } from '@kbn/expressions-plugin/common';
 import classNames from 'classnames';
@@ -46,6 +46,7 @@ export interface ExpressionWrapperProps {
   executionContext?: KibanaExecutionContext;
   lensInspector: LensInspector;
   noPadding?: boolean;
+  docLinks: CoreStart['docLinks'];
 }
 
 export function ExpressionWrapper({
@@ -71,6 +72,7 @@ export function ExpressionWrapper({
   executionContext,
   lensInspector,
   noPadding,
+  docLinks,
 }: ExpressionWrapperProps) {
   if (!expression) return null;
   return (
@@ -93,18 +95,9 @@ export function ExpressionWrapper({
           syncCursor={syncCursor}
           executionContext={executionContext}
           renderError={(errorMessage, error) => {
-            const messages = getOriginalRequestErrorMessages(error);
-            addUserMessages(
-              messages.map((message) => ({
-                uniqueId: message,
-                severity: 'error',
-                displayLocations: [{ id: 'visualizationOnEmbeddable' }],
-                longMessage: message,
-                shortMessage: message,
-                fixableInEditor: false,
-              }))
-            );
-            onRuntimeError(messages[0] ?? errorMessage);
+            const messages = getOriginalRequestErrorMessages(error || null, docLinks);
+            addUserMessages(messages);
+            onRuntimeError(messages[0].shortMessage ?? (errorMessage || ''));
 
             return <></>; // the embeddable will take care of displaying the messages
           }}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Lens] Improve message for unsupported aggregation when using a TSDB counter field (#161481)](https://github.com/elastic/kibana/pull/161481)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-07-20T07:11:22Z","message":"[Lens] Improve message for unsupported aggregation when using a TSDB counter field (#161481)\n\n## Summary\r\n\r\nThis PR improves the message for the case where a visualization where a\r\ncounter field was used, but it wasn't yet in time series mode, then it\r\ngets upgraded to timeseries and ES will restrict its agg support.\r\nAdded also few new documentation links to TSDS documentation pages.\r\n\r\nWithin a dashboard the error would be a reshape of the ES one:\r\n\r\n<img width=\"774\" alt=\"Screenshot 2023-07-17 at 17 58 17\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/766c60e3-166c-4038-bf04-bbb1d5c08cb2\">\r\n\r\nUnfortunately it is only possible to show simple text (no link) within a\r\ndashboard panel in view mode as it relies on native `Embeddable` types\r\nwhich only allow native JS errors.\r\n\r\nIf user has edit permissions then it would be possible to click the\r\n`Edit in Lens` to open the editor and see more information about the\r\nerror, i.e. the doc link:\r\n\r\n<img width=\"513\" alt=\"Screenshot 2023-07-17 at 17 50 39\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/54c19c9f-7385-405e-8c4c-9061185ac52b\">\r\n\r\nTo test just use the latest ES snapshot with this PR:\r\nhttps://github.com/elastic/elasticsearch/pull/93545\r\n\r\n~~Waiting for a link to some documentation from the ES team to be\r\nincluded here as well.~~\r\nAdded link to https://github.com/elastic/elasticsearch/pull/97618\r\nimproved documentation.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a3e1aab3634c2b318f8aac77a50134c9cccb6d25","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:prev-minor","v8.10.0","v8.11.0"],"number":161481,"url":"https://github.com/elastic/kibana/pull/161481","mergeCommit":{"message":"[Lens] Improve message for unsupported aggregation when using a TSDB counter field (#161481)\n\n## Summary\r\n\r\nThis PR improves the message for the case where a visualization where a\r\ncounter field was used, but it wasn't yet in time series mode, then it\r\ngets upgraded to timeseries and ES will restrict its agg support.\r\nAdded also few new documentation links to TSDS documentation pages.\r\n\r\nWithin a dashboard the error would be a reshape of the ES one:\r\n\r\n<img width=\"774\" alt=\"Screenshot 2023-07-17 at 17 58 17\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/766c60e3-166c-4038-bf04-bbb1d5c08cb2\">\r\n\r\nUnfortunately it is only possible to show simple text (no link) within a\r\ndashboard panel in view mode as it relies on native `Embeddable` types\r\nwhich only allow native JS errors.\r\n\r\nIf user has edit permissions then it would be possible to click the\r\n`Edit in Lens` to open the editor and see more information about the\r\nerror, i.e. the doc link:\r\n\r\n<img width=\"513\" alt=\"Screenshot 2023-07-17 at 17 50 39\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/54c19c9f-7385-405e-8c4c-9061185ac52b\">\r\n\r\nTo test just use the latest ES snapshot with this PR:\r\nhttps://github.com/elastic/elasticsearch/pull/93545\r\n\r\n~~Waiting for a link to some documentation from the ES team to be\r\nincluded here as well.~~\r\nAdded link to https://github.com/elastic/elasticsearch/pull/97618\r\nimproved documentation.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a3e1aab3634c2b318f8aac77a50134c9cccb6d25"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/161481","number":161481,"mergeCommit":{"message":"[Lens] Improve message for unsupported aggregation when using a TSDB counter field (#161481)\n\n## Summary\r\n\r\nThis PR improves the message for the case where a visualization where a\r\ncounter field was used, but it wasn't yet in time series mode, then it\r\ngets upgraded to timeseries and ES will restrict its agg support.\r\nAdded also few new documentation links to TSDS documentation pages.\r\n\r\nWithin a dashboard the error would be a reshape of the ES one:\r\n\r\n<img width=\"774\" alt=\"Screenshot 2023-07-17 at 17 58 17\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/766c60e3-166c-4038-bf04-bbb1d5c08cb2\">\r\n\r\nUnfortunately it is only possible to show simple text (no link) within a\r\ndashboard panel in view mode as it relies on native `Embeddable` types\r\nwhich only allow native JS errors.\r\n\r\nIf user has edit permissions then it would be possible to click the\r\n`Edit in Lens` to open the editor and see more information about the\r\nerror, i.e. the doc link:\r\n\r\n<img width=\"513\" alt=\"Screenshot 2023-07-17 at 17 50 39\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/54c19c9f-7385-405e-8c4c-9061185ac52b\">\r\n\r\nTo test just use the latest ES snapshot with this PR:\r\nhttps://github.com/elastic/elasticsearch/pull/93545\r\n\r\n~~Waiting for a link to some documentation from the ES team to be\r\nincluded here as well.~~\r\nAdded link to https://github.com/elastic/elasticsearch/pull/97618\r\nimproved documentation.\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n\r\n### Risk Matrix\r\n\r\nDelete this section if it is not applicable to this PR.\r\n\r\nBefore closing this PR, invite QA, stakeholders, and other developers to\r\nidentify risks that should be tested prior to the change/feature\r\nrelease.\r\n\r\nWhen forming the risk matrix, consider some of the following examples\r\nand how they may potentially impact the change:\r\n\r\n| Risk | Probability | Severity | Mitigation/Notes |\r\n\r\n|---------------------------|-------------|----------|-------------------------|\r\n| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space.\r\n| Low | High | Integration tests will verify that all features are still\r\nsupported in non-default Kibana Space and when user switches between\r\nspaces. |\r\n| Multiple nodes&mdash;Elasticsearch polling might have race conditions\r\nwhen multiple Kibana nodes are polling for the same tasks. | High | Low\r\n| Tasks are idempotent, so executing them multiple times will not result\r\nin logical error, but will degrade performance. To test for this case we\r\nadd plenty of unit tests around this logic and document manual testing\r\nprocedure. |\r\n| Code should gracefully handle cases when feature X or plugin Y are\r\ndisabled. | Medium | High | Unit tests will verify that any feature flag\r\nor plugin combination still results in our service operational. |\r\n| [See more potential risk\r\nexamples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"a3e1aab3634c2b318f8aac77a50134c9cccb6d25"}},{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->