### PR TITLE
[DOCS] Change deep link to ES book for CCS privileges

### DIFF
--- a/docs/user/alerting/alerting-setup.asciidoc
+++ b/docs/user/alerting/alerting-setup.asciidoc
@@ -109,5 +109,5 @@ The same behavior occurs when you change the API key in the header of your API c
 [[alerting-ccs-setup]]
 === {ccs-cap}
 
-If you want to use alerting rules with {ccs}, you must configure 
-{ref}/remote-clusters-privileges.html#clusters-privileges-ccs-kibana[privileges for {ccs-init} and {kib}].
+If you want to use alerting rules with {ccs}, you must configure privileges for
+{ccs-init} and {kib}. Refer to {ref}/remote-clusters.html[Remote clusters].


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/elasticsearch/pull/98330

8.10 introduces a new method to configure remote clusters (API key based), which will live next to the existing method (certificate based). As a result, the ES remote cluster docs will be restructured. The deep link from "[Alerting set up](https://www.elastic.co/guide/en/kibana/current/alerting-setup.html#alerting-ccs-setup)" to the setting up CCS privileges section in the ES docs will break (and would potentially bring folks to the wrong page anyway). 

This PR changes the link into a link to the higher-level remote cluster docs, from where folks can click through to the section that is relevant to them.



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->