### PR TITLE
[Security Solution] Unskip some timeline cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/creation.cy.ts
@@ -42,7 +42,7 @@ import {
 
 import { OVERVIEW_URL, TIMELINE_TEMPLATES_URL } from '../../../urls/navigation';
 
-describe.skip('Create a timeline from a template', { tags: ['@ess', '@serverless'] }, () => {
+describe('Create a timeline from a template', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     deleteTimelines();
     login();
@@ -109,9 +109,9 @@ describe('Timelines', (): void => {
     });
   });
 
-  describe.skip(
+  describe(
     'Creates a timeline by clicking untitled timeline from bottom bar',
-    { tags: '@brokenInServerless' },
+    { tags: ['@ess', '@brokenInServerless'] },
     () => {
       beforeEach(() => {
         login();
@@ -138,7 +138,8 @@ describe('Timelines', (): void => {
         cy.get(LOCKED_ICON).should('be.visible');
       });
 
-      it('can be added notes', () => {
+      // TO-DO: Issue 163398
+      it.skip('can be added notes', () => {
         addNotesToTimeline(getTimeline().notes);
         cy.get(TIMELINE_TAB_CONTENT_GRAPHS_NOTES)
           .find(NOTES_TEXT)

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/query_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/query_tab.cy.ts
@@ -14,7 +14,6 @@ import {
   TIMELINE_QUERY,
   NOTE_CARD_CONTENT,
 } from '../../../screens/timeline';
-import { addNoteToTimeline } from '../../../tasks/api_calls/notes';
 import { createTimeline } from '../../../tasks/api_calls/timelines';
 
 import { cleanKibana } from '../../../tasks/common';
@@ -23,7 +22,6 @@ import { login, visitWithoutDateRange } from '../../../tasks/login';
 import {
   addFilter,
   openTimelineById,
-  persistNoteToFirstEvent,
   pinFirstEvent,
   refreshTimelinesUntilTimeLinePresent,
 } from '../../../tasks/timeline';
@@ -44,14 +42,16 @@ describe.skip('Timeline query tab', { tags: ['@ess', '@serverless'] }, () => {
           .then(() => cy.wrap(timelineId).as('timelineId'))
           // eslint-disable-next-line cypress/no-unnecessary-waiting
           .then(() => cy.wait(1000))
-          .then(() =>
-            addNoteToTimeline(getTimeline().notes, timelineId).should((response) =>
-              expect(response.status).to.equal(200)
-            )
-          )
+          // TO-DO: Issue 163398
+          // .then(() =>
+          //   addNoteToTimeline(getTimeline().notes, timelineId).should((response) =>
+          //     expect(response.status).to.equal(200)
+          //   )
+          // )
           .then(() => openTimelineById(timelineId))
           .then(() => pinFirstEvent())
-          .then(() => persistNoteToFirstEvent('event note'))
+          // TO-DO: Issue 163398
+          // .then(() => persistNoteToFirstEvent('event note'))
           .then(() => addFilter(getTimeline().filter));
       });
   });
@@ -67,7 +67,8 @@ describe.skip('Timeline query tab', { tags: ['@ess', '@serverless'] }, () => {
       cy.get(TIMELINE_QUERY).should('have.text', `${getTimeline().query}`);
     });
 
-    it('should be able to add event note', () => {
+    // TO-DO: Issue 163398
+    it.skip('should be able to add event note', () => {
       cy.get(NOTE_CARD_CONTENT).should('contain', 'event note');
     });
 


### PR DESCRIPTION
## Summary

This PR unskipped some tests that were skipped in https://github.com/elastic/kibana/issues/163398. 

Some timeline tests began to fail due to chromium crashed after upgrading to chrome v115. Further upgrades to chrome v116 did not resolve the crash. I was able to isolate the crash to be note related actions within timeline. This PR unskipped tests unrelated to notes and seem to run fine.
