### PR TITLE
fix(slo): sli value summary calculation

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
@@ -58,7 +58,7 @@ Array [
                 "goodEvents": "goodEvents",
                 "totalEvents": "totalEvents",
               },
-              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+              "script": "if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }",
             },
           },
           "statusCode": Object {
@@ -286,7 +286,7 @@ Array [
                 "goodEvents": "goodEvents",
                 "totalEvents": "totalEvents",
               },
-              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+              "script": "if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }",
             },
           },
           "statusCode": Object {
@@ -514,7 +514,7 @@ Array [
                 "goodEvents": "goodEvents",
                 "totalEvents": "totalEvents",
               },
-              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+              "script": "if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }",
             },
           },
           "statusCode": Object {
@@ -757,7 +757,7 @@ Array [
                 "goodEvents": "goodEvents",
                 "totalEvents": "totalEvents",
               },
-              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+              "script": "if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }",
             },
           },
           "statusCode": Object {
@@ -1013,7 +1013,7 @@ Array [
                 "goodEvents": "goodEvents",
                 "totalEvents": "totalEvents",
               },
-              "script": "if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }",
+              "script": "if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }",
             },
           },
           "statusCode": Object {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
@@ -88,7 +88,7 @@ export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest =
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
@@ -88,7 +88,7 @@ export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = 
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
@@ -88,7 +88,7 @@ export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
@@ -116,7 +116,7 @@ export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = 
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
@@ -101,7 +101,7 @@ export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
             totalEvents: 'totalEvents',
           },
           script:
-            'if (params.totalEvents == 0) { return -1 } else { return params.goodEvents / params.totalEvents }',
+            'if (params.totalEvents == 0) { return -1 } else if (params.goodEvents >= params.totalEvents) { return 1 } else { return params.goodEvents / params.totalEvents }',
         },
       },
       errorBudgetInitial: {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/164602

## Summary

When the goodEvents is greater than the totalEvents, we return 1 (100%) for the SLI Value computed from the summary transforms.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->