### PR TITLE
Add Defend advanced option to exclude local connections from network events

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -195,8 +195,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.network_events_exclude_local',
       {
-        defaultMessage:
-          'Exclude local connections from network events. Default: false.',
+        defaultMessage: 'Exclude local connections from network events. Default: false.',
       }
     ),
   },
@@ -206,8 +205,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.network_events_exclude_local',
       {
-        defaultMessage:
-          'Exclude local connections from network events. Default: false.',
+        defaultMessage: 'Exclude local connections from network events. Default: false.',
       }
     ),
   },
@@ -420,8 +418,7 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     documentation: i18n.translate(
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.network_events_exclude_local',
       {
-        defaultMessage:
-          'Exclude local connections from network events. Default: false.',
+        defaultMessage: 'Exclude local connections from network events. Default: false.',
       }
     ),
   },

--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -190,6 +190,28 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
+    key: 'linux.advanced.network_events_exclude_local',
+    first_supported_version: '8.10.1',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.linux.advanced.network_events_exclude_local',
+      {
+        defaultMessage:
+          'Exclude local connections from network events. Default: false.',
+      }
+    ),
+  },
+  {
+    key: 'mac.advanced.network_events_exclude_local',
+    first_supported_version: '8.10.1',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.network_events_exclude_local',
+      {
+        defaultMessage:
+          'Exclude local connections from network events. Default: false.',
+      }
+    ),
+  },
+  {
     key: 'mac.advanced.agent.connection_delay',
     first_supported_version: '7.9',
     documentation: i18n.translate(
@@ -389,6 +411,17 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.mac.advanced.harden.self_protect',
       {
         defaultMessage: 'Enables self-protection on macOS. Default: true.',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.network_events_exclude_local',
+    first_supported_version: '8.10.1',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.network_events_exclude_local',
+      {
+        defaultMessage:
+          'Exclude local connections from network events. Default: false.',
       }
     ),
   },


### PR DESCRIPTION
## Summary

Add the following advanced policy option for Elastic Endpoint/Elastic Defend for all three OS (Linux, Mac, Windows):

`network_events_exclude_local`

with description:
`Exclude local connections from network events. Default: false`

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->