### PR TITLE
[DOCS] Move preconfigured email connector details 

### DIFF
--- a/docs/api-generated/connectors/connector-apis-passthru.asciidoc
+++ b/docs/api-generated/connectors/connector-apis-passthru.asciidoc
@@ -1003,6 +1003,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#action_response_properties"><code>action_response_properties</code> - Action response properties</a></li>
     <li><a href="#config_properties_cases_webhook"><code>config_properties_cases_webhook</code> - Connector request properties for Webhook - Case Management connector</a></li>
     <li><a href="#config_properties_d3security"><code>config_properties_d3security</code> - Connector request properties for a D3 Security connector</a></li>
+    <li><a href="#config_properties_email"><code>config_properties_email</code> - Connector request properties for an email connector</a></li>
     <li><a href="#config_properties_genai"><code>config_properties_genai</code> - Connector request properties for a generative AI connector</a></li>
     <li><a href="#config_properties_index"><code>config_properties_index</code> - Connector request properties for an index connector</a></li>
     <li><a href="#config_properties_jira"><code>config_properties_jira</code> - Connector request properties for a Jira connector</a></li>
@@ -1092,6 +1093,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#run_connector_subaction_pushtoservice_subActionParams_incident_source_ip"><code>run_connector_subaction_pushtoservice_subActionParams_incident_source_ip</code> - </a></li>
     <li><a href="#secrets_properties_cases_webhook"><code>secrets_properties_cases_webhook</code> - Connector secrets properties for Webhook - Case Management connector</a></li>
     <li><a href="#secrets_properties_d3security"><code>secrets_properties_d3security</code> - Connector secrets properties for a D3 Security connector</a></li>
+    <li><a href="#secrets_properties_email"><code>secrets_properties_email</code> - Connector secrets properties for an email connector</a></li>
     <li><a href="#secrets_properties_genai"><code>secrets_properties_genai</code> - Connector secrets properties for a generative AI connector</a></li>
     <li><a href="#secrets_properties_jira"><code>secrets_properties_jira</code> - Connector secrets properties for a Jira connector</a></li>
     <li><a href="#secrets_properties_opsgenie"><code>secrets_properties_opsgenie</code> - Connector secrets properties for an Opsgenie connector</a></li>
@@ -1107,6 +1109,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#updateConnector_400_response"><code>updateConnector_400_response</code> - </a></li>
     <li><a href="#update_connector_request_cases_webhook"><code>update_connector_request_cases_webhook</code> - Update Webhook - Case Managment connector request</a></li>
     <li><a href="#update_connector_request_d3security"><code>update_connector_request_d3security</code> - Update D3 Security connector request</a></li>
+    <li><a href="#update_connector_request_email"><code>update_connector_request_email</code> - Update email connector request</a></li>
     <li><a href="#update_connector_request_index"><code>update_connector_request_index</code> - Update index connector request</a></li>
     <li><a href="#update_connector_request_jira"><code>update_connector_request_jira</code> - Update Jira connector request</a></li>
     <li><a href="#update_connector_request_opsgenie"><code>update_connector_request_opsgenie</code> - Update Opsgenie connector request</a></li>
