### PR TITLE
[Security Solution][Investigations] - Fixes vertical scroll in expandable flyout

### DIFF
--- a/packages/kbn-expandable-flyout/src/components/left_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/left_section.tsx
@@ -7,7 +7,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { LEFT_SECTION } from './test_ids';
 
 interface LeftSectionProps {
@@ -25,8 +25,12 @@ interface LeftSectionProps {
  * Left section of the expanded flyout rendering a panel
  */
 export const LeftSection: React.FC<LeftSectionProps> = ({ component, width }: LeftSectionProps) => {
+  const style = useMemo<React.CSSProperties>(
+    () => ({ height: '100%', width: `${width * 100}%`, overflowY: 'scroll' }),
+    [width]
+  );
   return (
-    <EuiFlexItem grow data-test-subj={LEFT_SECTION} style={{ width: `${width * 100}%` }}>
+    <EuiFlexItem grow data-test-subj={LEFT_SECTION} style={style}>
       <EuiFlexGroup direction="column">{component}</EuiFlexGroup>
     </EuiFlexItem>
   );

--- a/packages/kbn-expandable-flyout/src/components/right_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/right_section.tsx
@@ -7,7 +7,7 @@
  */
 
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { RIGHT_SECTION } from './test_ids';
 
 interface RightSectionProps {
@@ -28,12 +28,13 @@ export const RightSection: React.FC<RightSectionProps> = ({
   component,
   width,
 }: RightSectionProps) => {
+  const style = useMemo<React.CSSProperties>(
+    () => ({ height: '100%', width: `${width * 100}%`, overflowY: 'scroll' }),
+    [width]
+  );
+
   return (
-    <EuiFlexItem
-      grow={false}
-      style={{ height: '100%', width: `${width * 100}%` }}
-      data-test-subj={RIGHT_SECTION}
-    >
+    <EuiFlexItem grow={false} style={style} data-test-subj={RIGHT_SECTION}>
       <EuiFlexGroup direction="column">{component}</EuiFlexGroup>
     </EuiFlexItem>
   );


### PR DESCRIPTION
## Summary

Addresses: 

https://github.com/elastic/kibana/issues/164530
https://github.com/elastic/kibana/issues/164812

The new scroll behavior can be seen below. One thing I was unsure about was locking the scroll of the global page, but a user may want to scroll down the table to open a new alert?



https://github.com/elastic/kibana/assets/17211684/a4e2796a-14dc-4f93-a040-6801d0f8769c





<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->