### PR TITLE
[8.9] [Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/rule_details_flow/read_only_view.cy.ts
@@ -11,7 +11,11 @@ import { ROLES } from '../../../../common/test';
 import { createRule } from '../../../tasks/api_calls/rules';
 import { login, visitWithoutDateRange } from '../../../tasks/login';
 import { goToExceptionsTab, goToAlertsTab } from '../../../tasks/rule_details';
-import { goToRuleDetails } from '../../../tasks/alerts_detection_rules';
+import {
+  disableAutoRefresh,
+  goToRuleDetails,
+  waitForRulesTableToBeLoaded,
+} from '../../../tasks/alerts_detection_rules';
 import { DETECTIONS_RULE_MANAGEMENT_URL } from '../../../urls/navigation';
 import { cleanKibana, deleteAlertsAndRules } from '../../../tasks/common';
 import {
@@ -55,8 +59,9 @@ describe('Exceptions viewer read only', () => {
   beforeEach(() => {
     login(ROLES.reader);
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL, ROLES.reader);
+    waitForRulesTableToBeLoaded();
+    disableAutoRefresh();
     goToRuleDetails();
-    cy.url().should('contain', 'app/security/rules/id');
     goToExceptionsTab();
   });
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283)](https://github.com/elastic/kibana/pull/164283)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2023-08-21T18:40:14Z","message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/162569\r\nFixes: https://github.com/elastic/kibana/issues/164061\r\nFixes: https://github.com/elastic/kibana/issues/164058\r\nFixes: https://github.com/elastic/kibana/issues/163546\r\nFixes: https://github.com/elastic/kibana/issues/162669\r\n\r\nWe tried to fix the issue with this PR\r\nhttps://github.com/elastic/kibana/pull/162839 but test failed again.\r\n\r\nThis is another attempt to fix it using the @jpdjere's approach where we\r\ndisable rule's table refreshing\r\n(https://github.com/elastic/kibana/pull/163698).","sha":"4477f642e3297355ef676dcf485efb0cb49c4fcb","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","Team:Detection Engine","v8.10.0","v8.11.0"],"number":164283,"url":"https://github.com/elastic/kibana/pull/164283","mergeCommit":{"message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/162569\r\nFixes: https://github.com/elastic/kibana/issues/164061\r\nFixes: https://github.com/elastic/kibana/issues/164058\r\nFixes: https://github.com/elastic/kibana/issues/163546\r\nFixes: https://github.com/elastic/kibana/issues/162669\r\n\r\nWe tried to fix the issue with this PR\r\nhttps://github.com/elastic/kibana/pull/162839 but test failed again.\r\n\r\nThis is another attempt to fix it using the @jpdjere's approach where we\r\ndisable rule's table refreshing\r\n(https://github.com/elastic/kibana/pull/163698).","sha":"4477f642e3297355ef676dcf485efb0cb49c4fcb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/164346","number":164346,"state":"MERGED","mergeCommit":{"sha":"bdbc3e7e0e7cf59397af3653ed2f8ba86bd3ea93","message":"[8.10] [Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283) (#164346)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.10`:\n- [[Security Solution] [Detections] Fixes flakey exceptions read-only\nviewer cypress test\n(#164283)](https://github.com/elastic/kibana/pull/164283)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Ievgen\nSorokopud\",\"email\":\"ievgen.sorokopud@elastic.co\"},\"sourceCommit\":{\"committedDate\":\"2023-08-21T18:40:14Z\",\"message\":\"[Security\nSolution] [Detections] Fixes flakey exceptions read-only viewer cypress\ntest (#164283)\\n\\n## Summary\\r\\n\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162569\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164061\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164058\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/163546\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162669\\r\\n\\r\\nWe tried to fix\nthe issue with this PR\\r\\nhttps://github.com/elastic/kibana/pull/162839\nbut test failed again.\\r\\n\\r\\nThis is another attempt to fix it using\nthe @jpdjere's approach where we\\r\\ndisable rule's table\nrefreshing\\r\\n(https://github.com/elastic/kibana/pull/163698).\",\"sha\":\"4477f642e3297355ef676dcf485efb0cb49c4fcb\",\"branchLabelMapping\":{\"^v8.11.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:\nSecuritySolution\",\"Team:Detection\nEngine\",\"v8.10.0\",\"v8.11.0\"],\"number\":164283,\"url\":\"https://github.com/elastic/kibana/pull/164283\",\"mergeCommit\":{\"message\":\"[Security\nSolution] [Detections] Fixes flakey exceptions read-only viewer cypress\ntest (#164283)\\n\\n## Summary\\r\\n\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162569\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164061\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164058\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/163546\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162669\\r\\n\\r\\nWe tried to fix\nthe issue with this PR\\r\\nhttps://github.com/elastic/kibana/pull/162839\nbut test failed again.\\r\\n\\r\\nThis is another attempt to fix it using\nthe @jpdjere's approach where we\\r\\ndisable rule's table\nrefreshing\\r\\n(https://github.com/elastic/kibana/pull/163698).\",\"sha\":\"4477f642e3297355ef676dcf485efb0cb49c4fcb\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.10\"],\"targetPullRequestStates\":[{\"branch\":\"8.10\",\"label\":\"v8.10.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.11.0\",\"labelRegex\":\"^v8.11.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/164283\",\"number\":164283,\"mergeCommit\":{\"message\":\"[Security\nSolution] [Detections] Fixes flakey exceptions read-only viewer cypress\ntest (#164283)\\n\\n## Summary\\r\\n\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162569\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164061\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/164058\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/163546\\r\\nFixes:\nhttps://github.com/elastic/kibana/issues/162669\\r\\n\\r\\nWe tried to fix\nthe issue with this PR\\r\\nhttps://github.com/elastic/kibana/pull/162839\nbut test failed again.\\r\\n\\r\\nThis is another attempt to fix it using\nthe @jpdjere's approach where we\\r\\ndisable rule's table\nrefreshing\\r\\n(https://github.com/elastic/kibana/pull/163698).\",\"sha\":\"4477f642e3297355ef676dcf485efb0cb49c4fcb\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Ievgen Sorokopud <ievgen.sorokopud@elastic.co>"}},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164283","number":164283,"mergeCommit":{"message":"[Security Solution] [Detections] Fixes flakey exceptions read-only viewer cypress test (#164283)\n\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/162569\r\nFixes: https://github.com/elastic/kibana/issues/164061\r\nFixes: https://github.com/elastic/kibana/issues/164058\r\nFixes: https://github.com/elastic/kibana/issues/163546\r\nFixes: https://github.com/elastic/kibana/issues/162669\r\n\r\nWe tried to fix the issue with this PR\r\nhttps://github.com/elastic/kibana/pull/162839 but test failed again.\r\n\r\nThis is another attempt to fix it using the @jpdjere's approach where we\r\ndisable rule's table refreshing\r\n(https://github.com/elastic/kibana/pull/163698).","sha":"4477f642e3297355ef676dcf485efb0cb49c4fcb"}}]}] BACKPORT-->