### PR TITLE
[8.10] Replaces kqlFilter with searchConfiguration and uses Unified Search bar in APM rules (#164540)

### DIFF
--- a/x-pack/plugins/apm/common/rules/schema.ts
+++ b/x-pack/plugins/apm/common/rules/schema.ts
@@ -9,6 +9,16 @@ import { schema, TypeOf } from '@kbn/config-schema';
 import { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import { AggregationType, ApmRuleType } from './apm_rule_types';
 
+export const searchConfigurationSchema = schema.object({
+  query: schema.object({
+    query: schema.oneOf([
+      schema.string(),
+      schema.recordOf(schema.string(), schema.any()),
+    ]),
+    language: schema.string(),
+  }),
+});
+
 export const errorCountParamsSchema = schema.object({
   windowSize: schema.number(),
   windowUnit: schema.string(),
@@ -18,7 +28,7 @@ export const errorCountParamsSchema = schema.object({
   groupBy: schema.maybe(schema.arrayOf(schema.string())),
   errorGroupingKey: schema.maybe(schema.string()),
   useKqlFilter: schema.maybe(schema.boolean()),
-  kqlFilter: schema.maybe(schema.string()),
+  searchConfiguration: schema.maybe(searchConfigurationSchema),
 });
 
 export const transactionDurationParamsSchema = schema.object({
@@ -36,7 +46,7 @@ export const transactionDurationParamsSchema = schema.object({
   environment: schema.string(),
   groupBy: schema.maybe(schema.arrayOf(schema.string())),
   useKqlFilter: schema.maybe(schema.boolean()),
-  kqlFilter: schema.maybe(schema.string()),
+  searchConfiguration: schema.maybe(searchConfigurationSchema),
 });
 
 export const anomalyParamsSchema = schema.object({
@@ -63,7 +73,7 @@ export const transactionErrorRateParamsSchema = schema.object({
   environment: schema.string(),
   groupBy: schema.maybe(schema.arrayOf(schema.string())),
   useKqlFilter: schema.maybe(schema.boolean()),
-  kqlFilter: schema.maybe(schema.string()),
+  searchConfiguration: schema.maybe(searchConfigurationSchema),
 });
 
 type ErrorCountParamsType = TypeOf<typeof errorCountParamsSchema>;
@@ -74,6 +84,8 @@ type AnomalyParamsType = TypeOf<typeof anomalyParamsSchema>;
 type TransactionErrorRateParamsType = TypeOf<
   typeof transactionErrorRateParamsSchema
 >;
+
+export type SearchConfigurationType = TypeOf<typeof searchConfigurationSchema>;
 
 export interface ApmRuleParamsType {
   [ApmRuleType.TransactionDuration]: TransactionDurationParamsType;

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -17,6 +17,7 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { EuiSwitchEvent } from '@elastic/eui';
+import { SearchConfigurationType } from '../../../../../common/rules/schema';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { asInteger } from '../../../../../common/utils/formatters';
 import {
@@ -58,7 +59,7 @@ export interface ErrorCountRuleParams {
   groupBy?: string[] | undefined;
   errorGroupingKey?: string;
   useKqlFilter?: boolean;
-  kqlFilter?: string;
+  searchConfiguration?: SearchConfigurationType;
 }
 
 interface Props {
@@ -105,7 +106,7 @@ export function ErrorCountRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                kqlFilter: params.kqlFilter,
+                searchConfiguration: JSON.stringify(params.searchConfiguration),
               },
             },
           }
@@ -119,7 +120,7 @@ export function ErrorCountRuleType(props: Props) {
       params.serviceName,
       params.errorGroupingKey,
       params.groupBy,
-      params.kqlFilter,
+      params.searchConfiguration,
     ]
   );
 
@@ -244,7 +245,9 @@ export function ErrorCountRuleType(props: Props) {
     setRuleParams('serviceName', undefined);
     setRuleParams('errorGroupingKey', undefined);
     setRuleParams('environment', ENVIRONMENT_ALL.value);
-    setRuleParams('kqlFilter', undefined);
+    setRuleParams('searchConfiguration', {
+      query: { query: '', language: 'kuery' },
+    });
     setRuleParams('useKqlFilter', e.target.checked);
   };
 

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -18,6 +18,7 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { EuiSwitchEvent } from '@elastic/eui';
+import { SearchConfigurationType } from '../../../../../common/rules/schema';
 import { AggregationType } from '../../../../../common/rules/apm_rule_types';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { getDurationFormatter } from '../../../../../common/utils/formatters';
@@ -67,7 +68,7 @@ export interface TransactionDurationRuleParams {
   windowUnit: string;
   groupBy?: string[] | undefined;
   useKqlFilter?: boolean;
-  kqlFilter?: string;
+  searchConfiguration?: SearchConfigurationType;
 }
 
 const TRANSACTION_ALERT_AGGREGATION_TYPES: Record<AggregationType, string> = {
@@ -135,7 +136,7 @@ export function TransactionDurationRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                kqlFilter: params.kqlFilter,
+                searchConfiguration: JSON.stringify(params.searchConfiguration),
               },
             },
           }
@@ -151,7 +152,7 @@ export function TransactionDurationRuleType(props: Props) {
       params.windowSize,
       params.windowUnit,
       params.groupBy,
-      params.kqlFilter,
+      params.searchConfiguration,
     ]
   );
 
@@ -314,7 +315,9 @@ export function TransactionDurationRuleType(props: Props) {
     setRuleParams('transactionType', undefined);
     setRuleParams('transactionName', undefined);
     setRuleParams('environment', ENVIRONMENT_ALL.value);
-    setRuleParams('kqlFilter', undefined);
+    setRuleParams('searchConfiguration', {
+      query: { query: '', language: 'kuery' },
+    });
     setRuleParams('useKqlFilter', e.target.checked);
   };
 

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -17,6 +17,7 @@ import {
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
 import { EuiSwitchEvent } from '@elastic/eui';
+import { SearchConfigurationType } from '../../../../../common/rules/schema';
 import { ENVIRONMENT_ALL } from '../../../../../common/environment_filter_values';
 import { asPercent } from '../../../../../common/utils/formatters';
 import {
@@ -59,7 +60,7 @@ export interface ErrorRateRuleParams {
   environment?: string;
   groupBy?: string[] | undefined;
   useKqlFilter?: boolean;
-  kqlFilter?: string;
+  searchConfiguration?: SearchConfigurationType;
 }
 
 export interface Props {
@@ -107,7 +108,7 @@ export function TransactionErrorRateRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                kqlFilter: params.kqlFilter,
+                searchConfiguration: JSON.stringify(params.searchConfiguration),
               },
             },
           }
@@ -122,7 +123,7 @@ export function TransactionErrorRateRuleType(props: Props) {
       params.windowSize,
       params.windowUnit,
       params.groupBy,
-      params.kqlFilter,
+      params.searchConfiguration,
     ]
   );
 
@@ -256,7 +257,9 @@ export function TransactionErrorRateRuleType(props: Props) {
     setRuleParams('transactionType', undefined);
     setRuleParams('transactionName', undefined);
     setRuleParams('environment', ENVIRONMENT_ALL.value);
-    setRuleParams('kqlFilter', undefined);
+    setRuleParams('searchConfiguration', {
+      query: { query: '', language: 'kuery' },
+    });
     setRuleParams('useKqlFilter', e.target.checked);
   };
 

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_kql_filter.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_kql_filter.tsx
@@ -6,16 +6,15 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import React, { useCallback } from 'react';
-import { debounce } from 'lodash';
+import React from 'react';
 import { EuiSwitch } from '@elastic/eui';
 import { EuiFormRow } from '@elastic/eui';
 import { EuiSpacer } from '@elastic/eui';
-import { RuleFlyoutKueryBar } from '@kbn/observability-plugin/public';
-import { useApmDataView } from '../../../hooks/use_apm_data_view';
+import { EuiSwitchEvent } from '@elastic/eui';
 import { TransactionDurationRuleParams } from '../rule_types/transaction_duration_rule_type';
 import { ErrorRateRuleParams } from '../rule_types/transaction_error_rate_rule_type';
 import { ErrorCountRuleParams } from '../rule_types/error_count_rule_type';
+import { ApmRuleUnifiedSearchBar } from './apm_rule_unified_search_bar';
 
 interface Props {
   ruleParams:
@@ -23,7 +22,7 @@ interface Props {
     | ErrorRateRuleParams
     | ErrorCountRuleParams;
   setRuleParams: (key: string, value: any) => void;
-  onToggleKqlFilter: any;
+  onToggleKqlFilter: (e: EuiSwitchEvent) => void;
 }
 
 export function ApmRuleKqlFilter({
@@ -31,30 +30,6 @@ export function ApmRuleKqlFilter({
   setRuleParams,
   onToggleKqlFilter,
 }: Props) {
-  const FILTER_TYPING_DEBOUNCE_MS = 500;
-
-  const { dataView: derivedIndexPattern } = useApmDataView();
-
-  const onFilterChange = useCallback(
-    (filter: string) => {
-      setRuleParams('kqlFilter', filter);
-    },
-    [setRuleParams]
-  );
-
-  /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  const debouncedOnFilterChange = useCallback(
-    debounce(onFilterChange, FILTER_TYPING_DEBOUNCE_MS),
-    [onFilterChange]
-  );
-
-  const placeHolder = i18n.translate(
-    'xpack.apm.rule.kqlSearchFieldPlaceholder',
-    {
-      defaultMessage: 'Search for APM data… (e.g. service.name: service-1)',
-    }
-  );
-
   const kqlFilterToggle = (
     <>
       <EuiSwitch
@@ -71,34 +46,27 @@ export function ApmRuleKqlFilter({
     </>
   );
 
-  const kqlFilter =
-    ruleParams.useKqlFilter && derivedIndexPattern ? (
-      <>
-        <EuiFormRow
-          label={i18n.translate('xpack.apm.rules.ruleFlyout.filterLabel', {
-            defaultMessage: 'Filter (Technical Preview)',
-          })}
-          helpText={i18n.translate(
-            'xpack.apm.rules.ruleFlyout.filterHelpText',
-            {
-              defaultMessage:
-                'Use a KQL expression to limit the scope of your alert trigger.',
-            }
-          )}
-          fullWidth
-          display="rowCompressed"
-        >
-          <RuleFlyoutKueryBar
-            placeholder={placeHolder}
-            derivedIndexPattern={derivedIndexPattern}
-            onChange={debouncedOnFilterChange}
-            onSubmit={onFilterChange}
-            value={ruleParams.kqlFilter}
-          />
-        </EuiFormRow>
-        <EuiSpacer size={'m'} />
-      </>
-    ) : null;
+  const kqlFilter = ruleParams.useKqlFilter ? (
+    <>
+      <EuiFormRow
+        label={i18n.translate('xpack.apm.rules.ruleFlyout.filterLabel', {
+          defaultMessage: 'Filter',
+        })}
+        helpText={i18n.translate('xpack.apm.rules.ruleFlyout.filterHelpText', {
+          defaultMessage:
+            'Use a KQL expression to limit the scope of your alert trigger.',
+        })}
+        fullWidth
+        display="rowCompressed"
+      >
+        <ApmRuleUnifiedSearchBar
+          ruleParams={ruleParams}
+          setRuleParams={setRuleParams}
+        />
+      </EuiFormRow>
+      <EuiSpacer size={'m'} />
+    </>
+  ) : null;
 
   return (
     <>

--- a/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_unified_search_bar.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/ui_components/apm_rule_unified_search_bar.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { i18n } from '@kbn/i18n';
+import { Query } from '@kbn/es-query';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import { ApmPluginStartDeps } from '../../../plugin';
+import { useApmDataView } from '../../../hooks/use_apm_data_view';
+import { TransactionDurationRuleParams } from '../rule_types/transaction_duration_rule_type';
+import { ErrorRateRuleParams } from '../rule_types/transaction_error_rate_rule_type';
+import { ErrorCountRuleParams } from '../rule_types/error_count_rule_type';
+
+export function ApmRuleUnifiedSearchBar({
+  placeholder,
+  ruleParams,
+  setRuleParams,
+}: {
+  placeholder?: string;
+  value?: string;
+  isClearable?: boolean;
+  ruleParams:
+    | TransactionDurationRuleParams
+    | ErrorRateRuleParams
+    | ErrorCountRuleParams;
+  setRuleParams: (key: string, value: any) => void;
+}) {
+  const { services } = useKibana<ApmPluginStartDeps>();
+
+  const {
+    unifiedSearch: {
+      ui: { SearchBar },
+    },
+  } = services;
+
+  const { dataView } = useApmDataView();
+  const searchbarPlaceholder =
+    'Search for APM data… (e.g. service.name: service-1)';
+
+  const handleSubmit = (payload: { query?: Query }) => {
+    const { query } = payload;
+    setRuleParams('searchConfiguration', { query });
+  };
+
+  return (
+    <SearchBar
+      appName={i18n.translate('xpack.apm.appName', {
+        defaultMessage: 'APM',
+      })}
+      iconType="search"
+      placeholder={placeholder || searchbarPlaceholder}
+      indexPatterns={dataView ? [dataView] : undefined}
+      showQueryInput={true}
+      showQueryMenu={false}
+      showFilterBar={false}
+      showDatePicker={false}
+      showSubmitButton={false}
+      displayStyle="inPage"
+      onQueryChange={handleSubmit}
+      onQuerySubmit={handleSubmit}
+      dataTestSubj="apmRuleUnifiedSearchBar"
+      query={ruleParams.searchConfiguration?.query}
+    />
+  );
+}

--- a/x-pack/plugins/apm/server/routes/alerts/route.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/route.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { jsonRt } from '@kbn/io-ts-utils';
 import { Coordinate } from '../../../typings/timeseries';
 import { getTransactionDurationChartPreview } from './rule_types/transaction_duration/get_transaction_duration_chart_preview';
 import { getTransactionErrorCountChartPreview } from './rule_types/error_count/get_error_count_chart_preview';
@@ -14,6 +15,13 @@ import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
 import { environmentRt, rangeRt } from '../default_api_types';
 import { AggregationType } from '../../../common/rules/apm_rule_types';
 import { getApmEventClient } from '../../lib/helpers/get_apm_event_client';
+
+const searchConfigurationRt = t.type({
+  query: t.type({
+    query: t.union([t.string, t.record(t.string, t.any)]),
+    language: t.string,
+  }),
+});
 
 const alertParamsRt = t.intersection([
   t.partial({
@@ -34,7 +42,7 @@ const alertParamsRt = t.intersection([
   }),
   t.partial({
     groupBy: t.array(t.string),
-    kqlFilter: t.string,
+    searchConfiguration: jsonRt.pipe(searchConfigurationRt),
   }),
 ]);
 

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/get_error_count_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/get_error_count_chart_preview.ts
@@ -42,7 +42,7 @@ export async function getTransactionErrorCountChartPreview({
     start,
     end,
     groupBy: groupByFields,
-    kqlFilter,
+    searchConfiguration,
   } = alertParams;
 
   const allGroupByFields = getAllGroupByFields(
@@ -50,7 +50,7 @@ export async function getTransactionErrorCountChartPreview({
     groupByFields
   );
 
-  const termFilterQuery = !kqlFilter
+  const termFilterQuery = !searchConfiguration
     ? [
         ...termQuery(SERVICE_NAME, serviceName, {
           queryEmptyString: false,
@@ -66,7 +66,7 @@ export async function getTransactionErrorCountChartPreview({
     bool: {
       filter: [
         ...termFilterQuery,
-        ...getParsedFilterQuery(kqlFilter),
+        ...getParsedFilterQuery(searchConfiguration?.query?.query as string),
         ...rangeQuery(start, end),
         { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
       ],

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.test.ts
@@ -709,7 +709,12 @@ describe('Error count alert', () => {
       windowSize: 5,
       windowUnit: 'm',
       serviceName: undefined,
-      kqlFilter: 'service.name: foo and service.environment: env-foo',
+      searchConfiguration: {
+        query: {
+          query: 'service.name: foo and service.environment: env-foo',
+          language: 'kuery',
+        },
+      },
       groupBy: ['service.name', 'service.environment'],
     };
 

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
@@ -124,7 +124,7 @@ export function registerErrorCountRuleType({
           savedObjectsClient,
         });
 
-        const termFilterQuery = !ruleParams.kqlFilter
+        const termFilterQuery = !ruleParams.searchConfiguration
           ? [
               ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
                 queryEmptyString: false,
@@ -153,7 +153,9 @@ export function registerErrorCountRuleType({
                   },
                   { term: { [PROCESSOR_EVENT]: ProcessorEvent.error } },
                   ...termFilterQuery,
-                  ...getParsedFilterQuery(ruleParams.kqlFilter),
+                  ...getParsedFilterQuery(
+                    ruleParams.searchConfiguration?.query?.query as string
+                  ),
                 ],
               },
             },

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/get_transaction_duration_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/get_transaction_duration_chart_preview.ts
@@ -60,7 +60,7 @@ export async function getTransactionDurationChartPreview({
     start,
     end,
     groupBy: groupByFields,
-    kqlFilter,
+    searchConfiguration,
   } = alertParams;
   const searchAggregatedTransactions = await getSearchTransactionsEvents({
     config,
@@ -68,7 +68,7 @@ export async function getTransactionDurationChartPreview({
     kuery: '',
   });
 
-  const termFilterQuery = !kqlFilter
+  const termFilterQuery = !searchConfiguration
     ? [
         ...termQuery(SERVICE_NAME, serviceName, {
           queryEmptyString: false,
@@ -87,7 +87,7 @@ export async function getTransactionDurationChartPreview({
     bool: {
       filter: [
         ...termFilterQuery,
-        ...getParsedFilterQuery(kqlFilter),
+        ...getParsedFilterQuery(searchConfiguration?.query?.query as string),
         ...rangeQuery(start, end),
         ...getDocumentTypeFilterForTransactions(searchAggregatedTransactions),
       ] as QueryDslQueryContainer[],

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.test.ts
@@ -327,7 +327,12 @@ describe('registerTransactionDurationRuleType', () => {
       transactionType: undefined,
       serviceName: undefined,
       aggregationType: 'avg',
-      kqlFilter: 'service.name: opbeans-java and transaction.type: request',
+      searchConfiguration: {
+        query: {
+          query: 'service.name: opbeans-java and transaction.type: request',
+          language: 'kuery',
+        },
+      },
       groupBy: ['service.name', 'service.environment', 'transaction.type'],
     };
 

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -141,7 +141,7 @@ export function registerTransactionDurationRuleType({
         searchAggregatedTransactions
       );
 
-      const termFilterQuery = !ruleParams.kqlFilter
+      const termFilterQuery = !ruleParams.searchConfiguration
         ? [
             ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
               queryEmptyString: false,
@@ -175,7 +175,9 @@ export function registerTransactionDurationRuleType({
                   searchAggregatedTransactions
                 ),
                 ...termFilterQuery,
-                ...getParsedFilterQuery(ruleParams.kqlFilter),
+                ...getParsedFilterQuery(
+                  ruleParams.searchConfiguration?.query?.query as string
+                ),
               ] as QueryDslQueryContainer[],
             },
           },

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/get_transaction_error_rate_chart_preview.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/get_transaction_error_rate_chart_preview.ts
@@ -52,7 +52,7 @@ export async function getTransactionErrorRateChartPreview({
     end,
     transactionName,
     groupBy: groupByFields,
-    kqlFilter,
+    searchConfiguration,
   } = alertParams;
 
   const searchAggregatedTransactions = await getSearchTransactionsEvents({
@@ -66,7 +66,7 @@ export async function getTransactionErrorRateChartPreview({
     groupByFields
   );
 
-  const termFilterQuery = !kqlFilter
+  const termFilterQuery = !searchConfiguration
     ? [
         ...termQuery(SERVICE_NAME, serviceName, {
           queryEmptyString: false,
@@ -92,7 +92,9 @@ export async function getTransactionErrorRateChartPreview({
         bool: {
           filter: [
             ...termFilterQuery,
-            ...getParsedFilterQuery(kqlFilter),
+            ...getParsedFilterQuery(
+              searchConfiguration?.query?.query as string
+            ),
             ...rangeQuery(start, end),
             ...getDocumentTypeFilterForTransactions(
               searchAggregatedTransactions

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.test.ts
@@ -481,8 +481,13 @@ describe('Transaction error rate alert', () => {
       threshold: 10,
       windowSize: 5,
       windowUnit: 'm',
-      kqlFilter:
-        'service.name: bar and service.environment: env-bar and transaction.type: type-bar',
+      searchConfiguration: {
+        query: {
+          query:
+            'service.name: bar and service.environment: env-bar and transaction.type: type-bar',
+          language: 'kuery',
+        },
+      },
       groupBy: ['service.name', 'service.environment', 'transaction.type'],
     };
 

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
@@ -143,7 +143,7 @@ export function registerTransactionErrorRateRuleType({
           ? indices.metric
           : indices.transaction;
 
-        const termFilterQuery = !ruleParams.kqlFilter
+        const termFilterQuery = !ruleParams.searchConfiguration
           ? [
               ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
                 queryEmptyString: false,
@@ -185,7 +185,9 @@ export function registerTransactionErrorRateRuleType({
                     },
                   },
                   ...termFilterQuery,
-                  ...getParsedFilterQuery(ruleParams.kqlFilter),
+                  ...getParsedFilterQuery(
+                    ruleParams.searchConfiguration?.query?.query as string
+                  ),
                 ],
               },
             },

--- a/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
@@ -123,7 +123,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           ruleTypeId: ApmRuleType.ErrorCount,
           name: 'Apm error count without kql query',
           params: {
-            kqlFilter: '',
             ...ruleParams,
           },
           actions: [indexAction],
@@ -271,7 +270,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           ruleTypeId: ApmRuleType.ErrorCount,
           name: 'Apm error count with kql query',
           params: {
-            kqlFilter: 'service.name: opbeans-php',
+            searchConfiguration: {
+              query: {
+                query: 'service.name: opbeans-php',
+                language: 'kuery',
+              },
+            },
             ...ruleParams,
           },
           actions: [],

--- a/x-pack/test/apm_api_integration/tests/alerts/preview_chart_error_count.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/preview_chart_error_count.spec.ts
@@ -41,7 +41,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         start: new Date(start).toISOString(),
         end: new Date(end).toISOString(),
         interval: '5m',
-        kqlFilter: 'service.name: synth-go',
+        searchConfiguration: JSON.stringify({
+          query: {
+            query: 'service.name: synth-go',
+            language: 'kuery',
+          },
+        }),
         serviceName: undefined,
         errorGroupingKey: undefined,
         environment: 'ENVIRONMENT_ALL',
@@ -328,9 +333,14 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: `service.name: synth-go and error.grouping_key: ${getErrorGroupingKey(
-                'Error 1'
-              )}`,
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: `service.name: synth-go and error.grouping_key: ${getErrorGroupingKey(
+                    'Error 1'
+                  )}`,
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -430,9 +440,14 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: `service.name: synth-go and error.grouping_key: ${getErrorGroupingKey(
-                'Error 0'
-              )}`,
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: `service.name: synth-go and error.grouping_key: ${getErrorGroupingKey(
+                    'Error 0'
+                  )}`,
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, ERROR_GROUP_ID],
             },
           },
@@ -463,7 +478,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -490,7 +510,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, ERROR_GROUP_ID],
             },
           },

--- a/x-pack/test/apm_api_integration/tests/alerts/preview_chart_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/preview_chart_error_rate.spec.ts
@@ -42,7 +42,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         start: new Date(start).toISOString(),
         end: new Date(end).toISOString(),
         interval: '5m',
-        kqlFilter: 'service.name: synth-go and transaction.type: request',
+        searchConfiguration: JSON.stringify({
+          query: {
+            query: 'service.name: synth-go and transaction.type: request',
+            language: 'kuery',
+          },
+        }),
         serviceName: undefined,
         transactionType: undefined,
         transactionName: undefined,
@@ -351,8 +356,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: GET /banana',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: GET /banana',
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -376,8 +386,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: foo',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: foo',
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -472,8 +487,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: GET /apple',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: GET /apple',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE, TRANSACTION_NAME],
             },
           },
@@ -499,7 +519,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -526,7 +551,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE, TRANSACTION_NAME],
             },
           },

--- a/x-pack/test/apm_api_integration/tests/alerts/preview_chart_transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/preview_chart_transaction_duration.spec.ts
@@ -32,7 +32,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         transactionType: 'request',
         environment: 'ENVIRONMENT_ALL',
         interval: '5m',
-        kqlFilter: '',
       },
     },
   });
@@ -43,7 +42,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         start: new Date(start).toISOString(),
         end: new Date(end).toISOString(),
         interval: '5m',
-        kqlFilter: 'service.name: synth-go and transaction.type: request',
+        searchConfiguration: JSON.stringify({
+          query: {
+            query: 'service.name: synth-go and transaction.type: request',
+            language: 'kuery',
+          },
+        }),
         serviceName: undefined,
         transactionType: undefined,
         transactionName: undefined,
@@ -322,8 +326,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: GET /banana',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: GET /banana',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE],
             },
           },
@@ -348,8 +357,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: foo',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: foo',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE],
             },
           },
@@ -439,8 +453,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter:
-                'service.name: synth-go and transaction.type: request and transaction.name: GET /apple',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query:
+                    'service.name: synth-go and transaction.type: request and transaction.name: GET /apple',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE, TRANSACTION_NAME],
             },
           },
@@ -466,7 +485,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
             },
           },
         };
@@ -493,7 +517,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           params: {
             query: {
               ...getOptionsWithFilterQuery().params.query,
-              kqlFilter: '',
+              searchConfiguration: JSON.stringify({
+                query: {
+                  query: '',
+                  language: 'kuery',
+                },
+              }),
               groupBy: [SERVICE_NAME, SERVICE_ENVIRONMENT, TRANSACTION_TYPE, TRANSACTION_NAME],
             },
           },

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
@@ -97,7 +97,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           ruleTypeId: ApmRuleType.TransactionDuration,
           name: 'Apm transaction duration without kql filter',
           params: {
-            kqlFilter: '',
             ...ruleParams,
           },
           actions: [indexAction],
@@ -209,8 +208,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           ruleTypeId: ApmRuleType.TransactionDuration,
           name: 'Apm transaction duration with kql filter',
           params: {
-            kqlFilter:
-              'service.name: opbeans-node and transaction.type: request and service.environment: production',
+            searchConfiguration: {
+              query: {
+                query:
+                  'service.name: opbeans-node and transaction.type: request and service.environment: production',
+                language: 'kuery',
+              },
+            },
             ...ruleParams,
           },
           actions: [],

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -102,7 +102,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             transactionType: 'request',
             serviceName: 'opbeans-java',
             environment: 'production',
-            kqlFilter: '',
             groupBy: [
               'service.name',
               'service.environment',
@@ -225,8 +224,13 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             transactionType: undefined,
             serviceName: undefined,
             environment: 'ENVIRONMENT_ALL',
-            kqlFilter:
-              'service.name: opbeans-node and transaction.type: request and service.environment: production',
+            searchConfiguration: {
+              query: {
+                query:
+                  'service.name: opbeans-node and transaction.type: request and service.environment: production',
+                language: 'kuery',
+              },
+            },
             groupBy: [
               'service.name',
               'service.environment',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [Replaces kqlFilter with searchConfiguration and uses Unified Search bar in APM rules (#164540)](https://github.com/elastic/kibana/pull/164540)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Bena Kansara","email":"69037875+benakansara@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-08-26T13:55:05Z","message":"Replaces kqlFilter with searchConfiguration and uses Unified Search bar in APM rules (#164540)\n\nFixes https://github.com/elastic/kibana/issues/163781\r\n\r\n- `kqlFilter` which was string is replaced with `searchConfiguration`\r\n- Replaces KQL filter component with Unified Search bar\r\n- Removed \"Technical Preview\" from the \"Filter\" label","sha":"b88235aafe9b6993ef7bb3918f60c6d8462e9e46","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:APM","release_note:skip","Team: Actionable Observability","backport:prev-minor","v8.10.0","v8.11.0"],"number":164540,"url":"https://github.com/elastic/kibana/pull/164540","mergeCommit":{"message":"Replaces kqlFilter with searchConfiguration and uses Unified Search bar in APM rules (#164540)\n\nFixes https://github.com/elastic/kibana/issues/163781\r\n\r\n- `kqlFilter` which was string is replaced with `searchConfiguration`\r\n- Replaces KQL filter component with Unified Search bar\r\n- Removed \"Technical Preview\" from the \"Filter\" label","sha":"b88235aafe9b6993ef7bb3918f60c6d8462e9e46"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164540","number":164540,"mergeCommit":{"message":"Replaces kqlFilter with searchConfiguration and uses Unified Search bar in APM rules (#164540)\n\nFixes https://github.com/elastic/kibana/issues/163781\r\n\r\n- `kqlFilter` which was string is replaced with `searchConfiguration`\r\n- Replaces KQL filter component with Unified Search bar\r\n- Removed \"Technical Preview\" from the \"Filter\" label","sha":"b88235aafe9b6993ef7bb3918f60c6d8462e9e46"}}]}] BACKPORT-->