### PR TITLE
[Security Solution] Reputation Service is turned ON when Behavior toggle is turned back ON

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/behaviour_protection_card.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/behaviour_protection_card.tsx
@@ -23,6 +23,7 @@ import type { BehaviorProtectionOSes } from '../../../../../types';
 import { useLicense } from '../../../../../../../../common/hooks/use_license';
 import { SettingLockedCard } from '../../setting_locked_card';
 import type { PolicyFormComponentCommonProps } from '../../../types';
+import type { ProtectionSettingCardSwitchProps } from '../../protection_setting_card_switch';
 
 export const LOCKED_CARD_BEHAVIOR_TITLE = i18n.translate(
   'xpack.securitySolution.endpoint.policy.details.behavior',
@@ -38,6 +39,15 @@ const BEHAVIOUR_OS_VALUES: Immutable<BehaviorProtectionOSes[]> = [
 ];
 
 export type BehaviourProtectionCardProps = PolicyFormComponentCommonProps;
+
+const adjustReputationServiceSettingsOnProtectionSwitch: ProtectionSettingCardSwitchProps['additionalOnSwitchChange'] =
+  ({ value, policyConfigData, protectionOsList }) => {
+    for (const os of protectionOsList) {
+      policyConfigData[os].behavior_protection.reputation_service = value;
+    }
+
+    return policyConfigData;
+  };
 
 export const BehaviourProtectionCard = memo<BehaviourProtectionCardProps>(
   ({ policy, onChange, mode, 'data-test-subj': dataTestSubj }) => {
@@ -80,6 +90,7 @@ export const BehaviourProtectionCard = memo<BehaviourProtectionCardProps>(
             protection={protection}
             protectionLabel={protectionLabel}
             osList={BEHAVIOUR_OS_VALUES}
+            additionalOnSwitchChange={adjustReputationServiceSettingsOnProtectionSwitch}
             data-test-subj={getTestId('enableDisableSwitch')}
           />
         }
@@ -98,6 +109,8 @@ export const BehaviourProtectionCard = memo<BehaviourProtectionCardProps>(
           onChange={onChange}
           mode={mode}
           protection={protection}
+          osList={BEHAVIOUR_OS_VALUES}
+          additionalOnSwitchChange={adjustReputationServiceSettingsOnProtectionSwitch}
           data-test-subj={getTestId('reputationService')}
         />
 

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/components/reputation_service.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/components/reputation_service.tsx
@@ -95,7 +95,7 @@ export const ReputationService = React.memo(
 
         onChange({ isValid: true, updatedPolicy: newPayload });
       },
-      [policy, onChange]
+      [policy, onChange, osList, additionalOnSwitchChange]
     );
 
     const checkboxLabel = checkboxChecked

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/components/reputation_service.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/protection_seetings_card/components/reputation_service.tsx
@@ -23,9 +23,24 @@ import { SettingCardHeader } from '../../../setting_card';
 import type { PolicyProtection } from '../../../../../../types';
 import type { PolicyFormComponentCommonProps } from '../../../../types';
 import { ProtectionModes } from '../../../../../../../../../../common/endpoint/types';
+import type {
+  ImmutableArray,
+  PolicyConfig,
+  UIPolicyConfig,
+} from '../../../../../../../../../../common/endpoint/types';
 
 interface ReputationServiceProps extends PolicyFormComponentCommonProps {
   protection: PolicyProtection;
+  additionalOnSwitchChange: ({
+    value,
+    policyConfigData,
+    protectionOsList,
+  }: {
+    value: boolean;
+    policyConfigData: PolicyConfig;
+    protectionOsList: ImmutableArray<Partial<keyof UIPolicyConfig>>;
+  }) => PolicyConfig;
+  osList: ImmutableArray<Partial<keyof UIPolicyConfig>>;
 }
 
 const USE_REPUTATION_SERVICE_CHECKBOX_LABEL = i18n.translate(
@@ -48,6 +63,8 @@ export const ReputationService = React.memo(
     onChange,
     mode,
     protection,
+    additionalOnSwitchChange,
+    osList,
     'data-test-subj': dataTestSubj,
   }: ReputationServiceProps) => {
     const isEditMode = mode === 'edit';
@@ -65,9 +82,16 @@ export const ReputationService = React.memo(
     const handleChange = useCallback(
       (event) => {
         const newPayload = cloneDeep(policy);
-        newPayload.windows.behavior_protection.reputation_service = event.target.checked;
-        newPayload.mac.behavior_protection.reputation_service = event.target.checked;
-        newPayload.linux.behavior_protection.reputation_service = event.target.checked;
+        const value = event.target.checked;
+        newPayload.windows.behavior_protection.reputation_service = value;
+        newPayload.mac.behavior_protection.reputation_service = value;
+        newPayload.linux.behavior_protection.reputation_service = value;
+
+        additionalOnSwitchChange({
+          value,
+          policyConfigData: newPayload,
+          protectionOsList: osList,
+        });
 
         onChange({ isValid: true, updatedPolicy: newPayload });
       },


### PR DESCRIPTION
## Summary

When Malicious behavior protection is toggled on/off, we should always turn Reputation Service back ON when when Malicious behavior turned back on.  The same is true if the user turns Reputation Service OFF.  If they then switch Behavior OFF, we should turn Reputation service back ON.

This behavior is consistent with the the way the Notify User checkbox works.

Start with Switch ON
<img width="1728" alt="image" src="https://github.com/elastic/kibana/assets/56395104/3e785127-1fa3-4ead-afe3-06e02548ed8a">

Turn if OFF
<img width="1728" alt="image" src="https://github.com/elastic/kibana/assets/56395104/658f4507-6319-42e9-ad72-4168b561b943">

Then when turning it back ON, Reputation Service should be ON
<img width="1728" alt="image" src="https://github.com/elastic/kibana/assets/56395104/3e785127-1fa3-4ead-afe3-06e02548ed8a">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
