### PR TITLE
[APM] reenabling api test for last agent version

### DIFF
--- a/x-pack/test/apm_api_integration/tests/agent_explorer/latest_agent_versions.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/agent_explorer/latest_agent_versions.spec.ts
@@ -21,8 +21,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/161853
-  registry.when.skip(
+  registry.when(
     'Agent latest versions when configuration is defined',
     { config: 'basic', archives: [] },
     () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/161853.