### PR TITLE
[Fleet] set typeMigrationVersion instead of migrationVersion

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.test.ts
@@ -19,7 +19,7 @@ jest.mock('timers/promises', () => ({
   async setTimeout() {},
 }));
 
-import { installKibanaSavedObjects } from './install';
+import { createSavedObjectKibanaAsset, installKibanaSavedObjects } from './install';
 
 const mockLogger = loggingSystemMock.createLogger();
 
@@ -120,5 +120,29 @@ describe('installKibanaSavedObjects', () => {
 
     expect(mockImporter.import).toHaveBeenCalledTimes(1);
     expect(mockImporter.resolveImportErrors).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createSavedObjectKibanaAsset', () => {
+  it('should set migrationVersion as typeMigrationVersion in so', () => {
+    const asset = createAsset({
+      attributes: { hello: 'world' },
+      migrationVersion: { dashboard: '8.6.0' },
+    });
+    const result = createSavedObjectKibanaAsset(asset);
+
+    expect(result.typeMigrationVersion).toEqual('8.6.0');
+  });
+
+  it('should set coreMigrationVersion and typeMigrationVersion in so', () => {
+    const asset = createAsset({
+      attributes: { hello: 'world' },
+      typeMigrationVersion: '8.6.0',
+      coreMigrationVersion: '8.7.0',
+    });
+    const result = createSavedObjectKibanaAsset(asset);
+
+    expect(result.typeMigrationVersion).toEqual('8.6.0');
+    expect(result.coreMigrationVersion).toEqual('8.7.0');
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/assets/install.ts
@@ -53,7 +53,7 @@ export type ArchiveAsset = Pick<
   SavedObject,
   | 'id'
   | 'attributes'
-  | 'migrationVersion'
+  | 'migrationVersion' // deprecated
   | 'references'
   | 'coreMigrationVersion'
   | 'typeMigrationVersion'
@@ -99,8 +99,9 @@ export function createSavedObjectKibanaAsset(asset: ArchiveAsset): SavedObjectTo
     references: asset.references || [],
   };
 
-  if (asset.migrationVersion) {
-    so.migrationVersion = asset.migrationVersion;
+  // migrating deprecated migrationVersion to typeMigrationVersion
+  if (asset.migrationVersion && asset.migrationVersion[asset.type]) {
+    so.typeMigrationVersion = asset.migrationVersion[asset.type];
   }
   if (asset.coreMigrationVersion) {
     so.coreMigrationVersion = asset.coreMigrationVersion;


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/164690

`migrationVersion` was removed from es mapping in 8.8: https://github.com/elastic/kibana/issues/154246
Replacing it with `typeMigrationVersion` using the same logic as in kibana core: 
https://github.com/elastic/kibana/blob/ba843882a7bb35aa3062efd6562ed85d5db157f4/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/migrations/transform_migration_version.ts#L17


To verify:
- add Kubernetes integration to a new policy
- verify that it is added successfully

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->