### PR TITLE
chore(slo): optional filter fields

### DIFF
--- a/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -125,13 +125,17 @@ const histogramMetricDef = t.union([
 const histogramIndicatorTypeSchema = t.literal('sli.histogram.custom');
 const histogramIndicatorSchema = t.type({
   type: histogramIndicatorTypeSchema,
-  params: t.type({
-    index: t.string,
-    timestampField: t.string,
-    filter: t.string,
-    good: histogramMetricDef,
-    total: histogramMetricDef,
-  }),
+  params: t.intersection([
+    t.type({
+      index: t.string,
+      timestampField: t.string,
+      good: histogramMetricDef,
+      total: histogramMetricDef,
+    }),
+    t.partial({
+      filter: t.string,
+    }),
+  ]),
 });
 
 const indicatorDataSchema = t.type({

--- a/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -46,13 +46,17 @@ const apmTransactionErrorRateIndicatorSchema = t.type({
 const kqlCustomIndicatorTypeSchema = t.literal('sli.kql.custom');
 const kqlCustomIndicatorSchema = t.type({
   type: kqlCustomIndicatorTypeSchema,
-  params: t.type({
-    index: t.string,
-    filter: t.string,
-    good: t.string,
-    total: t.string,
-    timestampField: t.string,
-  }),
+  params: t.intersection([
+    t.type({
+      index: t.string,
+      good: t.string,
+      total: t.string,
+      timestampField: t.string,
+    }),
+    t.partial({
+      filter: t.string,
+    }),
+  ]),
 });
 
 const metricCustomValidAggregations = t.keyof({

--- a/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
+++ b/x-pack/packages/kbn-slo-schema/src/schema/indicators.ts
@@ -80,13 +80,17 @@ const metricCustomMetricDef = t.type({
 const metricCustomIndicatorTypeSchema = t.literal('sli.metric.custom');
 const metricCustomIndicatorSchema = t.type({
   type: metricCustomIndicatorTypeSchema,
-  params: t.type({
-    index: t.string,
-    filter: t.string,
-    good: metricCustomMetricDef,
-    total: metricCustomMetricDef,
-    timestampField: t.string,
-  }),
+  params: t.intersection([
+    t.type({
+      index: t.string,
+      good: metricCustomMetricDef,
+      total: metricCustomMetricDef,
+      timestampField: t.string,
+    }),
+    t.partial({
+      filter: t.string,
+    }),
+  ]),
 });
 
 const rangeHistogramMetricType = t.literal('range');

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.json
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.json
@@ -798,7 +798,9 @@
             "nullable": false,
             "required": [
               "index",
-              "timestampField"
+              "timestampField",
+              "good",
+              "total"
             ],
             "properties": {
               "index": {

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -504,6 +504,8 @@ components:
           required:
             - index
             - timestampField
+            - good
+            - total
           properties:
             index:
               description: The index or index pattern to use

--- a/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_custom_kql.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/components/schemas/indicator_properties_custom_kql.yaml
@@ -12,6 +12,8 @@ properties:
     required:
       - index
       - timestampField
+      - good
+      - total
     properties:
       index:
         description: The index or index pattern to use

--- a/x-pack/plugins/observability/server/services/slo/get_preview_data.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_preview_data.ts
@@ -316,7 +316,7 @@ export class GetPreviewData {
   }
 }
 
-function getElastichsearchQueryOrThrow(kuery: string) {
+function getElastichsearchQueryOrThrow(kuery: string | undefined = '') {
   try {
     return toElasticsearchQuery(fromKueryExpression(kuery));
   } catch (err) {

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/common.ts
@@ -8,7 +8,7 @@
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
 import { InvalidTransformError } from '../../../errors';
 
-export function getElastichsearchQueryOrThrow(kuery: string) {
+export function getElastichsearchQueryOrThrow(kuery: string | undefined = '') {
   try {
     return toElasticsearchQuery(fromKueryExpression(kuery));
   } catch (err) {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/163902

## Summary

This PR makes the `filter` indicator param field for custom kql, custom metric and histogram indicators optional.


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->