### PR TITLE
[8.9] [Security Solution] Fix flaky test: x-pack/test/detection_engine_api_integration/security_and_spaces/update_prebuilt_rules_package/update_prebuilt_rules_package·ts - update_prebuilt_rules_package should allow user to install prebuilt rules from scratch, then install new rules and upgrade existing rules from the new package

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
-import { DETECTION_ENGINE_RULES_URL_FIND } from '@kbn/security-solution-plugin/common/constants';
 import expect from 'expect';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
+import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
 import { getPrebuiltRulesStatus } from '../../utils/prebuilt_rules/get_prebuilt_rules_status';
 import { installPrebuiltRules } from '../../utils/prebuilt_rules/install_prebuilt_rules';
 
@@ -38,8 +37,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.stats.num_prebuilt_rules_to_install).toBe(0);
       expect(statusBeforePackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
 
-      await installPrebuiltRules(supertest);
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      await installPrebuiltRules(es, supertest);
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);
@@ -48,11 +46,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
 
       // Get installed rules
-      const { body: rulesResponse } = await supertest
-        .get(DETECTION_ENGINE_RULES_URL_FIND)
-        .set('kbn-xsrf', 'true')
-        .send()
-        .expect(200);
+      const rulesResponse = await getInstalledRules(supertest);
 
       // Assert that installed rules are from package 99.0.0 and not from prerelease (beta) package
       expect(rulesResponse.data.length).toBe(1);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/large_prebuilt_rules_package/install_large_prebuilt_rules_package.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/large_prebuilt_rules_package/install_large_prebuilt_rules_package.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import expect from 'expect';
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllRules, getPrebuiltRulesAndTimelinesStatus } from '../../utils';
 import { deleteAllPrebuiltRuleAssets } from '../../utils/prebuilt_rules/delete_all_prebuilt_rule_assets';
@@ -36,8 +35,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.rules_not_updated).toBe(0);
 
       // Install the package with 15000 prebuilt historical version of rules rules and 750 unique rules
-      await installPrebuiltRulesAndTimelines(supertest);
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      await installPrebuiltRulesAndTimelines(es, supertest);
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/fleet_integration.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/fleet_integration.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 import expect from 'expect';
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
   deleteAllRules,
@@ -43,23 +42,10 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.rules_not_updated).toBe(0);
 
       await installPrebuiltRulesFleetPackage({
+        es,
         supertest,
         overrideExistingPackage: true,
       });
-
-      // Before we proceed, we need to refresh saved object indices. This comment will explain why.
-      // At the previous step we installed the Fleet package with prebuilt detection rules.
-      // Prebuilt rules are assets that Fleet indexes as saved objects of a certain type.
-      // Fleet does this via a savedObjectsClient.import() call with explicit `refresh: false`.
-      // So, despite of the fact that the endpoint waits until the prebuilt rule assets will be
-      // successfully indexed, it doesn't wait until they become "visible" for subsequent read
-      // operations. Which is what we do next: we read these SOs in getPrebuiltRulesAndTimelinesStatus().
-      // Now, the time left until the next refresh can be anything from 0 to the default value, and
-      // it depends on the time when savedObjectsClient.import() call happens relative to the time of
-      // the next refresh. Also, probably the refresh time can be delayed when ES is under load?
-      // Anyway, here we have a race condition between a write and subsequent read operation, and to
-      // fix it deterministically we have to refresh saved object indices and wait until it's done.
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);
@@ -68,18 +54,9 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusAfterPackageInstallation.rules_not_updated).toBe(0);
 
       // Verify that all previously not installed rules were installed
-      const response = await installPrebuiltRulesAndTimelines(supertest);
+      const response = await installPrebuiltRulesAndTimelines(es, supertest);
       expect(response.rules_installed).toBe(statusAfterPackageInstallation.rules_not_installed);
       expect(response.rules_updated).toBe(0);
-
-      // Similar to the previous refresh, we need to do it again between the two operations:
-      // - previous write operation: install prebuilt rules and timelines
-      // - subsequent read operation: get prebuilt rules and timelines status
-      // You may ask why? I'm not sure, probably because the write operation can install the Fleet
-      // package under certain circumstances, and it all works with `refresh: false` again.
-      // Anyway, there were flaky runs failing specifically at one of the next assertions,
-      // which means some kind of the same race condition we have here too.
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after rules installation
       const statusAfterRuleInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/get_prebuilt_rules_status.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/get_prebuilt_rules_status.ts
