### PR TITLE
[Fleet] Fix user dark mode for integration app

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/app.tsx
@@ -255,7 +255,7 @@ export const FleetAppContext: React.FC<{
     theme$,
     fleetStatus,
   }) => {
-    const darkModeObservable = useObservable(startServices.theme.theme$);
+    const darkModeObservable = useObservable(theme$);
     const isDarkMode = darkModeObservable && darkModeObservable.darkMode;
 
     return (

--- a/x-pack/plugins/fleet/public/applications/integrations/app.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/app.tsx
@@ -75,7 +75,9 @@ export const IntegrationsAppContext: React.FC<{
     theme$,
     fleetStatus,
   }) => {
-    const isDarkMode = useObservable<boolean>(startServices.uiSettings.get$('theme:darkMode'));
+    const theme = useObservable(theme$);
+    const isDarkMode = theme && theme.darkMode;
+
     const CloudContext = startServices.cloud?.CloudContextProvider || EmptyContext;
 
     return (


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/163328

When user was setting dark mode, the integration app was not corretcly handling it (it was already good for the Fleet APP)
That PR fix that.

## Test/UI Changes

Set dark mode for your user and observe the integration app is correctly rendered.

<img width="1495" alt="Screenshot 2023-08-25 at 1 43 45 PM" src="https://github.com/elastic/kibana/assets/1336873/7681b788-72b2-470e-924b-2f43d7653267">
