### PR TITLE
[OAS] Add more Elasticsearch query rule examples

### DIFF
--- a/x-pack/plugins/alerting/docs/openapi/bundled.json
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.json
@@ -6730,8 +6730,35 @@
     },
     "examples": {
       "create_es_query_rule_request": {
-        "summary": "Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).",
+        "summary": "Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL) to define its query and a server log connector to send notifications.",
         "value": {
+          "actions": [
+            {
+              "group": "query matched",
+              "params": {
+                "level": "info",
+                "message": "The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts."
+              },
+              "id": "fdbece50-406c-11ee-850e-c71febc4ca7f",
+              "frequency": {
+                "throttle": "1d",
+                "summary": true,
+                "notify_when": "onThrottleInterval"
+              }
+            },
+            {
+              "group": "recovered",
+              "params": {
+                "level": "info",
+                "message": "Recovered"
+              },
+              "id": "fdbece50-406c-11ee-850e-c71febc4ca7f",
+              "frequency": {
+                "summary": false,
+                "notify_when": "onActionGroupChange"
+              }
+            }
+          ],
           "consumer": "alerts",
           "name": "my Elasticsearch query rule",
           "params": {
@@ -6741,7 +6768,7 @@
             ],
             "size": 100,
             "threshold": [
-              10
+              100
             ],
             "thresholdComparator": ">",
             "timeField": "@timestamp",
@@ -6750,7 +6777,7 @@
           },
           "rule_type_id": ".es-query",
           "schedule": {
-            "interval": "1m"
+            "interval": "1d"
           }
         }
       },
@@ -6840,15 +6867,46 @@
           "rule_type_id": ".es-query",
           "consumer": "alerts",
           "schedule": {
-            "interval": "1m"
+            "interval": "1d"
           },
-          "actions": [],
+          "actions": [
+            {
+              "group": "query matched",
+              "id": "fdbece50-406c-11ee-850e-c71febc4ca7f",
+              "params": {
+                "level": "info",
+                "message": "The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts."
+              },
+              "connector_type_id": ".server-log",
+              "frequency": {
+                "summary": true,
+                "notify_when": "onThrottleInterval",
+                "throttle": "1d"
+              },
+              "uuid": "53f3c2a3-e5d0-4cfa-af3b-6f0881385e78"
+            },
+            {
+              "group": "recovered",
+              "id": "fdbece50-406c-11ee-850e-c71febc4ca7f",
+              "params": {
+                "level": "info",
+                "message": "Recovered"
+              },
+              "connector_type_id": ".server-log",
+              "frequency": {
+                "summary": false,
+                "notify_when": "onActionGroupChange",
+                "throttle": null
+              },
+              "uuid": "2324e45b-c0df-45c7-9d70-4993e30be758"
+            }
+          ],
           "params": {
             "thresholdComparator": ">",
             "timeWindowSize": 1,
             "timeWindowUnit": "d",
             "threshold": [
-              10
+              100
             ],
             "size": 100,
             "timeField": "@timestamp",

--- a/x-pack/plugins/alerting/docs/openapi/bundled.json
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.json
@@ -12,16 +12,24 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     }
   },
