### PR TITLE
[Synthetics] Refactor code to use monitor location id for filtering

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_overview_status.ts
@@ -33,7 +33,7 @@ export const OverviewStatusMetaDataCodec = t.interface({
   monitorQueryId: t.string,
   configId: t.string,
   status: t.string,
-  location: t.string,
+  locationId: t.string,
   timestamp: t.string,
   ping: OverviewPingCodec,
 });

--- a/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
@@ -148,6 +148,7 @@ export const PingType = t.intersection([
     timestamp: t.string,
     monitor: MonitorType,
     docId: t.string,
+    observer: ObserverCodec,
   }),
   t.partial({
     '@timestamp': t.string,
@@ -198,7 +199,6 @@ export const PingType = t.intersection([
         uid: t.string,
       }),
     }),
-    observer: ObserverCodec,
     resolve: t.partial({
       ip: t.string,
       rtt: t.partial({
@@ -262,37 +262,6 @@ export const PingStatusType = t.intersection([
 ]);
 
 export type PingStatus = t.TypeOf<typeof PingStatusType>;
-
-// Convenience function for tests etc that makes an empty ping
-// object with the minimum of fields.
-export const makePing = (f: {
-  docId?: string;
-  type?: string;
-  id?: string;
-  timestamp?: string;
-  ip?: string;
-  status?: string;
-  duration?: number;
-  location?: string;
-  name?: string;
-  url?: string;
-}): Ping => {
-  return {
-    docId: f.docId || 'myDocId',
-    timestamp: f.timestamp || '2020-07-07T01:14:08Z',
-    monitor: {
-      id: f.id || 'myId',
-      type: f.type || 'myType',
-      ip: f.ip || '127.0.0.1',
-      status: f.status || 'up',
-      duration: { us: f.duration || 100000 },
-      name: f.name,
-      check_group: 'myCheckGroup',
-    },
-    ...(f.location ? { observer: { geo: { name: f.location } } } : {}),
-    ...(f.url ? { url: { full: f.url } } : {}),
-  };
-};
 
 export const PingsResponseType = t.type({
   total: t.number,

--- a/x-pack/plugins/synthetics/e2e/synthetics/journeys/services/data/browser_docs.ts
+++ b/x-pack/plugins/synthetics/e2e/synthetics/journeys/services/data/browser_docs.ts
@@ -7,13 +7,13 @@
 
 import { DocOverrides } from './sample_docs';
 
-export const getGeoData = (locationName?: string) => ({
+export const getGeoData = (locationName?: string, locationId?: string) => ({
   observer: {
     geo: {
       name: locationName ?? 'North America - US Central',
       location: '41.8780, 93.0977',
     },
-    name: locationName ?? 'North America - US Central',
+    name: locationId ?? 'us_central',
   },
 });
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
@@ -65,10 +65,10 @@ export const MetricItem = ({
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const isErrorPopoverOpen = useSelector(selectErrorPopoverState);
   const locationName =
-    useLocationName({ locationId: monitor.location?.id })?.label || monitor.location?.id;
+    useLocationName({ locationId: monitor.location.id })?.label || monitor.location?.id;
   const { status, timestamp, ping, configIdByLocation } = useStatusByLocationOverview(
     monitor.configId,
-    locationName
+    monitor.location.id
   );
   const theme = useTheme();
 
@@ -116,7 +116,7 @@ export const MetricItem = ({
                   configId: monitor.configId,
                   id: monitor.id,
                   location: locationName,
-                  locationId: monitor.location?.id,
+                  locationId: monitor.location.id,
                 });
               }
             }}

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/monitor_detail_flyout.test.tsx
@@ -40,6 +40,7 @@ describe('Monitor Detail Flyout', () => {
           full: 'https://www.elastic.co',
         },
         tags: ['tag1', 'tag2'],
+        observer: {},
       },
     });
     jest.spyOn(statusByLocation, 'useStatusByLocation').mockReturnValue({

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.test.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.test.tsx
@@ -120,34 +120,34 @@ describe('useMonitorsSortedByStatus', () => {
                 [`test-monitor-1-${location2.label}`]: {
                   configId: 'test-monitor-1',
                   monitorQueryId: 'test-monitor-1',
-                  location: location2.label,
+                  locationId: location2.label,
                 },
                 [`test-monitor-2-${location2.label}`]: {
                   configId: 'test-monitor-2',
                   monitorQueryId: 'test-monitor-2',
-                  location: location2.label,
+                  locationId: location2.label,
                 },
                 [`test-monitor-3-${location2.label}`]: {
                   configId: 'test-monitor-3',
                   monitorQueryId: 'test-monitor-3',
-                  location: location2.label,
+                  locationId: location2.label,
                 },
               },
               downConfigs: {
                 [`test-monitor-1-${location1.label}`]: {
                   configId: 'test-monitor-1',
                   monitorQueryId: 'test-monitor-1',
-                  location: location1.label,
+                  locationId: location1.label,
                 },
                 [`test-monitor-2-${location1.label}`]: {
                   configId: 'test-monitor-2',
                   monitorQueryId: 'test-monitor-2',
-                  location: location1.label,
+                  locationId: location1.label,
                 },
                 [`test-monitor-3${location1.label}`]: {
                   configId: 'test-monitor-3',
                   monitorQueryId: 'test-monitor-3',
-                  location: location1.label,
+                  locationId: location1.label,
                 },
               },
               pendingConfigs: {

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_monitors_sorted_by_status.tsx
@@ -37,11 +37,11 @@ export function useMonitorsSortedByStatus() {
 
     const { downConfigs, pendingConfigs } = status;
     const downMonitorMap: Record<string, string[]> = {};
-    Object.values(downConfigs).forEach(({ location, configId }) => {
+    Object.values(downConfigs).forEach(({ locationId, configId }) => {
       if (downMonitorMap[configId]) {
-        downMonitorMap[configId].push(location);
+        downMonitorMap[configId].push(locationId);
       } else {
-        downMonitorMap[configId] = [location];
+        downMonitorMap[configId] = [locationId];
       }
     });
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_status_by_location_overview.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/hooks/use_status_by_location_overview.ts
@@ -9,22 +9,22 @@ import { useSelector } from 'react-redux';
 import { OverviewStatusState } from '../../../../common/runtime_types';
 import { selectOverviewStatus } from '../state/overview_status';
 
-export function useStatusByLocationOverview(configId: string, locationName?: string) {
+export function useStatusByLocationOverview(configId: string, locationId: string) {
   const { status } = useSelector(selectOverviewStatus);
 
-  return getConfigStatusByLocation(status, configId, locationName);
+  return getConfigStatusByLocation(status, configId, locationId);
 }
 
 export const getConfigStatusByLocation = (
   status: OverviewStatusState | null,
   configId: string,
-  locationName?: string
+  locationId: string
 ) => {
-  if (!locationName || !status) {
+  if (!status) {
     return { status: 'unknown' };
   }
   const allConfigs = status.allConfigs;
-  const configIdByLocation = `${configId}-${locationName}`;
+  const configIdByLocation = `${configId}-${locationId}`;
   const config = allConfigs[configIdByLocation];
 
   return {

--- a/x-pack/plugins/synthetics/server/alert_rules/common.test.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/common.test.ts
@@ -202,7 +202,7 @@ describe('setRecoveredAlertsContext', () => {
       configId,
       monitorQueryId: 'stale-config',
       status: 'up',
-      location: '',
+      locationId: '',
       ping: {
         '@timestamp': new Date().toISOString(),
         state: {
@@ -235,7 +235,7 @@ describe('setRecoveredAlertsContext', () => {
         configId,
         monitorQueryId: 'stale-config',
         status: 'down',
-        location: 'location',
+        locationId: 'location',
         ping: {
           '@timestamp': new Date().toISOString(),
           state: {
@@ -294,7 +294,7 @@ describe('setRecoveredAlertsContext', () => {
         configId,
         monitorQueryId: 'stale-config',
         status: 'down',
-        location: 'location',
+        locationId: 'location',
         ping: {
           '@timestamp': new Date().toISOString(),
           state: {
@@ -355,7 +355,7 @@ describe('setRecoveredAlertsContext', () => {
         configId,
         monitorQueryId: 'stale-config',
         status: 'down',
-        location: 'location',
+        locationId: 'location',
         ping: {
           state: {
             id: '123456',

--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
@@ -93,7 +93,7 @@ export const registerSyntheticsStatusCheckRule = (
       );
 
       Object.entries(downConfigs).forEach(([idWithLocation, { ping, configId }]) => {
-        const locationId = statusRule.getLocationId(ping.observer?.geo?.name!) ?? '';
+        const locationId = ping.observer.name ?? '';
         const alertId = idWithLocation;
         const monitorSummary = getMonitorSummary(
           ping,

--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/status_rule_executor.test.ts
@@ -97,7 +97,7 @@ describe('StatusRuleExecutor', () => {
 
     const staleDownConfigs = await statusRule.markDeletedConfigs({
       id1: {
-        location: 'us-east-1',
+        locationId: 'us-east-1',
         configId: 'id1',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -105,7 +105,7 @@ describe('StatusRuleExecutor', () => {
         ping: {} as any,
       },
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_dev': {
-        location: 'US Central DEV',
+        locationId: 'us_central_dev',
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -113,7 +113,7 @@ describe('StatusRuleExecutor', () => {
         ping: {} as any,
       },
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_qa': {
-        location: 'US Central QA',
+        locationId: 'us_central_qa',
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -126,7 +126,7 @@ describe('StatusRuleExecutor', () => {
       id1: {
         configId: 'id1',
         isDeleted: true,
-        location: 'us-east-1',
+        locationId: 'us-east-1',
         monitorQueryId: 'test',
         ping: {},
         status: 'down',
@@ -135,7 +135,7 @@ describe('StatusRuleExecutor', () => {
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_dev': {
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         isLocationRemoved: true,
-        location: 'US Central DEV',
+        locationId: 'us_central_dev',
         monitorQueryId: 'test',
         ping: {},
         status: 'down',
@@ -175,7 +175,7 @@ describe('StatusRuleExecutor', () => {
 
     const staleDownConfigs = await statusRule.markDeletedConfigs({
       id1: {
-        location: 'us-east-1',
+        locationId: 'us-east-1',
         configId: 'id1',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -183,7 +183,7 @@ describe('StatusRuleExecutor', () => {
         ping: {} as any,
       },
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_dev': {
-        location: 'US Central DEV',
+        locationId: 'us_central_dev',
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -191,7 +191,7 @@ describe('StatusRuleExecutor', () => {
         ping: {} as any,
       },
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_qa': {
-        location: 'US Central QA',
+        locationId: 'us_central_qa',
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         status: 'down',
         timestamp: '2021-06-01T00:00:00.000Z',
@@ -204,7 +204,7 @@ describe('StatusRuleExecutor', () => {
       id1: {
         configId: 'id1',
         isDeleted: true,
-        location: 'us-east-1',
+        locationId: 'us-east-1',
         monitorQueryId: 'test',
         ping: {},
         status: 'down',
@@ -213,7 +213,7 @@ describe('StatusRuleExecutor', () => {
       '2548dab3-4752-4b4d-89a2-ae3402b6fb04-us_central_dev': {
         configId: '2548dab3-4752-4b4d-89a2-ae3402b6fb04',
         isLocationRemoved: true,
-        location: 'US Central DEV',
+        locationId: 'us_central_dev',
         monitorQueryId: 'test',
         ping: {},
         status: 'down',

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule_executor.ts
@@ -70,20 +70,15 @@ export class TLSRuleExecutor {
     const {
       allIds,
       enabledMonitorQueryIds,
-      listOfLocations,
+      monitorLocationIds,
       monitorLocationMap,
       projectMonitorsCount,
       monitorQueryIdToConfigIdMap,
-    } = await processMonitors(
-      this.monitors,
-      this.server,
-      this.soClient,
-      this.syntheticsMonitorClient
-    );
+    } = processMonitors(this.monitors, this.server, this.soClient, this.syntheticsMonitorClient);
 
     return {
       enabledMonitorQueryIds,
-      listOfLocations,
+      monitorLocationIds,
       allIds,
       monitorLocationMap,
       projectMonitorsCount,

--- a/x-pack/plugins/synthetics/server/queries/query_monitor_status.ts
+++ b/x-pack/plugins/synthetics/server/queries/query_monitor_status.ts
@@ -34,7 +34,7 @@ const fields = [
 
 export async function queryMonitorStatus(
   esClient: UptimeEsClient,
-  listOfLocations: string[],
+  monitorLocationIds: string[],
   range: { from: string; to: string },
   monitorQueryIds: string[],
   monitorLocationsMap: Record<string, string[]>,
@@ -50,7 +50,7 @@ export async function queryMonitorStatus(
     | 'allIds'
   >
 > {
-  const idSize = Math.trunc(DEFAULT_MAX_ES_BUCKET_SIZE / listOfLocations.length || 1);
+  const idSize = Math.trunc(DEFAULT_MAX_ES_BUCKET_SIZE / monitorLocationIds.length || 1);
   const pageCount = Math.ceil(monitorQueryIds.length / idSize);
   let up = 0;
   let down = 0;
@@ -95,8 +95,8 @@ export async function queryMonitorStatus(
               aggs: {
                 location: {
                   terms: {
-                    field: 'observer.geo.name',
-                    size: listOfLocations.length || 100,
+                    field: 'observer.name',
+                    size: monitorLocationIds.length || 100,
                   },
                   aggs: {
                     status: {
@@ -122,10 +122,10 @@ export async function queryMonitorStatus(
         },
       });
 
-      if (listOfLocations.length > 0) {
+      if (monitorLocationIds.length > 0) {
         params.body.query.bool.filter.push({
           terms: {
-            'observer.geo.name': listOfLocations,
+            'observer.name': monitorLocationIds,
           },
         });
       }
@@ -144,7 +144,7 @@ export async function queryMonitorStatus(
         // discard any locations that are not in the monitorLocationsMap for the given monitor as well as those which are
         // in monitorLocationsMap but not in listOfLocations
         const monLocations = monitorLocationsMap?.[queryId];
-        const monQueriedLocations = intersection(monLocations, listOfLocations);
+        const monQueriedLocations = intersection(monLocations, monitorLocationIds);
         monQueriedLocations?.forEach((monLocation) => {
           const locationSummary = locationSummaries.find(
             (summary) => summary.location === monLocation
@@ -154,14 +154,14 @@ export async function queryMonitorStatus(
             const { ping } = locationSummary;
             const downCount = ping.summary?.down ?? 0;
             const upCount = ping.summary?.up ?? 0;
-            const configId = ping.config_id!;
+            const configId = ping.config_id;
             const monitorQueryId = ping.monitor.id;
 
             const meta = {
               ping,
               configId,
               monitorQueryId,
-              location: monLocation,
+              locationId: monLocation,
               timestamp: ping['@timestamp'],
             };
 

--- a/x-pack/plugins/synthetics/server/routes/certs/get_certificates.ts
+++ b/x-pack/plugins/synthetics/server/routes/certs/get_certificates.ts
@@ -57,7 +57,7 @@ export const getSyntheticsCertsRoute: SyntheticsRestApiRouteFactory<
       };
     }
 
-    const { enabledMonitorQueryIds } = await processMonitors(
+    const { enabledMonitorQueryIds } = processMonitors(
       monitors,
       server,
       savedObjectsClient,

--- a/x-pack/plugins/synthetics/server/routes/common.ts
+++ b/x-pack/plugins/synthetics/server/routes/common.ts
@@ -81,7 +81,7 @@ export const getMonitors = async (
     monitorQueryIds,
   } = context.request.query;
 
-  const filterStr = await getMonitorFilters({
+  const { filtersStr } = await getMonitorFilters({
     filter,
     monitorTypes,
     tags,
@@ -100,7 +100,7 @@ export const getMonitors = async (
     sortOrder,
     searchFields: SEARCH_FIELDS,
     search: query ? `${query}*` : undefined,
-    filter: filterStr,
+    filter: filtersStr,
     searchAfter,
     fields,
   };
@@ -129,7 +129,7 @@ export const getMonitorFilters = async ({
 }) => {
   const locationFilter = await parseLocationFilter(context, locations);
 
-  return [
+  const filtersStr = [
     filter,
     getKqlFilter({ field: 'tags', values: tags }),
     getKqlFilter({ field: 'project_id', values: projects }),
@@ -140,6 +140,7 @@ export const getMonitorFilters = async ({
   ]
     .filter((f) => !!f)
     .join(' AND ');
+  return { filtersStr, locationFilter };
 };
 
 export const getKqlFilter = ({
@@ -172,7 +173,7 @@ export const getKqlFilter = ({
 
 const parseLocationFilter = async (context: RouteContext, locations?: string | string[]) => {
   if (!locations || locations?.length === 0) {
-    return '';
+    return;
   }
 
   const { allLocations } = await getAllLocations(context);
@@ -183,7 +184,7 @@ const parseLocationFilter = async (context: RouteContext, locations?: string | s
       .filter((val) => !!val);
   }
 
-  return findLocationItem(locations, allLocations)?.id ?? '';
+  return [findLocationItem(locations, allLocations)?.id ?? ''];
 };
 
 export const findLocationItem = (

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/get_monitor.ts
@@ -91,7 +91,7 @@ export const getSyntheticsMonitorOverviewRoute: SyntheticsRestApiRouteFactory = 
       locations: queriedLocations,
     } = request.query as MonitorsQuery;
 
-    const filtersStr = await getMonitorFilters({
+    const { filtersStr } = await getMonitorFilters({
       ...request.query,
       context: routeContext,
     });

--- a/x-pack/plugins/synthetics/server/routes/overview_status/overview_status.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/overview_status/overview_status.test.ts
@@ -15,39 +15,80 @@ import { EncryptedSyntheticsMonitorAttributes } from '../../../common/runtime_ty
 import { RouteContext } from '../types';
 import { getUptimeESMockClient } from '../../legacy_uptime/lib/requests/test_helpers';
 
+import * as commonLibs from '../common';
+import { SyntheticsServerSetup } from '../../types';
+import { mockEncryptedSO } from '../../synthetics_service/utils/mocks';
+import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
+import { loggerMock } from '@kbn/logging-mocks';
+import * as allLocationsFn from '../../synthetics_service/get_all_locations';
+const allLocations: any = [
+  {
+    id: 'us_central_qa',
+    label: 'US Central QA',
+  },
+  {
+    id: 'us_central',
+    label: 'North America - US Central',
+  },
+];
+jest.spyOn(allLocationsFn, 'getAllLocations').mockResolvedValue({
+  publicLocations: allLocations,
+  privateLocations: [],
+  allLocations,
+});
+
 jest.mock('../../saved_objects/synthetics_monitor/get_all_monitors', () => ({
   ...jest.requireActual('../../saved_objects/synthetics_monitor/get_all_monitors'),
   getAllMonitors: jest.fn(),
 }));
 
-jest.mock('../common', () => ({
-  getMonitors: jest.fn().mockReturnValue({
-    per_page: 10,
-    saved_objects: [
-      {
-        id: 'mon-1',
-        attributes: {
-          enabled: false,
-          locations: ['us-east1', 'us-west1', 'japan'],
+jest.spyOn(commonLibs, 'getMonitors').mockResolvedValue({
+  per_page: 10,
+  saved_objects: [
+    {
+      id: 'mon-1',
+      attributes: {
+        enabled: false,
+        locations: [{ id: 'us-east1' }, { id: 'us-west1' }, { id: 'japan' }],
+      },
+    },
+    {
+      id: 'mon-2',
+      attributes: {
+        enabled: true,
+        locations: [{ id: 'us-east1' }, { id: 'us-west1' }, { id: 'japan' }],
+        schedule: {
+          number: '10',
+          unit: 'm',
         },
       },
-      {
-        id: 'mon-2',
-        attributes: {
-          enabled: true,
-          locations: ['us-east1', 'us-west1', 'japan'],
-          schedule: {
-            number: '10',
-            unit: 'm',
-          },
-        },
-      },
-    ],
-  }),
-  getMonitorFilters: () => '',
-}));
+    },
+  ],
+} as any);
 
 describe('current status route', () => {
+  const logger = loggerMock.create();
+
+  const serverMock: SyntheticsServerSetup = {
+    logger,
+    config: {
+      service: {
+        username: 'dev',
+        password: '12345',
+        manifestUrl: 'http://localhost:8080/api/manifest',
+      },
+    },
+    spaces: {
+      spacesService: {
+        getSpaceId: jest.fn().mockReturnValue('test-space'),
+      },
+    },
+    encryptedSavedObjects: mockEncryptedSO(),
+    coreStart: {
+      savedObjects: savedObjectsServiceMock.createStartContract(),
+    },
+  } as unknown as SyntheticsServerSetup;
+
   describe('periodToMs', () => {
     it('returns 0 for unsupported unit type', () => {
       // @ts-expect-error Providing invalid value to test handler in function
@@ -190,7 +231,7 @@ describe('current status route', () => {
           'id1-Asia/Pacific - Japan': {
             configId: 'id1',
             monitorQueryId: 'id1',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -198,7 +239,7 @@ describe('current status route', () => {
           'id2-Asia/Pacific - Japan': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -208,7 +249,7 @@ describe('current status route', () => {
           'id2-Europe - Germany': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Europe - Germany',
+            locationId: 'Europe - Germany',
             status: 'down',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -355,7 +396,7 @@ describe('current status route', () => {
           'id1-Asia/Pacific - Japan': {
             configId: 'id1',
             monitorQueryId: 'id1',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -363,7 +404,7 @@ describe('current status route', () => {
           'id2-Asia/Pacific - Japan': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -373,7 +414,7 @@ describe('current status route', () => {
           'id2-Europe - Germany': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Europe - Germany',
+            locationId: 'Europe - Germany',
             status: 'down',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -525,7 +566,7 @@ describe('current status route', () => {
           'id1-Asia/Pacific - Japan': {
             configId: 'id1',
             monitorQueryId: 'id1',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -533,7 +574,7 @@ describe('current status route', () => {
           'id2-Asia/Pacific - Japan': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Asia/Pacific - Japan',
+            locationId: 'Asia/Pacific - Japan',
             status: 'up',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -543,7 +584,7 @@ describe('current status route', () => {
           'id2-Europe - Germany': {
             configId: 'id2',
             monitorQueryId: 'id2',
-            location: 'Europe - Germany',
+            locationId: 'Europe - Germany',
             status: 'down',
             ping: expect.any(Object),
             timestamp: expect.any(String),
@@ -729,17 +770,17 @@ describe('current status route', () => {
           },
         ])
       );
-      expect(
-        await getStatus(
-          {
-            uptimeEsClient,
-            savedObjectsClient: savedObjectsClientMock.create(),
-          } as unknown as RouteContext,
-          {
-            locations,
-          }
-        )
-      ).toEqual(
+      const result = await getStatus(
+        {
+          uptimeEsClient,
+          savedObjectsClient: savedObjectsClientMock.create(),
+          server: serverMock,
+        } as unknown as RouteContext,
+        {
+          locations,
+        }
+      );
+      expect(result).toEqual(
         expect.objectContaining({
           disabledCount,
         })

--- a/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
+++ b/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.test.ts
@@ -45,7 +45,7 @@ describe('processMonitors', () => {
   const monitorClient = new SyntheticsMonitorClient(syntheticsService, serverMock);
 
   it('should return a processed data', async () => {
-    const result = await processMonitors(testMonitors, serverMock, soClient, monitorClient);
+    const result = processMonitors(testMonitors, serverMock, soClient, monitorClient);
     expect(result).toEqual({
       allIds: [
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
@@ -60,15 +60,15 @@ describe('processMonitors', () => {
         '7f796001-a795-4c0b-afdb-3ce74edea775',
       ],
       disabledMonitorQueryIds: ['test-project-id-default'],
-      listOfLocations: ['US Central QA', 'US Central Staging', 'North America - US Central'],
+      monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
       monitorLocationMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'US Central QA',
-          'North America - US Central',
-          'US Central Staging',
+          'us_central_qa',
+          'us_central',
+          'us_central_staging',
         ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['US Central QA', 'US Central Staging'],
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
       },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',
@@ -81,7 +81,7 @@ describe('processMonitors', () => {
   it('should return a processed data where location label is missing', async () => {
     testMonitors[0].attributes.locations[0].label = undefined;
 
-    const result = await processMonitors(testMonitors, serverMock, soClient, monitorClient);
+    const result = processMonitors(testMonitors, serverMock, soClient, monitorClient);
     expect(result).toEqual({
       allIds: [
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
@@ -96,20 +96,15 @@ describe('processMonitors', () => {
         '7f796001-a795-4c0b-afdb-3ce74edea775',
       ],
       disabledMonitorQueryIds: ['test-project-id-default'],
-      listOfLocations: [
-        'US Central Staging',
-        'us_central_qa',
-        'US Central QA',
-        'North America - US Central',
-      ],
+      monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
       monitorLocationMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'US Central QA',
-          'North America - US Central',
-          'US Central Staging',
+          'us_central_qa',
+          'us_central',
+          'us_central_staging',
         ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['US Central Staging', 'us_central_qa'],
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
       },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',
@@ -160,7 +155,7 @@ describe('processMonitors', () => {
       )
     );
 
-    const result = await processMonitors(testMonitors, serverMock, soClient, monitorClient);
+    const result = processMonitors(testMonitors, serverMock, soClient, monitorClient);
     expect(result).toEqual({
       allIds: [
         'aa925d91-40b0-4f8f-b695-bb9b53cd4e22',
@@ -175,15 +170,15 @@ describe('processMonitors', () => {
         '7f796001-a795-4c0b-afdb-3ce74edea775',
       ],
       disabledMonitorQueryIds: ['test-project-id-default'],
-      listOfLocations: ['US Central Staging', 'US Central QA', 'North America - US Central'],
+      monitorLocationIds: ['us_central_qa', 'us_central_staging', 'us_central'],
       maxPeriod: 600000,
       monitorLocationMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': [
-          'US Central QA',
-          'North America - US Central',
-          'US Central Staging',
+          'us_central_qa',
+          'us_central',
+          'us_central_staging',
         ],
-        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['US Central Staging', 'US Central QA'],
+        'aa925d91-40b0-4f8f-b695-bb9b53cd4e22': ['us_central_qa', 'us_central_staging'],
       },
       monitorQueryIdToConfigIdMap: {
         '7f796001-a795-4c0b-afdb-3ce74edea775': '7f796001-a795-4c0b-afdb-3ce74edea775',

--- a/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
+++ b/x-pack/plugins/synthetics/server/saved_objects/synthetics_monitor/get_all_monitors.ts
@@ -10,16 +10,13 @@ import {
   SavedObjectsFindOptions,
   SavedObjectsFindResult,
 } from '@kbn/core-saved-objects-api-server';
-import pMap from 'p-map';
 import { intersection } from 'lodash';
 import { SyntheticsServerSetup } from '../../types';
 import { syntheticsMonitorType } from '../../../common/types/saved_objects';
 import { periodToMs } from '../../routes/overview_status/overview_status';
-import { getAllLocations } from '../../synthetics_service/get_all_locations';
 import {
   ConfigKey,
   EncryptedSyntheticsMonitorAttributes,
-  ServiceLocation,
   SourceType,
 } from '../../../common/runtime_types';
 import { SyntheticsMonitorClient } from '../../synthetics_service/synthetics_monitor/synthetics_monitor_client';
@@ -59,7 +56,7 @@ export const getAllMonitors = async ({
   return hits;
 };
 
-export const processMonitors = async (
+export const processMonitors = (
   allMonitors: Array<SavedObjectsFindResult<EncryptedSyntheticsMonitorAttributes>>,
   server: SyntheticsServerSetup,
   soClient: SavedObjectsClientContract,
@@ -83,22 +80,6 @@ export const processMonitors = async (
   const monitorLocationMap: Record<string, string[]> = {};
   const monitorQueryIdToConfigIdMap: Record<string, string> = {};
 
-  let allLocations: ServiceLocation[] | null = null;
-
-  const getLocationLabel = async (locationId: string) => {
-    if (!allLocations) {
-      const { publicLocations, privateLocations } = await getAllLocations({
-        server,
-        syntheticsMonitorClient,
-        savedObjectsClient: soClient,
-      });
-
-      allLocations = [...publicLocations, ...privateLocations];
-    }
-
-    return allLocations.find((loc) => loc.id === locationId)?.label ?? locationId;
-  };
-
   for (const monitor of allMonitors) {
     const attrs = monitor.attributes;
 
@@ -108,8 +89,9 @@ export const processMonitors = async (
 
     monitorQueryIdToConfigIdMap[attrs[ConfigKey.MONITOR_QUERY_ID]] = attrs[ConfigKey.CONFIG_ID];
 
+    const monitorLocations = attrs[ConfigKey.LOCATIONS].map((location) => location.id);
+
     if (attrs[ConfigKey.ENABLED] === false) {
-      const monitorLocations = attrs[ConfigKey.LOCATIONS].map((location) => location.label);
       const queriedLocations = Array.isArray(queryLocations) ? queryLocations : [queryLocations];
       const intersectingLocations = intersection(
         monitorLocations,
@@ -119,32 +101,12 @@ export const processMonitors = async (
       disabledMonitorsCount += 1;
       disabledMonitorQueryIds.push(attrs[ConfigKey.MONITOR_QUERY_ID]);
     } else {
-      const missingLabels = new Set<string>();
-
       enabledMonitorQueryIds.push(attrs[ConfigKey.MONITOR_QUERY_ID]);
-      const monLocs = new Set([
-        ...(attrs[ConfigKey.LOCATIONS]
-          .filter((loc) => {
-            if (!loc.label) {
-              missingLabels.add(loc.id);
-            }
-            return loc.label;
-          })
-          .map((location) => location.label) as string[]),
-      ]);
 
-      // since label wasn't always part of location, there can be a case where we have a location
-      // with an id but no label. We need to fetch the label from the API
-      // Adding a migration to add the label to the saved object is a future consideration
-      const locLabels = await pMap([...missingLabels], async (locationId) =>
-        getLocationLabel(locationId)
-      );
-
-      const monitorLocations = [...monLocs, ...locLabels];
       monitorLocationMap[attrs[ConfigKey.MONITOR_QUERY_ID]] = queryLocations
         ? intersection(monitorLocations, queryLocations)
         : monitorLocations;
-      listOfLocationsSet = new Set([...listOfLocationsSet, ...monLocs, ...locLabels]);
+      listOfLocationsSet = new Set([...listOfLocationsSet, ...monitorLocations]);
 
       maxPeriod = Math.max(maxPeriod, periodToMs(attrs[ConfigKey.SCHEDULE]));
     }
@@ -159,7 +121,7 @@ export const processMonitors = async (
     monitorLocationMap,
     disabledMonitorsCount,
     projectMonitorsCount,
-    listOfLocations: [...listOfLocationsSet],
+    monitorLocationIds: [...listOfLocationsSet],
     monitorQueryIdToConfigIdMap,
   };
 };


### PR DESCRIPTION
## Summary

Use monitor location id for filtering. 

Also removed redundant code which was their to account for missing label in location objects which were part of monitors.

### Testing

1. Make sure location filtering is working as expected in overview and management pages
2. Make sure sorting by locaiton is working as expected on both pages