### PR TITLE
[Example] Make Serverless API integration and functional tests fail due to `esArchiver.emptyKibanaIndex()` call

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/search/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/index.ts
@@ -7,10 +7,18 @@
 
 import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('Serverless search API', function () {
-    loadTestFile(require.resolve('./telemetry/snapshot_telemetry'));
-    loadTestFile(require.resolve('./cases/find_cases'));
-    loadTestFile(require.resolve('./cases/post_case'));
+export default function ({ getService }: FtrProviderContext) {
+  // eslint-disable-next-line ban/ban
+  describe.only('Serverless search API', function () {
+    const esArchiver = getService('esArchiver');
+
+    before(async () => {
+      await esArchiver.emptyKibanaIndex();
+    });
+
+    it('should fail to run due to esArchiver.emptyKibanaIndex() throwing an exception', () => {
+      // eslint-disable-next-line no-console
+      console.log("I'm a failure!");
+    });
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/search/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index.ts
@@ -7,11 +7,18 @@
 
 import { FtrProviderContext } from '../../ftr_provider_context';
 
-export default function ({ loadTestFile }: FtrProviderContext) {
-  describe('serverless search UI', function () {
-    loadTestFile(require.resolve('./landing_page'));
-    loadTestFile(require.resolve('./empty_page'));
-    loadTestFile(require.resolve('./navigation'));
-    loadTestFile(require.resolve('./cases/attachment_framework'));
+export default function ({ getService }: FtrProviderContext) {
+  // eslint-disable-next-line ban/ban
+  describe.only('serverless search UI', function () {
+    const esArchiver = getService('esArchiver');
+
+    before(async () => {
+      await esArchiver.emptyKibanaIndex();
+    });
+
+    it('should fail to run due to esArchiver.emptyKibanaIndex() throwing an exception', () => {
+      // eslint-disable-next-line no-console
+      console.log("I'm a failure!");
+    });
   });
 }


### PR DESCRIPTION
## Summary

An example PR demonstrating that Serverless API integration and functional tests fail when `esArchiver.emptyKibanaIndex()` is called.