-  "tags": [
-    {
-      "name": "alerting",
-      "description": "Alerting APIs enable you to create and manage rules and alerts."
-    }
-  ],
   "servers": [
     {
       "url": "http://localhost:5601",
       "description": "local"
+    }
+  ],
+  "security": [
+    {
+      "basicAuth": []
+    },
+    {
+      "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "alerting",
+      "description": "Alerting APIs enable you to create and manage rules and alerts."
     }
   ],
   "paths": {
@@ -52,6 +60,9 @@
                 "createEsQueryRuleRequest": {
                   "$ref": "#/components/examples/create_es_query_rule_request"
                 },
+                "createEsQueryKqlRuleRequest": {
+                  "$ref": "#/components/examples/create_es_query_kql_rule_request"
+                },
                 "createIndexThresholdRuleRequest": {
                   "$ref": "#/components/examples/create_index_threshold_rule_request"
                 }
@@ -70,6 +81,9 @@
                 "examples": {
                   "createEsQueryRuleResponse": {
                     "$ref": "#/components/examples/create_es_query_rule_response"
+                  },
+                  "createEsQueryKqlRuleResponse": {
+                    "$ref": "#/components/examples/create_es_query_kql_rule_response"
                   },
                   "createIndexThresholdRuleResponse": {
                     "$ref": "#/components/examples/create_index_threshold_rule_response"
@@ -255,6 +269,9 @@
                 "createEsQueryRuleIdRequest": {
                   "$ref": "#/components/examples/create_es_query_rule_request"
                 },
+                "createEsQueryKqlRuleIdRequest": {
+                  "$ref": "#/components/examples/create_es_query_kql_rule_request"
+                },
                 "createIndexThreholdRuleIdRequest": {
                   "$ref": "#/components/examples/create_index_threshold_rule_request"
                 }
@@ -273,6 +290,9 @@
                 "examples": {
                   "createEsQueryRuleIdResponse": {
                     "$ref": "#/components/examples/create_es_query_rule_response"
+                  },
+                  "createEsQueryKqlRuleIdResponse": {
+                    "$ref": "#/components/examples/create_es_query_kql_rule_response"
                   },
                   "createIndexThresholdRuleIdResponse": {
                     "$ref": "#/components/examples/create_index_threshold_rule_response"
@@ -6710,10 +6730,35 @@
     },
     "examples": {
       "create_es_query_rule_request": {
-        "summary": "Create an Elasticsearch query rule.",
+        "summary": "Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).",
         "value": {
           "consumer": "alerts",
           "name": "my Elasticsearch query rule",
+          "params": {
+            "esQuery": "\"\"\"{\"query\":{\"match_all\" : {}}}\"\"\"",
+            "index": [
+              "kibana_sample_data_logs"
+            ],
+            "size": 100,
+            "threshold": [
+              10
+            ],
+            "thresholdComparator": ">",
+            "timeField": "@timestamp",
+            "timeWindowSize": 1,
+            "timeWindowUnit": "d"
+          },
+          "rule_type_id": ".es-query",
+          "schedule": {
+            "interval": "1m"
+          }
+        }
+      },
+      "create_es_query_kql_rule_request": {
+        "summary": "Create an Elasticsearch query rule that uses Kibana query language (KQL).",
+        "value": {
+          "consumer": "alerts",
+          "name": "my Elasticsearch query KQL rule",
           "params": {
             "aggType": "count",
             "excludeHitsFromPreviousRun": true,
@@ -6788,9 +6833,59 @@
       "create_es_query_rule_response": {
         "summary": "The create rule API returns a JSON object that contains details about the rule.",
         "value": {
+          "id": "58148c70-407f-11ee-850e-c71febc4ca7f",
+          "enabled": true,
+          "name": "my Elasticsearch query rule",
+          "tags": [],
+          "rule_type_id": ".es-query",
+          "consumer": "alerts",
+          "schedule": {
+            "interval": "1m"
+          },
+          "actions": [],
+          "params": {
+            "thresholdComparator": ">",
+            "timeWindowSize": 1,
+            "timeWindowUnit": "d",
+            "threshold": [
+              10
+            ],
+            "size": 100,
+            "timeField": "@timestamp",
+            "index": [
+              "kibana_sample_data_logs"
+            ],
+            "esQuery": "\"\"\"{\"query\":{\"match_all\" : {}}}\"\"\"",
+            "excludeHitsFromPreviousRun": true,
+            "aggType": "count",
+            "groupBy": "all",
+            "searchType": "esQuery"
+          },
+          "scheduled_task_id": "58148c70-407f-11ee-850e-c71febc4ca7f",
+          "created_by": "elastic",
+          "updated_by": "elastic",
+          "created_at": "2023-08-22T00:03:38.263Z",
+          "updated_at": "2023-08-22T00:03:38.263Z",
+          "api_key_owner": "elastic",
+          "api_key_created_by_user": false,
+          "throttle": null,
+          "mute_all": false,
+          "notify_when": null,
+          "muted_alert_ids": [],
+          "execution_status": {
+            "status": "pending",
+            "last_execution_date": "2023-08-22T00:03:38.263Z"
+          },
+          "revision": 0,
+          "running": false
+        }
+      },
+      "create_es_query_kql_rule_response": {
+        "summary": "The create rule API returns a JSON object that contains details about the rule.",
+        "value": {
           "id": "7bd506d0-2284-11ee-8fad-6101956ced88",
           "enabled": true,
-          "name": "my Elasticsearch query rule\"",
+          "name": "my Elasticsearch query KQL rule\"",
           "tags": [],
           "rule_type_id": ".es-query",
           "consumer": "alerts",
@@ -7504,13 +7599,5 @@
         ]
       }
     }
-  },
-  "security": [
-    {
-      "basicAuth": []
-    },
-    {
-      "apiKeyAuth": []
-    }
-  ]
+  }
 }

--- a/x-pack/plugins/alerting/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.yaml
@@ -4599,8 +4599,26 @@ components:
           example: elastic
   examples:
     create_es_query_rule_request:
-      summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).
+      summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL) to define its query and a server log connector to send notifications.
       value:
+        actions:
+          - group: query matched
+            params:
+              level: info
+              message: The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts.
+            id: fdbece50-406c-11ee-850e-c71febc4ca7f
+            frequency:
+              throttle: 1d
+              summary: true
+              notify_when: onThrottleInterval
+          - group: recovered
+            params:
+              level: info
+              message: Recovered
+            id: fdbece50-406c-11ee-850e-c71febc4ca7f
+            frequency:
+              summary: false
+              notify_when: onActionGroupChange
         consumer: alerts
         name: my Elasticsearch query rule
         params:
@@ -4609,14 +4627,14 @@ components:
             - kibana_sample_data_logs
           size: 100
           threshold:
-            - 10
+            - 100
           thresholdComparator: '>'
           timeField: '@timestamp'
           timeWindowSize: 1
           timeWindowUnit: d
         rule_type_id: .es-query
         schedule:
-          interval: 1m
+          interval: 1d
     create_es_query_kql_rule_request:
       summary: Create an Elasticsearch query rule that uses Kibana query language (KQL).
       value:
@@ -4689,14 +4707,36 @@ components:
         rule_type_id: .es-query
         consumer: alerts
         schedule:
-          interval: 1m
-        actions: []
+          interval: 1d
+        actions:
+          - group: query matched
+            id: fdbece50-406c-11ee-850e-c71febc4ca7f
+            params:
+              level: info
+              message: The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts.
+            connector_type_id: .server-log
+            frequency:
+              summary: true
+              notify_when: onThrottleInterval
+              throttle: 1d
+            uuid: 53f3c2a3-e5d0-4cfa-af3b-6f0881385e78
+          - group: recovered
+            id: fdbece50-406c-11ee-850e-c71febc4ca7f
+            params:
+              level: info
+              message: Recovered
+            connector_type_id: .server-log
+            frequency:
+              summary: false
+              notify_when: onActionGroupChange
+              throttle: null
+            uuid: 2324e45b-c0df-45c7-9d70-4993e30be758
         params:
           thresholdComparator: '>'
           timeWindowSize: 1
           timeWindowUnit: d
           threshold:
-            - 10
+            - 100
           size: 100
           timeField: '@timestamp'
           index:

--- a/x-pack/plugins/alerting/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.yaml
@@ -8,12 +8,15 @@ info:
   license:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
-tags:
-  - name: alerting
-    description: Alerting APIs enable you to create and manage rules and alerts.
 servers:
   - url: http://localhost:5601
     description: local
+security:
+  - basicAuth: []
+  - apiKeyAuth: []
+tags:
+  - name: alerting
+    description: Alerting APIs enable you to create and manage rules and alerts.
 paths:
   /s/{spaceId}/api/alerting/rule:
     post:
@@ -35,6 +38,8 @@ paths:
             examples:
               createEsQueryRuleRequest:
                 $ref: '#/components/examples/create_es_query_rule_request'
+              createEsQueryKqlRuleRequest:
+                $ref: '#/components/examples/create_es_query_kql_rule_request'
               createIndexThresholdRuleRequest:
                 $ref: '#/components/examples/create_index_threshold_rule_request'
       responses:
@@ -47,6 +52,8 @@ paths:
               examples:
                 createEsQueryRuleResponse:
                   $ref: '#/components/examples/create_es_query_rule_response'
+                createEsQueryKqlRuleResponse:
+                  $ref: '#/components/examples/create_es_query_kql_rule_response'
                 createIndexThresholdRuleResponse:
                   $ref: '#/components/examples/create_index_threshold_rule_response'
         '401':
@@ -155,6 +162,8 @@ paths:
             examples:
               createEsQueryRuleIdRequest:
                 $ref: '#/components/examples/create_es_query_rule_request'
+              createEsQueryKqlRuleIdRequest:
+                $ref: '#/components/examples/create_es_query_kql_rule_request'
               createIndexThreholdRuleIdRequest:
                 $ref: '#/components/examples/create_index_threshold_rule_request'
       responses:
@@ -167,6 +176,8 @@ paths:
               examples:
                 createEsQueryRuleIdResponse:
                   $ref: '#/components/examples/create_es_query_rule_response'
+                createEsQueryKqlRuleIdResponse:
+                  $ref: '#/components/examples/create_es_query_kql_rule_response'
                 createIndexThresholdRuleIdResponse:
                   $ref: '#/components/examples/create_index_threshold_rule_response'
         '401':
@@ -4588,10 +4599,29 @@ components:
           example: elastic
   examples:
     create_es_query_rule_request:
-      summary: Create an Elasticsearch query rule.
+      summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).
       value:
         consumer: alerts
         name: my Elasticsearch query rule
+        params:
+          esQuery: '"""{"query":{"match_all" : {}}}"""'
+          index:
+            - kibana_sample_data_logs
+          size: 100
+          threshold:
+            - 10
+          thresholdComparator: '>'
+          timeField: '@timestamp'
+          timeWindowSize: 1
+          timeWindowUnit: d
+        rule_type_id: .es-query
+        schedule:
+          interval: 1m
+    create_es_query_kql_rule_request:
+      summary: Create an Elasticsearch query rule that uses Kibana query language (KQL).
+      value:
+        consumer: alerts
+        name: my Elasticsearch query KQL rule
         params:
           aggType: count
           excludeHitsFromPreviousRun: true
@@ -4652,9 +4682,52 @@ components:
     create_es_query_rule_response:
       summary: The create rule API returns a JSON object that contains details about the rule.
       value:
+        id: 58148c70-407f-11ee-850e-c71febc4ca7f
+        enabled: true
+        name: my Elasticsearch query rule
+        tags: []
+        rule_type_id: .es-query
+        consumer: alerts
+        schedule:
+          interval: 1m
+        actions: []
+        params:
+          thresholdComparator: '>'
+          timeWindowSize: 1
+          timeWindowUnit: d
+          threshold:
+            - 10
+          size: 100
+          timeField: '@timestamp'
+          index:
+            - kibana_sample_data_logs
+          esQuery: '"""{"query":{"match_all" : {}}}"""'
+          excludeHitsFromPreviousRun: true
+          aggType: count
+          groupBy: all
+          searchType: esQuery
+        scheduled_task_id: 58148c70-407f-11ee-850e-c71febc4ca7f
+        created_by: elastic
+        updated_by: elastic
+        created_at: '2023-08-22T00:03:38.263Z'
+        updated_at: '2023-08-22T00:03:38.263Z'
+        api_key_owner: elastic
+        api_key_created_by_user: false
+        throttle: null
+        mute_all: false
+        notify_when: null
+        muted_alert_ids: []
+        execution_status:
+          status: pending
+          last_execution_date: '2023-08-22T00:03:38.263Z'
+        revision: 0
+        running: false
+    create_es_query_kql_rule_response:
+      summary: The create rule API returns a JSON object that contains details about the rule.
+      value:
         id: 7bd506d0-2284-11ee-8fad-6101956ced88
         enabled: true
-        name: my Elasticsearch query rule"
+        name: my Elasticsearch query KQL rule"
         tags: []
         rule_type_id: .es-query
         consumer: alerts
@@ -5217,6 +5290,3 @@ components:
             id: recovered
             name: Recovered
           rule_task_timeout: 5m
-security:
-  - basicAuth: []
-  - apiKeyAuth: []

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_kql_rule_request.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_kql_rule_request.yaml
@@ -1,0 +1,23 @@
+summary: Create an Elasticsearch query rule that uses Kibana query language (KQL).
+value:
+  consumer: alerts
+  name: my Elasticsearch query KQL rule
+  params:
+    aggType: count
+    excludeHitsFromPreviousRun: true
+    groupBy: all
+    searchConfiguration:
+      query:
+        query: '""geo.src : "US" ""'
+        language: kuery
+      index: 90943e30-9a47-11e8-b64d-95841ca0b247
+    searchType: searchSource
+    size: 100
+    threshold:
+      - 1000
+    thresholdComparator: ">"
+    timeWindowSize: 5
+    timeWindowUnit: m
+  rule_type_id: .es-query
+  schedule:
+    interval: 1m

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_kql_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_kql_rule_response.yaml
@@ -1,0 +1,43 @@
+summary: The create rule API returns a JSON object that contains details about the rule.
+value:
+  id: 7bd506d0-2284-11ee-8fad-6101956ced88
+  enabled: true
+  name: my Elasticsearch query KQL rule"
+  tags: []
+  rule_type_id: .es-query
+  consumer: alerts
+  schedule: 
+    interval: 1m
+  actions: []
+  params: 
+    searchConfiguration:
+      query:
+        query: '""geo.src : "US" ""'
+        language: kuery
+      index: 90943e30-9a47-11e8-b64d-95841ca0b247
+    searchType: searchSource
+    timeWindowSize: 5
+    timeWindowUnit: m
+    threshold:
+      - 1000
+    thresholdComparator: ">"
+    size: 100
+    aggType: count
+    groupBy: all
+    excludeHitsFromPreviousRun: true
+  created_by: elastic
+  updated_by: elastic
+  created_at: '2023-07-14T20:24:50.729Z'
+  updated_at: '2023-07-14T20:24:50.729Z'
+  api_key_owner: elastic
+  api_key_created_by_user: false
+  throttle: null
+  notify_when: null
+  mute_all: false
+  muted_alert_ids: []
+  scheduled_task_id: 7bd506d0-2284-11ee-8fad-6101956ced88
+  execution_status:
+    status: pending
+    last_execution_date: '2023-07-14T20:24:50.729Z'
+  revision: 0
+  running: false

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_request.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_request.yaml
@@ -1,5 +1,23 @@
-summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).
+summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL) to define its query and a server log connector to send notifications.
 value:
