### PR TITLE
Re-enable skipped endpoint setup Fleet tests

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/epm/setup.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/setup.ts
@@ -21,8 +21,7 @@ export default function (providerContext: FtrProviderContext) {
   describe('setup api', async () => {
     skipIfNoDockerRegistry(providerContext);
     setupFleetAndAgents(providerContext);
-    // FAILING ES FORWARD COMPATIBILITY: https://github.com/elastic/kibana/issues/164205
-    describe.skip('setup performs upgrades', async () => {
+    describe('setup performs upgrades', async () => {
       const oldEndpointVersion = '0.13.0';
       beforeEach(async () => {
         await supertest


### PR DESCRIPTION
## Summary

Re-enable skipped tests in https://github.com/elastic/kibana/issues/164205 

As it's seems not reproducible