### PR TITLE
[Security Solution] expandable flyout - fix topN opening with Raw Events instead of Detection Alerts + add missing interaction in cell actions

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/entities_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/entities_details.tsx
@@ -19,7 +19,7 @@ export const ENTITIES_TAB_ID = 'entities-details';
  * Entities displayed in the document details expandable flyout left section under the Insights tab
  */
 export const EntitiesDetails: React.FC = () => {
-  const { getFieldsData } = useLeftPanelContext();
+  const { getFieldsData, scopeId } = useLeftPanelContext();
   const hostName = getField(getFieldsData('host.name'));
   const userName = getField(getFieldsData('user.name'));
   const timestamp = getField(getFieldsData('@timestamp'));
@@ -28,12 +28,12 @@ export const EntitiesDetails: React.FC = () => {
     <EuiFlexGroup direction="column" gutterSize="m" data-test-subj={ENTITIES_DETAILS_TEST_ID}>
       {userName && timestamp && (
         <EuiFlexItem>
-          <UserDetails userName={userName} timestamp={timestamp} />
+          <UserDetails userName={userName} timestamp={timestamp} scopeId={scopeId} />
         </EuiFlexItem>
       )}
       {hostName && timestamp && (
         <EuiFlexItem>
-          <HostDetails hostName={hostName} timestamp={timestamp} />
+          <HostDetails hostName={hostName} timestamp={timestamp} scopeId={scopeId} />
         </EuiFlexItem>
       )}
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/flyout/left/components/host_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/host_details.test.tsx
@@ -91,6 +91,7 @@ const timestamp = '2022-07-25T08:20:18.966Z';
 const defaultProps = {
   hostName: 'test host',
   timestamp,
+  scopeId: 'scopeId',
 };
 
 const mockHostDetailsResponse = [

--- a/x-pack/plugins/security_solution/public/flyout/left/components/host_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/host_details.tsx
@@ -20,6 +20,7 @@ import {
   EuiPanel,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import { getSourcererScopeId } from '../../../helpers';
 import { ExpandablePanel } from '../../shared/components/expandable_panel';
 import type { RelatedUser } from '../../../../common/search_strategy/security_solution/related_entities/related_users';
 import type { RiskSeverity } from '../../../../common/search_strategy';
@@ -67,11 +68,16 @@ export interface HostDetailsProps {
    * timestamp of alert or event
    */
   timestamp: string;
+  /**
+   * Maintain backwards compatibility // TODO remove when possible
+   */
+  scopeId: string;
 }
+
 /**
  * Host details and related users, displayed in the document details expandable flyout left section under the Insights tab, Entities tab
  */
-export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp }) => {
+export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, scopeId }) => {
   const { to, from, deleteQuery, setQuery, isInitializing } = useGlobalTime();
   const { selectedPatterns } = useSourcererDataView();
   const dispatch = useDispatch();
@@ -126,14 +132,16 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp })
         render: (user: string) => (
           <EuiText grow={false} size="xs">
             <SecurityCellActions
-              mode={CellActionsMode.HOVER_RIGHT}
-              visibleCellActions={5}
-              showActionTooltips
-              triggerId={SecurityCellActionsTrigger.DEFAULT}
               data={{
                 field: 'user.name',
                 value: user,
               }}
+              mode={CellActionsMode.HOVER_RIGHT}
+              triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
+              visibleCellActions={6}
+              sourcererScopeId={getSourcererScopeId(scopeId)}
+              metadata={{ scopeId }}
+              showActionTooltips
             >
               {user}
             </SecurityCellActions>
@@ -180,7 +188,7 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp })
           ]
         : []),
     ],
-    [isEntityAnalyticsAuthorized]
+    [isEntityAnalyticsAuthorized, scopeId]
   );
 
   const relatedUsersCount = useMemo(

--- a/x-pack/plugins/security_solution/public/flyout/left/components/host_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/host_details.tsx
@@ -137,8 +137,8 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
                 value: user,
               }}
               mode={CellActionsMode.HOVER_RIGHT}
