### PR TITLE
[Dashboard Navigation] Store unwrapped attributes in componentState

### DIFF
--- a/src/plugins/navigation_embeddable/public/components/navigation_embeddable_component.tsx
+++ b/src/plugins/navigation_embeddable/public/components/navigation_embeddable_component.tsx
@@ -7,10 +7,7 @@
  */
 
 import React, { useMemo } from 'react';
-
 import { EuiListGroup, EuiPanel } from '@elastic/eui';
-
-import { NavigationEmbeddableByValueInput } from '../embeddable/types';
 import { useNavigationEmbeddable } from '../embeddable/navigation_embeddable';
 import { ExternalLinkComponent } from './external_link/external_link_component';
 import { DashboardLinkComponent } from './dashboard_link/dashboard_link_component';
@@ -25,12 +22,8 @@ import './navigation_embeddable_component.scss';
 
 export const NavigationEmbeddableComponent = () => {
   const navEmbeddable = useNavigationEmbeddable();
-  const links = navEmbeddable.select(
-    (state) => (state.explicitInput as NavigationEmbeddableByValueInput).attributes?.links
-  );
-  const layout = navEmbeddable.select(
-    (state) => (state.explicitInput as NavigationEmbeddableByValueInput).attributes?.layout
-  );
+  const links = navEmbeddable.select((state) => state.componentState.links);
+  const layout = navEmbeddable.select((state) => state.componentState.layout);
 
   const orderedLinks = useMemo(() => {
     if (!links) return [];

--- a/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_factory.ts
+++ b/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_factory.ts
@@ -7,41 +7,25 @@
  */
 
 import {
-  ACTION_ADD_PANEL,
   EmbeddableFactory,
   EmbeddableFactoryDefinition,
-  EmbeddablePackageState,
   ErrorEmbeddable,
 } from '@kbn/embeddable-plugin/public';
 import { lazyLoadReduxToolsPackage } from '@kbn/presentation-util-plugin/public';
 import { EmbeddablePersistableStateService } from '@kbn/embeddable-plugin/common';
 import { DashboardContainer } from '@kbn/dashboard-plugin/public/dashboard_container';
 
-import {
-  NavigationEmbeddableByValueInput,
-  NavigationEmbeddableByReferenceInput,
-  NavigationEmbeddableInput,
-} from './types';
+import { NavigationEmbeddableByReferenceInput, NavigationEmbeddableInput } from './types';
 import { APP_ICON, APP_NAME, CONTENT_ID } from '../../common';
 import type { NavigationEmbeddable } from './navigation_embeddable';
-import { NAV_VERTICAL_LAYOUT } from '../../common/content_management';
 import { getNavigationEmbeddableAttributeService } from '../services/attribute_service';
 import { coreServices, untilPluginStartServicesReady } from '../services/kibana_services';
 
 export type NavigationEmbeddableFactory = EmbeddableFactory;
 
-export interface NavigationEmbeddableCreationOptions {
-  getInitialInput?: () => Partial<NavigationEmbeddableInput>;
-  getIncomingEmbeddable?: () => EmbeddablePackageState | undefined;
-}
-
 // TODO: Replace string 'OPEN_FLYOUT_ADD_DRILLDOWN' with constant as part of https://github.com/elastic/kibana/issues/154381
-const getDefaultNavigationEmbeddableInput = (): Omit<NavigationEmbeddableByValueInput, 'id'> => ({
-  attributes: {
-    title: '',
-    layout: NAV_VERTICAL_LAYOUT,
-  },
-  disabledActions: [ACTION_ADD_PANEL, 'OPEN_FLYOUT_ADD_DRILLDOWN'],
+const getDefaultNavigationEmbeddableInput = (): Partial<NavigationEmbeddableInput> => ({
+  disabledActions: ['OPEN_FLYOUT_ADD_DRILLDOWN'],
 });
 
 export class NavigationEmbeddableFactoryDefinition

--- a/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_reducers.ts
+++ b/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_reducers.ts
@@ -11,6 +11,7 @@ import { WritableDraft } from 'immer/dist/types/types-external';
 import { PayloadAction } from '@reduxjs/toolkit';
 
 import { NavigationEmbeddableReduxState } from './types';
+import { NavigationEmbeddableAttributes } from '../../common/content_management';
 
 export const navigationEmbeddableReducers = {
   /**
@@ -23,5 +24,12 @@ export const navigationEmbeddableReducers = {
     action: PayloadAction<boolean>
   ) => {
     state.output.loading = action.payload;
+  },
+
+  setAttributes: (
+    state: WritableDraft<NavigationEmbeddableReduxState>,
+    action: PayloadAction<NavigationEmbeddableAttributes>
+  ) => {
+    state.componentState = { ...action.payload };
   },
 };

--- a/src/plugins/navigation_embeddable/public/embeddable/types.ts
+++ b/src/plugins/navigation_embeddable/public/embeddable/types.ts
@@ -82,10 +82,10 @@ export type NavigationEmbeddableOutput = EmbeddableOutput & {
 /**
  *  Navigation embeddable redux state
  */
-// export interface NavigationEmbeddableComponentState {} // TODO: Uncomment this if we end up needing component state
+export type NavigationEmbeddableComponentState = NavigationEmbeddableAttributes;
 
 export type NavigationEmbeddableReduxState = ReduxEmbeddableState<
   NavigationEmbeddableInput,
   NavigationEmbeddableOutput,
-  {} // We currently don't have any component state - TODO: Replace with `NavigationEmbeddableComponentState` if necessary
+  NavigationEmbeddableComponentState
 >;


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/164322

Store the unwrapped attributes from by-reference links panels in `componentState`. 

Since the `explictInput` for a Links panel can be either by-reference or by-value, we need to be sure to share the unwrapped attributes (as in from a by-reference panel) to our component. 