### PR TITLE
[Security Solution] UI collapse on rule Preview under create rule

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
@@ -231,7 +231,7 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
           <EuiSpacer />
         </>
       )}
-      <EuiText size="xs">
+      <EuiText size="xs" data-test-subj="rule-preview">
         <h4>{i18n.QUERY_PREVIEW_LABEL}</h4>
       </EuiText>
       <EuiSpacer size="xs" />

--- a/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/rule_preview/index.tsx
@@ -12,7 +12,6 @@ import {
   EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
   EuiSpacer,
   EuiSuperDatePicker,
   EuiSuperUpdateButton,
@@ -232,36 +231,32 @@ const RulePreviewComponent: React.FC<RulePreviewProps> = ({
           <EuiSpacer />
         </>
       )}
-      <EuiFormRow
-        label={i18n.QUERY_PREVIEW_LABEL}
-        error={undefined}
-        isInvalid={false}
-        data-test-subj="rule-preview"
-        describedByIds={['rule-preview']}
-      >
-        <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
-          <EuiSuperDatePicker
-            start={startDate}
-            end={endDate}
-            isDisabled={isDisabled}
-            onTimeChange={onTimeChange}
-            showUpdateButton={false}
-            commonlyUsedRanges={timeRanges}
-            onRefresh={onTimeframeRefresh}
-            data-test-subj="preview-time-frame"
+      <EuiText size="xs">
+        <h4>{i18n.QUERY_PREVIEW_LABEL}</h4>
+      </EuiText>
+      <EuiSpacer size="xs" />
+      <EuiFlexGroup alignItems="center" responsive={false} gutterSize="s">
+        <EuiSuperDatePicker
+          start={startDate}
+          end={endDate}
+          isDisabled={isDisabled}
+          onTimeChange={onTimeChange}
+          showUpdateButton={false}
+          commonlyUsedRanges={timeRanges}
+          onRefresh={onTimeframeRefresh}
+          data-test-subj="preview-time-frame"
+        />
+        <EuiFlexItem grow={false}>
+          <EuiSuperUpdateButton
+            isDisabled={isDateRangeInvalid || isDisabled}
+            iconType={isDirty ? 'kqlFunction' : 'refresh'}
+            onClick={onTimeframeRefresh}
+            color={isDirty ? 'success' : 'primary'}
+            fill={true}
+            data-test-subj="previewSubmitButton"
           />
-          <EuiFlexItem grow={false}>
-            <EuiSuperUpdateButton
-              isDisabled={isDateRangeInvalid || isDisabled}
-              iconType={isDirty ? 'kqlFunction' : 'refresh'}
-              onClick={onTimeframeRefresh}
-              color={isDirty ? 'success' : 'primary'}
-              fill={true}
-              data-test-subj="previewSubmitButton"
-            />
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
       <EuiSpacer size="l" />
       {isPreviewRequestInProgress && <LoadingHistogram />}
       {!isPreviewRequestInProgress && previewId && spaceId && (


### PR DESCRIPTION
## Summary

Original ticket: https://github.com/elastic/kibana/issues/163472

This PR fixes Rule Preview UI which is broken when user closes the preview component.

**Broken State:**

<img width="1724" alt="Screenshot 2023-08-28 at 14 56 42" src="https://github.com/elastic/kibana/assets/2700761/ec123a06-fef1-47c2-8b29-3567b8037cff">


**Fixed UI:**

<img width="1723" alt="Screenshot 2023-08-28 at 14 55 23" src="https://github.com/elastic/kibana/assets/2700761/fb4955fc-77af-4f02-b326-cec01f09f4ed">



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->