+  actions:
+    - group: query matched
+      params:
+        level: info
+        message: "The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts."
+      id: fdbece50-406c-11ee-850e-c71febc4ca7f
+      frequency:
+        throttle: "1d"
+        summary: true
+        notify_when: onThrottleInterval
+    - group: recovered
+      params:
+        level: info
+        message: Recovered
+      id: fdbece50-406c-11ee-850e-c71febc4ca7f
+      frequency: 
+        summary: false
+        notify_when: onActionGroupChange
   consumer: alerts
   name: my Elasticsearch query rule
   params:    
@@ -8,11 +26,11 @@ value:
       - kibana_sample_data_logs
     size: 100
     threshold:
-      - 10
+      - 100
     thresholdComparator: ">"
     timeField: "@timestamp"
     timeWindowSize: 1
     timeWindowUnit: d
   rule_type_id: .es-query
   schedule:
-    interval: 1m
+    interval: 1d

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_request.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_request.yaml
@@ -1,23 +1,18 @@
-summary: Create an Elasticsearch query rule.
+summary: Create an Elasticsearch query rule that uses Elasticsearch query domain specific language (DSL).
 value:
   consumer: alerts
   name: my Elasticsearch query rule
-  params:
-    aggType: count
-    excludeHitsFromPreviousRun: true
-    groupBy: all
-    searchConfiguration:
-      query:
-        query: '""geo.src : "US" ""'
-        language: kuery
-      index: 90943e30-9a47-11e8-b64d-95841ca0b247
-    searchType: searchSource
+  params:    
+    esQuery: '"""{"query":{"match_all" : {}}}"""'
+    index:
+      - kibana_sample_data_logs
     size: 100
     threshold:
