### PR TITLE
Add missing sourcemap config

### DIFF
--- a/x-pack/plugins/apm_data_access/server/index.ts
+++ b/x-pack/plugins/apm_data_access/server/index.ts
@@ -16,6 +16,7 @@ const configSchema = schema.object({
     error: schema.string({ defaultValue: 'logs-apm*,apm-*' }),
     metric: schema.string({ defaultValue: 'metrics-apm*,apm-*' }),
     onboarding: schema.string({ defaultValue: 'apm-*' }), // Unused: to be deleted
+    sourcemap: schema.string({ defaultValue: 'apm-*' }), // Unused: to be deleted
   }),
 });
 
@@ -23,7 +24,11 @@ const configSchema = schema.object({
 export const config: PluginConfigDescriptor<APMDataAccessConfig> = {
   deprecations: ({ renameFromRoot, unused, deprecate }) => [
     // deprecations
-    unused('indices.sourcemap', { level: 'warning' }),
+    deprecate('indices.sourcemap', 'a future version', {
+      level: 'warning',
+      message: `Configuring "xpack.apm.indices.sourcemap" is deprecated and will be removed in a future version. Please remove this setting.`,
+    }),
+
     deprecate('indices.onboarding', 'a future version', {
       level: 'warning',
       message: `Configuring "xpack.apm.indices.onboarding" is deprecated and will be removed in a future version. Please remove this setting.`,

--- a/x-pack/test/apm_api_integration/tests/settings/apm_indices/apm_indices.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/apm_indices/apm_indices.spec.ts
@@ -49,6 +49,7 @@ export default function apmIndicesTests({ getService }: FtrProviderContext) {
         error: 'logs-apm*,apm-*',
         metric: 'metrics-apm*,apm-*',
         onboarding: 'apm-*',
+        sourcemap: 'apm-*',
       });
     });
 


### PR DESCRIPTION
The source map index is no longer used but should still be declared to avoid breaking existing cluster configurations