### PR TITLE
[8.9] Add warning for max alerts circuit breaker (#164217)

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -245,6 +245,8 @@ Specifies the maximum number of actions that a rule can generate each time detec
 
 `xpack.alerting.rules.run.alerts.max` {ess-icon}::
 Specifies the maximum number of alerts that a rule can generate each time detection checks run. Default: 1000.
++
+WARNING: The exact number of alerts your cluster can safely handle depends on your cluster configuration and workload, however setting a value higher than the default (`1000`) is not recommended or supported. Doing so could strain system resources and lead to performance issues, delays in alert processing, and potential disruptions during high alert activity periods.
 
 `xpack.alerting.rules.run.timeout` {ess-icon}::
 Specifies the default timeout for tasks associated with all types of rules.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [Add warning for max alerts circuit breaker (#164217)](https://github.com/elastic/kibana/pull/164217)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mike Côté","email":"mikecote@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-08-22T11:01:29Z","message":"Add warning for max alerts circuit breaker (#164217)\n\nIn this PR, I'm adding a warning message to the docs for the\r\n`xpack.alerting.rules.run.alerts.max` setting that indicates the\r\nconsequences when setting a value higher than the default, while also\r\nindicating it's not supported.\r\n\r\n<img width=\"862\" alt=\"Screenshot 2023-08-21 at 5 03 52 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/3694571/46a7f5d6-f6d5-475a-ab93-edf256eb9141\">\r\n\r\ncc @lcawl\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"327af6ca2e92ad57a99d18b06a0bf03e8f08b59b","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Alerting","release_note:skip","Team:ResponseOps","backport:prev-minor","v8.11.0"],"number":164217,"url":"https://github.com/elastic/kibana/pull/164217","mergeCommit":{"message":"Add warning for max alerts circuit breaker (#164217)\n\nIn this PR, I'm adding a warning message to the docs for the\r\n`xpack.alerting.rules.run.alerts.max` setting that indicates the\r\nconsequences when setting a value higher than the default, while also\r\nindicating it's not supported.\r\n\r\n<img width=\"862\" alt=\"Screenshot 2023-08-21 at 5 03 52 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/3694571/46a7f5d6-f6d5-475a-ab93-edf256eb9141\">\r\n\r\ncc @lcawl\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"327af6ca2e92ad57a99d18b06a0bf03e8f08b59b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164217","number":164217,"mergeCommit":{"message":"Add warning for max alerts circuit breaker (#164217)\n\nIn this PR, I'm adding a warning message to the docs for the\r\n`xpack.alerting.rules.run.alerts.max` setting that indicates the\r\nconsequences when setting a value higher than the default, while also\r\nindicating it's not supported.\r\n\r\n<img width=\"862\" alt=\"Screenshot 2023-08-21 at 5 03 52 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/3694571/46a7f5d6-f6d5-475a-ab93-edf256eb9141\">\r\n\r\ncc @lcawl\r\n\r\n---------\r\n\r\nCo-authored-by: Lisa Cawley <lcawley@elastic.co>","sha":"327af6ca2e92ad57a99d18b06a0bf03e8f08b59b"}}]}] BACKPORT-->