### PR TITLE
[Cloud Security] [Alerts] Fix Misconfigurations Flyout navigation to detection rule

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_detection_rule_counter.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_detection_rule_counter.tsx
@@ -9,13 +9,19 @@ import type { HttpSetup } from '@kbn/core/public';
 import React from 'react';
 import { CspFinding } from '../../../../common/schemas/csp_finding';
 import { DetectionRuleCounter } from '../../../components/detection_rule_counter';
-import { createDetectionRuleFromFinding } from '../utils/create_detection_rule_from_finding';
+import {
+  createDetectionRuleFromFinding,
+  getFindingsDetectionRuleSearchTags,
+} from '../utils/create_detection_rule_from_finding';
 
 export const FindingsDetectionRuleCounter = ({ finding }: { finding: CspFinding }) => {
   const createMisconfigurationRuleFn = async (http: HttpSetup) =>
     await createDetectionRuleFromFinding(http, finding);
 
   return (
-    <DetectionRuleCounter tags={finding.rule.tags} createRuleFn={createMisconfigurationRuleFn} />
+    <DetectionRuleCounter
+      tags={getFindingsDetectionRuleSearchTags(finding)}
+      createRuleFn={createMisconfigurationRuleFn}
+    />
   );
 };

--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/utils/create_detection_rule_from_finding.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/utils/create_detection_rule_from_finding.ts
@@ -50,9 +50,23 @@ const CSP_RULE_TAG_DATA_SOURCE_PREFIX = 'Data Source: ';
 
 const STATIC_RULE_TAGS = [CSP_RULE_TAG, CSP_RULE_TAG_USE_CASE];
 
+/*
+ * Returns an array of CspFinding tags that can be used to search and filter a detection rule
+ */
+export const getFindingsDetectionRuleSearchTags = ({ rule }: CspFinding) => {
+  // ex: cis_gcp to ['CIS', 'GCP']
+  const benchmarkIdTags = rule.benchmark.id.split('_').map((tag) => tag.toUpperCase());
+  // ex: 'CIS GCP 1.1'
+  const benchmarkRuleNumberTag = `${rule.benchmark.id.replace('_', ' ').toUpperCase()} ${
+    rule.benchmark.rule_number
+  }`;
+
+  return benchmarkIdTags.concat([benchmarkRuleNumberTag]);
+};
+
 const generateFindingsTags = (finding: CspFinding) => {
   return [STATIC_RULE_TAGS]
-    .concat(finding.rule.tags)
+    .concat(getFindingsDetectionRuleSearchTags(finding))
     .concat(
       finding.rule.benchmark.posture_type
         ? [


### PR DESCRIPTION
## Summary

This PR fixes #164508 by implementing a custom method to retrieve tags from a `CspFindings` object, only the custom tags are used to filter the rules instead of the full tags array as that is more accurate and predictable. 


### Recording

https://github.com/elastic/kibana/assets/19270322/d8585c81-624e-426f-a255-e8172ed4440e



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->