### PR TITLE
Initialize session index even if the legacy template API is not available.

### DIFF
--- a/x-pack/plugins/security/server/session_management/session_index.test.ts
+++ b/x-pack/plugins/security/server/session_management/session_index.test.ts
@@ -100,10 +100,34 @@ describe('Session index', () => {
       expect(mockElasticsearchClient.indices.create).not.toHaveBeenCalled();
     });
 
-    it('does not delete legacy index template if the legacy template API is not available', async () => {
+    it('does not delete legacy index template if the legacy template API is not available (410)', async () => {
       const goneError = new errors.ResponseError(
         securityMock.createApiResponse(
           securityMock.createApiResponse({ body: { type: 'And it is gone!' }, statusCode: 410 })
+        )
+      );
+      mockElasticsearchClient.indices.existsTemplate.mockRejectedValueOnce(goneError);
+      mockElasticsearchClient.indices.existsIndexTemplate.mockResponse(false);
+      mockElasticsearchClient.indices.exists.mockResponse(false);
+
+      await sessionIndex.initialize();
+
+      assertExistenceChecksPerformed();
+
+      expect(mockElasticsearchClient.indices.deleteTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.deleteIndexTemplate).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.putAlias).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.getMapping).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.putMapping).not.toHaveBeenCalled();
+      expect(mockElasticsearchClient.indices.create).toHaveBeenCalledWith(
+        getSessionIndexSettings({ indexName, aliasName })
+      );
+    });
+
+    it('does not delete legacy index template if the legacy template API is not available (404)', async () => {
+      const goneError = new errors.ResponseError(
+        securityMock.createApiResponse(
+          securityMock.createApiResponse({ body: { type: 'And it is gone!' }, statusCode: 404 })
         )
       );
       mockElasticsearchClient.indices.existsTemplate.mockRejectedValueOnce(goneError);


### PR DESCRIPTION
## Summary

Elasticsearch [legacy template API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html) isn't available in the Serverless offering (returns 410), but it shouldn't prevent session index initialization.

## How to test
1. Run ES Serverless with `./gradlew :run`
2. Run Kibana with `yarn start --serverless --elasticsearch.serviceAccountToken=AAEAAWVsYXN0aWMva2liYW5hL2tpYmFuYS1kZXY6VVVVVVVVTEstKiBaNA --no-dev-credentials`
