### PR TITLE
[8.9] [Security Solution] Fix flaky test: detection_rules/bulk_edit_rules_actions.cy.ts

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_detection_callouts_index_outdated.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/alerts_detection_callouts_index_outdated.cy.ts
@@ -13,7 +13,11 @@ import { PAGE_TITLE } from '../../screens/common/page';
 import { login, visitWithoutDateRange, waitForPageWithoutDateRange } from '../../tasks/login';
 import { goToRuleDetails } from '../../tasks/alerts_detection_rules';
 import { createRule, deleteCustomRule } from '../../tasks/api_calls/rules';
-import { getCallOut, waitForCallOutToBeShown } from '../../tasks/common/callouts';
+import {
+  getCallOut,
+  NEED_ADMIN_FOR_UPDATE_CALLOUT,
+  waitForCallOutToBeShown,
+} from '../../tasks/common/callouts';
 
 const loadPageAsPlatformEngineerUser = (url: string) => {
   login(ROLES.soc_manager);
@@ -26,8 +30,6 @@ const waitForPageTitleToBeShown = () => {
 };
 
 describe('Detections > Need Admin Callouts indicating an admin is needed to migrate the alert data set', () => {
-  const NEED_ADMIN_FOR_UPDATE_CALLOUT = 'need-admin-for-update-rules';
-
   before(() => {
     // First, we have to open the app on behalf of a privileged user in order to initialize it.
     // Otherwise the app will be disabled and show a "welcome"-like page.

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/missing_privileges_callout.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_alerts/missing_privileges_callout.cy.ts
@@ -13,7 +13,12 @@ import { PAGE_TITLE } from '../../screens/common/page';
 import { login, visitWithoutDateRange, waitForPageWithoutDateRange } from '../../tasks/login';
 import { goToRuleDetails } from '../../tasks/alerts_detection_rules';
 import { createRule, deleteCustomRule } from '../../tasks/api_calls/rules';
-import { getCallOut, waitForCallOutToBeShown, dismissCallOut } from '../../tasks/common/callouts';
+import {
+  getCallOut,
+  waitForCallOutToBeShown,
+  dismissCallOut,
+  MISSING_PRIVILEGES_CALLOUT,
+} from '../../tasks/common/callouts';
 
 const loadPageAsReadOnlyUser = (url: string) => {
   login(ROLES.reader);
@@ -37,8 +42,6 @@ const waitForPageTitleToBeShown = () => {
 };
 
 describe('Detections > Callouts', () => {
-  const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
-
   before(() => {
     // First, we have to open the app on behalf of a privileged user in order to initialize it.
     // Otherwise the app will be disabled and show a "welcome"-like page.

--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/all_rules_read_only.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/all_rules_read_only.cy.ts
@@ -16,11 +16,14 @@ import { VALUE_LISTS_MODAL_ACTIVATOR } from '../../screens/lists';
 import { waitForRulesTableToBeLoaded } from '../../tasks/alerts_detection_rules';
 import { createRule } from '../../tasks/api_calls/rules';
 import { cleanKibana } from '../../tasks/common';
-import { dismissCallOut, getCallOut, waitForCallOutToBeShown } from '../../tasks/common/callouts';
+import {
+  dismissCallOut,
+  getCallOut,
+  waitForCallOutToBeShown,
+  MISSING_PRIVILEGES_CALLOUT,
+} from '../../tasks/common/callouts';
 import { login, visitWithoutDateRange } from '../../tasks/login';
 import { SECURITY_DETECTIONS_RULES_URL } from '../../urls/navigation';
-
-const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
 
 describe('All rules - read only', () => {
   before(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { esArchiverResetKibana } from '../../../../tasks/es_archiver';
 import { ROLES } from '../../../../../common/test';
 import { getExceptionList } from '../../../../objects/exception';
 import {
@@ -25,7 +24,7 @@ const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
 
 describe('Shared exception lists - read only', () => {
   before(() => {
-    esArchiverResetKibana();
+    cy.task('esArchiverResetKibana');
   });
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { esArchiverResetKibana } from '../../../../tasks/es_archiver';
 import { ROLES } from '../../../../../common/test';
 import { getExceptionList } from '../../../../objects/exception';
 import {
@@ -24,7 +25,7 @@ const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
 
 describe('Shared exception lists - read only', () => {
   before(() => {
-    cy.task('esArchiverResetKibana');
+    esArchiverResetKibana();
   });
 
   beforeEach(() => {

--- a/x-pack/plugins/security_solution/cypress/tasks/common/callouts.ts
+++ b/x-pack/plugins/security_solution/cypress/tasks/common/callouts.ts
@@ -7,6 +7,9 @@
 
 import { callOutWithId, CALLOUT_DISMISS_BTN } from '../../screens/common/callouts';
 
+export const NEED_ADMIN_FOR_UPDATE_CALLOUT = 'need-admin-for-update-rules';
+export const MISSING_PRIVILEGES_CALLOUT = 'missing-user-privileges';
+
 export const getCallOut = (id: string, options?: Cypress.Timeoutable) => {
   return cy.get(callOutWithId(id), options);
 };


### PR DESCRIPTION
**NOTE: This is a manual backport of https://github.com/elastic/kibana/pull/163698**

**Original PR description:**

Fixes: https://github.com/elastic/kibana/issues/154721

## Summary

- Fixes flaky test: `x-pack/plugins/security_solution/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules_actions.cy.ts`
- Test title: `Detection rules, bulk edit of rule actions`


## Details

For: `Detection rules, bulk edit of rule actions - Restricted action privileges - User with no privileges can't add rule actions`
- Since this test logs in with a user with missing privileges, the "Missing privileges" callout is shown at the top of the Rules Table. The `selectNumberOfRules();` command selects rules one by one by clicking on their checkboxes. However, flakiness was caused when the callout was rendered while the selection of the rules was happening, causing a layout shift that caused the selection of a checkbox to lose focus, and not being able to be checked. This was solved by waiting the callout to be rendered before the selection of rules start, with the new `waitForCallOutToBeShown`method.

For: `Detection rules, bulk edit of rule actions - All actions privileges - before/beforeEach Clause`
- Tests were failing in the `beforeEach` clause because the first test, mentioned above, would be logged in with a `ROLES.hunter_no_actions` role, and logging in with a user with permissions happened in a `before` clause instead of a `beforeEach` clause. This caused the rest of the suite to continue with a role without permissions, and the setup of the second test would fail as the API requests done would fail with `401`. Moving the initial logging-in from a `before` clause to a `beforeEach` clause solved this issue.

For: `Detection rules, bulk edit of rule actions - All actions privileges - Add a rule action to rules (existing connector)`
- This flakiness was extremely rare, but could be reproduced after about 400 iterations. It was caused by a similar reason as the first case above: while rules were being selected one by one, the table would auto refresh and focus would be lost from the checkbox that was about to be selected. This aws fixed by disabling autorefresh in the setup.

### Other changes
- Prevents the installation of `security_detection_engine` package and creates mock rules instead.
- Creates the `waitForCallOutToBeShown` method and moves the callout IDs spread across different files to a a single file where they are exported from.
