### PR TITLE
[Search] Disable crawler on overview without ent-search

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/ingestion_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/ingestion_selector.tsx
@@ -9,6 +9,8 @@ import React from 'react';
 
 import { generatePath } from 'react-router-dom';
 
+import { useValues } from 'kea';
+
 import { EuiButton, EuiCard, EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -27,13 +29,18 @@ import {
   NEW_INDEX_METHOD_PATH,
   NEW_INDEX_SELECT_CONNECTOR_PATH,
 } from '../../../enterprise_search_content/routes';
-import { EuiLinkTo } from '../../../shared/react_router_helpers';
+import { HttpLogic } from '../../../shared/http/http_logic';
+import { KibanaLogic } from '../../../shared/kibana';
+import { EuiButtonTo, EuiLinkTo } from '../../../shared/react_router_helpers';
 
 const START_LABEL = i18n.translate('xpack.enterpriseSearch.ingestSelector.startButton', {
   defaultMessage: 'Start',
 });
 
 export const IngestionSelector: React.FC = () => {
+  const { config, productFeatures } = useValues(KibanaLogic);
+  const { errorConnectingMessage } = useValues(HttpLogic);
+  const crawlerDisabled = Boolean(errorConnectingMessage || !config.host);
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
@@ -61,60 +68,67 @@ export const IngestionSelector: React.FC = () => {
           }
         />
       </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiCard
-          hasBorder
-          icon={<EuiIcon type={connectorLogo} size="xxl" />}
-          textAlign="left"
-          title={i18n.translate('xpack.enterpriseSearch.ingestSelector.method.connectors', {
-            defaultMessage: 'Connectors',
-          })}
-          description={i18n.translate(
-            'xpack.enterpriseSearch.ingestSelector.method.connectors.description',
-            {
-              defaultMessage:
-                'Extract, transform, index and sync data from a third-party data source.',
+      {productFeatures.hasConnectors && (
+        <EuiFlexItem>
+          <EuiCard
+            hasBorder
+            icon={<EuiIcon type={connectorLogo} size="xxl" />}
+            textAlign="left"
+            title={i18n.translate('xpack.enterpriseSearch.ingestSelector.method.connectors', {
+              defaultMessage: 'Connectors',
+            })}
+            description={i18n.translate(
+              'xpack.enterpriseSearch.ingestSelector.method.connectors.description',
+              {
+                defaultMessage:
+                  'Extract, transform, index and sync data from a third-party data source.',
+              }
+            )}
+            footer={
+              <EuiLinkTo
+                to={generatePath(
+                  ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_SELECT_CONNECTOR_PATH
+                )}
+                shouldNotCreateHref
+              >
+                <EuiButton fullWidth>{START_LABEL}</EuiButton>
+              </EuiLinkTo>
             }
-          )}
-          footer={
-            <EuiLinkTo
-              to={generatePath(
-                ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_SELECT_CONNECTOR_PATH
-              )}
-              shouldNotCreateHref
-            >
-              <EuiButton fullWidth>{START_LABEL}</EuiButton>
-            </EuiLinkTo>
-          }
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <EuiCard
-          hasBorder
-          icon={<EuiIcon type={crawlerLogo} size="xxl" />}
-          textAlign="left"
-          title={i18n.translate('xpack.enterpriseSearch.ingestSelector.method.crawler', {
-            defaultMessage: 'Web Crawler',
-          })}
-          description={i18n.translate(
-            'xpack.enterpriseSearch.ingestSelector.method.crawler.description',
-            {
-              defaultMessage:
-                'Discover, extract, and index searchable content from websites and knowledge bases.',
+          />
+        </EuiFlexItem>
+      )}
+      {productFeatures.hasWebCrawler && (
+        <EuiFlexItem>
+          <EuiCard
+            hasBorder
+            isDisabled={crawlerDisabled}
+            icon={<EuiIcon type={crawlerLogo} size="xxl" />}
+            textAlign="left"
+            title={i18n.translate('xpack.enterpriseSearch.ingestSelector.method.crawler', {
+              defaultMessage: 'Web Crawler',
+            })}
+            description={i18n.translate(
+              'xpack.enterpriseSearch.ingestSelector.method.crawler.description',
+              {
+                defaultMessage:
+                  'Discover, extract, and index searchable content from websites and knowledge bases.',
+              }
+            )}
+            footer={
+              <EuiButtonTo
+                fullWidth
+                isDisabled={crawlerDisabled}
+                to={generatePath(ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_METHOD_PATH, {
+                  type: INGESTION_METHOD_IDS.CRAWLER,
+                })}
+                shouldNotCreateHref
+              >
+                {START_LABEL}
+              </EuiButtonTo>
             }
-          )}
-          footer={
-            <EuiLinkTo
-              to={generatePath(ENTERPRISE_SEARCH_CONTENT_PLUGIN.URL + NEW_INDEX_METHOD_PATH, {
-                type: INGESTION_METHOD_IDS.CRAWLER,
-              })}
-              shouldNotCreateHref
-            >
-              <EuiButton fullWidth>{START_LABEL}</EuiButton>
-            </EuiLinkTo>
-          }
-        />
-      </EuiFlexItem>
+          />
+        </EuiFlexItem>
+      )}
     </EuiFlexGroup>
   );
 };


### PR DESCRIPTION
## Summary

This disables the crawler if Enterprise Search is not available on the new overview page. 


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->