### PR TITLE
[8.9] [Rule Details] - Update rule details data view id text (#164494)

### DIFF
--- a/x-pack/plugins/security_solution/cypress/screens/rule_details.ts
+++ b/x-pack/plugins/security_solution/cypress/screens/rule_details.ts
@@ -28,7 +28,7 @@ export const SAVED_QUERY_DETAILS = /^Saved query$/;
 
 export const SAVED_QUERY_FILTERS_DETAILS = 'Saved query filters';
 
-export const DATA_VIEW_DETAILS = 'Data View';
+export const DATA_VIEW_DETAILS = 'Data view';
 
 export const DEFINITION_DETAILS =
   '[data-test-subj=definitionRule] [data-test-subj="listItemColumnStepRuleDescription"]';

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/schema.tsx
@@ -79,21 +79,11 @@ export const schema: FormSchema<DefineStepRule> = {
       },
     ],
   },
-  dataViewTitle: {
-    label: i18n.translate(
-      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
-      {
-        defaultMessage: 'Data View',
-      }
-    ),
-    validations: [],
-  },
-  // TODO: populate the dataViewTitle in a better way
   dataViewId: {
     label: i18n.translate(
       'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewSelector',
       {
-        defaultMessage: 'Data View',
+        defaultMessage: 'Data view',
       }
     ),
     fieldsToValidateOnChange: ['dataViewId'],
@@ -128,6 +118,15 @@ export const schema: FormSchema<DefineStepRule> = {
         },
       },
     ],
+  },
+  dataViewTitle: {
+    label: i18n.translate(
+      'xpack.securitySolution.detectionEngine.createRule.stepAboutRule.dataViewTitleSelector',
+      {
+        defaultMessage: 'Data view index pattern',
+      }
+    ),
+    validations: [],
   },
   eqlOptions: {},
   queryBar: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[Rule Details] - Update rule details data view id text (#164494)](https://github.com/elastic/kibana/pull/164494)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yara Tercero","email":"yctercero@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-08-28T16:29:00Z","message":"[Rule Details] - Update rule details data view id text (#164494)\n\n**Resolves: https://github.com/elastic/kibana/issues/164828**\r\n**Related UX writing issue:\r\nhttps://github.com/elastic/ux-writing/issues/46**\r\n\r\n## Summary\r\n\r\nIn rule details page, when a rule has a data view selected, two labels\r\nshow up as \"Data View\". This appears to be a bug, as one of those labels\r\nshould be \"Data view ID\" and another should be \"Data view index\r\npattern\".\r\n\r\nThanks to @MadameSheema @nikitaindik for finding this. \r\n\r\n### Before \r\n\r\n![image](https://github.com/elastic/kibana/assets/10927944/8ac8b6d4-1005-4c03-a71a-31216a1287c5)\r\n\r\n### After\r\n<img width=\"808\" alt=\"Screenshot 2023-08-26 at 19 30 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/15949146/b511bf92-0e90-4455-834c-36b8e75b2a58\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n---------\r\n\r\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>","sha":"31e95574ae6d8cfa9e0ba4595e1068e9391b423d","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:Detection Rule Management","ui-copy","Feature:Rule Details","Team:Detection Engine","v8.10.0","v8.11.0","v8.9.2"],"number":164494,"url":"https://github.com/elastic/kibana/pull/164494","mergeCommit":{"message":"[Rule Details] - Update rule details data view id text (#164494)\n\n**Resolves: https://github.com/elastic/kibana/issues/164828**\r\n**Related UX writing issue:\r\nhttps://github.com/elastic/ux-writing/issues/46**\r\n\r\n## Summary\r\n\r\nIn rule details page, when a rule has a data view selected, two labels\r\nshow up as \"Data View\". This appears to be a bug, as one of those labels\r\nshould be \"Data view ID\" and another should be \"Data view index\r\npattern\".\r\n\r\nThanks to @MadameSheema @nikitaindik for finding this. \r\n\r\n### Before \r\n\r\n![image](https://github.com/elastic/kibana/assets/10927944/8ac8b6d4-1005-4c03-a71a-31216a1287c5)\r\n\r\n### After\r\n<img width=\"808\" alt=\"Screenshot 2023-08-26 at 19 30 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/15949146/b511bf92-0e90-4455-834c-36b8e75b2a58\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n---------\r\n\r\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>","sha":"31e95574ae6d8cfa9e0ba4595e1068e9391b423d"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/165015","number":165015,"state":"OPEN"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164494","number":164494,"mergeCommit":{"message":"[Rule Details] - Update rule details data view id text (#164494)\n\n**Resolves: https://github.com/elastic/kibana/issues/164828**\r\n**Related UX writing issue:\r\nhttps://github.com/elastic/ux-writing/issues/46**\r\n\r\n## Summary\r\n\r\nIn rule details page, when a rule has a data view selected, two labels\r\nshow up as \"Data View\". This appears to be a bug, as one of those labels\r\nshould be \"Data view ID\" and another should be \"Data view index\r\npattern\".\r\n\r\nThanks to @MadameSheema @nikitaindik for finding this. \r\n\r\n### Before \r\n\r\n![image](https://github.com/elastic/kibana/assets/10927944/8ac8b6d4-1005-4c03-a71a-31216a1287c5)\r\n\r\n### After\r\n<img width=\"808\" alt=\"Screenshot 2023-08-26 at 19 30 54\"\r\nsrc=\"https://github.com/elastic/kibana/assets/15949146/b511bf92-0e90-4455-834c-36b8e75b2a58\">\r\n\r\n\r\n### Checklist\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n\r\n---------\r\n\r\nCo-authored-by: Nikita Indik <nikita.indik@elastic.co>","sha":"31e95574ae6d8cfa9e0ba4595e1068e9391b423d"}},{"branch":"8.9","label":"v8.9.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->