### PR TITLE
[8.10] [OAS] Add is_system_action to connector responses (#163969)

### DIFF
--- a/docs/api-generated/connectors/connector-apis-passthru.asciidoc
+++ b/docs/api-generated/connectors/connector-apis-passthru.asciidoc
@@ -368,6 +368,7 @@ Any modifications made to this file will be overwritten.
   "is_deprecated" : false,
   "is_preconfigured" : false,
   "name" : "my-connector",
+  "is_system_action" : false,
   "referenced_by_count" : 2,
   "id" : "b0766e10-d190-11ec-b04c-776c77d14fca",
   "config" : {
@@ -1204,6 +1205,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
 <div class="param">referenced_by_count </div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> Indicates the number of saved objects that reference the connector. If <code>is_preconfigured</code> is true, this value is not calculated. </div>
     </div>  <!-- field-items -->
@@ -1460,6 +1462,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1475,6 +1478,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1490,6 +1494,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1505,6 +1510,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1520,6 +1526,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1535,6 +1542,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1550,6 +1558,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1565,6 +1574,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1580,6 +1590,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1595,6 +1606,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1610,6 +1622,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1625,6 +1638,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1639,6 +1653,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1653,6 +1668,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1668,6 +1684,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1682,6 +1699,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1697,6 +1715,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1712,6 +1731,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>
@@ -1727,6 +1747,7 @@ Any modifications made to this file will be overwritten.
 <div class="param">is_deprecated </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector type is deprecated. </div>
 <div class="param">is_missing_secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type. </div>
 <div class="param">is_preconfigured </div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether it is a preconfigured connector. If true, the <code>config</code> and <code>is_missing_secrets</code> properties are omitted from the response. </div>
+<div class="param">is_system_action (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Indicates whether the connector is used for system actions. </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
     </div>  <!-- field-items -->
   </div>

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -12,16 +12,24 @@
       "url": "https://www.elastic.co/licensing/elastic-license"
     }
   },
-  "tags": [
-    {
-      "name": "connectors",
-      "description": "Connector APIs enable you to create and manage connectors."
-    }
-  ],
   "servers": [
     {
       "url": "http://localhost:5601",
       "description": "local"
+    }
+  ],
+  "security": [
+    {
+      "basicAuth": []
+    },
+    {
+      "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "connectors",
+      "description": "Connector APIs enable you to create and manage connectors."
     }
   ],
   "paths": {
@@ -580,6 +588,9 @@
                       },
                       "is_preconfigured": {
                         "$ref": "#/components/schemas/is_preconfigured"
+                      },
+                      "is_system_action": {
+                        "$ref": "#/components/schemas/is_system_action"
                       },
                       "name": {
                         "type": "string",
@@ -2691,6 +2702,11 @@
         "description": "Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response.",
         "example": false
       },
+      "is_system_action": {
+        "type": "boolean",
+        "description": "Indicates whether the connector is used for system actions.",
+        "example": false
+      },
       "connector_response_properties_cases_webhook": {
         "title": "Connector request properties for a Webhook - Case Management connector",
         "type": "object",
@@ -2725,6 +2741,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -2767,6 +2786,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -2807,6 +2829,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -2849,6 +2874,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -2889,6 +2917,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -2931,6 +2962,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -2971,6 +3005,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -3014,6 +3051,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3054,6 +3094,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -3096,6 +3139,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3137,6 +3183,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3174,6 +3223,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3210,6 +3262,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -3252,6 +3307,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3288,6 +3346,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -3330,6 +3391,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3371,6 +3435,9 @@
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
           },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
+          },
           "name": {
             "type": "string",
             "description": "The display name for the connector."
@@ -3411,6 +3478,9 @@
           },
           "is_preconfigured": {
             "$ref": "#/components/schemas/is_preconfigured"
+          },
+          "is_system_action": {
+            "$ref": "#/components/schemas/is_system_action"
           },
           "name": {
             "type": "string",
@@ -4467,7 +4537,8 @@
           },
           "is_preconfigured": false,
           "is_deprecated": false,
-          "is_missing_secrets": false
+          "is_missing_secrets": false,
+          "is_system_action": false
         }
       },
       "get_connector_response": {
@@ -4479,7 +4550,8 @@
           "connector_type_id": ".server-log",
           "is_preconfigured": false,
           "is_deprecated": false,
-          "is_missing_secrets": false
+          "is_missing_secrets": false,
+          "is_system_action": false
         }
       },
       "update_index_connector_request": {
@@ -4500,7 +4572,8 @@
             "connector_type_id": ".email",
             "is_preconfigured": true,
             "is_deprecated": false,
-            "referenced_by_count": 0
+            "referenced_by_count": 0,
+            "is_system_action": false
           },
           {
             "id": "e07d0c80-8b8b-11ed-a780-3b746c987a81",
@@ -4514,7 +4587,8 @@
             "is_preconfigured": false,
             "is_deprecated": false,
             "referenced_by_count": 2,
-            "is_missing_secrets": false
+            "is_missing_secrets": false,
+            "is_system_action": false
           }
         ]
       },
@@ -4852,13 +4926,5 @@
         }
       }
     }
-  },
-  "security": [
-    {
-      "basicAuth": []
-    },
-    {
-      "apiKeyAuth": []
-    }
-  ]
+  }
 }

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -8,12 +8,15 @@ info:
   license:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
-tags:
-  - name: connectors
-    description: Connector APIs enable you to create and manage connectors.
 servers:
   - url: http://localhost:5601
     description: local
+security:
+  - basicAuth: []
+  - apiKeyAuth: []
+tags:
+  - name: connectors
+    description: Connector APIs enable you to create and manage connectors.
 paths:
   /s/{spaceId}/api/actions/connector:
     post:
