### PR TITLE
[Search] refactor(serverless_search): rename logstash doclink key

### DIFF
--- a/packages/kbn-search-api-panels/components/ingest_data.tsx
+++ b/packages/kbn-search-api-panels/components/ingest_data.tsx
@@ -25,7 +25,7 @@ interface IngestDataProps {
     beats: string;
     connectors: string;
     integrations: string;
-    logStash: string;
+    logstash: string;
   };
   assetBasePath: string;
   application?: ApplicationStart;

--- a/packages/kbn-search-api-panels/components/integrations_panel.tsx
+++ b/packages/kbn-search-api-panels/components/integrations_panel.tsx
@@ -24,7 +24,7 @@ import { LEARN_MORE_LABEL } from '../constants';
 import { GithubLink } from './github_link';
 
 export interface IntegrationsPanelProps {
-  docLinks: { beats: string; connectors: string; logStash: string };
+  docLinks: { beats: string; connectors: string; logstash: string };
   assetBasePath: string;
 }
 
@@ -61,7 +61,7 @@ export const IntegrationsPanel: React.FC<IntegrationsPanelProps> = ({
             <EuiFlexGroup justifyContent="flexStart">
               <EuiFlexItem>
                 <EuiText size="s">
-                  <EuiLink href={docLinks.logStash} target="_blank">
+                  <EuiLink href={docLinks.logstash} target="_blank">
                     {LEARN_MORE_LABEL}
                   </EuiLink>
                 </EuiText>

--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -14,7 +14,7 @@ class ESDocLinks {
   public integrations: string = '';
   public kibanaFeedback: string = '';
   public kibanaRunApiInConsole: string = '';
-  public logStash: string = '';
+  public logstash: string = '';
   public metadata: string = '';
   public roleDescriptors: string = '';
   public securityApis: string = '';
@@ -51,7 +51,7 @@ class ESDocLinks {
   setDocLinks(newDocLinks: DocLinks) {
     this.apiIntro = newDocLinks.serverlessClients.httpApis;
     this.integrations = newDocLinks.serverlessSearch.integrations;
-    this.logStash = newDocLinks.serverlessSearch.integrationsLogstash;
+    this.logstash = newDocLinks.serverlessSearch.integrationsLogstash;
     this.beats = newDocLinks.serverlessSearch.integrationsBeats;
     this.connectors = newDocLinks.serverlessSearch.integrationsConnectorClient;
     this.kibanaFeedback = newDocLinks.kibana.feedback;


### PR DESCRIPTION
## Summary

Renaming the `logStash` doclink key to `logstash`


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->