### PR TITLE
[Fleet][Kafka] When compression is enabled, "None" shouldn't be an option for codec

### DIFF
--- a/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -184,8 +184,6 @@ describe('Outputs', () => {
         // Compression
         cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_CODEC_INPUT).should('not.exist');
         cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_SWITCH).click();
-        cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_LEVEL_INPUT).should('not.exist');
-        cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_CODEC_INPUT).select('gzip');
         cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_LEVEL_INPUT).should('exist');
         cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_LEVEL_INPUT).select('1');
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_compression.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_kafka_compression.tsx
@@ -21,12 +21,12 @@ export const OutputFormKafkaCompression: React.FunctionComponent<{
 
   const kafkaCompressionTypeOptions = useMemo(
     () =>
-      (Object.keys(kafkaCompressionType) as Array<keyof typeof kafkaCompressionType>).map(
-        (key) => ({
+      (Object.keys(kafkaCompressionType) as Array<keyof typeof kafkaCompressionType>)
+        .filter((c) => c !== 'None')
+        .map((key) => ({
           text: kafkaCompressionType[key],
           label: kafkaCompressionType[key],
-        })
-      ),
+        })),
     []
   );
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -391,7 +391,9 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     isDisabled('compression_level')
   );
   const kafkaCompressionCodecInput = useInput(
-    kafkaOutput?.compression ?? kafkaCompressionType.None,
+    kafkaOutput?.compression && kafkaOutput.compression !== kafkaCompressionType.None
+      ? kafkaOutput.compression
+      : kafkaCompressionType.Gzip,
     undefined,
     isDisabled('compression')
   );
@@ -642,8 +644,11 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
               client_id: kafkaClientIdInput.value || undefined,
               version: kafkaVersionInput.value,
               ...(kafkaKeyInput.value ? { key: kafkaKeyInput.value } : {}),
-              compression: kafkaCompressionCodecInput.value,
-              ...(kafkaCompressionCodecInput.value === kafkaCompressionType.Gzip
+              compression: kafkaCompressionInput.value
+                ? kafkaCompressionCodecInput.value
+                : kafkaCompressionType.None,
+              ...(kafkaCompressionInput.value &&
+              kafkaCompressionCodecInput.value === kafkaCompressionType.Gzip
                 ? {
                     compression_level: parseIntegerIfStringDefined(
                       kafkaCompressionLevelInput.value
@@ -785,6 +790,7 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
     loadBalanceEnabledInput.value,
     typeInput.value,
     kafkaSslCertificateAuthoritiesInput.value,
+    kafkaCompressionInput.value,
     nameInput.value,
     kafkaHostsInput.value,
     defaultOutputInput.value,

--- a/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/full_agent_policy.ts
@@ -20,7 +20,7 @@ import type {
 } from '../../types';
 import type { FullAgentPolicyOutputPermissions, PackageInfo } from '../../../common/types';
 import { agentPolicyService } from '../agent_policy';
-import { dataTypes, outputType } from '../../../common/constants';
+import { dataTypes, kafkaCompressionType, outputType } from '../../../common/constants';
 import { DEFAULT_OUTPUT } from '../../constants';
 
 import { getPackageInfo } from '../epm/packages';
@@ -344,7 +344,7 @@ export function transformOutputToFullPolicyOutput(
       version,
       key,
       compression,
-      compression_level,
+      ...(compression === kafkaCompressionType.Gzip ? { compression_level } : {}),
       ...(username ? { username } : {}),
       ...(password ? { password } : {}),
       ...(sasl ? { sasl } : {}),

--- a/x-pack/plugins/fleet/server/services/output.ts
+++ b/x-pack/plugins/fleet/server/services/output.ts
@@ -764,7 +764,7 @@ class OutputService {
         ) {
           updateData.compression_level = 4;
         }
-        if (data.compression !== kafkaCompressionType.Gzip) {
+        if (data.compression && data.compression !== kafkaCompressionType.Gzip) {
           // Clear compression level if compression is not gzip
           updateData.compression_level = null;
         }

--- a/x-pack/plugins/fleet/server/services/output.ts
+++ b/x-pack/plugins/fleet/server/services/output.ts
@@ -764,6 +764,11 @@ class OutputService {
         ) {
           updateData.compression_level = 4;
         }
+        if (data.compression !== kafkaCompressionType.Gzip) {
+          // Clear compression level if compression is not gzip
+          updateData.compression_level = null;
+        }
+
         if (!data.client_id) {
           updateData.client_id = 'Elastic';
         }


### PR DESCRIPTION
Closes https://github.com/elastic/ingest-dev/issues/2327

`None` option removed from UI, tests aligned. 


https://github.com/elastic/kibana/assets/29123534/b8b7ac7a-e3e9-4800-94b9-f80e1f42f044

