### PR TITLE
Fix useMatrixHistogram test console errors

### DIFF
--- a/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts
@@ -137,12 +137,12 @@ export const useMatrixHistogram = ({
                   buckets: histogramBuckets,
                 }));
                 endTracking('success');
-                searchSubscription$.current.unsubscribe();
+                searchSubscription$.current?.unsubscribe();
               } else if (isErrorResponse(response)) {
                 setLoading(false);
                 addWarning(i18n.ERROR_MATRIX_HISTOGRAM);
                 endTracking('invalid');
-                searchSubscription$.current.unsubscribe();
+                searchSubscription$.current?.unsubscribe();
               }
             },
             error: (msg) => {
@@ -151,11 +151,11 @@ export const useMatrixHistogram = ({
                 title: errorMessage ?? i18n.FAIL_MATRIX_HISTOGRAM,
               });
               endTracking('error');
-              searchSubscription$.current.unsubscribe();
+              searchSubscription$.current?.unsubscribe();
             },
           });
       };
-      searchSubscription$.current.unsubscribe();
+      searchSubscription$.current?.unsubscribe();
       abortCtrl.current.abort();
       asyncSearch();
       refetch.current = asyncSearch;
@@ -201,7 +201,7 @@ export const useMatrixHistogram = ({
       search(matrixHistogramRequest);
     }
     return () => {
-      searchSubscription$.current.unsubscribe();
+      searchSubscription$.current?.unsubscribe();
       abortCtrl.current.abort();
     };
   }, [matrixHistogramRequest, search, skip]);