-      - 1000
+      - 10
     thresholdComparator: ">"
-    timeWindowSize: 5
-    timeWindowUnit: m
+    timeField: "@timestamp"
+    timeWindowSize: 1
+    timeWindowUnit: d
   rule_type_id: .es-query
   schedule:
     interval: 1m

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_response.yaml
@@ -7,14 +7,36 @@ value:
   rule_type_id: .es-query
   consumer: alerts
   schedule:
-    interval: 1m
-  actions: []
+    interval: 1d
+  actions:
+    - group: query matched
+      id: fdbece50-406c-11ee-850e-c71febc4ca7f
+      params:
+        level: info
+        message: "The system has detected {{alerts.new.count}} new, {{alerts.ongoing.count}} ongoing, and {{alerts.recovered.count}} recovered alerts."
+      connector_type_id: .server-log
+      frequency:
+        summary: true
+        notify_when: onThrottleInterval
+        throttle: "1d"
+      uuid: 53f3c2a3-e5d0-4cfa-af3b-6f0881385e78
+    - group: recovered
+      id: fdbece50-406c-11ee-850e-c71febc4ca7f
+      params:
+        level: info
+        message: Recovered
+      connector_type_id: .server-log
+      frequency:
+        summary: false
+        notify_when: onActionGroupChange
+        throttle: null
+      uuid: 2324e45b-c0df-45c7-9d70-4993e30be758
   params:
     thresholdComparator: ">"
     timeWindowSize: 1
     timeWindowUnit: d
     threshold:
