### PR TITLE
[APM] Swallow unhandled exceptions

### DIFF
--- a/x-pack/plugins/apm/public/components/app/diagnostics/indices_tab.tsx
+++ b/x-pack/plugins/apm/public/components/app/diagnostics/indices_tab.tsx
@@ -27,7 +27,7 @@ export function DiagnosticsIndices() {
     return <EuiLoadingElastic size="m" />;
   }
 
-  const { invalidIndices, validIndices } = diagnosticsBundle;
+  const { invalidIndices = [], validIndices = [] } = diagnosticsBundle;
   const columns: Array<EuiBasicTableColumn<IndiciesItem>> = [
     {
       field: 'index',

--- a/x-pack/plugins/apm/public/components/app/diagnostics/summary_tab/indicies_status.tsx
+++ b/x-pack/plugins/apm/public/components/app/diagnostics/summary_tab/indicies_status.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { EuiLink } from '@elastic/eui';
+import { isEmpty } from 'lodash';
 import { useApmParams } from '../../../../hooks/use_apm_params';
 import { FETCH_STATUS } from '../../../../hooks/use_fetcher';
 import { APIReturnType } from '../../../../services/rest/create_call_apm_api';
@@ -45,5 +46,5 @@ export function getIsIndicesTabOk(diagnosticsBundle?: DiagnosticsBundle) {
     return true;
   }
 
-  return diagnosticsBundle.invalidIndices.length === 0;
+  return isEmpty(diagnosticsBundle.invalidIndices);
 }

--- a/x-pack/plugins/apm/server/routes/diagnostics/bundle/get_index_templates_by_index_pattern.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/bundle/get_index_templates_by_index_pattern.ts
@@ -110,6 +110,8 @@ async function handleInvalidIndexTemplateException<T>(promise: Promise<T>) {
       return [];
     }
 
-    throw error;
+    console.error(`Suppressed unknown exception: ${error.message}`);
+
+    return [];
   }
 }

--- a/x-pack/plugins/apm/server/routes/diagnostics/get_diagnostics_bundle.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/get_diagnostics_bundle.ts
@@ -6,6 +6,7 @@
  */
 
 import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { NOT_AVAILABLE_LABEL } from '../../../common/i18n';
 import { ApmIndicesConfig } from '../settings/apm_indices/get_apm_indices';
 import { getDataStreams } from './bundle/get_data_streams';
 import { getNonDataStreamIndices } from './bundle/get_non_data_stream_indices';
@@ -85,7 +86,8 @@ export async function getDiagnosticsBundle({
     )) ?? [];
 
   const elasticsearchVersion =
-    (await handleExceptions(getElasticsearchVersion(esClient))) ?? 'N/A';
+    (await handleExceptions(getElasticsearchVersion(esClient))) ??
+    NOT_AVAILABLE_LABEL;
 
   return {
     created_at: new Date().toISOString(),

--- a/x-pack/plugins/apm/server/routes/diagnostics/get_diagnostics_bundle.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/get_diagnostics_bundle.ts
@@ -15,7 +15,7 @@ import { getExistingApmIndexTemplates } from './bundle/get_existing_index_templa
 import { getIndicesStates } from './bundle/get_indices_states';
 import { getApmEvents } from './bundle/get_apm_events';
 import { getApmIndexTemplates } from './helpers/get_apm_index_template_names';
-import { handle403Exception } from './helpers/handle_403_exception';
+import { handleExceptions } from './helpers/handle_exceptions';
 import { getDiagnosticsPrivileges } from './helpers/get_diagnostic_privileges';
 
 const DEFEAULT_START = Date.now() - 60 * 5 * 1000; // 5 minutes
@@ -39,62 +39,53 @@ export async function getDiagnosticsBundle({
     apmIndices,
   });
 
-  const indexTemplatesByIndexPattern = await handle403Exception(
-    getIndexTemplatesByIndexPattern({
-      esClient,
-      apmIndices,
-    }),
-    []
-  );
+  const indexTemplatesByIndexPattern =
+    (await handleExceptions(
+      getIndexTemplatesByIndexPattern({
+        esClient,
+        apmIndices,
+      })
+    )) ?? [];
 
-  const existingIndexTemplates = await handle403Exception(
-    getExistingApmIndexTemplates({
-      esClient,
-    }),
-    []
-  );
+  const existingIndexTemplates =
+    (await handleExceptions(
+      getExistingApmIndexTemplates({
+        esClient,
+      })
+    )) ?? [];
 
-  const dataStreams = await handle403Exception(
-    getDataStreams({ esClient, apmIndices }),
-    []
-  );
-  const nonDataStreamIndices = await handle403Exception(
-    getNonDataStreamIndices({
-      esClient,
-      apmIndices,
-    }),
-    []
-  );
+  const dataStreams =
+    (await handleExceptions(getDataStreams({ esClient, apmIndices }))) ?? [];
+
+  const nonDataStreamIndices =
+    (await handleExceptions(
+      getNonDataStreamIndices({
+        esClient,
+        apmIndices,
+      })
+    )) ?? [];
 
   const { invalidIndices, validIndices, indices, ingestPipelines, fieldCaps } =
-    await handle403Exception(
+    (await handleExceptions(
       getIndicesStates({
         esClient,
         apmIndices,
-      }),
-      {
-        invalidIndices: [],
-        validIndices: [],
-        indices: [],
-        ingestPipelines: [],
-        fieldCaps: {},
-      }
-    );
+      })
+    )) ?? {};
 
