### PR TITLE
Add warning for max alerts circuit breaker

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -246,7 +246,7 @@ Specifies the maximum number of actions that a rule can generate each time detec
 `xpack.alerting.rules.run.alerts.max` {ess-icon}::
 Specifies the maximum number of alerts that a rule can generate each time detection checks run. Default: 1000.
 +
-WARNING: Configuring your alerting system to handle more than 1000 alerts per run requires careful consideration and is not supported. Doing so could strain system resources, leading to performance issues, delays in alert processing, and potential disruptions during high alert activity periods.
+WARNING: The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload, however setting a value higher than the default (`1000`) is not recommended or supported. Doing so could strain system resources and lead to performance issues, delays in alert processing, and potential disruptions during high alert activity periods.
 
 `xpack.alerting.rules.run.timeout` {ess-icon}::
 Specifies the default timeout for tasks associated with all types of rules.

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -245,6 +245,8 @@ Specifies the maximum number of actions that a rule can generate each time detec
 
 `xpack.alerting.rules.run.alerts.max` {ess-icon}::
 Specifies the maximum number of alerts that a rule can generate each time detection checks run. Default: 1000.
++
+WARNING: Configuring your alerting system to handle more than 1000 alerts per run requires careful consideration and is not supported. Doing so could strain system resources, leading to performance issues, delays in alert processing, and potential disruptions during high alert activity periods.
 
 `xpack.alerting.rules.run.timeout` {ess-icon}::
 Specifies the default timeout for tasks associated with all types of rules.


### PR DESCRIPTION
In this PR, I'm adding a warning message to the docs for the `xpack.alerting.rules.run.alerts.max` setting that indicates the consequences when setting a value higher than the default, while also indicating it's not supported.

<img width="862" alt="Screenshot 2023-08-21 at 5 03 52 PM" src="https://github.com/elastic/kibana/assets/3694571/46a7f5d6-f6d5-475a-ab93-edf256eb9141">

cc @lcawl 

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->