### PR TITLE
Exclude disabled tasks from task manager health API and Stack Monitoring

### DIFF
--- a/x-pack/plugins/task_manager/server/task_store.test.ts
+++ b/x-pack/plugins/task_manager/server/task_store.test.ts
@@ -381,7 +381,9 @@ describe('TaskStore', () => {
         index: 'tasky',
         body: {
           size: 0,
-          query: { bool: { filter: [{ term: { type: 'task' } }] } },
+          query: {
+            bool: { filter: [{ term: { type: 'task' } }, { term: { 'task.enabled': true } }] },
+          },
           aggs: { testAgg: { terms: { field: 'task.taskType' } } },
         },
       });
@@ -401,7 +403,11 @@ describe('TaskStore', () => {
           query: {
             bool: {
               must: [
-                { bool: { filter: [{ term: { type: 'task' } }] } },
+                {
+                  bool: {
+                    filter: [{ term: { type: 'task' } }, { term: { 'task.enabled': true } }],
+                  },
+                },
                 { term: { 'task.taskType': 'bar' } },
               ],
             },
@@ -420,7 +426,9 @@ describe('TaskStore', () => {
       expect(args).toMatchObject({
         body: {
           size: 0,
-          query: { bool: { filter: [{ term: { type: 'task' } }] } },
+          query: {
+            bool: { filter: [{ term: { type: 'task' } }, { term: { 'task.enabled': true } }] },
+          },
           aggs: { testAgg: { terms: { field: 'task.taskType' } } },
           runtime_mappings: { testMapping: { type: 'long', script: { source: `` } } },
         },

--- a/x-pack/plugins/task_manager/server/task_store.ts
+++ b/x-pack/plugins/task_manager/server/task_store.ts
@@ -477,7 +477,7 @@ export class TaskStore {
       index: this.index,
       ignore_unavailable: true,
       track_total_hits: true,
-      body: ensureAggregationOnlyReturnsTaskObjects({
+      body: ensureAggregationOnlyReturnsEnabledTaskObjects({
         query,
         aggs,
         runtime_mappings,
@@ -595,11 +595,11 @@ function ensureQueryOnlyReturnsTaskObjects(opts: SearchOpts): SearchOpts {
   };
 }
 
-function ensureAggregationOnlyReturnsTaskObjects(opts: AggregationOpts): AggregationOpts {
+function ensureAggregationOnlyReturnsEnabledTaskObjects(opts: AggregationOpts): AggregationOpts {
   const originalQuery = opts.query;
   const filterToOnlyTasks = {
     bool: {
-      filter: [{ term: { type: 'task' } }],
+      filter: [{ term: { type: 'task' } }, { term: { 'task.enabled': true } }],
     },
   };
   const query = originalQuery

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/init_routes.ts
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/init_routes.ts
@@ -51,6 +51,7 @@ export function initRoutes(
       validate: {
         body: schema.object({
           task: schema.object({
+            enabled: schema.boolean({ defaultValue: true }),
             taskType: schema.string(),
             schedule: schema.maybe(
               schema.object({

--- a/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
+++ b/x-pack/test/plugin_api_integration/plugins/sample_task_plugin/server/plugin.ts
@@ -233,6 +233,15 @@ export class SampleTaskManagerFixturePlugin
           },
         }),
       },
+      taskToDisable: {
+        title: 'Task used for testing it being disabled',
+        description: '',
+        maxAttempts: 1,
+        paramsSchema: schema.object({}),
+        createTaskRunner: () => ({
+          async run() {},
+        }),
+      },
     });
 
     const taskWithTiming = {

--- a/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
+++ b/x-pack/test/plugin_api_integration/test_suites/task_manager/check_registered_task_types.ts
@@ -34,6 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
     'sampleRecurringTaskWithInvalidIndirectParam',
     'sampleOneTimeTaskWithInvalidIndirectParam',
     'sampleTaskWithParamsSchema',
+    'taskToDisable',
   ];
 
   // This test is meant to fail when any change is made in task manager registered types.


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/163958.
Resolves https://github.com/elastic/kibana/issues/163023.

In this PR, I'm modifying the task store's aggregate function to exclude tasks that are disabled. This function is only used by the monitoring functionality of alerting and actions plugin and the Task Manager's health API which all experienced bugs where they shouldn't be considering disabled task types.

## To verify

1. Create 20 alerting rules running every 1s
2. Call the `/api/task_manager/_health` endpoint
3. Notice capacity_estimation stats are changing to accomodate 20 rules constantly running
4. Disable all the alerting rules
5. Call the `/api/task_manager/_health` endpoint (wait for runtime and workload stats to update by looking at their timestamp and ensuring it's after the time you disabled the rules)
6. Notice capacity_estimation stats no longer consider the 20 rules that use to run constantly

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->