### PR TITLE
[Rule Details] - Update rule details data view id text

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/translations.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/translations.ts
@@ -182,10 +182,24 @@ export const INDEX_FIELD_LABEL = i18n.translate(
   }
 );
 
-export const DATA_VIEW_FIELD_LABEL = i18n.translate(
-  'xpack.securitySolution.detectionEngine.ruleDetails.dataViewFieldLabel',
+export const DATA_VIEW_ID_FIELD_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.dataViewIdFieldLabel',
   {
-    defaultMessage: 'Data View',
+    defaultMessage: 'Data view',
+  }
+);
+
+export const DATA_VIEW_INDEX_PATTERN_FIELD_LABEL = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.dataViewIndexPatternFieldLabel',
+  {
+    defaultMessage: 'Data view index pattern',
+  }
+);
+
+export const DATA_VIEW_INDEX_PATTERN_FETCH_ERROR_MESSAGE = i18n.translate(
+  'xpack.securitySolution.detectionEngine.ruleDetails.dataViewIndexPatternFetchErrorMessage',
+  {
+    defaultMessage: 'Could not load data view index pattern',
   }
 );
 

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -78,21 +78,12 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  dataViewTitle: {
-    label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewTitleSelector',
-      {
-        defaultMessage: 'Data view indices',
-      }
-    ),
-    validations: [],
-  },
   // TODO: populate the dataViewTitle in a better way
   dataViewId: {
     label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewIDSelector',
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
       {
-        defaultMessage: 'Data view ID',
+        defaultMessage: 'Data view',
       }
     ),
     fieldsToValidateOnChange: ['dataViewId'],
@@ -127,6 +118,16 @@ export const schema: FormSchema<DefineStepRule> = {
         },
       },
     ],
+  },
+  // TODO: populate the dataViewTitle in a better way
+  dataViewTitle: {
+    label: i18n.translate(
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewTitleSelector',
+      {
+        defaultMessage: 'Data view index pattern',
+      }
+    ),
+    validations: [],
   },
   eqlOptions: {},
   queryBar: {

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -92,7 +92,7 @@ export const schema: FormSchema<DefineStepRule> = {
     label: i18n.translate(
       'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
       {
-        defaultMessage: 'Data View',
+        defaultMessage: 'Data View ID',
       }
     ),
     fieldsToValidateOnChange: ['dataViewId'],

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -80,9 +80,9 @@ export const schema: FormSchema<DefineStepRule> = {
   },
   dataViewTitle: {
     label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewTitleSelector',
       {
-        defaultMessage: 'Data View',
+        defaultMessage: 'Data view indices',
       }
     ),
     validations: [],
@@ -90,9 +90,9 @@ export const schema: FormSchema<DefineStepRule> = {
   // TODO: populate the dataViewTitle in a better way
   dataViewId: {
     label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewIDSelector',
       {
-        defaultMessage: 'Data View ID',
+        defaultMessage: 'Data view ID',
       }
     ),
     fieldsToValidateOnChange: ['dataViewId'],

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -78,7 +78,6 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  // TODO: populate the dataViewTitle in a better way
   dataViewId: {
     label: i18n.translate(
       'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
@@ -119,7 +118,6 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  // TODO: populate the dataViewTitle in a better way
   dataViewTitle: {
     label: i18n.translate(
       'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewTitleSelector',

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -30998,7 +30998,6 @@
     "xpack.securitySolution.detectionEngine.createRule.savedQueryFiltersLabel": "已保存查询筛选",
     "xpack.securitySolution.detectionEngine.createRule.savedQueryLabel": "已保存查询",
     "xpack.securitySolution.detectionEngine.createRule.stepAboutRule.authorFieldEmptyError": "作者不得为空",
-    "xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector": "数据视图",
     "xpack.securitySolution.detectionEngine.createRule.stepAboutRule.descriptionFieldRequiredError": "描述必填。",
     "xpack.securitySolution.detectionEngine.createRule.stepAboutRule.fiedIndexPatternsLabel": "索引模式",
     "xpack.securitySolution.detectionEngine.createRule.stepAboutRule.fieldAssociatedToEndpointListLabel": "将现有的终端例外添加到规则",

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -29,7 +29,7 @@ export const SAVED_QUERY_DETAILS = /^Saved query$/;
 
 export const SAVED_QUERY_FILTERS_DETAILS = 'Saved query filters';
 
-export const DATA_VIEW_DETAILS = 'Data View';
+export const DATA_VIEW_DETAILS = 'Data view';
 
 export const DEFINITION_DETAILS =
   '[data-test-subj=definitionRule] [data-test-subj="listItemColumnStepRuleDescription"]';


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/164828**
**Related UX writing issue: https://github.com/elastic/ux-writing/issues/46**

## Summary

In rule details page, when a rule has a data view selected, two labels show up as "Data View". This appears to be a bug, as one of those labels should be "Data view ID" and another should be "Data view index pattern".

Thanks to @MadameSheema @nikitaindik for finding this. 

### Before 
![image](https://github.com/elastic/kibana/assets/10927944/8ac8b6d4-1005-4c03-a71a-31216a1287c5)

### After
<img width="808" alt="Screenshot 2023-08-26 at 19 30 54" src="https://github.com/elastic/kibana/assets/15949146/b511bf92-0e90-4455-834c-36b8e75b2a58">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->