### PR TITLE
[Security Solution] expandable flyout - show deleted rule badge in rule preview

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview.tsx
@@ -34,7 +34,11 @@ import * as i18n from './translations';
 export const RulePreview: React.FC = memo(() => {
   const { ruleId, indexPattern } = usePreviewPanelContext();
   const [rule, setRule] = useState<Rule | null>(null);
-  const { rule: maybeRule, loading: ruleLoading } = useRuleWithFallback(ruleId ?? '');
+  const {
+    rule: maybeRule,
+    loading: ruleLoading,
+    isExistingRule,
+  } = useRuleWithFallback(ruleId ?? '');
   const { data } = useKibana().services;
 
   // persist rule until refresh is complete
@@ -77,7 +81,7 @@ export const RulePreview: React.FC = memo(() => {
 
   return rule ? (
     <EuiPanel hasShadow={false} data-test-subj={RULE_PREVIEW_BODY_TEST_ID} className="eui-yScroll">
-      <RulePreviewTitle rule={rule} />
+      <RulePreviewTitle rule={rule} isSuppressed={!isExistingRule} />
       <EuiHorizontalRule margin="s" />
       <ExpandableSection
         title={i18n.RULE_PREVIEW_ABOUT_TEXT}

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.test.tsx
@@ -16,15 +16,17 @@ import {
   RULE_PREVIEW_TITLE_TEST_ID,
   RULE_PREVIEW_RULE_CREATED_BY_TEST_ID,
   RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID,
+  RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID,
 } from './test_ids';
 
 const defaultProps = {
   rule: { id: 'id' } as Rule,
+  isSuppressed: false,
 };
 
 describe('<RulePreviewTitle />', () => {
   it('should render title and its components', () => {
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <TestProviders>
         <ExpandableFlyoutContext.Provider value={mockFlyoutContextValue}>
           <RulePreviewTitle {...defaultProps} />
@@ -34,5 +36,21 @@ describe('<RulePreviewTitle />', () => {
     expect(getByTestId(RULE_PREVIEW_TITLE_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(RULE_PREVIEW_RULE_CREATED_BY_TEST_ID)).toBeInTheDocument();
     expect(getByTestId(RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID)).toBeInTheDocument();
+    expect(queryByTestId(RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID)).not.toBeInTheDocument();
+  });
+
+  it('should render deleted rule badge', () => {
+    const props = {
+      ...defaultProps,
+      isSuppressed: true,
+    };
+    const { getByTestId } = render(
+      <TestProviders>
+        <ExpandableFlyoutContext.Provider value={mockFlyoutContextValue}>
+          <RulePreviewTitle {...props} />
+        </ExpandableFlyoutContext.Provider>
+      </TestProviders>
+    );
+    expect(getByTestId(RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.tsx
@@ -4,9 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+
 import React from 'react';
 import { EuiTitle, EuiText, EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
-import { DELETED_RULE_BADGE } from './translations';
+import { DELETED_RULE } from '../../../detection_engine/rule_details_ui/pages/rule_details/translations';
 import type { Rule } from '../../../detection_engine/rule_management/logic';
 import { CreatedBy, UpdatedBy } from '../../../detections/components/rules/rule_info';
 import {
@@ -40,7 +41,7 @@ export const RulePreviewTitle: React.FC<RulePreviewTitleProps> = ({ rule, isSupp
         <>
           <EuiSpacer size="s" />
           <EuiBadge data-test-subj={RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID} title="">
-            {DELETED_RULE_BADGE}
+            {DELETED_RULE}
           </EuiBadge>
         </>
       )}

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/rule_preview_title.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiTitle, EuiText, EuiSpacer, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiTitle, EuiText, EuiSpacer, EuiFlexGroup, EuiFlexItem, EuiBadge } from '@elastic/eui';
+import { DELETED_RULE_BADGE } from './translations';
 import type { Rule } from '../../../detection_engine/rule_management/logic';
 import { CreatedBy, UpdatedBy } from '../../../detections/components/rules/rule_info';
 import {
   RULE_PREVIEW_TITLE_TEST_ID,
   RULE_PREVIEW_RULE_CREATED_BY_TEST_ID,
   RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID,
+  RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID,
 } from './test_ids';
 
 interface RulePreviewTitleProps {
@@ -19,17 +21,29 @@ interface RulePreviewTitleProps {
    * Rule object that represents relevant information about a rule
    */
   rule: Rule;
+  /**
+   * Flag to indicate if rule is suppressed
+   */
+  isSuppressed: boolean;
 }
 
 /**
  * Title component that shows basic information of a rule. This is displayed above rule preview body in rule preview panel
  */
-export const RulePreviewTitle: React.FC<RulePreviewTitleProps> = ({ rule }) => {
+export const RulePreviewTitle: React.FC<RulePreviewTitleProps> = ({ rule, isSuppressed }) => {
   return (
     <div data-test-subj={RULE_PREVIEW_TITLE_TEST_ID}>
       <EuiTitle>
         <h6>{rule.name}</h6>
       </EuiTitle>
+      {isSuppressed && (
+        <>
+          <EuiSpacer size="s" />
+          <EuiBadge data-test-subj={RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID} title="">
+            {DELETED_RULE_BADGE}
+          </EuiBadge>
+        </>
+      )}
       <EuiSpacer size="s" />
       <EuiFlexGroup gutterSize="xs" direction="column">
         <EuiFlexItem data-test-subj={RULE_PREVIEW_RULE_CREATED_BY_TEST_ID}>

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/test_ids.ts
@@ -10,6 +10,8 @@ import { CONTENT_TEST_ID, HEADER_TEST_ID } from '../../right/components/expandab
 /* Rule preview */
 
 export const RULE_PREVIEW_TITLE_TEST_ID = 'securitySolutionDocumentDetailsFlyoutRulePreviewTitle';
+export const RULE_PREVIEW_RULE_TITLE_SUPPRESSED_TEST_ID =
+  'securitySolutionDocumentDetailsFlyoutRulePreviewTitleSuppressed';
 export const RULE_PREVIEW_RULE_CREATED_BY_TEST_ID =
   'securitySolutionDocumentDetailsFlyoutRulePreviewCreatedByText';
 export const RULE_PREVIEW_RULE_UPDATED_BY_TEST_ID =

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/translations.ts
@@ -36,10 +36,3 @@ export const ALERT_REASON_TITLE = i18n.translate(
   'xpack.securitySolution.flyout.documentDetails.alertReasonTitle',
   { defaultMessage: 'Alert reason' }
 );
-
-export const DELETED_RULE_BADGE = i18n.translate(
-  'xpack.securitySolution.flyout.documentDetails.rulePreviewDeletedRuleBadge',
-  {
-    defaultMessage: 'Deleted rule',
-  }
-);

--- a/x-pack/plugins/security_solution/public/flyout/preview/components/translations.ts
+++ b/x-pack/plugins/security_solution/public/flyout/preview/components/translations.ts
@@ -36,3 +36,10 @@ export const ALERT_REASON_TITLE = i18n.translate(
   'xpack.securitySolution.flyout.documentDetails.alertReasonTitle',
   { defaultMessage: 'Alert reason' }
 );
+
+export const DELETED_RULE_BADGE = i18n.translate(
+  'xpack.securitySolution.flyout.documentDetails.rulePreviewDeletedRuleBadge',
+  {
+    defaultMessage: 'Deleted rule',
+  }
+);


### PR DESCRIPTION
## Summary

This PR adds the `Deleted rule` badge to the expandable flyout rule preview panel for rules that were deleted.
![Screenshot 2023-08-28 at 2 06 48 PM](https://github.com/elastic/kibana/assets/17276605/07fb2c88-57a3-4e56-911a-669f3b790541)

Fixes https://github.com/elastic/kibana/issues/164960

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or 

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->