### PR TITLE
[Serverless Search] Hide Connectors page from side nav

### DIFF
--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -16,6 +16,14 @@ import { i18n } from '@kbn/i18n';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 
+// Hiding this until page is in a better space
+const _connectorItem = {
+  link: 'serverlessConnectors',
+  title: i18n.translate('xpack.serverlessSearch.nav.connectors', {
+    defaultMessage: 'Connectors',
+  }),
+};
+
 const navigationTree: NavigationTreeDefinition = {
   body: [
     { type: 'recentlyAccessed' },
@@ -70,12 +78,6 @@ const navigationTree: NavigationTreeDefinition = {
               link: 'management:triggersActions',
               title: i18n.translate('xpack.serverlessSearch.nav.alerts', {
                 defaultMessage: 'Alerts',
-              }),
-            },
-            {
-              link: 'serverlessConnectors',
-              title: i18n.translate('xpack.serverlessSearch.nav.connectors', {
-                defaultMessage: 'Connectors',
               }),
             },
           ],

--- a/x-pack/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/plugins/serverless_search/public/plugin.ts
@@ -54,6 +54,7 @@ export class ServerlessSearchPlugin
         defaultMessage: 'Connectors',
       }),
       appRoute: '/app/connectors',
+      searchable: false,
       async mount({ element }: AppMountParameters) {
         const { renderApp } = await import('./application/connectors');
         const [coreStart, services] = await core.getStartServices();


### PR DESCRIPTION
## Summary

Removing the connectors from the side nav for now. It is currently a WIP and should not be included in Feature Freeze until its ready.