### PR TITLE
[ML] Fixes Trained models list crashes on browser refresh if not on page 1 

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -131,6 +131,7 @@ export const ModelsList: FC<Props> = ({
 
   const { displayErrorToast } = useToastNotificationService();
 
+  const [isInitialized, setIsInitialized] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [items, setItems] = useState<ModelItem[]>([]);
   const [selectedModels, setSelectedModels] = useState<ModelItem[]>([]);
@@ -183,7 +184,6 @@ export const ModelsList: FC<Props> = ({
     try {
       const response = await trainedModelsApiService.getTrainedModels(undefined, {
         with_pipelines: true,
-        size: 1000,
       });
 
       const newItems: ModelItem[] = [];
@@ -235,6 +235,7 @@ export const ModelsList: FC<Props> = ({
         })
       );
     }
+    setIsInitialized(true);
     setIsLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [itemIdToExpandedRowMap]);
@@ -267,7 +268,7 @@ export const ModelsList: FC<Props> = ({
     try {
       if (models) {
         const { trained_model_stats: modelsStatsResponse } =
-          await trainedModelsApiService.getTrainedModelStats(models.map((m) => m.model_id));
+          await trainedModelsApiService.getTrainedModelStats();
 
         const groupByModelId = groupBy(modelsStatsResponse, 'model_id');
 
@@ -595,6 +596,8 @@ export const ModelsList: FC<Props> = ({
       });
     return [...items, ...notDownloaded];
   }, [items]);
+
+  if (!isInitialized) return null;
 
   return (
     <>

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/analytics_manager.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/analytics_manager.ts
@@ -37,6 +37,7 @@ import {
   GetAnalyticsModelIdArg,
 } from './types';
 import type { MlClient } from '../../lib/ml_client';
+import { DEFAULT_TRAINED_MODELS_PAGE_SIZE } from '../../routes/trained_models';
 
 export class AnalyticsManager {
   private _trainedModels: estypes.MlTrainedModelConfig[] = [];
@@ -47,8 +48,8 @@ export class AnalyticsManager {
 
   private async initData() {
     const [models, jobs] = await Promise.all([
-      this._mlClient.getTrainedModels({ size: 10000 }),
-      this._mlClient.getDataFrameAnalytics({ size: 10000 }),
+      this._mlClient.getTrainedModels({ size: DEFAULT_TRAINED_MODELS_PAGE_SIZE }),
+      this._mlClient.getDataFrameAnalytics({ size: 1000 }),
     ]);
     this._trainedModels = models.trained_model_configs;
     this._jobs = jobs.data_frame_analytics;

--- a/x-pack/plugins/ml/server/models/data_frame_analytics/analytics_manager.ts
+++ b/x-pack/plugins/ml/server/models/data_frame_analytics/analytics_manager.ts
@@ -47,8 +47,8 @@ export class AnalyticsManager {
 
   private async initData() {
     const [models, jobs] = await Promise.all([
-      this._mlClient.getTrainedModels(),
-      this._mlClient.getDataFrameAnalytics({ size: 1000 }),
+      this._mlClient.getTrainedModels({ size: 10000 }),
+      this._mlClient.getDataFrameAnalytics({ size: 10000 }),
     ]);
     this._trainedModels = models.trained_model_configs;
     this._jobs = jobs.data_frame_analytics;

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -29,6 +29,8 @@ import { mlLog } from '../lib/log';
 import { forceQuerySchema } from './schemas/anomaly_detectors_schema';
 import { modelsProvider } from '../models/model_management';
 
+const DEFAULT_SIZE = 10000;
+
 export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization) {
   /**
    * @apiGroup TrainedModels
@@ -60,10 +62,10 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
           const { modelId } = request.params;
           const { with_pipelines: withPipelines, ...query } = request.query;
           const body = await mlClient.getTrainedModels({
-            // @ts-expect-error @elastic-elasticsearch not sure why this is an error, size is a number
-            size: 1000,
             ...query,
             ...(modelId ? { model_id: modelId } : {}),
+            size: DEFAULT_SIZE,
+            include: undefined,
           });
           // model_type is missing
           // @ts-ignore
@@ -152,7 +154,7 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
       },
       routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
         try {
-          const body = await mlClient.getTrainedModelsStats();
+          const body = await mlClient.getTrainedModelsStats({ size: DEFAULT_SIZE });
           return response.ok({
             body,
           });

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import { ErrorType } from '@kbn/ml-error-utils';
+import { type MlGetTrainedModelsRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { ML_INTERNAL_BASE_PATH } from '../../common/constants/app';
 import { RouteInitialization } from '../types';
 import { wrapError } from '../client/error_wrapper';
@@ -65,8 +66,7 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
             ...query,
             ...(modelId ? { model_id: modelId } : {}),
             size: DEFAULT_SIZE,
-            include: undefined,
-          });
+          } as MlGetTrainedModelsRequest);
           // model_type is missing
           // @ts-ignore
           const result = body.trained_model_configs as TrainedModelConfigResponse[];

--- a/x-pack/plugins/ml/server/routes/trained_models.ts
+++ b/x-pack/plugins/ml/server/routes/trained_models.ts
@@ -30,7 +30,7 @@ import { mlLog } from '../lib/log';
 import { forceQuerySchema } from './schemas/anomaly_detectors_schema';
 import { modelsProvider } from '../models/model_management';
 
-const DEFAULT_SIZE = 10000;
+export const DEFAULT_TRAINED_MODELS_PAGE_SIZE = 10000;
 
 export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization) {
   /**
@@ -65,7 +65,7 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
           const body = await mlClient.getTrainedModels({
             ...query,
             ...(modelId ? { model_id: modelId } : {}),
-            size: DEFAULT_SIZE,
+            size: DEFAULT_TRAINED_MODELS_PAGE_SIZE,
           } as MlGetTrainedModelsRequest);
           // model_type is missing
           // @ts-ignore
@@ -154,7 +154,9 @@ export function trainedModelsRoutes({ router, routeGuard }: RouteInitialization)
       },
       routeGuard.fullLicenseAPIGuard(async ({ mlClient, request, response }) => {
         try {
-          const body = await mlClient.getTrainedModelsStats({ size: DEFAULT_SIZE });
+          const body = await mlClient.getTrainedModelsStats({
+            size: DEFAULT_TRAINED_MODELS_PAGE_SIZE,
+          });
           return response.ok({
             body,
           });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/162618

There was an issue with setting pagination for the EUI table before models are fetched. Providing a page index while the items count is 0 caused pagination to reset with an uninitialized URL state callback. This PR adds a check to verify model list has been retrieved.

Also, the Kibana `_stats` endpoint has been updated to provide a `size` parameter. 

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->