### PR TITLE
feat(slo): add partition by field in APM indicators

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -12,10 +12,12 @@ import { useFormContext } from 'react-hook-form';
 import { CreateSLOForm } from '../../types';
 import { FieldSelector } from '../apm_common/field_selector';
 import { DataPreviewChart } from '../common/data_preview_chart';
+import { GroupByFieldSelector } from '../common/group_by_field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmAvailabilityIndicatorTypeForm() {
   const { watch } = useFormContext<CreateSLOForm>();
+  const index = watch('indicator.params.index');
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
@@ -118,6 +120,8 @@ export function ApmAvailabilityIndicatorTypeForm() {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
+
+      <GroupByFieldSelector index={index} />
 
       <DataPreviewChart />
     </EuiFlexGroup>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -12,10 +12,12 @@ import { Controller, useFormContext } from 'react-hook-form';
 import { CreateSLOForm } from '../../types';
 import { FieldSelector } from '../apm_common/field_selector';
 import { DataPreviewChart } from '../common/data_preview_chart';
+import { GroupByFieldSelector } from '../common/group_by_field_selector';
 import { QueryBuilder } from '../common/query_builder';
 
 export function ApmLatencyIndicatorTypeForm() {
   const { control, watch, getFieldState } = useFormContext<CreateSLOForm>();
+  const index = watch('indicator.params.index');
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">
@@ -161,6 +163,8 @@ export function ApmLatencyIndicatorTypeForm() {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
+
+      <GroupByFieldSelector index={index} />
 
       <DataPreviewChart />
     </EuiFlexGroup>


### PR DESCRIPTION
Resolves https://github.com/elastic/actionable-observability/issues/121

## Summary

This PR adds the partition by field selector in the APM indicator forms


Dashboard | Create Form | Edit Form |
-- | -- | --
![image](https://github.com/elastic/kibana/assets/1376800/20218cbb-71d3-4ce6-ac41-a6441e78e18e) | ![image](https://github.com/elastic/kibana/assets/1376800/dca8bdd8-88e6-4a8c-bf80-b745a6c16700) | ![image](https://github.com/elastic/kibana/assets/1376800/95115e46-2c67-4a4d-b555-e66ee77fdbc6)

