### PR TITLE
[DOCS] Removes 8.9.1 coming tag.

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -49,8 +49,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.9.1]]
 == {kib} 8.9.1
 
-coming::[8.9.1]
-
 Review the following information about the {kib} 8.9.1 release. 
 
 [float]


### PR DESCRIPTION
Removes `coming` tag from the 8.9.1 release notes. 



<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->