### PR TITLE
[SecuritySolution] Hide loading icon when the user has no permission to read Security dashboard

### DIFF
--- a/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.test.tsx
@@ -157,6 +157,16 @@ describe('Dashboards landing', () => {
       expect(screen.queryByTestId('dashboardsTable')).not.toBeInTheDocument();
     });
 
+    it('should not render loading icon if no read capability', async () => {
+      mockUseCapabilities.mockReturnValue({
+        ...DEFAULT_DASHBOARD_CAPABILITIES,
+        show: false,
+      });
+      await renderDashboardLanding();
+
+      expect(screen.queryByTestId('dashboardLoadingIcon')).not.toBeInTheDocument();
+    });
+
     describe('Create Security Dashboard button', () => {
       it('should render', async () => {
         await renderDashboardLanding();

--- a/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
+++ b/x-pack/plugins/security_solution/public/dashboards/pages/landing_page/index.tsx
@@ -132,7 +132,7 @@ export const DashboardsLandingPage = () => {
       />
       <EuiSpacer size="m" />
 
-      {canReadDashboard && securityTagsExist && initialFilter ? (
+      {canReadDashboard && securityTagsExist && initialFilter && (
         <>
           <EuiSpacer size="m" />
           <EuiTitle size="xxxs">
@@ -148,8 +148,11 @@ export const DashboardsLandingPage = () => {
             urlStateEnabled={false}
           />
         </>
-      ) : (
-        <EuiEmptyPrompt icon={<EuiLoadingSpinner size="l" />} />
+      )}
+      {canReadDashboard && !securityTagsExist && (
+        <EuiEmptyPrompt
+          icon={<EuiLoadingSpinner size="l" data-test-subj="dashboardLoadingIcon" />}
+        />
       )}
 
       <SpyRoute pageName={SecurityPageName.dashboards} />


### PR DESCRIPTION
## Summary

Original issue and **Steps to reproduce**: https://github.com/elastic/kibana/issues/164405



**Before** - User without SecuritySolution read permission saw the loading icon spinning.

<img width="1726" alt="Screenshot 2023-08-22 at 11 10 38" src="https://github.com/elastic/kibana/assets/17427073/49cd1902-4266-418a-b464-1fc67198f6ca">


**After** - User without SecuritySolution read permission cannot see the dashboard list.

<img width="2544" alt="Screenshot 2023-08-22 at 13 27 24" src="https://github.com/elastic/kibana/assets/6295984/12de393b-363c-4aa6-97f1-8f0462da8b06">


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios





<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->