### PR TITLE
[Fleet] Fix flaky unit test for the details page

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.test.tsx
@@ -67,15 +67,20 @@ describe('when on integration detail', () => {
   });
 
   describe('and the package is installed', () => {
-    beforeEach(async () => await render());
+    beforeEach(async () => {
+      await render();
+      await act(() => mockedApi.waitForApi());
+      // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+    });
 
     it('should display agent policy usage count', async () => {
-      await act(() => mockedApi.waitForApi());
       expect(renderResult.queryByTestId('agentPolicyCount')).not.toBeNull();
     });
 
     it('should show the Policies tab', async () => {
-      await act(() => mockedApi.waitForApi());
       expect(renderResult.queryByTestId('tab-policies')).not.toBeNull();
     });
   });
@@ -95,32 +100,32 @@ describe('when on integration detail', () => {
     });
   }
 
-  // FLAKY: https://github.com/elastic/kibana/issues/150607
-  describe.skip('and the package is not installed and prerelease enabled', () => {
+  describe('and the package is not installed and prerelease enabled', () => {
     beforeEach(async () => {
       mockGAAndPrereleaseVersions('1.0.0-beta');
       await render();
+      await act(() => mockedApi.waitForApi());
+      // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
     });
 
     it('should NOT display agent policy usage count', async () => {
-      await mockedApi.waitForApi();
       expect(renderResult.queryByTestId('agentPolicyCount')).toBeNull();
     });
 
     it('should NOT display the Policies tab', async () => {
-      await mockedApi.waitForApi();
       expect(renderResult.queryByTestId('tab-policies')).toBeNull();
     });
 
     it('should display version select if prerelease setting enabled and prererelase version available', async () => {
-      await mockedApi.waitForApi();
       const versionSelect = renderResult.queryByTestId('versionSelect');
       expect(versionSelect?.textContent).toEqual('1.0.0-beta1.0.0');
       expect((versionSelect as any)?.value).toEqual('1.0.0-beta');
     });
 
     it('should display prerelease callout if prerelease setting enabled and prerelease version available', async () => {
-      await mockedApi.waitForApi();
       const calloutTitle = renderResult.getByTestId('prereleaseCallout');
       expect(calloutTitle).toBeInTheDocument();
       const calloutGABtn = renderResult.getByTestId('switchToGABtn');
@@ -137,20 +142,22 @@ describe('when on integration detail', () => {
         item: { prerelease_integrations_enabled: false, id: '', fleet_server_hosts: [] },
       });
       await render();
+      await act(() => mockedApi.waitForApi());
+      // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
     });
 
     it('should NOT display agent policy usage count', async () => {
-      await mockedApi.waitForApi();
       expect(renderResult.queryByTestId('agentPolicyCount')).toBeNull();
     });
 
     it('should NOT display the Policies tab', async () => {
-      await mockedApi.waitForApi();
       expect(renderResult.queryByTestId('tab-policies')).toBeNull();
     });
 
     it('should display version text and no callout if prerelease setting disabled', async () => {
-      await mockedApi.waitForApi();
       expect((renderResult.queryByTestId('versionText') as any)?.textContent).toEqual('1.0.0');
       expect(renderResult.queryByTestId('prereleaseCallout')).toBeNull();
     });
@@ -159,6 +166,11 @@ describe('when on integration detail', () => {
   describe('and a custom UI extension is NOT registered', () => {
     beforeEach(async () => {
       await render();
+      await act(() => mockedApi.waitForApi());
+      // All those waitForApi call are needed to avoid flakyness because details conditionnaly refetch multiple time
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
+      await act(() => mockedApi.waitForApi());
     });
 
     it('should show overview and settings tabs', () => {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/readme.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiText, EuiSkeletonText } from '@elastic/eui';
+import { EuiText, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
 import React, { Fragment, useEffect, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -56,15 +56,11 @@ export function Readme({
       ) : (
         <EuiText>
           {/* simulates a long page of text loading */}
-          <p>
-            <EuiSkeletonText lines={5} />
-          </p>
-          <p>
-            <EuiSkeletonText lines={6} />
-          </p>
-          <p>
-            <EuiSkeletonText lines={4} />
-          </p>
+          <EuiSkeletonText lines={5} />
+          <EuiSpacer size="m" />
+          <EuiSkeletonText lines={6} />
+          <EuiSpacer size="m" />
+          <EuiSkeletonText lines={4} />
         </EuiText>
       )}
     </Fragment>


### PR DESCRIPTION
## Summary

Resolve #150607

Fix flaky unit test for the details package, the details page is refetching data multiple times and we were missing some wait for api calls. 

At some point we should rethink what we fetch in these page, there seems to be a lot of redudant calls.