### PR TITLE
[Security Solution] Migrate detection engine API to versioned router

### DIFF
--- a/x-pack/plugins/security_solution/common/api/detection_engine/rule_exceptions/urls.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/rule_exceptions/urls.ts
@@ -10,8 +10,8 @@ import {
   INTERNAL_DETECTION_ENGINE_URL as INTERNAL_URL,
 } from '../../../constants';
 
-const INTERNAL_RULES_URL = `${INTERNAL_URL}/rules`;
+const INTERNAL_RULES_URL = `${INTERNAL_URL}/rules` as const;
 
-export const CREATE_RULE_EXCEPTIONS_URL = `${PUBLIC_RULES_URL}/{id}/exceptions`;
+export const CREATE_RULE_EXCEPTIONS_URL = `${PUBLIC_RULES_URL}/{id}/exceptions` as const;
 export const DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL =
   `${INTERNAL_RULES_URL}/exceptions/_find_references` as const;

--- a/x-pack/plugins/security_solution/public/common/containers/alert_tags/api.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/alert_tags/api.ts
@@ -23,6 +23,7 @@ export const setAlertTags = async ({
     DETECTION_ENGINE_ALERT_TAGS_URL,
     {
       method: 'POST',
+      version: '2023-10-31',
       body: JSON.stringify({ tags, ids }),
       signal,
     }

--- a/x-pack/plugins/security_solution/public/common/containers/dashboards/api.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/dashboards/api.ts
@@ -23,6 +23,7 @@ export const getDashboardsByTagIds = (
   abortSignal?: AbortSignal
 ): Promise<Dashboard[] | null> =>
   http.post(INTERNAL_DASHBOARDS_URL, {
+    version: '1',
     body: JSON.stringify({ tagIds }),
     signal: abortSignal,
   });

--- a/x-pack/plugins/security_solution/public/common/containers/tags/api.ts
+++ b/x-pack/plugins/security_solution/public/common/containers/tags/api.ts
@@ -21,7 +21,12 @@ export interface Tag {
 export const getTagsByName = (
   { http, tagName }: { http: HttpSetup; tagName: string },
   abortSignal?: AbortSignal
-): Promise<Tag[]> => http.get(INTERNAL_TAGS_URL, { query: { name: tagName }, signal: abortSignal });
+): Promise<Tag[]> =>
+  http.get(INTERNAL_TAGS_URL, {
+    version: '1',
+    query: { name: tagName },
+    signal: abortSignal,
+  });
 
 // Dashboard listing needs savedObjectsTaggingClient to work correctly with cache.
 // https://github.com/elastic/kibana/issues/160723#issuecomment-1641904984

--- a/x-pack/plugins/security_solution/public/common/store/store.ts
+++ b/x-pack/plugins/security_solution/public/common/store/store.ts
@@ -69,6 +69,7 @@ export const createStoreFactory = async (
   try {
     if (coreStart.application.capabilities[SERVER_APP_ID].show === true) {
       signal = await coreStart.http.fetch(DETECTION_ENGINE_INDEX_URL, {
+        version: '2023-10-31',
         method: 'GET',
       });
     }

--- a/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
+++ b/x-pack/plugins/security_solution/public/dashboards/containers/use_fetch_security_tags.test.ts
@@ -56,10 +56,13 @@ describe('useFetchSecurityTags', () => {
     mockGet.mockResolvedValue([]);
     await asyncRenderUseCreateSecurityDashboardLink();
 
-    expect(mockGet).toHaveBeenCalledWith(INTERNAL_TAGS_URL, {
-      query: { name: SECURITY_TAG_NAME },
-      signal: mockAbortSignal,
-    });
+    expect(mockGet).toHaveBeenCalledWith(
+      INTERNAL_TAGS_URL,
+      expect.objectContaining({
+        query: { name: SECURITY_TAG_NAME },
+        signal: mockAbortSignal,
+      })
+    );
   });
 
   test('should create a Security Solution tag if no Security Solution tags were found', async () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations/api/api_client.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/fleet_integrations/api/api_client.ts
@@ -22,6 +22,7 @@ export const fleetIntegrationsApi: IFleetIntegrationsApiClient = {
 
     return http().fetch<GetInstalledIntegrationsResponse>(GET_INSTALLED_INTEGRATIONS_URL, {
       method: 'GET',
+      version: '1',
       query: {
         packages: packages?.sort()?.join(','),
       },

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/api/api.ts
@@ -153,6 +153,7 @@ export const patchRule = async ({
 export const previewRule = async ({ rule, signal }: PreviewRulesProps): Promise<PreviewResponse> =>
   KibanaServices.get().http.fetch<PreviewResponse>(DETECTION_ENGINE_RULES_PREVIEW, {
     method: 'POST',
+    version: '2023-10-31',
     body: JSON.stringify(rule),
     signal,
   });
@@ -542,6 +543,7 @@ export const findRuleExceptionReferences = async ({
     DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL,
     {
       method: 'GET',
+      version: '1',
       query,
       signal,
     }
@@ -570,6 +572,7 @@ export const addRuleExceptions = async ({
     `${DETECTION_ENGINE_RULES_URL}/${ruleId}/exceptions`,
     {
       method: 'POST',
+      version: '2023-10-31',
       body: JSON.stringify({ items }),
       signal,
     }

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.test.ts
@@ -42,11 +42,14 @@ describe('Detections Alerts API', () => {
 
     test('check parameter url, body', async () => {
       await fetchQueryAlerts({ query: mockAlertsQuery, signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/signals/search', {
-        body: '{"aggs":{"alertsByGrouping":{"terms":{"field":"signal.rule.risk_score","missing":"All others","order":{"_count":"desc"},"size":10},"aggs":{"alerts":{"date_histogram":{"field":"@timestamp","fixed_interval":"81000000ms","min_doc_count":0,"extended_bounds":{"min":1579644343954,"max":1582236343955}}}}}},"query":{"bool":{"filter":[{"bool":{"must":[],"filter":[{"match_all":{}}],"should":[],"must_not":[]}},{"range":{"@timestamp":{"gte":1579644343954,"lte":1582236343955}}}]}}}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/search',
+        expect.objectContaining({
+          body: '{"aggs":{"alertsByGrouping":{"terms":{"field":"signal.rule.risk_score","missing":"All others","order":{"_count":"desc"},"size":10},"aggs":{"alerts":{"date_histogram":{"field":"@timestamp","fixed_interval":"81000000ms","min_doc_count":0,"extended_bounds":{"min":1579644343954,"max":1582236343955}}}}}},"query":{"bool":{"filter":[{"bool":{"must":[],"filter":[{"match_all":{}}],"should":[],"must_not":[]}},{"range":{"@timestamp":{"gte":1579644343954,"lte":1582236343955}}}]}}}',
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -70,11 +73,14 @@ describe('Detections Alerts API', () => {
         signal: abortCtrl.signal,
         status: 'closed',
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/signals/status', {
-        body: '{"conflicts":"proceed","status":"closed","query":{"bool":{"filter":{"terms":{"_id":["b4ee5c32e3a321057edcc953ca17228c6fdfe5ba43fdbbdaffa8cefa11605cc5"]}}}}}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/status',
+        expect.objectContaining({
+          body: '{"conflicts":"proceed","status":"closed","query":{"bool":{"filter":{"terms":{"_id":["b4ee5c32e3a321057edcc953ca17228c6fdfe5ba43fdbbdaffa8cefa11605cc5"]}}}}}',
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('check parameter url, body when opening an alert', async () => {
@@ -83,11 +89,14 @@ describe('Detections Alerts API', () => {
         signal: abortCtrl.signal,
         status: 'open',
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/signals/status', {
-        body: '{"conflicts":"proceed","status":"open","query":{"bool":{"filter":{"terms":{"_id":["b4ee5c32e3a321057edcc953ca17228c6fdfe5ba43fdbbdaffa8cefa11605cc5"]}}}}}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/status',
+        expect.objectContaining({
+          body: '{"conflicts":"proceed","status":"open","query":{"bool":{"filter":{"terms":{"_id":["b4ee5c32e3a321057edcc953ca17228c6fdfe5ba43fdbbdaffa8cefa11605cc5"]}}}}}',
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -112,11 +121,14 @@ describe('Detections Alerts API', () => {
         signal: abortCtrl.signal,
         status: 'closed',
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/signals/status', {
-        body: '{"status":"closed","signal_ids":["123"]}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/status',
+        expect.objectContaining({
+          body: '{"status":"closed","signal_ids":["123"]}',
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('check parameter url, body when opening an alert', async () => {
@@ -125,11 +137,14 @@ describe('Detections Alerts API', () => {
         signal: abortCtrl.signal,
         status: 'open',
       });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/signals/status', {
-        body: '{"status":"open","signal_ids":["123"]}',
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/status',
+        expect.objectContaining({
+          body: '{"status":"open","signal_ids":["123"]}',
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -150,10 +165,13 @@ describe('Detections Alerts API', () => {
 
     test('check parameter url', async () => {
       await getSignalIndex({ signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/index', {
-        method: 'GET',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/index',
+        expect.objectContaining({
+          method: 'GET',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -172,10 +190,13 @@ describe('Detections Alerts API', () => {
 
     test('check parameter url', async () => {
       await getUserPrivilege({ signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/privileges', {
-        method: 'GET',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/privileges',
+        expect.objectContaining({
+          method: 'GET',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -194,10 +215,13 @@ describe('Detections Alerts API', () => {
 
     test('check parameter url', async () => {
       await createSignalIndex({ signal: abortCtrl.signal });
-      expect(fetchMock).toHaveBeenCalledWith('/api/detection_engine/index', {
-        method: 'POST',
-        signal: abortCtrl.signal,
-      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/index',
+        expect.objectContaining({
+          method: 'POST',
+          signal: abortCtrl.signal,
+        })
+      );
     });
 
     test('happy path', async () => {
@@ -222,10 +246,13 @@ describe('Detections Alerts API', () => {
         comment: 'commento',
         caseIds: ['88c04a90-b19c-11eb-b838-bf3c7840b969'],
       });
-      expect(postMock).toHaveBeenCalledWith('/api/endpoint/action/isolate', {
-        body: '{"endpoint_ids":["fd8a122b-4c54-4c05-b295-e5f8381fc59d"],"comment":"commento","case_ids":["88c04a90-b19c-11eb-b838-bf3c7840b969"]}',
-        version: '2023-10-31',
-      });
+      expect(postMock).toHaveBeenCalledWith(
+        '/api/endpoint/action/isolate',
+        expect.objectContaining({
+          body: '{"endpoint_ids":["fd8a122b-4c54-4c05-b295-e5f8381fc59d"],"comment":"commento","case_ids":["88c04a90-b19c-11eb-b838-bf3c7840b969"]}',
+          version: '2023-10-31',
+        })
+      );
     });
 
     test('happy path', async () => {

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.ts
@@ -47,6 +47,7 @@ export const fetchQueryAlerts = async <Hit, Aggregations>({
   return KibanaServices.get().http.fetch<AlertSearchResponse<Hit, Aggregations>>(
     DETECTION_ENGINE_QUERY_SIGNALS_URL,
     {
+      version: '2023-10-31',
       method: 'POST',
       body: JSON.stringify(query),
       signal,
@@ -91,6 +92,7 @@ export const updateAlertStatusByQuery = async ({
   signal,
 }: UpdateAlertStatusByQueryProps): Promise<estypes.UpdateByQueryResponse> =>
   KibanaServices.get().http.fetch(DETECTION_ENGINE_SIGNALS_STATUS_URL, {
+    version: '2023-10-31',
     method: 'POST',
     body: JSON.stringify({ conflicts: 'proceed', status, query }),
     signal,
@@ -111,6 +113,7 @@ export const updateAlertStatusByIds = async ({
   signal,
 }: UpdateAlertStatusByIdsProps): Promise<estypes.UpdateByQueryResponse> =>
   KibanaServices.get().http.fetch(DETECTION_ENGINE_SIGNALS_STATUS_URL, {
+    version: '2023-10-31',
     method: 'POST',
     body: JSON.stringify({ status, signal_ids: signalIds }),
     signal,
@@ -125,6 +128,7 @@ export const updateAlertStatusByIds = async ({
  */
 export const getSignalIndex = async ({ signal }: BasicSignals): Promise<AlertsIndex> =>
   KibanaServices.get().http.fetch<AlertsIndex>(DETECTION_ENGINE_INDEX_URL, {
+    version: '2023-10-31',
     method: 'GET',
     signal,
   });
@@ -138,6 +142,7 @@ export const getSignalIndex = async ({ signal }: BasicSignals): Promise<AlertsIn
  */
 export const checkSignalIndex = async ({ signal }: BasicSignals): Promise<CheckSignalIndex> =>
   KibanaServices.get().http.fetch<CheckSignalIndex>(DETECTION_ENGINE_ALERTS_INDEX_URL, {
+    version: '2023-10-31',
     method: 'GET',
     signal,
   });
@@ -151,6 +156,7 @@ export const checkSignalIndex = async ({ signal }: BasicSignals): Promise<CheckS
  */
 export const getUserPrivilege = async ({ signal }: BasicSignals): Promise<Privilege> =>
   KibanaServices.get().http.fetch<Privilege>(DETECTION_ENGINE_PRIVILEGES_URL, {
+    version: '2023-10-31',
     method: 'GET',
     signal,
   });
@@ -164,6 +170,7 @@ export const getUserPrivilege = async ({ signal }: BasicSignals): Promise<Privil
  */
 export const createSignalIndex = async ({ signal }: BasicSignals): Promise<AlertsIndex> =>
   KibanaServices.get().http.fetch<AlertsIndex>(DETECTION_ENGINE_INDEX_URL, {
+    version: '2023-10-31',
     method: 'POST',
     signal,
   });

--- a/x-pack/plugins/security_solution/public/exceptions/hooks/use_create_shared_list/index.tsx
+++ b/x-pack/plugins/security_solution/public/exceptions/hooks/use_create_shared_list/index.tsx
@@ -24,6 +24,7 @@ export const createSharedExceptionList = async ({
   description: string;
 }): Promise<ExceptionListSchema> => {
   const res: ExceptionListSchema = await http.post<ExceptionListSchema>(SHARED_EXCEPTION_LIST_URL, {
+    version: '2023-10-31',
     body: JSON.stringify({ name, description }),
     headers: { 'Content-Type': 'application/json' },
     method: 'POST',

--- a/x-pack/plugins/security_solution/server/lib/dashboards/routes/get_dashboards_by_tags.ts
+++ b/x-pack/plugins/security_solution/server/lib/dashboards/routes/get_dashboards_by_tags.ts
@@ -22,43 +22,48 @@ export const getDashboardsByTagsRoute = (
   logger: Logger,
   security: SetupPlugins['security']
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: INTERNAL_DASHBOARDS_URL,
-      validate: { body: buildRouteValidationWithExcess(getDashboardsRequest) },
+      access: 'internal',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const frameworkRequest = await buildFrameworkRequest(context, security, request);
-      const savedObjectsClient = (await frameworkRequest.context.core).savedObjects.client;
-      const { tagIds } = request.body;
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: { request: { body: buildRouteValidationWithExcess(getDashboardsRequest) } },
+      },
+      async (context, request, response) => {
+        const frameworkRequest = await buildFrameworkRequest(context, security, request);
+        const savedObjectsClient = (await frameworkRequest.context.core).savedObjects.client;
+        const { tagIds } = request.body;
 
-      try {
-        const dashboardsResponse = await savedObjectsClient.find<DashboardAttributes>({
-          type: 'dashboard',
-          hasReference: tagIds.map((id) => ({ id, type: 'tag' })),
-        });
-        const dashboards = dashboardsResponse.saved_objects ?? [];
+        try {
+          const dashboardsResponse = await savedObjectsClient.find<DashboardAttributes>({
+            type: 'dashboard',
+            hasReference: tagIds.map((id) => ({ id, type: 'tag' })),
+          });
+          const dashboards = dashboardsResponse.saved_objects ?? [];
 
-        return response.ok({ body: dashboards });
-      } catch (err) {
-        const error = transformError(err);
-        logger.error(`Failed to find dashboards tags - ${JSON.stringify(error.message)}`);
+          return response.ok({ body: dashboards });
+        } catch (err) {
+          const error = transformError(err);
+          logger.error(`Failed to find dashboards tags - ${JSON.stringify(error.message)}`);
 
-        const siemResponse = buildSiemResponse(response);
-        return siemResponse.error({
-          statusCode: error.statusCode ?? 500,
-          body: i18n.translate(
-            'xpack.securitySolution.dashboards.getSecuritySolutionDashboardsErrorTitle',
-            {
-              values: { message: error.message },
-              defaultMessage: `Failed to find dashboards - {message}`,
-            }
-          ),
-        });
+          const siemResponse = buildSiemResponse(response);
+          return siemResponse.error({
+            statusCode: error.statusCode ?? 500,
+            body: i18n.translate(
+              'xpack.securitySolution.dashboards.getSecuritySolutionDashboardsErrorTitle',
+              {
+                values: { message: error.message },
+                defaultMessage: `Failed to find dashboards - {message}`,
+              }
+            ),
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_installed_integrations/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/fleet_integrations/api/get_installed_integrations/route.ts
@@ -21,48 +21,56 @@ export const getInstalledIntegrationsRoute = (
   router: SecuritySolutionPluginRouter,
   logger: Logger
 ) => {
-  router.get(
-    {
+  router.versioned
+    .get({
+      access: 'internal',
       path: GET_INSTALLED_INTEGRATIONS_URL,
-      validate: {},
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: false,
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve(['core', 'securitySolution']);
-        const fleet = ctx.securitySolution.getInternalFleetServices();
-        const set = createInstalledIntegrationSet();
+        try {
+          const ctx = await context.resolve(['core', 'securitySolution']);
+          const fleet = ctx.securitySolution.getInternalFleetServices();
+          const set = createInstalledIntegrationSet();
 
-        // Pulls all packages into memory just like the main fleet landing page
-        // No pagination support currently, so cannot batch this call
-        const allThePackages = await fleet.packages.getPackages();
-        allThePackages.forEach((fleetPackage) => {
-          set.addPackage(fleetPackage);
-        });
+          // Pulls all packages into memory just like the main fleet landing page
+          // No pagination support currently, so cannot batch this call
+          const allThePackages = await fleet.packages.getPackages();
+          allThePackages.forEach((fleetPackage) => {
+            set.addPackage(fleetPackage);
+          });
 
-        const packagePolicies = await fleet.packagePolicy.list(fleet.internalReadonlySoClient, {});
-        packagePolicies.items.forEach((policy) => {
-          set.addPackagePolicy(policy);
-        });
+          const packagePolicies = await fleet.packagePolicy.list(
+            fleet.internalReadonlySoClient,
+            {}
+          );
+          packagePolicies.items.forEach((policy) => {
+            set.addPackagePolicy(policy);
+          });
 
-        const installedIntegrations = set.getIntegrations();
+          const installedIntegrations = set.getIntegrations();
 
-        const body: GetInstalledIntegrationsResponse = {
-          installed_integrations: installedIntegrations,
-        };
+          const body: GetInstalledIntegrationsResponse = {
+            installed_integrations: installedIntegrations,
+          };
 
-        return response.ok({ body });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_index_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/create_index_route.ts
@@ -36,34 +36,39 @@ import { getIndexVersion } from './get_index_version';
 import { isOutdated } from '../../migrations/helpers';
 
 export const createIndexRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_INDEX_URL,
-      validate: false,
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, _, response): Promise<IKibanaResponse<CreateIndexResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, _, response): Promise<IKibanaResponse<CreateIndexResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const securitySolution = await context.securitySolution;
-        const siemClient = securitySolution?.getAppClient();
-        if (!siemClient) {
-          return siemResponse.error({ statusCode: 404 });
+        try {
+          const securitySolution = await context.securitySolution;
+          const siemClient = securitySolution?.getAppClient();
+          if (!siemClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+          await createDetectionIndex(securitySolution);
+          return response.ok({ body: { acknowledged: true } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-        await createDetectionIndex(securitySolution);
-        return response.ok({ body: { acknowledged: true } });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };
 
 export const createDetectionIndex = async (

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/delete_index_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/delete_index_route.ts
@@ -31,57 +31,62 @@ import type { DeleteIndexResponse } from '../../../../../common/api/detection_en
  * And ensuring they're all gone
  */
 export const deleteIndexRoute = (router: SecuritySolutionPluginRouter) => {
-  router.delete(
-    {
+  router.versioned
+    .delete({
       path: DETECTION_ENGINE_INDEX_URL,
-      validate: false,
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, _, response): Promise<IKibanaResponse<DeleteIndexResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, _, response): Promise<IKibanaResponse<DeleteIndexResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const esClient = (await context.core).elasticsearch.client.asCurrentUser;
+        try {
+          const esClient = (await context.core).elasticsearch.client.asCurrentUser;
 
-        const siemClient = (await context.securitySolution)?.getAppClient();
+          const siemClient = (await context.securitySolution)?.getAppClient();
 
-        if (!siemClient) {
-          return siemResponse.error({ statusCode: 404 });
-        }
+          if (!siemClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
 
-        const index = siemClient.getSignalsIndex();
-        const indexExists = await getIndexExists(esClient, index);
+          const index = siemClient.getSignalsIndex();
+          const indexExists = await getIndexExists(esClient, index);
 
-        if (!indexExists) {
+          if (!indexExists) {
+            return siemResponse.error({
+              statusCode: 404,
+              body: `index: "${index}" does not exist`,
+            });
+          } else {
+            await deleteAllIndex(esClient, index, true);
+            const policyExists = await getPolicyExists(esClient, index);
+            if (policyExists) {
+              await deletePolicy(esClient, index);
+            }
+            const templateExists = await esClient.indices.existsIndexTemplate({ name: index });
+            if (templateExists) {
+              await esClient.indices.deleteIndexTemplate({ name: index });
+            }
+            const legacyTemplateExists = await esClient.indices.existsTemplate({ name: index });
+            if (legacyTemplateExists) {
+              await esClient.indices.deleteTemplate({ name: index });
+            }
+            return response.ok({ body: { acknowledged: true } });
+          }
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
-            statusCode: 404,
-            body: `index: "${index}" does not exist`,
+            body: error.message,
+            statusCode: error.statusCode,
           });
-        } else {
-          await deleteAllIndex(esClient, index, true);
-          const policyExists = await getPolicyExists(esClient, index);
-          if (policyExists) {
-            await deletePolicy(esClient, index);
-          }
-          const templateExists = await esClient.indices.existsIndexTemplate({ name: index });
-          if (templateExists) {
-            await esClient.indices.deleteIndexTemplate({ name: index });
-          }
-          const legacyTemplateExists = await esClient.indices.existsTemplate({ name: index });
-          if (legacyTemplateExists) {
-            await esClient.indices.deleteTemplate({ name: index });
-          }
-          return response.ok({ body: { acknowledged: true } });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/read_alerts_index_exists_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/read_alerts_index_exists_route.ts
@@ -14,41 +14,46 @@ import { buildSiemResponse } from '../utils';
 import type { ReadAlertsIndexExistsResponse } from '../../../../../common/api/detection_engine';
 
 export const readAlertsIndexExistsRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: DETECTION_ENGINE_ALERTS_INDEX_URL,
-      validate: false,
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, _, response): Promise<IKibanaResponse<ReadAlertsIndexExistsResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, _, response): Promise<IKibanaResponse<ReadAlertsIndexExistsResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const core = await context.core;
-        const securitySolution = await context.securitySolution;
-        const siemClient = securitySolution?.getAppClient();
+        try {
+          const core = await context.core;
+          const securitySolution = await context.securitySolution;
+          const siemClient = securitySolution?.getAppClient();
 
-        if (!siemClient) {
-          return siemResponse.error({ statusCode: 404 });
+          if (!siemClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+
+          const index = siemClient.getSignalsIndex();
+
+          const indexExists = await getIndexExists(core.elasticsearch.client.asInternalUser, index);
+          return response.ok({
+            body: {
+              indexExists,
+            },
+          });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-
-        const index = siemClient.getSignalsIndex();
-
-        const indexExists = await getIndexExists(core.elasticsearch.client.asInternalUser, index);
-        return response.ok({
-          body: {
-            indexExists,
-          },
-        });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/read_index_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/index/read_index_route.ts
@@ -22,79 +22,84 @@ export const readIndexRoute = (
   router: SecuritySolutionPluginRouter,
   ruleDataService: RuleDataPluginService
 ) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: DETECTION_ENGINE_INDEX_URL,
-      validate: false,
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, _, response): Promise<IKibanaResponse<ReadIndexResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, _, response): Promise<IKibanaResponse<ReadIndexResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const core = await context.core;
-        const securitySolution = await context.securitySolution;
+        try {
+          const core = await context.core;
+          const securitySolution = await context.securitySolution;
 
-        const siemClient = securitySolution?.getAppClient();
-        const esClient = core.elasticsearch.client.asCurrentUser;
+          const siemClient = securitySolution?.getAppClient();
+          const esClient = core.elasticsearch.client.asCurrentUser;
 
-        if (!siemClient) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-
-        const spaceId = securitySolution.getSpaceId();
-        const indexName = ruleDataService.getResourceName(`security.alerts-${spaceId}`);
-
-        const index = siemClient.getSignalsIndex();
-        const indexExists = await getBootstrapIndexExists(
-          core.elasticsearch.client.asInternalUser,
-          index
-        );
-
-        if (indexExists) {
-          let mappingOutdated: boolean | null = null;
-          let aliasesOutdated: boolean | null = null;
-          try {
-            const indexVersion = await getIndexVersion(esClient, index);
-            mappingOutdated = isOutdated({
-              current: indexVersion,
-              target: SIGNALS_TEMPLATE_VERSION,
-            });
-            aliasesOutdated = await fieldAliasesOutdated(esClient, index);
-          } catch (err) {
-            const error = transformError(err);
-            // Some users may not have the view_index_metadata permission necessary to check the index mapping version
-            // so just continue and return null for index_mapping_outdated if the error is a 403
-            if (error.statusCode !== 403) {
-              return siemResponse.error({
-                body: error.message,
-                statusCode: error.statusCode,
-              });
-            }
+          if (!siemClient) {
+            return siemResponse.error({ statusCode: 404 });
           }
-          return response.ok({
-            body: {
-              name: indexName,
-              index_mapping_outdated: mappingOutdated || aliasesOutdated,
-            },
-          });
-        } else {
-          return response.ok({
-            body: {
-              name: indexName,
-              index_mapping_outdated: false,
-            },
+
+          const spaceId = securitySolution.getSpaceId();
+          const indexName = ruleDataService.getResourceName(`security.alerts-${spaceId}`);
+
+          const index = siemClient.getSignalsIndex();
+          const indexExists = await getBootstrapIndexExists(
+            core.elasticsearch.client.asInternalUser,
+            index
+          );
+
+          if (indexExists) {
+            let mappingOutdated: boolean | null = null;
+            let aliasesOutdated: boolean | null = null;
+            try {
+              const indexVersion = await getIndexVersion(esClient, index);
+              mappingOutdated = isOutdated({
+                current: indexVersion,
+                target: SIGNALS_TEMPLATE_VERSION,
+              });
+              aliasesOutdated = await fieldAliasesOutdated(esClient, index);
+            } catch (err) {
+              const error = transformError(err);
+              // Some users may not have the view_index_metadata permission necessary to check the index mapping version
+              // so just continue and return null for index_mapping_outdated if the error is a 403
+              if (error.statusCode !== 403) {
+                return siemResponse.error({
+                  body: error.message,
+                  statusCode: error.statusCode,
+                });
+              }
+            }
+            return response.ok({
+              body: {
+                name: indexName,
+                index_mapping_outdated: mappingOutdated || aliasesOutdated,
+              },
+            });
+          } else {
+            return response.ok({
+              body: {
+                name: indexName,
+                index_mapping_outdated: false,
+              },
+            });
+          }
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/privileges/read_privileges_route.ts
@@ -18,45 +18,50 @@ export const readPrivilegesRoute = (
   router: SecuritySolutionPluginRouter,
   hasEncryptionKey: boolean
 ) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: DETECTION_ENGINE_PRIVILEGES_URL,
-      validate: false,
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<ReadPrivilegesResponse>> => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: false,
+      },
+      async (context, request, response): Promise<IKibanaResponse<ReadPrivilegesResponse>> => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const core = await context.core;
-        const securitySolution = await context.securitySolution;
-        const esClient = core.elasticsearch.client.asCurrentUser;
-        const siemClient = securitySolution?.getAppClient();
+        try {
+          const core = await context.core;
+          const securitySolution = await context.securitySolution;
+          const esClient = core.elasticsearch.client.asCurrentUser;
+          const siemClient = securitySolution?.getAppClient();
 
-        if (!siemClient) {
-          return siemResponse.error({ statusCode: 404 });
+          if (!siemClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+
+          const spaceId = securitySolution.getSpaceId();
+          const index = securitySolution
+            .getRuleDataService()
+            .getResourceName(`security.alerts-${spaceId}`);
+          const clusterPrivileges = await readPrivileges(esClient, index);
+          const privileges = merge(clusterPrivileges, {
+            is_authenticated: request.auth.isAuthenticated ?? false,
+            has_encryption_key: hasEncryptionKey,
+          });
+
+          return response.ok({ body: privileges });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-
-        const spaceId = securitySolution.getSpaceId();
-        const index = securitySolution
-          .getRuleDataService()
-          .getResourceName(`security.alerts-${spaceId}`);
-        const clusterPrivileges = await readPrivileges(esClient, index);
-        const privileges = merge(clusterPrivileges, {
-          is_authenticated: request.auth.isAuthenticated ?? false,
-          has_encryption_key: hasEncryptionKey,
-        });
-
-        return response.ok({ body: privileges });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/create_signals_migration_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/create_signals_migration_route.ts
@@ -24,123 +24,129 @@ export const createSignalsMigrationRoute = (
   router: SecuritySolutionPluginRouter,
   security: SetupPlugins['security']
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_SIGNALS_MIGRATION_URL,
-      validate: {
-        body: buildRouteValidation(createSignalsMigrationSchema),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
-      const { index: indices, ...reindexOptions } = request.body;
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: { request: { body: buildRouteValidation(createSignalsMigrationSchema) } },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
+        const { index: indices, ...reindexOptions } = request.body;
 
-      try {
-        const core = await context.core;
-        const securitySolution = await context.securitySolution;
+        try {
+          const core = await context.core;
+          const securitySolution = await context.securitySolution;
 
-        const esClient = core.elasticsearch.client.asCurrentUser;
-        const soClient = core.savedObjects.client;
-        const appClient = securitySolution?.getAppClient();
-        if (!appClient) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const user = await security?.authc.getCurrentUser(request);
-        const migrationService = signalsMigrationService({
-          esClient,
-          soClient,
-          username: user?.username ?? 'elastic',
-        });
+          const esClient = core.elasticsearch.client.asCurrentUser;
+          const soClient = core.savedObjects.client;
+          const appClient = securitySolution?.getAppClient();
+          if (!appClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+          const user = await security?.authc.getCurrentUser(request);
+          const migrationService = signalsMigrationService({
+            esClient,
+            soClient,
+            username: user?.username ?? 'elastic',
+          });
 
-        const signalsAlias = appClient.getSignalsIndex();
-        const currentVersion = await getTemplateVersion({
-          alias: signalsAlias,
-          esClient,
-        });
+          const signalsAlias = appClient.getSignalsIndex();
+          const currentVersion = await getTemplateVersion({
+            alias: signalsAlias,
+            esClient,
+          });
 
-        if (isOutdated({ current: currentVersion, target: SIGNALS_TEMPLATE_VERSION })) {
-          throw new BadRequestError(
-            `Cannot migrate due to the signals template being out of date. Latest version: [${SIGNALS_TEMPLATE_VERSION}], template version: [${currentVersion}]. Please visit Detections to automatically update your template, then try again.`
+          if (isOutdated({ current: currentVersion, target: SIGNALS_TEMPLATE_VERSION })) {
+            throw new BadRequestError(
+              `Cannot migrate due to the signals template being out of date. Latest version: [${SIGNALS_TEMPLATE_VERSION}], template version: [${currentVersion}]. Please visit Detections to automatically update your template, then try again.`
+            );
+          }
+
+          const signalsIndexAliases = await getIndexAliases({ esClient, alias: signalsAlias });
+
+          const nonSignalsIndices = indices.filter(
+            (index) => !signalsIndexAliases.some((alias) => alias.index === index)
           );
-        }
+          if (nonSignalsIndices.length > 0) {
+            throw new BadRequestError(
+              `The following indices are not signals indices and cannot be migrated: [${nonSignalsIndices.join()}].`
+            );
+          }
 
-        const signalsIndexAliases = await getIndexAliases({ esClient, alias: signalsAlias });
+          const indexVersionsByIndex = await getIndexVersionsByIndex({ esClient, index: indices });
+          const signalVersionsByIndex = await getSignalVersionsByIndex({
+            esClient,
+            index: indices,
+          });
 
-        const nonSignalsIndices = indices.filter(
-          (index) => !signalsIndexAliases.some((alias) => alias.index === index)
-        );
-        if (nonSignalsIndices.length > 0) {
-          throw new BadRequestError(
-            `The following indices are not signals indices and cannot be migrated: [${nonSignalsIndices.join()}].`
-          );
-        }
+          const migrationResults = await Promise.all(
+            indices.map(async (index) => {
+              const indexVersion = indexVersionsByIndex[index] ?? 0;
+              const signalVersions = signalVersionsByIndex[index] ?? [];
 
-        const indexVersionsByIndex = await getIndexVersionsByIndex({ esClient, index: indices });
-        const signalVersionsByIndex = await getSignalVersionsByIndex({ esClient, index: indices });
-
-        const migrationResults = await Promise.all(
-          indices.map(async (index) => {
-            const indexVersion = indexVersionsByIndex[index] ?? 0;
-            const signalVersions = signalVersionsByIndex[index] ?? [];
-
-            if (
-              isOutdated({ current: indexVersion, target: currentVersion }) ||
-              signalsAreOutdated({ signalVersions, target: currentVersion })
-            ) {
-              try {
-                const isWriteIndex = signalsIndexAliases.some(
-                  (alias) => alias.isWriteIndex && alias.index === index
-                );
-                if (isWriteIndex) {
-                  throw new BadRequestError(
-                    'The specified index is a write index and cannot be migrated.'
+              if (
+                isOutdated({ current: indexVersion, target: currentVersion }) ||
+                signalsAreOutdated({ signalVersions, target: currentVersion })
+              ) {
+                try {
+                  const isWriteIndex = signalsIndexAliases.some(
+                    (alias) => alias.isWriteIndex && alias.index === index
                   );
+                  if (isWriteIndex) {
+                    throw new BadRequestError(
+                      'The specified index is a write index and cannot be migrated.'
+                    );
+                  }
+
+                  const migration = await migrationService.create({
+                    index,
+                    reindexOptions,
+                    version: currentVersion,
+                  });
+
+                  return {
+                    index: migration.attributes.sourceIndex,
+                    migration_id: migration.id,
+                    migration_index: migration.attributes.destinationIndex,
+                  };
+                } catch (err) {
+                  const error = transformError(err);
+                  return {
+                    index,
+                    error: {
+                      message: error.message,
+                      status_code: error.statusCode,
+                    },
+                    migration_id: null,
+                    migration_index: null,
+                  };
                 }
-
-                const migration = await migrationService.create({
-                  index,
-                  reindexOptions,
-                  version: currentVersion,
-                });
-
-                return {
-                  index: migration.attributes.sourceIndex,
-                  migration_id: migration.id,
-                  migration_index: migration.attributes.destinationIndex,
-                };
-              } catch (err) {
-                const error = transformError(err);
+              } else {
                 return {
                   index,
-                  error: {
-                    message: error.message,
-                    status_code: error.statusCode,
-                  },
                   migration_id: null,
                   migration_index: null,
                 };
               }
-            } else {
-              return {
-                index,
-                migration_id: null,
-                migration_index: null,
-              };
-            }
-          })
-        );
+            })
+          );
 
-        return response.ok({ body: { indices: migrationResults } });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({ body: { indices: migrationResults } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/delete_signals_migration_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/delete_signals_migration_route.ts
@@ -20,86 +20,89 @@ export const deleteSignalsMigrationRoute = (
   router: SecuritySolutionPluginRouter,
   security: SetupPlugins['security']
 ) => {
-  router.delete(
-    {
+  router.versioned
+    .delete({
       path: DETECTION_ENGINE_SIGNALS_MIGRATION_URL,
-      validate: {
-        body: buildRouteValidation(deleteSignalsMigrationSchema),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
-      const { migration_ids: migrationIds } = request.body;
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: { request: { body: buildRouteValidation(deleteSignalsMigrationSchema) } },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
+        const { migration_ids: migrationIds } = request.body;
 
-      try {
-        const core = await context.core;
-        const securitySolution = await context.securitySolution;
+        try {
+          const core = await context.core;
+          const securitySolution = await context.securitySolution;
 
-        const esClient = core.elasticsearch.client.asCurrentUser;
-        const soClient = core.savedObjects.client;
-        const appClient = securitySolution?.getAppClient();
-        if (!appClient) {
-          return siemResponse.error({ statusCode: 404 });
+          const esClient = core.elasticsearch.client.asCurrentUser;
+          const soClient = core.savedObjects.client;
+          const appClient = securitySolution?.getAppClient();
+          if (!appClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+
+          const user = await security?.authc.getCurrentUser(request);
+          const migrationService = signalsMigrationService({
+            esClient,
+            soClient,
+            username: user?.username ?? 'elastic',
+          });
+
+          const signalsAlias = appClient.getSignalsIndex();
+          const migrations = await getMigrationSavedObjectsById({
+            ids: migrationIds,
+            soClient,
+          });
+
+          const deletionResults = await Promise.all(
+            migrations.map(async (migration) => {
+              try {
+                const deletedMigration = await migrationService.delete({
+                  migration,
+                  signalsAlias,
+                });
+
+                return {
+                  id: deletedMigration.id,
+                  destinationIndex: deletedMigration.attributes.destinationIndex,
+                  status: deletedMigration.attributes.status,
+                  sourceIndex: deletedMigration.attributes.sourceIndex,
+                  version: deletedMigration.attributes.version,
+                  updated: deletedMigration.attributes.updated,
+                };
+              } catch (err) {
+                const error = transformError(err);
+                return {
+                  id: migration.id,
+                  destinationIndex: migration.attributes.destinationIndex,
+                  error: {
+                    message: error.message,
+                    status_code: error.statusCode,
+                  },
+                  status: migration.attributes.status,
+                  sourceIndex: migration.attributes.sourceIndex,
+                  version: migration.attributes.version,
+                  updated: migration.attributes.updated,
+                };
+              }
+            })
+          );
+
+          return response.ok({ body: { migrations: deletionResults } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-
-        const user = await security?.authc.getCurrentUser(request);
-        const migrationService = signalsMigrationService({
-          esClient,
-          soClient,
-          username: user?.username ?? 'elastic',
-        });
-
-        const signalsAlias = appClient.getSignalsIndex();
-        const migrations = await getMigrationSavedObjectsById({
-          ids: migrationIds,
-          soClient,
-        });
-
-        const deletionResults = await Promise.all(
-          migrations.map(async (migration) => {
-            try {
-              const deletedMigration = await migrationService.delete({
-                migration,
-                signalsAlias,
-              });
-
-              return {
-                id: deletedMigration.id,
-                destinationIndex: deletedMigration.attributes.destinationIndex,
-                status: deletedMigration.attributes.status,
-                sourceIndex: deletedMigration.attributes.sourceIndex,
-                version: deletedMigration.attributes.version,
-                updated: deletedMigration.attributes.updated,
-              };
-            } catch (err) {
-              const error = transformError(err);
-              return {
-                id: migration.id,
-                destinationIndex: migration.attributes.destinationIndex,
-                error: {
-                  message: error.message,
-                  status_code: error.statusCode,
-                },
-                status: migration.attributes.status,
-                sourceIndex: migration.attributes.sourceIndex,
-                version: migration.attributes.version,
-                updated: migration.attributes.updated,
-              };
-            }
-          })
-        );
-
-        return response.ok({ body: { migrations: deletionResults } });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/finalize_signals_migration_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/finalize_signals_migration_route.ts
@@ -23,95 +23,98 @@ export const finalizeSignalsMigrationRoute = (
   ruleDataService: RuleDataPluginService,
   security: SetupPlugins['security']
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_SIGNALS_FINALIZE_MIGRATION_URL,
-      validate: {
-        body: buildRouteValidation(finalizeSignalsMigrationSchema),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: { request: { body: buildRouteValidation(finalizeSignalsMigrationSchema) } },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      const core = await context.core;
-      const securitySolution = await context.securitySolution;
+        const core = await context.core;
+        const securitySolution = await context.securitySolution;
 
-      const esClient = core.elasticsearch.client.asCurrentUser;
-      const soClient = core.savedObjects.client;
-      const { migration_ids: migrationIds } = request.body;
+        const esClient = core.elasticsearch.client.asCurrentUser;
+        const soClient = core.savedObjects.client;
+        const { migration_ids: migrationIds } = request.body;
 
-      try {
-        const appClient = securitySolution?.getAppClient();
-        if (!appClient) {
-          return siemResponse.error({ statusCode: 404 });
-        }
-        const user = await security?.authc.getCurrentUser(request);
-        const migrationService = signalsMigrationService({
-          esClient,
-          soClient,
-          username: user?.username ?? 'elastic',
-        });
-        const migrations = await getMigrationSavedObjectsById({
-          ids: migrationIds,
-          soClient,
-        });
+        try {
+          const appClient = securitySolution?.getAppClient();
+          if (!appClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+          const user = await security?.authc.getCurrentUser(request);
+          const migrationService = signalsMigrationService({
+            esClient,
+            soClient,
+            username: user?.username ?? 'elastic',
+          });
+          const migrations = await getMigrationSavedObjectsById({
+            ids: migrationIds,
+            soClient,
+          });
 
-        const spaceId = securitySolution.getSpaceId();
-        const signalsAlias = ruleDataService.getResourceName(`security.alerts-${spaceId}`);
-        const finalizeResults = await Promise.all(
-          migrations.map(async (migration) => {
-            try {
-              const finalizedMigration = await migrationService.finalize({
-                migration,
-                signalsAlias,
-              });
+          const spaceId = securitySolution.getSpaceId();
+          const signalsAlias = ruleDataService.getResourceName(`security.alerts-${spaceId}`);
+          const finalizeResults = await Promise.all(
+            migrations.map(async (migration) => {
+              try {
+                const finalizedMigration = await migrationService.finalize({
+                  migration,
+                  signalsAlias,
+                });
 
-              if (isMigrationFailed(finalizedMigration)) {
-                throw new BadRequestError(
-                  finalizedMigration.attributes.error ?? 'The migration was not successful.'
-                );
+                if (isMigrationFailed(finalizedMigration)) {
+                  throw new BadRequestError(
+                    finalizedMigration.attributes.error ?? 'The migration was not successful.'
+                  );
+                }
+
+                return {
+                  id: finalizedMigration.id,
+                  completed: !isMigrationPending(finalizedMigration),
+                  destinationIndex: finalizedMigration.attributes.destinationIndex,
+                  status: finalizedMigration.attributes.status,
+                  sourceIndex: finalizedMigration.attributes.sourceIndex,
+                  version: finalizedMigration.attributes.version,
+                  updated: finalizedMigration.attributes.updated,
+                };
+              } catch (err) {
+                const error = transformError(err);
+                return {
+                  id: migration.id,
+                  destinationIndex: migration.attributes.destinationIndex,
+                  error: {
+                    message: error.message,
+                    status_code: error.statusCode,
+                  },
+                  status: migration.attributes.status,
+                  sourceIndex: migration.attributes.sourceIndex,
+                  version: migration.attributes.version,
+                  updated: migration.attributes.updated,
+                };
               }
+            })
+          );
 
-              return {
-                id: finalizedMigration.id,
-                completed: !isMigrationPending(finalizedMigration),
-                destinationIndex: finalizedMigration.attributes.destinationIndex,
-                status: finalizedMigration.attributes.status,
-                sourceIndex: finalizedMigration.attributes.sourceIndex,
-                version: finalizedMigration.attributes.version,
-                updated: finalizedMigration.attributes.updated,
-              };
-            } catch (err) {
-              const error = transformError(err);
-              return {
-                id: migration.id,
-                destinationIndex: migration.attributes.destinationIndex,
-                error: {
-                  message: error.message,
-                  status_code: error.statusCode,
-                },
-                status: migration.attributes.status,
-                sourceIndex: migration.attributes.sourceIndex,
-                version: migration.attributes.version,
-                updated: migration.attributes.updated,
-              };
-            }
-          })
-        );
-
-        return response.ok({
-          body: { migrations: finalizeResults },
-        });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+          return response.ok({
+            body: { migrations: finalizeResults },
+          });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/get_signals_migration_status_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/get_signals_migration_status_route.ts
@@ -19,83 +19,86 @@ import { getTemplateVersion } from '../index/check_template_version';
 import { buildSiemResponse } from '../utils';
 
 export const getSignalsMigrationStatusRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: DETECTION_ENGINE_SIGNALS_MIGRATION_STATUS_URL,
-      validate: {
-        query: buildRouteValidation(getSignalsMigrationStatusSchema),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: { request: { query: buildRouteValidation(getSignalsMigrationStatusSchema) } },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      const core = await context.core;
-      const securitySolution = await context.securitySolution;
+        const core = await context.core;
+        const securitySolution = await context.securitySolution;
 
-      const esClient = core.elasticsearch.client.asCurrentUser;
-      const soClient = core.savedObjects.client;
+        const esClient = core.elasticsearch.client.asCurrentUser;
+        const soClient = core.savedObjects.client;
 
-      try {
-        const appClient = securitySolution?.getAppClient();
-        if (!appClient) {
-          return siemResponse.error({ statusCode: 404 });
+        try {
+          const appClient = securitySolution?.getAppClient();
+          if (!appClient) {
+            return siemResponse.error({ statusCode: 404 });
+          }
+          const { from } = request.query;
+
+          const signalsAlias = appClient.getSignalsIndex();
+          const currentVersion = await getTemplateVersion({ alias: signalsAlias, esClient });
+          const indexAliases = await getIndexAliases({ alias: signalsAlias, esClient });
+          const signalsIndices = indexAliases.map((indexAlias) => indexAlias.index);
+          const indicesInRange = await getSignalsIndicesInRange({
+            esClient,
+            index: signalsIndices,
+            from,
+          });
+          const migrationsByIndex = await getMigrationSavedObjectsByIndex({
+            index: indicesInRange,
+            soClient,
+          });
+          const indexVersionsByIndex = await getIndexVersionsByIndex({
+            esClient,
+            index: indicesInRange,
+          });
+          const signalVersionsByIndex = await getSignalVersionsByIndex({
+            esClient,
+            index: indicesInRange,
+          });
+
+          const indexStatuses = indicesInRange.map((index) => {
+            const version = indexVersionsByIndex[index] ?? 0;
+            const signalVersions = signalVersionsByIndex[index] ?? [];
+            const migrations = migrationsByIndex[index] ?? [];
+
+            return {
+              index,
+              version,
+              signal_versions: signalVersions,
+              migrations: migrations.map((m) => ({
+                id: m.id,
+                status: m.attributes.status,
+                version: m.attributes.version,
+                updated: m.attributes.updated,
+              })),
+              is_outdated:
+                isOutdated({ current: version, target: currentVersion }) ||
+                signalsAreOutdated({ signalVersions, target: currentVersion }),
+            };
+          });
+
+          return response.ok({ body: { indices: indexStatuses } });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
-        const { from } = request.query;
-
-        const signalsAlias = appClient.getSignalsIndex();
-        const currentVersion = await getTemplateVersion({ alias: signalsAlias, esClient });
-        const indexAliases = await getIndexAliases({ alias: signalsAlias, esClient });
-        const signalsIndices = indexAliases.map((indexAlias) => indexAlias.index);
-        const indicesInRange = await getSignalsIndicesInRange({
-          esClient,
-          index: signalsIndices,
-          from,
-        });
-        const migrationsByIndex = await getMigrationSavedObjectsByIndex({
-          index: indicesInRange,
-          soClient,
-        });
-        const indexVersionsByIndex = await getIndexVersionsByIndex({
-          esClient,
-          index: indicesInRange,
-        });
-        const signalVersionsByIndex = await getSignalVersionsByIndex({
-          esClient,
-          index: indicesInRange,
-        });
-
-        const indexStatuses = indicesInRange.map((index) => {
-          const version = indexVersionsByIndex[index] ?? 0;
-          const signalVersions = signalVersionsByIndex[index] ?? [];
-          const migrations = migrationsByIndex[index] ?? [];
-
-          return {
-            index,
-            version,
-            signal_versions: signalVersions,
-            migrations: migrations.map((m) => ({
-              id: m.id,
-              status: m.attributes.status,
-              version: m.attributes.version,
-              updated: m.attributes.updated,
-            })),
-            is_outdated:
-              isOutdated({ current: version, target: currentVersion }) ||
-              signalsAreOutdated({ signalVersions, target: currentVersion }),
-          };
-        });
-
-        return response.ok({ body: { indices: indexStatuses } });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/open_close_signals_route.ts
@@ -35,84 +35,92 @@ export const setSignalsStatusRoute = (
   security: SetupPlugins['security'],
   sender: ITelemetryEventsSender
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_SIGNALS_STATUS_URL,
-      validate: {
-        body: buildRouteValidation<typeof setSignalsStatusSchema, SetSignalsStatusSchemaDecoded>(
-          setSignalsStatusSchema
-        ),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const { conflicts, signal_ids: signalIds, query, status } = request.body;
-      const core = await context.core;
-      const securitySolution = await context.securitySolution;
-      const esClient = core.elasticsearch.client.asCurrentUser;
-      const siemClient = securitySolution?.getAppClient();
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = setSignalStatusValidateTypeDependents(request.body);
-      const spaceId = securitySolution?.getSpaceId() ?? 'default';
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation<
+              typeof setSignalsStatusSchema,
+              SetSignalsStatusSchemaDecoded
+            >(setSignalsStatusSchema),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const { conflicts, signal_ids: signalIds, query, status } = request.body;
+        const core = await context.core;
+        const securitySolution = await context.securitySolution;
+        const esClient = core.elasticsearch.client.asCurrentUser;
+        const siemClient = securitySolution?.getAppClient();
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = setSignalStatusValidateTypeDependents(request.body);
+        const spaceId = securitySolution?.getSpaceId() ?? 'default';
 
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
+        }
 
-      if (!siemClient) {
-        return siemResponse.error({ statusCode: 404 });
-      }
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
-      const clusterId = sender.getClusterID();
-      const [isTelemetryOptedIn, username] = await Promise.all([
-        sender.isTelemetryOptedIn(),
-        security?.authc.getCurrentUser(request)?.username,
-      ]);
-      if (isTelemetryOptedIn && clusterId) {
-        // Sometimes the ids are in the query not passed in the request?
-        const toSendAlertIds = get(query, 'bool.filter.terms._id') || signalIds;
-        // Get Context for Insights Payloads
-        const sessionId = getSessionIDfromKibanaRequest(clusterId, request);
-        if (username && toSendAlertIds && sessionId && status) {
-          const insightsPayloads = createAlertStatusPayloads(
-            clusterId,
-            toSendAlertIds,
-            sessionId,
-            username,
-            DETECTION_ENGINE_SIGNALS_STATUS_URL,
-            status
-          );
-          logger.debug(`Sending Insights Payloads ${JSON.stringify(insightsPayloads)}`);
-          await sender.sendOnDemand(INSIGHTS_CHANNEL, insightsPayloads);
+        const clusterId = sender.getClusterID();
+        const [isTelemetryOptedIn, username] = await Promise.all([
+          sender.isTelemetryOptedIn(),
+          security?.authc.getCurrentUser(request)?.username,
+        ]);
+        if (isTelemetryOptedIn && clusterId) {
+          // Sometimes the ids are in the query not passed in the request?
+          const toSendAlertIds = get(query, 'bool.filter.terms._id') || signalIds;
+          // Get Context for Insights Payloads
+          const sessionId = getSessionIDfromKibanaRequest(clusterId, request);
+          if (username && toSendAlertIds && sessionId && status) {
+            const insightsPayloads = createAlertStatusPayloads(
+              clusterId,
+              toSendAlertIds,
+              sessionId,
+              username,
+              DETECTION_ENGINE_SIGNALS_STATUS_URL,
+              status
+            );
+            logger.debug(`Sending Insights Payloads ${JSON.stringify(insightsPayloads)}`);
+            await sender.sendOnDemand(INSIGHTS_CHANNEL, insightsPayloads);
+          }
+        }
+
+        try {
+          if (signalIds) {
+            const body = await updateSignalsStatusByIds(status, signalIds, spaceId, esClient);
+            return response.ok({ body });
+          } else {
+            const body = await updateSignalsStatusByQuery(
+              status,
+              query,
+              { conflicts: conflicts ?? 'abort' },
+              spaceId,
+              esClient
+            );
+            return response.ok({ body });
+          }
+        } catch (err) {
+          // error while getting or updating signal with id: id in signal index .siem-signals
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
         }
       }
-
-      try {
-        if (signalIds) {
-          const body = await updateSignalsStatusByIds(status, signalIds, spaceId, esClient);
-          return response.ok({ body });
-        } else {
-          const body = await updateSignalsStatusByQuery(
-            status,
-            query,
-            { conflicts: conflicts ?? 'abort' },
-            spaceId,
-            esClient
-          );
-          return response.ok({ body });
-        }
-      } catch (err) {
-        // error while getting or updating signal with id: id in signal index .siem-signals
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
-      }
-    }
-  );
+    );
 };
 
 const updateSignalsStatusByIds = async (

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/query_signals_route.ts
@@ -20,63 +20,70 @@ export const querySignalsRoute = (
   router: SecuritySolutionPluginRouter,
   ruleDataClient: IRuleDataClient | null
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_QUERY_SIGNALS_URL,
-      validate: {
-        body: buildRouteValidation<typeof querySignalsSchema, QuerySignalsSchemaDecoded>(
-          querySignalsSchema
-        ),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      const { query, aggs, _source, fields, track_total_hits, size, runtime_mappings, sort } =
-        request.body;
-      const siemResponse = buildSiemResponse(response);
-      if (
-        query == null &&
-        aggs == null &&
-        _source == null &&
-        fields == null &&
-        track_total_hits == null &&
-        size == null &&
-        sort == null
-      ) {
-        return siemResponse.error({
-          statusCode: 400,
-          body: '"value" must have at least 1 children',
-        });
-      }
-
-      try {
-        const spaceId = (await context.securitySolution).getSpaceId();
-        const result = await ruleDataClient?.getReader({ namespace: spaceId }).search({
-          body: {
-            query,
-            // Note: I use a spread operator to please TypeScript with aggs: { ...aggs }
-            aggs: { ...aggs },
-            _source,
-            fields,
-            track_total_hits,
-            size,
-            runtime_mappings: runtime_mappings as MappingRuntimeFields,
-            sort: sort as Sort,
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation<typeof querySignalsSchema, QuerySignalsSchemaDecoded>(
+              querySignalsSchema
+            ),
           },
-          ignore_unavailable: true,
-        });
-        return response.ok({ body: result });
-      } catch (err) {
-        // error while getting or updating signal with id: id in signal index .siem-signals
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+        },
+      },
+      async (context, request, response) => {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        const { query, aggs, _source, fields, track_total_hits, size, runtime_mappings, sort } =
+          request.body;
+        const siemResponse = buildSiemResponse(response);
+        if (
+          query == null &&
+          aggs == null &&
+          _source == null &&
+          fields == null &&
+          track_total_hits == null &&
+          size == null &&
+          sort == null
+        ) {
+          return siemResponse.error({
+            statusCode: 400,
+            body: '"value" must have at least 1 children',
+          });
+        }
+
+        try {
+          const spaceId = (await context.securitySolution).getSpaceId();
+          const result = await ruleDataClient?.getReader({ namespace: spaceId }).search({
+            body: {
+              query,
+              // Note: I use a spread operator to please TypeScript with aggs: { ...aggs }
+              aggs: { ...aggs },
+              _source,
+              fields,
+              track_total_hits,
+              size,
+              runtime_mappings: runtime_mappings as MappingRuntimeFields,
+              sort: sort as Sort,
+            },
+            ignore_unavailable: true,
+          });
+          return response.ok({ body: result });
+        } catch (err) {
+          // error while getting or updating signal with id: id in signal index .siem-signals
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/set_alert_tags_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/set_alert_tags_route.ts
@@ -19,42 +19,50 @@ import { buildRouteValidation } from '../../../../utils/build_validation/route_v
 import { validateAlertTagsArrays } from './helpers';
 
 export const setAlertTagsRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_ALERT_TAGS_URL,
-      validate: {
-        body: buildRouteValidation<typeof setAlertTagsRequestBody, SetAlertTagsRequestBodyDecoded>(
-          setAlertTagsRequestBody
-        ),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const { tags, ids } = request.body;
-      const core = await context.core;
-      const securitySolution = await context.securitySolution;
-      const esClient = core.elasticsearch.client.asCurrentUser;
-      const siemClient = securitySolution?.getAppClient();
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = validateAlertTagsArrays(tags, ids);
-      const spaceId = securitySolution?.getSpaceId() ?? 'default';
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            body: buildRouteValidation<
+              typeof setAlertTagsRequestBody,
+              SetAlertTagsRequestBodyDecoded
+            >(setAlertTagsRequestBody),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const { tags, ids } = request.body;
+        const core = await context.core;
+        const securitySolution = await context.securitySolution;
+        const esClient = core.elasticsearch.client.asCurrentUser;
+        const siemClient = securitySolution?.getAppClient();
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = validateAlertTagsArrays(tags, ids);
+        const spaceId = securitySolution?.getSpaceId() ?? 'default';
 
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
+        }
 
-      if (!siemClient) {
-        return siemResponse.error({ statusCode: 404 });
-      }
+        if (!siemClient) {
+          return siemResponse.error({ statusCode: 404 });
+        }
 
-      const tagsToAdd = uniq(tags.tags_to_add);
-      const tagsToRemove = uniq(tags.tags_to_remove);
+        const tagsToAdd = uniq(tags.tags_to_add);
+        const tagsToRemove = uniq(tags.tags_to_remove);
 
-      const painlessScript = {
-        params: { tagsToAdd, tagsToRemove },
-        source: `List newTagsArray = [];
+        const painlessScript = {
+          params: { tagsToAdd, tagsToRemove },
+          source: `List newTagsArray = [];
         if (ctx._source["kibana.alert.workflow_tags"] != null) {
           for (tag in ctx._source["kibana.alert.workflow_tags"]) {
             if (!params.tagsToRemove.contains(tag)) {
@@ -71,45 +79,45 @@ export const setAlertTagsRoute = (router: SecuritySolutionPluginRouter) => {
           ctx._source["kibana.alert.workflow_tags"] = params.tagsToAdd;
         }
         `,
-        lang: 'painless',
-      };
+          lang: 'painless',
+        };
 
-      const bulkUpdateRequest = [];
-      for (const id of ids) {
-        bulkUpdateRequest.push(
-          {
-            update: {
-              _index: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
-              _id: id,
-            },
-          },
-          {
-            script: painlessScript,
-          }
-        );
-      }
-
-      try {
-        const body = await esClient.updateByQuery({
-          index: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
-          refresh: false,
-          body: {
-            script: painlessScript,
-            query: {
-              bool: {
-                filter: { terms: { _id: ids } },
+        const bulkUpdateRequest = [];
+        for (const id of ids) {
+          bulkUpdateRequest.push(
+            {
+              update: {
+                _index: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
+                _id: id,
               },
             },
-          },
-        });
-        return response.ok({ body });
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
+            {
+              script: painlessScript,
+            }
+          );
+        }
+
+        try {
+          const body = await esClient.updateByQuery({
+            index: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
+            refresh: false,
+            body: {
+              script: painlessScript,
+              query: {
+                bool: {
+                  filter: { terms: { _id: ids } },
+                },
+              },
+            },
+          });
+          return response.ok({ body });
+        } catch (err) {
+          const error = transformError(err);
+          return siemResponse.error({
+            body: error.message,
+            statusCode: error.statusCode,
+          });
+        }
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/telemetry/telemetry_detection_rules_preview_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/telemetry/telemetry_detection_rules_preview_route.ts
@@ -22,47 +22,52 @@ export const telemetryDetectionRulesPreviewRoute = (
   telemetryReceiver: ITelemetryReceiver,
   telemetrySender: ITelemetryEventsSender
 ) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: SECURITY_TELEMETRY_URL,
-      validate: false,
+      access: 'internal',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const detectionRules = await getDetectionRulesPreview({
-        logger,
-        telemetryReceiver,
-        telemetrySender,
-      });
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: false,
+      },
+      async (context, request, response) => {
+        const detectionRules = await getDetectionRulesPreview({
+          logger,
+          telemetryReceiver,
+          telemetrySender,
+        });
 
-      const securityLists = await getSecurityListsPreview({
-        logger,
-        telemetryReceiver,
-        telemetrySender,
-      });
+        const securityLists = await getSecurityListsPreview({
+          logger,
+          telemetryReceiver,
+          telemetrySender,
+        });
 
-      const endpoints = await getEndpointPreview({
-        logger,
-        telemetryReceiver,
-        telemetrySender,
-      });
+        const endpoints = await getEndpointPreview({
+          logger,
+          telemetryReceiver,
+          telemetrySender,
+        });
 
-      const diagnostics = await getDiagnosticsPreview({
-        logger,
-        telemetryReceiver,
-        telemetrySender,
-      });
+        const diagnostics = await getDiagnosticsPreview({
+          logger,
+          telemetryReceiver,
+          telemetrySender,
+        });
 
-      return response.ok({
-        body: {
-          detection_rules: detectionRules,
-          security_lists: securityLists,
-          endpoints,
-          diagnostics,
-        },
-      });
-    }
-  );
+        return response.ok({
+          body: {
+            detection_rules: detectionRules,
+            security_lists: securityLists,
+            endpoints,
+            diagnostics,
+          },
+        });
+      }
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/api/create_legacy_notification/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_actions_legacy/api/create_legacy_notification/route.ts
@@ -17,6 +17,7 @@ import { legacyReadNotifications } from '../../logic/notifications/legacy_read_n
 import type { LegacyRuleNotificationAlertTypeParams } from '../../logic/notifications/legacy_types';
 // eslint-disable-next-line no-restricted-imports
 import { legacyCreateNotifications } from '../../logic/notifications/legacy_create_notifications';
+import { UPDATE_OR_CREATE_LEGACY_ACTIONS } from '../../../../../../common/constants';
 
 /**
  * Given an "alert_id" and a valid "action_id" this will create a legacy notification. This is for testing
@@ -29,86 +30,93 @@ export const legacyCreateLegacyNotificationRoute = (
   router: SecuritySolutionPluginRouter,
   logger: Logger
 ): void => {
-  router.post(
-    {
-      path: '/internal/api/detection/legacy/notifications',
-      validate: {
-        query: schema.object({ alert_id: schema.string() }),
-        body: schema.object({
-          name: schema.string(),
-          interval: schema.string(),
-          actions: schema.arrayOf(
-            schema.object({
-              id: schema.string(),
-              group: schema.string(),
-              params: schema.object({
-                message: schema.string(),
-              }),
-              actionTypeId: schema.string(),
-            })
-          ),
-        }),
-      },
+  router.versioned
+    .post({
+      path: UPDATE_OR_CREATE_LEGACY_ACTIONS,
+      access: 'internal',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const rulesClient = (await context.alerting).getRulesClient();
-      const savedObjectsClient = (await context.core).savedObjects.client;
-      const { alert_id: ruleAlertId } = request.query;
-      const { actions, interval, name } = request.body;
-      try {
-        // This is to ensure it exists before continuing.
-        await rulesClient.get({ id: ruleAlertId });
-        const notification = await legacyReadNotifications({
-          rulesClient,
-          id: undefined,
-          ruleAlertId,
-        });
-        if (notification != null) {
-          await rulesClient.update<LegacyRuleNotificationAlertTypeParams>({
-            id: notification.id,
-            data: {
-              tags: [],
-              name,
-              schedule: {
-                interval,
-              },
-              actions,
-              params: {
-                ruleAlertId,
-              },
-              throttle: null,
-              notifyWhen: null,
-            },
-          });
-        } else {
-          await legacyCreateNotifications({
-            rulesClient,
-            actions,
-            enabled: true,
-            ruleAlertId,
-            interval,
-            name,
-          });
-        }
-        await legacyUpdateOrCreateRuleActionsSavedObject({
-          ruleAlertId,
-          savedObjectsClient,
-          actions,
-          throttle: interval,
-          logger,
-        });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'unknown';
-        return response.badRequest({ body: message });
-      }
-      return response.ok({
-        body: {
-          ok: 'acknowledged',
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            query: schema.object({ alert_id: schema.string() }),
+            body: schema.object({
+              name: schema.string(),
+              interval: schema.string(),
+              actions: schema.arrayOf(
+                schema.object({
+                  id: schema.string(),
+                  group: schema.string(),
+                  params: schema.object({
+                    message: schema.string(),
+                  }),
+                  actionTypeId: schema.string(),
+                })
+              ),
+            }),
+          },
         },
-      });
-    }
-  );
+      },
+      async (context, request, response) => {
+        const rulesClient = (await context.alerting).getRulesClient();
+        const savedObjectsClient = (await context.core).savedObjects.client;
+        const { alert_id: ruleAlertId } = request.query;
+        const { actions, interval, name } = request.body;
+        try {
+          // This is to ensure it exists before continuing.
+          await rulesClient.get({ id: ruleAlertId });
+          const notification = await legacyReadNotifications({
+            rulesClient,
+            id: undefined,
+            ruleAlertId,
+          });
+          if (notification != null) {
+            await rulesClient.update<LegacyRuleNotificationAlertTypeParams>({
+              id: notification.id,
+              data: {
+                tags: [],
+                name,
+                schedule: {
+                  interval,
+                },
+                actions,
+                params: {
+                  ruleAlertId,
+                },
+                throttle: null,
+                notifyWhen: null,
+              },
+            });
+          } else {
+            await legacyCreateNotifications({
+              rulesClient,
+              actions,
+              enabled: true,
+              ruleAlertId,
+              interval,
+              name,
+            });
+          }
+          await legacyUpdateOrCreateRuleActionsSavedObject({
+            ruleAlertId,
+            savedObjectsClient,
+            actions,
+            throttle: interval,
+            logger,
+          });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : 'unknown';
+          return response.badRequest({ body: message });
+        }
+        return response.ok({
+          body: {
+            ok: 'acknowledged',
+          },
+        });
+      }
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions/api/create_rule_exceptions/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions/api/create_rule_exceptions/route.ts
@@ -47,71 +47,83 @@ import { buildSiemResponse } from '../../../routes/utils';
 import { buildRouteValidation } from '../../../../../utils/build_validation/route_validation';
 
 export const createRuleExceptionsRoute = (router: SecuritySolutionPluginRouter) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: CREATE_RULE_EXCEPTIONS_URL,
-      validate: {
-        params: buildRouteValidation<
-          typeof CreateRuleExceptionsRequestParams,
-          CreateRuleExceptionsRequestParamsDecoded
-        >(CreateRuleExceptionsRequestParams),
-        body: buildRouteValidation<
-          typeof CreateRuleExceptionsRequestBody,
-          CreateRuleExceptionsRequestBodyDecoded
-        >(CreateRuleExceptionsRequestBody),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: {
+          request: {
+            params: buildRouteValidation<
+              typeof CreateRuleExceptionsRequestParams,
+              CreateRuleExceptionsRequestParamsDecoded
+            >(CreateRuleExceptionsRequestParams),
+            body: buildRouteValidation<
+              typeof CreateRuleExceptionsRequestBody,
+              CreateRuleExceptionsRequestBodyDecoded
+            >(CreateRuleExceptionsRequestBody),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const ctx = await context.resolve([
-          'core',
-          'securitySolution',
-          'alerting',
-          'licensing',
-          'lists',
-        ]);
-        const rulesClient = ctx.alerting.getRulesClient();
-        const listsClient = ctx.securitySolution.getExceptionListClient();
+        try {
+          const ctx = await context.resolve([
+            'core',
+            'securitySolution',
+            'alerting',
+            'licensing',
+            'lists',
+          ]);
+          const rulesClient = ctx.alerting.getRulesClient();
+          const listsClient = ctx.securitySolution.getExceptionListClient();
 
-        const { items } = request.body;
-        const { id: ruleId } = request.params;
+          const { items } = request.body;
+          const { id: ruleId } = request.params;
 
-        // Check that the rule they're trying to add an exception list to exists
-        const rule = await readRules({
-          rulesClient,
-          ruleId: undefined,
-          id: ruleId,
-        });
+          // Check that the rule they're trying to add an exception list to exists
+          const rule = await readRules({
+            rulesClient,
+            ruleId: undefined,
+            id: ruleId,
+          });
 
-        if (rule == null) {
+          if (rule == null) {
+            return siemResponse.error({
+              statusCode: 500,
+              body: `Unable to add exception to rule - rule with id:"${ruleId}" not found`,
+            });
+          }
+
+          const createdItems = await createRuleExceptions({
+            items,
+            rule,
+            listsClient,
+            rulesClient,
+          });
+
+          const [validated, errors] = validate(createdItems, t.array(exceptionListItemSchema));
+          if (errors != null) {
+            return siemResponse.error({ body: errors, statusCode: 500 });
+          } else {
+            return response.ok({ body: validated ?? {} });
+          }
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
-            statusCode: 500,
-            body: `Unable to add exception to rule - rule with id:"${ruleId}" not found`,
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-
-        const createdItems = await createRuleExceptions({ items, rule, listsClient, rulesClient });
-
-        const [validated, errors] = validate(createdItems, t.array(exceptionListItemSchema));
-        if (errors != null) {
-          return siemResponse.error({ body: errors, statusCode: 500 });
-        } else {
-          return response.ok({ body: validated ?? {} });
-        }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };
 
 export const createRuleExceptions = async ({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions/api/find_exception_references/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_exceptions/api/find_exception_references/route.ts
@@ -27,105 +27,115 @@ import { enrichFilterWithRuleTypeMapping } from '../../../rule_management/logic/
 import type { RuleParams } from '../../../rule_schema';
 
 export const findRuleExceptionReferencesRoute = (router: SecuritySolutionPluginRouter) => {
-  router.get(
-    {
+  router.versioned
+    .get({
       path: DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL,
-      validate: {
-        query: buildRouteValidation<
-          typeof findExceptionReferencesOnRuleSchema,
-          FindExceptionReferencesOnRuleSchemaDecoded
-        >(findExceptionReferencesOnRuleSchema),
-      },
+      access: 'internal',
       options: {
         tags: ['access:securitySolution'],
       },
-    },
-    async (context, request, response) => {
-      const siemResponse = buildSiemResponse(response);
+    })
+    .addVersion(
+      {
+        version: '1',
+        validate: {
+          request: {
+            query: buildRouteValidation<
+              typeof findExceptionReferencesOnRuleSchema,
+              FindExceptionReferencesOnRuleSchemaDecoded
+            >(findExceptionReferencesOnRuleSchema),
+          },
+        },
+      },
+      async (context, request, response) => {
+        const siemResponse = buildSiemResponse(response);
 
-      try {
-        const { ids, namespace_types: namespaceTypes, list_ids: listIds } = request.query;
+        try {
+          const { ids, namespace_types: namespaceTypes, list_ids: listIds } = request.query;
 
-        const ctx = await context.resolve(['core', 'securitySolution', 'alerting']);
-        const rulesClient = ctx.alerting.getRulesClient();
-        const listsClient = ctx.securitySolution.getExceptionListClient();
+          const ctx = await context.resolve(['core', 'securitySolution', 'alerting']);
+          const rulesClient = ctx.alerting.getRulesClient();
+          const listsClient = ctx.securitySolution.getExceptionListClient();
 
-        if (
-          ids != null &&
-          listIds != null &&
-          (ids.length !== namespaceTypes.length || ids.length !== listIds.length)
-        ) {
+          if (
+            ids != null &&
+            listIds != null &&
+            (ids.length !== namespaceTypes.length || ids.length !== listIds.length)
+          ) {
+            return siemResponse.error({
+              body: `"ids", "list_ids" and "namespace_types" need to have the same comma separated number of values. Expected "ids" length: ${ids.length} to equal "namespace_types" length: ${namespaceTypes.length} and "list_ids" length: ${listIds.length}.`,
+              statusCode: 400,
+            });
+          }
+
+          const fetchExact = ids != null && listIds != null;
+          const foundExceptionLists = await listsClient?.findExceptionList({
+            filter: fetchExact
+              ? `(${listIds
+                  .map(
+                    (listId, index) =>
+                      `${getSavedObjectType({
+                        namespaceType: namespaceTypes[index],
+                      })}.attributes.list_id:${listId}`
+                  )
+                  .join(' OR ')})`
+              : undefined,
+            namespaceType: namespaceTypes,
+            page: 1,
+            perPage: 10000,
+            sortField: undefined,
+            sortOrder: undefined,
+          });
+
+          if (foundExceptionLists == null) {
+            return response.ok({ body: { references: [] } });
+          }
+          const references: RuleReferencesSchema[] = await Promise.all(
+            foundExceptionLists.data.map(async (list, index) => {
+              const foundRules = await rulesClient.find<RuleParams>({
+                options: {
+                  perPage: 10000,
+                  filter: enrichFilterWithRuleTypeMapping(null),
+                  hasReference: {
+                    id: list.id,
+                    type: getSavedObjectType({ namespaceType: list.namespace_type }),
+                  },
+                },
+              });
+
+              const ruleData = foundRules.data.map(({ name, id, params }) => ({
+                name,
+                id,
+                rule_id: params.ruleId,
+                exception_lists: params.exceptionsList,
+              }));
+
+              return {
+                [list.list_id]: {
+                  ...list,
+                  referenced_rules: ruleData,
+                },
+              };
+            })
+          );
+
+          const [validated, errors] = validate(
+            { references },
+            rulesReferencedByExceptionListsSchema
+          );
+
+          if (errors != null) {
+            return siemResponse.error({ statusCode: 500, body: errors });
+          } else {
+            return response.ok({ body: validated ?? { references: [] } });
+          }
+        } catch (err) {
+          const error = transformError(err);
           return siemResponse.error({
-            body: `"ids", "list_ids" and "namespace_types" need to have the same comma separated number of values. Expected "ids" length: ${ids.length} to equal "namespace_types" length: ${namespaceTypes.length} and "list_ids" length: ${listIds.length}.`,
-            statusCode: 400,
+            body: error.message,
+            statusCode: error.statusCode,
           });
         }
-
-        const fetchExact = ids != null && listIds != null;
-        const foundExceptionLists = await listsClient?.findExceptionList({
-          filter: fetchExact
-            ? `(${listIds
-                .map(
-                  (listId, index) =>
-                    `${getSavedObjectType({
-                      namespaceType: namespaceTypes[index],
-                    })}.attributes.list_id:${listId}`
-                )
-                .join(' OR ')})`
-            : undefined,
-          namespaceType: namespaceTypes,
-          page: 1,
-          perPage: 10000,
-          sortField: undefined,
-          sortOrder: undefined,
-        });
-
-        if (foundExceptionLists == null) {
-          return response.ok({ body: { references: [] } });
-        }
-        const references: RuleReferencesSchema[] = await Promise.all(
-          foundExceptionLists.data.map(async (list, index) => {
-            const foundRules = await rulesClient.find<RuleParams>({
-              options: {
-                perPage: 10000,
-                filter: enrichFilterWithRuleTypeMapping(null),
-                hasReference: {
-                  id: list.id,
-                  type: getSavedObjectType({ namespaceType: list.namespace_type }),
-                },
-              },
-            });
-
-            const ruleData = foundRules.data.map(({ name, id, params }) => ({
-              name,
-              id,
-              rule_id: params.ruleId,
-              exception_lists: params.exceptionsList,
-            }));
-
-            return {
-              [list.list_id]: {
-                ...list,
-                referenced_rules: ruleData,
-              },
-            };
-          })
-        );
-
-        const [validated, errors] = validate({ references }, rulesReferencedByExceptionListsSchema);
-
-        if (errors != null) {
-          return siemResponse.error({ statusCode: 500, body: errors });
-        } else {
-          return response.ok({ body: validated ?? { references: [] } });
-        }
-      } catch (err) {
-        const error = transformError(err);
-        return siemResponse.error({
-          body: error.message,
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_preview/api/preview_rules/route.ts
@@ -78,407 +78,413 @@ export const previewRulesRoute = async (
   getStartServices: StartServicesAccessor<StartPlugins>,
   logger: Logger
 ) => {
-  router.post(
-    {
+  router.versioned
+    .post({
       path: DETECTION_ENGINE_RULES_PREVIEW,
-      validate: {
-        body: buildRouteValidation(previewRulesSchema),
-      },
+      access: 'public',
       options: {
         tags: ['access:securitySolution', routeLimitedConcurrencyTag(MAX_ROUTE_CONCURRENCY)],
       },
-    },
-    async (context, request, response): Promise<IKibanaResponse<PreviewResponse>> => {
-      const siemResponse = buildSiemResponse(response);
-      const validationErrors = validateCreateRuleProps(request.body);
-      const coreContext = await context.core;
-      if (validationErrors.length) {
-        return siemResponse.error({ statusCode: 400, body: validationErrors });
-      }
-      try {
-        const [, { data, security: securityService, share, dataViews }] = await getStartServices();
-        const searchSourceClient = await data.search.searchSource.asScoped(request);
-        const savedObjectsClient = coreContext.savedObjects.client;
-        const siemClient = (await context.securitySolution).getAppClient();
-
-        const timeframeEnd = request.body.timeframeEnd;
-        let invocationCount = request.body.invocationCount;
-        if (invocationCount < 1) {
-          return response.ok({
-            body: {
-              logs: [{ errors: ['Invalid invocation count'], warnings: [], duration: 0 }],
-              previewId: undefined,
-              isAborted: undefined,
-            },
-          });
+    })
+    .addVersion(
+      {
+        version: '2023-10-31',
+        validate: { request: { body: buildRouteValidation(previewRulesSchema) } },
+      },
+      async (context, request, response): Promise<IKibanaResponse<PreviewResponse>> => {
+        const siemResponse = buildSiemResponse(response);
+        const validationErrors = validateCreateRuleProps(request.body);
+        const coreContext = await context.core;
+        if (validationErrors.length) {
+          return siemResponse.error({ statusCode: 400, body: validationErrors });
         }
+        try {
+          const [, { data, security: securityService, share, dataViews }] =
+            await getStartServices();
+          const searchSourceClient = await data.search.searchSource.asScoped(request);
+          const savedObjectsClient = coreContext.savedObjects.client;
+          const siemClient = (await context.securitySolution).getAppClient();
 
-        const internalRule = convertCreateAPIToInternalSchema(request.body);
-        const previewRuleParams = internalRule.params;
-
-        const mlAuthz = buildMlAuthz({
-          license: (await context.licensing).license,
-          ml,
-          request,
-          savedObjectsClient,
-        });
-        throwAuthzError(await mlAuthz.validateRuleType(internalRule.params.type));
-
-        const listsContext = await context.lists;
-        await listsContext?.getExceptionListClient().createEndpointList();
-
-        const spaceId = siemClient.getSpaceId();
-        const previewId = uuidv4();
-        const username = security?.authc.getCurrentUser(request)?.username;
-        const loggedStatusChanges: Array<RuleExecutionContext & StatusChangeArgs> = [];
-        const previewRuleExecutionLogger = createPreviewRuleExecutionLogger(loggedStatusChanges);
-        const runState: Record<string, unknown> = {};
-        const logs: RulePreviewLogs[] = [];
-        let isAborted = false;
-
-        const { hasAllRequested } = await securityService.authz
-          .checkPrivilegesWithRequest(request)
-          .atSpace(spaceId, {
-            elasticsearch: {
-              index: {
-                [`${DEFAULT_PREVIEW_INDEX}-${spaceId}`]: ['read'],
-                [`.internal${DEFAULT_PREVIEW_INDEX}-${spaceId}-*`]: ['read'],
+          const timeframeEnd = request.body.timeframeEnd;
+          let invocationCount = request.body.invocationCount;
+          if (invocationCount < 1) {
+            return response.ok({
+              body: {
+                logs: [{ errors: ['Invalid invocation count'], warnings: [], duration: 0 }],
+                previewId: undefined,
+                isAborted: undefined,
               },
-              cluster: [],
-            },
-          });
-
-        if (!hasAllRequested) {
-          return response.ok({
-            body: {
-              logs: [
-                {
-                  errors: [
-                    'Missing "read" privileges for the ".preview.alerts-security.alerts" or ".internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
-                  ],
-                  warnings: [],
-                  duration: 0,
-                },
-              ],
-              previewId: undefined,
-              isAborted: undefined,
-            },
-          });
-        }
-
-        const previewRuleTypeWrapper = createSecurityRuleTypeWrapper({
-          ...securityRuleTypeOptions,
-          ruleDataClient: previewRuleDataClient,
-          ruleExecutionLoggerFactory: previewRuleExecutionLogger.factory,
-          isPreview: true,
-        });
-
-        const runExecutors = async <
-          TParams extends RuleParams,
-          TState extends RuleTypeState,
-          TInstanceState extends AlertInstanceState,
-          TInstanceContext extends AlertInstanceContext,
-          TActionGroupIds extends string = ''
-        >(
-          executor: ExecutorType<
-            TParams,
-            TState,
-            TInstanceState,
-            TInstanceContext,
-            TActionGroupIds
-          >,
-          ruleTypeId: string,
-          ruleTypeName: string,
-          params: TParams,
-          shouldWriteAlerts: () => boolean,
-          alertFactory: {
-            create: (
-              id: string
-            ) => Pick<
-              Alert<TInstanceState, TInstanceContext, TActionGroupIds>,
-              | 'getState'
-              | 'replaceState'
-              | 'scheduleActions'
-              | 'setContext'
-              | 'getContext'
-              | 'hasContext'
-              | 'getUuid'
-              | 'getStart'
-            >;
-            alertLimit: {
-              getValue: () => number;
-              setLimitReached: () => void;
-            };
-            done: () => { getRecoveredAlerts: () => [] };
+            });
           }
-        ) => {
-          let statePreview = runState as TState;
 
-          const abortController = new AbortController();
-          setTimeout(() => {
-            abortController.abort();
-            isAborted = true;
-          }, PREVIEW_TIMEOUT_SECONDS * 1000);
+          const internalRule = convertCreateAPIToInternalSchema(request.body);
+          const previewRuleParams = internalRule.params;
 
-          const startedAt = moment(timeframeEnd);
-          const parsedDuration = parseDuration(internalRule.schedule.interval) ?? 0;
-          startedAt.subtract(moment.duration(parsedDuration * (invocationCount - 1)));
-
-          let previousStartedAt = null;
-
-          const rule = {
-            ...internalRule,
-            id: previewId,
-            createdAt: new Date(),
-            createdBy: username ?? 'preview-created-by',
-            producer: 'preview-producer',
-            revision: 0,
-            ruleTypeId,
-            ruleTypeName,
-            updatedAt: new Date(),
-            updatedBy: username ?? 'preview-updated-by',
-            muteAll: false,
-            snoozeSchedule: [],
-          };
-
-          let invocationStartTime;
-
-          const dataViewsService = await dataViews.dataViewsServiceFactory(
+          const mlAuthz = buildMlAuthz({
+            license: (await context.licensing).license,
+            ml,
+            request,
             savedObjectsClient,
-            coreContext.elasticsearch.client.asInternalUser
-          );
+          });
+          throwAuthzError(await mlAuthz.validateRuleType(internalRule.params.type));
 
-          while (invocationCount > 0 && !isAborted) {
-            invocationStartTime = moment();
+          const listsContext = await context.lists;
+          await listsContext?.getExceptionListClient().createEndpointList();
 
-            ({ state: statePreview } = (await executor({
-              executionId: uuidv4(),
-              params,
-              previousStartedAt,
-              rule,
-              services: {
-                shouldWriteAlerts,
-                shouldStopExecution: () => false,
-                alertsClient: null,
-                alertFactory,
-                savedObjectsClient: coreContext.savedObjects.client,
-                scopedClusterClient: wrapScopedClusterClient({
-                  abortController,
-                  scopedClusterClient: coreContext.elasticsearch.client,
-                }),
-                searchSourceClient: wrapSearchSourceClient({
-                  abortController,
-                  searchSourceClient,
-                }),
-                uiSettingsClient: coreContext.uiSettings.client,
-                dataViews: dataViewsService,
-                share,
+          const spaceId = siemClient.getSpaceId();
+          const previewId = uuidv4();
+          const username = security?.authc.getCurrentUser(request)?.username;
+          const loggedStatusChanges: Array<RuleExecutionContext & StatusChangeArgs> = [];
+          const previewRuleExecutionLogger = createPreviewRuleExecutionLogger(loggedStatusChanges);
+          const runState: Record<string, unknown> = {};
+          const logs: RulePreviewLogs[] = [];
+          let isAborted = false;
+
+          const { hasAllRequested } = await securityService.authz
+            .checkPrivilegesWithRequest(request)
+            .atSpace(spaceId, {
+              elasticsearch: {
+                index: {
+                  [`${DEFAULT_PREVIEW_INDEX}-${spaceId}`]: ['read'],
+                  [`.internal${DEFAULT_PREVIEW_INDEX}-${spaceId}-*`]: ['read'],
+                },
+                cluster: [],
               },
-              spaceId,
-              startedAt: startedAt.toDate(),
-              state: statePreview,
-              logger,
-              flappingSettings: DISABLE_FLAPPING_SETTINGS,
-            })) as { state: TState });
-
-            const errors = loggedStatusChanges
-              .filter((item) => item.newStatus === RuleExecutionStatus.failed)
-              .map((item) => item.message ?? 'Unknown Error');
-
-            const warnings = loggedStatusChanges
-              .filter((item) => item.newStatus === RuleExecutionStatus['partial failure'])
-              .map((item) => item.message ?? 'Unknown Warning');
-
-            logs.push({
-              errors,
-              warnings,
-              startedAt: startedAt.toDate().toISOString(),
-              duration: moment().diff(invocationStartTime, 'milliseconds'),
             });
 
-            loggedStatusChanges.length = 0;
-
-            if (errors.length) {
-              break;
-            }
-
-            previousStartedAt = startedAt.toDate();
-            startedAt.add(parseInterval(internalRule.schedule.interval));
-            invocationCount--;
+          if (!hasAllRequested) {
+            return response.ok({
+              body: {
+                logs: [
+                  {
+                    errors: [
+                      'Missing "read" privileges for the ".preview.alerts-security.alerts" or ".internal.preview.alerts-security.alerts" indices. Without these privileges you cannot use the Rule Preview feature.',
+                    ],
+                    warnings: [],
+                    duration: 0,
+                  },
+                ],
+                previewId: undefined,
+                isAborted: undefined,
+              },
+            });
           }
-        };
 
-        switch (previewRuleParams.type) {
-          case 'query':
-            const queryAlertType = previewRuleTypeWrapper(
-              createQueryAlertType({
-                ...ruleOptions,
-                id: QUERY_RULE_TYPE_ID,
-                name: 'Custom Query Rule',
-              })
+          const previewRuleTypeWrapper = createSecurityRuleTypeWrapper({
+            ...securityRuleTypeOptions,
+            ruleDataClient: previewRuleDataClient,
+            ruleExecutionLoggerFactory: previewRuleExecutionLogger.factory,
+            isPreview: true,
+          });
+
+          const runExecutors = async <
+            TParams extends RuleParams,
+            TState extends RuleTypeState,
+            TInstanceState extends AlertInstanceState,
+            TInstanceContext extends AlertInstanceContext,
+            TActionGroupIds extends string = ''
+          >(
+            executor: ExecutorType<
+              TParams,
+              TState,
+              TInstanceState,
+              TInstanceContext,
+              TActionGroupIds
+            >,
+            ruleTypeId: string,
+            ruleTypeName: string,
+            params: TParams,
+            shouldWriteAlerts: () => boolean,
+            alertFactory: {
+              create: (
+                id: string
+              ) => Pick<
+                Alert<TInstanceState, TInstanceContext, TActionGroupIds>,
+                | 'getState'
+                | 'replaceState'
+                | 'scheduleActions'
+                | 'setContext'
+                | 'getContext'
+                | 'hasContext'
+                | 'getUuid'
+                | 'getStart'
+              >;
+              alertLimit: {
+                getValue: () => number;
+                setLimitReached: () => void;
+              };
+              done: () => { getRecoveredAlerts: () => [] };
+            }
+          ) => {
+            let statePreview = runState as TState;
+
+            const abortController = new AbortController();
+            setTimeout(() => {
+              abortController.abort();
+              isAborted = true;
+            }, PREVIEW_TIMEOUT_SECONDS * 1000);
+
+            const startedAt = moment(timeframeEnd);
+            const parsedDuration = parseDuration(internalRule.schedule.interval) ?? 0;
+            startedAt.subtract(moment.duration(parsedDuration * (invocationCount - 1)));
+
+            let previousStartedAt = null;
+
+            const rule = {
+              ...internalRule,
+              id: previewId,
+              createdAt: new Date(),
+              createdBy: username ?? 'preview-created-by',
+              producer: 'preview-producer',
+              revision: 0,
+              ruleTypeId,
+              ruleTypeName,
+              updatedAt: new Date(),
+              updatedBy: username ?? 'preview-updated-by',
+              muteAll: false,
+              snoozeSchedule: [],
+            };
+
+            let invocationStartTime;
+
+            const dataViewsService = await dataViews.dataViewsServiceFactory(
+              savedObjectsClient,
+              coreContext.elasticsearch.client.asInternalUser
             );
-            await runExecutors(
-              queryAlertType.executor,
-              queryAlertType.id,
-              queryAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
+
+            while (invocationCount > 0 && !isAborted) {
+              invocationStartTime = moment();
+
+              ({ state: statePreview } = (await executor({
+                executionId: uuidv4(),
+                params,
+                previousStartedAt,
+                rule,
+                services: {
+                  shouldWriteAlerts,
+                  shouldStopExecution: () => false,
+                  alertsClient: null,
+                  alertFactory,
+                  savedObjectsClient: coreContext.savedObjects.client,
+                  scopedClusterClient: wrapScopedClusterClient({
+                    abortController,
+                    scopedClusterClient: coreContext.elasticsearch.client,
+                  }),
+                  searchSourceClient: wrapSearchSourceClient({
+                    abortController,
+                    searchSourceClient,
+                  }),
+                  uiSettingsClient: coreContext.uiSettings.client,
+                  dataViews: dataViewsService,
+                  share,
                 },
-                done: () => ({ getRecoveredAlerts: () => [] }),
+                spaceId,
+                startedAt: startedAt.toDate(),
+                state: statePreview,
+                logger,
+                flappingSettings: DISABLE_FLAPPING_SETTINGS,
+              })) as { state: TState });
+
+              const errors = loggedStatusChanges
+                .filter((item) => item.newStatus === RuleExecutionStatus.failed)
+                .map((item) => item.message ?? 'Unknown Error');
+
+              const warnings = loggedStatusChanges
+                .filter((item) => item.newStatus === RuleExecutionStatus['partial failure'])
+                .map((item) => item.message ?? 'Unknown Warning');
+
+              logs.push({
+                errors,
+                warnings,
+                startedAt: startedAt.toDate().toISOString(),
+                duration: moment().diff(invocationStartTime, 'milliseconds'),
+              });
+
+              loggedStatusChanges.length = 0;
+
+              if (errors.length) {
+                break;
               }
-            );
-            break;
-          case 'saved_query':
-            const savedQueryAlertType = previewRuleTypeWrapper(
-              createQueryAlertType({
-                ...ruleOptions,
-                id: SAVED_QUERY_RULE_TYPE_ID,
-                name: 'Saved Query Rule',
-              })
-            );
-            await runExecutors(
-              savedQueryAlertType.executor,
-              savedQueryAlertType.id,
-              savedQueryAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          case 'threshold':
-            const thresholdAlertType = previewRuleTypeWrapper(
-              createThresholdAlertType(ruleOptions)
-            );
-            await runExecutors(
-              thresholdAlertType.executor,
-              thresholdAlertType.id,
-              thresholdAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          case 'threat_match':
-            const threatMatchAlertType = previewRuleTypeWrapper(
-              createIndicatorMatchAlertType(ruleOptions)
-            );
-            await runExecutors(
-              threatMatchAlertType.executor,
-              threatMatchAlertType.id,
-              threatMatchAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          case 'eql':
-            const eqlAlertType = previewRuleTypeWrapper(createEqlAlertType(ruleOptions));
-            await runExecutors(
-              eqlAlertType.executor,
-              eqlAlertType.id,
-              eqlAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          case 'machine_learning':
-            const mlAlertType = previewRuleTypeWrapper(createMlAlertType(ruleOptions));
-            await runExecutors(
-              mlAlertType.executor,
-              mlAlertType.id,
-              mlAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          case 'new_terms':
-            const newTermsAlertType = previewRuleTypeWrapper(createNewTermsAlertType(ruleOptions));
-            await runExecutors(
-              newTermsAlertType.executor,
-              newTermsAlertType.id,
-              newTermsAlertType.name,
-              previewRuleParams,
-              () => true,
-              {
-                create: alertInstanceFactoryStub,
-                alertLimit: {
-                  getValue: () => 1000,
-                  setLimitReached: () => {},
-                },
-                done: () => ({ getRecoveredAlerts: () => [] }),
-              }
-            );
-            break;
-          default:
-            assertUnreachable(previewRuleParams);
+
+              previousStartedAt = startedAt.toDate();
+              startedAt.add(parseInterval(internalRule.schedule.interval));
+              invocationCount--;
+            }
+          };
+
+          switch (previewRuleParams.type) {
+            case 'query':
+              const queryAlertType = previewRuleTypeWrapper(
+                createQueryAlertType({
+                  ...ruleOptions,
+                  id: QUERY_RULE_TYPE_ID,
+                  name: 'Custom Query Rule',
+                })
+              );
+              await runExecutors(
+                queryAlertType.executor,
+                queryAlertType.id,
+                queryAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'saved_query':
+              const savedQueryAlertType = previewRuleTypeWrapper(
+                createQueryAlertType({
+                  ...ruleOptions,
+                  id: SAVED_QUERY_RULE_TYPE_ID,
+                  name: 'Saved Query Rule',
+                })
+              );
+              await runExecutors(
+                savedQueryAlertType.executor,
+                savedQueryAlertType.id,
+                savedQueryAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'threshold':
+              const thresholdAlertType = previewRuleTypeWrapper(
+                createThresholdAlertType(ruleOptions)
+              );
+              await runExecutors(
+                thresholdAlertType.executor,
+                thresholdAlertType.id,
+                thresholdAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'threat_match':
+              const threatMatchAlertType = previewRuleTypeWrapper(
+                createIndicatorMatchAlertType(ruleOptions)
+              );
+              await runExecutors(
+                threatMatchAlertType.executor,
+                threatMatchAlertType.id,
+                threatMatchAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'eql':
+              const eqlAlertType = previewRuleTypeWrapper(createEqlAlertType(ruleOptions));
+              await runExecutors(
+                eqlAlertType.executor,
+                eqlAlertType.id,
+                eqlAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'machine_learning':
+              const mlAlertType = previewRuleTypeWrapper(createMlAlertType(ruleOptions));
+              await runExecutors(
+                mlAlertType.executor,
+                mlAlertType.id,
+                mlAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            case 'new_terms':
+              const newTermsAlertType = previewRuleTypeWrapper(
+                createNewTermsAlertType(ruleOptions)
+              );
+              await runExecutors(
+                newTermsAlertType.executor,
+                newTermsAlertType.id,
+                newTermsAlertType.name,
+                previewRuleParams,
+                () => true,
+                {
+                  create: alertInstanceFactoryStub,
+                  alertLimit: {
+                    getValue: () => 1000,
+                    setLimitReached: () => {},
+                  },
+                  done: () => ({ getRecoveredAlerts: () => [] }),
+                }
+              );
+              break;
+            default:
+              assertUnreachable(previewRuleParams);
+          }
+
+          // Refreshes alias to ensure index is able to be read before returning
+          await coreContext.elasticsearch.client.asInternalUser.indices.refresh(
+            {
+              index: previewRuleDataClient.indexNameWithNamespace(spaceId),
+            },
+            { ignore: [404] }
+          );
+
+          return response.ok({
+            body: {
+              previewId,
+              logs,
+              isAborted,
+            },
+          });
+        } catch (err) {
+          const error = transformError(err as Error);
+          return siemResponse.error({
+            body: {
+              errors: [error.message],
+            },
+            statusCode: error.statusCode,
+          });
         }
-
-        // Refreshes alias to ensure index is able to be read before returning
-        await coreContext.elasticsearch.client.asInternalUser.indices.refresh(
-          {
-            index: previewRuleDataClient.indexNameWithNamespace(spaceId),
-          },
-          { ignore: [404] }
-        );
-
-        return response.ok({
-          body: {
-            previewId,
-            logs,
-            isAborted,
-          },
-        });
-      } catch (err) {
-        const error = transformError(err as Error);
-        return siemResponse.error({
-          body: {
-            errors: [error.message],
-          },
-          statusCode: error.statusCode,
-        });
       }
-    }
-  );
+    );
 };

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/export_rules.ts
@@ -7,7 +7,10 @@
 
 import expect from 'expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import {
+  DETECTION_ENGINE_RULES_URL,
+  UPDATE_OR_CREATE_LEGACY_ACTIONS,
+} from '@kbn/security-solution-plugin/common/constants';
 import { RuleResponse } from '@kbn/security-solution-plugin/common/api/detection_engine';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
@@ -427,8 +430,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
           // attach the legacy notification
           await supertest
-            .post(`/internal/api/detection/legacy/notifications?alert_id=${rule.id}`)
+            .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${rule.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               name: 'Legacy notification with one action',
               interval: '1h',
@@ -496,8 +500,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
           // attach the legacy notification with actions
           await supertest
-            .post(`/internal/api/detection/legacy/notifications?alert_id=${rule.id}`)
+            .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${rule.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               name: 'Legacy notification with one action',
               interval: '1h',
@@ -585,8 +590,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
           // attach the legacy notification with actions to the first rule
           await supertest
-            .post(`/internal/api/detection/legacy/notifications?alert_id=${rule1.id}`)
+            .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${rule1.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               name: 'Legacy notification with one action',
               interval: '1h',
@@ -615,8 +621,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
           // attach the legacy notification with actions to the 2nd rule
           await supertest
-            .post(`/internal/api/detection/legacy/notifications?alert_id=${rule2.id}`)
+            .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${rule2.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               name: 'Legacy notification with one action',
               interval: '1h',

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rule_exception_references.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rule_exception_references.ts
@@ -67,6 +67,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: references } = await supertest
         .get(DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({
           ids: `${exceptionList.id}`,
           list_ids: `${exceptionList.list_id}`,
@@ -120,6 +121,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: references } = await supertest
         .get(DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({
           ids: `1234`,
           list_ids: `i_dont_exist`,
@@ -166,6 +168,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: references } = await supertest
         .get(DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({
           ids: `${exceptionList.id},${exceptionList2.id}`,
           list_ids: `${exceptionList.list_id},${exceptionList2.list_id}`,
@@ -214,6 +217,7 @@ export default ({ getService }: FtrProviderContext) => {
       const { body: references } = await supertest
         .get(DETECTION_ENGINE_RULES_EXCEPTIONS_REFERENCE_URL)
         .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '1')
         .query({
           namespace_types: 'single,agnostic',
         })

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group1/find_rules.ts
@@ -7,7 +7,10 @@
 
 import expect from '@kbn/expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import {
+  DETECTION_ENGINE_RULES_URL,
+  UPDATE_OR_CREATE_LEGACY_ACTIONS,
+} from '@kbn/security-solution-plugin/common/constants';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
   createRule,
@@ -211,8 +214,9 @@ export default ({ getService }: FtrProviderContext): void => {
 
         // attach the legacy notification
         await supertest
-          .post(`/internal/api/detection/legacy/notifications?alert_id=${createRuleBody.id}`)
+          .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${createRuleBody.id}`)
           .set('kbn-xsrf', 'true')
+          .set('elastic-api-version', '1')
           .send({
             name: 'Legacy notification with one action',
             interval: '1h',

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/read_rules.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/read_rules.ts
@@ -7,7 +7,10 @@
 
 import expect from '@kbn/expect';
 
-import { DETECTION_ENGINE_RULES_URL } from '@kbn/security-solution-plugin/common/constants';
+import {
+  DETECTION_ENGINE_RULES_URL,
+  UPDATE_OR_CREATE_LEGACY_ACTIONS,
+} from '@kbn/security-solution-plugin/common/constants';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
   createRule,
@@ -216,8 +219,9 @@ export default ({ getService }: FtrProviderContext) => {
 
           // attach the legacy notification
           await supertest
-            .post(`/internal/api/detection/legacy/notifications?alert_id=${createRuleBody.id}`)
+            .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}?alert_id=${createRuleBody.id}`)
             .set('kbn-xsrf', 'true')
+            .set('elastic-api-version', '1')
             .send({
               name: 'Legacy notification with one action',
               interval: '1h',

--- a/x-pack/test/detection_engine_api_integration/utils/create_legacy_rule_action.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_legacy_rule_action.ts
@@ -15,8 +15,9 @@ export const createLegacyRuleAction = async (
   connectorId: string
 ): Promise<unknown> =>
   supertest
-    .post(`${UPDATE_OR_CREATE_LEGACY_ACTIONS}`)
+    .post(UPDATE_OR_CREATE_LEGACY_ACTIONS)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .query({ alert_id: alertId })
     .send({
       name: 'Legacy notification with one action',

--- a/x-pack/test/detection_engine_api_integration/utils/create_signals_index.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/create_signals_index.ts
@@ -22,7 +22,11 @@ export const createSignalsIndex = async (
 ): Promise<void> => {
   await countDownTest(
     async () => {
-      await supertest.post(DETECTION_ENGINE_INDEX_URL).set('kbn-xsrf', 'true').send();
+      await supertest
+        .post(DETECTION_ENGINE_INDEX_URL)
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
+        .send();
       return {
         passed: true,
       };

--- a/x-pack/test/detection_engine_api_integration/utils/delete_all_alerts.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/delete_all_alerts.ts
@@ -25,7 +25,11 @@ export const deleteAllAlerts = async (
 ): Promise<void> => {
   await countDownTest(
     async () => {
-      await supertest.delete(DETECTION_ENGINE_INDEX_URL).set('kbn-xsrf', 'true').send();
+      await supertest
+        .delete(DETECTION_ENGINE_INDEX_URL)
+        .set('kbn-xsrf', 'true')
+        .set('elastic-api-version', '2023-10-31')
+        .send();
       await es.deleteByQuery({
         index,
         body: {

--- a/x-pack/test/detection_engine_api_integration/utils/get_security_telemetry_stats.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/get_security_telemetry_stats.ts
@@ -23,6 +23,7 @@ export const getSecurityTelemetryStats = async (
   const response = await supertest
     .get(SECURITY_TELEMETRY_URL)
     .set('kbn-xsrf', 'true')
+    .set('elastic-api-version', '1')
     .send({ unencrypted: true, refreshCache: true });
   if (response.status !== 200) {
     log.error(


### PR DESCRIPTION
*Resolves: https://github.com/elastic/security-team/issues/7143*

## Summary

This PR migrates all HTTP Endpoints under the ownership of @elastic/security-detection-engine to the [versioned router](https://docs.elastic.dev/kibana-dev-docs/versioning-http-apis#use-the-versioned-router).

- Endpoints that are documented and start with `/api` were marked as `access: 'public'`. So in production, if accessed without the version header, they will be automatically resolved to the latest available version.
- Endpoints that start with `/internal` are now flagged as `access: 'internal'`, implying a special origin header is needed to access them in a Serverless environment. The version header (`'elastic-api-version': '1'`) should always be provided for these endpoints to work.

### Migrated endpoints:

- [x] Signals
- [x] Telemetry
- [x] Exceptions
- [x] Index

For further reference, here's the [complete list of Security Solution APIs](https://docs.google.com/spreadsheets/d/1VCoJ74EkyGuj59VwWj_3v2ecB84pNCpzGqkYnS0SUKw/edit?pli=1#gid=0).