### PR TITLE
[Telemetry] Fetch snapshot: allow specifying the version via querystring

### DIFF
--- a/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
+++ b/src/plugins/telemetry/server/routes/telemetry_usage_stats.ts
@@ -92,6 +92,7 @@ export function registerTelemetryUsageStatsRoutes(
     .post({
       access: 'internal',
       path: FetchSnapshotTelemetry,
+      enableQueryVersion: true, // Allow specifying the version through querystring so that we can use it in Dev Console
     })
     // Just because it used to be /v2/, we are creating identical v1 and v2.
     .addVersion({ version: '1', validate: v2Validations }, v2Handler)


### PR DESCRIPTION
## Summary

We tend to use the Telemetry Snapshot endpoint during development to test our collectors and to understand the behavior of Kibana.

The easiest way to interact with it is the Dev Console. However, it does not allow specifying any headers. Let's allow specifying the version through the query parameter for this endpoint:

```
POST kbn:/internal/telemetry/clusters/_stats?apiVersion=2
{ "unencrypted": true }
```

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->