### PR TITLE
[Security Solution] Fix coverage overview endpoint

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/coverage_overview/handle_coverage_overview_request.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/api/rules/coverage_overview/handle_coverage_overview_request.test.ts
@@ -7,17 +7,14 @@
 
 import type { Rule } from '@kbn/alerting-plugin/common';
 import { rulesClientMock } from '@kbn/alerting-plugin/server/mocks';
+import { findRules } from '../../../logic/search/find_rules';
 import { handleCoverageOverviewRequest } from './handle_coverage_overview_request';
 
+jest.mock('../../../logic/search/find_rules');
+
 describe('handleCoverageOverviewRequest', () => {
-  let rulesClient: ReturnType<typeof rulesClientMock.create>;
-
-  beforeEach(() => {
-    rulesClient = rulesClientMock.create();
-  });
-
-  it('does not request more than 10k', async () => {
-    rulesClient.find
+  it('does not request more than 10k rules', async () => {
+    (findRules as jest.Mock)
       .mockResolvedValueOnce({
         total: 25555,
         page: 1,
@@ -40,17 +37,17 @@ describe('handleCoverageOverviewRequest', () => {
     await handleCoverageOverviewRequest({
       params: {},
       deps: {
-        rulesClient,
+        rulesClient: rulesClientMock.create(),
       },
     });
 
-    expect(rulesClient.find).toHaveBeenCalledTimes(1);
-    expect(rulesClient.find).toHaveBeenCalledWith({
-      options: expect.objectContaining({
+    expect(findRules).toHaveBeenCalledTimes(1);
+    expect(findRules).toHaveBeenCalledWith(
+      expect.objectContaining({
         page: 1,
         perPage: 10000,
-      }),
-    });
+      })
+    );
   });
 });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.test.ts
@@ -17,18 +17,18 @@ import {
 
 import { enrichFilterWithRuleTypeMapping } from './enrich_filter_with_rule_type_mappings';
 
-const allAlertTypeIds = `(alert.attributes.alertTypeId: ${EQL_RULE_TYPE_ID}
+const allAlertTypeIds = `alert.attributes.alertTypeId: ${EQL_RULE_TYPE_ID}
  OR alert.attributes.alertTypeId: ${ML_RULE_TYPE_ID}
  OR alert.attributes.alertTypeId: ${QUERY_RULE_TYPE_ID}
  OR alert.attributes.alertTypeId: ${SAVED_QUERY_RULE_TYPE_ID}
  OR alert.attributes.alertTypeId: ${INDICATOR_RULE_TYPE_ID}
  OR alert.attributes.alertTypeId: ${THRESHOLD_RULE_TYPE_ID}
- OR alert.attributes.alertTypeId: ${NEW_TERMS_RULE_TYPE_ID})`.replace(/[\n\r]/g, '');
+ OR alert.attributes.alertTypeId: ${NEW_TERMS_RULE_TYPE_ID}`.replace(/[\n\r]/g, '');
 
 describe('enrichFilterWithRuleTypeMapping', () => {
   test('it returns a full filter with an AND if sent down', () => {
     expect(enrichFilterWithRuleTypeMapping('alert.attributes.enabled: true')).toEqual(
-      `${allAlertTypeIds} AND alert.attributes.enabled: true`
+      `(${allAlertTypeIds}) AND (alert.attributes.enabled: true)`
     );
   });
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.test.ts
@@ -35,4 +35,8 @@ describe('enrichFilterWithRuleTypeMapping', () => {
   test('it returns existing filter with no AND when not set [rule registry enabled: %p]', () => {
     expect(enrichFilterWithRuleTypeMapping(null)).toEqual(allAlertTypeIds);
   });
+
+  test('it returns existing filter with no AND when filter is an empty string', () => {
+    expect(enrichFilterWithRuleTypeMapping('')).toEqual(allAlertTypeIds);
+  });
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.ts
@@ -7,23 +7,25 @@
 
 import { ruleTypeMappings } from '@kbn/securitysolution-rules';
 
-const alertTypeFilter = `(${Object.values(ruleTypeMappings)
+const alertTypeFilter = Object.values(ruleTypeMappings)
   .map((type) => `alert.attributes.alertTypeId: ${type}`)
   .filter((type, i, arr) => type != null && arr.indexOf(type) === i)
-  .join(' OR ')})`;
+  .join(' OR ');
 
 /**
  * updates filter to restrict search results to only Security Solution rule types (siem.eqlRule, siem.mlRule, etc..)
  * @example
  * filter BEFORE: "alert.attributes.enabled: true"
- * modified filter AFTER: "(alert.attributes.alertTypeId: siem.eqlRule OR alert.attributes.alertTypeId: siem.mlRule OR alert.attributes.alertTypeId: siem.queryRule OR alert.attributes.alertTypeId: siem.savedQueryRule OR alert.attributes.alertTypeId: siem.indicatorRule OR alert.attributes.alertTypeId: siem.thresholdRule) AND alert.attributes.enabled: true"
+ * modified filter AFTER: "(alert.attributes.alertTypeId: siem.eqlRule OR alert.attributes.alertTypeId: siem.mlRule OR alert.attributes.alertTypeId: siem.queryRule OR alert.attributes.alertTypeId: siem.savedQueryRule OR alert.attributes.alertTypeId: siem.indicatorRule OR alert.attributes.alertTypeId: siem.thresholdRule) AND (alert.attributes.enabled: true")
+ *
  * @param filter
  * @returns modified filter
  */
 export const enrichFilterWithRuleTypeMapping = (filter: string | null | undefined) => {
   if (filter == null || filter.length === 0) {
     return alertTypeFilter;
-  } else {
-    return `${alertTypeFilter} AND ${filter}`;
   }
+
+  // Just in case of statements OR'ed in the filter wrap it in parentheses
+  return `(${alertTypeFilter}) AND (${filter})`;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/enrich_filter_with_rule_type_mappings.ts
@@ -21,7 +21,7 @@ const alertTypeFilter = `(${Object.values(ruleTypeMappings)
  * @returns modified filter
  */
 export const enrichFilterWithRuleTypeMapping = (filter: string | null | undefined) => {
-  if (filter == null) {
+  if (filter == null || filter.length === 0) {
     return alertTypeFilter;
   } else {
     return `${alertTypeFilter} AND ${filter}`;

--- a/x-pack/test/detection_engine_api_integration/utils/create_non_security_rule.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_non_security_rule.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type SuperTest from 'supertest';
+
+const SIMPLE_APM_RULE_DATA = {
+  name: 'Test rule',
+  rule_type_id: 'apm.anomaly',
+  enabled: false,
+  consumer: 'alerts',
+  tags: [],
+  actions: [],
+  params: {
+    windowSize: 30,
+    windowUnit: 'm',
+    anomalySeverityType: 'critical',
+    environment: 'ENVIRONMENT_ALL',
+  },
+  schedule: {
+    interval: '10m',
+  },
+};
+
+/**
+ * Created a non security rule. Helpful in tests to verify functionality works with presence of non security rules.
+ * @param supertest The supertest deps
+ */
+export async function createNonSecurityRule(
+  supertest: SuperTest.SuperTest<SuperTest.Test>
+): Promise<void> {
+  await supertest
+    .post('/api/alerting/rule')
+    .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '2023-10-31')
+    .send(SIMPLE_APM_RULE_DATA)
+    .expect(200);
+}


### PR DESCRIPTION
## Summary

This PR fixes a bug found by @jamesspi when it's Coverage Overview page doesn't show the cards but applying individual filters makes the page rendering.

## Steps to reproduce the problem

- create a non security rule in your environment
- navigate to the Coverage Overview page

Expected behavior
Coverage Overview page is loaded and displays the cards.

Actual behavior
Coverage Overview page does not display the cards.

## Details

`rulesClient.find()` was used directly instead of `findRules()` helper function defined in Security Solution. The subtle different between these two is that `findRules()` passes filter to `enrichFilterWithRuleTypeMapping()` to make sure only security rules are fetched and processed. As `rulesClient.find()` returned all the rules there was a non security rule in the list with missing `rule.params` field causing the endpoint to fail. This has been fixed by using `findRules()`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->