### PR TITLE
[Fleet] Change 'Out-of-date' to 'Outdated policy' in agent list table

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -191,7 +191,7 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
                   &nbsp;
                   <FormattedMessage
                     id="xpack.fleet.agentList.outOfDateLabel"
-                    defaultMessage="Out-of-date"
+                    defaultMessage="Outdated policy"
                   />
                 </EuiText>
               </EuiFlexItem>

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_list_table.tsx
@@ -180,9 +180,11 @@ export const AgentListTable: React.FC<Props> = (props: Props) => {
         const showWarning = agent.policy_revision && agentPolicy?.revision > agent.policy_revision;
 
         return (
-          <EuiFlexGroup gutterSize="none" style={{ minWidth: 0 }} direction="column">
+          <EuiFlexGroup gutterSize="m" style={{ minWidth: 0 }} alignItems="center">
             {agentPolicy && (
-              <AgentPolicySummaryLine direction="column" policy={agentPolicy} agent={agent} />
+              <EuiFlexItem grow={false}>
+                <AgentPolicySummaryLine direction="column" policy={agentPolicy} agent={agent} />
+              </EuiFlexItem>
             )}
             {showWarning && (
               <EuiFlexItem grow={false}>

--- a/x-pack/plugins/fleet/scripts/create_agents/create_agents.ts
+++ b/x-pack/plugins/fleet/scripts/create_agents/create_agents.ts
@@ -141,6 +141,7 @@ function createAgentWithStatus({
   policyId: string;
   status: AgentStatus;
   version: string;
+  hostname: string;
 }) {
   const baseAgent = {
     access_api_key_id: 'api-key-1',


### PR DESCRIPTION
## Summary

Closes #164575.

Bonus: also fix the bug where the warning goes under the policy revision I thought that looked a bit weird.

Double bonus: Updated the create agent test script to be able to create outdated agents + to use nicer policy names so the table doesnt get messy

Before:

<img width="1237" alt="Screenshot 2023-08-24 at 10 10 58" src="https://github.com/elastic/kibana/assets/3315046/86a88ad6-a2c7-4f17-82bb-fe026d05d937">


After:

<img width="1244" alt="Screenshot 2023-08-24 at 10 09 53" src="https://github.com/elastic/kibana/assets/3315046/1cf76dd3-2e6a-4aa9-a004-109797f54c52">




<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->