### PR TITLE
[Cases] Create case form tests in serverless.

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { v4 as uuidv4 } from 'uuid';
+import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+import { navigateToCasesApp } from '../../../../shared/lib/cases';
+import { OBSERVABILITY_OWNER } from '@kbn/cases-plugin/common';
+
+const owner = OBSERVABILITY_OWNER;
+
+export default ({ getService, getPageObject }: FtrProviderContext) => {
+  describe('Create case', function () {
+    const find = getService('find');
+    const cases = getService('cases');
+    const testSubjects = getService('testSubjects');
+    const config = getService('config');
+
+    beforeEach(async () => {
+      await navigateToCasesApp(getPageObject, getService, owner);
+    });
+
+    after(async () => {
+      await cases.api.deleteAllCases();
+    });
+
+    it('creates a case', async () => {
+      const caseTitle = 'test-' + uuidv4();
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: caseTitle,
+        description: 'test description',
+        tag: 'tagme',
+        severity: CaseSeverity.HIGH,
+        category: 'new',
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      await testSubjects.existOrFail('case-view-title', {
+        timeout: config.get('timeouts.waitFor'),
+      });
+
+      // validate title
+      const title = await find.byCssSelector('[data-test-subj="editable-title-header-value"]');
+      expect(await title.getVisibleText()).equal(caseTitle);
+
+      // validate description
+      const description = await testSubjects.find('scrollable-markdown');
+      expect(await description.getVisibleText()).equal('test description');
+
+      // validate tag exists
+      await testSubjects.existOrFail('tag-tagme');
+
+      // validate category exists
+      await testSubjects.existOrFail('category-viewer-new');
+
+      // validate no connector added
+      const button = await find.byCssSelector('[data-test-subj*="case-callout"] button');
+      expect(await button.getVisibleText()).equal('Add connector');
+    });
+
+    it('displays errors correctly while creating a case', async () => {
+      const caseTitle = Array(161).fill('x').toString();
+      const longTag = Array(256).fill('a').toString();
+      const longCategory = Array(51).fill('x').toString();
+
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: caseTitle,
+        description: '',
+        tag: longTag,
+        severity: CaseSeverity.HIGH,
+        category: longCategory,
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      const title = await find.byCssSelector('[data-test-subj="caseTitle"]');
+      expect(await title.getVisibleText()).contain(
+        'The length of the name is too long. The maximum length is 160 characters.'
+      );
+
+      const description = await testSubjects.find('caseDescription');
+      expect(await description.getVisibleText()).contain('A description is required.');
+
+      const tags = await testSubjects.find('caseTags');
+      expect(await tags.getVisibleText()).contain(
+        'The length of the tag is too long. The maximum length is 256 characters.'
+      );
+
+      const category = await testSubjects.find('case-create-form-category');
+      expect(await category.getVisibleText()).contain(
+        'The length of the category is too long. The maximum length is 50 characters.'
+      );
+    });
+
+    it('trims fields correctly while creating a case', async () => {
+      const titleWithSpace = 'This is a title with spaces       ';
+      const descriptionWithSpace =
+        'This is a case description with empty spaces at the end!!             ';
+      const categoryWithSpace = 'security        ';
+      const tagWithSpace = 'coke     ';
+
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: titleWithSpace,
+        description: descriptionWithSpace,
+        tag: tagWithSpace,
+        severity: CaseSeverity.HIGH,
+        category: categoryWithSpace,
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      // validate title is trimmed
+      const title = await find.byCssSelector('[data-test-subj="editable-title-header-value"]');
+      expect(await title.getVisibleText()).equal(titleWithSpace.trim());
+
+      // validate description is trimmed
+      const description = await testSubjects.find('scrollable-markdown');
+      expect(await description.getVisibleText()).equal(descriptionWithSpace.trim());
+
+      // validate tag exists and is trimmed
+      const tag = await testSubjects.find(`tag-${tagWithSpace.trim()}`);
+      expect(await tag.getVisibleText()).equal(tagWithSpace.trim());
+
+      // validate category exists and is trimmed
+      const category = await testSubjects.find(`category-viewer-${categoryWithSpace.trim()}`);
+      expect(await category.getVisibleText()).equal(categoryWithSpace.trim());
+    });
+  });
+};

--- a/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
@@ -8,9 +8,9 @@
 import expect from '@kbn/expect';
 import { v4 as uuidv4 } from 'uuid';
 import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import { OBSERVABILITY_OWNER } from '@kbn/cases-plugin/common';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import { navigateToCasesApp } from '../../../../shared/lib/cases';
-import { OBSERVABILITY_OWNER } from '@kbn/cases-plugin/common';
 
 const owner = OBSERVABILITY_OWNER;
 

--- a/x-pack/test_serverless/functional/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.ts
@@ -15,5 +15,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadDiscoverLogExplorerSuite(loadTestFile);
     loadTestFile(require.resolve('./cases/attachment_framework'));
     loadTestFile(require.resolve('./cases/list_view'));
