### PR TITLE
[8.9] [Security Solution] Flaky Cypress test: Detection rules, Prebuilt Rules Installation and Update workflow - Installation of prebuilt rules package via Fleet should install package from Fleet in the background 

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_install_update_workflows.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_install_update_workflows.cy.ts
@@ -25,6 +25,7 @@ import {
   getRuleAssets,
 } from '../../tasks/api_calls/prebuilt_rules';
 import { deleteAlertsAndRules, reload, resetRulesTableState } from '../../tasks/common';
+import { esArchiverResetKibana } from '../../tasks/es_archiver';
 import { login, visitWithoutDateRange } from '../../tasks/login';
 import {
   addElasticRulesButtonClick,
@@ -45,7 +46,7 @@ describe('Detection rules, Prebuilt Rules Installation and Update workflow', () 
     login();
     resetRulesTableState();
     deleteAlertsAndRules();
-    cy.task('esArchiverResetKibana');
+    esArchiverResetKibana();
 
     visitWithoutDateRange(SECURITY_DETECTIONS_RULES_URL);
   });


### PR DESCRIPTION
**NOTE: This is a manual backport of https://github.com/elastic/kibana/pull/163468 to 8.9.**

**Original PR description:**

Fixes: https://github.com/elastic/kibana/issues/163447
Fixes: https://github.com/elastic/kibana/issues/163586

## Summary

- Fixes flaky test: `x-pack/plugins/security_solution/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts`
- Test title: `Detection rules, Prebuilt Rules Installation and Update workflow - Installation of prebuilt rules package via Fleet should install package from Fleet in the background`

## Details

- Initially ran the flaky test runner with multiple iterations and all gave succesful results, i.e. no flakiness or failed tests.
- But: after checking the logs for the failed tests in the original failed build, discovered that the reason the test failed is because:
  - when checking Fleet's response for the installation of the `security_detection_engine`, the API response was not as expected from the API spec:
```
**Expected:** [{ name: 'security_detection_engine', installSource: 'registry' }]
**Actual:** [{ name: 'security_detection_engine', installSource: undefined }]
```
Since we cannot rely 100% that the Fleet API will return the correct value for the installSource, this PR deletes this part of the test to prevent any type of flakiness caused by external factors such as this.
