### PR TITLE
[ci] Fix on-merge labels

### DIFF
--- a/.buildkite/scripts/steps/add_gh_labels_to_bk_metadata.ts
+++ b/.buildkite/scripts/steps/add_gh_labels_to_bk_metadata.ts
@@ -27,15 +27,15 @@ const fetchLabels = (prNumber: PrNumber) =>
 
 try {
   const labels = pipe(head, firstMatch, parseInt10, fetchLabels)(`${process.env[parseTarget]}`);
-  execSync(`buildkite-agent meta-data set gh_labels ${labels}`);
-  if (alsoAnnotate)
-    execSync(
-      `buildkite-agent annotate --context 'default' --style 'info' "Github Labels: ${labels}"`
-    );
+  if (labels) {
+    execSync(`buildkite-agent meta-data set gh_labels ${labels}`);
+    if (alsoAnnotate)
+      execSync(
+        `buildkite-agent annotate --context 'default' --style 'info' "Github Labels: ${labels}"`
+      );
+  }
 } catch (e) {
-  console.error(
-    `\n!!! Error fetching Github Labels (stringified): \n${JSON.stringify(e, null, 2)}`
-  );
+  console.error(`Error fetching Github Labels for issue ${firstMatch}`);
 }
 
 export {};

--- a/.buildkite/scripts/steps/functional/apm_cypress.sh
+++ b/.buildkite/scripts/steps/functional/apm_cypress.sh
@@ -16,7 +16,7 @@ GH_APM_TEAM_LABEL="Team:APM"
 if (! is_pr); then
   echo "--- Add GH labels to buildkite metadata"
   ts-node .buildkite/scripts/steps/add_gh_labels_to_bk_metadata.ts BUILDKITE_MESSAGE true
-  GH_ON_MERGE_LABELS="$(buildkite-agent meta-data get gh_labels)"
+  GH_ON_MERGE_LABELS="$(buildkite-agent meta-data get gh_labels --default '')"
 fi
 
 # Enabling cypress dashboard recording when PR is labeled with `apm:cypress-record` and we are not using the flaky test runner OR on merge with Team:APM label applied


### PR DESCRIPTION
Currently some on merge steps fetch labels from the merged pull request by parsing the first line of the commit message.  This convention usually works, but it overlaps with the convention of skipping test suites linking to an issue instead of a pull request.  Errors are thrown when a step attempts to pull metadata from an unset value.

This sets a default value of an empty string if the label metadata is unset and cleans up the log message when an error occurs.

Example error: https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs/builds/5821#018a1d62-fbd2-486d-afe3-9a448449bbf7/257-258