### PR TITLE
[RAM] Add rule on click handler to global rule event log list

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_data_grid.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_data_grid.tsx
@@ -64,6 +64,7 @@ export interface EventLogDataGrid {
   onChangeItemsPerPage: (pageSize: number) => void;
   onChangePage: (pageIndex: number) => void;
   onFlyoutOpen?: (runLog: IExecutionLog) => void;
+  onRuleNameClick?: (ruleId: string) => void;
   setVisibleColumns: (visibleColumns: string[]) => void;
   setSortingColumns: (sortingColumns: EuiDataGridSorting['columns']) => void;
 }
@@ -167,6 +168,7 @@ export const EventLogDataGrid = (props: EventLogDataGrid) => {
     onChangeItemsPerPage,
     onChangePage,
     onFlyoutOpen,
+    onRuleNameClick,
   } = props;
 
   const { euiTheme } = useEuiTheme();
@@ -343,6 +345,7 @@ export const EventLogDataGrid = (props: EventLogDataGrid) => {
             ruleId={ruleId}
             spaceIds={spaceIds}
             useExecutionStatus={isRuleUsingExecutionStatus}
+            onRuleNameClick={onRuleNameClick}
           />
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_cell_renderer.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_cell_renderer.test.tsx
@@ -147,4 +147,22 @@ describe('rule_event_log_list_cell_renderer', () => {
 
     window.location = savedLocation;
   });
+
+  it('calls onRuleNameClick if the function is provided', () => {
+    const onRuleNameClick = jest.fn();
+
+    const wrapper1 = shallow(
+      <EventLogListCellRenderer
+        columnId="rule_name"
+        value="Rule"
+        ruleId="1"
+        spaceIds={['space1']}
+        onRuleNameClick={onRuleNameClick}
+      />
+    );
+
+    wrapper1.find(EuiLink).simulate('click');
+
+    expect(onRuleNameClick).toHaveBeenCalledWith('1');
+  });
 });

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_cell_renderer.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/common/components/event_log/event_log_list_cell_renderer.tsx
@@ -36,6 +36,7 @@ interface EventLogListCellRendererProps {
   ruleId?: string;
   spaceIds?: string[];
   useExecutionStatus?: boolean;
+  onRuleNameClick?: (ruleId: string) => void;
 }
 
 export const EventLogListCellRenderer = (props: EventLogListCellRendererProps) => {
@@ -47,6 +48,7 @@ export const EventLogListCellRenderer = (props: EventLogListCellRendererProps) =
     ruleId,
     spaceIds,
     useExecutionStatus = true,
+    onRuleNameClick,
   } = props;
   const spacesData = useSpacesData();
   const { http } = useKibana().services;
@@ -84,15 +86,21 @@ export const EventLogListCellRenderer = (props: EventLogListCellRendererProps) =
     return ruleRoute;
   }, [ruleId, ruleOnDifferentSpace, history, activeSpace, http, spaceIds]);
 
-  const onClickRuleName = useCallback(() => {
-    if (!ruleId) return;
+  const onRuleNameClickInternal = useCallback(() => {
+    if (!ruleId) {
+      return;
+    }
+    if (onRuleNameClick) {
+      onRuleNameClick(ruleId);
+      return;
+    }
     if (ruleOnDifferentSpace) {
       const newUrl = window.location.href.replace(window.location.pathname, ruleNamePathname);
       window.open(newUrl, '_blank');
       return;
     }
     history.push(ruleNamePathname);
-  }, [ruleNamePathname, history, ruleOnDifferentSpace, ruleId]);
+  }, [ruleNamePathname, history, ruleOnDifferentSpace, ruleId, onRuleNameClick]);
 
   if (typeof value === 'undefined') {
     return null;
@@ -113,7 +121,7 @@ export const EventLogListCellRenderer = (props: EventLogListCellRendererProps) =
 
   if (columnId === 'rule_name' && ruleId) {
     return (
-      <EuiLink onClick={onClickRuleName} data-href={ruleNamePathname}>
+      <EuiLink onClick={onRuleNameClickInternal} data-href={ruleNamePathname}>
         {value}
       </EuiLink>
     );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/global_rule_event_log_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/global_rule_event_log_list.tsx
@@ -16,6 +16,7 @@ export interface GlobalRuleEventLogListProps {
   setHeaderActions?: RuleEventLogListCommonProps['setHeaderActions'];
   localStorageKey?: RuleEventLogListCommonProps['localStorageKey'];
   filteredRuleTypes?: RuleEventLogListCommonProps['filteredRuleTypes'];
+  onRuleNameClick?: RuleEventLogListCommonProps['onRuleNameClick'];
 }
 
 const GLOBAL_EVENT_LOG_LIST_STORAGE_KEY =
@@ -31,7 +32,7 @@ const REFRESH_TOKEN = {
 };
 
 export const GlobalRuleEventLogList = (props: GlobalRuleEventLogListProps) => {
-  const { setHeaderActions, localStorageKey, filteredRuleTypes } = props;
+  const { setHeaderActions, localStorageKey, filteredRuleTypes, onRuleNameClick } = props;
   const { spaces } = useKibana().services;
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -51,6 +52,7 @@ export const GlobalRuleEventLogList = (props: GlobalRuleEventLogListProps) => {
         localStorageKey={localStorageKey || GLOBAL_EVENT_LOG_LIST_STORAGE_KEY}
         filteredRuleTypes={filteredRuleTypes}
         setHeaderActions={setHeaderActions}
+        onRuleNameClick={onRuleNameClick}
       />
     </SpacesContextWrapper>
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_details/components/rule_event_log_list_table.tsx
@@ -95,6 +95,7 @@ export interface RuleEventLogListCommonProps {
   hasAllSpaceSwitch?: boolean;
   filteredRuleTypes?: string[];
   setHeaderActions?: (components?: React.ReactNode[]) => void;
+  onRuleNameClick?: (ruleId: string) => void;
 }
 
 export type RuleEventLogListTableProps<T extends RuleEventLogListOptions = 'default'> =
@@ -116,6 +117,7 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
     hasAllSpaceSwitch = false,
     setHeaderActions,
     filteredRuleTypes,
+    onRuleNameClick,
   } = props;
 
   const { uiSettings, notifications } = useKibana().services;
@@ -627,6 +629,7 @@ export const RuleEventLogListTable = <T extends RuleEventLogListOptions>(
           onChangeItemsPerPage={onChangeItemsPerPage}
           onChangePage={onChangePage}
           onFlyoutOpen={onFlyoutOpen}
+          onRuleNameClick={onRuleNameClick}
           setVisibleColumns={setVisibleColumns}
           setSortingColumns={setSortingColumns}
         />


### PR DESCRIPTION
## Summary

Adds the ability to let the implementer of the global rule event log list override the default behaviour of clicking on a rule name. This might be useful for o11y since they will have their own rule details page. 

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios