### PR TITLE
[Cloud Security] Fix credential type switch

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/aws_credentials_form/aws_credentials_form.tsx
@@ -235,7 +235,9 @@ export const AwsCredentialsForm = ({
         size="m"
         options={getSetupFormatOptions()}
         idSelected={setupFormat}
-        onChange={onSetupFormatChange}
+        onChange={(idSelected: SetupFormat) =>
+          idSelected !== setupFormat && onSetupFormatChange(idSelected)
+        }
       />
       <EuiSpacer size="l" />
       {setupFormat === 'cloud_formation' && (


### PR DESCRIPTION
Resolves https://github.com/elastic/security-team/issues/7394

https://github.com/elastic/kibana/assets/51442161/6897f93b-2157-4acc-a1dd-d70a17633d1f

I've simply added a condition before calling the function, making sure we are not calling it when the selected value is the same. The function itself can use a refactor as there are some bugs if called with the same credential type, such as deleting the previous data or locking the previous type as we can see in the video at the issue.

For now I didn't want to introduce big changes since this function is using refs and messing with this logic can introduce new problems. with this change we avoid the bug by simply not calling the function, should be a relatively safe change.

@kfirpeled, tagging you so you can decide if you want to add that to the tech debt list

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->