### PR TITLE
[Enterprise Search] type clean-up

### DIFF
--- a/packages/kbn-search-api-panels/components/ingest_data.tsx
+++ b/packages/kbn-search-api-panels/components/ingest_data.tsx
@@ -21,7 +21,12 @@ interface IngestDataProps {
   codeSnippet: string;
   selectedLanguage: LanguageDefinition;
   setSelectedLanguage: (language: LanguageDefinition) => void;
-  docLinks: any;
+  docLinks: {
+    beats: string;
+    connectors: string;
+    integrations: string;
+    logStash: string;
+  };
   assetBasePath: string;
   application?: ApplicationStart;
   sharePlugin: SharePluginStart;

--- a/packages/kbn-search-api-panels/components/integrations_panel.tsx
+++ b/packages/kbn-search-api-panels/components/integrations_panel.tsx
@@ -24,7 +24,7 @@ import { LEARN_MORE_LABEL } from '../constants';
 import { GithubLink } from './github_link';
 
 export interface IntegrationsPanelProps {
-  docLinks: any;
+  docLinks: { beats: string; connectors: string; logStash: string };
   assetBasePath: string;
 }
 

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -203,7 +203,7 @@ export const ElasticsearchOverview = () => {
             'ingestData',
             codeSnippetArguments
           )}
-          showTryInConsole={getConsoleRequest('ingestData')}
+          consoleRequest={getConsoleRequest('ingestData')}
           languages={languageDefinitions}
           selectedLanguage={selectedLanguage}
           setSelectedLanguage={setSelectedLanguage}


### PR DESCRIPTION
## Summary

Updated the search-api-panels docLinks types to not use `any`
Fixed prop in serverless search, I _think_ this was a merge conflict between PRs

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->