### PR TITLE
[data views] fix fields for wildcard integration test

### DIFF
--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
@@ -45,7 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
               {
                 name: 'number_conflict',
                 type: 'number',
-                esTypes: ['integer', 'float'],
+                esTypes: ['float', 'integer'],
                 aggregatable: true,
                 searchable: true,
                 readFromDocValues: true,
@@ -54,16 +54,16 @@ export default function ({ getService }: FtrProviderContext) {
               {
                 name: 'string_conflict',
                 type: 'string',
-                esTypes: ['text', 'keyword'],
+                esTypes: ['keyword', 'text'],
                 aggregatable: true,
                 searchable: true,
-                readFromDocValues: false,
+                readFromDocValues: true,
                 metadata_field: false,
               },
               {
                 name: 'success',
                 type: 'conflict',
-                esTypes: ['boolean', 'keyword'],
+                esTypes: ['keyword', 'boolean'],
                 aggregatable: true,
                 searchable: true,
                 readFromDocValues: false,

--- a/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
+++ b/test/api_integration/apis/data_views/fields_for_wildcard_route/conflicts.ts
@@ -16,8 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/164753
-  describe.skip('conflicts', () => {
+  describe('conflicts', () => {
     before(() =>
       esArchiver.load('test/api_integration/fixtures/es_archiver/index_patterns/conflicts')
     );


### PR DESCRIPTION
## Summary

I'm waiting for this to fail CI - this means that a new ES snapshot is being used. Then we update the test snapshot and should be good to merge.

The lastest ES snapshot is returning field types in a different order which really doesn't matter to this endpoint so I'll just update the snapshot.

Closes https://github.com/elastic/kibana/issues/164753
