### PR TITLE
[Ops] Fix @kbn/imports/no_unused_imports rule

### DIFF
--- a/packages/kbn-eslint-plugin-imports/src/rules/no_unused_imports.ts
+++ b/packages/kbn-eslint-plugin-imports/src/rules/no_unused_imports.ts
@@ -78,6 +78,7 @@ function isTsOrEslintIgnore(comment: Comment) {
 
 export const NoUnusedImportsRule: Rule.RuleModule = {
   meta: {
+    hasSuggestions: true,
     fixable: 'code',
     docs: {
       url: 'https://github.com/elastic/kibana/blob/main/packages/kbn-eslint-plugin-imports/README.mdx#kbnimportsno_unused_imports',


### PR DESCRIPTION
## Summary
@jloleysens reported that ESLint breaks (probably in IDEs only) because of this bug. When there's an unused import, linting stops for the whole file.

By adding this flag, it no longer breaks on my machine, however, auto-fixing still doesn't work from the CLI. The IDE auto-fixes because it also recognizes it as a non-unsed variable.

- add `meta.hasSuggestions` to `@kbn/imports/no_unused_imports` prevent ESLint from breaking


<!--ONMERGE {"backportTargets":["7.17","8.10","8.9"]} ONMERGE-->