### PR TITLE
Fix autocomplete on only 1 letter typed in request editor

### DIFF
--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -1076,11 +1076,7 @@ export default function ({
     tracer('has started evaluating current token', currentToken);
 
     if (!currentToken) {
-      if (pos.lineNumber === 1) {
-        lastEvaluatedToken = null;
-        tracer('not starting autocomplete due to invalid current token at line 1');
-        return;
-      }
+      lastEvaluatedToken = null;
       currentToken = { position: { column: 0, lineNumber: 0 }, value: '', type: '' }; // empty row
     }
 

--- a/test/functional/apps/console/_autocomplete.ts
+++ b/test/functional/apps/console/_autocomplete.ts
@@ -47,7 +47,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     describe('anti-regression watchdogs', () => {
       beforeEach(async () => {
         await PageObjects.console.clearTextArea();
-        await PageObjects.console.pressEnter();
       });
 
       it('should suppress auto-complete on arrow keys', async () => {
@@ -91,7 +90,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         for (const method of methods) {
           await PageObjects.console.clearTextArea();
-          await PageObjects.console.pressEnter();
 
           for (const char of method.slice(0, -1)) {
             await PageObjects.console.sleepForDebouncePeriod();


### PR DESCRIPTION
## Summary

This PR fixes autocomplete on only 1 letter typed in request editor.

Closes #164542

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fixes autocomplete on only 1 letter typed in Console's request editor