-              triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
-              visibleCellActions={6}
+              triggerId={SecurityCellActionsTrigger.DEFAULT} // TODO use SecurityCellActionsTrigger.DETAILS_FLYOUT when https://github.com/elastic/kibana/issues/155243 is fixed
+              visibleCellActions={5} // TODO use 6 when https://github.com/elastic/kibana/issues/155243 is fixed
               sourcererScopeId={getSourcererScopeId(scopeId)}
               metadata={{ scopeId }}
               showActionTooltips

--- a/x-pack/plugins/security_solution/public/flyout/left/components/user_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/user_details.test.tsx
@@ -88,6 +88,7 @@ const timestamp = '2022-07-25T08:20:18.966Z';
 const defaultProps = {
   userName: 'test user',
   timestamp,
+  scopeId: 'scopeId',
 };
 
 const mockUserDetailsResponse = [

--- a/x-pack/plugins/security_solution/public/flyout/left/components/user_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/user_details.tsx
@@ -138,8 +138,8 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
                 field: 'host.name',
               }}
               mode={CellActionsMode.HOVER_RIGHT}
-              triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
-              visibleCellActions={6}
+              triggerId={SecurityCellActionsTrigger.DEFAULT} // TODO use SecurityCellActionsTrigger.DETAILS_FLYOUT when https://github.com/elastic/kibana/issues/155243 is fixed
+              visibleCellActions={5} // TODO use 6 when https://github.com/elastic/kibana/issues/155243 is fixed
               sourcererScopeId={getSourcererScopeId(scopeId)}
               metadata={{ scopeId }}
               showActionTooltips

--- a/x-pack/plugins/security_solution/public/flyout/left/components/user_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/user_details.tsx
@@ -20,6 +20,7 @@ import {
   EuiPanel,
 } from '@elastic/eui';
 import type { EuiBasicTableColumn } from '@elastic/eui';
+import { getSourcererScopeId } from '../../../helpers';
 import { ExpandablePanel } from '../../shared/components/expandable_panel';
 import type { RelatedHost } from '../../../../common/search_strategy/security_solution/related_entities/related_hosts';
 import type { RiskSeverity } from '../../../../common/search_strategy';
@@ -67,11 +68,16 @@ export interface UserDetailsProps {
    * timestamp of alert or event
    */
   timestamp: string;
+  /**
+   * Maintain backwards compatibility // TODO remove when possible
+   */
+  scopeId: string;
 }
+
 /**
  * User details and related users, displayed in the document details expandable flyout left section under the Insights tab, Entities tab
  */
-export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp }) => {
+export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, scopeId }) => {
   const { to, from, deleteQuery, setQuery, isInitializing } = useGlobalTime();
   const { selectedPatterns } = useSourcererDataView();
   const dispatch = useDispatch();
@@ -127,14 +133,16 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp })
         render: (host: string) => (
           <EuiText grow={false} size="xs">
             <SecurityCellActions
-              mode={CellActionsMode.HOVER_RIGHT}
-              visibleCellActions={5}
-              showActionTooltips
-              triggerId={SecurityCellActionsTrigger.DEFAULT}
               data={{
                 value: host,
                 field: 'host.name',
               }}
+              mode={CellActionsMode.HOVER_RIGHT}
+              triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
+              visibleCellActions={6}
+              sourcererScopeId={getSourcererScopeId(scopeId)}
+              metadata={{ scopeId }}
+              showActionTooltips
             >
               {host}
             </SecurityCellActions>
@@ -181,7 +189,7 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp })
           ]
         : []),
     ],
