### PR TITLE
[Security Solution] Expandable flyout - exclude rule creation from using new flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -9,7 +9,7 @@ import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
-import { dataTableActions } from '@kbn/securitysolution-data-table';
+import { dataTableActions, TableId } from '@kbn/securitysolution-data-table';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import { ENABLE_EXPANDABLE_FLYOUT_SETTING } from '../../../../../common/constants';
 import { RightPanelKey } from '../../../../flyout/right';
@@ -97,7 +97,7 @@ const RowActionComponent = ({
       },
     };
 
-    if (isSecurityFlyoutEnabled) {
+    if (isSecurityFlyoutEnabled && tableId !== TableId.rulePreview) {
       openFlyout({
         right: {
           id: RightPanelKey,


### PR DESCRIPTION
## Summary

The alert flyout (expand button in data table) is available in a lot of places in the security app. When creating a new rule, in the rule preview section, there is an alert table where the flyout is present. In this scenario, the rule is not yet set up, sections like the rule summary and hover actions are not applicable in this state. 

This PR reverts the use of the new expandable flyout in the rule creation page -> rule preview section. This will revert the flyout to the older version and address bugs such as https://github.com/elastic/kibana/issues/164397


**How to test**
- First generate some alerts
- Create a new rule and finish the first section
- Click continue to go to the right (rule preview section)
- Pick an alert and click expand
- The old flyout should appear

![image](https://github.com/elastic/kibana/assets/18648970/7a025dd2-dc75-44ef-a13c-25e44b2502ed)

![image](https://github.com/elastic/kibana/assets/18648970/33d47eb1-6b6b-4314-8dae-cfff2956b1c4)


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->