### PR TITLE
[Profiling] removing setup resoucers api test

### DIFF
--- a/x-pack/test/profiling_api_integration/tests/feature_controls.spec.ts
+++ b/x-pack/test/profiling_api_integration/tests/feature_controls.spec.ts
@@ -66,7 +66,6 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
       params: { query: { timeFrom: start, timeTo: end, kuery: '' } },
     },
     { url: profilingRoutePaths.SetupDataCollectionInstructions },
-    { url: profilingRoutePaths.HasSetupESResources },
   ];
 
   async function executeRequests({


### PR DESCRIPTION
The '/internal/profiling/setup/instructions' is a complex API that relies on other plugins to be setup in order to test it properly. I'm removing it from the tests for now.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->