### PR TITLE
[RAM] bring back generic o11y threshold rule

### DIFF
--- a/x-pack/plugins/apm/server/feature.ts
+++ b/x-pack/plugins/apm/server/feature.ts
@@ -13,10 +13,16 @@ import {
   LicensingApiRequestHandlerContext,
 } from '@kbn/licensing-plugin/server';
 import { APM_INDEX_SETTINGS_SAVED_OBJECT_TYPE } from '@kbn/apm-data-access-plugin/server/saved_objects/apm_indices';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/observability-plugin/common/constants';
 import {
   ApmRuleType,
   APM_SERVER_FEATURE_ID,
 } from '../common/rules/apm_rule_types';
+
+const ruleTypes = [
+  ...Object.values(ApmRuleType),
+  OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+];
 
 export const APM_FEATURE = {
   id: APM_SERVER_FEATURE_ID,
@@ -30,7 +36,7 @@ export const APM_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: Object.values(ApmRuleType),
+  alerting: ruleTypes,
   // see x-pack/plugins/features/common/feature_kibana_privileges.ts
   privileges: {
     all: {
@@ -43,10 +49,10 @@ export const APM_FEATURE = {
       },
       alerting: {
         alert: {
-          all: Object.values(ApmRuleType),
+          all: ruleTypes,
         },
         rule: {
-          all: Object.values(ApmRuleType),
+          all: ruleTypes,
         },
       },
       management: {
@@ -64,10 +70,10 @@ export const APM_FEATURE = {
       },
       alerting: {
         alert: {
-          read: Object.values(ApmRuleType),
+          read: ruleTypes,
         },
         rule: {
-          read: Object.values(ApmRuleType),
+          read: ruleTypes,
         },
       },
       management: {

--- a/x-pack/plugins/infra/server/features.ts
+++ b/x-pack/plugins/infra/server/features.ts
@@ -8,6 +8,7 @@
 import { i18n } from '@kbn/i18n';
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
 import { logViewSavedObjectName } from '@kbn/logs-shared-plugin/server';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/observability-plugin/common/constants';
 import { LOG_DOCUMENT_COUNT_RULE_TYPE_ID } from '../common/alerting/logs/log_threshold/types';
 import {
   METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
@@ -15,6 +16,12 @@ import {
 } from '../common/alerting/metrics';
 import { LOGS_FEATURE_ID, METRICS_FEATURE_ID } from '../common/constants';
 import { infraSourceConfigurationSavedObjectName } from './lib/sources/saved_object_type';
+
+const metricRuleTypes = [
+  METRIC_THRESHOLD_ALERT_TYPE_ID,
+  METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
+  OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+];
 
 export const METRICS_FEATURE = {
   id: METRICS_FEATURE_ID,
@@ -28,7 +35,7 @@ export const METRICS_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+  alerting: metricRuleTypes,
   privileges: {
     all: {
       app: ['infra', 'metrics', 'kibana'],
@@ -40,10 +47,10 @@ export const METRICS_FEATURE = {
       },
       alerting: {
         rule: {
-          all: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          all: metricRuleTypes,
         },
         alert: {
-          all: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          all: metricRuleTypes,
         },
       },
       management: {
@@ -61,10 +68,10 @@ export const METRICS_FEATURE = {
       },
       alerting: {
         rule: {
-          read: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          read: metricRuleTypes,
         },
         alert: {
-          read: [METRIC_THRESHOLD_ALERT_TYPE_ID, METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID],
+          read: metricRuleTypes,
         },
       },
       management: {
@@ -74,6 +81,8 @@ export const METRICS_FEATURE = {
     },
   },
 };
+
+const logsRuleTypes = [LOG_DOCUMENT_COUNT_RULE_TYPE_ID, OBSERVABILITY_THRESHOLD_RULE_TYPE_ID];
 
 export const LOGS_FEATURE = {
   id: LOGS_FEATURE_ID,
@@ -87,7 +96,7 @@ export const LOGS_FEATURE = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+  alerting: logsRuleTypes,
   privileges: {
     all: {
       app: ['infra', 'logs', 'kibana'],
@@ -99,10 +108,10 @@ export const LOGS_FEATURE = {
       },
       alerting: {
         rule: {
-          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          all: logsRuleTypes,
         },
         alert: {
-          all: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          all: logsRuleTypes,
         },
       },
       management: {
@@ -116,10 +125,10 @@ export const LOGS_FEATURE = {
       api: ['infra', 'rac'],
       alerting: {
         rule: {
-          read: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          read: logsRuleTypes,
         },
         alert: {
-          read: [LOG_DOCUMENT_COUNT_RULE_TYPE_ID],
+          read: logsRuleTypes,
         },
       },
       management: {

--- a/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
@@ -33,6 +33,7 @@ import { getAlertSummaryTimeRange } from '../../utils/alert_summary_widget';
 import { observabilityAlertFeatureIds } from '../../../common/constants';
 import { ALERTS_URL_STORAGE_KEY } from '../../../common/constants';
 import { HeaderMenu } from '../overview/components/header_menu/header_menu';
+import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
 
 const ALERTS_SEARCH_BAR_ID = 'alerts-search-bar-o11y';
 const ALERTS_PER_PAGE = 50;
@@ -59,10 +60,12 @@ function InternalAlertsPage() {
       getAlertSummaryWidget: AlertSummaryWidget,
     },
   } = kibanaServices;
-  const { ObservabilityPageTemplate, observabilityRuleTypeRegistry } = usePluginContext();
+  const { ObservabilityPageTemplate } = usePluginContext();
   const alertSearchBarStateProps = useAlertSearchBarStateContainer(ALERTS_URL_STORAGE_KEY, {
     replace: false,
   });
+
+  const filteredRuleTypes = useGetFilteredRuleTypes();
 
   const onBrushEnd: BrushEndListener = (brushEvent) => {
     const { x } = brushEvent as XYBrushEvent;
@@ -126,7 +129,7 @@ function InternalAlertsPage() {
     try {
       const response = await loadRuleAggregations({
         http,
-        typesFilter: observabilityRuleTypeRegistry.list(),
+        typesFilter: filteredRuleTypes,
       });
       const { ruleExecutionStatus, ruleMutedStatus, ruleEnabledStatus, ruleSnoozedStatus } =
         response;

--- a/x-pack/plugins/observability/public/pages/rule_details/rule_details.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/rule_details.tsx
@@ -39,6 +39,7 @@ import {
 } from '../../utils/alert_summary_widget';
 import type { AlertStatus } from '../../../common/typings';
 import { HeaderMenu } from '../overview/components/header_menu/header_menu';
+import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
 
 export type TabId = typeof RULE_DETAILS_ALERTS_TAB | typeof RULE_DETAILS_EXECUTION_TAB;
 
@@ -64,7 +65,7 @@ export function RuleDetailsPage() {
       getRuleStatusPanel: RuleStatusPanel,
     },
   } = useKibana().services;
-  const { ObservabilityPageTemplate, observabilityRuleTypeRegistry } = usePluginContext();
+  const { ObservabilityPageTemplate } = usePluginContext();
 
   const { ruleId } = useParams<RuleDetailsPathParams>();
   const { search } = useLocation();
@@ -73,9 +74,9 @@ export function RuleDetailsPage() {
   const baseTheme = useChartsBaseTheme();
 
   const { rule, isLoading, isError, refetch } = useFetchRule({ ruleId });
-
+  const filteredRuleTypes = useGetFilteredRuleTypes();
   const { ruleTypes } = useFetchRuleTypes({
-    filterByRuleTypeIds: observabilityRuleTypeRegistry.list(),
+    filterByRuleTypeIds: filteredRuleTypes,
   });
 
   useBreadcrumbs([

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -28,7 +28,10 @@ import { SpacesPluginSetup } from '@kbn/spaces-plugin/server';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 import { ObservabilityConfig } from '.';
 import { casesFeatureId, observabilityFeatureId, sloFeatureId } from '../common';
-import { SLO_BURN_RATE_RULE_TYPE_ID } from '../common/constants';
+import {
+  SLO_BURN_RATE_RULE_TYPE_ID,
+  OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+} from '../common/constants';
 import {
   kubernetesGuideConfig,
   kubernetesGuideId,
@@ -69,6 +72,8 @@ interface PluginSetup {
 interface PluginStart {
   alerting: PluginStartContract;
 }
+
+const sloRuleTypes = [SLO_BURN_RATE_RULE_TYPE_ID, OBSERVABILITY_THRESHOLD_RULE_TYPE_ID];
 
 export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
   private logger: Logger;
@@ -192,7 +197,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
       category: DEFAULT_APP_CATEGORIES.observability,
       app: [sloFeatureId, 'kibana'],
       catalogue: [sloFeatureId, 'observability'],
-      alerting: [SLO_BURN_RATE_RULE_TYPE_ID],
+      alerting: sloRuleTypes,
       privileges: {
         all: {
           app: [sloFeatureId, 'kibana'],
@@ -204,10 +209,10 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
           },
           alerting: {
             rule: {
-              all: [SLO_BURN_RATE_RULE_TYPE_ID],
+              all: sloRuleTypes,
             },
             alert: {
-              all: [SLO_BURN_RATE_RULE_TYPE_ID],
+              all: sloRuleTypes,
             },
           },
           ui: ['read', 'write'],
@@ -222,10 +227,10 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
           },
           alerting: {
             rule: {
-              read: [SLO_BURN_RATE_RULE_TYPE_ID],
+              read: sloRuleTypes,
             },
             alert: {
-              read: [SLO_BURN_RATE_RULE_TYPE_ID],
+              read: sloRuleTypes,
             },
           },
           ui: ['read'],

--- a/x-pack/plugins/synthetics/server/feature.ts
+++ b/x-pack/plugins/synthetics/server/feature.ts
@@ -6,6 +6,7 @@
  */
 
 import { DEFAULT_APP_CATEGORIES } from '@kbn/core/server';
+import { OBSERVABILITY_THRESHOLD_RULE_TYPE_ID } from '@kbn/observability-plugin/common/constants';
 import { syntheticsMonitorType, syntheticsParamType } from '../common/types/saved_objects';
 import { SYNTHETICS_RULE_TYPES } from '../common/constants/synthetics_alerts';
 import { privateLocationsSavedObjectName } from '../common/saved_objects/private_locations';
@@ -19,6 +20,13 @@ const UPTIME_RULE_TYPES = [
   'xpack.uptime.alerts.monitorStatus',
   'xpack.uptime.alerts.durationAnomaly',
 ];
+
+const ruleTypes = [
+  ...UPTIME_RULE_TYPES,
+  ...SYNTHETICS_RULE_TYPES,
+  OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,
+];
+
 export const uptimeFeature = {
   id: PLUGIN.ID,
   name: PLUGIN.NAME,
@@ -29,7 +37,7 @@ export const uptimeFeature = {
   management: {
     insightsAndAlerting: ['triggersActions'],
   },
-  alerting: [...UPTIME_RULE_TYPES, ...SYNTHETICS_RULE_TYPES],
+  alerting: ruleTypes,
   privileges: {
     all: {
       app: ['uptime', 'kibana', 'synthetics'],
@@ -47,10 +55,10 @@ export const uptimeFeature = {
       },
       alerting: {
         rule: {
-          all: [...UPTIME_RULE_TYPES, ...SYNTHETICS_RULE_TYPES],
+          all: ruleTypes,
         },
         alert: {
-          all: [...UPTIME_RULE_TYPES, ...SYNTHETICS_RULE_TYPES],
+          all: ruleTypes,
         },
       },
       management: {
@@ -74,10 +82,10 @@ export const uptimeFeature = {
       },
       alerting: {
         rule: {
-          read: [...UPTIME_RULE_TYPES, ...SYNTHETICS_RULE_TYPES],
+          read: ruleTypes,
         },
         alert: {
-          read: [...UPTIME_RULE_TYPES, ...SYNTHETICS_RULE_TYPES],
+          read: ruleTypes,
         },
       },
       management: {


### PR DESCRIPTION
## Summary

The rule `Threshold (Technical Preview)` was not anymore showing under the rule form for a super user because of our latest [PR](https://github.com/elastic/kibana/pull/163574) to build our filter authorization from the feature ids that the user have access.
We brought it back by adding this new rule type id under the alerting privileges of every o11y solutions.
 
FYI => We have a [branch feature](https://github.com/elastic/kibana/tree/o11y-rbac-rule-feature-branch) that will allow to create this rule for different roles and access

<img width="602" alt="image" src="https://github.com/elastic/kibana/assets/189600/223e510a-0ee7-4d66-9517-d733c0cd9a0c">





<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->