### PR TITLE
[DOCS] Update GitHub links in dev docs

### DIFF
--- a/docs/developer/advanced/sharing-saved-objects.asciidoc
+++ b/docs/developer/advanced/sharing-saved-objects.asciidoc
@@ -166,7 +166,7 @@ const savedObject = resolveResult.saved_object;
 TIP: See an example of this in https://github.com/elastic/kibana/pull/107256#user-content-example-steps[step 2 of the POC]!
 
 The
-https://github.com/elastic/kibana/blob/main/docs/development/core/server/kibana-plugin-core-server.savedobjectsresolveresponse.md[SavedObjectsResolveResponse
+{kib-repo}blob/{branch}/packages/core/saved-objects/core-saved-objects-api-server/src/apis/resolve.ts[SavedObjectsResolveResponse
 interface] has four fields, summarized below:
 
 * `saved_object` - The saved object that was found.
@@ -373,7 +373,7 @@ image::images/sharing-saved-objects-step-6.png["Sharing Saved Objects registrati
 > *Update saved object delete API usage to handle multiple spaces*
 
 If an object is shared to multiple spaces, it cannot be deleted without using the
-https://github.com/elastic/kibana/blob/{branch}/docs/development/core/server/kibana-plugin-core-server.savedobjectsdeleteoptions.md[`force`
+{kib-repo}blob/{branch}/packages/core/saved-objects/core-saved-objects-api-server/src/apis/delete.ts[`force`
 delete option]. You should always be aware when a saved object exists in multiple spaces, and you should warn users in that case.
 
 If your UI allows users to delete your objects, you can define a warning message like this:
@@ -477,7 +477,7 @@ return (
 
 2. Allow users to access your objects in the <<managing-saved-objects,Saved Objects Management page>> in <<management>>. You can do this by
    ensuring that your objects are marked as
-   https://github.com/elastic/kibana/blob/{branch}/docs/development/core/server/kibana-plugin-core-server.savedobjectstypemanagementdefinition.md[importable and exportable] in your <<saved-objects-type-registration,saved object type registration>>:
+   {kib-repo}blob/{branch}/packages/core/saved-objects/core-saved-objects-server/src/saved_objects_management.ts[importable and exportable] in your <<saved-objects-type-registration,saved object type registration>>:
 +
 ```ts
 name: 'my-object-type',

--- a/docs/developer/architecture/add-data-tutorials.asciidoc
+++ b/docs/developer/architecture/add-data-tutorials.asciidoc
@@ -16,7 +16,7 @@ Each tutorial contains three sets of instructions:
 The function must return a function object that conforms to the `TutorialSchema` interface link:{kib-repo}tree/{branch}/src/plugins/home/server/services/tutorials/lib/tutorial_schema.ts[tutorial schema].
 3. Register the tutorial in link:{kib-repo}tree/{branch}/src/plugins/home/server/tutorials/register.ts[register.ts] by adding it to the `builtInTutorials`.
 // TODO update path once assets are migrated
-4. Add image assets to the link:{kib-repo}tree/{branch}/src/legacy/core_plugins/kibana/public/home/tutorial_resources[tutorial_resources directory].
+4. Add image assets to the `tutorial_resources` directory.
 5. Run {kib} locally to preview the tutorial.
 6. Create a PR and go through the review process to get the changes approved.
 
@@ -34,5 +34,5 @@ link:{kib-repo}tree/{branch}/src/plugins/home/public/application/components/tuto
 ==== Markdown
 String values can contain limited Markdown syntax.
 
-link:{kib-repo}tree/{branch}/src/legacy/core_plugins/kibana/public/home/components/tutorial/content.js[Enabled Markdown grammars]
+https://elastic.github.io/eui/#/editors-syntax/markdown-format[Enabled Markdown grammars]
 

--- a/docs/developer/architecture/development/csv-integration.asciidoc
+++ b/docs/developer/architecture/development/csv-integration.asciidoc
@@ -21,7 +21,7 @@ interface jobParameters {
 }
 ----
 
-The `searchRequest.body` should abide by the {ref}/search-request-body.html[Elasticsearch Search Request Body] syntax
+The `searchRequest.body` should abide by the {ref}/search-search.html[Elasticsearch Search Request Body] syntax
 
 [float]
 ==== `export-config` Directive
@@ -48,4 +48,4 @@ function getSharingTitle() string;
 
 ----
 
-The `sharingData.searchRequest.body` should abide by the {ref}/search-request-body.html[Elasticsearch Search Request Body] syntax
+The `sharingData.searchRequest.body` should abide by the {ref}/search-search.html[{es} Search Request Body] syntax

--- a/docs/developer/architecture/index.asciidoc
+++ b/docs/developer/architecture/index.asciidoc
@@ -14,7 +14,7 @@ To begin plugin development, we recommend reading our overview of how plugins wo
 
 Our developer services are changing all the time. One of the best ways to discover and learn about them is to read the available
 READMEs inside our plugins folders: {kib-repo}tree/{branch}/src/plugins[src/plugins] and
-{kib-repo}/tree/{branch}/x-pack/plugins[x-pack/plugins].
+{kib-repo}tree/{branch}/x-pack/plugins[x-pack/plugins].
 
 A few services also automatically generate api documentation which can be browsed inside the {kib-repo}tree/{branch}/docs/development[docs/development section of our repo]
 

--- a/docs/developer/architecture/kibana-platform-plugin-api.asciidoc
+++ b/docs/developer/architecture/kibana-platform-plugin-api.asciidoc
@@ -44,14 +44,14 @@ plugin and to specify if this plugin has server-side code, browser-side code, or
 }
 ----
 
-Learn about the {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.pluginmanifest.md[manifest
+Learn about the {kib-repo}blob/{branch}/packages/core/plugins/core-plugins-server/src/types.ts[manifest
 file format].
 
 NOTE: `package.json` files are irrelevant to and ignored by {kib} for discovering and loading plugins.
 
 *[2] `public/index.ts`* is the entry point into the client-side code of
 this plugin. It must export a function named `plugin`, which will
-receive {kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.plugininitializercontext.md[a standard set of core capabilities] as an argument.
+receive {kib-repo}blob/{branch}/packages/core/plugins/core-plugins-browser/src/plugin_initializer.ts[a standard set of core capabilities] as an argument.
 It should return an instance of its plugin class for
 {kib} to load.
 
@@ -93,7 +93,7 @@ export class MyPlugin implements Plugin {
 ----
 
 *[4] `server/index.ts`* is the entry-point into the server-side code of
-this plugin. {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.plugininitializercontext.md[It is identical] in almost every way to the client-side
+this plugin. {kib-repo}blob/{branch}/packages/core/plugins/core-plugins-server/src/types.ts[It is identical] in almost every way to the client-side
 entry-point:
 
 
@@ -221,16 +221,16 @@ These are the contracts exposed by the core services for each lifecycle:
 |===
 |lifecycle |server contract|browser contract
 |_constructor_
-|{kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.plugininitializercontext.md[PluginInitializerContext]
-|{kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.plugininitializercontext.md[PluginInitializerContext]
+|{kib-repo}blob/{branch}/packages/core/plugins/core-plugins-server/src/types.ts[PluginInitializerContext]
+|{kib-repo}blob/{branch}/packages/core/plugins/core-plugins-browser/src/plugin_initializer.ts[PluginInitializerContext]
 
 |_setup_
-|{kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.coresetup.md[CoreSetup]
-|{kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.coresetup.md[CoreSetup]
+|{kib-repo}blob/{branch}/packages/core/lifecycle/core-lifecycle-server/src/core_setup.ts[CoreSetup]
+|{kib-repo}blob/{branch}/packages/core/lifecycle/core-lifecycle-browser-internal/src/internal_core_setup.ts[CoreSetup]
 
 |_start_
-|{kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.corestart.md[CoreStart]
-|{kib-repo}blob/{branch}/docs/development/core/public/kibana-plugin-core-public.corestart.md[CoreStart]
+|{kib-repo}blob/{branch}/packages/core/lifecycle/core-lifecycle-server/src/core_start.ts[CoreStart]
+|{kib-repo}blob/{branch}/packages/core/lifecycle/core-lifecycle-browser/src/core_start.ts[CoreStart]
 
 |_stop_ |
 |===
@@ -283,7 +283,7 @@ export class MyPlugin implements Plugin<FoobarPluginSetup, FoobarPluginStart> {
 Unlike core, capabilities exposed by plugins are _not_ automatically
 injected into all plugins. Instead, if a plugin wishes to use the public
 interface provided by another plugin, it must first declare that
-plugin as a dependency in it's {kib-repo}blob/{branch}/docs/development/core/server/kibana-plugin-core-server.pluginmanifest.md[`kibana.json`] manifest file.
+plugin as a dependency in it's {kib-repo}blob/{branch}/packages/core/plugins/core-plugins-server/src/types.ts[`kibana.json`] manifest file.
 
 *demo kibana.json:*
 

--- a/docs/developer/architecture/security/feature-registration.asciidoc
+++ b/docs/developer/architecture/security/feature-registration.asciidoc
@@ -39,7 +39,7 @@ Registering a feature consists of the following fields. For more information, co
 |A human readable name for your feature.
 
 |`category` (required)
-|{kib-repo}blob/{branch}/src/core/types/app_category.ts[`AppCategory`]
+|{kib-repo}blob/{branch}/packages/core/application/core-application-common/src/app_category.ts[`AppCategory`]
 |`DEFAULT_APP_CATEGORIES.kibana`
 |The `AppCategory` which best represents your feature. Used to organize the display
 of features within the management screens.
@@ -50,12 +50,12 @@ of features within the management screens.
 |An array of applications this feature enables. Typically, all of your plugin's apps (from `uiExports`) will be included here.
 
 |`privileges` (required)
-|{kib-repo}blob/{branch}/x-pack/plugins/features/common/feature.ts[`KibanaFeatureConfig`].
+|{kib-repo}blob/{branch}/x-pack/plugins/features/common/kibana_feature.ts[`KibanaFeatureConfig`].
 |See <<example-1-canvas,Example 1>> and <<example-2-dev-tools,Example 2>>
 |The set of privileges this feature requires to function.
 
 |`subFeatures` (optional)
-|{kib-repo}blob/{branch}/x-pack/plugins/features/common/feature.ts[`KibanaFeatureConfig`].
+|{kib-repo}blob/{branch}/x-pack/plugins/features/common/kibana_feature.ts[`KibanaFeatureConfig`].
 |See <<example-3-discover,Example 3>>
 |The set of subfeatures that enables finer access control than the `all` and `read` feature privileges. These options are only available in the Gold subscription level and higher.
 

--- a/docs/developer/best-practices/index.asciidoc
+++ b/docs/developer/best-practices/index.asciidoc
@@ -78,7 +78,7 @@ strategies]
 *** Use the `esSearchStrategy` to make raw queries to ES that will
 support async searching and partial results, as well as injecting the
 right advanced settings like whether to include frozen indices or not.
-* {kib-repo}tree/{branch}/src/plugins/embeddable/README.asciidoc[Embeddables]
+* {kib-repo}blob/{branch}/src/plugins/embeddable/README.md[Embeddables]
 ** Rendering maps, visualizations, dashboards in your application
 ** Register new widgets that will can be added to a dashboard or Canvas
 workpad, or rendered in another plugin.
@@ -105,8 +105,8 @@ Eventually we want to guarantee to our plugin developers that their plugins will
 
 Any time you create or change a public API, keep this in mind, and consider potential
 backward compatibility issues. While we have a formal
-{kib-repo}tree/{branch}/src/core/server/saved_objects/migrations/README.md[saved
-object migration system] and are working on adding a formal state migration system, introducing state changes and migrations in a
+saved
+object migration system and are working on adding a formal state migration system, introducing state changes and migrations in a
 minor always comes with a risk. Consider this before making huge and
 risky changes in minors, _especially_ to saved objects.
 

--- a/docs/developer/best-practices/navigation.asciidoc
+++ b/docs/developer/best-practices/navigation.asciidoc
@@ -25,7 +25,7 @@ Assuming you want to link from your app to *Discover*. When building such URL th
 
 ==== Prepending a proper `basePath`
 
-To prepend {kib}'s `basePath` use {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.ibasepath.prepend.md[core.http.basePath.prepend] helper: 
+To prepend {kib}'s `basePath` use {kib-repo}tree/{branch}/packages/core/http/core-http-browser-internal/src/base_path.ts[core.http.basePath.prepend] helper: 
 
 [source,typescript jsx]
 ----
@@ -58,7 +58,7 @@ const discoverUrl = await plugins.discover.locator.getUrl({filters, timeRange});
 await plugins.discover.locator.navigate({filters, timeRange});
 ----
 
-To get a better idea, take a look at *Discover* locator {kib-repo}tree/{branch}/src/plugins/discover/public/locator.ts[implementation].
+To get a better idea, take a look at *Discover* locator {kib-repo}tree/{branch}/src/plugins/discover/public/application/doc/locator.ts[implementation].
 It allows specifying various **Discover** app state pieces like: index pattern, filters, query, time range and more.
 
 There are two ways to access locators of other apps:
@@ -87,12 +87,13 @@ window.location.href = urlToADashboard;
 
 To navigate between different {kib} apps without a page reload (by default) there are APIs in `core`:
 
-* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetoapp.md[core.application.navigateToApp]
-* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.applicationstart.navigatetourl.md[core.application.navigateToUrl]
+* {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/contracts.ts[core.application.navigateToApp]
+* {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/contracts.ts[core.application.navigateToUrl]
 
 Both methods offer customization such as opening the target in a new page, with an `options` parameter. All the options are optional be default.
-* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.navigatetoappoptions.md[core.application.navigateToApp options]
-* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.navigatetourloptions.md[core.application.navigateToUrl options]
+
+* {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/contracts.ts[core.application.navigateToApp options]
+* {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/contracts.ts[core.application.navigateToUrl options]
 
 *Rendering a link to a different {kib} app on its own would also cause a full page reload:*
 
@@ -162,8 +163,8 @@ Common rules to follow in this scenario:
 
 This is required to make sure `core` is aware of navigations triggered inside your app, so it could act accordingly when needed.
 
-* `Core`'s {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.scopedhistory.md[ScopedHistory] instance.
-* {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.appmountparameters.history.md[Example usage]
+* `Core`'s {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/scoped_history.ts[ScopedHistory] instance.
+* {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/app_mount.ts[Example usage]
 * {kib-repo}tree/{branch}/test/plugin_functional/plugins/core_plugin_a/public/application.tsx#L120[Example plugin]
 
 Relative links will be resolved relative to your app's route (e.g.: `http://localhost5601/app/{your-app-id}`)
@@ -180,14 +181,14 @@ const MyInternalLink = () => <Link to="/my-other-page"></Link>
 === Using history and browser location
 
 Try to avoid using `window.location` and `window.history` directly. +  
-Instead, consider using {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.scopedhistory.md[ScopedHistory]
+Instead, consider using {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/scoped_history.ts[ScopedHistory]
 instance provided by `core`.
 
 * This way `core` will know about location changes triggered within your app, and it would act accordingly.
 * Some plugins are listening to location changes. Triggering location change manually could lead to unpredictable and hard-to-catch bugs.
 
 Common use-case for using 
-`core`'s {kib-repo}tree/{branch}/docs/development/core/public/kibana-plugin-core-public.scopedhistory.md[ScopedHistory] directly: 
+`core`'s {kib-repo}tree/{branch}/packages/core/application/core-application-browser/src/scoped_history.ts[ScopedHistory] directly: 
 
 * Reading/writing query params or hash.
 * Imperatively triggering internal navigations within your app.

--- a/docs/developer/contributing/development-functional-tests.asciidoc
+++ b/docs/developer/contributing/development-functional-tests.asciidoc
@@ -118,7 +118,7 @@ The tests are written in https://mochajs.org[mocha] using https://github.com/ela
 
 We use https://www.w3.org/TR/webdriver1/[WebDriver Protocol] to run tests in both Chrome and Firefox with the help of https://sites.google.com/a/chromium.org/chromedriver/[chromedriver] and https://firefox-source-docs.mozilla.org/testing/geckodriver/[geckodriver]. When the `FunctionalTestRunner` launches, remote service creates a new webdriver session, which starts the driver and a stripped-down browser instance. We use `browser` service and `webElementWrapper` class to wrap up https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/[Webdriver API].
 
-The `FunctionalTestRunner` automatically transpiles functional tests using babel, so that tests can use the same ECMAScript features that {kib} source code uses. See {kibana-blob}style_guides/js_style_guide.md[style_guides/js_style_guide.md].
+The `FunctionalTestRunner` automatically transpiles functional tests using babel, so that tests can use the same ECMAScript features that {kib} source code uses. See {kibana-blob}/STYLEGUIDE.mdx[STYLEGUIDE.mdx].
 
 [discrete]
 ==== Definitions
@@ -270,7 +270,7 @@ The first and only argument to all providers is a Provider API Object. This obje
 Within config files the API has the following properties
 
 [horizontal]
-`log`::: An instance of the {kibana-blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[`ToolingLog`] that is ready for use
+`log`::: An instance of the `ToolingLog` that is ready for use
 `readConfigFile(path)`::: Returns a promise that will resolve to a Config instance that provides the values from the config file at `path`
 
 Within service and PageObject Providers the API is:
@@ -293,17 +293,17 @@ Within a test Provider the API is exactly the same as the service providers API 
 The `FunctionalTestRunner` comes with three built-in services:
 
 **config:**:::
-* Source: {kibana-blob}src/functional_test_runner/lib/config/config.ts[src/functional_test_runner/lib/config/config.ts]
-* Schema: {kibana-blob}src/functional_test_runner/lib/config/schema.ts[src/functional_test_runner/lib/config/schema.ts]
+// * Source: {kibana-blob}src/functional_test_runner/lib/config/config.ts[src/functional_test_runner/lib/config/config.ts]
+// * Schema: {kibana-blob}src/functional_test_runner/lib/config/schema.ts[src/functional_test_runner/lib/config/schema.ts]
 * Use `config.get(path)` to read any value from the config file
 
 **log:**:::
-* Source: {kibana-blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[packages/kbn-dev-utils/src/tooling_log/tooling_log.js]
+// * Source: {kibana-blob}packages/kbn-dev-utils/src/tooling_log/tooling_log.js[packages/kbn-dev-utils/src/tooling_log/tooling_log.js]
 * `ToolingLog` instances are readable streams. The instance provided by this service is automatically piped to stdout by the `FunctionalTestRunner` CLI
 * `log.verbose()`, `log.debug()`, `log.info()`, `log.warning()` all work just like console.log but produce more organized output
 
 **lifecycle:**:::
-* Source: {kibana-blob}src/functional_test_runner/lib/lifecycle.ts[src/functional_test_runner/lib/lifecycle.ts]
+// * Source: {kibana-blob}src/functional_test_runner/lib/lifecycle.ts[src/functional_test_runner/lib/lifecycle.ts]
 * Designed primary for use in services
 * Exposes lifecycle events for basic coordination. Handlers can return a promise and resolve/fail asynchronously
 * Phases include: `beforeLoadTests`, `beforeTests`, `beforeEachTest`, `cleanup`
@@ -314,14 +314,14 @@ The `FunctionalTestRunner` comes with three built-in services:
 The {kib} functional tests define the vast majority of the actual functionality used by tests.
 
 **browser**:::
-* Source: {kibana-blob}test/functional/services/browser.ts[test/functional/services/browser.ts]
+// * Source: {kibana-blob}test/functional/services/browser.ts[test/functional/services/browser.ts]
 * Higher level wrapper for `remote` service, which exposes available browser actions
 * Popular methods:
 ** `browser.getWindowSize()`
 ** `browser.refresh()`
 
 **testSubjects:**:::
-* Source: {kibana-blob}test/functional/services/test_subjects.ts[test/functional/services/test_subjects.ts]
+// * Source: {kibana-blob}test/functional/services/test_subjects.ts[test/functional/services/test_subjects.ts]
 * Test subjects are elements that are tagged specifically for selecting from tests
 * Use `testSubjects` over CSS selectors when possible
 * Usage:
@@ -346,21 +346,21 @@ await testSubjects.click(‘containerButton’);
 ** `testSubjects.click(testSubjectSelector)` - Click a test subject in the page; throw if it can't be found after some time
 
 **find:**:::
-* Source: {kibana-blob}test/functional/services/find.ts[test/functional/services/find.ts]
+// * Source: {kibana-blob}test/functional/services/find.ts[test/functional/services/find.ts]
 * Helpers for `remote.findBy*` methods that log and manage timeouts
 * Popular methods:
 ** `find.byCssSelector()`
 ** `find.allByCssSelector()`
 
 **retry:**:::
-* Source: {kibana-blob}test/common/services/retry/retry.ts[test/common/services/retry/retry.ts]
+// * Source: {kibana-blob}test/common/services/retry/retry.ts[test/common/services/retry/retry.ts]
 * Helpers for retrying operations
 * Popular methods:
 ** `retry.try(fn, onFailureBlock)` - Execute `fn` in a loop until it succeeds or the default timeout elapses. The optional `onFailureBlock` is executed before each retry attempt.
 ** `retry.tryForTime(ms, fn, onFailureBlock)` - Execute `fn` in a loop until it succeeds or `ms` milliseconds elapses. The optional `onFailureBlock` is executed before each retry attempt.
 
 **kibanaServer:**:::
-* Source: {kibana-blob}test/common/services/kibana_server/kibana_server.js[test/common/services/kibana_server/kibana_server.js]
+// * Source: {kibana-blob}test/common/services/kibana_server/kibana_server.js[test/common/services/kibana_server/kibana_server.js]
 * Helpers for interacting with {kib}'s server
 * Commonly used methods:
 ** `kibanaServer.uiSettings.update()`
@@ -368,7 +368,7 @@ await testSubjects.click(‘containerButton’);
 ** `kibanaServer.status.getOverallState()`
 
 **esArchiver:**:::
-* Source: {kibana-blob}test/common/services/es_archiver.ts[test/common/services/es_archiver.ts]
+// * Source: {kibana-blob}test/common/services/es_archiver.ts[test/common/services/es_archiver.ts]
 * Load/unload archives created with the `esArchiver`
 * Popular methods:
 ** `esArchiver.load(path)`
@@ -380,11 +380,11 @@ Full list of services that are used in functional tests can be found here: {kiba
 
 **Low-level utilities:**:::
 * es
-** Source: {kibana-blob}test/common/services/es.ts[test/common/services/es.ts]
+// ** Source: {kibana-blob}test/common/services/es.ts[test/common/services/es.ts]
 ** {es} client
 ** Higher level options: `kibanaServer.uiSettings` or `esArchiver`
 * remote
-** Source: {kibana-blob}test/functional/services/remote/remote.ts[test/functional/services/remote/remote.ts]
+// ** Source: {kibana-blob}test/functional/services/remote/remote.ts[test/functional/services/remote/remote.ts]
 ** Instance of https://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/index_exports_WebDriver.html[WebDriver] class
 ** Responsible for all communication with the browser
 ** To perform browser actions, use `remote` service

--- a/docs/developer/contributing/linting.asciidoc
+++ b/docs/developer/contributing/linting.asciidoc
@@ -2,7 +2,7 @@
 == Linting
 
 A note about linting: We use http://eslint.org[eslint] to check that the
-link:STYLEGUIDE.mdx[styleguide] is being followed. It runs in a
+{kib-repo}blob/{branch}/STYLEGUIDE.mdx[styleguide] is being followed. It runs in a
 pre-commit hook and as a part of the tests, but most contributors
 integrate it with their code editors for real-time feedback.
 

--- a/docs/developer/getting-started/index.asciidoc
+++ b/docs/developer/getting-started/index.asciidoc
@@ -72,10 +72,7 @@ you can use:
 yarn kbn bootstrap --force-install
 ----
 
-(You can also run `yarn kbn` to see the other available commands. For
-more info about this tool, see
-{kib-repo}tree/{branch}/packages/kbn-pm[{kib-repo}tree/{branch}/packages/kbn-pm]. If you want more 
-information about how to actively develop over packages please read <<monorepo-packages>>)
+You can also run `yarn kbn` to see the other available commands.
 
 When switching branches which use different versions of npm packages you
 may need to run:

--- a/docs/developer/plugin/external-plugin-functional-tests.asciidoc
+++ b/docs/developer/plugin/external-plugin-functional-tests.asciidoc
@@ -80,5 +80,5 @@ node ../../kibana/scripts/functional_test_runner
 [discrete]
 === Using esArchiver
 
-We're working on documentation for this, but for now the best place to look is the original {kib-repo}/issues/10359[pull request].
+We're working on documentation for this, but for now the best place to look is the original {kib-repo}issues/10359[pull request].
 

--- a/src/plugins/expressions/README.asciidoc
+++ b/src/plugins/expressions/README.asciidoc
@@ -44,6 +44,8 @@ filters
 [role="screenshot"]
 image::https://user-images.githubusercontent.com/9773803/74162514-3250a880-4c21-11ea-9e68-86f66862a183.png[]
 
+////
+// Commenting out due to broken links
 === API documentation
 
 ==== Server API
@@ -57,3 +59,4 @@ https://github.com/elastic/kibana/blob/main/docs/development/plugins/expressions
 
 ==== Other documentation
 https://www.elastic.co/guide/en/kibana/current/canvas-function-arguments.html[See Canvas documentation about expressions]
+////


### PR DESCRIPTION
## Summary

Updates broken GitHub links in the [Kibana developer guide](https://www.elastic.co/guide/en/kibana/current/development.html).
If I couldn't find a replacement link, I removed or commented out the link.

Closes https://github.com/elastic/platform-docs-team/issues/165

<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->