### PR TITLE
[Fleet] Fix wrong fleet server host URL in kubernetes manifest yaml when policy specifies non-default fleet server

### DIFF
--- a/x-pack/plugins/fleet/cypress/screens/fleet.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet.ts
@@ -88,6 +88,7 @@ export const AGENT_FLYOUT = {
   MANAGED_TAB: 'managedTab',
   CONFIRM_AGENT_ENROLLMENT_BUTTON: 'ConfirmAgentEnrollmentButton',
   INCOMING_DATA_CONFIRMED_CALL_OUT: 'IncomingDataConfirmedCallOut',
+  KUBERNETES_PLATFORM_TYPE: 'platformTypeKubernetes',
 };
 
 export const AGENT_POLICIES_CREATE_AGENT_POLICY_FLYOUT = {
@@ -227,4 +228,8 @@ export const FLEET_SERVER_SETUP = {
 
 export const API_KEYS = {
   REVOKE_KEY_BUTTON: 'enrollmentTokenTable.revokeBtn',
+};
+
+export const AGENT_POLICY_DETAILS_PAGE = {
+  ADD_AGENT_LINK: 'addAgentLink',
 };

--- a/x-pack/plugins/fleet/cypress/tasks/fleet_server.ts
+++ b/x-pack/plugins/fleet/cypress/tasks/fleet_server.ts
@@ -9,22 +9,27 @@ import { createAgentDoc } from './agents';
 const FLEET_SERVER_POLICY_ID = 'fleet-server-policy';
 
 // Create a Fleet server policy
-export function setupFleetServer() {
-  let policyId: string;
+export async function setupFleetServer() {
+  const policyId: string = FLEET_SERVER_POLICY_ID;
   let kibanaVersion: string;
 
   cy.request({
     method: 'POST',
     url: '/api/fleet/agent_policies',
     headers: { 'kbn-xsrf': 'xx' },
+    failOnStatusCode: false,
     body: {
       id: FLEET_SERVER_POLICY_ID,
       name: 'Fleet Server policy',
       namespace: 'default',
       has_fleet_server: true,
     },
-  }).then((response: any) => {
-    policyId = response.body.item.id;
+  }).then((response) => {
+    // 409 is expected if the policy already exists
+    // this allows the test to be run repeatedly in dev
+    if (response.status > 299 && response.status !== 409) {
+      throw new Error(`Failed to create Fleet Server policy: ${response.body.message}`);
+    }
   });
 
   cy.getKibanaVersion().then((version) => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_managed.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/multi_page_layout/components/page_steps/install_agent/install_agent_managed.tsx
@@ -78,6 +78,7 @@ export const InstallElasticAgentManagedPageStep: React.FC<InstallAgentPageProps>
       selectedApiKeyId: enrollmentAPIKey.id,
       isComplete: commandCopied || !!enrolledAgentIds.length,
       fullCopyButton: true,
+      fleetServerHost: fleetServerHosts?.[0],
       onCopy: () => setCommandCopied(true),
     }),
   ];

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/right_content.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/header/right_content.tsx
@@ -69,7 +69,7 @@ export const HeaderRightContent: React.FunctionComponent<HeaderRightContentProps
   }
 
   const addAgentLink = (
-    <EuiLink onClick={addAgent}>
+    <EuiLink onClick={addAgent} data-test-subj="addAgentLink">
       {isFleetServerPolicy ? (
         <FormattedMessage
           id="xpack.fleet.policyDetails.addFleetServerButton"

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.tsx
@@ -18,7 +18,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
-import { useGetSettings, useStartServices } from '../../hooks';
+import { useStartServices } from '../../hooks';
 
 import { agentPolicyRouteService } from '../../../common';
 
@@ -28,19 +28,19 @@ interface Props {
   enrollmentAPIKey?: string;
   onCopy?: () => void;
   onDownload?: () => void;
+  fleetServerHost?: string;
 }
 
 export const KubernetesInstructions: React.FunctionComponent<Props> = ({
   enrollmentAPIKey,
   onCopy,
   onDownload,
+  fleetServerHost,
 }) => {
   const core = useStartServices();
-  const settings = useGetSettings();
   const { notifications } = core;
 
   const [yaml, setYaml] = useState<string>('');
-  const [fleetServer, setFleetServer] = useState<string | ''>();
   const [copyButtonClicked, setCopyButtonClicked] = useState(false);
   const [downloadButtonClicked, setDownloadButtonClicked] = useState(false);
 
@@ -59,13 +59,10 @@ export const KubernetesInstructions: React.FunctionComponent<Props> = ({
   useEffect(() => {
     async function fetchK8sManifest() {
       try {
-        const fleetServerHosts = settings.data?.item.fleet_server_hosts;
-        let host = '';
-        if (fleetServerHosts !== undefined && fleetServerHosts.length !== 0) {
-          setFleetServer(fleetServerHosts[0]);
-          host = fleetServerHosts[0];
-        }
-        const query = { fleetServer: host, enrolToken: enrollmentAPIKey };
+        const query = {
+          enrolToken: enrollmentAPIKey,
+          ...(fleetServerHost && { fleetServer: fleetServerHost }),
+        };
         const res = await sendGetK8sManifest(query);
         if (res.error) {
           throw res.error;
@@ -85,7 +82,7 @@ export const KubernetesInstructions: React.FunctionComponent<Props> = ({
       }
     }
     fetchK8sManifest();
-  }, [notifications.toasts, enrollmentAPIKey, settings.data?.item.fleet_server_hosts]);
+  }, [notifications.toasts, enrollmentAPIKey, fleetServerHost]);
 
   const downloadDescription = (
     <FormattedMessage
@@ -114,8 +111,13 @@ export const KubernetesInstructions: React.FunctionComponent<Props> = ({
     </EuiCopy>
   );
 
+  const searchParams = new URLSearchParams({
+    ...(fleetServerHost && { fleetServer: fleetServerHost }),
+    ...(enrollmentAPIKey && { enrolToken: enrollmentAPIKey }),
+  });
+
   const downloadLink = core.http.basePath.prepend(
-    `${agentPolicyRouteService.getK8sFullDownloadPath()}?fleetServer=${fleetServer}&enrolToken=${enrollmentAPIKey}`
+    `${agentPolicyRouteService.getK8sFullDownloadPath()}${searchParams.toString()}`
   );
 
   const k8sDownloadYaml = (

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/compute_steps.tsx
@@ -273,6 +273,7 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
           selectedApiKeyId,
           isK8s,
           cloudSecurityIntegration,
+          fleetServerHost: fleetServerHosts?.[0],
           enrollToken,
         })
       );
@@ -310,16 +311,17 @@ export const ManagedSteps: React.FunctionComponent<InstructionProps> = ({
     setSelectedPolicyId,
     refreshAgentPolicies,
     selectionType,
-    isK8s,
     cloudSecurityIntegration,
-    installManagedCommands,
     apiKeyData,
-    enrolledAgentIds,
     mode,
     setMode,
     enrollToken,
+    installManagedCommands,
+    isK8s,
+    fleetServerHosts,
     onClickViewAgents,
     link,
+    enrolledAgentIds,
     agentDataConfirmed,
     installedPackagePolicy,
   ]);

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps/install_managed_agent_step.tsx
@@ -25,6 +25,7 @@ export const InstallManagedAgentStep = ({
   isK8s,
   cloudSecurityIntegration,
   enrollToken,
+  fleetServerHost,
   isComplete,
   fullCopyButton,
   onCopy,
@@ -34,6 +35,7 @@ export const InstallManagedAgentStep = ({
   isK8s?: K8sMode;
   cloudSecurityIntegration?: CloudSecurityIntegration | undefined;
   enrollToken?: string;
+  fleetServerHost?: string;
   installCommand: CommandsByPlatform;
   isComplete?: boolean;
   fullCopyButton?: boolean;
@@ -55,6 +57,7 @@ export const InstallManagedAgentStep = ({
           enrollToken={enrollToken}
           onCopy={onCopy}
           fullCopyButton={fullCopyButton}
+          fleetServerHost={fleetServerHost}
         />
       ) : (
         <React.Fragment />

--- a/x-pack/plugins/fleet/public/components/enrollment_instructions/install_section.tsx
+++ b/x-pack/plugins/fleet/public/components/enrollment_instructions/install_section.tsx
@@ -19,6 +19,7 @@ interface Props {
   isK8s: K8sMode | undefined;
   cloudSecurityIntegration: CloudSecurityIntegration | undefined;
   enrollToken?: string;
+  fleetServerHost?: string;
   fullCopyButton?: boolean;
   isManaged?: boolean;
   onCopy?: () => void;
@@ -29,6 +30,7 @@ export const InstallSection: React.FunctionComponent<Props> = ({
   isK8s,
   cloudSecurityIntegration,
   enrollToken,
+  fleetServerHost,
   fullCopyButton = false,
   isManaged = true,
   onCopy,
@@ -50,6 +52,7 @@ export const InstallSection: React.FunctionComponent<Props> = ({
         hasK8sIntegrationMultiPage={isK8s === 'IS_KUBERNETES_MULTIPAGE'}
         isManaged={isManaged}
         enrollToken={enrollToken}
+        fleetServerHost={fleetServerHost}
       />
     </>
   );

--- a/x-pack/plugins/fleet/public/components/platform_selector.tsx
+++ b/x-pack/plugins/fleet/public/components/platform_selector.tsx
@@ -43,6 +43,7 @@ interface Props {
   hasFleetServer?: boolean;
   enrollToken?: string | undefined;
   fullCopyButton?: boolean;
+  fleetServerHost?: string;
   onCopy?: () => void;
 }
 
@@ -64,6 +65,7 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
   isManaged,
   enrollToken,
   hasFleetServer,
+  fleetServerHost,
   fullCopyButton,
   onCopy,
 }) => {
@@ -205,6 +207,7 @@ export const PlatformSelector: React.FunctionComponent<Props> = ({
               onCopy={onCopy}
               onDownload={onCopy}
               enrollmentAPIKey={enrollToken}
+              fleetServerHost={fleetServerHost}
             />
             <EuiSpacer size="s" />
           </>


### PR DESCRIPTION
## Summary

If an agent policy used a fleet server host which is not the default fleet server host, then when adding an agent the kubernetes manifest would contain the incorrect URL.

This is because the settings request was returning all fleet servers not the one for the policy, and we were picking the first one. I have opted instead to pass the fleet server host down to the component from the already filtered list we have higher up the component stack, we do the same for the enrollment token.

**Test steps**

- add a custom fleet server URL (in Fleet settings)
- create an agent policy, use your custom URL (under agent policy settings)
- go to add an agent to the policy, select kubernetes on the platform selector
- Check the manifest yaml, under `  - name: FLEET_URL` should be the correct custom URL 


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->