### PR TITLE
[8.9] [Security Solution] Fix flakiness in: prebuilt_rules_management.cy.ts - Deletes and recovers more than one rule

### DIFF
--- a/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_management.cy.ts
+++ b/x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_management.cy.ts
@@ -22,6 +22,7 @@ import {
   confirmRulesDelete,
   deleteFirstRule,
   deleteSelectedRules,
+  disableAutoRefresh,
   disableSelectedRules,
   enableSelectedRules,
   selectAllRules,
@@ -32,6 +33,7 @@ import {
 import {
   createAndInstallMockedPrebuiltRules,
   getAvailablePrebuiltRulesCount,
+  preventPrebuiltRulesPackageInstallation,
 } from '../../tasks/api_calls/prebuilt_rules';
 import { cleanKibana, deleteAlertsAndRules, deletePrebuiltRulesAssets } from '../../tasks/common';
 import { login, visitWithoutDateRange } from '../../tasks/login';
@@ -53,9 +55,11 @@ describe('Prebuilt rules', () => {
     login();
     deleteAlertsAndRules();
     deletePrebuiltRulesAssets();
+    preventPrebuiltRulesPackageInstallation();
     visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
     createAndInstallMockedPrebuiltRules({ rules });
     cy.reload();
+    disableAutoRefresh();
     waitForPrebuiltDetectionRulesToBeLoaded();
   });
 


### PR DESCRIPTION
**NOTE: This is a manual backport of https://github.com/elastic/kibana/pull/164694**


Relates to: https://github.com/elastic/kibana/issues/161507

## Summary

- Solves flakiness in following test:
    - Filename: `x-pack/plugins/security_solution/cypress/e2e/detection_rules/prebuilt_rules_management.cy.ts`
    - Test name: **Prebuilt rules Actions with prebuilt rules Rules table Deletes and recovers more than one rule** 

- Test was failing because of already observed issue of `autoRefresh` taking place while the rule selection is happening, causing Cypress to lose focus and preventing the checkbox from being checked. This PR disables autorefresh from the table to prevent that from happening.

## Flaky test runner

350 iters: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2976 🟢 