-  const apmEvents = await handle403Exception(
-    getApmEvents({
-      esClient,
-      apmIndices,
-      start,
-      end,
-      kuery,
-    }),
-    []
-  );
-  const elasticsearchVersion = await handle403Exception(
-    getElasticsearchVersion(esClient),
-    'N/A'
-  );
+  const apmEvents =
+    (await handleExceptions(
+      getApmEvents({
+        esClient,
+        apmIndices,
+        start,
+        end,
+        kuery,
+      })
+    )) ?? [];
+
+  const elasticsearchVersion =
+    (await handleExceptions(getElasticsearchVersion(esClient))) ?? 'N/A';
 
   return {
     created_at: new Date().toISOString(),

--- a/x-pack/plugins/apm/server/routes/diagnostics/helpers/handle_exceptions.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/helpers/handle_exceptions.ts
@@ -6,10 +6,7 @@
  */
 import { errors } from '@elastic/elasticsearch';
 
-export async function handle403Exception<T>(
-  promise: Promise<T>,
-  defaultValue: unknown
-) {
+export async function handleExceptions<T>(promise: Promise<T>) {
   try {
     return await promise;
   } catch (error) {
@@ -18,13 +15,13 @@ export async function handle403Exception<T>(
       error.meta.statusCode === 403
     ) {
       console.error(`Suppressed insufficient access error: ${error.message}}`);
-      return defaultValue as T;
+      return;
     }
 
     console.error(
       `Unhandled error: ${error.message} ${JSON.stringify(error)}}`
     );
 
-    throw error;
+    return;
   }
 }

--- a/x-pack/plugins/apm/server/routes/diagnostics/route.ts
+++ b/x-pack/plugins/apm/server/routes/diagnostics/route.ts
@@ -53,9 +53,9 @@ const getDiagnosticsRoute = createApmServerRoute({
   ): Promise<{
     esResponses: {
       existingIndexTemplates: IndicesGetIndexTemplateIndexTemplateItem[];
-      fieldCaps: FieldCapsResponse;
-      indices: IndicesGetResponse;
-      ingestPipelines: IngestGetPipelineResponse;
+      fieldCaps?: FieldCapsResponse;
+      indices?: IndicesGetResponse;
+      ingestPipelines?: IngestGetPipelineResponse;
     };
     diagnosticsPrivileges: {
       index: Record<string, SecurityHasPrivilegesPrivileges>;
@@ -77,8 +77,8 @@ const getDiagnosticsRoute = createApmServerRoute({
     kibanaVersion: string;
     elasticsearchVersion: string;
     apmEvents: ApmEvent[];
-    invalidIndices: IndiciesItem[];
-    validIndices: IndiciesItem[];
+    invalidIndices?: IndiciesItem[];
+    validIndices?: IndiciesItem[];
     dataStreams: IndicesDataStream[];
     nonDataStreamIndices: string[];
     indexTemplatesByIndexPattern: Array<{


### PR DESCRIPTION
If an unhandled error occurs, it will break the diagnostics bundle. This change will log errors and then swallow them.
This should go out in 8.10 since it is already affecting users.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->