@@ -209,7 +209,7 @@ export const useMatrixHistogram = ({
   useEffect(() => {
     if (skip) {
       setLoading(false);
-      searchSubscription$.current.unsubscribe();
+      searchSubscription$.current?.unsubscribe();
       abortCtrl.current.abort();
     }
   }, [skip]);


### PR DESCRIPTION
Running useMatrixHistogram test `node scripts/jest x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.test.ts` floods console with errors like the below. This makes debugging these tests almost impossible with all of the noise. This PR resolves the issue flooding tests with console error messages.

```
console.error
    Error: Uncaught [TypeError: Cannot read properties of undefined (reading 'unsubscribe')]
        at reportException (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
        at innerInvokeEventListeners (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
        at invokeEventListeners (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
        at HTMLUnknownElementImpl._dispatch (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
        at HTMLUnknownElementImpl.dispatchEvent (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
        at HTMLUnknownElement.dispatchEvent (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
        at Object.invokeGuardedCallbackDev (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11440:16)
        at invokeGuardedCallback (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11499:31)
        at flushPassiveEffectsImpl (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14560:11)
        at unstable_runWithPriority (/Users/nreese/projects/kibana/node_modules/scheduler/cjs/scheduler.development.js:468:12)
        at runWithPriority (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2486:10)
        at flushPassiveEffects (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14464:14)
        at flushActWork (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15227:14)
        at act (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15345:9)
        at unmount (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/native/pure.js:85:34)
        at unmountHook (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/index.js:123:7)
        at cleanup (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/cleanup.js:14:11)
        at Object.<anonymous> (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/cleanup.js:42:13)
        at Promise.then.completed (/Users/nreese/projects/kibana/node_modules/jest-circus/build/utils.js:300:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (/Users/nreese/projects/kibana/node_modules/jest-circus/build/utils.js:233:10)
        at _callCircusHook (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:279:40)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at _runTest (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:252:5)
        at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:125:9)
        at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:120:9)
        at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:120:9)
        at run (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:70:3)
        at runAndTransformResultsToJestFormat (/Users/nreese/projects/kibana/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
        at jestAdapter (/Users/nreese/projects/kibana/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
        at runTestInternal (/Users/nreese/projects/kibana/node_modules/jest-runner/build/runTest.js:367:16)
        at runTest (/Users/nreese/projects/kibana/node_modules/jest-runner/build/runTest.js:444:34) {
      detail: TypeError: Cannot read properties of undefined (reading 'unsubscribe')
          at unsubscribe (/Users/nreese/projects/kibana/x-pack/plugins/security_solution/public/common/containers/matrix_histogram/index.ts:204:35)
          at HTMLUnknownElement.callCallback (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11391:14)
          at HTMLUnknownElement.callTheUserObjectsOperation (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/generated/EventListener.js:26:30)
          at innerInvokeEventListeners (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:350:25)
          at invokeEventListeners (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
          at HTMLUnknownElementImpl._dispatch (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
          at HTMLUnknownElementImpl.dispatchEvent (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
          at HTMLUnknownElement.dispatchEvent (/Users/nreese/projects/kibana/node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
          at Object.invokeGuardedCallbackDev (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11440:16)
          at invokeGuardedCallback (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11499:31)
          at flushPassiveEffectsImpl (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14560:11)
          at unstable_runWithPriority (/Users/nreese/projects/kibana/node_modules/scheduler/cjs/scheduler.development.js:468:12)
          at runWithPriority (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2486:10)
          at flushPassiveEffects (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14464:14)
          at flushActWork (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15227:14)
          at act (/Users/nreese/projects/kibana/node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15345:9)
          at unmount (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/native/pure.js:85:34)
          at unmountHook (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/index.js:123:7)
          at cleanup (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/cleanup.js:14:11)
          at Object.<anonymous> (/Users/nreese/projects/kibana/node_modules/@testing-library/react-hooks/lib/core/cleanup.js:42:13)
          at Promise.then.completed (/Users/nreese/projects/kibana/node_modules/jest-circus/build/utils.js:300:28)
          at new Promise (<anonymous>)
          at callAsyncCircusFn (/Users/nreese/projects/kibana/node_modules/jest-circus/build/utils.js:233:10)
          at _callCircusHook (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:279:40)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at _runTest (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:252:5)
          at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:125:9)
          at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:120:9)
          at _runTestsForDescribeBlock (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:120:9)
          at run (/Users/nreese/projects/kibana/node_modules/jest-circus/build/run.js:70:3)
          at runAndTransformResultsToJestFormat (/Users/nreese/projects/kibana/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapterInit.js:122:21)
          at jestAdapter (/Users/nreese/projects/kibana/node_modules/jest-circus/build/legacy-code-todo-rewrite/jestAdapter.js:79:19)
          at runTestInternal (/Users/nreese/projects/kibana/node_modules/jest-runner/build/runTest.js:367:16)
          at runTest (/Users/nreese/projects/kibana/node_modules/jest-runner/build/runTest.js:444:34),
      type: 'unhandled exception'
    }

      29 |     return;
      30 |   }
    > 31 |   consoleError(message, ...rest);
         |   ^
      32 | };
      33 |

      at consoleError (packages/kbn-test/src/jest/setup/emotion.js:31:3)
      at console.error (node_modules/@testing-library/react-hooks/lib/core/console.js:19:7)
      at reportException (node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:70:28)
      at innerInvokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:9)
      at invokeEventListeners (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
      at HTMLUnknownElementImpl._dispatch (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:233:9)
      at HTMLUnknownElementImpl.dispatchEvent (node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:104:17)
      at HTMLUnknownElement.dispatchEvent (node_modules/jsdom/lib/jsdom/living/generated/EventTarget.js:241:34)
      at Object.invokeGuardedCallbackDev (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11440:16)
      at invokeGuardedCallback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:11499:31)
      at flushPassiveEffectsImpl (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14560:11)
      at unstable_runWithPriority (node_modules/scheduler/cjs/scheduler.development.js:468:12)
      at runWithPriority (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:2486:10)
      at flushPassiveEffects (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:14464:14)
      at flushActWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15227:14)
      at act (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:15345:9)
      at unmount (node_modules/@testing-library/react-hooks/lib/native/pure.js:85:34)
      at unmountHook (node_modules/@testing-library/react-hooks/lib/core/index.js:123:7)
      at cleanup (node_modules/@testing-library/react-hooks/lib/core/cleanup.js:14:11)
      at Object.<anonymous> (node_modules/@testing-library/react-hooks/lib/core/cleanup.js:42:13)
```