### PR TITLE
[Security Solution] Expandable flyout - add data view title and query bar to rule preview panel

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.test.tsx
@@ -22,6 +22,7 @@ import {
   mockDefineStepRule,
   mockScheduleStepRule,
 } from '../../../detection_engine/rule_management_ui/components/rules_table/__mocks__/mock';
+import { useGetSavedQuery } from '../../../detections/pages/detection_engine/rules/use_get_saved_query';
 import {
   RULE_PREVIEW_BODY_TEST_ID,
   RULE_PREVIEW_ABOUT_HEADER_TEST_ID,
@@ -42,6 +43,9 @@ jest.mock('../../../detection_engine/rule_management/logic/use_rule_with_fallbac
 
 const mockGetStepsData = getStepsData as jest.Mock;
 jest.mock('../../../detections/pages/detection_engine/rules/helpers');
+
+const mockUseGetSavedQuery = useGetSavedQuery as jest.Mock;
+jest.mock('../../../detections/pages/detection_engine/rules/use_get_saved_query');
 
 const mockTheme = getMockTheme({ eui: { euiColorMediumShade: '#ece' } });
 
@@ -69,6 +73,7 @@ describe('<RulePreview />', () => {
       scheduleRuleData: mockScheduleStepRule(),
       ruleActionsData: { actions: ['action'] },
     });
+    mockUseGetSavedQuery.mockReturnValue({ isSavedQueryLoading: false, savedQueryBar: null });
     const { getByTestId } = render(
       <TestProviders>
         <ThemeProvider theme={mockTheme}>

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.tsx
@@ -6,6 +6,8 @@
  */
 import React, { memo, useState, useEffect } from 'react';
 import { EuiText, EuiHorizontalRule, EuiSpacer, EuiPanel, EuiLoadingSpinner } from '@elastic/eui';
+import { useKibana } from '../../../common/lib/kibana';
+import { useGetSavedQuery } from '../../../detections/pages/detection_engine/rules/use_get_saved_query';
 import type { Rule } from '../../../detection_engine/rule_management/logic';
 import { usePreviewPanelContext } from '../context';
 import { ExpandableSection } from '../../right/components/expandable_section';
@@ -33,6 +35,7 @@ export const RulePreview: React.FC = memo(() => {
   const { ruleId, indexPattern } = usePreviewPanelContext();
   const [rule, setRule] = useState<Rule | null>(null);
   const { rule: maybeRule, loading: ruleLoading } = useRuleWithFallback(ruleId ?? '');
+  const { data } = useKibana().services;
 
   // persist rule until refresh is complete
   useEffect(() => {
@@ -50,6 +53,23 @@ export const RulePreview: React.FC = memo(() => {
           scheduleRuleData: null,
           ruleActionsData: null,
         };
+
+  const [dataViewTitle, setDataViewTitle] = useState<string>();
+
+  useEffect(() => {
+    const fetchDataViewTitle = async () => {
+      if (defineRuleData?.dataViewId != null && defineRuleData?.dataViewId !== '') {
+        const dataView = await data.dataViews.get(defineRuleData?.dataViewId);
+        setDataViewTitle(dataView.title);
+      }
+    };
+    fetchDataViewTitle();
+  }, [data.dataViews, defineRuleData?.dataViewId]);
+
+  const { isSavedQueryLoading, savedQueryBar } = useGetSavedQuery({
+    savedQueryId: rule?.saved_id,
+    ruleType: rule?.type,
+  });
 
   const hasNotificationActions = Boolean(ruleActionsData?.actions?.length);
   const hasResponseActions = Boolean(ruleActionsData?.responseActions?.length);
@@ -76,7 +96,7 @@ export const RulePreview: React.FC = memo(() => {
         )}
       </ExpandableSection>
       <EuiHorizontalRule margin="l" />
-      {defineRuleData && (
+      {defineRuleData && !isSavedQueryLoading && (
         <>
           <ExpandableSection
             title={i18n.RULE_PREVIEW_DEFINITION_TEXT}
@@ -86,7 +106,11 @@ export const RulePreview: React.FC = memo(() => {
             <StepDefineRuleReadOnly
               addPadding={false}
               descriptionColumns="single"
-              defaultValues={defineRuleData}
+              defaultValues={{
+                ...defineRuleData,
+                dataViewTitle,
+                queryBar: savedQueryBar ?? defineRuleData.queryBar,
+              }}
               indexPattern={indexPattern}
               isInPanelView
             />


### PR DESCRIPTION
## Summary

This PR adds `dataViewTitle` to rule preview panel -> define section when data view is available in a rule. This addresses https://github.com/elastic/kibana/issues/164529.

**How to test**
- Create a rule with data view
- Generate some alerts, go to alerts page, pick a alert and open expandable flyout
- Go to About, open `Rule summary`
- Expand `Define` section, the content should match the define section in rule details page for that rule

![image](https://github.com/elastic/kibana/assets/18648970/30aeff6b-547a-4b68-be87-9b52ab58501b)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->