### PR TITLE
[APM] Improved Observability Alerts UI, unified pageheader links

### DIFF
--- a/x-pack/plugins/observability/public/pages/alerts/components/rule_stats.test.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/rule_stats.test.tsx
@@ -28,6 +28,64 @@ describe('Rule stats', () => {
     );
     expect(stats.length).toEqual(6);
   });
+
+  test('total stat is not clickable, when there are no rules', async () => {
+    const stats = renderRuleStats(
+      {
+        total: 0,
+        disabled: 0,
+        muted: 0,
+        error: 0,
+        snoozed: 0,
+      },
+      RULES_PAGE_LINK,
+      false
+    );
+    const { findByText, container } = render(stats[5]);
+    const ruleCountElement = await findByText('Rule count');
+    expect(ruleCountElement).toBeInTheDocument();
+    expect(container.getElementsByClassName(STAT_CLASS).length).toBe(1);
+    expect(container.querySelector(STAT_TITLE_PRIMARY_SELECTOR)).toBeFalsy();
+    expect(container.getElementsByClassName(STAT_BUTTON_CLASS).length).toBe(0);
+  });
+
+  test('total stat is clickable, when there are any rules', async () => {
+    const stats = renderRuleStats(
+      {
+        total: 11,
+        disabled: 0,
+        muted: 0,
+        error: 0,
+        snoozed: 0,
+      },
+      RULES_PAGE_LINK,
+      false
+    );
+    const { container } = render(stats[5]);
+    expect(screen.getByText('Rule count').closest('a')).toHaveAttribute(
+      'href',
+      `${RULES_PAGE_LINK}?_a=(lastResponse:!(),status:!())`
+    );
+
+    expect(container.getElementsByClassName(STAT_BUTTON_CLASS).length).toBe(1);
+  });
+
+  test('total stat count is link-colored, when there are any rules', async () => {
+    const stats = renderRuleStats(
+      {
+        total: 11,
+        disabled: 0,
+        muted: 0,
+        error: 0,
+        snoozed: 0,
+      },
+      RULES_PAGE_LINK,
+      false
+    );
+    const { container } = render(stats[5]);
+    expect(container.querySelector(STAT_TITLE_PRIMARY_SELECTOR)).toBeTruthy();
+  });
+
   test('disabled stat is not clickable, when there are no disabled rules', async () => {
     const stats = renderRuleStats(
       {

--- a/x-pack/plugins/observability/public/pages/alerts/components/rule_stats.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/components/rule_stats.tsx
@@ -18,7 +18,7 @@ export interface RuleStatsState {
   error: number;
   snoozed: number;
 }
-type StatType = 'disabled' | 'snoozed' | 'error';
+type StatType = 'total' | 'disabled' | 'snoozed' | 'error';
 
 const Divider = euiStyled.div`
   border-right: 1px solid ${euiThemeVars.euiColorLightShade};
@@ -69,6 +69,32 @@ export const renderRuleStats = (
     }
     return statsLink;
   };
+
+  const ruleCountStatsComponent = (
+    <ConditionalWrap
+      condition={ruleStats.total > 0}
+      wrap={(wrappedChildren) => (
+        <EuiButtonEmpty
+          data-test-subj="o11yTotalStatsComponentButton"
+          href={createRuleStatsLink(ruleStats, 'total')}
+        >
+          {wrappedChildren}
+        </EuiButtonEmpty>
+      )}
+    >
+      <StyledStat
+        title={ruleStats.total}
+        description={i18n.translate('xpack.observability.alerts.ruleStats.ruleCount', {
+          defaultMessage: 'Rule count',
+        })}
+        color="primary"
+        titleColor={ruleStats.total > 0 ? 'primary' : ''}
+        titleSize="xs"
+        isLoading={ruleStatsLoading}
+        data-test-subj="statRuleCount"
+      />
+    </ConditionalWrap>
+  );
 
   const disabledStatsComponent = (
     <ConditionalWrap
@@ -147,17 +173,9 @@ export const renderRuleStats = (
       />
     </ConditionalWrap>
   );
+
   return [
-    <StyledStat
-      title={ruleStats.total}
-      description={i18n.translate('xpack.observability.alerts.ruleStats.ruleCount', {
-        defaultMessage: 'Rule count',
-      })}
-      color="primary"
-      titleSize="xs"
-      isLoading={ruleStatsLoading}
-      data-test-subj="statRuleCount"
-    />,
+    ruleCountStatsComponent,
     disabledStatsComponent,
     snoozedStatsComponent,
     errorStatsComponent,


### PR DESCRIPTION
## Summary

This improves and unifies UI in **Observability / Alerts** view. Previously the hyperlink was missing in page header. The list of all alerts view could be seen by clicking "Manage Rules" button, but this is inconsistent visually and I believe Rule count should also become a hyperlink. It also cleans up code a little bit.

I have been using APM a lot and this inconsistency always confused me, I kept trying to click on Rule Count.


| Main branch  | Pull Request  |
| ------------- | ------------- |
| <img width="520" alt="image" src="https://github.com/elastic/kibana/assets/14107724/5509e25a-aa93-4b3b-b95d-0fd337538c91">  | <img width="520" alt="image" src="https://github.com/elastic/kibana/assets/14107724/0f1873f6-19b9-4ebd-aefe-bd513898df5d"> |






