### PR TITLE
[ML] Fix continuous with the latest function transform test

### DIFF
--- a/x-pack/test/functional/apps/transform/creation/index_pattern/continuous_transform.ts
+++ b/x-pack/test/functional/apps/transform/creation/index_pattern/continuous_transform.ts
@@ -7,6 +7,7 @@
 
 import { TRANSFORM_STATE } from '@kbn/transform-plugin/common/constants';
 
+import type { MappingTypeMapping } from '@elastic/elasticsearch/lib/api/types';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 import {
   GroupByEntry,
@@ -224,8 +225,27 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     ];
 
     for (const testData of testDataList) {
-      // FLAKY: https://github.com/elastic/kibana/issues/158612
-      describe.skip(`${testData.suiteTitle}`, function () {
+      describe(`${testData.suiteTitle}`, function () {
+        before(async () => {
+          // Add explicit mapping for destination index https://github.com/elastic/elasticsearch/issues/67148
+          if (testData.type === 'latest') {
+            const destIndexMappings: MappingTypeMapping = {
+              properties: {
+                products: {
+                  properties: {
+                    base_price: {
+                      type: 'float',
+                    },
+                  },
+                },
+              },
+            };
+
+            await transform.api.createIndices(testData.destinationIndex, {
+              mappings: destIndexMappings,
+            });
+          }
+        });
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
           await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);

--- a/x-pack/test/functional/services/transform/api.ts
+++ b/x-pack/test/functional/services/transform/api.ts
@@ -11,10 +11,11 @@ import type { PutTransformsRequestSchema } from '@kbn/transform-plugin/common/ap
 import { TransformState, TRANSFORM_STATE } from '@kbn/transform-plugin/common/constants';
 import type { TransformStats } from '@kbn/transform-plugin/common/types/transform_stats';
 
-import { GetTransformsResponseSchema } from '@kbn/transform-plugin/common/api_schemas/transforms';
-import { PostTransformsUpdateRequestSchema } from '@kbn/transform-plugin/common/api_schemas/update_transforms';
-import { TransformPivotConfig } from '@kbn/transform-plugin/common/types/transform';
-import { FtrProviderContext } from '../../ftr_provider_context';
+import type { GetTransformsResponseSchema } from '@kbn/transform-plugin/common/api_schemas/transforms';
+import type { PostTransformsUpdateRequestSchema } from '@kbn/transform-plugin/common/api_schemas/update_transforms';
+import type { TransformPivotConfig } from '@kbn/transform-plugin/common/types/transform';
+import type { IndicesCreateRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type { FtrProviderContext } from '../../ftr_provider_context';
 
 export async function asyncForEach(array: any[], callback: Function) {
   for (let index = 0; index < array.length; index++) {
@@ -39,14 +40,17 @@ export function TransformAPIProvider({ getService }: FtrProviderContext) {
       );
     },
 
-    async createIndices(indices: string) {
+    async createIndices(
+      indices: string,
+      params: IndicesCreateRequest['body'] = {} as NonNullable<IndicesCreateRequest['body']>
+    ) {
       log.debug(`Creating indices: '${indices}'...`);
       if ((await es.indices.exists({ index: indices, allow_no_indices: false })) === true) {
         log.debug(`Indices '${indices}' already exist. Nothing to create.`);
         return;
       }
 
-      const createResponse = await es.indices.create({ index: indices });
+      const createResponse = await es.indices.create({ index: indices, ...params });
       expect(createResponse)
         .to.have.property('acknowledged')
         .eql(true, 'Response for create request indices should be acknowledged.');


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/158612 and https://github.com/elastic/kibana/issues/158613, which is caused due to a known issue https://github.com/elastic/elasticsearch/issues/67148. This PR creates the destination index before running the test, with explicit mappings of the field. It also unskips the tests.


[Flaky test suite runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2954) successful after 80 runs ✅

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->