### PR TITLE
[Fleet] Increase number of attempts on flaky unenroll test

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/reassign.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/reassign.ts
@@ -201,7 +201,7 @@ export default function (providerContext: FtrProviderContext) {
           const intervalId = setInterval(async () => {
             if (attempts > 2) {
               clearInterval(intervalId);
-              reject('action timed out');
+              reject(new Error('action timed out'));
             }
             ++attempts;
             const {

--- a/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/request_diagnostics.ts
@@ -87,7 +87,7 @@ export default function (providerContext: FtrProviderContext) {
         const intervalId = setInterval(async () => {
           if (attempts > 2) {
             clearInterval(intervalId);
-            reject('action timed out');
+            reject(new Error('action timed out'));
           }
           ++attempts;
           const {

--- a/x-pack/test/fleet_api_integration/apis/agents/unenroll.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/unenroll.ts
@@ -204,9 +204,9 @@ export default function (providerContext: FtrProviderContext) {
       await new Promise((resolve, reject) => {
         let attempts = 0;
         const intervalId = setInterval(async () => {
-          if (attempts > 2) {
+          if (attempts > 3) {
             clearInterval(intervalId);
-            reject('action timed out');
+            reject(new Error('action timed out'));
           }
           ++attempts;
           const {

--- a/x-pack/test/fleet_api_integration/apis/agents/update_agent_tags.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/update_agent_tags.ts
@@ -78,7 +78,7 @@ export default function (providerContext: FtrProviderContext) {
           const intervalId = setInterval(async () => {
             if (attempts > 4) {
               clearInterval(intervalId);
-              reject('action timed out');
+              reject(new Error('action timed out'));
             }
             ++attempts;
             const {

--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -618,7 +618,7 @@ export default function (providerContext: FtrProviderContext) {
           const intervalId = setInterval(async () => {
             if (attempts > 4) {
               clearInterval(intervalId);
-              reject('action timed out');
+              reject(new Error('action timed out'));
             }
             ++attempts;
             const {


### PR DESCRIPTION
## Summary

Closes #157205 

Add an extra attempt to this flky test.

bonus: we were rejecting with strings which was giving us this funny error:

```
[Error: the string "action timed out" was thrown, throw an Error :)]
```



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->