### PR TITLE
[RAM] Fix flaky legacy alerts test suite

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
@@ -58,7 +58,7 @@ export default function alertTests({ getService }: FtrProviderContext) {
 
   // FLAKY: https://github.com/elastic/kibana/issues/159123
   // FLAKY: https://github.com/elastic/kibana/issues/15912
-  describe.skip('alerts', () => {
+  describe('alerts', () => {
     const authorizationIndex = '.kibana-test-authorization';
     const objectRemover = new ObjectRemover(supertest);
 
@@ -87,7 +87,7 @@ export default function alertTests({ getService }: FtrProviderContext) {
       describe(scenario.id, () => {
         let alertUtils: AlertUtils;
 
-        before(async () => {
+        before(() => {
           alertUtils = new AlertUtils({
             user,
             space,

--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/rbac_legacy.ts
@@ -56,8 +56,6 @@ export default function alertTests({ getService }: FtrProviderContext) {
     ),
   };
 
-  // FLAKY: https://github.com/elastic/kibana/issues/159123
-  // FLAKY: https://github.com/elastic/kibana/issues/15912
   describe('alerts', () => {
     const authorizationIndex = '.kibana-test-authorization';
     const objectRemover = new ObjectRemover(supertest);


### PR DESCRIPTION
## Summary

Closes #159124
Closes #159123

It looks like removing an `async` from a function that didn't actually `await` anything fixed a flaky Promise execution. Flaky test runner succeeds on this branch: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2957#018a1ef8-6514-4abe-a55c-cbe646bf64a2

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->