### PR TITLE
Change `i18n.translate()` to return `string` type instead of leaving it up to Typescript parser

### DIFF
--- a/packages/kbn-i18n/src/core/i18n.ts
+++ b/packages/kbn-i18n/src/core/i18n.ts
@@ -165,7 +165,7 @@ export interface TranslateArguments {
  * @param [options.values] - values to pass into translation
  * @param [options.defaultMessage] - will be used unless translation was successful
  */
-export function translate(id: string, { values = {}, defaultMessage }: TranslateArguments) {
+export function translate(id: string, { values = {}, defaultMessage }: TranslateArguments): string {
   const shouldUsePseudoLocale = isPseudoLocale(currentLocale);
 
   if (!id || !isString(id)) {


### PR DESCRIPTION
## Summary

While researching why we had so many `ANY`s in our "Any counts by team" quality report, I noticed that all of the `i18n.translate` in our `uiSettings` we being reported as `any` even though Typescript says that function returns a `string`. When I explicitly define the return value, our `any` count drops from `46` to `2`.

This is the command I ran for the report: `node scripts/build_api_docs --plugin observability --stats any`

### Before
```
┌─────────┬─────────────────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │                                             id                                              │                                                                      link                                                                       │
├─────────┼─────────────────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    0    │                        'def-server.getInspectResponse.$1.esResponse'                        │       'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/get_inspect_response.ts#:~:text=esResponse'        │
│    1    │                     'def-server.uiSettings.enableInspectEsQueries.name'                     │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│    2    │                 'def-server.uiSettings.enableInspectEsQueries.description'                  │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│    3    │                         'def-server.uiSettings.maxSuggestions.name'                         │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│    4    │                     'def-server.uiSettings.maxSuggestions.description'                      │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│    5    │                   'def-server.uiSettings.enableComparisonByDefault.name'                    │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│    6    │                'def-server.uiSettings.enableComparisonByDefault.description'                │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│    7    │                  'def-server.uiSettings.defaultApmServiceEnvironment.name'                  │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│    8    │              'def-server.uiSettings.defaultApmServiceEnvironment.description'               │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│    9    │                     'def-server.uiSettings.apmProgressiveLoading.name'                      │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   10    │                  'def-server.uiSettings.apmProgressiveLoading.description'                  │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   11    │  'def-server.uiSettings.apmProgressiveLoading.optionLabels.ProgressiveLoadingQuality.off'   │  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=%5BProgressiveLoadingQuality.off%5D'   │
│   12    │  'def-server.uiSettings.apmProgressiveLoading.optionLabels.ProgressiveLoadingQuality.low'   │  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=%5BProgressiveLoadingQuality.low%5D'   │
│   13    │ 'def-server.uiSettings.apmProgressiveLoading.optionLabels.ProgressiveLoadingQuality.medium' │ 'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=%5BProgressiveLoadingQuality.medium%5D' │
│   14    │  'def-server.uiSettings.apmProgressiveLoading.optionLabels.ProgressiveLoadingQuality.high'  │  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=%5BProgressiveLoadingQuality.high%5D'  │
│   15    │              'def-server.uiSettings.apmServiceInventoryOptimizedSorting.name'               │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   16    │           'def-server.uiSettings.apmServiceInventoryOptimizedSorting.description'           │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   17    │               'def-server.uiSettings.apmServiceGroupMaxNumberOfServices.name'               │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   18    │           'def-server.uiSettings.apmServiceGroupMaxNumberOfServices.description'            │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   19    │                      'def-server.uiSettings.apmTraceExplorerTab.name'                       │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   20    │                   'def-server.uiSettings.apmTraceExplorerTab.description'                   │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   21    │                         'def-server.uiSettings.apmLabsButton.name'                          │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   22    │                      'def-server.uiSettings.apmLabsButton.description'                      │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   23    │                 'def-server.uiSettings.enableInfrastructureHostsView.name'                  │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   24    │              'def-server.uiSettings.enableInfrastructureHostsView.description'              │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   25    │                     'def-server.uiSettings.enableAwsLambdaMetrics.name'                     │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   26    │                 'def-server.uiSettings.enableAwsLambdaMetrics.description'                  │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   27    │                    'def-server.uiSettings.enableAgentExplorerView.name'                     │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   28    │                 'def-server.uiSettings.enableAgentExplorerView.description'                 │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   29    │                    'def-server.uiSettings.apmAWSLambdaPriceFactor.name'                     │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   30    │                 'def-server.uiSettings.apmAWSLambdaPriceFactor.description'                 │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   31    │               'def-server.uiSettings.apmAWSLambdaRequestCostPerMillion.name'                │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   32    │                    'def-server.uiSettings.apmEnableServiceMetrics.name'                     │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   33    │                 'def-server.uiSettings.apmEnableServiceMetrics.description'                 │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   34    │                   'def-server.uiSettings.apmEnableContinuousRollups.name'                   │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   35    │               'def-server.uiSettings.apmEnableContinuousRollups.description'                │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   36    │                       'def-server.uiSettings.enableCriticalPath.name'                       │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   37    │                   'def-server.uiSettings.enableCriticalPath.description'                    │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   38    │                  'def-server.uiSettings.syntheticsThrottlingEnabled.name'                   │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   39    │               'def-server.uiSettings.syntheticsThrottlingEnabled.description'               │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   40    │                     'def-server.uiSettings.enableLegacyUptimeApp.name'                      │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   41    │                  'def-server.uiSettings.enableLegacyUptimeApp.description'                  │              'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=description'               │
│   42    │                 'def-server.uiSettings.apmEnableProfilingIntegration.name'                  │                  'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/server/ui_settings.ts#:~:text=name'                  │
│   43    │                                  'def-common.AsPercent.$3'                                  │     'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/formatters/formatters.ts#:~:text=fallbackResult'     │
│   44    │                                  'def-common.asPercent.$3'                                  │     'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/formatters/formatters.ts#:~:text=fallbackResult'     │
│   45    │                        'def-common.getInspectResponse.$1.esResponse'                        │       'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/get_inspect_response.ts#:~:text=esResponse'        │
└─────────┴─────────────────────────────────────────────────────────────────────────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

```

### After
```
┌─────────┬───────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (index) │                      id                       │                                                                link                                                                │
├─────────┼───────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│    0    │ 'def-server.getInspectResponse.$1.esResponse' │ 'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/get_inspect_response.ts#:~:text=esResponse' │
│    1    │ 'def-common.getInspectResponse.$1.esResponse' │ 'https://github.com/elastic/kibana/tree/main/x-pack/plugins/observability/common/utils/get_inspect_response.ts#:~:text=esResponse' │
└─────────┴───────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```