-      - 10
+      - 100
     size: 100
     timeField: "@timestamp"
     index:

--- a/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_response.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/components/examples/create_es_query_rule_response.yaml
@@ -1,43 +1,42 @@
 summary: The create rule API returns a JSON object that contains details about the rule.
 value:
-  id: 7bd506d0-2284-11ee-8fad-6101956ced88
+  id: 58148c70-407f-11ee-850e-c71febc4ca7f
   enabled: true
-  name: my Elasticsearch query rule"
+  name: my Elasticsearch query rule
   tags: []
   rule_type_id: .es-query
   consumer: alerts
-  schedule: 
+  schedule:
     interval: 1m
   actions: []
-  params: 
-    searchConfiguration:
-      query:
-        query: '""geo.src : "US" ""'
-        language: kuery
-      index: 90943e30-9a47-11e8-b64d-95841ca0b247
-    searchType: searchSource
-    timeWindowSize: 5
-    timeWindowUnit: m
-    threshold:
-      - 1000
+  params:
     thresholdComparator: ">"
+    timeWindowSize: 1
+    timeWindowUnit: d
+    threshold:
+      - 10
     size: 100
+    timeField: "@timestamp"
+    index:
+      - kibana_sample_data_logs
+    esQuery: '"""{"query":{"match_all" : {}}}"""'
+    excludeHitsFromPreviousRun: true
     aggType: count
     groupBy: all
