### PR TITLE
[ResponseOps] use `ignore_unavailable` when searcing Kibana indices for connector references

### DIFF
--- a/x-pack/plugins/actions/server/data/connector/search_connectors_so.ts
+++ b/x-pack/plugins/actions/server/data/connector/search_connectors_so.ts
@@ -14,6 +14,7 @@ export const searchConnectorsSo = async ({
 }: SearchConnectorsSoParams) => {
   return scopedClusterClient.asInternalUser.search({
     index: kibanaIndices,
+    ignore_unavailable: true,
     body: {
       aggs,
       size: 0,


### PR DESCRIPTION
resolves https://github.com/elastic/kibana/issues/165165 

resolves https://github.com/elastic/kibana/issues/165150

## Summary

Adds `ignore_unavailable` to the cross-index search for connector references, to avoid issues with Kibana Core returning index names not available in the current environment.
