### PR TITLE
[8.9] [ML] Unskips outlier creation functional tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // Failing: See https://github.com/elastic/kibana/issues/142093
-  describe.skip('outlier detection creation', function () {
+  describe('outlier detection creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
       await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier');


### PR DESCRIPTION
## Summary

Unskips the outlier detection creation functional tests for 8.9 that were skipped in https://github.com/elastic/kibana/issues/142093#issuecomment-1683009827.

The failing test on `8.9.2` was caused by the incomplete version bump that was done in https://github.com/elastic/kibana/pull/164192, and since rectified in https://github.com/elastic/kibana/pull/164230.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
