### PR TITLE
Do not enforce app authorization for features that have opted out of RBAC.

### DIFF
--- a/x-pack/plugins/security/server/authorization/app_authorization.ts
+++ b/x-pack/plugins/security/server/authorization/app_authorization.ts
@@ -20,10 +20,11 @@ class ProtectedApplications {
     // we wait until we actually need to consume these before getting them
     if (this.applications == null) {
       this.applications = new Set(
-        this.featuresService
-          .getKibanaFeatures()
-          .map((feature) => feature.app)
-          .flat()
+        this.featuresService.getKibanaFeatures().flatMap((feature) => {
+          // If the feature has explicitly opted out of our RBAC by setting the `privileges` field to `null`, we
+          // shouldn't check permissions when the app defined by such feature is accessed.
+          return feature.privileges === null ? [] : feature.app;
+        })
       );
     }
 


### PR DESCRIPTION
## Summary

The title says it all, we shouldn't enforce app authorization for features that have opted out of RBAC. Currently we have just two such features: Enterprise Search and Monitoring.


<!--ONMERGE {"backportTargets":["7.17","8.10","8.9"]} ONMERGE-->