### PR TITLE
[ML] API integration tests for `model_management` endpoints 

### DIFF
--- a/x-pack/test/api_integration/apis/ml/index.ts
+++ b/x-pack/test/api_integration/apis/ml/index.ts
@@ -73,5 +73,6 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./system'));
     loadTestFile(require.resolve('./trained_models'));
     loadTestFile(require.resolve('./notifications'));
+    loadTestFile(require.resolve('./model_management'));
   });
 }

--- a/x-pack/test/api_integration/apis/ml/model_management/index.ts
+++ b/x-pack/test/api_integration/apis/ml/model_management/index.ts
@@ -10,5 +10,6 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('model management', function () {
     loadTestFile(require.resolve('./memory_usage'));
+    loadTestFile(require.resolve('./nodes_overview'));
   });
 }

--- a/x-pack/test/api_integration/apis/ml/model_management/index.ts
+++ b/x-pack/test/api_integration/apis/ml/model_management/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('model management', function () {
+    loadTestFile(require.resolve('./memory_usage'));
+  });
+}

--- a/x-pack/test/api_integration/apis/ml/model_management/memory_usage.ts
+++ b/x-pack/test/api_integration/apis/ml/model_management/memory_usage.ts
@@ -88,7 +88,7 @@ export default ({ getService }: FtrProviderContext) => {
       expect(body).to.eql([]);
     });
 
-    it('returns an error for the user with viewer persmissions', async () => {
+    it('returns an error for the user with viewer permissions', async () => {
       const { body, status } = await supertest
         .get(`/internal/ml/model_management/memory_usage`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))

--- a/x-pack/test/api_integration/apis/ml/model_management/memory_usage.ts
+++ b/x-pack/test/api_integration/apis/ml/model_management/memory_usage.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { Datafeed, Job } from '@kbn/ml-plugin/common/types/anomaly_detection_jobs';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { USER } from '../../../../functional/services/ml/security_common';
+import { getCommonRequestHeader } from '../../../../functional/services/ml/common_api';
+
+export default ({ getService }: FtrProviderContext) => {
+  const supertest = getService('supertestWithoutAuth');
+  const ml = getService('ml');
+  const esArchiver = getService('esArchiver');
+
+  // @ts-expect-error not full interface
+  const JOB_CONFIG: Job = {
+    job_id: `fq_multi_1_ae`,
+    description:
+      'mean/min/max(responsetime) partition=airline on farequote dataset with 1h bucket span',
+    groups: ['farequote', 'automated', 'multi-metric'],
+    analysis_config: {
+      bucket_span: '1h',
+      influencers: ['airline'],
+      detectors: [
+        { function: 'mean', field_name: 'responsetime', partition_field_name: 'airline' },
+        { function: 'min', field_name: 'responsetime', partition_field_name: 'airline' },
+        { function: 'max', field_name: 'responsetime', partition_field_name: 'airline' },
+      ],
+    },
+    data_description: { time_field: '@timestamp' },
+    analysis_limits: { model_memory_limit: '20mb' },
+    model_plot_config: { enabled: true },
+  };
+
+  // @ts-expect-error not full interface
+  const DATAFEED_CONFIG: Datafeed = {
+    datafeed_id: 'datafeed-fq_multi_1_ae',
+    indices: ['ft_farequote'],
+    job_id: 'fq_multi_1_ae',
+    query: { bool: { must: [{ match_all: {} }] } },
+  };
+
+  async function createMockJobs() {
+    await ml.api.createAnomalyDetectionJob(JOB_CONFIG);
+    await ml.api.createDatafeed(DATAFEED_CONFIG);
+    await ml.api.openAnomalyDetectionJob(JOB_CONFIG.job_id);
+    await ml.api.startDatafeed(DATAFEED_CONFIG.datafeed_id);
+  }
+
+  describe('GET model_management/memory_usage', () => {
+    before(async () => {
+      await ml.testResources.setKibanaTimeZoneToUTC();
+      await ml.api.createTestTrainedModels('regression', 2);
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
+      await createMockJobs();
+    });
+
+    after(async () => {
+      await ml.api.closeAnomalyDetectionJob(JOB_CONFIG.job_id);
+      await ml.api.cleanMlIndices();
+      await ml.testResources.cleanMLSavedObjects();
+    });
+
+    it('returns model memory usage', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/model_management/memory_usage`)
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body[0].id).to.eql('fq_multi_1_ae');
+      expect(body[0].type).to.eql('anomaly-detector');
+      expect(body[0].size).to.greaterThan(10000000);
+    });
+
+    it('filter out memory usage response based on the entity type', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/model_management/memory_usage`)
+        .query({ type: 'data-frame-analytics' })
+        .auth(USER.ML_POWERUSER, ml.securityCommon.getPasswordForUser(USER.ML_POWERUSER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body).to.eql([]);
+    });
+
+    it('returns an error for unauthorized user', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/model_management/memory_usage`)
+        .auth(USER.ML_UNAUTHORIZED, ml.securityCommon.getPasswordForUser(USER.ML_UNAUTHORIZED))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(403, status, body);
+    });
+  });
+};

--- a/x-pack/test/api_integration/apis/ml/model_management/nodes_overview.ts
+++ b/x-pack/test/api_integration/apis/ml/model_management/nodes_overview.ts
@@ -78,7 +78,7 @@ export default ({ getService }: FtrProviderContext) => {
       expect(body.nodes[0].memory_overview.trained_models.total).to.eql(0);
     });
 
-    it('returns an error for the user with viewer persmissions', async () => {
+    it('returns an error for the user with viewer permissions', async () => {
       const { body, status } = await supertest
         .get(`/internal/ml/model_management/nodes_overview`)
         .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))

--- a/x-pack/test/api_integration/apis/ml/trained_models/get_model_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/get_model_stats.ts
@@ -24,6 +24,16 @@ export default ({ getService }: FtrProviderContext) => {
       await ml.api.cleanMlIndices();
     });
 
+    it('returns trained model stats', async () => {
+      const { body, status } = await supertest
+        .get(`/internal/ml/trained_models/_stats`)
+        .auth(USER.ML_VIEWER, ml.securityCommon.getPasswordForUser(USER.ML_VIEWER))
+        .set(getCommonRequestHeader('1'));
+      ml.api.assertResponseStatusCode(200, status, body);
+
+      expect(body.count).to.eql(3);
+    });
+
     it('returns trained model stats by id', async () => {
       const { body, status } = await supertest
         .get(`/internal/ml/trained_models/dfa_regression_model_n_0/_stats`)


### PR DESCRIPTION
## Summary

Part of #160712 

- Adds API integration tests for `/model_management/nodes_overview` and `/model_management/memory_usage` endpoints. 

Also adds an API integration test for `/trained_models/_stats`.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->