@@ -1398,6 +1401,23 @@ Any modifications made to this file will be overwritten.
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="config_properties_email"><code>config_properties_email</code> - Connector request properties for an email connector</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Defines properties for connectors when type is <code>.email</code>.</div>
+    <div class="field-items">
+      <div class="param">clientId (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format. If <code>service</code> is <code>exchange_server</code>, this property is required. </div>
+<div class="param">from </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The from address for all emails sent by the connector. It must be specified in <code>user@host-name</code> format. </div>
+<div class="param">hasAuth (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Specifies whether a user and password are required inside the secrets configuration. </div>
+<div class="param">host (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The host name of the service provider. If the <code>service</code> is <code>elastic_cloud</code> (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If <code>service</code> is <code>other</code>, this property must be defined. </div>
+<div class="param">oauthTokenUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span>  </div>
+<div class="param">port (optional)</div><div class="param-desc"><span class="param-type"><a href="#integer">Integer</a></span> The port to connect to on the service provider. If the <code>service</code> is <code>elastic_cloud</code> (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If <code>service</code> is <code>other</code>, this property must be defined. </div>
+<div class="param">secure (optional)</div><div class="param-desc"><span class="param-type"><a href="#boolean">Boolean</a></span> Specifies whether the connection to the service provider will use TLS. If the <code>service</code> is <code>elastic_cloud</code> (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. </div>
+<div class="param">service (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The name of the email service. </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">elastic_cloud</div><div class="param-enum">exchange_server</div><div class="param-enum">gmail</div><div class="param-enum">other</div><div class="param-enum">outlook365</div><div class="param-enum">ses</div>
+<div class="param">tenantId (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format. If <code>service</code> is <code>exchange_server</code>, this property is required. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="config_properties_genai"><code>config_properties_genai</code> - Connector request properties for a generative AI connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>Defines properties for connectors when type is <code>.gen-ai</code>.</div>
     <div class="field-items">
@@ -1561,7 +1581,7 @@ Any modifications made to this file will be overwritten.
     <h3><a name="connector_response_properties_email"><code>connector_response_properties_email</code> - Connector response properties for an email connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#AnyType">map[String, oas_any_type_not_mapped]</a></span> Defines properties for connectors when type is <code>.email</code>. </div>
+      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_email">config_properties_email</a></span>  </div>
 <div class="param">connector_type_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The type of connector. </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">.email</div>
@@ -1861,12 +1881,12 @@ Any modifications made to this file will be overwritten.
     <h3><a name="create_connector_request_email"><code>create_connector_request_email</code> - Create email connector request</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>The email connector uses the SMTP protocol to send mail messages, using an integration of Nodemailer. An exception is Microsoft Exchange, which uses HTTP protocol for sending emails, Send mail. Email message text is sent as both plain text and html text.</div>
     <div class="field-items">
-      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#AnyType">map[String, oas_any_type_not_mapped]</a></span> Defines properties for connectors when type is <code>.email</code>. </div>
+      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_email">config_properties_email</a></span>  </div>
 <div class="param">connector_type_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The type of connector. </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">.email</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
-<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#AnyType">map[String, oas_any_type_not_mapped]</a></span> Defines secrets for connectors when type is <code>.email</code>. </div>
+<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_email">secrets_properties_email</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -2426,6 +2446,15 @@ Any modifications made to this file will be overwritten.
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="secrets_properties_email"><code>secrets_properties_email</code> - Connector secrets properties for an email connector</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Defines secrets for connectors when type is <code>.email</code>.</div>
+    <div class="field-items">
+      <div class="param">clientSecret (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The Microsoft Exchange Client secret for OAuth 2.0 client credentials authentication. It must be URL-encoded. If <code>service</code> is <code>exchange_server</code>, this property is required. </div>
+<div class="param">password (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The password for HTTP basic authentication. If <code>hasAuth</code> is set to <code>true</code>, this property is required. </div>
+<div class="param">user (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The username for HTTP basic authentication. If <code>hasAuth</code> is set to <code>true</code>, this property is required. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="secrets_properties_genai"><code>secrets_properties_genai</code> - Connector secrets properties for a generative AI connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>Defines secrets for connectors when type is <code>.gen-ai</code>.</div>
     <div class="field-items">
@@ -2546,6 +2575,15 @@ Any modifications made to this file will be overwritten.
       <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_d3security">config_properties_d3security</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
 <div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_d3security">secrets_properties_d3security</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="update_connector_request_email"><code>update_connector_request_email</code> - Update email connector request</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_email">config_properties_email</a></span>  </div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
+<div class="param">secrets (optional)</div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_email">secrets_properties_email</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/management/cases/manage-cases.asciidoc
+++ b/docs/management/cases/manage-cases.asciidoc
@@ -105,14 +105,13 @@ For self-managed {kib}:
 +
 --
 NOTE: At this time, email notifications support only preconfigured connectors,
-which are defined in the `kibana.yml` file. For examples, refer to
-{kibana-ref}/email-action-type.html#preconfigured-email-configuration[Preconfigured email connector]
-and {kibana-ref}/email-action-type.html#configuring-email[Configuring email connectors for well-known services].
+which are defined in the `kibana.yml` file.
+For examples, refer to <<preconfigured-email-configuration>> and <<configuring-email>>.
 --
 . Set the `notifications.connectors.default.email` {kib} setting to the name of
 your email connector.
 . If you want the email notifications to contain links back to the case, you
-must configure the {kibana-ref}/settings.html#server-publicBaseUrl[server.publicBaseUrl] setting.
+must configure the <<server-publicBaseUrl,server.publicBaseUrl>> setting.
 
 When you subsequently add assignees to cases, they receive an email.
 // end::case-notifications[]

--- a/docs/management/connectors/action-types/email.asciidoc
+++ b/docs/management/connectors/action-types/email.asciidoc
@@ -98,87 +98,11 @@ Password::
 Password for login type authentication.
 
 [float]
-[[preconfigured-email-configuration]]
-=== Create preconfigured connectors
-
-If you are running {kib} on-prem, you can define connectors by
-adding `xpack.actions.preconfigured` settings to your `kibana.yml` file.
-For example:
-
-[source,text]
---
-xpack.actions.preconfigured:
-  my-email:
-    name: preconfigured-email-connector-type
-    actionTypeId: .email
-    config:
-      service: other
-      from: testsender@test.com
-      host: validhostname
-      port: 8080
-      secure: false
-    secrets:
-      user: testuser
-      password: passwordkeystorevalue
---
-
-Config defines information for the connector type.
-
-`service`::
-The name of the email service. If `service` is `elastic_cloud` (for Elastic 
-Cloud notifications) or one of Nodemailer's well-known email service providers,
-the `host`, `port`, and `secure` properties are ignored. If `service` is `other`,  
-the `host` and `port` properties must be defined. For more information on the 
-`gmail` service value, refer to 
-https://nodemailer.com/usage/using-gmail/[Nodemailer Gmail documentation]. If 
-`service` is `exchange_server`, the `tenantId`, `clientId`, `clientSecret` 
-properties are required instead of `host` and `port`.
-
-`from`::
-An email address that corresponds to *Sender*.
-
-`host`::
-A string that corresponds to *Host*.
-
-`port`::
-A number that corresponds to *Port*.
-
-`secure`::
-A boolean that corresponds to *Secure*.
-
-`hasAuth`::
-A boolean that corresponds to *Requires authentication*. If `true`, this 
-connector will require values for `user` and `password` inside the secrets 
-configuration. Defaults to `true`.
-
-`tenantId`::
-A GUID format value that corresponds to *Tenant ID*, which is a part of OAuth 
-2.0 Client Credentials Authentication.
-
-`clientId`::
-A GUID format value that corresponds to *Client ID*, which is a part of OAuth 
-2.0 Client Credentials Authentication.
-
-Secrets defines sensitive information for the connector type.
-
-`user`::
-A string that corresponds to *Username*. Required if `hasAuth` is set to `true`.
-
-`password`::
-A string that corresponds to *Password*. Should be stored in the 
-<<creating-keystore,{kib} keystore>>. Required if `hasAuth` is set to `true`.
-
-`clientSecret`::
-A string that corresponds to *Client Secret*. Should be stored in the 
-<<creating-keystore,{kib} keystore>>. Required if `service` is set to 
-`exchange_server`, which uses OAuth 2.0 Client Credentials Authentication.
-
-[float]
 [[email-action-configuration]]
 === Test connectors
 
-You can test connectors with the <<execute-connector-api,run connector API>> or
-as you're creating or editing the connector in {kib}. For example:
+You can test connectors as you're creating or editing the connector in {kib}.
+For example:
 
 [role="screenshot"]
 image::management/connectors/images/email-params-test.png[Email params test]
@@ -214,14 +138,6 @@ settings. You can set configurations that apply to all your connectors or use
 The email connector uses an integration of https://nodemailer.com/[Nodemailer] to send email from many popular SMTP email services.
 For Microsoft Exchange email, it uses the Microsoft Graph API.
 
-To configure the email connector to work with common email systems, refer to:
-
-* <<elasticcloud>>
-* <<gmail>>
-* <<outlook>>
-* <<amazon-ses>>
-* <<exchange>>
-
 For other email servers, you can check the list of well-known services that 
 Nodemailer supports in the JSON file
 https://github.com/nodemailer/nodemailer/blob/master/lib/well-known/services.json[well-known/services.json]. 
@@ -233,32 +149,17 @@ is considered `false`.  Typically, `port: 465` uses `secure: true`, and
 
 [float]
 [[elasticcloud]]
-==== Sending email from Elastic Cloud
+==== {ecloud}
     
-Use the preconfigured email connector (`Elastic-Cloud-SMTP`) to send emails from 
-Elastic Cloud.
+Use the preconfigured email connector (`Elastic-Cloud-SMTP`) to send emails from {ecloud}.
 
-NOTE: For more information on the preconfigured email connector, see link:{cloud}/ec-watcher.html#ec-cloud-email-service-limits[Elastic Cloud email service limits].
+NOTE: For more information on the preconfigured email connector, see link:{cloud}/ec-watcher.html#ec-cloud-email-service-limits[{ecloud} email service limits].
 
 [float]
 [[gmail]]
-==== Sending email from Gmail
+==== Gmail
 
-Use the following email connector configuration to send email from the
-https://mail.google.com[Gmail] SMTP service:
-
-[source,text]
---------------------------------------------------
-  config:
-    service: gmail
-    // `host`, `port` and `secure` have the following default values and do not need to set: 
-    // host: smtp.gmail.com
-    // port: 465
-    // secure: true
-  secrets:
-    user: <username>
-    password: <password>
---------------------------------------------------
+To create a connector that sends email from the https://mail.google.com[Gmail] SMTP service, set the **Service** to `Gmail`.
 
 If you get an authentication error that indicates that you need to continue the
 sign-in process from a web browser when the action attempts to send email, you 
@@ -272,23 +173,10 @@ for more information.
 
 [float]
 [[outlook]]
-==== Sending email from Outlook.com
+==== Outlook.com
 
-Use the following email connector configuration to send email from the
-https://www.outlook.com/[Outlook.com] SMTP service:
-
-[source,text]
---------------------------------------------------
-config:
-    service: outlook365
-    // `host`, `port` and `secure` have the following default values and do not need to set: 
-    // host: smtp.office365.com
-    // port: 587
-    // secure: false
-secrets:
-    user: <email.address>
-    password: <password>
---------------------------------------------------
+To create a connector that sends email from the
+https://www.outlook.com/[Outlook.com] SMTP service, set the **Service** to `Outlook`.
 
 When sending emails, you must provide a `from` address, either as the default 
 in your connector configuration or as part of the email action in the rule.
@@ -300,24 +188,10 @@ for more information.
 
 [float]
 [[amazon-ses]]
-==== Sending email from Amazon SES (Simple Email Service)
+==== Amazon SES
 
-Use the following email connector configuration to send email from the
-http://aws.amazon.com/ses[Amazon Simple Email Service] (SES) SMTP service:
-
-[source,text]
---------------------------------------------------
-config:
-    service: ses
-    // `host`, `port` and `secure` have the following default values and do not need to set: 
-    // host: email-smtp.us-east-1.amazonaws.com <1>
-    // port: 465
-    // secure: true
-secrets:
-    user: <username>
-    password: <password>
---------------------------------------------------
-<1> `config.host` varies depending on the region
+To create a connector that sends email from the
+http://aws.amazon.com/ses[Amazon Simple Email Service] (SES) SMTP service, set the **Service** to `Amazon SES`.
 
 NOTE: You must use your Amazon SES SMTP credentials to send email through Amazon 
 SES. For more information, see
@@ -328,30 +202,11 @@ or
 https://docs.aws.amazon.com/ses/latest/DeveloperGuide/verify-domains.html[your whole domain]
 at AWS.
 
-
 [float]
 [[exchange-basic-auth]]
-==== Sending email from Microsoft Exchange with Basic Authentication
+==== Microsoft Exchange with basic authentication
 
 deprecated:[7.16.0,"This Microsoft Exchange configuration is deprecated and will be removed later because Microsoft is deprecating basic authentication."]
-
-[source,text]
---------------------------------------------------
-config:
-    service: other
-    host: <your exchange server>
-    port: 465
-    secure: true
-    from: <email address of service account> <1>
-secrets:
-    user: <email address of service account> <2>
-    password: <password>
---------------------------------------------------
-<1> Some organizations configure Exchange to validate that the `from` field is a
-    valid local email account.
-<2> Many organizations support use of your email address as your username.
-    Check with your system administrator if you receive
-    authentication-related failures.
 
 To prepare for the removal of Basic Auth, you must update all existing Microsoft 
 Exchange connectors with the new configuration based on the 
@@ -359,7 +214,7 @@ https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-client
 
 [float]
 [[exchange]]
-==== Sending email from Microsoft Exchange with OAuth 2.0
+==== Microsoft Exchange with OAuth 2.0
 
 NOTE: The email connector uses Microsoft Graph REST API v1.0, in particular the https://docs.microsoft.com/en-us/graph/api/user-sendmail[sendMail] endpoint. It supports only the https://learn.microsoft.com/en-us/graph/deployments#microsoft-graph-and-graph-explorer-service-root-endpoints[Microsoft Graph global service] root endpoint (`https://graph.microsoft.com`).
 
@@ -396,9 +251,9 @@ image::management/connectors/images/exchange-granted.png[MS Exchange grant confi
 
 [float]
 [[exchange-client-secret]]
-===== Configure Microsoft Exchange Client secret
+===== Configure the Microsoft Exchange Client secret
 
-To configure the Client secret , open *Manage > Certificates & secrets*.
+To configure the Microsoft Exchange Client secret, open *Manage > Certificates & secrets*:
 
 [role="screenshot"]
 image::management/connectors/images/exchange-secrets.png[MS Exchange secrets configuration]
@@ -408,29 +263,12 @@ the Microsoft Exchange email connector.
 
 [float]
 [[exchange-client-tenant-id]]
-===== Configure Microsoft Exchange Client ID and Tenant ID
+===== Configure the Microsoft Exchange client and tenant identifiers
 
-To find the application Client ID, open the *Overview* page.
+To find the Microsoft Exchange client and tenant IDs, open the *Overview* page:
 
 [role="screenshot"]
 image::management/connectors/images/exchange-client-tenant.png[MS Exchange Client ID and Tenant ID configuration]
 
-Copy and paste this values to the proper fields in the Microsoft Exchange email 
-connector.
-
-Use the following email connector configuration to send email from Microsoft 
-Exchange:
-
-[source,text]
---------------------------------------------------
-config:
-    service: exchange_server
-    clientId: <The Application (client) ID> <1>
-    tenantId: <The directory tenant ID, in GUID format.>
-    from: <email address of service account> <2>
-secrets:
-    clientSecret: <URL-encoded string>
---------------------------------------------------
-<1> This application information is on the https://go.microsoft.com/fwlink/?linkid=2083908[Azure portal – App registrations].
-<2> Some organizations configure Exchange to validate that the `from` field is a
-    valid local email account.
+Create a connector and set the **Service** to `MS Exchange Server`.
+Copy and paste the values into the proper fields.

--- a/docs/management/connectors/pre-configured-connectors.asciidoc
+++ b/docs/management/connectors/pre-configured-connectors.asciidoc
@@ -108,6 +108,7 @@ Index names must start with `kibana-alert-history-` to take advantage of the pre
 
 * <<preconfigured-d3security-configuration>>
 * <<preconfigured-resilient-configuration>>
+* <<preconfigured-email-configuration>>
 * <<preconfigured-index-configuration>>
 * <<preconfigured-jira-configuration>>
 * <<preconfigured-opsgenie-configuration>>
@@ -137,6 +138,141 @@ xpack.actions.preconfigured:
 --
 <1> The D3 Security API request URL.
 <2> The D3 Security token.
+
+[float]
+[[preconfigured-email-configuration]]
+==== Email connectors
+
+The following example creates an <<email-action-type,email connector>>:
+
+[source,text]
+--
+xpack.actions.preconfigured:
+  my-email:
+    name: preconfigured-email-connector-type
+    actionTypeId: .email
+    config:
+      service: other <1>
+      from: testsender@test.com <2>
+      host: validhostname <3>
+      port: 8080 <4>
+      secure: false <5>
+      hasAuth: true <6>
+    secrets:
+      user: testuser <7>
+      password: passwordkeystorevalue <8>
+--
+
+<1> The name of the email service. If `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, the `host`, `port`, and `secure` properties are ignored. If `service` is `other`, the `host` and `port` properties must be defined. For more information on the `gmail` service value, refer to https://nodemailer.com/usage/using-gmail/[Nodemailer Gmail documentation]. If `service` is `exchange_server`, the `tenantId`, `clientId`, `clientSecret` 
+properties are required instead of `host` and `port`.
+<2> The email address for all emails sent with this connector. It must be specified in `user@host-name` format. 
+<3> The host name of the service provider.
+<4> The port to connect to on the service provider.
+<5> If true, the connection will use TLS when connecting to the service provider. 
+<6> If `true`, this connector will require values for `user` and `password` inside the secrets configuration. Defaults to `true`.
+<7> A user name for authentication. Required if `hasAuth` is set to `true`.
+<8> A password for authentication. Should be stored in the <<creating-keystore,{kib} keystore>>. Required if `hasAuth` is set to `true`.
+
+
+[float]
+[[preconfigured-email-configuration-amazon-ses]]
+===== Amazon SES (Simple Email Service)
+
+Use the following email connector configuration to send email from the
+http://aws.amazon.com/ses[Amazon Simple Email Service] (SES) SMTP service:
+
+[source,text]
+--------------------------------------------------
+config:
+    service: ses
+    // `host`, `port` and `secure` have the following default values and do not need to set: 
+    // host: email-smtp.us-east-1.amazonaws.com <1>
+    // port: 465
+    // secure: true
+secrets:
+    user: <username>
+    password: <password>
+--------------------------------------------------
+<1> `config.host` varies depending on the region
+
+[float]
+[[preconfigured-email-configuration-gmail]]
+===== Gmail
+
+Use the following email connector configuration to send email from the https://mail.google.com[Gmail] SMTP service:
+
+[source,text]
+--------------------------------------------------
+  config:
+    service: gmail
+    // `host`, `port` and `secure` have the following default values and do not need to set: 
+    // host: smtp.gmail.com
+    // port: 465
+    // secure: true
+  secrets:
+    user: <username>
+    password: <password>
+--------------------------------------------------
+
+[float]
+[[preconfigured-email-configuration-exchange-basic-auth]]
+===== Microsoft Exchange with basic authentication
+
+deprecated:[7.16.0,"This Microsoft Exchange configuration is deprecated and will be removed later because Microsoft is deprecating basic authentication."]
+
+[source,text]
+--------------------------------------------------
+config:
+    service: other
+    host: <your exchange server>
+    port: 465
+    secure: true
+    from: <email address of service account> <1>
+secrets:
+    user: <email address of service account> <2>
+    password: <password>
+--------------------------------------------------
+<1> Some organizations configure Exchange to validate that the `from` field is a valid local email account.
+<2> Many organizations support use of your email address as your username. Check with your system administrator if you receive authentication-related failures.
+
+[float]
+[[preconfigured-email-configuration-exchange]]
+===== Microsoft Exchange with OAuth 2.0
+
+Use the following email connector configuration to send email from Microsoft Exchange:
+
+[source,text]
+--------------------------------------------------
+config:
+    service: exchange_server
+    clientId: <The Application (client) ID> <1>
+    tenantId: <The directory tenant ID, in GUID format.>
+    from: <email address of service account> <2>
+secrets:
+    clientSecret: <URL-encoded string>
+--------------------------------------------------
+<1> This application information is on the https://go.microsoft.com/fwlink/?linkid=2083908[Azure portal – App registrations].
+<2> Some organizations configure Exchange to validate that the `from` field is a valid local email account.
+
+[float]
+[[preconfigured-email-configuration-outlook]]
+===== Outlook.com
+
+Use the following email connector configuration to send email from the
+https://www.outlook.com/[Outlook.com] SMTP service:
+
+[source,text]
+--------------------------------------------------
+config:
+    service: outlook365
+    // `host`, `port` and `secure` have the following default values and do not need to set: 
+    // host: smtp.office365.com
+    // port: 587
+    // secure: false
+secrets:
+    user: <email.address>
+    password: <password>
+--------------------------------------------------
 
 [float]
 [[preconfigured-resilient-configuration]]

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -270,6 +270,9 @@ A configuration URL that varies by connector:
 NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts.
 --
 
+`xpack.actions.preconfigured.<connector-id>.config.clientId`::
+For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to the client ID, which is a part of OAuth 2.0 client credentials authentication.
+
 `xpack.actions.preconfigured.<connector-id>.config.configUrl`::
 For an <<xmatters-action-type,xMatters connector>> with basic authentication, specifies the request URL for the Elastic Alerts trigger in xMatters.
 
@@ -306,6 +309,10 @@ For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string f
 `xpack.actions.preconfigured.<connector-id>.config.executionTimeField`::
 For an <<index-action-type,index connector>>, a field that indicates when the document was indexed.
 
+`xpack.actions.preconfigured.<connector-id>.config.from`::
+For an <<email-action-type,email connector>>, specifies the from address for all emails sent by the connector.
+It must be specified in `user@host-name` format.
+
 `xpack.actions.preconfigured.<connector-id>.config.getIncidentResponseExternalTitleKey`::
 For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a string from the response body of the get case method that corresponds to the external service title.
 
@@ -315,10 +322,13 @@ For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API
 NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts. 
 
 `xpack.actions.preconfigured.<connector-id>.config.hasAuth`::
-For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration. Defaults to `true`.
+For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration. Defaults to `true`.
 
 `xpack.actions.preconfigured.<connector-id>.config.headers`::
 For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request.
+
+`xpack.actions.preconfigured.<connector-id>.config.host`::
+For an <<email-action-type,email connector>>, specifies the host name of the service provider.
 
 `xpack.actions.preconfigured.<connector-id>.config.index`::
 For an <<index-action-type,index connector>>, specifies the {es} index.
@@ -326,8 +336,20 @@ For an <<index-action-type,index connector>>, specifies the {es} index.
 `xpack.actions.preconfigured.<connector-id>.config.orgId`::
 For an <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} organization identifier.
 
+`xpack.actions.preconfigured.<connector-id>.config.port`::
+For an <<email-action-type,email connector>>, specifies the port to connect to on the service provider.
+
 `xpack.actions.preconfigured.<connector-id>.config.projectKey`::
 For a <<jira-action-type,Jira connector>>, specifies the Jira project key.
+
+`xpack.actions.preconfigured.<connector-id>.config.secure`::
+For an <<email-action-type,email connector>>, specifies whether the connection will use TLS when connecting to the service provider. If not true, the connection will initially connect over TCP then attempt to switch to TLS via the SMTP STARTTLS command.
+
+`xpack.actions.preconfigured.<connector-id>.config.service`::
+For an <<email-action-type,email connector>>, specifies the name of the email service. For example, `elastic_cloud`, `exchange_server`, `gmail`, `other`, `outlook365`, or `ses`.
+
+`xpack.actions.preconfigured.<connector-id>.config.tenantId`::
+For an <<email-action-type,email connector>>, specifies a GUID format value that corresponds to a tenant ID, which is a part of OAuth 2.0 client credentials authentication.
 
 `xpack.actions.preconfigured.<connector-id>.config.updateIncidentJson`::
 For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a stringified JSON payload with Mustache variables that is sent to the update case URL to update a case. Required variables are `case.title` and `case.description`.
@@ -382,6 +404,15 @@ For an <<resilient-action-type,{ibm-r} connector>>, specifies the authentication
 `xpack.actions.preconfigured.<connector-id>.secrets.apiToken`::
 For a <<jira-action-type,Jira connector>>, specifies the API authentication token for HTTP basic authentication.
 
+`xpack.actions.preconfigured.<connector-id>.secrets.clientSecret`::
+A client secret that varies by connector:
++
+--
+* For an <<email-action-type,email connector>>, specifies the client secret that you generated for your app in the app registration portal. It is required when the email service is `exchange_server`, which uses OAuth 2.0 client credentials authentication.
+
+NOTE: The client secret must be URL-encoded.
+--
+
 `xpack.actions.preconfigured.<connector-id>.secrets.email`::
 For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP basic authentication.
 
@@ -389,7 +420,7 @@ For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP 
 A password secret that varies by connector:
 +
 --
-* For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+* For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
 
@@ -414,7 +445,7 @@ A token secret that varies by connector:
 A user name secret that varies by connector:
 +
 --
-* For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+* For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
 

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -123,6 +123,9 @@
                 }
               },
               "examples": {
+                "createEmailConnectorRequest": {
+                  "$ref": "#/components/examples/create_email_connector_request"
+                },
                 "createIndexConnectorRequest": {
                   "$ref": "#/components/examples/create_index_connector_request"
                 },
@@ -145,6 +148,9 @@
                   "$ref": "#/components/schemas/connector_response_properties"
                 },
                 "examples": {
+                  "createEmailConnectorResponse": {
+                    "$ref": "#/components/examples/create_email_connector_response"
+                  },
                   "createIndexConnectorResponse": {
                     "$ref": "#/components/examples/create_index_connector_response"
                   },
@@ -459,6 +465,9 @@
                   },
                   {
                     "$ref": "#/components/schemas/update_connector_request_d3security"
+                  },
+                  {
+                    "$ref": "#/components/schemas/update_connector_request_email"
                   },
                   {
                     "$ref": "#/components/schemas/update_connector_request_index"
@@ -1635,14 +1644,78 @@
       "config_properties_email": {
         "title": "Connector request properties for an email connector",
         "description": "Defines properties for connectors when type is `.email`.",
+        "required": [
+          "from"
+        ],
         "type": "object",
-        "additionalProperties": true
+        "properties": {
+          "clientId": {
+            "description": "The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.\n",
+            "type": "string",
+            "nullable": true
+          },
+          "from": {
+            "description": "The from address for all emails sent by the connector. It must be specified in `user@host-name` format.\n",
+            "type": "string"
+          },
+          "hasAuth": {
+            "description": "Specifies whether a user and password are required inside the secrets configuration.\n",
+            "default": true,
+            "type": "boolean"
+          },
+          "host": {
+            "description": "The host name of the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. \n",
+            "type": "string"
+          },
+          "oauthTokenUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "description": "The port to connect to on the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. \n",
+            "type": "integer"
+          },
+          "secure": {
+            "description": "Specifies whether the connection to the service provider will use TLS. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored.\n",
+            "type": "boolean"
+          },
+          "service": {
+            "description": "The name of the email service.\n",
+            "type": "string",
+            "enum": [
+              "elastic_cloud",
+              "exchange_server",
+              "gmail",
+              "other",
+              "outlook365",
+              "ses"
+            ]
+          },
+          "tenantId": {
+            "description": "The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.\n",
+            "type": "string",
+            "nullable": true
+          }
+        }
       },
       "secrets_properties_email": {
         "title": "Connector secrets properties for an email connector",
         "description": "Defines secrets for connectors when type is `.email`.",
         "type": "object",
-        "additionalProperties": true
+        "properties": {
+          "clientSecret": {
+            "type": "string",
+            "description": "The Microsoft Exchange Client secret for OAuth 2.0 client credentials authentication. It must be URL-encoded. If `service` is `exchange_server`, this property is required.\n"
+          },
+          "password": {
+            "type": "string",
+            "description": "The password for HTTP basic authentication. If `hasAuth` is set to `true`, this property is required.\n"
+          },
+          "user": {
+            "type": "string",
+            "description": "The username for HTTP basic authentication. If `hasAuth` is set to `true`, this property is required.\n"
+          }
+        }
       },
       "create_connector_request_email": {
         "title": "Create email connector request",
@@ -3855,6 +3928,26 @@
           }
         }
       },
+      "update_connector_request_email": {
+        "title": "Update email connector request",
+        "type": "object",
+        "required": [
+          "config",
+          "name"
+        ],
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/config_properties_email"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name for the connector."
+          },
+          "secrets": {
+            "$ref": "#/components/schemas/secrets_properties_email"
+          }
+        }
+      },
       "update_connector_request_index": {
         "title": "Update index connector request",
         "type": "object",
@@ -4858,6 +4951,25 @@
       }
     },
     "examples": {
+      "create_email_connector_request": {
+        "summary": "Create an email connector.",
+        "value": {
+          "name": "email-connector-1",
+          "connector_type_id": ".email",
+          "config": {
+            "from": "tester@example.com",
+            "hasAuth": true,
+            "host": "https://example.com",
+            "port": 1025,
+            "secure": false,
+            "service": "other"
+          },
+          "secrets": {
+            "user": "username",
+            "password": "password"
+          }
+        }
+      },
       "create_index_connector_request": {
         "summary": "Create an index connector.",
         "value": {
@@ -4897,6 +5009,29 @@
           "secrets": {
             "secretsUrl": "https://example.com?apiKey=xxxxx"
           }
+        }
+      },
+      "create_email_connector_response": {
+        "summary": "A new email connector.",
+        "value": {
+          "id": "90a82c60-478f-11ee-a343-f98a117c727f",
+          "connector_type_id": ".email",
+          "name": "email-connector-1",
+          "config": {
+            "from": "tester@example.com",
+            "service": "other",
+            "host": "https://example.com",
+            "port": 1025,
+            "secure": false,
+            "hasAuth": true,
+            "tenantId": null,
+            "clientId": null,
+            "oauthTokenUrl": null
+          },
+          "is_preconfigured": false,
+          "is_deprecated": false,
+          "is_missing_secrets": false,
+          "is_system_action": false
         }
       },
       "create_index_connector_response": {

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -60,6 +60,8 @@ paths:
               discriminator:
                 propertyName: connector_type_id
             examples:
+              createEmailConnectorRequest:
+                $ref: '#/components/examples/create_email_connector_request'
               createIndexConnectorRequest:
                 $ref: '#/components/examples/create_index_connector_request'
               createWebhookConnectorRequest:
@@ -74,6 +76,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/connector_response_properties'
               examples:
+                createEmailConnectorResponse:
+                  $ref: '#/components/examples/create_email_connector_response'
                 createIndexConnectorResponse:
                   $ref: '#/components/examples/create_index_connector_response'
                 createWebhookConnectorResponse:
@@ -246,6 +250,7 @@ paths:
               oneOf:
                 - $ref: '#/components/schemas/update_connector_request_cases_webhook'
                 - $ref: '#/components/schemas/update_connector_request_d3security'
+                - $ref: '#/components/schemas/update_connector_request_email'
                 - $ref: '#/components/schemas/update_connector_request_index'
                 - $ref: '#/components/schemas/update_connector_request_jira'
                 - $ref: '#/components/schemas/update_connector_request_opsgenie'
@@ -1000,13 +1005,72 @@ components:
     config_properties_email:
       title: Connector request properties for an email connector
       description: Defines properties for connectors when type is `.email`.
+      required:
+        - from
       type: object
-      additionalProperties: true
+      properties:
+        clientId:
+          description: |
+            The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.
+          type: string
+          nullable: true
+        from:
+          description: |
+            The from address for all emails sent by the connector. It must be specified in `user@host-name` format.
+          type: string
+        hasAuth:
+          description: |
+            Specifies whether a user and password are required inside the secrets configuration.
+          default: true
+          type: boolean
+        host:
+          description: |
+            The host name of the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. 
+          type: string
+        oauthTokenUrl:
+          type: string
+          nullable: true
+        port:
+          description: |
+            The port to connect to on the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. 
+          type: integer
+        secure:
+          description: |
+            Specifies whether the connection to the service provider will use TLS. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored.
+          type: boolean
+        service:
+          description: |
+            The name of the email service.
+          type: string
+          enum:
+            - elastic_cloud
+            - exchange_server
+            - gmail
+            - other
+            - outlook365
+            - ses
+        tenantId:
+          description: |
+            The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.
+          type: string
+          nullable: true
     secrets_properties_email:
       title: Connector secrets properties for an email connector
       description: Defines secrets for connectors when type is `.email`.
       type: object
-      additionalProperties: true
+      properties:
+        clientSecret:
+          type: string
+          description: |
+            The Microsoft Exchange Client secret for OAuth 2.0 client credentials authentication. It must be URL-encoded. If `service` is `exchange_server`, this property is required.
+        password:
+          type: string
+          description: |
+            The password for HTTP basic authentication. If `hasAuth` is set to `true`, this property is required.
+        user:
+          type: string
+          description: |
+            The username for HTTP basic authentication. If `hasAuth` is set to `true`, this property is required.
     create_connector_request_email:
       title: Create email connector request
       description: |
@@ -2655,6 +2719,20 @@ components:
           description: The display name for the connector.
         secrets:
           $ref: '#/components/schemas/secrets_properties_d3security'
+    update_connector_request_email:
+      title: Update email connector request
+      type: object
+      required:
+        - config
+        - name
+      properties:
+        config:
+          $ref: '#/components/schemas/config_properties_email'
+        name:
+          type: string
+          description: The display name for the connector.
+        secrets:
+          $ref: '#/components/schemas/secrets_properties_email'
     update_connector_request_index:
       title: Update index connector request
       type: object
@@ -3380,6 +3458,21 @@ components:
         name:
           type: string
   examples:
+    create_email_connector_request:
+      summary: Create an email connector.
+      value:
+        name: email-connector-1
+        connector_type_id: .email
+        config:
+          from: tester@example.com
+          hasAuth: true
+          host: https://example.com
+          port: 1025
+          secure: false
+          service: other
+        secrets:
+          user: username
+          password: password
     create_index_connector_request:
       summary: Create an index connector.
       value:
@@ -3410,6 +3503,26 @@ components:
           usesBasic: false
         secrets:
           secretsUrl: https://example.com?apiKey=xxxxx
+    create_email_connector_response:
+      summary: A new email connector.
+      value:
+        id: 90a82c60-478f-11ee-a343-f98a117c727f
+        connector_type_id: .email
+        name: email-connector-1
+        config:
+          from: tester@example.com
+          service: other
+          host: https://example.com
+          port: 1025
+          secure: false
+          hasAuth: true
+          tenantId: null
+          clientId: null
+          oauthTokenUrl: null
+        is_preconfigured: false
+        is_deprecated: false
+        is_missing_secrets: false
+        is_system_action: false
     create_index_connector_response:
       summary: A new index connector.
       value:

--- a/x-pack/plugins/actions/docs/openapi/components/examples/create_email_connector_request.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/create_email_connector_request.yaml
@@ -1,0 +1,14 @@
+summary: Create an email connector.
+value:
+  name: email-connector-1
+  connector_type_id: .email
+  config:
+    from: tester@example.com
+    hasAuth: true
+    host: https://example.com
+    port: 1025
+    secure: false
+    service: other
+  secrets:
+    user: username
+    password: password

--- a/x-pack/plugins/actions/docs/openapi/components/examples/create_email_connector_response.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/create_email_connector_response.yaml
@@ -1,0 +1,19 @@
+summary: A new email connector.
+value:
+  id: 90a82c60-478f-11ee-a343-f98a117c727f
+  connector_type_id: .email
+  name: email-connector-1
+  config:
+    from: tester@example.com
+    service: other
+    host: https://example.com
+    port: 1025
+    secure: false
+    hasAuth: true
+    tenantId: null
+    clientId: null
+    oauthTokenUrl: null
+  is_preconfigured: false
+  is_deprecated: false
+  is_missing_secrets: false
+  is_system_action: false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_email.yaml
@@ -1,5 +1,59 @@
 title: Connector request properties for an email connector
 description: Defines properties for connectors when type is `.email`.
+required:
+  - from
 type: object
-additionalProperties: true
-# TO-DO: Add the properties for this connector.
+properties:
+  clientId:
+    description: >
+      The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format.
+      If `service` is `exchange_server`, this property is required.
+    type: string
+    nullable: true
+  from:
+    description: >
+      The from address for all emails sent by the connector. It must be specified in `user@host-name` format.
+    type: string
+  hasAuth:
+    description: >
+      Specifies whether a user and password are required inside the secrets configuration.
+    default: true
+    type: boolean
+  host:
+    description: >
+      The host name of the service provider.
+      If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored.
+      If `service` is `other`, this property must be defined. 
+    type: string
+  oauthTokenUrl:
+    # description: TBD
+    type: string
+    nullable: true
+  port:
+    description: >
+      The port to connect to on the service provider.
+      If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored.
+      If `service` is `other`, this property must be defined. 
+    type: integer
+  secure:
+    description: >
+      Specifies whether the connection to the service provider will use TLS.
+      If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored.
+    type: boolean
+  service:
+    description: >
+      The name of the email service.
+    type: string
+    enum:
+      - elastic_cloud
+      - exchange_server
+      - gmail
+      - other
+      - outlook365
+      - ses
+  tenantId:
+    description: >
+      The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format.
+      If `service` is `exchange_server`, this property is required.
+    type: string
+    nullable: true

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/secrets_properties_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/secrets_properties_email.yaml
@@ -1,5 +1,20 @@
 title: Connector secrets properties for an email connector
 description: Defines secrets for connectors when type is `.email`.
 type: object
-additionalProperties: true
-# TO-DO: Add the properties for this connector.
+properties:
+  clientSecret:
+    type: string
+    description: >
+      The Microsoft Exchange Client secret for OAuth 2.0 client credentials authentication.
+      It must be URL-encoded.
+      If `service` is `exchange_server`, this property is required.
+  password:
+    type: string
+    description: >
+      The password for HTTP basic authentication.
+      If `hasAuth` is set to `true`, this property is required.
+  user:
+    type: string
+    description: >
+      The username for HTTP basic authentication.
+      If `hasAuth` is set to `true`, this property is required.

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector.yaml
@@ -39,6 +39,8 @@ post:
           discriminator:
             propertyName: connector_type_id
         examples:
+          createEmailConnectorRequest:
+            $ref: '../components/examples/create_email_connector_request.yaml'
           createIndexConnectorRequest:
             $ref: '../components/examples/create_index_connector_request.yaml'
           createWebhookConnectorRequest:
@@ -53,6 +55,8 @@ post:
           schema:
             $ref: '../components/schemas/connector_response_properties.yaml'
           examples:
+            createEmailConnectorResponse:
+              $ref: '../components/examples/create_email_connector_response.yaml'
             createIndexConnectorResponse:
               $ref: '../components/examples/create_index_connector_response.yaml'
             createWebhookConnectorResponse:

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -161,7 +161,7 @@ put:
           oneOf:
             - $ref: '../components/schemas/update_connector_request_cases_webhook.yaml'
             - $ref: '../components/schemas/update_connector_request_d3security.yaml'
-#            - $ref: '../components/schemas/update_connector_request_email.yaml'
+            - $ref: '../components/schemas/update_connector_request_email.yaml'
 #            - $ref: '../components/schemas/create_connector_request_genai.yaml'
             - $ref: '../components/schemas/update_connector_request_index.yaml'  
             - $ref: '../components/schemas/update_connector_request_jira.yaml'


### PR DESCRIPTION
## Summary

This PR:

- Moves the preconfigured connector examples from https://www.elastic.co/guide/en/kibana/master/email-action-type.html to https://www.elastic.co/guide/en/kibana/master/pre-configured-connectors.html since that functionality is only applicable if you are running Kibana on-prem and therefore won't be applicable to serverless projects.
- Adds the setting names to https://www.elastic.co/guide/en/kibana/master/alert-action-settings-kb.html
- Adds the config and secrets properties to the open API specification, including `oauthTokenUrl` for which I don't currently have a description

### Preview

- https://kibana_165181.docs-preview.app.elstc.co/guide/en/kibana/master/alert-action-settings-kb.html#preconfigured-connector-settings
- https://kibana_165181.docs-preview.app.elstc.co/guide/en/kibana/master/pre-configured-connectors.html#preconfigured-email-configuration
- https://kibana_165181.docs-preview.app.elstc.co/guide/en/kibana/master/email-action-type.html [no more kibana.yml examples]