-    [isEntityAnalyticsAuthorized]
+    [isEntityAnalyticsAuthorized, scopeId]
   );
 
   const relatedHostsCount = useMemo(

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/alert_reason_preview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/alert_reason_preview.tsx
@@ -26,7 +26,7 @@ const ReasonPreviewContainer = styled.div``;
  * Alert reason renderer on a preview panel on top of the right section of expandable flyout
  */
 export const AlertReasonPreview: React.FC = () => {
-  const { dataAsNestedObject } = usePreviewPanelContext();
+  const { dataAsNestedObject, scopeId } = usePreviewPanelContext();
 
   const renderer = useMemo(
     () =>
@@ -43,10 +43,10 @@ export const AlertReasonPreview: React.FC = () => {
             contextId: 'event-details',
             data: dataAsNestedObject,
             isDraggable: false,
-            scopeId: 'global',
+            scopeId,
           })
         : null,
-    [renderer, dataAsNestedObject]
+    [renderer, dataAsNestedObject, scopeId]
   );
 
   if (!dataAsNestedObject || !renderer) {

--- a/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.test.tsx
@@ -26,6 +26,7 @@ describe('<HighlightedFields />', () => {
   it('should render the component', () => {
     const panelContextValue = {
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
     (useHighlightedFields as jest.Mock).mockReturnValue({
       field: {
@@ -48,6 +49,7 @@ describe('<HighlightedFields />', () => {
   it(`should render empty component if there aren't any highlighted fields`, () => {
     const panelContextValue = {
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
     (useHighlightedFields as jest.Mock).mockReturnValue({});
 
@@ -63,6 +65,7 @@ describe('<HighlightedFields />', () => {
   it('should render empty component if dataFormattedForFieldBrowser is null', () => {
     const panelContextValue = {
       dataFormattedForFieldBrowser: null,
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
     (useHighlightedFields as jest.Mock).mockReturnValue({
       field: {

--- a/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
@@ -70,8 +70,8 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
           value: description.values,
         }}
         mode={CellActionsMode.HOVER_RIGHT}
-        triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
-        visibleCellActions={6}
+        triggerId={SecurityCellActionsTrigger.DEFAULT} // TODO use SecurityCellActionsTrigger.DETAILS_FLYOUT when https://github.com/elastic/kibana/issues/155243 is fixed
+        visibleCellActions={5} // TODO use 6 when https://github.com/elastic/kibana/issues/155243 is fixed
         sourcererScopeId={getSourcererScopeId(description.scopeId)}
         metadata={{ scopeId: description.scopeId }}
       >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/highlighted_fields.tsx
@@ -9,6 +9,7 @@ import type { FC } from 'react';
 import React, { useMemo } from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiInMemoryTable, EuiPanel, EuiTitle } from '@elastic/eui';
+import { getSourcererScopeId } from '../../../helpers';
 import { convertHighlightedFieldsToTableRow } from '../../shared/utils/highlighted_fields_helpers';
 import { useRuleWithFallback } from '../../../detection_engine/rule_management/logic/use_rule_with_fallback';
 import { useBasicDataFromDetailsData } from '../../../timelines/components/side_panel/event_details/helpers';
@@ -41,6 +42,10 @@ export interface HighlightedFieldsTableRow {
      * Highlighted field value
      */
     values: string[] | null | undefined;
+    /**
+     * Maintain backwards compatibility // TODO remove when possible
+     */
+    scopeId: string;
   };
 }
 
@@ -54,15 +59,21 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
     field: 'description',
     name: HIGHLIGHTED_FIELDS_VALUE_COLUMN,
     'data-test-subj': 'valueCell',
-    render: (description: { field: string; values: string[] | null | undefined }) => (
+    render: (description: {
+      field: string;
+      values: string[] | null | undefined;
+      scopeId: string;
+    }) => (
       <SecurityCellActions
         data={{
           field: description.field,
           value: description.values,
         }}
         mode={CellActionsMode.HOVER_RIGHT}
-        triggerId={SecurityCellActionsTrigger.DEFAULT}
+        triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
         visibleCellActions={6}
+        sourcererScopeId={getSourcererScopeId(description.scopeId)}
+        metadata={{ scopeId: description.scopeId }}
       >
         <HighlightedFieldsCell values={description.values} field={description.field} />
       </SecurityCellActions>
@@ -74,7 +85,7 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
  * Component that displays the highlighted fields in the right panel under the Investigation section.
  */
 export const HighlightedFields: FC = () => {
-  const { dataFormattedForFieldBrowser } = useRightPanelContext();
+  const { dataFormattedForFieldBrowser, scopeId } = useRightPanelContext();
   const { ruleId } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
   const { rule: maybeRule } = useRuleWithFallback(ruleId);
 
@@ -83,8 +94,8 @@ export const HighlightedFields: FC = () => {
     investigationFields: maybeRule?.investigation_fields ?? [],
   });
   const items = useMemo(
-    () => convertHighlightedFieldsToTableRow(highlightedFields),
-    [highlightedFields]
+    () => convertHighlightedFieldsToTableRow(highlightedFields, scopeId),
+    [highlightedFields, scopeId]
   );
 
   if (!dataFormattedForFieldBrowser || items.length === 0) {

--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.test.tsx
@@ -20,6 +20,7 @@ describe('<DocumentSeverity />', () => {
   it('should render severity information', () => {
     const contextValue = {
       getFieldsData: jest.fn().mockImplementation(mockGetFieldsData),
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
 
     const { getByTestId } = render(
@@ -39,6 +40,7 @@ describe('<DocumentSeverity />', () => {
   it('should render empty component if missing getFieldsData value', () => {
     const contextValue = {
       getFieldsData: jest.fn(),
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
 
     const { container } = render(
@@ -53,6 +55,7 @@ describe('<DocumentSeverity />', () => {
   it('should render empty component if getFieldsData is invalid array', () => {
     const contextValue = {
       getFieldsData: jest.fn().mockImplementation(() => ['abc']),
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
 
     const { container } = render(
@@ -67,6 +70,7 @@ describe('<DocumentSeverity />', () => {
   it('should render empty component if getFieldsData is invalid string', () => {
     const contextValue = {
       getFieldsData: jest.fn().mockImplementation(() => 'abc'),
+      scopeId: 'scopeId',
     } as unknown as RightPanelContext;
 
     const { container } = render(

--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
@@ -56,8 +56,8 @@ export const DocumentSeverity: FC = memo(() => {
             value: alertSeverity,
           }}
           mode={CellActionsMode.HOVER_RIGHT}
-          triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
-          visibleCellActions={6}
+          triggerId={SecurityCellActionsTrigger.DEFAULT} // TODO use SecurityCellActionsTrigger.DETAILS_FLYOUT when https://github.com/elastic/kibana/issues/155243 is fixed
+          visibleCellActions={5} // TODO use 6 when https://github.com/elastic/kibana/issues/155243 is fixed
           sourcererScopeId={getSourcererScopeId(scopeId)}
           metadata={{ scopeId }}
         >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/severity.tsx
@@ -11,6 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui';
 import { ALERT_SEVERITY } from '@kbn/rule-data-utils';
 import type { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import { CellActionsMode } from '@kbn/cell-actions';
+import { getSourcererScopeId } from '../../../helpers';
 import { SecurityCellActions } from '../../../common/components/cell_actions';
 import { SecurityCellActionsTrigger } from '../../../actions/constants';
 import { SEVERITY_TITLE } from './translations';
@@ -25,7 +26,7 @@ const isSeverity = (x: unknown): x is Severity =>
  * Document details severity displayed in flyout right section header
  */
 export const DocumentSeverity: FC = memo(() => {
-  const { getFieldsData } = useRightPanelContext();
+  const { getFieldsData, scopeId } = useRightPanelContext();
   const fieldsData = getFieldsData(ALERT_SEVERITY);
 
   if (!fieldsData) {
@@ -55,8 +56,10 @@ export const DocumentSeverity: FC = memo(() => {
             value: alertSeverity,
           }}
           mode={CellActionsMode.HOVER_RIGHT}
-          triggerId={SecurityCellActionsTrigger.DEFAULT}
+          triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
           visibleCellActions={6}
+          sourcererScopeId={getSourcererScopeId(scopeId)}
+          metadata={{ scopeId }}
         >
           <SeverityBadge value={alertSeverity} />
         </SecurityCellActions>

--- a/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
@@ -62,8 +62,8 @@ export const DocumentStatus: FC = () => {
         value: statusData.values[0],
       }}
       mode={CellActionsMode.HOVER_RIGHT}
-      triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
-      visibleCellActions={6}
+      triggerId={SecurityCellActionsTrigger.DEFAULT} // TODO use SecurityCellActionsTrigger.DETAILS_FLYOUT when https://github.com/elastic/kibana/issues/155243 is fixed
+      visibleCellActions={5} // TODO use 6 when https://github.com/elastic/kibana/issues/155243 is fixed
       sourcererScopeId={getSourcererScopeId(scopeId)}
       metadata={{ scopeId }}
     >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/status.tsx
@@ -10,6 +10,7 @@ import React, { useMemo } from 'react';
 import { find } from 'lodash/fp';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
 import { CellActionsMode } from '@kbn/cell-actions';
+import { getSourcererScopeId } from '../../../helpers';
 import { SecurityCellActions } from '../../../common/components/cell_actions';
 import type {
   EnrichedFieldInfo,
@@ -61,8 +62,10 @@ export const DocumentStatus: FC = () => {
         value: statusData.values[0],
       }}
       mode={CellActionsMode.HOVER_RIGHT}
-      triggerId={SecurityCellActionsTrigger.DEFAULT}
+      triggerId={SecurityCellActionsTrigger.DETAILS_FLYOUT}
       visibleCellActions={6}
+      sourcererScopeId={getSourcererScopeId(scopeId)}
+      metadata={{ scopeId }}
     >
       <StatusPopoverButton
         eventId={eventId}

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
@@ -10,6 +10,8 @@ import {
   convertHighlightedFieldsToTableRow,
 } from './highlighted_fields_helpers';
 
+const scopeId = 'scopeId';
+
 describe('convertHighlightedFieldsToTableRow', () => {
   it('should convert highlighted fields to a table row', () => {
     const highlightedFields = {
@@ -17,12 +19,13 @@ describe('convertHighlightedFieldsToTableRow', () => {
         values: ['host-1'],
       },
     };
-    expect(convertHighlightedFieldsToTableRow(highlightedFields)).toEqual([
+    expect(convertHighlightedFieldsToTableRow(highlightedFields, scopeId)).toEqual([
       {
         field: 'host.name',
         description: {
           field: 'host.name',
           values: ['host-1'],
+          scopeId: 'scopeId',
         },
       },
     ]);
@@ -35,12 +38,13 @@ describe('convertHighlightedFieldsToTableRow', () => {
         values: ['host-1'],
       },
     };
-    expect(convertHighlightedFieldsToTableRow(highlightedFields)).toEqual([
+    expect(convertHighlightedFieldsToTableRow(highlightedFields, scopeId)).toEqual([
       {
         field: 'host.name-override',
         description: {
           field: 'host.name-override',
           values: ['host-1'],
+          scopeId: 'scopeId',
         },
       },
     ]);

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
@@ -12,9 +12,11 @@ import type { HighlightedFieldsTableRow } from '../../right/components/highlight
 /**
  * Converts the highlighted fields to a format that can be consumed by the HighlightedFields component
  * @param highlightedFields
+ * @param scopeId
  */
 export const convertHighlightedFieldsToTableRow = (
-  highlightedFields: UseHighlightedFieldsResult
+  highlightedFields: UseHighlightedFieldsResult,
+  scopeId: string
 ): HighlightedFieldsTableRow[] => {
   const fieldNames = Object.keys(highlightedFields);
   return fieldNames.map((fieldName) => {
@@ -27,6 +29,7 @@ export const convertHighlightedFieldsToTableRow = (
       description: {
         field,
         values,
+        scopeId,
       },
     };
   });


### PR DESCRIPTION
## Summary

This PR aims at fixing a couple of behaviors related to cell actions in the new expandable flyout:
- `showTopN` action now shows `Detection Alerts` by default instead of `Raw Events` for:
    -  the severity and status components in the header
    - the highlighted field table
    - the alert reason preview
- display more cell actions (we were the `toggleColumInTable` action) for:
    -  the severity and status components in the header
    - the highlighted field table
_I couldn't have the `toggleColumInTable` action in the alert reason preview because the component we're using doesn't expose the option (the other instances of that component don't provide the option either...)_

https://github.com/elastic/kibana/assets/17276605/4cec9db3-d974-4122-a553-ee7b8d1bc3f6

https://github.com/elastic/kibana/assets/17276605/b76ee2c1-bd7a-4548-a145-a2c03a1bbbde

The following places could not be changed:
- entities overview (user and host) in the right panel Insights section
- entities details (user and hosts) in the left panel Insights section
_Because we're leveraging existing components. Changing those is feasible (I had a working POC) but seems very risky a couple of days before BC3, as it impacts other teams._ 

https://github.com/elastic/kibana/assets/17276605/70f3acd2-a2c3-41f6-9c49-3a81aee792ea

Fixes https://github.com/elastic/kibana/issues/164801
Partially fixes https://github.com/elastic/kibana/issues/164553

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->