### PR TITLE
[Fleet] Make routing_rule namespace optionnal

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -382,8 +382,8 @@ export interface RegistryDataStreamRoutingRules {
   source_dataset: string;
   rules: Array<{
     target_dataset: string;
-    if: string;
-    namespace: string;
+    if?: string;
+    namespace?: string;
   }>;
 }
 

--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -382,7 +382,7 @@ export interface RegistryDataStreamRoutingRules {
   source_dataset: string;
   rules: Array<{
     target_dataset: string;
-    if?: string;
+    if: string;
     namespace?: string;
   }>;
 }


### PR DESCRIPTION
## Summary

Resolve #165033 

Looks like optional routing rule namespace is already supported in Fleet, that PR just fix the type to match the package-spec