### PR TITLE
Don't set refresh interval as user templates can no longer affect it

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/clone_index.ts
@@ -74,10 +74,6 @@ export const cloneIndex = ({
             // we repeat it here for explicitness.
             number_of_shards: INDEX_NUMBER_OF_SHARDS,
             auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
-            // Set an explicit refresh interval so that we don't inherit the
-            // value from incorrectly configured index templates (not required
-            // after we adopt system indices)
-            refresh_interval: '1s',
             // Bump priority so that recovery happens before newer indices
             priority: 10,
             // Increase the fields limit beyond the default of 1000

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/actions/create_index.ts
@@ -92,10 +92,6 @@ export const createIndex = ({
             // Kibana is unlikely to cross that limit.
             number_of_shards: 1,
             auto_expand_replicas: INDEX_AUTO_EXPAND_REPLICAS,
-            // Set an explicit refresh interval so that we don't inherit the
-            // value from incorrectly configured index templates (not required
-            // after we adopt system indices)
-            refresh_interval: '1s',
             // Bump priority so that recovery happens before newer indices
             priority: 10,
             // Increase the fields limit beyond the default of 1000


### PR DESCRIPTION
## Summary

Remove explicitly setting `refresh_interval` when migrations create or clone an index as this is not allowed on serverless. The refresh_interval was previously set explicitly to avoid user templates overriding the refresh interval to a value that effectively breaks Kibana.

User templates should not affect system indices, but when this feature was introduced in 8.4.0 an exception was made for Kibana because Kibana was still using a index template for the user sesssions index. See https://github.com/elastic/elasticsearch/issues/98695 for more details.

Blocked on https://github.com/elastic/elasticsearch/pull/98696


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
