### PR TITLE
[Security Solution][Bug] Fix legacy showTopN popover actions

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/with_hover_actions/index.tsx
@@ -93,7 +93,9 @@ export const WithHoverActions = React.memo<Props>(
       setShowHoverContent(false);
 
       if (onCloseRequested != null) {
-        onCloseRequested();
+        setTimeout(() => {
+          onCloseRequested();
+        });
       }
     }, [onCloseRequested]);
 


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/164800

The bug was caused by the popover closing before the actions were able to execute. 
Since all action executions are async, closing the popover at the end of the event loop (using `setTimeout`) is enough to allow the action to execute properly before the showTopN popover is closed.

### Demo

https://github.com/elastic/kibana/assets/17747913/e427a81f-17ed-436c-89b3-903a94632d70




<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->