@@ -82,7 +82,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return the number of installed prebuilt rules after installing them', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
           expect(stats).toMatchObject({
@@ -95,7 +95,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should notify the user again that a rule is available for install after it is deleted', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
           await deleteRule(supertest, 'rule-1');
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
@@ -110,7 +110,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should return available rule updates', async () => {
           const ruleAssetSavedObjects = getRuleAssetSavedObjects();
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Clear previous rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -130,7 +130,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should not return any available update if rule has been successfully upgraded', async () => {
           const ruleAssetSavedObjects = getRuleAssetSavedObjects();
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Clear previous rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -138,7 +138,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ruleAssetSavedObjects[0]['security-rule'].version += 1;
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
           // Upgrade all rules
-          await upgradePrebuiltRules(supertest);
+          await upgradePrebuiltRules(es, supertest);
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
           expect(stats).toMatchObject({
@@ -152,7 +152,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should not return any updates if none are available', async () => {
           const ruleAssetSavedObjects = getRuleAssetSavedObjects();
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Clear previous rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -193,7 +193,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return the number of installed prebuilt rules after installing them', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
           expect(stats).toMatchObject({
@@ -206,7 +206,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should notify the user again that a rule is available for install after it is deleted', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
           await deleteRule(supertest, 'rule-1');
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
@@ -220,7 +220,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return available rule updates when previous historical versions available', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Add a new version of one of the installed rules
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
@@ -238,7 +238,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return available rule updates when previous historical versions unavailable', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Delete the previous versions of rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -261,7 +261,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should not return available rule updates after rule has been upgraded', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRules(supertest);
+          await installPrebuiltRules(es, supertest);
 
           // Delete the previous versions of rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -272,7 +272,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
 
           // Upgrade the rule
-          await upgradePrebuiltRules(supertest);
+          await upgradePrebuiltRules(es, supertest);
 
           const { stats } = await getPrebuiltRulesStatus(supertest);
           expect(stats).toMatchObject({
@@ -339,7 +339,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return the number of installed prebuilt rules after installing them', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           const body = await getPrebuiltRulesAndTimelinesStatus(supertest);
           expect(body).toMatchObject({
@@ -352,7 +352,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should notify the user again that a rule is available for install after it is deleted', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
           await deleteRule(supertest, 'rule-1');
 
           const body = await getPrebuiltRulesAndTimelinesStatus(supertest);
@@ -367,7 +367,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should return available rule updates', async () => {
           const ruleAssetSavedObjects = getRuleAssetSavedObjects();
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           // Clear previous rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -387,7 +387,7 @@ export default ({ getService }: FtrProviderContext): void => {
         it('should not return any updates if none are available', async () => {
           const ruleAssetSavedObjects = getRuleAssetSavedObjects();
           await createPrebuiltRuleAssetSavedObjects(es, ruleAssetSavedObjects);
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           // Clear previous rule assets
           await deleteAllPrebuiltRuleAssets(es);
@@ -428,7 +428,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return the number of installed prebuilt rules after installing them', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           const body = await getPrebuiltRulesAndTimelinesStatus(supertest);
           expect(body).toMatchObject({
@@ -441,7 +441,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should notify the user again that a rule is available for install after it is deleted', async () => {
           await createPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
           await deleteRule(supertest, 'rule-1');
 
           const body = await getPrebuiltRulesAndTimelinesStatus(supertest);
@@ -455,7 +455,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return available rule updates when previous historical versions available', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           // Add a new version of one of the installed rules
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, [
@@ -473,7 +473,7 @@ export default ({ getService }: FtrProviderContext): void => {
 
         it('should return available rule updates when previous historical versions unavailable', async () => {
           await createHistoricalPrebuiltRuleAssetSavedObjects(es, getRuleAssetSavedObjects());
-          await installPrebuiltRulesAndTimelines(supertest);
+          await installPrebuiltRulesAndTimelines(es, supertest);
 
           // Delete the previous versions of rule assets
           await deleteAllPrebuiltRuleAssets(es);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/get_prebuilt_timelines_status.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/get_prebuilt_timelines_status.ts
@@ -35,7 +35,7 @@ export default ({ getService }: FtrProviderContext): void => {
     });
 
     it('should return the number of installed timeline templates after installing them', async () => {
-      await installPrebuiltRulesAndTimelines(supertest);
+      await installPrebuiltRulesAndTimelines(es, supertest);
 
       const body = await getPrebuiltRulesAndTimelinesStatus(supertest);
       expect(body).toMatchObject({

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type SuperTest from 'supertest';
+import { DETECTION_ENGINE_RULES_URL_FIND } from '@kbn/security-solution-plugin/common/constants';
+import { FindRulesResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
+
+/**
+ * Get all installed security rules (both prebuilt + custom)
+ *
+ * @param es Elasticsearch client
+ * @param supertest SuperTest instance
+ * @param version Semver version of the `security_detection_engine` package to install
+ * @returns Fleet install package response
+ */
+
+export const getInstalledRules = async (
+  supertest: SuperTest.SuperTest<SuperTest.Test>
+): Promise<FindRulesResponse> => {
+  const { body: rulesResponse } = await supertest
+    .get(`${DETECTION_ENGINE_RULES_URL_FIND}?per_page=10000`)
+    .set('kbn-xsrf', 'true')
+    .send()
+    .expect(200);
+
+  return rulesResponse;
+};

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/get_installed_rules.ts
@@ -6,7 +6,7 @@
  */
 import type SuperTest from 'supertest';
 import { DETECTION_ENGINE_RULES_URL_FIND } from '@kbn/security-solution-plugin/common/constants';
-import { FindRulesResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
+import { RuleResponse } from '@kbn/security-solution-plugin/common/detection_engine/rule_schema';
 
 /**
  * Get all installed security rules (both prebuilt + custom)
@@ -17,9 +17,16 @@ import { FindRulesResponse } from '@kbn/security-solution-plugin/common/api/dete
  * @returns Fleet install package response
  */
 
+interface GetInstalledRulesResponse {
+  page: number;
+  perPage: number;
+  total: number;
+  data: RuleResponse[];
+}
+
 export const getInstalledRules = async (
   supertest: SuperTest.SuperTest<SuperTest.Test>
-): Promise<FindRulesResponse> => {
+): Promise<GetInstalledRulesResponse> => {
   const { body: rulesResponse } = await supertest
     .get(`${DETECTION_ENGINE_RULES_URL_FIND}?per_page=10000`)
     .set('kbn-xsrf', 'true')

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { Client } from '@elastic/elasticsearch';
+import type SuperTest from 'supertest';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { InstallPackageResponse } from '@kbn/fleet-plugin/common/types';
+
+/**
+ * Installs prebuilt rules package `security_detection_engine` by version.
+ *
+ * @param es Elasticsearch client
+ * @param supertest SuperTest instance
+ * @param version Semver version of the `security_detection_engine` package to install
+ * @returns Fleet install package response
+ */
+
+export const installPrebuiltRulesPackageByVersion = async (
+  es: Client,
+  supertest: SuperTest.SuperTest<SuperTest.Test>,
+  version: string
+): Promise<InstallPackageResponse> => {
+  const fleetResponse = await supertest
+    .post(`/api/fleet/epm/packages/security_detection_engine/${version}`)
+    .set('kbn-xsrf', 'xxxx')
+    .type('application/json')
+    .send({ force: true })
+    .expect(200);
+
+  // Before we proceed, we need to refresh saved object indices.
+  // At the previous step we installed the Fleet package with prebuilt detection rules.
+  // Prebuilt rules are assets that Fleet indexes as saved objects of a certain type.
+  // Fleet does this via a savedObjectsClient.import() call with explicit `refresh: false`.
+  // So, despite of the fact that the endpoint waits until the prebuilt rule assets will be
+  // successfully indexed, it doesn't wait until they become "visible" for subsequent read
+  // operations.
+  // And this is usually what we do next in integration tests: we read these SOs with utility
+  // function such as getPrebuiltRulesAndTimelinesStatus().
+  // Now, the time left until the next refresh can be anything from 0 to the default value, and
+  // it depends on the time when savedObjectsClient.import() call happens relative to the time of
+  // the next refresh. Also, probably the refresh time can be delayed when ES is under load?
+  // Anyway, this can cause race condition between a write and subsequent read operation, and to
+  // fix it deterministically we have to refresh saved object indices and wait until it's done.
+  await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+
+  return fleetResponse.body as InstallPackageResponse;
+};

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_mock_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_mock_prebuilt_rules.ts
@@ -6,7 +6,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
-import { InstallPrebuiltRulesAndTimelinesResponse } from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
+import { InstallPrebuiltRulesAndTimelinesResponse } from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
 import type SuperTest from 'supertest';
 import { createPrebuiltRuleAssetSavedObjects } from './create_prebuilt_rule_saved_objects';
 import { installPrebuiltRulesAndTimelines } from './install_prebuilt_rules_and_timelines';

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_mock_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_mock_prebuilt_rules.ts
@@ -6,7 +6,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
-import { InstallPrebuiltRulesAndTimelinesResponse } from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
+import { InstallPrebuiltRulesAndTimelinesResponse } from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
 import type SuperTest from 'supertest';
 import { createPrebuiltRuleAssetSavedObjects } from './create_prebuilt_rule_saved_objects';
 import { installPrebuiltRulesAndTimelines } from './install_prebuilt_rules_and_timelines';
@@ -24,5 +24,5 @@ export const installMockPrebuiltRules = async (
 ): Promise<InstallPrebuiltRulesAndTimelinesResponse> => {
   // Ensure there are prebuilt rule saved objects before installing rules
   await createPrebuiltRuleAssetSavedObjects(es);
-  return installPrebuiltRulesAndTimelines(supertest);
+  return installPrebuiltRulesAndTimelines(es, supertest);
 };

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
@@ -7,10 +7,12 @@
 
 import {
   PERFORM_RULE_INSTALLATION_URL,
+  RuleVersionSpecifier,
   PerformRuleInstallationResponseBody,
-} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
-import { RuleVersionSpecifier } from '@kbn/security-solution-plugin/server/lib/detection_engine/prebuilt_rules/model/rule_versions/rule_version_specifier';
+} from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
+import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 
 /**
  * Installs available prebuilt rules in Kibana. Rules are
@@ -27,6 +29,7 @@ import type SuperTest from 'supertest';
  * @returns Install prebuilt rules response
  */
 export const installPrebuiltRules = async (
+  es: Client,
   supertest: SuperTest.SuperTest<SuperTest.Test>,
   rules?: RuleVersionSpecifier[]
 ): Promise<PerformRuleInstallationResponseBody> => {
@@ -41,6 +44,18 @@ export const installPrebuiltRules = async (
     .set('kbn-xsrf', 'true')
     .send(payload)
     .expect(200);
+
+  // Before we proceed, we need to refresh saved object indices.
+  // At the previous step we installed the prebuilt detection rules SO of type 'security-rule'.
+  // The savedObjectsClient does this with a call with explicit `refresh: false`.
+  // So, despite of the fact that the endpoint waits until the prebuilt rule will be
+  // successfully indexed, it doesn't wait until they become "visible" for subsequent read
+  // operations.
+  // And this is usually what we do next in integration tests: we read these SOs with utility
+  // function such as getPrebuiltRulesAndTimelinesStatus().
+  // This can cause race conditions between a write and subsequent read operation, and to
+  // fix it deterministically we have to refresh saved object indices and wait until it's done.
+  await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
   return response.body;
 };

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules.ts
@@ -5,14 +5,14 @@
  * 2.0.
  */
 
-import {
-  PERFORM_RULE_INSTALLATION_URL,
-  RuleVersionSpecifier,
-  PerformRuleInstallationResponseBody,
-} from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
 import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
 import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { RuleVersionSpecifier } from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_request_schema';
+import {
+  PerformRuleInstallationResponseBody,
+  PERFORM_RULE_INSTALLATION_URL,
+} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
 
 /**
  * Installs available prebuilt rules in Kibana. Rules are

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
@@ -5,13 +5,13 @@
  * 2.0.
  */
 
-import {
-  InstallPrebuiltRulesAndTimelinesResponse,
-  PREBUILT_RULES_URL,
-} from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
 import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
 import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import {
+  InstallPrebuiltRulesAndTimelinesResponse,
+  PREBUILT_RULES_URL,
+} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
 
 /**
  * (LEGACY)

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_prebuilt_rules_and_timelines.ts
@@ -8,8 +8,10 @@
 import {
   InstallPrebuiltRulesAndTimelinesResponse,
   PREBUILT_RULES_URL,
-} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
+} from '@kbn/security-solution-plugin/common/api/detection_engine/prebuilt_rules';
+import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 
 /**
  * (LEGACY)
@@ -28,6 +30,7 @@ import type SuperTest from 'supertest';
  * @returns Install prebuilt rules response
  */
 export const installPrebuiltRulesAndTimelines = async (
+  es: Client,
   supertest: SuperTest.SuperTest<SuperTest.Test>
 ): Promise<InstallPrebuiltRulesAndTimelinesResponse> => {
   const response = await supertest
@@ -35,6 +38,18 @@ export const installPrebuiltRulesAndTimelines = async (
     .set('kbn-xsrf', 'true')
     .send()
     .expect(200);
+
+  // Before we proceed, we need to refresh saved object indices.
+  // At the previous step we installed the prebuilt detection rules SO of type 'security-rule'.
+  // The savedObjectsClient does this with a call with explicit `refresh: false`.
+  // So, despite of the fact that the endpoint waits until the prebuilt rule will be
+  // successfully indexed, it doesn't wait until they become "visible" for subsequent read
+  // operations.
+  // And this is usually what we do next in integration tests: we read these SOs with utility
+  // function such as getPrebuiltRulesAndTimelinesStatus().
+  // This can cause race condition between a write and subsequent read operation, and to
+  // fix it deterministically we have to refresh saved object indices and wait until it's done.
+  await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
   return response.body;
 };

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/upgrade_prebuilt_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/upgrade_prebuilt_rules.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import {
-  PERFORM_RULE_UPGRADE_URL,
-  PerformRuleUpgradeResponseBody,
-} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
-import { RuleVersionSpecifier } from '@kbn/security-solution-plugin/server/lib/detection_engine/prebuilt_rules/model/rule_versions/rule_version_specifier';
+import type { Client } from '@elastic/elasticsearch';
 import type SuperTest from 'supertest';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import {
+  PerformRuleUpgradeResponseBody,
+  PERFORM_RULE_UPGRADE_URL,
+} from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules';
+import { RuleVersionSpecifier } from '@kbn/security-solution-plugin/common/detection_engine/prebuilt_rules/api/perform_rule_installation/perform_rule_installation_request_schema';
 
 /**
  * Upgrades available prebuilt rules in Kibana.
@@ -23,6 +25,7 @@ import type SuperTest from 'supertest';
  * @returns Upgrade prebuilt rules response
  */
 export const upgradePrebuiltRules = async (
+  es: Client,
   supertest: SuperTest.SuperTest<SuperTest.Test>,
   rules?: RuleVersionSpecifier[]
 ): Promise<PerformRuleUpgradeResponseBody> => {
@@ -37,6 +40,19 @@ export const upgradePrebuiltRules = async (
     .set('kbn-xsrf', 'true')
     .send(payload)
     .expect(200);
+
+  // Before we proceed, we need to refresh saved object indices.
+  // At the previous step we upgraded the prebuilt rules, which, under the hoods, installs new versions
+  // of the prebuilt detection rules SO of type 'security-rule'.
+  // The savedObjectsClient does this with a call with explicit `refresh: false`.
+  // So, despite of the fact that the endpoint waits until the prebuilt rule will be
+  // successfully indexed, it doesn't wait until they become "visible" for subsequent read
+  // operations.
+  // And this is usually what we do next in integration tests: we read these SOs with utility
+  // function such as getPrebuiltRulesAndTimelinesStatus().
+  // This can cause race conditions between a write and subsequent read operation, and to
+  // fix it deterministically we have to refresh saved object indices and wait until it's done.
+  await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
   return response.body;
 };


### PR DESCRIPTION
**NOTE: This is a manual backport of https://github.com/elastic/kibana/pull/163241. It had to be done manually because of changes that happened from 8.9 -> 8.10 like the common folder restructuring and some type changes because of the OpenAPI effort, but it is mostly the changes to the same files as that PR.**

**Original PR description follows:**

Fixes: https://github.com/elastic/kibana/issues/162658

## Summary

- Fixes flaky test: `x-pack/test/detection_engine_api_integration/security_and_spaces/update_prebuilt_rules_package/update_prebuilt_rules_package·ts`
- Test title: `update_prebuilt_rules_package should allow user to install prebuilt rules from scratch, then install new rules and upgrade existing rules from the new package`

## Passing flaky test runner

300 runs: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2799

## Root cause and what this PR does

- On initial investigation, the flaky test runner was executed for this test with 300 iterations and all of them succeeded. This gives us great confidence that the test is not actually flaky.
- Further investigation showed that @kibanamachine reported this tests as failing when running the CI for two backport PRs to `8.9`:
    - https://buildkite.com/elastic/kibana-on-merge/builds/33282#0189987d-3a80-49c2-8332-3105ec3c2109
    - https://buildkite.com/elastic/kibana-on-merge/builds/33444#0189b1fa-4bc4-4422-9ce9-5c9a24f11ad5
- These flakiness was caused **by a race condition** between the writing of rules into indeces, and them being made available for reading. This is a known issue, already and solved for other integration test, by manually refreshing ES's indeces. 
- In order to reduce the probability of flakiness in a similar scenario, this PR adds code to refresh the indices after each  rule installation or upgrade during the test.

## Refactor

- Moves the refreshing of the indexes within the utility function that write to indexes:
    - `installPrebuiltRules`
    - `upgradePrebuiltRules`
    - `installPrebuiltRulesAndTimelines` (legacy, but still used)
    - `installPrebuiltRulesFleetPackage`
- Creates 2 new utils:
    - `installPrebuiltRulesPackageByVersion`, which installs `security_detection_engine` package via Fleet API, with its version passed in as param
    - `getInstalledRules`, reusable function to fetch all installed rules
    -   
