### PR TITLE
[Cloud Security] Adding API version to detection engine rule API

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -22,6 +22,7 @@ export const FIND_CSP_RULE_TEMPLATE_ROUTE_PATH = '/internal/cloud_security_postu
 export const FIND_CSP_RULE_TEMPLATE_API_CURRENT_VERSION = '1';
 
 export const DETECTION_RULE_ALERTS_STATUS_API_CURRENT_VERSION = '1';
+export const DETECTION_RULE_RULES_API_CURRENT_VERSION = '2023-10-31';
 
 export const GET_DETECTION_RULE_ALERTS_STATUS_PATH =
   '/internal/cloud_security_posture/detection_engine_rules/alerts/_status';

--- a/x-pack/plugins/cloud_security_posture/public/common/api/create_detection_rule.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/create_detection_rule.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import { HttpSetup } from '@kbn/core/public';
+import { DETECTION_RULE_RULES_API_CURRENT_VERSION } from '../../../common/constants';
 import { RuleCreateProps, RuleResponse } from '../types';
 
 const DETECTION_ENGINE_URL = '/api/detection_engine' as const;
@@ -18,6 +19,7 @@ export const createDetectionRule = async ({
   rule: RuleCreateProps;
 }): Promise<RuleResponse> => {
   const res = await http.post<RuleCreateProps>(DETECTION_ENGINE_RULES_URL, {
+    version: DETECTION_RULE_RULES_API_CURRENT_VERSION,
     body: JSON.stringify(rule),
   });
 

--- a/x-pack/plugins/cloud_security_posture/public/common/api/use_fetch_detection_rules_by_tags.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/use_fetch_detection_rules_by_tags.ts
@@ -8,6 +8,7 @@
 import { CoreStart } from '@kbn/core/public';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { useQuery } from '@tanstack/react-query';
+import { DETECTION_RULE_RULES_API_CURRENT_VERSION } from '../../../common/constants';
 import { RuleResponse } from '../types';
 import { DETECTION_ENGINE_RULES_KEY } from '../constants';
 
@@ -47,6 +48,7 @@ export const useFetchDetectionRulesByTags = (tags: string[]) => {
   return useQuery([DETECTION_ENGINE_RULES_KEY, tags], () =>
     http.fetch<FetchRulesResponse>(DETECTION_ENGINE_RULES_URL_FIND, {
       method: 'GET',
+      version: DETECTION_RULE_RULES_API_CURRENT_VERSION,
       query,
     })
   );


### PR DESCRIPTION
## Summary

Adding version for detection engine rule APIs, version was introduced on v 8.11