### PR TITLE
chore: disable flaky FTR test

### DIFF
--- a/x-pack/test/api_integration/apis/search/search.ts
+++ b/x-pack/test/api_integration/apis/search/search.ts
@@ -455,7 +455,7 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(404);
       });
 
-      it('should delete a completed search', async function () {
+      it.skip('should delete a completed search', async function () {
         await markRequiresShardDelayAgg(this);
 
         const resp = await supertest

--- a/x-pack/test/api_integration/apis/search/search.ts
+++ b/x-pack/test/api_integration/apis/search/search.ts
@@ -455,6 +455,7 @@ export default function ({ getService }: FtrProviderContext) {
           .expect(404);
       });
 
+      // FLAKY: https://github.com/elastic/kibana/issues/164856
       it.skip('should delete a completed search', async function () {
         await markRequiresShardDelayAgg(this);
 


### PR DESCRIPTION
## Summary
@dgieselaar suggested we quarantine this test because it's pretty flaky.

https://elastic.slack.com/archives/C5UDAFZQU/p1692963699773759