### PR TITLE
[Discover] Split a drag & drop test into 2 tests

### DIFF
--- a/test/functional/apps/discover/group3/_drag_drop.ts
+++ b/test/functional/apps/discover/group3/_drag_drop.ts
@@ -60,17 +60,35 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           '@timestamp, extension'
         );
 
+        await PageObjects.discover.waitUntilSearchingHasFinished();
+
+        expect(
+          (await PageObjects.unifiedFieldList.getSidebarSectionFieldNames('selected')).join(', ')
+        ).to.be('extension');
+      });
+
+      it('should support dragging and dropping a field onto the grid (with keyboard)', async function () {
+        await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
+
+        expect(await PageObjects.unifiedFieldList.getSidebarAriaDescription()).to.be(
+          '53 available fields. 0 empty fields. 3 meta fields.'
+        );
+        expect((await PageObjects.discover.getColumnHeaders()).join(', ')).to.be(
+          '@timestamp, Document'
+        );
+
         await PageObjects.discover.dragFieldWithKeyboardToTable('@message');
 
         expect((await PageObjects.discover.getColumnHeaders()).join(', ')).to.be(
-          '@timestamp, extension, @message'
+          '@timestamp, @message'
         );
 
         await PageObjects.discover.waitUntilSearchingHasFinished();
 
         expect(
           (await PageObjects.unifiedFieldList.getSidebarSectionFieldNames('selected')).join(', ')
-        ).to.be('extension, @message');
+        ).to.be('@message');
       });
     });
   });


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/163979
- Closes https://github.com/elastic/kibana/issues/163980

It was adding both fields too fast.
100x https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2908

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->