### PR TITLE
[Serverless Search] fix: gate ent-search results with config

### DIFF
--- a/x-pack/plugins/enterprise_search/server/utils/search_result_provider.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/search_result_provider.ts
@@ -98,32 +98,34 @@ export function getSearchResultProvider(
             ]
           : []),
         ...(config.hasConnectors ? CONNECTOR_DEFINITIONS : []),
-        ...[
-          {
-            keywords: ['app', 'search', 'engines'],
-            name: i18n.translate('xpack.enterpriseSearch.searchProvider.appSearch.name', {
-              defaultMessage: 'App Search',
-            }),
-            serviceType: 'app_search',
-            url: APP_SEARCH_PLUGIN.URL,
-          },
-          {
-            keywords: ['workplace', 'search'],
-            name: i18n.translate('xpack.enterpriseSearch.searchProvider.workplaceSearch.name', {
-              defaultMessage: 'Workplace Search',
-            }),
-            serviceType: 'workplace_search',
-            url: WORKPLACE_SEARCH_PLUGIN.URL,
-          },
-          {
-            keywords: ['esre', 'search'],
-            name: i18n.translate('xpack.enterpriseSearch.searchProvider.esre.name', {
-              defaultMessage: 'ESRE',
-            }),
-            serviceType: 'esre',
-            url: ESRE_PLUGIN.URL,
-          },
-        ],
+        ...(config.canDeployEntSearch
+          ? [
+              {
+                keywords: ['app', 'search', 'engines'],
+                name: i18n.translate('xpack.enterpriseSearch.searchProvider.appSearch.name', {
+                  defaultMessage: 'App Search',
+                }),
+                serviceType: 'app_search',
+                url: APP_SEARCH_PLUGIN.URL,
+              },
+              {
+                keywords: ['workplace', 'search'],
+                name: i18n.translate('xpack.enterpriseSearch.searchProvider.workplaceSearch.name', {
+                  defaultMessage: 'Workplace Search',
+                }),
+                serviceType: 'workplace_search',
+                url: WORKPLACE_SEARCH_PLUGIN.URL,
+              },
+              {
+                keywords: ['esre', 'search'],
+                name: i18n.translate('xpack.enterpriseSearch.searchProvider.esre.name', {
+                  defaultMessage: 'ESRE',
+                }),
+                serviceType: 'esre',
+                url: ESRE_PLUGIN.URL,
+              },
+            ]
+          : []),
       ];
       const result = services
         .map((service) => {

--- a/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/api_key/api_key.tsx
@@ -53,7 +53,7 @@ export const ApiKeyPanel = ({ setClientApiKey }: { setClientApiKey: (value: stri
         />
       )}
       {apiKey ? (
-        <EuiPanel color="success">
+        <EuiPanel color="success" hasShadow>
           <EuiStep
             css={css`
               .euiStep__content {


### PR DESCRIPTION
## Summary

Gates returning Enterprise Search results when ent-search nodes are not going to be available.