### PR TITLE
[env] throw an error when UUID file is empty

### DIFF
--- a/packages/core/environment/core-environment-server-internal/src/resolve_uuid.test.ts
+++ b/packages/core/environment/core-environment-server-internal/src/resolve_uuid.test.ts
@@ -158,6 +158,15 @@ describe('resolveInstanceUuid', () => {
       });
     });
 
+    describe('when file exists but is empty', () => {
+      it('throws an explicit error for uuid formatting', async () => {
+        mockReadFile({ uuid: '' });
+        await expect(
+          resolveInstanceUuid({ pathConfig, serverConfig, logger })
+        ).rejects.toThrowErrorMatchingInlineSnapshot(`"data-folder/uuid contains an invalid UUID"`);
+      });
+    });
+
     describe('when file contains a trailing new line', () => {
       it('returns the trimmed file uuid', async () => {
         mockReadFile({ uuid: DEFAULT_FILE_UUID + '\n' });

--- a/packages/core/environment/core-environment-server-internal/src/resolve_uuid.ts
+++ b/packages/core/environment/core-environment-server-internal/src/resolve_uuid.ts
@@ -71,7 +71,7 @@ async function readUuidFromFile(filepath: string, logger: Logger): Promise<strin
     return undefined;
   }
 
-  if (content && !content.match(uuidRegexp)) {
+  if (content !== undefined && !content.match(uuidRegexp)) {
     throw new Error(`${filepath} contains an invalid UUID`);
   }
 

--- a/packages/core/environment/core-environment-server-internal/src/resolve_uuid.ts
+++ b/packages/core/environment/core-environment-server-internal/src/resolve_uuid.ts
@@ -65,13 +65,16 @@ export async function resolveInstanceUuid({
 
 async function readUuidFromFile(filepath: string, logger: Logger): Promise<string | undefined> {
   const content = await readFileContent(filepath);
+  if (content === undefined) {
+    return undefined;
+  }
 
   if (content === UUID_7_6_0_BUG) {
     logger.debug(`UUID from 7.6.0 bug detected, ignoring file UUID`);
     return undefined;
   }
 
-  if (content !== undefined && !content.match(uuidRegexp)) {
+  if (!content.match(uuidRegexp)) {
     throw new Error(`${filepath} contains an invalid UUID`);
   }
 


### PR DESCRIPTION
## Summary

Another victim of the infamous javascript true-ish/false-ish.

 Fix a bug that allowed an empty UUID file to bypass the regexp validation and use an empty string as instance UUID.