@@ -322,6 +325,8 @@ paths:
                       $ref: '#/components/schemas/is_missing_secrets'
                     is_preconfigured:
                       $ref: '#/components/schemas/is_preconfigured'
+                    is_system_action:
+                      $ref: '#/components/schemas/is_system_action'
                     name:
                       type: string
                       description: The display name for the connector.
@@ -1826,6 +1831,10 @@ components:
       type: boolean
       description: Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response.
       example: false
+    is_system_action:
+      type: boolean
+      description: Indicates whether the connector is used for system actions.
+      example: false
     connector_response_properties_cases_webhook:
       title: Connector request properties for a Webhook - Case Management connector
       type: object
@@ -1853,6 +1862,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -1883,6 +1894,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -1913,6 +1926,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -1943,6 +1958,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -1973,6 +1990,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2003,6 +2022,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2033,6 +2054,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2064,6 +2087,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2094,6 +2119,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2124,6 +2151,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2154,6 +2183,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2181,6 +2212,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2208,6 +2241,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2238,6 +2273,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2265,6 +2302,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2295,6 +2334,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2325,6 +2366,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -2355,6 +2398,8 @@ components:
           $ref: '#/components/schemas/is_missing_secrets'
         is_preconfigured:
           $ref: '#/components/schemas/is_preconfigured'
+        is_system_action:
+          $ref: '#/components/schemas/is_system_action'
         name:
           type: string
           description: The display name for the connector.
@@ -3098,6 +3143,7 @@ components:
         is_preconfigured: false
         is_deprecated: false
         is_missing_secrets: false
+        is_system_action: false
     get_connector_response:
       summary: A list of connector types
       value:
@@ -3108,6 +3154,7 @@ components:
         is_preconfigured: false
         is_deprecated: false
         is_missing_secrets: false
+        is_system_action: false
     update_index_connector_request:
       summary: Update an index connector.
       value:
@@ -3123,6 +3170,7 @@ components:
           is_preconfigured: true
           is_deprecated: false
           referenced_by_count: 0
+          is_system_action: false
         - id: e07d0c80-8b8b-11ed-a780-3b746c987a81
           name: my-index-connector
           config:
@@ -3134,6 +3182,7 @@ components:
           is_deprecated: false
           referenced_by_count: 2
           is_missing_secrets: false
+          is_system_action: false
     get_connector_types_response:
       summary: A list of connector types
       value:
@@ -3354,6 +3403,3 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/action_response_properties'
-security:
-  - basicAuth: []
-  - apiKeyAuth: []

--- a/x-pack/plugins/actions/docs/openapi/components/examples/create_index_connector_response.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/create_index_connector_response.yaml
@@ -10,3 +10,4 @@ value:
   is_preconfigured: false
   is_deprecated: false
   is_missing_secrets: false
+  is_system_action: false

--- a/x-pack/plugins/actions/docs/openapi/components/examples/get_connector_response.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/get_connector_response.yaml
@@ -7,3 +7,4 @@ value:
   is_preconfigured: false
   is_deprecated: false
   is_missing_secrets: false
+  is_system_action: false

--- a/x-pack/plugins/actions/docs/openapi/components/examples/get_connectors_response.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/get_connectors_response.yaml
@@ -6,6 +6,7 @@ value:
     is_preconfigured: true
     is_deprecated: false
     referenced_by_count: 0
+    is_system_action: false
   - id: e07d0c80-8b8b-11ed-a780-3b746c987a81
     name: my-index-connector
     config:
@@ -17,3 +18,4 @@ value:
     is_deprecated: false
     referenced_by_count: 2
     is_missing_secrets: false
+    is_system_action: false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_cases_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_cases_webhook.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_email.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_genai.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_genai.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_index.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_index.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_jira.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_jira.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_opsgenie.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_opsgenie.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_pagerduty.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_resilient.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_resilient.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_serverlog.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_serverlog.yaml
@@ -25,6 +25,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_itom.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_itom.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_sir.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_sir.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_api.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_api.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_webhook.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_swimlane.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_swimlane.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_tines.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_tines.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_webhook.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_xmatters.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_xmatters.yaml
@@ -24,6 +24,8 @@ properties:
     $ref: 'is_missing_secrets.yaml'
   is_preconfigured:
     $ref: 'is_preconfigured.yaml'
+  is_system_action:
+    $ref: 'is_system_action.yaml'
   name:
     type: string
     description: The display name for the connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/is_system_action.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/is_system_action.yaml
@@ -1,0 +1,3 @@
+type: boolean
+description: Indicates whether the connector is used for system actions.
+example: false

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
@@ -43,6 +43,8 @@ get:
                   $ref: '../components/schemas/is_missing_secrets.yaml'  
                 is_preconfigured:
                   $ref: '../components/schemas/is_preconfigured.yaml'
+                is_system_action:
+                  $ref: '../components/schemas/is_system_action.yaml'
                 name:
                   type: string
                   description: The display name for the connector.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[OAS] Add is_system_action to connector responses (#163969)](https://github.com/elastic/kibana/pull/163969)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2023-08-17T20:13:35Z","message":"[OAS] Add is_system_action to connector responses (#163969)","sha":"5c1d118c36a9d6cc572fb49326a9d059da73d1fc","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:ResponseOps","Feature:Actions/ConnectorsManagement","v8.10.0","v8.11.0"],"number":163969,"url":"https://github.com/elastic/kibana/pull/163969","mergeCommit":{"message":"[OAS] Add is_system_action to connector responses (#163969)","sha":"5c1d118c36a9d6cc572fb49326a9d059da73d1fc"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163969","number":163969,"mergeCommit":{"message":"[OAS] Add is_system_action to connector responses (#163969)","sha":"5c1d118c36a9d6cc572fb49326a9d059da73d1fc"}},{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->