### PR TITLE
[Ops] Improve serverless_ftr.sh result output

### DIFF
--- a/.buildkite/scripts/steps/functional/serverless_ftr.sh
+++ b/.buildkite/scripts/steps/functional/serverless_ftr.sh
@@ -28,6 +28,7 @@ elif [[ "$SERVERLESS_ENVIRONMENT" == "security" ]]; then
 fi
 
 EXIT_CODE=0
+OFFENDING_CONFIG=
 
 for CONFIG in "${SERVERLESS_CONFIGS[@]}"
 do
@@ -42,7 +43,17 @@ do
 
   if [ $LAST_CODE -ne 0 ]; then
     EXIT_CODE=10
+    OFFENDING_CONFIG=$CONFIG
   fi
 done
+
+echo "--- Serverless FTR Results for $JOB"
+if  [ $EXIT_CODE -eq 0 ]; then
+  echo "✅ Success!"
+elif [ $EXIT_CODE -eq 10 ]; then
+  echo "❌ Failed in config: $OFFENDING_CONFIG, exit code set to 10 for soft-failure"
+else
+  echo "❌ Failed."
+fi
 
 exit $EXIT_CODE


### PR DESCRIPTION
## Summary
The FTR serverless pipeline's output can be confusing, because in case any of the configs fail, the error log is always attached to the last collapsing block (thus making devs think it was the last block that was erroneous).

This PR adds an output message after the configs are ran, and separates the log from the last run's logs.

- chore: Add result logging for serverless_ftr.sh with a new collapsing block to avoid confusion

Was:
<img width="1086" alt="Screenshot 2023-08-28 at 16 08 43" src="https://github.com/elastic/kibana/assets/4738868/46721879-8add-49a2-8448-b9ed40ac8bc0">

Would be:
<img width="1079" alt="Screenshot 2023-08-28 at 16 08 20" src="https://github.com/elastic/kibana/assets/4738868/3eaf7f2b-7fc8-4777-81e3-1c21ec57faaa">
