### PR TITLE
[8.10] Enable requeue_invalid_tasks config for functional tests (#163768)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -106,3 +106,6 @@ xpack.alerting.rules.run.ruleTypeOverrides:
     timeout: 1m
 xpack.alerting.rules.minimumScheduleInterval.enforce: true
 xpack.actions.run.maxAttempts: 10
+
+## TaskManager requeue invalid tasks, supports ZDT
+xpack.task_manager.requeue_invalid_tasks.enabled: true

--- a/x-pack/plugins/actions/server/raw_connector_schema.ts
+++ b/x-pack/plugins/actions/server/raw_connector_schema.ts
@@ -14,7 +14,7 @@ export const rawConnectorSchema = schema.object({
   config: schema.recordOf(schema.string(), schema.any()),
   secrets: schema.recordOf(schema.string(), schema.any()),
   isPreconfigured: schema.maybe(schema.boolean()),
-  isSystemAction: schema.boolean(),
+  isSystemAction: schema.maybe(schema.boolean()),
   id: schema.maybe(schema.string()),
   isDeprecated: schema.maybe(schema.boolean()),
 });

--- a/x-pack/test/alerting_api_integration/common/config.ts
+++ b/x-pack/test/alerting_api_integration/common/config.ts
@@ -333,6 +333,7 @@ export function createTestConfig(name: string, options: CreateTestConfigOptions)
               ]
             : []),
           '--notifications.connectors.default.email=notification-email',
+          '--xpack.task_manager.requeue_invalid_tasks.enabled=true',
         ],
       },
     };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Enable requeue_invalid_tasks config for functional tests (#163768)](https://github.com/elastic/kibana/pull/163768)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ersin Erdal","email":"92688503+ersin-erdal@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-08-17T10:53:02Z","message":"Enable requeue_invalid_tasks config for functional tests (#163768)\n\nMakes isSystemAction field in RawConnector optional and enables\r\n`requeue_invalid_tasks` config for functional tests.","sha":"9079b1c60b6f306e73187a215b4a09221bf9e089","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","v8.10.0"],"number":163768,"url":"https://github.com/elastic/kibana/pull/163768","mergeCommit":{"message":"Enable requeue_invalid_tasks config for functional tests (#163768)\n\nMakes isSystemAction field in RawConnector optional and enables\r\n`requeue_invalid_tasks` config for functional tests.","sha":"9079b1c60b6f306e73187a215b4a09221bf9e089"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163768","number":163768,"mergeCommit":{"message":"Enable requeue_invalid_tasks config for functional tests (#163768)\n\nMakes isSystemAction field in RawConnector optional and enables\r\n`requeue_invalid_tasks` config for functional tests.","sha":"9079b1c60b6f306e73187a215b4a09221bf9e089"}}]}] BACKPORT-->