### PR TITLE
[Security Solution][Investigations] - Fix resolver full screen background

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/graph_overlay/index.tsx
@@ -50,6 +50,7 @@ const OverlayContainer = styled.div`
 `;
 
 const FullScreenOverlayStyles = css`
+  background-color:  ${({ theme }) => `${theme.eui.euiColorEmptyShade};`}
   position: fixed;
   top: 0;
   bottom: 2em;


### PR DESCRIPTION
## Summary

Addresses: https://github.com/elastic/kibana/issues/164813

Added a background to the full screen overlay:

<img width="1676" alt="Screenshot 2023-08-25 at 1 10 35 PM" src="https://github.com/elastic/kibana/assets/17211684/2cda15bb-9e1b-4897-8ba8-54a74e89b6f1">


dark mode:

<img width="1722" alt="Screenshot 2023-08-25 at 1 34 23 PM" src="https://github.com/elastic/kibana/assets/17211684/19a82077-5612-4de2-9020-1238a6d6d7d4">




<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->