### PR TITLE
fix(slo): number fields safari

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section.tsx
@@ -241,17 +241,17 @@ export function SloEditFormObjectiveSection() {
                 min: 0.001,
                 max: 99.999,
               }}
-              render={({ field: { ref, ...field }, fieldState }) => (
+              render={({ field: { ref, onChange, ...field }, fieldState }) => (
                 <EuiFieldNumber
                   {...field}
                   required
                   isInvalid={fieldState.invalid}
                   data-test-subj="sloFormObjectiveTargetInput"
-                  value={String(field.value)}
+                  value={field.value}
                   min={0.001}
                   max={99.999}
                   step={0.001}
-                  onChange={(event) => field.onChange(Number(event.target.value))}
+                  onChange={(event) => onChange(event.target.value)}
                 />
               )}
             />

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form_objective_section_timeslices.tsx
@@ -43,17 +43,17 @@ export function SloEditFormObjectiveSectionTimeslices() {
               min: 0.001,
               max: 99.999,
             }}
-            render={({ field: { ref, ...field }, fieldState }) => (
+            render={({ field: { ref, onChange, ...field }, fieldState }) => (
               <EuiFieldNumber
                 {...field}
                 required
                 isInvalid={fieldState.invalid}
-                value={String(field.value)}
+                value={field.value}
                 data-test-subj="sloFormObjectiveTimesliceTargetInput"
                 min={0.001}
                 max={99.999}
                 step={0.001}
-                onChange={(event) => field.onChange(Number(event.target.value))}
+                onChange={(event) => onChange(event.target.value)}
               />
             )}
           />
@@ -82,17 +82,17 @@ export function SloEditFormObjectiveSectionTimeslices() {
             defaultValue="1"
             control={control}
             rules={{ required: true, min: 1, max: 120 }}
-            render={({ field: { ref, ...field }, fieldState }) => (
+            render={({ field: { ref, onChange, ...field }, fieldState }) => (
               <EuiFieldNumber
                 {...field}
                 isInvalid={fieldState.invalid}
                 required
                 data-test-subj="sloFormObjectiveTimesliceWindowInput"
-                value={String(field.value)}
+                value={field.value}
                 min={1}
                 max={120}
                 step={1}
-                onChange={(event) => field.onChange(String(Number(event.target.value)))}
+                onChange={(event) => onChange(String(parseInt(event.target.value, 10)))}
               />
             )}
           />


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/164460

## Summary

This PR fixes the number input fields bug happening with safari.

https://github.com/elastic/kibana/assets/1376800/35191875-46c6-4fdd-8a70-c8b267bbe977




<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->