### PR TITLE
[Security Solution] Enable Detections Coverage Overview dashboard by default

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -92,11 +92,11 @@ export const allowedExperimentalValues = Object.freeze({
   /**
    * Enables Protections/Detections Coverage Overview page (Epic link https://github.com/elastic/security-team/issues/2905)
    *
-   * This flag aims to facilitate the development process as the feature may not make it to 8.9 release.
+   * This flag aims to facilitate the development process as the feature may not make it to 8.10 release.
    *
    * The flag doesn't have to be documented and has to be removed after the feature is ready to release.
    */
-  detectionsCoverageOverview: false,
+  detectionsCoverageOverview: true,
 
   /**
    * Enable risk engine client and initialisation of datastream, component templates and mappings


### PR DESCRIPTION
**Epic:** https://github.com/elastic/security-team/issues/2905 (internal)

## Summary

Enables the Detections Coverage Overview dashboard feature flag by default. We're aiming to release this feature in 8.10.

Before the last BC, we will:

- remove the flag if we're confident that we should release the feature in 8.10
- otherwise, revert the flag back to `false` by default


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->