### PR TITLE
[DOCS] Move preconfigured server log connector details

### DIFF
--- a/docs/management/connectors/action-types/server-log.asciidoc
+++ b/docs/management/connectors/action-types/server-log.asciidoc
@@ -3,11 +3,12 @@
 ++++
 <titleabbrev>Server log</titleabbrev>
 ++++
+:frontmatter-description: Add a connector that can write in {kib} server logs.
+:frontmatter-tags-products: [kibana] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [configure]
 
 A server log connector writes an entry to the {kib} server log.
-
-You can create a server log connectors in {kib} or by using the
-<<create-connector-api,create connector API>>.
 
 [float]
 [[define-serverlog-ui]]
@@ -30,8 +31,8 @@ Server log connectors do not have any configuration properties other than a name
 [[server-log-action-configuration]]
 === Test connectors
 
-You can test connectors with the <<execute-connector-api,run connector API>> or
-as you're creating or editing the connector in {kib}. For example:
+You can test connectors as you're creating or editing the connector in {kib}.
+For example:
 
 [role="screenshot"]
 image::management/connectors/images/serverlog-params-test.png[Server log connector test]

--- a/docs/management/connectors/action-types/server-log.asciidoc
+++ b/docs/management/connectors/action-types/server-log.asciidoc
@@ -7,8 +7,7 @@
 A server log connector writes an entry to the {kib} server log.
 
 You can create a server log connectors in {kib} or by using the
-<<create-connector-api,create connector API>>. If you are running {kib}
-on-prem, you can also create preconfigured server log connectors.
+<<create-connector-api,create connector API>>.
 
 [float]
 [[define-serverlog-ui]]
@@ -26,23 +25,6 @@ image::management/connectors/images/serverlog-connector.png[Server log connector
 ==== Connector configuration
 
 Server log connectors do not have any configuration properties other than a name.
-
-[float]
-[[preconfigured-server-log-configuration]]
-=== Create preconfigured connectors
-
-If you are running {kib} on-prem, you can define connectors by adding
-`xpack.actions.preconfigured` settings to your `kibana.yml` file. For example:
-
-[source,text]
---
-xpack.actions.preconfigured:
-  my-server-log:
-    name: preconfigured-server-log-connector-type
-    actionTypeId: .server-log
---
-
-For more information, go to <<pre-configured-connectors>>.
 
 [float]
 [[server-log-action-configuration]]

--- a/docs/management/connectors/pre-configured-connectors.asciidoc
+++ b/docs/management/connectors/pre-configured-connectors.asciidoc
@@ -81,8 +81,28 @@ Clicking a preconfigured connector shows the description, but not the
 configuration.
 
 [float]
+=== Examples
+
+* <<preconfigured-server-log-configuration>>
+* <<preconfigured-webhook-configuration>>
+
+[float]
+[[preconfigured-server-log-configuration]]
+==== Server log connectors
+
+The following example creates a <<server-log-action-type,server log connector>>:
+
+[source,text]
+--
+xpack.actions.preconfigured:
+  my-server-log:
+    name: preconfigured-server-log-connector-type
+    actionTypeId: .server-log
+--
+
+[float]
 [[preconfigured-webhook-configuration]]
-=== Webhook preconfigured connector example
+==== Webhook connectors
 
 The following example creates a <<webhook-action-type,webhook connector>> with basic authentication:
 

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -142,12 +142,6 @@ A list of action types that are enabled. It defaults to `["*"]`, enabling all ty
 +
 Disabled action types will not appear as an option when creating new connectors, but existing connectors and actions of that type will remain in {kib} and will not function.
 
-`xpack.actions.preconfiguredAlertHistoryEsIndex` {ess-icon}::
-Enables a preconfigured alert history {es} <<index-action-type, Index>> connector. Default: `false`.
-
-`xpack.actions.preconfigured`::
-Specifies preconfigured connector IDs and configs. Default: {}.
-
 `xpack.actions.proxyUrl` {ess-icon}::
 Specifies the proxy URL to use, if using a proxy for actions. By default, no proxy is used.
 +
@@ -216,6 +210,34 @@ xpack.actions.run:
         - id: '.server-log'
           maxAttempts: 5
 --
+
+[float]
+[[preconfigured-connector-settings]]
+=== Preconfigured connector settings
+
+These settings vary depending on which type of <<pre-configured-connectors,preconfigured connector>> you're adding.
+For example:
+
+[source,yaml]
+----------------------------------------
+xpack.actions.preconfigured:
+  my-server-log:
+    name: preconfigured-server-log-connector-type
+    actionTypeId: .server-log
+----------------------------------------
+
+`xpack.actions.preconfiguredAlertHistoryEsIndex` {ess-icon}::
+Enables a preconfigured alert history {es} <<index-action-type, Index>> connector. Default: `false`.
+
+`xpack.actions.preconfigured`::
+Specifies configuration details that are specific to the type of preconfigured connector.
+
+`xpack.actions.preconfigured.<connector-id>.actionTypeId`::
+The type of preconfigured connector.
+For example: `.email`, `.index`, `.opsgenie`, `.server-log`, `.resilient`, `.slack`, and `.webhook`.
+
+`xpack.actions.preconfigured.<connector-id>.name`::
+The name of the preconfigured connector.
 
 [float]
 [[alert-settings]]


### PR DESCRIPTION
## Summary

This PR

- Moves the preconfigured connector example from https://www.elastic.co/guide/en/kibana/master/server-log-action-type.html#preconfigured-server-log-configuration to https://www.elastic.co/guide/en/kibana/master/pre-configured-connectors.html since that functionality is only applicable if you are running Kibana on-prem and therefore won't be applicable to serverless projects.
- Adds the setting names to https://www.elastic.co/guide/en/kibana/master/alert-action-settings-kb.html
- Adds frontmatter for migration purposes.
- Removes references to the APIs, since this page is focused on completing a task within Kibana.

### Preview

- https://kibana_164898.docs-preview.app.elstc.co/guide/en/kibana/master/alert-action-settings-kb.html#preconfigured-connector-settings
- https://kibana_164898.docs-preview.app.elstc.co/guide/en/kibana/master/pre-configured-connectors.html#_examples_3
- https://kibana_164898.docs-preview.app.elstc.co/guide/en/kibana/master/server-log-action-type.html [section removed,  minor changes]