### PR TITLE
[8.10] [Serverless Search] Updating doc links (#164354)

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -34,6 +34,8 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
   const WORKPLACE_SEARCH_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/workplace-search/${DOC_LINK_VERSION}/`;
   const SEARCH_UI_DOCS = `${DOCS_WEBSITE_URL}search-ui/`;
   const MACHINE_LEARNING_DOCS = `${ELASTIC_WEBSITE_URL}guide/en/machine-learning/${DOC_LINK_VERSION}/`;
+  const SERVERLESS_DOCS = `${DOCS_WEBSITE_URL}serverless/`;
+  const SERVERLESS_ELASTICSEARCH_DOCS = `${SERVERLESS_DOCS}elasticsearch/`;
 
   return deepFreeze({
     settings: `${ELASTIC_WEBSITE_URL}guide/en/kibana/${DOC_LINK_VERSION}/settings.html`,
@@ -65,6 +67,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     },
     console: {
       guide: `${KIBANA_DOCS}console-kibana.html`,
+      serverlessGuide: `${SERVERLESS_ELASTICSEARCH_DOCS}dev-tools-console`,
     },
     dashboard: {
       guide: `${KIBANA_DOCS}dashboard.html`,
@@ -805,8 +808,29 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       appSearch: `${SEARCH_UI_DOCS}tutorials/app-search`,
       elasticsearch: `${SEARCH_UI_DOCS}tutorials/elasticsearch`,
     },
+    serverlessClients: {
+      goApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}go-apis-references`,
+      goGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}go-apis`,
+      httpApis: `${SERVERLESS_ELASTICSEARCH_DOCS}http-apis`,
+      httpApiReferences: `${SERVERLESS_ELASTICSEARCH_DOCS}http-apis-references`,
+      jsApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}nodejs-apis-references`,
+      jsGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}nodejs-apis-getting-started`,
+      phpApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}php-apis-references`,
+      phpGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}php-apis-getting-started`,
+      pythonApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}python-apis-references`,
+      pythonGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}python-apis-getting-started`,
+      pythonReferences: `${SERVERLESS_ELASTICSEARCH_DOCS}python-apis-references`,
+      rubyApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}ruby-apis-references`,
+      rubyGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}ruby-apis-getting-started`,
+    },
     serverlessSearch: {
-      integrations: `${ELASTIC_WEBSITE_URL}/integrations`,
+      integrations: `${SERVERLESS_ELASTICSEARCH_DOCS}ingest-data-through-integrations`,
+      integrationsLogstash: `${SERVERLESS_ELASTICSEARCH_DOCS}ingest-data-through-integrations-logstash`,
+      integrationsBeats: `${SERVERLESS_ELASTICSEARCH_DOCS}ingest-data-through-integrations-beats`,
+      integrationsConnectorClient: `${SERVERLESS_ELASTICSEARCH_DOCS}ingest-data-through-integrations-connector-client`,
+      gettingStartedExplore: `${SERVERLESS_ELASTICSEARCH_DOCS}get-started-explore`,
+      gettingStartedIngest: `${SERVERLESS_ELASTICSEARCH_DOCS}get-started-ingest`,
+      gettingStartedSearch: `${SERVERLESS_ELASTICSEARCH_DOCS}get-started-search`,
     },
     synthetics: {
       featureRoles: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-feature-roles.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -49,6 +49,7 @@ export interface DocLinks {
   };
   readonly console: {
     readonly guide: string;
+    readonly serverlessGuide: string;
   };
   readonly dashboard: {
     readonly guide: string;
@@ -569,8 +570,29 @@ export interface DocLinks {
     readonly appSearch: string;
     readonly elasticsearch: string;
   };
+  readonly serverlessClients: {
+    readonly goApiReference: string;
+    readonly goGettingStarted: string;
+    readonly httpApis: string;
+    readonly httpApiReferences: string;
+    readonly jsApiReference: string;
+    readonly jsGettingStarted: string;
+    readonly phpApiReference: string;
+    readonly phpGettingStarted: string;
+    readonly pythonApiReference: string;
+    readonly pythonGettingStarted: string;
+    readonly pythonReferences: string;
+    readonly rubyApiReference: string;
+    readonly rubyGettingStarted: string;
+  };
   readonly serverlessSearch: {
+    readonly gettingStartedExplore: string;
+    readonly gettingStartedIngest: string;
+    readonly gettingStartedSearch: string;
     readonly integrations: string;
+    readonly integrationsBeats: string;
+    readonly integrationsConnectorClient: string;
+    readonly integrationsLogstash: string;
   };
   readonly synthetics: {
     readonly featureRoles: string;

--- a/packages/kbn-search-api-panels/components/install_client.tsx
+++ b/packages/kbn-search-api-panels/components/install_client.tsx
@@ -15,7 +15,7 @@ import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import { CodeBox } from './code_box';
 import { OverviewPanel } from './overview_panel';
-import { LanguageDefinition, Languages } from '../types';
+import { LanguageDefinition } from '../types';
 import { GithubLink } from './github_link';
 
 interface InstallClientProps {
@@ -32,45 +32,20 @@ interface InstallClientProps {
   overviewPanelProps?: Partial<EuiPanelProps>;
 }
 
-const Link: React.FC<{ language: Languages; http: HttpStart; pluginId: string }> = ({
+const Link: React.FC<{ language: LanguageDefinition; http: HttpStart; pluginId: string }> = ({
   language,
   http,
   pluginId,
 }) => {
-  switch (language) {
-    case Languages.CURL:
-      return (
-        <GithubLink
-          href="https://github.com/curl/curl"
-          label={i18n.translate('searchApiPanels.welcomeBanner.githubLink.curl.label', {
-            defaultMessage: 'curl',
-          })}
-          http={http}
-          pluginId={pluginId}
-        />
-      );
-    case Languages.JAVASCRIPT:
-      return (
-        <GithubLink
-          href="https://github.com/elastic/elasticsearch-js"
-          label={i18n.translate('searchApiPanels.welcomeBanner.githubLink.javascript.label', {
-            defaultMessage: 'elasticsearch',
-          })}
-          http={http}
-          pluginId={pluginId}
-        />
-      );
-    case Languages.RUBY:
-      return (
-        <GithubLink
-          href="https://github.com/elastic/elasticsearch-ruby"
-          label={i18n.translate('searchApiPanels.welcomeBanner.githubLink.ruby.label', {
-            defaultMessage: 'elasticsearch-ruby',
-          })}
-          http={http}
-          pluginId={pluginId}
-        />
-      );
+  if (language.github) {
+    return (
+      <GithubLink
+        href={language.github.link}
+        label={language.github.label}
+        http={http}
+        pluginId={pluginId}
+      />
+    );
   }
   return null;
 };
@@ -103,7 +78,7 @@ export const InstallClientPanel: React.FC<InstallClientProps> = ({
         sharePlugin={sharePlugin}
       />
       <EuiSpacer />
-      <Link language={language.id} http={http} pluginId={pluginId} />
+      <Link language={language} http={http} pluginId={pluginId} />
       <EuiSpacer />
       <EuiCallOut
         iconType="iInCircle"

--- a/packages/kbn-search-api-panels/index.tsx
+++ b/packages/kbn-search-api-panels/index.tsx
@@ -21,6 +21,7 @@ export * from './components/try_in_console_button';
 export * from './components/install_client';
 
 export * from './types';
+export * from './utils';
 
 export interface WelcomeBannerProps {
   userProfile: {

--- a/packages/kbn-search-api-panels/types.ts
+++ b/packages/kbn-search-api-panels/types.ts
@@ -32,6 +32,10 @@ export interface LanguageDefinition {
   basicConfig?: string;
   configureClient: CodeSnippet;
   docLink: string;
+  github?: {
+    link: string;
+    label: string;
+  };
   iconType: string;
   id: Languages;
   ingestData: CodeSnippet;

--- a/packages/kbn-search-api-panels/utils.ts
+++ b/packages/kbn-search-api-panels/utils.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { LanguageDefinition, LanguageDefinitionSnippetArguments } from './types';
+
+export const getLanguageDefinitionCodeSnippet = (
+  language: Partial<LanguageDefinition>,
+  key: keyof LanguageDefinition,
+  args: LanguageDefinitionSnippetArguments
+): string => {
+  const snippetVal = language[key];
+  if (snippetVal === undefined) return '';
+  switch (typeof snippetVal) {
+    case 'string':
+      return snippetVal;
+    case 'function':
+      return snippetVal(args);
+    default:
+      return '';
+  }
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/getting_started.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/getting_started.tsx
@@ -31,6 +31,7 @@ import {
   InstallClientPanel,
   OverviewPanel,
   CodeBox,
+  getLanguageDefinitionCodeSnippet,
 } from '@kbn/search-api-panels';
 
 import { LanguageDefinition } from '@kbn/search-api-panels';
@@ -49,7 +50,7 @@ import { GenerateApiKeyModal } from '../generate_api_key_modal/modal';
 
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
-import { getCodeSnippet, showTryInConsole } from './languages/utils';
+import { showTryInConsole } from './languages/utils';
 
 const DEFAULT_URL = 'https://localhost:9200';
 
@@ -104,7 +105,7 @@ export const APIGettingStarted = () => {
         ))}
       </SelectClientPanel>
       <InstallClientPanel
-        codeSnippet={getCodeSnippet(selectedLanguage, 'installClient', codeArgs)}
+        codeSnippet={getLanguageDefinitionCodeSnippet(selectedLanguage, 'installClient', codeArgs)}
         showTryInConsole={showTryInConsole('installClient')}
         languages={languageDefinitions}
         language={selectedLanguage}
@@ -295,7 +296,11 @@ export const APIGettingStarted = () => {
         rightPanelContent={
           <CodeBox
             languages={languageDefinitions}
-            codeSnippet={getCodeSnippet(selectedLanguage, 'configureClient', codeArgs)}
+            codeSnippet={getLanguageDefinitionCodeSnippet(
+              selectedLanguage,
+              'configureClient',
+              codeArgs
+            )}
             showTryInConsole={showTryInConsole('configureClient')}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}
@@ -326,7 +331,11 @@ export const APIGettingStarted = () => {
         rightPanelContent={
           <CodeBox
             languages={languageDefinitions}
-            codeSnippet={getCodeSnippet(selectedLanguage, 'testConnection', codeArgs)}
+            codeSnippet={getLanguageDefinitionCodeSnippet(
+              selectedLanguage,
+              'testConnection',
+              codeArgs
+            )}
             showTryInConsole={showTryInConsole('testConnection')}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}
@@ -355,7 +364,7 @@ export const APIGettingStarted = () => {
         rightPanelContent={
           <CodeBox
             languages={languageDefinitions}
-            codeSnippet={getCodeSnippet(selectedLanguage, 'ingestData', codeArgs)}
+            codeSnippet={getLanguageDefinitionCodeSnippet(selectedLanguage, 'ingestData', codeArgs)}
             showTryInConsole={showTryInConsole('ingestData')}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}
@@ -383,7 +392,11 @@ export const APIGettingStarted = () => {
         rightPanelContent={
           <CodeBox
             languages={languageDefinitions}
-            codeSnippet={getCodeSnippet(selectedLanguage, 'buildSearchQuery', codeArgs)}
+            codeSnippet={getLanguageDefinitionCodeSnippet(
+              selectedLanguage,
+              'buildSearchQuery',
+              codeArgs
+            )}
             showTryInConsole={showTryInConsole('buildSearchQuery')}
             selectedLanguage={selectedLanguage}
             setSelectedLanguage={setSelectedLanguage}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/curl.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/curl.ts
@@ -25,6 +25,12 @@ export const curlDefinition: LanguageDefinition = {
   configureClient: ({ apiKey, url }) => `export ES_URL="${url}"
 export API_KEY="${apiKey}"`,
   docLink: docLinks.restApis,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.cURL.githubLink', {
+      defaultMessage: 'curl',
+    }),
+    link: 'https://github.com/curl/curl',
+  },
   iconType: 'curl.svg',
   id: Languages.CURL,
   ingestData: `curl -X POST "\$\{ES_URL\}/_bulk?pretty" \\

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/go.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/go.ts
@@ -23,7 +23,7 @@ fmt.Println(searchResp, err)`,
   "log"
   "strings"
 ​
-  "github.com/elastic/elasticsearch-serverless-go"
+  elasticsearch "github.com/elastic/go-elasticsearch/v8"
 )
 
 func main() {
@@ -37,6 +37,12 @@ func main() {
   }
 }`,
   docLink: docLinks.clientsGoIndex,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.go.githubLink', {
