### PR TITLE
[Search] Add missing salesforce connector tile and docs link

### DIFF
--- a/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
+++ b/x-pack/plugins/enterprise_search/common/connectors/connectors.ts
@@ -140,6 +140,17 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
     serviceType: 'postgresql',
   },
   {
+    iconPath: 'salesforce.svg',
+    isBeta: true,
+    isNative: false,
+    isTechPreview: false,
+    keywords: ['salesforce', 'cloud', 'connector'],
+    name: i18n.translate('xpack.enterpriseSearch.content.nativeConnectors.salesforce.name', {
+      defaultMessage: 'Salesforce',
+    }),
+    serviceType: 'salesforce',
+  },
+  {
     iconPath: 'servicenow.svg',
     isBeta: true,
     isNative: true,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -410,6 +410,7 @@ class DocLinks {
     this.connectorsOracle = docLinks.links.enterpriseSearch.connectorsOracle;
     this.connectorsPostgreSQL = docLinks.links.enterpriseSearch.connectorsPostgreSQL;
     this.connectorsS3 = docLinks.links.enterpriseSearch.connectorsS3;
+    this.connectorsSalesforce = docLinks.links.enterpriseSearch.connectorsSalesforce;
     this.connectorsServiceNow = docLinks.links.enterpriseSearch.connectorsServiceNow;
     this.connectorsSharepoint = docLinks.links.enterpriseSearch.connectorsSharepoint;
     this.connectorsSharepointOnline = docLinks.links.enterpriseSearch.connectorsSharepointOnline;


### PR DESCRIPTION
## Summary

Add connector tile and docs link for Salesforce connector.
Salesforce already exists as a connector type so only adding the tile seems to be required.
Documentation link goes to https://www.elastic.co/guide/en/enterprise-search/8.10/connectors-salesforce.html

Tile:
<img width="400" alt="Screenshot 2023-08-23 at 11 54 28" src="https://github.com/elastic/kibana/assets/13634519/a6f38df4-0243-4b62-bcc1-774dff1f83af">


Full page:
<img width="623" alt="Screenshot 2023-08-23 at 11 54 25" src="https://github.com/elastic/kibana/assets/13634519/63e59a33-9251-458b-abe8-095e21cd32bd">


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->