### PR TITLE
[Security Solution] Fix bulk edit rules tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -95,6 +95,7 @@ import {
 import {
   createAndInstallMockedPrebuiltRules,
   getAvailablePrebuiltRulesCount,
+  preventPrebuiltRulesPackageInstallation,
 } from '../../../../../tasks/api_calls/prebuilt_rules';
 import { setRowsPerPageTo, sortByTableColumn } from '../../../../../tasks/table_pagination';
 
@@ -122,6 +123,7 @@ describe('Detection rules, bulk edit', { tags: ['@ess', '@brokenInServerless'] }
     // Make sure persisted rules table state is cleared
     resetRulesTableState();
     deleteAlertsAndRules();
+    preventPrebuiltRulesPackageInstallation(); // Make prebuilt rules aren't pulled from Fleet API
     cy.task('esArchiverResetKibana');
     createRule(getNewRule({ name: RULE_NAME, ...defaultRuleData, rule_id: '1', enabled: false }));
     createRule(
@@ -232,9 +234,7 @@ describe('Detection rules, bulk edit', { tags: ['@ess', '@brokenInServerless'] }
         clickAddTagsMenuItem();
         waitForMixedRulesBulkEditModal(rows.length);
 
-        getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-          checkPrebuiltRulesCannotBeModified(availablePrebuiltRulesCount);
-        });
+        checkPrebuiltRulesCannotBeModified(PREBUILT_RULES.length);
 
         // user cancels action and modal disappears
         cancelConfirmationModal();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/bulk_actions/bulk_edit_rules.cy.ts
@@ -123,7 +123,7 @@ describe('Detection rules, bulk edit', { tags: ['@ess', '@brokenInServerless'] }
     // Make sure persisted rules table state is cleared
     resetRulesTableState();
     deleteAlertsAndRules();
-    preventPrebuiltRulesPackageInstallation(); // Make prebuilt rules aren't pulled from Fleet API
+    preventPrebuiltRulesPackageInstallation(); // Make sure prebuilt rules aren't pulled from Fleet API
     cy.task('esArchiverResetKibana');
     createRule(getNewRule({ name: RULE_NAME, ...defaultRuleData, rule_id: '1', enabled: false }));
     createRule(


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/161507

## Summary

This PR fixes **bulk_edit_rules.cy.ts** flakiness found while running Security Solution Cypress tests in Flaky test runner ([run 1](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2969) and [run 2](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2970)).

## Flaky test runner

[bulk_edit_rules.cy.ts 300 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2975) 🟢



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->