### PR TITLE
Construct HTTP log message only if needed

### DIFF
--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -399,8 +399,10 @@ export class HttpServer {
     const log = this.logger.get('http', 'server', 'response');
 
     this.handleServerResponseEvent = (request) => {
-      const { message, meta } = getEcsResponseLog(request, this.log);
-      log.debug(message!, meta);
+      if(log.isLevelEnabled('debug')) {
+        const { message, meta } = getEcsResponseLog(request, this.log);
+        log.debug(message!, meta);
+      }
     };
 
     this.server.events.on('response', this.handleServerResponseEvent);

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -399,7 +399,7 @@ export class HttpServer {
     const log = this.logger.get('http', 'server', 'response');
 
     this.handleServerResponseEvent = (request) => {
-      if(log.isLevelEnabled('debug')) {
+      if (log.isLevelEnabled('debug')) {
         const { message, meta } = getEcsResponseLog(request, this.log);
         log.debug(message!, meta);
       }


### PR DESCRIPTION
## Summary

Previously we have unconditionally created a debug log message that potentially involved serializing a large response object only to ignore it if the the log level 'debug' is disabled for that logger. With this commit we add a check if the respective level is enabled on the logger before we proceed to construct the log message.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