+      defaultMessage: 'go-elasticsearch',
+    }),
+    link: 'https://github.com/elastic/go-elasticsearch',
+  },
   iconType: 'go.svg',
   id: Languages.GO,
   ingestData: `ingestResult, err := es.Bulk().

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/javascript.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/javascript.ts
@@ -27,6 +27,12 @@ const client = new Client({
   }
 });`,
   docLink: docLinks.clientsJsIntro,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.javascript.githubLink', {
+      defaultMessage: 'elasticsearch',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-js',
+  },
   iconType: 'javascript.svg',
   id: Languages.JAVASCRIPT,
   ingestData: `// Sample flight data

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/php.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/php.ts
@@ -25,6 +25,12 @@ print_r($response->asArray());`,
   ->setApiKey('${apiKey}')
   ->build();`,
   docLink: docLinks.clientsPhpOverview,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.php.githubLink', {
+      defaultMessage: 'elasticsearch-php',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-php',
+  },
   iconType: 'php.svg',
   id: Languages.PHP,
   ingestData: `$params = [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/python.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/python.ts
@@ -19,6 +19,12 @@ client = Elasticsearch(
   api_key="${apiKey}"
 )`,
   docLink: docLinks.clientsPythonOverview,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.python.githubLink', {
+      defaultMessage: 'elasticsearch-py',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-py',
+  },
   iconType: 'python.svg',
   id: Languages.PYTHON,
   ingestData: `documents = [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/ruby.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/ruby.ts
@@ -18,6 +18,12 @@ export const rubyDefinition: LanguageDefinition = {
 )
 `,
   docLink: docLinks.clientsRubyOverview,
+  github: {
+    label: i18n.translate('xpack.enterpriseSearch.languages.ruby.githubLink', {
+      defaultMessage: 'elasticsearch-ruby',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-ruby',
+  },
   iconType: 'ruby.svg',
   id: Languages.RUBY,
   ingestData: `documents = [

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/getting_started/languages/utils.ts
@@ -5,19 +5,8 @@
  * 2.0.
  */
 
-import { LanguageDefinition, LanguageDefinitionSnippetArguments } from '@kbn/search-api-panels';
+import { LanguageDefinition } from '@kbn/search-api-panels';
 
 import { consoleDefinition } from './console';
 
 export const showTryInConsole = (code: keyof LanguageDefinition) => code in consoleDefinition;
-
-export const getCodeSnippet = (
-  language: Partial<LanguageDefinition>,
-  key: keyof LanguageDefinition,
-  args: LanguageDefinitionSnippetArguments
-): string => {
-  const snippetVal = language[key];
-  if (snippetVal === undefined) return '';
-  if (typeof snippetVal === 'string') return snippetVal;
-  return snippetVal(args);
-};

--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -11,58 +11,82 @@ class ESDocLinks {
   public apiIntro: string = '';
   public beats: string = '';
   public connectors: string = '';
-  public elasticsearchClients: string = '';
   public integrations: string = '';
-  public goAdvancedConfig: string = '';
-  public goBasicConfig: string = '';
-  public goClient: string = '';
-  public jsApiReference: string = '';
-  public jsAdvancedConfig: string = '';
-  public jsBasicConfig: string = '';
-  public jsClient: string = '';
+  public kibanaFeedback: string = '';
   public kibanaRunApiInConsole: string = '';
   public logStash: string = '';
   public metadata: string = '';
-  public phpAdvancedConfig: string = '';
+  public roleDescriptors: string = '';
+  public securityApis: string = '';
+  // Client links
+  public elasticsearchClients: string = '';
+  // go
+  public goApiReference: string | undefined = undefined;
+  public goBasicConfig: string = '';
+  public goClient: string = '';
+  // javascript
+  public jsApiReference: string = '';
+  public jsBasicConfig: string = '';
+  public jsClient: string = '';
+  // php
+  public phpApiReference: string | undefined = undefined;
   public phpBasicConfig: string = '';
   public phpClient: string = '';
-  public pythonAdvancedConfig: string = '';
+  // python
+  public pythonApiReference: string | undefined = undefined;
   public pythonBasicConfig: string = '';
   public pythonClient: string = '';
-  public roleDescriptors: string = '';
-  public rubyAdvancedConfig: string = '';
+  // ruby
   public rubyBasicConfig: string = '';
   public rubyClient: string = '';
   public rubyExamples: string = '';
-  public securityApis: string = '';
+
+  // Getting Started
+  public gettingStartedIngest: string = '';
+  public gettingStartedSearch: string = '';
+  public gettingStartedExplore: string = '';
+
   constructor() {}
 
   setDocLinks(newDocLinks: DocLinks) {
-    this.apiIntro = newDocLinks.apis.restApis;
-    this.elasticsearchClients = newDocLinks.clients.guide;
+    this.apiIntro = newDocLinks.serverlessClients.httpApis;
     this.integrations = newDocLinks.serverlessSearch.integrations;
-    this.goAdvancedConfig = newDocLinks.clients.goConnecting;
-    this.goBasicConfig = newDocLinks.clients.goGettingStarted;
-    this.goClient = newDocLinks.clients.goOverview;
-    this.jsAdvancedConfig = newDocLinks.clients.jsAdvancedConfig;
-    this.jsApiReference = newDocLinks.clients.jsApiReference;
-    this.jsBasicConfig = newDocLinks.clients.jsBasicConfig;
-    this.jsClient = newDocLinks.clients.jsIntro;
-    this.kibanaRunApiInConsole = newDocLinks.console.guide;
+    this.logStash = newDocLinks.serverlessSearch.integrationsLogstash;
+    this.beats = newDocLinks.serverlessSearch.integrationsBeats;
+    this.connectors = newDocLinks.serverlessSearch.integrationsConnectorClient;
+    this.kibanaFeedback = newDocLinks.kibana.feedback;
+    this.kibanaRunApiInConsole = newDocLinks.console.serverlessGuide;
     this.metadata = newDocLinks.security.mappingRoles;
-    this.phpAdvancedConfig = newDocLinks.clients.phpConfiguration;
-    this.phpBasicConfig = newDocLinks.clients.phpConnecting;
-    this.phpClient = newDocLinks.clients.phpOverview;
-    this.phpBasicConfig = newDocLinks.clients.phpConnecting;
-    this.pythonAdvancedConfig = newDocLinks.clients.pythonConfig;
-    this.pythonBasicConfig = newDocLinks.clients.pythonConnecting;
-    this.pythonClient = newDocLinks.clients.pythonOverview;
     this.roleDescriptors = newDocLinks.security.mappingRoles;
-    this.rubyAdvancedConfig = newDocLinks.clients.rubyAdvancedConfig;
-    this.rubyBasicConfig = newDocLinks.clients.rubyBasicConfig;
-    this.rubyExamples = newDocLinks.clients.rubyExamples;
-    this.rubyClient = newDocLinks.clients.rubyOverview;
     this.securityApis = newDocLinks.apis.securityApis;
+
+    // Client links
+    this.elasticsearchClients = newDocLinks.serverlessClients.httpApis;
+    // Go
+    this.goApiReference = newDocLinks.serverlessClients.goApiReference;
+    this.goBasicConfig = newDocLinks.serverlessClients.goGettingStarted;
+    this.goClient = newDocLinks.serverlessClients.goGettingStarted;
+    // JS
+    this.jsApiReference = newDocLinks.serverlessClients.jsApiReference;
+    this.jsBasicConfig = newDocLinks.serverlessClients.jsGettingStarted;
+    this.jsClient = newDocLinks.serverlessClients.jsGettingStarted;
+    // PHP
+    this.phpApiReference = newDocLinks.serverlessClients.phpApiReference;
+    this.phpBasicConfig = newDocLinks.serverlessClients.phpGettingStarted;
+    this.phpClient = newDocLinks.serverlessClients.phpGettingStarted;
+    // Python
+    this.pythonApiReference = newDocLinks.serverlessClients.pythonGettingStarted;
+    this.pythonBasicConfig = newDocLinks.clients.pythonConnecting;
+    this.pythonClient = newDocLinks.serverlessClients.pythonGettingStarted;
+    // Python
+    this.rubyBasicConfig = newDocLinks.serverlessClients.rubyGettingStarted;
+    this.rubyExamples = newDocLinks.serverlessClients.rubyApiReference;
+    this.rubyClient = newDocLinks.serverlessClients.rubyGettingStarted;
+
+    // Getting Started
+    this.gettingStartedIngest = newDocLinks.serverlessSearch.gettingStartedIngest;
+    this.gettingStartedSearch = newDocLinks.serverlessSearch.gettingStartedSearch;
+    this.gettingStartedExplore = newDocLinks.serverlessSearch.gettingStartedExplore;
   }
 }
 

--- a/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/indexing_api.tsx
@@ -23,20 +23,26 @@ import {
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { useQuery } from '@tanstack/react-query';
-import { OverviewPanel, LanguageClientPanel, CodeBox } from '@kbn/search-api-panels';
+import {
+  OverviewPanel,
+  LanguageClientPanel,
+  CodeBox,
+  getLanguageDefinitionCodeSnippet,
+} from '@kbn/search-api-panels';
 import type {
   LanguageDefinition,
   LanguageDefinitionSnippetArguments,
 } from '@kbn/search-api-panels';
 
 import { PLUGIN_ID } from '../../../common';
+import { docLinks } from '../../../common/doc_links';
 import { IndexData, FetchIndicesResult } from '../../../common/types';
 import { FETCH_INDICES_PATH } from '../routes';
 import { API_KEY_PLACEHOLDER, ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
 import { useKibanaServices } from '../hooks/use_kibana';
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
-import { getCodeSnippet, showTryInConsole } from './languages/utils';
+import { showTryInConsole } from './languages/utils';
 
 const NoIndicesContent = () => (
   <>
@@ -47,7 +53,7 @@ const NoIndicesContent = () => (
         defaultMessage="Don't have an index yet? {getStartedLink}"
         values={{
           getStartedLink: (
-            <EuiLink href="#" external>
+            <EuiLink href={docLinks.gettingStartedIngest} external>
               {i18n.translate(
                 'xpack.serverlessSearch.content.indexingApi.clientPanel.noIndices.getStartedLink',
                 { defaultMessage: 'Get started' }
@@ -102,7 +108,6 @@ const IndicesContent = ({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiStat
-            // TODO: format count based on locale
             title={selectedIndex ? selectedIndex.count.toLocaleString() : '--'}
             titleColor="primary"
             description={i18n.translate(
@@ -211,7 +216,7 @@ export const ElasticsearchIndexingApi = () => {
               <EuiSpacer />
               <CodeBox
                 languages={languageDefinitions}
-                codeSnippet={getCodeSnippet(
+                codeSnippet={getLanguageDefinitionCodeSnippet(
                   selectedLanguage,
                   'ingestDataIndex',
                   codeSnippetArguments
@@ -234,7 +239,7 @@ export const ElasticsearchIndexingApi = () => {
                       'xpack.serverlessSearch.content.indexingApi.ingestDocsLink',
                       { defaultMessage: 'Ingestion documentation' }
                     ),
-                    href: '#', // TODO: get doc links ?
+                    href: docLinks.gettingStartedIngest,
                   },
                 ]
           }

--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -24,6 +24,12 @@ export const curlDefinition: LanguageDefinition = {
   configureClient: ({ apiKey, url }) => `export ES_URL="${url}"
 export API_KEY="${apiKey}"`,
   docLink: docLinks.apiIntro,
+  github: {
+    link: 'https://github.com/curl/curl',
+    label: i18n.translate('xpack.serverlessSearch.languages.cURL.githubLabel', {
+      defaultMessage: 'curl',
+    }),
+  },
   iconType: 'curl.svg',
   id: Languages.CURL,
   ingestData: `curl -X POST "\$\{ES_URL\}/_bulk?pretty" \\

--- a/x-pack/plugins/serverless_search/public/application/components/languages/go.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/go.ts
@@ -10,7 +10,7 @@ import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
 import { docLinks } from '../../../../common/doc_links';
 
 export const goDefinition: LanguageDefinition = {
-  advancedConfig: docLinks.goAdvancedConfig,
+  apiReference: docLinks.goApiReference,
   basicConfig: docLinks.goBasicConfig,
   buildSearchQuery: `searchResp, err := es.Search().
   Index("books").
@@ -38,6 +38,12 @@ func main() {
   }
 }`,
   docLink: docLinks.goClient,
+  github: {
+    link: 'https://github.com/elastic/elasticsearch-serverless-go',
+    label: i18n.translate('xpack.serverlessSearch.languages.go.githubLabel', {
+      defaultMessage: 'elasticsearch-serverless-go',
+    }),
+  },
   iconType: 'go.svg',
   id: Languages.GO,
   ingestData: `ingestResult, err := es.Bulk().

--- a/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/javascript.ts
@@ -10,7 +10,6 @@ import { i18n } from '@kbn/i18n';
 import { docLinks } from '../../../../common/doc_links';
 
 export const javascriptDefinition: LanguageDefinition = {
-  advancedConfig: docLinks.jsAdvancedConfig,
   apiReference: docLinks.jsApiReference,
   basicConfig: docLinks.jsBasicConfig,
   buildSearchQuery: `// Let's search!
@@ -29,6 +28,12 @@ auth: {
 }
 });`,
   docLink: docLinks.jsClient,
+  github: {
+    link: 'https://github.com/elastic/elasticsearch-serverless-js',
+    label: i18n.translate('xpack.serverlessSearch.languages.javascript.githubLabel', {
+      defaultMessage: 'elasticsearch-serverless',
+    }),
+  },
   iconType: 'javascript.svg',
   id: Languages.JAVASCRIPT,
   ingestData: `// Sample flight data

--- a/x-pack/plugins/serverless_search/public/application/components/languages/php.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/php.ts
@@ -11,7 +11,7 @@ import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 
 export const phpDefinition: LanguageDefinition = {
-  advancedConfig: docLinks.phpAdvancedConfig,
+  apiReference: docLinks.phpApiReference,
   basicConfig: docLinks.phpBasicConfig,
   buildSearchQuery: `$params = [
   'index' => 'books',
@@ -27,6 +27,12 @@ print_r($response->asArray());`,
   ->setApiKey('${apiKey}')
   ->build();`,
   docLink: docLinks.phpClient,
+  github: {
+    link: 'https://github.com/elastic/elasticsearch-serverless-php',
+    label: i18n.translate('xpack.serverlessSearch.languages.php.githubLink', {
+      defaultMessage: 'elasticsearch-serverless-php',
+    }),
+  },
   iconType: 'php.svg',
   id: Languages.PHP,
   ingestData: `$params = [

--- a/x-pack/plugins/serverless_search/public/application/components/languages/python.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/python.ts
@@ -11,7 +11,7 @@ import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 
 export const pythonDefinition: LanguageDefinition = {
-  advancedConfig: docLinks.pythonAdvancedConfig,
+  apiReference: docLinks.pythonApiReference,
   basicConfig: docLinks.pythonBasicConfig,
   buildSearchQuery: `client.search(index="books", q="snow")`,
   configureClient: ({ url, apiKey }) => `from elasticsearch import Elasticsearch
@@ -21,6 +21,12 @@ client = Elasticsearch(
   api_key="${apiKey}"
 )`,
   docLink: docLinks.pythonClient,
+  github: {
+    link: 'https://github.com/elastic/elasticsearch-serverless-python',
+    label: i18n.translate('xpack.serverlessSearch.languages.python.githubLabel', {
+      defaultMessage: 'elasticsearch-serverless-python',
+    }),
+  },
   iconType: 'python.svg',
   id: Languages.PYTHON,
   ingestData: `documents = [

--- a/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
@@ -11,7 +11,6 @@ import { docLinks } from '../../../../common/doc_links';
 import { INDEX_NAME_PLACEHOLDER } from '../../constants';
 
 export const rubyDefinition: LanguageDefinition = {
-  advancedConfig: docLinks.rubyAdvancedConfig,
   apiReference: docLinks.rubyExamples,
   buildSearchQuery: `client.search(index: 'books', q: 'snow')`,
   configureClient: ({ url, apiKey }) => `client = ElasticsearchServerless::Client.new(
@@ -21,6 +20,12 @@ export const rubyDefinition: LanguageDefinition = {
 `,
   basicConfig: docLinks.rubyBasicConfig,
   docLink: docLinks.rubyClient,
+  github: {
+    link: 'https://github.com/elastic/elasticsearch-serverless-ruby',
+    label: i18n.translate('xpack.serverlessSearch.languages.ruby.githubLabel', {
+      defaultMessage: 'elasticsearch-serverless-ruby',
+    }),
+  },
   iconType: 'ruby.svg',
   id: Languages.RUBY,
   ingestData: `documents = [

--- a/x-pack/plugins/serverless_search/public/application/components/languages/utils.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/utils.ts
@@ -5,18 +5,7 @@
  * 2.0.
  */
 
-import { LanguageDefinition, LanguageDefinitionSnippetArguments } from '@kbn/search-api-panels';
+import { LanguageDefinition } from '@kbn/search-api-panels';
 import { consoleDefinition } from './console';
 
 export const showTryInConsole = (code: keyof LanguageDefinition) => code in consoleDefinition;
-
-export const getCodeSnippet = (
-  language: Partial<LanguageDefinition>,
-  key: keyof LanguageDefinition,
-  args: LanguageDefinitionSnippetArguments
-): string => {
-  const snippetVal = language[key];
-  if (snippetVal === undefined) return '';
-  if (typeof snippetVal === 'string') return snippetVal;
-  return snippetVal(args);
-};

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -27,6 +27,7 @@ import {
   CodeBox,
   LanguageClientPanel,
   InstallClientPanel,
+  getLanguageDefinitionCodeSnippet,
 } from '@kbn/search-api-panels';
 
 import React, { useMemo, useState } from 'react';
@@ -42,7 +43,7 @@ import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
 import './overview.scss';
 import { ApiKeyPanel } from './api_key/api_key';
-import { getCodeSnippet, showTryInConsole } from './languages/utils';
+import { showTryInConsole } from './languages/utils';
 
 export const ElasticsearchOverview = () => {
   const [selectedLanguage, setSelectedLanguage] =
@@ -85,7 +86,11 @@ export const ElasticsearchOverview = () => {
 
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <InstallClientPanel
-          codeSnippet={getCodeSnippet(selectedLanguage, 'installClient', codeSnippetArguments)}
+          codeSnippet={getLanguageDefinitionCodeSnippet(
+            selectedLanguage,
+            'installClient',
+            codeSnippetArguments
+          )}
           showTryInConsole={showTryInConsole('installClient')}
           languages={languageDefinitions}
           language={selectedLanguage}
@@ -124,7 +129,7 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               languages={languageDefinitions}
-              codeSnippet={getCodeSnippet(
+              codeSnippet={getLanguageDefinitionCodeSnippet(
                 selectedLanguage,
                 'configureClient',
                 codeSnippetArguments
@@ -152,19 +157,6 @@ export const ElasticsearchOverview = () => {
                   },
                 ]
               : []),
-            ...(selectedLanguage.advancedConfig
-              ? [
-                  {
-                    href: selectedLanguage.advancedConfig,
-                    label: i18n.translate(
-                      'xpack.serverlessSearch.configureClient.advancedConfigLabel',
-                      {
-                        defaultMessage: 'Advanced configuration',
-                      }
-                    ),
-                  },
-                ]
-              : []),
           ]}
           title={i18n.translate('xpack.serverlessSearch.configureClient.title', {
             defaultMessage: 'Configure your client',
@@ -180,7 +172,11 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               languages={languageDefinitions}
-              codeSnippet={getCodeSnippet(selectedLanguage, 'testConnection', codeSnippetArguments)}
+              codeSnippet={getLanguageDefinitionCodeSnippet(
+                selectedLanguage,
+                'testConnection',
+                codeSnippetArguments
+              )}
               showTryInConsole={showTryInConsole('testConnection')}
               selectedLanguage={selectedLanguage}
               setSelectedLanguage={setSelectedLanguage}
@@ -198,7 +194,11 @@ export const ElasticsearchOverview = () => {
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <IngestData
-          codeSnippet={getCodeSnippet(selectedLanguage, 'ingestData', codeSnippetArguments)}
+          codeSnippet={getLanguageDefinitionCodeSnippet(
+            selectedLanguage,
+            'ingestData',
+            codeSnippetArguments
+          )}
           showTryInConsole={showTryInConsole('ingestData')}
           languages={languageDefinitions}
           selectedLanguage={selectedLanguage}
@@ -219,7 +219,7 @@ export const ElasticsearchOverview = () => {
           leftPanelContent={
             <CodeBox
               languages={languageDefinitions}
-              codeSnippet={getCodeSnippet(
+              codeSnippet={getLanguageDefinitionCodeSnippet(
                 selectedLanguage,
                 'buildSearchQuery',
                 codeSnippetArguments
@@ -360,26 +360,28 @@ export const ElasticsearchOverview = () => {
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section alignment="top" className="serverlessSearchFooter">
         <EuiFlexGroup gutterSize="l">
-          <EuiFlexItem>
-            <FooterIcon
-              // TODO: update with real link
-              href="https://elastic.co"
-              imgSrc={`${assetBasePath}invite_users_icon.png`}
-              title={i18n.translate('xpack.serverlessSearch.footer.inviteUsers.title', {
-                defaultMessage: 'Invite more users',
-              })}
-            />
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <FooterIcon
-              // TODO: update with real link
-              href="https://elastic.co"
-              imgSrc={`${assetBasePath}billing_icon.png`}
-              title={i18n.translate('xpack.serverlessSearch.footer.billing.title', {
-                defaultMessage: 'Billing and usage',
-              })}
-            />
-          </EuiFlexItem>
+          {cloud.usersAndRolesUrl && (
+            <EuiFlexItem>
+              <FooterIcon
+                href={cloud.usersAndRolesUrl}
+                imgSrc={`${assetBasePath}invite_users_icon.png`}
+                title={i18n.translate('xpack.serverlessSearch.footer.inviteUsers.title', {
+                  defaultMessage: 'Invite more users',
+                })}
+              />
+            </EuiFlexItem>
+          )}
+          {cloud.billingUrl && (
+            <EuiFlexItem>
+              <FooterIcon
+                href={cloud.billingUrl}
+                imgSrc={`${assetBasePath}billing_icon.png`}
+                title={i18n.translate('xpack.serverlessSearch.footer.billing.title', {
+                  defaultMessage: 'Billing and usage',
+                })}
+              />
+            </EuiFlexItem>
+          )}
           <EuiFlexItem>
             <FooterIcon
               href="https://www.elastic.co/community/"
@@ -391,8 +393,7 @@ export const ElasticsearchOverview = () => {
           </EuiFlexItem>
           <EuiFlexItem>
             <FooterIcon
-              // TODO: update with real link
-              href="https://www.elastic.co/kibana/feedback"
+              href={docLinks.kibanaFeedback}
               imgSrc={`${assetBasePath}feedback_icon.png`}
               title={i18n.translate('xpack.serverlessSearch.footer.feedback.title', {
                 defaultMessage: 'Give feedback',

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -34693,7 +34693,6 @@
     "xpack.serverlessSearch.apiKey.userFieldLabel": "用户",
     "xpack.serverlessSearch.back": "返回",
     "xpack.serverlessSearch.cancel": "取消",
-    "xpack.serverlessSearch.configureClient.advancedConfigLabel": "高级配置",
     "xpack.serverlessSearch.configureClient.basicConfigLabel": "基本配置",
     "xpack.serverlessSearch.configureClient.description": "使用唯一 API 密钥和云 ID 对客户端进行初始化",
     "xpack.serverlessSearch.configureClient.title": "配置客户端",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Serverless Search] Updating doc links (#164354)](https://github.com/elastic/kibana/pull/164354)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2023-08-23T17:24:58Z","message":"[Serverless Search] Updating doc links (#164354)\n\n## Summary\r\n\r\n- Updating serverless search doc links, specifically replacing client\r\nlinks to the upcoming serverless client docs.\r\n- Updated the github repo links for clients to the language definition\r\nand set them to the serverless client repos\r\n- Removed the \"Advanced Configuration\" links from the getting started\r\npage, we wont have these pages for M0\r\n- Used the cloud urls for invite users and billing","sha":"da394f94dfe61bdd574dbf06a764f259f918481c","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v8.11.0"],"number":164354,"url":"https://github.com/elastic/kibana/pull/164354","mergeCommit":{"message":"[Serverless Search] Updating doc links (#164354)\n\n## Summary\r\n\r\n- Updating serverless search doc links, specifically replacing client\r\nlinks to the upcoming serverless client docs.\r\n- Updated the github repo links for clients to the language definition\r\nand set them to the serverless client repos\r\n- Removed the \"Advanced Configuration\" links from the getting started\r\npage, we wont have these pages for M0\r\n- Used the cloud urls for invite users and billing","sha":"da394f94dfe61bdd574dbf06a764f259f918481c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164354","number":164354,"mergeCommit":{"message":"[Serverless Search] Updating doc links (#164354)\n\n## Summary\r\n\r\n- Updating serverless search doc links, specifically replacing client\r\nlinks to the upcoming serverless client docs.\r\n- Updated the github repo links for clients to the language definition\r\nand set them to the serverless client repos\r\n- Removed the \"Advanced Configuration\" links from the getting started\r\npage, we wont have these pages for M0\r\n- Used the cloud urls for invite users and billing","sha":"da394f94dfe61bdd574dbf06a764f259f918481c"}}]}] BACKPORT-->