### PR TITLE
[Security Solutions] Fix The 'Show top N' action inside the timeline

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -116,6 +116,7 @@ const TopNComponent: React.FC<Props> = ({
       <TopNContent>
         {view === 'raw' || view === 'all' ? (
           <EventsByDataset
+            applyGlobalQueriesAndFilters={false} // Global filters are already included in combinedQueries
             combinedQueries={combinedQueries}
             deleteQuery={deleteQuery}
             filters={applicableFilters}

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/events.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_attributes/common/events.ts
@@ -10,7 +10,8 @@ import type { GetLensAttributes } from '../../types';
 const layerId = uuidv4();
 
 export const getEventsHistogramLensAttributes: GetLensAttributes = (
-  stackByField = 'event.action'
+  stackByField = 'event.action',
+  extraOptions = {}
 ) => {
   return {
     title: 'Events',
@@ -55,7 +56,7 @@ export const getEventsHistogramLensAttributes: GetLensAttributes = (
         query: '',
         language: 'kuery',
       },
-      filters: [],
+      filters: extraOptions.filters ?? [],
       datasourceStates: {
         formBased: {
           layers: {

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -60,6 +60,7 @@ interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery' | 'se
   scopeId?: string;
   toggleTopN?: () => void;
   hideQueryToggle?: boolean;
+  applyGlobalQueriesAndFilters?: boolean;
 }
 
 const getHistogramOption = (fieldName: string): MatrixHistogramOption => ({
@@ -95,6 +96,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
   to,
   toggleTopN,
   hideQueryToggle = false,
+  applyGlobalQueriesAndFilters = true,
 }) => {
   const uniqueQueryId = useMemo(() => `${ID}-${queryType}`, [queryType]);
 


### PR DESCRIPTION
issue: https://github.com/elastic/kibana/issues/165075

## Summary

The "Show top N" action inside the timeline doesn't take the timeline filter and query into consideration 

### Solutions
Pass the `combinedQuery` created by the `top_n` component as a filter to Lens and disable `applyGlobalQueriesAndFilters` property (only for `top_n` component). 


<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->