+    loadTestFile(require.resolve('./cases/create_case_form'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
@@ -8,9 +8,9 @@
 import expect from '@kbn/expect';
 import { v4 as uuidv4 } from 'uuid';
 import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
 import { FtrProviderContext } from '../../../../ftr_provider_context';
 import { navigateToCasesApp } from '../../../../../shared/lib/cases';
-import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
 
 const owner = SECURITY_SOLUTION_OWNER;
 

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { v4 as uuidv4 } from 'uuid';
+import { CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+import { navigateToCasesApp } from '../../../../../shared/lib/cases';
+import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
+
+const owner = SECURITY_SOLUTION_OWNER;
+
+export default ({ getService, getPageObject }: FtrProviderContext) => {
+  describe('Create case', function () {
+    const find = getService('find');
+    const cases = getService('cases');
+    const testSubjects = getService('testSubjects');
+    const config = getService('config');
+
+    beforeEach(async () => {
+      await navigateToCasesApp(getPageObject, getService, owner);
+    });
+
+    after(async () => {
+      await cases.api.deleteAllCases();
+    });
+
+    it('creates a case', async () => {
+      const caseTitle = 'test-' + uuidv4();
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: caseTitle,
+        description: 'test description',
+        tag: 'tagme',
+        severity: CaseSeverity.HIGH,
+        category: 'new',
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      await testSubjects.existOrFail('case-view-title', {
+        timeout: config.get('timeouts.waitFor'),
+      });
+
+      // validate title
+      const title = await find.byCssSelector('[data-test-subj="editable-title-header-value"]');
+      expect(await title.getVisibleText()).equal(caseTitle);
+
+      // validate description
+      const description = await testSubjects.find('scrollable-markdown');
+      expect(await description.getVisibleText()).equal('test description');
+
+      // validate tag exists
+      await testSubjects.existOrFail('tag-tagme');
+
+      // validate category exists
+      await testSubjects.existOrFail('category-viewer-new');
+
+      // validate no connector added
+      const button = await find.byCssSelector('[data-test-subj*="case-callout"] button');
+      expect(await button.getVisibleText()).equal('Add connector');
+    });
+
+    it('displays errors correctly while creating a case', async () => {
+      const caseTitle = Array(161).fill('x').toString();
+      const longTag = Array(256).fill('a').toString();
+      const longCategory = Array(51).fill('x').toString();
+
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: caseTitle,
+        description: '',
+        tag: longTag,
+        severity: CaseSeverity.HIGH,
+        category: longCategory,
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      const title = await find.byCssSelector('[data-test-subj="caseTitle"]');
+      expect(await title.getVisibleText()).contain(
+        'The length of the name is too long. The maximum length is 160 characters.'
+      );
+
+      const description = await testSubjects.find('caseDescription');
+      expect(await description.getVisibleText()).contain('A description is required.');
+
+      const tags = await testSubjects.find('caseTags');
+      expect(await tags.getVisibleText()).contain(
+        'The length of the tag is too long. The maximum length is 256 characters.'
+      );
+
+      const category = await testSubjects.find('case-create-form-category');
+      expect(await category.getVisibleText()).contain(
+        'The length of the category is too long. The maximum length is 50 characters.'
+      );
+    });
+
+    it('trims fields correctly while creating a case', async () => {
+      const titleWithSpace = 'This is a title with spaces       ';
+      const descriptionWithSpace =
+        'This is a case description with empty spaces at the end!!             ';
+      const categoryWithSpace = 'security        ';
+      const tagWithSpace = 'coke     ';
+
+      await cases.create.openCreateCasePage();
+      await cases.create.createCase({
+        title: titleWithSpace,
+        description: descriptionWithSpace,
+        tag: tagWithSpace,
+        severity: CaseSeverity.HIGH,
+        category: categoryWithSpace,
+      });
+
+      await testSubjects.click('create-case-submit');
+
+      // validate title is trimmed
+      const title = await find.byCssSelector('[data-test-subj="editable-title-header-value"]');
+      expect(await title.getVisibleText()).equal(titleWithSpace.trim());
+
+      // validate description is trimmed
+      const description = await testSubjects.find('scrollable-markdown');
+      expect(await description.getVisibleText()).equal(descriptionWithSpace.trim());
+
+      // validate tag exists and is trimmed
+      const tag = await testSubjects.find(`tag-${tagWithSpace.trim()}`);
+      expect(await tag.getVisibleText()).equal(tagWithSpace.trim());
+
+      // validate category exists and is trimmed
+      const category = await testSubjects.find(`category-viewer-${categoryWithSpace.trim()}`);
+      expect(await category.getVisibleText()).equal(categoryWithSpace.trim());
+    });
+  });
+};

--- a/x-pack/test_serverless/functional/test_suites/security/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/index.ts
@@ -14,5 +14,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./ftr/management'));
     loadTestFile(require.resolve('./ftr/cases/attachment_framework'));
     loadTestFile(require.resolve('./ftr/cases/list_view'));
+    loadTestFile(require.resolve('./ftr/cases/create_case_form'));
   });
 }

--- a/x-pack/test_serverless/shared/lib/cases/helpers.ts
+++ b/x-pack/test_serverless/shared/lib/cases/helpers.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SECURITY_SOLUTION_OWNER } from '@kbn/cases-plugin/common';
+import { FtrProviderContext } from '../../../functional/ftr_provider_context';
+
+export const navigateToCasesApp = async (
+  getPageObject: FtrProviderContext['getPageObject'],
+  getService: FtrProviderContext['getService'],
+  owner: string
+) => {
+  const testSubjects = getService('testSubjects');
+
+  const common = getPageObject('common');
+  const svlCommonNavigation = getPageObject('svlCommonNavigation');
+
+  await common.navigateToApp('landingPage');
+
+  if (owner === SECURITY_SOLUTION_OWNER) {
+    await testSubjects.click('solutionSideNavItemLink-cases');
+  } else {
+    await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'observability-overview:cases' });
+  }
+};

--- a/x-pack/test_serverless/shared/lib/cases/index.ts
+++ b/x-pack/test_serverless/shared/lib/cases/index.ts
@@ -5,5 +5,4 @@
  * 2.0.
  */
 
-export * from './security';
-export * from './cases';
+export * from './helpers';


### PR DESCRIPTION
Connected with https://github.com/elastic/kibana/issues/164552

## Summary
This PR creates a serverless version of the tests currently in `x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts`.