### PR TITLE
[ES|QL] Hover feature

### DIFF
--- a/packages/kbn-monaco/src/esql/language.ts
+++ b/packages/kbn-monaco/src/esql/language.ts
@@ -17,6 +17,7 @@ import { DiagnosticsAdapter } from '../common/diagnostics_adapter';
 import { WorkerProxyService } from '../common/worker_proxy';
 import { ESQLCompletionAdapter } from './lib/monaco/esql_completion_provider';
 import type { ESQLCustomAutocompleteCallbacks } from './lib/autocomplete/types';
+import { createHoverProvider, HoverProviderProps } from './lib/hover';
 
 const workerProxyService = new WorkerProxyService<ESQLWorker>();
 
@@ -34,5 +35,9 @@ export const ESQLLang: CustomLangModuleType = {
 
   getSuggestionProvider(callbacks?: ESQLCustomAutocompleteCallbacks) {
     return new ESQLCompletionAdapter((...uris) => workerProxyService.getWorker(uris), callbacks);
+  },
+
+  getHoverProvider(callbacks: HoverProviderProps) {
+    return createHoverProvider(callbacks);
   },
 };

--- a/packages/kbn-monaco/src/esql/lib/hover/index.ts
+++ b/packages/kbn-monaco/src/esql/lib/hover/index.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { SerializedEnrichPolicy } from '@kbn/index-management-plugin/common';
+import type { Datatable } from '@kbn/expressions-plugin/public';
+import { monaco } from '../../../monaco_imports';
+
+function findEnrichStatementPosition(fullText: string, position: number) {
+  const lastPipeBeforeIndex = fullText.substring(0, position).lastIndexOf('|');
+  const nextPipeBeforeIndex = fullText.substring(lastPipeBeforeIndex + 1).indexOf('|');
+  const statementEnd = nextPipeBeforeIndex !== -1 ? nextPipeBeforeIndex : fullText.length;
+  return {
+    text: fullText.substring(lastPipeBeforeIndex + 1, statementEnd),
+    start: lastPipeBeforeIndex,
+    end: statementEnd,
+  };
+}
+
+function findPreviousWord(fullText: string, position: number) {
+  const { text } = findEnrichStatementPosition(fullText, position);
+  return text.split(' ').filter((w) => w.trim().length)[0];
+}
+
+function getPolicyName(fullText: string, position: number) {
+  const { text: enrichStatement, end } = findEnrichStatementPosition(fullText, position);
+  const enrichIndex = enrichStatement.toLowerCase().indexOf('enrich');
+  return enrichStatement
+    .substring(enrichIndex + 6, end)
+    .split(' ')
+    .filter((w) => w.trim().length)[0];
+}
+
+export interface HoverProviderProps {
+  getCurrentPolicies: () => SerializedEnrichPolicy[];
+  getResultPreview: (partialQuery: string) => Promise<Datatable | undefined>;
+}
+
+export function createHoverProvider({ getCurrentPolicies, getResultPreview }: HoverProviderProps) {
+  return {
+    provideHover: async (
+      model: monaco.editor.ITextModel,
+      position: monaco.Position,
+      token: monaco.CancellationToken
+    ) => {
+      const innerText = model.getValue();
+      const textRange = model.getFullModelRange();
+
+      const lengthAfterPosition = model.getValueLengthInRange({
+        startLineNumber: position.lineNumber,
+        startColumn: position.column,
+        endLineNumber: textRange.endLineNumber,
+        endColumn: textRange.endColumn,
+      });
+
+      const currentPosition = innerText.length - lengthAfterPosition;
+
+      if (innerText[currentPosition] === '|') {
+        const isLastPipeAtEnd = innerText[innerText.length - 1] === '|';
+        const partialExpression = innerText.substring(
+          0,
+          innerText.length - lengthAfterPosition - (isLastPipeAtEnd ? 1 : 2)
+        );
+        try {
+          const table = await getResultPreview(partialExpression);
+          if (!table) {
+            return { contents: [] };
+          }
+          return {
+            contents: [
+              {
+                value: 'Table preview',
+              },
+              {
+                value: `${table.columns.map((column) => column.name).join(' | ')}${table.rows.map(
+                  (row) => table.columns.map((c) => row[c.id])
+                )}`,
+              },
+            ],
+          };
+          // eslint-disable-next-line no-empty
+        } catch (e) {}
+      }
+      const word = model.getWordAtPosition(position);
+
+      if (word?.word && findPreviousWord(innerText, currentPosition) === 'enrich') {
+        const policyName = getPolicyName(innerText, currentPosition);
+        const hoveredPolicy = getCurrentPolicies().find((policy) => policy.name === policyName);
+        // TODO: improve range highlight
+        return {
+          contents: [
+            { value: 'Policy preview' },
+            { value: JSON.stringify(hoveredPolicy, null, 2) },
+          ],
+        };
+      }
+
+      return { contents: [] };
+    },
+  };
+}

--- a/packages/kbn-monaco/src/types.ts
+++ b/packages/kbn-monaco/src/types.ts
@@ -14,6 +14,7 @@ export interface LangModuleType {
   lexerRules?: monaco.languages.IMonarchLanguage;
   languageConfiguration?: monaco.languages.LanguageConfiguration;
   getSuggestionProvider?: Function;
+  getHoverProvider?: Function;
 }
 
 export interface CompleteLangModuleType extends LangModuleType {

--- a/packages/kbn-monaco/tsconfig.json
+++ b/packages/kbn-monaco/tsconfig.json
@@ -25,6 +25,8 @@
     "@kbn/i18n",
     "@kbn/repo-info",
     "@kbn/ui-theme",
+    "@kbn/index-management-plugin",
+    "@kbn/expressions-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -452,6 +452,24 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
       [getPoliciesIdentifiers]
     );
 
+  const getCurrentPolicies = useCallback(() => {
+    return policiesRef.current;
+  }, []);
+  const getResultPreview = useCallback(
+    async (partialExpression: string) => {
+      const esqlQuery = {
+        esql: `${partialExpression} | limit 0`,
+      };
+      try {
+        const table = await fetchFieldsFromESQL(esqlQuery, expressions);
+        return table;
+      } catch (e) {
+        // no action yet
+      }
+    },
+    [expressions]
+  );
+
   const codeEditorOptions: CodeEditorProps['options'] = {
     automaticLayout: false,
     accessibilitySupport: 'off',
@@ -667,6 +685,14 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                               getPoliciesIdentifiers,
                               getPolicyFieldsIdentifiers,
                               getPolicyMatchingFieldIdentifiers,
+                            })
+                          : undefined
+                      }
+                      hoverProvider={
+                        language === 'esql'
+                          ? ESQLLang.getHoverProvider?.({
+                              getCurrentPolicies,
+                              getResultPreview,
                             })
                           : undefined
                       }


### PR DESCRIPTION
## Summary

Add some hover capability to ES|QL editor:

1. Hovering over the pipe `|` operation will show a table preview:
<img width="384" alt="Screenshot 2023-08-29 at 11 45 02" src="https://github.com/elastic/kibana/assets/924948/112f28c9-5e1d-4291-868b-40c3575b96cf">

2. Hovering over a policy name will show the RAW json definition:
<img width="606" alt="Screenshot 2023-08-29 at 11 45 23" src="https://github.com/elastic/kibana/assets/924948/5ae224b3-b3d4-4616-911a-66078e665d26">

The PoC is based purely on string manipulation but using the parser would make it more robust and precise.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
