### PR TITLE
[8.9] [Security Solution][Endpoint] Split blocklist entry in multiple entries when different hash types (#164599)

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/integrations/mocks.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/mocks.ts
@@ -368,7 +368,8 @@ export const getArtifactsListTestsData = () => [
         {
           type: 'input',
           selector: 'blocklist-form-values-input',
-          value: 'A4370C0CF81686C0B696FA6261c9d3e0d810ae704ab8301839dffd5d5112f476',
+          value:
+            'A4370C0CF81686C0B696FA6261c9d3e0d810ae704ab8301839dffd5d5112f476,aedb279e378BED6C2DB3C9DC9e12ba635e0b391c,741462ab431a22233C787BAAB9B653C7',
         },
         {
           type: 'click',
@@ -379,7 +380,7 @@ export const getArtifactsListTestsData = () => [
         {
           selector: 'blocklistPage-card-criteriaConditions',
           value:
-            'OSIS Windows\nAND file.hash.*IS ONE OF\na4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476',
+            'OSIS Windows\nAND file.hash.*IS ONE OF\n741462ab431a22233c787baab9b653c7\naedb279e378bed6c2db3c9dc9e12ba635e0b391c\na4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476',
         },
       ],
     },
@@ -407,6 +408,14 @@ export const getArtifactsListTestsData = () => [
           type: 'clear',
           selector:
             'blocklist-form-values-input-a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476',
+        },
+        {
+          type: 'clear',
+          selector: 'blocklist-form-values-input-741462ab431a22233c787baab9b653c7',
+        },
+        {
+          type: 'clear',
+          selector: 'blocklist-form-values-input-aedb279e378bed6c2db3c9dc9e12ba635e0b391c',
         },
         {
           type: 'input',
@@ -449,19 +458,41 @@ export const getArtifactsListTestsData = () => [
         type: 'blocklist',
         identifier: 'endpoint-blocklist-windows-v1',
         relative_url:
-          '/api/fleet/artifacts/endpoint-blocklist-windows-v1/730aee3fea0a4d119285ecec500343262fb9f710915536a901a7b1cec8dff714',
-        body: 'eJxVzM0KgzAQBOB32XORxJ81+ipSZM1uMJCqmFgq0ndvCr2Uuc03zAWypN1LhH64IJ2bQA/RP7YgcPsz5yVwRueDFDPFuYgzlQ3m2brJTmnds/rFhoOFc/s7kxfZNFqKwiMtZ4YnhSPLAFRXrbLKOqPRoFUTdugIS9S240oUG61IWlXTZCqlTdWxc9xwo3Xp6hbh/v7mA+fuPhA=',
+          '/api/fleet/artifacts/endpoint-blocklist-windows-v1/637f1e8795406904980ae2ab4a69cea967756571507f6bd7fc94cde0add20df2',
+        body: 'eJylzsFqwzAMgOF38bkU27Jlu69SQpEtmQTSNCTpWCl595qyy45bj9IvxPdUMm3LIKs6nZ9qe8yiTmodrvMo6vCr1UFGbrEOoxx7WvvjlX27uc2y0HZbWhqmMt5ZuG1/Psk3le1SaBW+0PRo4YvGeytnFZxxaCk7MGStBSghhkyUU0bfBtXt3X74q2ntyXyAIuFsQxIIMQtjsZyhJC5JjM2E4EVnSKb8G2c9fsJzEHTRpUaDEYvOmLASWjQNCaI5Gk0StKMcQZsIiWtlz94YW13AN7vbX9OOoO0=',
         encryption_algorithm: 'none',
         package_name: 'endpoint',
-        encoded_size: 155,
-        encoded_sha256: 'caa472e57d793539061e438337b519367303f4a75adf5a883c4104b88c30ee08',
-        decoded_size: 196,
-        decoded_sha256: '730aee3fea0a4d119285ecec500343262fb9f710915536a901a7b1cec8dff714',
+        encoded_size: 218,
+        encoded_sha256: '751aacf865573055bef82795d23d99b7ab695eb5fb2a36f1231f02f52da8adc0',
+        decoded_size: 501,
+        decoded_sha256: '637f1e8795406904980ae2ab4a69cea967756571507f6bd7fc94cde0add20df2',
         compression_algorithm: 'zlib',
         created: '2000-01-01T00:00:00.000Z',
       }),
       getExpectedUpdatedArtifactBodyWhenCreate: (): ArtifactBodyType => ({
         entries: [
+          {
+            type: 'simple',
+            entries: [
+              {
+                field: 'file.hash.md5',
+                operator: 'included',
+                type: 'exact_cased_any',
+                value: ['741462ab431a22233c787baab9b653c7'],
+              },
+            ],
+          },
+          {
+            type: 'simple',
+            entries: [
+              {
+                field: 'file.hash.sha1',
+                operator: 'included',
+                type: 'exact_cased_any',
+                value: ['aedb279e378bed6c2db3c9dc9e12ba635e0b391c'],
+              },
+            ],
+          },
           {
             type: 'simple',
             entries: [


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Security Solution][Endpoint] Split blocklist entry in multiple entries when different hash types (#164599)](https://github.com/elastic/kibana/pull/164599)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"David Sánchez","email":"david.sanchezsoler@elastic.co"},"sourceCommit":{"committedDate":"2023-08-24T12:10:23Z","message":"[Security Solution][Endpoint] Split blocklist entry in multiple entries when different hash types (#164599)\n\nFixes: https://github.com/elastic/kibana/issues/164374\r\n## Summary\r\n\r\nDuring fleet artifact generation, we split those blocklist entries that\r\ncontains multiple hash types in it, so the resulting artifact contains\r\nan entry for each hash type. This is done for each blocklist if they\r\ncontain multiple hash types in it.\r\n\r\nIt also updates ftr test to ensure the resulting artifact is generated\r\ncorrectly.\r\n\r\nFor a blocklist containing these hashes: \r\n```\r\n['741462ab431a22233c787baab9b653c7', 'aedb279e378bed6c2db3c9dc9e12ba635e0b391c',  'a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476']\r\n```\r\n\r\nThe artifact generated is:\r\n\r\n```\r\n{\r\n        entries: [\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.md5',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['741462ab431a22233c787baab9b653c7'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha1',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['aedb279e378bed6c2db3c9dc9e12ba635e0b391c'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha256',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476'],\r\n              },\r\n            ],\r\n          },\r\n        ]\r\n}\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"665937683845322e6c75b18b14041854dcb761c9","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.10.0","v8.11.0","v8.9.2"],"number":164599,"url":"https://github.com/elastic/kibana/pull/164599","mergeCommit":{"message":"[Security Solution][Endpoint] Split blocklist entry in multiple entries when different hash types (#164599)\n\nFixes: https://github.com/elastic/kibana/issues/164374\r\n## Summary\r\n\r\nDuring fleet artifact generation, we split those blocklist entries that\r\ncontains multiple hash types in it, so the resulting artifact contains\r\nan entry for each hash type. This is done for each blocklist if they\r\ncontain multiple hash types in it.\r\n\r\nIt also updates ftr test to ensure the resulting artifact is generated\r\ncorrectly.\r\n\r\nFor a blocklist containing these hashes: \r\n```\r\n['741462ab431a22233c787baab9b653c7', 'aedb279e378bed6c2db3c9dc9e12ba635e0b391c',  'a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476']\r\n```\r\n\r\nThe artifact generated is:\r\n\r\n```\r\n{\r\n        entries: [\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.md5',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['741462ab431a22233c787baab9b653c7'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha1',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['aedb279e378bed6c2db3c9dc9e12ba635e0b391c'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha256',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476'],\r\n              },\r\n            ],\r\n          },\r\n        ]\r\n}\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"665937683845322e6c75b18b14041854dcb761c9"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/164700","number":164700,"state":"OPEN"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164599","number":164599,"mergeCommit":{"message":"[Security Solution][Endpoint] Split blocklist entry in multiple entries when different hash types (#164599)\n\nFixes: https://github.com/elastic/kibana/issues/164374\r\n## Summary\r\n\r\nDuring fleet artifact generation, we split those blocklist entries that\r\ncontains multiple hash types in it, so the resulting artifact contains\r\nan entry for each hash type. This is done for each blocklist if they\r\ncontain multiple hash types in it.\r\n\r\nIt also updates ftr test to ensure the resulting artifact is generated\r\ncorrectly.\r\n\r\nFor a blocklist containing these hashes: \r\n```\r\n['741462ab431a22233c787baab9b653c7', 'aedb279e378bed6c2db3c9dc9e12ba635e0b391c',  'a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476']\r\n```\r\n\r\nThe artifact generated is:\r\n\r\n```\r\n{\r\n        entries: [\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.md5',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['741462ab431a22233c787baab9b653c7'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha1',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['aedb279e378bed6c2db3c9dc9e12ba635e0b391c'],\r\n              },\r\n            ],\r\n          },\r\n          {\r\n            type: 'simple',\r\n            entries: [\r\n              {\r\n                field: 'file.hash.sha256',\r\n                operator: 'included',\r\n                type: 'exact_cased_any',\r\n                value: ['a4370c0cf81686c0b696fa6261c9d3e0d810ae704ab8301839dffd5d5112f476'],\r\n              },\r\n            ],\r\n          },\r\n        ]\r\n}\r\n```\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"665937683845322e6c75b18b14041854dcb761c9"}},{"branch":"8.9","label":"v8.9.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->