-    excludeHitsFromPreviousRun: true
+    searchType: esQuery
+  scheduled_task_id: 58148c70-407f-11ee-850e-c71febc4ca7f
   created_by: elastic
   updated_by: elastic
-  created_at: '2023-07-14T20:24:50.729Z'
-  updated_at: '2023-07-14T20:24:50.729Z'
+  created_at: '2023-08-22T00:03:38.263Z'
+  updated_at: '2023-08-22T00:03:38.263Z'
   api_key_owner: elastic
   api_key_created_by_user: false
   throttle: null
-  notify_when: null
   mute_all: false
+  notify_when: null
   muted_alert_ids: []
-  scheduled_task_id: 7bd506d0-2284-11ee-8fad-6101956ced88
   execution_status:
     status: pending
-    last_execution_date: '2023-07-14T20:24:50.729Z'
+    last_execution_date: '2023-08-22T00:03:38.263Z'
   revision: 0
   running: false

--- a/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rule.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rule.yaml
@@ -23,6 +23,8 @@ post:
         examples:
           createEsQueryRuleRequest:
             $ref: '../components/examples/create_es_query_rule_request.yaml'
+          createEsQueryKqlRuleRequest:
+            $ref: '../components/examples/create_es_query_kql_rule_request.yaml'
           createIndexThresholdRuleRequest:
             $ref: '../components/examples/create_index_threshold_rule_request.yaml'
   responses:
@@ -35,6 +37,8 @@ post:
           examples:
             createEsQueryRuleResponse:
               $ref: '../components/examples/create_es_query_rule_response.yaml'
+            createEsQueryKqlRuleResponse:
+              $ref: '../components/examples/create_es_query_kql_rule_response.yaml'
             createIndexThresholdRuleResponse:
               $ref: '../components/examples/create_index_threshold_rule_response.yaml'
     '401':

--- a/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rule@{ruleid}.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rule@{ruleid}.yaml
@@ -104,6 +104,8 @@ post:
         examples:
           createEsQueryRuleIdRequest:
             $ref: '../components/examples/create_es_query_rule_request.yaml'
+          createEsQueryKqlRuleIdRequest:
+            $ref: '../components/examples/create_es_query_kql_rule_request.yaml'
           createIndexThreholdRuleIdRequest:
             $ref: '../components/examples/create_index_threshold_rule_request.yaml'
   responses:
@@ -116,6 +118,8 @@ post:
           examples:
             createEsQueryRuleIdResponse:
               $ref: '../components/examples/create_es_query_rule_response.yaml'
+            createEsQueryKqlRuleIdResponse:
+              $ref: '../components/examples/create_es_query_kql_rule_response.yaml'
             createIndexThresholdRuleIdResponse:
               $ref: '../components/examples/create_index_threshold_rule_response.yaml'
     '401':


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/pull/161685

This PR adds a second example of creating an Elasticsearch query rule. In this case, it uses query DSL and has two actions that use a server log connector. The purpose of the latter is to demonstrate that Elasticsearch query rules support alert summaries.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->