### PR TITLE
[Fleet] copy `inactivity_timeout` when duplicating agent policy

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -13,6 +13,8 @@ import type { Output } from './output';
 
 export type AgentPolicyStatus = typeof agentPolicyStatuses;
 
+// adding a property here? If it should be cloned when duplicating a policy, add it to `agentPolicyService.copy`
+// x-pack/plugins/fleet/server/services/agent_policy.ts#L571
 export interface NewAgentPolicy {
   id?: string;
   name: string;

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { omit, isEqual, keyBy, groupBy } from 'lodash';
+import { omit, isEqual, keyBy, groupBy, pick } from 'lodash';
 import { v5 as uuidv5 } from 'uuid';
 import { safeDump } from 'js-yaml';
 import pMap from 'p-map';
@@ -562,14 +562,24 @@ class AgentPolicyService {
     if (!baseAgentPolicy) {
       throw new Error('Agent policy not found');
     }
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    const { namespace, monitoring_enabled } = baseAgentPolicy;
+
+    const {} = baseAgentPolicy;
     const newAgentPolicy = await this.create(
       soClient,
       esClient,
       {
-        namespace,
-        monitoring_enabled,
+        ...pick(baseAgentPolicy, [
+          'namespace',
+          'monitoring_enabled',
+          'inactivity_timeout',
+          'unenroll_timeout',
+          'agent_features',
+          'overrides',
+          'data_output_id',
+          'monitoring_output_id',
+          'download_source_id',
+          'fleet_server_host_id',
+        ]),
         ...newAgentPolicyProps,
       },
       options

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -563,7 +563,6 @@ class AgentPolicyService {
       throw new Error('Agent policy not found');
     }
 
-    const {} = baseAgentPolicy;
     const newAgentPolicy = await this.create(
       soClient,
       esClient,

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -562,7 +562,6 @@ class AgentPolicyService {
     if (!baseAgentPolicy) {
       throw new Error('Agent policy not found');
     }
-
     const newAgentPolicy = await this.create(
       soClient,
       esClient,

--- a/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
+++ b/x-pack/test/fleet_api_integration/apis/agent_policy/agent_policy.ts
@@ -454,6 +454,34 @@ export default function (providerContext: FtrProviderContext) {
         });
       });
 
+      it('should copy inactivity timeout', async () => {
+        const {
+          body: { item: policyWithTimeout },
+        } = await supertest
+          .post(`/api/fleet/agent_policies`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Inactivity test',
+            namespace: 'default',
+            is_managed: true,
+            inactivity_timeout: 123,
+          })
+          .expect(200);
+
+        const {
+          body: { item: newPolicy },
+        } = await supertest
+          .post(`/api/fleet/agent_policies/${policyWithTimeout.id}/copy`)
+          .set('kbn-xsrf', 'xxxx')
+          .send({
+            name: 'Inactivity test copy',
+            description: 'Test',
+          })
+          .expect(200);
+
+        expect(newPolicy.inactivity_timeout).to.eql(123);
+      });
+
       it('should increment package policy copy names', async () => {
         async function getSystemPackagePolicyCopyVersion(policyId: string) {
           const {


### PR DESCRIPTION
## Summary

Closes #164532 

`inactivity_timeout` and a lot of other properties on the agent policy saved object were not being copied over when duplicating an agent policy.

The other properties that are now duplicated when cloning an agent policy are :

- `inactivity_timeout` 
- `unenroll_timeout` 
- `agent_features` - this contains the hostname mode 
- `overrides` 
- `data_output_id` 
- `monitoring_output_id` 
- `download_source_id` 
- `fleet_server_host_id`

Automated test added.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->