### PR TITLE
[8.10] [security_solution_cypress] Add support for options in EsArchiver.load (#164988)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/alert_tags.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/alert_tags.cy.ts
@@ -35,7 +35,7 @@ describe('Alert tagging', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
-    cy.task('esArchiverLoad', 'endpoint');
+    cy.task('esArchiverLoad', { archiveName: 'endpoint' });
     createRule(getNewRule({ rule_id: 'new custom rule' }));
     visit(ALERTS_URL);
     waitForAlertsToPopulate();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/cti_enrichments.cy.ts
@@ -33,8 +33,8 @@ import { addsFieldsToTimeline } from '../../tasks/rule_details';
 describe('CTI Enrichment', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'threat_indicator');
-    cy.task('esArchiverLoad', 'suspicious_source_event');
+    cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });
+    cy.task('esArchiverLoad', { archiveName: 'suspicious_source_event' });
     login();
     createRule({ ...getNewThreatIndicatorRule(), rule_id: 'rule_testing', enabled: true });
     disableExpandableFlyout();
@@ -157,7 +157,7 @@ describe('CTI Enrichment', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   describe('with additional indicators', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'threat_indicator2');
+      cy.task('esArchiverLoad', { archiveName: 'threat_indicator2' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/enrichments.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/enrichments.cy.ts
@@ -35,7 +35,7 @@ import { ALERTS_URL } from '../../urls/navigation';
 describe('Enrichment', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'risk_users');
+    cy.task('esArchiverLoad', { archiveName: 'risk_users' });
   });
 
   after(() => {
@@ -45,7 +45,7 @@ describe('Enrichment', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('Custom query rule', () => {
     beforeEach(() => {
       disableExpandableFlyout();
-      cy.task('esArchiverLoad', 'risk_hosts');
+      cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
       deleteAlertsAndRules();
       createRule(getNewRule({ rule_id: 'rule1' }));
       login();
@@ -77,7 +77,7 @@ describe('Enrichment', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
       closeAlertFlyout();
       cy.task('esArchiverUnload', 'risk_hosts');
-      cy.task('esArchiverLoad', 'risk_hosts_updated');
+      cy.task('esArchiverLoad', { archiveName: 'risk_hosts_updated' });
       expandFirstAlert();
       cy.get(ENRICHED_DATA_ROW).contains('Critical');
       cy.get(ENRICHED_DATA_ROW).contains('Original host risk classification');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/ransomware_detection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/ransomware_detection.cy.ts
@@ -18,7 +18,9 @@ import { createTimeline } from '../../tasks/timelines';
 
 describe('Ransomware Detection Alerts', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
-    cy.task('esArchiverLoad', 'ransomware_detection');
+    cy.task('esArchiverLoad', {
+      archiveName: 'ransomware_detection',
+    });
   });
 
   describe('Ransomware display in Alerts Section', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/ransomware_prevention.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/ransomware_prevention.cy.ts
@@ -15,10 +15,14 @@ import { ALERTS_HISTOGRAM_SERIES, ALERT_RULE_NAME, MESSAGE } from '../../screens
 import { TIMELINE_QUERY, TIMELINE_VIEW_IN_ANALYZER } from '../../screens/timeline';
 import { selectAlertsHistogram } from '../../tasks/alerts';
 import { createTimeline } from '../../tasks/timelines';
+import { cleanKibana } from '../../tasks/common';
 
 describe('Ransomware Prevention Alerts', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
-    cy.task('esArchiverLoad', 'ransomware_prevention');
+    cleanKibana();
+    cy.task('esArchiverLoad', {
+      archiveName: 'ransomware_prevention',
+    });
   });
 
   after(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
@@ -153,7 +153,7 @@ describe('EQL rules', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
     const rule = getEqlSequenceRule();
 
     beforeEach(() => {
-      cy.task('esArchiverLoad', 'auditbeat_big');
+      cy.task('esArchiverLoad', { archiveName: 'auditbeat_big' });
     });
     afterEach(() => {
       cy.task('esArchiverUnload', 'auditbeat_big');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
@@ -122,8 +122,8 @@ describe('indicator match', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () =>
 
     before(() => {
       cleanKibana();
-      cy.task('esArchiverLoad', 'threat_indicator');
-      cy.task('esArchiverLoad', 'suspicious_source_event');
+      cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });
+      cy.task('esArchiverLoad', { archiveName: 'suspicious_source_event' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
@@ -50,7 +50,7 @@ describe(
   () => {
     before(() => {
       cleanKibana();
-      cy.task('esArchiverLoad', 'all_users');
+      cy.task('esArchiverLoad', { archiveName: 'all_users' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/endpoint_exceptions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/endpoint_exceptions.cy.ts
@@ -56,7 +56,7 @@ describe.skip(
       cy.task('esArchiverResetKibana');
       login();
       deleteAlertsAndRules();
-      cy.task('esArchiverLoad', 'endpoint');
+      cy.task('esArchiverLoad', { archiveName: 'endpoint' });
       createRule(getEndpointRule());
       visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);
       goToRuleDetails();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/rule_exceptions/auto_populate_with_alert_data.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/rule_exceptions/auto_populate_with_alert_data.cy.ts
@@ -51,7 +51,7 @@ describe.skip(
     beforeEach(() => {
       cy.task('esArchiverUnload', 'endpoint');
       cy.task('esArchiverResetKibana');
-      cy.task('esArchiverLoad', 'endpoint');
+      cy.task('esArchiverLoad', { archiveName: 'endpoint' });
       login();
       createRule(getEndpointRule());
       visitWithoutDateRange(DETECTIONS_RULE_MANAGEMENT_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/rule_exceptions/closing_all_matching_alerts.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/alerts_table_flow/rule_exceptions/closing_all_matching_alerts.cy.ts
@@ -36,7 +36,7 @@ describe('Close matching Alerts ', () => {
     cy.task('esArchiverUnload', 'exceptions');
     cy.task('esArchiverResetKibana');
     deleteAlertsAndRules();
-    cy.task('esArchiverLoad', 'exceptions');
+    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
 
     login();
     postDataView('exceptions-*');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/entry/flyout_validation.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/entry/flyout_validation.cy.ts
@@ -72,10 +72,10 @@ describe.skip('Exceptions flyout', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
     // this is a made-up index that has just the necessary
     // mappings to conduct tests, avoiding loading large
     // amounts of data like in auditbeat_exceptions
-    cy.task('esArchiverLoad', 'exceptions');
+    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
     // Comment the Conflicts here as they are skipped
-    // cy.task('esArchiverLoad', 'conflicts_1');
-    // cy.task('esArchiverLoad', 'conflicts_2');
+    // cy.task('esArchiverLoad',{ archiveName: 'conflicts_1' });
+    // cy.task('esArchiverLoad',{ archiveName: 'conflicts_2' });
     login();
     createExceptionList(getExceptionList(), getExceptionList().list_id).then((response) =>
       createRule(

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/entry/use_value_list.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/entry/use_value_list.cy.ts
@@ -55,7 +55,7 @@ describe('Use Value list in exception entry', { tags: [tag.ESS, tag.SERVERLESS] 
   before(() => {
     cleanKibana();
     login();
-    cy.task('esArchiverLoad', 'exceptions');
+    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
     createRule({
       ...getNewRule(),
       query: 'user.name:*',

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_endpoint_exception.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_endpoint_exception.cy.ts
@@ -50,7 +50,7 @@ describe('Add endpoint exception from rule details', { tags: [tag.ESS, tag.SERVE
 
   before(() => {
     cy.task('esArchiverResetKibana');
-    cy.task('esArchiverLoad', 'auditbeat');
+    cy.task('esArchiverLoad', { archiveName: 'auditbeat' });
     login();
     deleteAlertsAndRules();
     // create rule with exception

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_exception.cy.ts
@@ -70,7 +70,7 @@ describe(
 
     before(() => {
       cy.task('esArchiverResetKibana');
-      cy.task('esArchiverLoad', 'exceptions');
+      cy.task('esArchiverLoad', { archiveName: 'exceptions' });
       login();
     });
 
@@ -326,7 +326,7 @@ describe(
         cy.get(NO_EXCEPTIONS_EXIST_PROMPT).should('exist');
 
         // load more docs
-        cy.task('esArchiverLoad', 'exceptions_2');
+        cy.task('esArchiverLoad', { archiveName: 'exceptions_2' });
 
         // now that there are no more exceptions, the docs should match and populate alerts
         goToAlertsTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/rule_details_flow/add_edit_exception_data_view.cy.ts
@@ -51,7 +51,7 @@ describe(
 
     before(() => {
       cy.task('esArchiverResetKibana');
-      cy.task('esArchiverLoad', 'exceptions');
+      cy.task('esArchiverLoad', { archiveName: 'exceptions' });
       login();
       postDataView('exceptions-*');
     });
@@ -118,7 +118,7 @@ describe(
       cy.get(NO_EXCEPTIONS_EXIST_PROMPT).should('exist');
 
       // load more docs
-      cy.task('esArchiverLoad', 'exceptions_2');
+      cy.task('esArchiverLoad', { archiveName: 'exceptions_2' });
 
       // now that there are no more exceptions, the docs should match and populate alerts
       goToAlertsTab();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
@@ -42,7 +42,7 @@ import {
 describe('Add, edit and delete exception', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cy.task('esArchiverResetKibana');
-    cy.task('esArchiverLoad', 'exceptions');
+    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
 
     createRule(getNewRule());
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/dashboards/entity_analytics.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/dashboards/entity_analytics.cy.ts
@@ -78,8 +78,8 @@ describe('Entity Analytics Dashboard', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
   describe('Risk Score enabled but still no data', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'risk_hosts_no_data');
-      cy.task('esArchiverLoad', 'risk_users_no_data');
+      cy.task('esArchiverLoad', { archiveName: 'risk_hosts_no_data' });
+      cy.task('esArchiverLoad', { archiveName: 'risk_users_no_data' });
     });
 
     beforeEach(() => {
@@ -103,8 +103,8 @@ describe('Entity Analytics Dashboard', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
   describe('With Legacy data', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'risk_hosts_legacy_data');
-      cy.task('esArchiverLoad', 'risk_users_legacy_data');
+      cy.task('esArchiverLoad', { archiveName: 'risk_hosts_legacy_data' });
+      cy.task('esArchiverLoad', { archiveName: 'risk_users_legacy_data' });
     });
 
     beforeEach(() => {
@@ -128,7 +128,7 @@ describe('Entity Analytics Dashboard', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
   describe('With host risk data', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'risk_hosts');
+      cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
     });
 
     beforeEach(() => {
@@ -216,7 +216,7 @@ describe('Entity Analytics Dashboard', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
   describe('With user risk data', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'risk_users');
+      cy.task('esArchiverLoad', { archiveName: 'risk_users' });
     });
 
     beforeEach(() => {
@@ -305,7 +305,7 @@ describe('Entity Analytics Dashboard', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLES
 
   describe('With anomalies data', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'network');
+      cy.task('esArchiverLoad', { archiveName: 'network' });
       login();
       visit(ENTITY_ANALYTICS_URL);
       cy.get(ANOMALIES_TABLE).should('be.visible');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/host_details/risk_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/host_details/risk_tab.cy.ts
@@ -14,7 +14,7 @@ import { TABLE_CELL, TABLE_ROWS } from '../../../screens/alerts_details';
 describe('risk tab', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'risk_hosts');
+    cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/events_viewer.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/events_viewer.cy.ts
@@ -48,7 +48,7 @@ const defaultHeadersInDefaultEcsCategory = [
 
 describe('Events Viewer', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
   before(() => {
-    cy.task('esArchiverLoad', 'auditbeat_big');
+    cy.task('esArchiverLoad', { archiveName: 'auditbeat_big' });
   });
 
   after(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/host_risk_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/host_risk_tab.cy.ts
@@ -25,7 +25,7 @@ import { clearSearchBar, kqlSearch } from '../../../tasks/security_header';
 describe('risk tab', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'risk_hosts');
+    cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/hosts_risk_column.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/hosts/hosts_risk_column.cy.ts
@@ -16,7 +16,7 @@ import { kqlSearch } from '../../../tasks/security_header';
 describe('All hosts table', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'risk_hosts');
+    cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/hover_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/hover_actions.cy.ts
@@ -33,7 +33,7 @@ describe.skip('Hover actions', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   };
 
   before(() => {
-    cy.task('esArchiverLoad', 'network');
+    cy.task('esArchiverLoad', { archiveName: 'network' });
   });
 
   after(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
@@ -26,7 +26,7 @@ const testDomainTwo = 'myTest2';
 describe('Overflow items', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   context('Network stats and tables', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'network');
+      cy.task('esArchiverLoad', { archiveName: 'network' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/overview/overview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/overview/overview.cy.ts
@@ -20,7 +20,7 @@ import { getTimeline } from '../../../objects/timeline';
 describe('Overview Page', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'overview');
+    cy.task('esArchiverLoad', { archiveName: 'overview' });
   });
 
   beforeEach(() => {
@@ -70,7 +70,7 @@ describe('Overview page with no data', { tags: tag.BROKEN_IN_SERVERLESS }, () =>
     cy.task('esArchiverUnload', 'auditbeat');
   });
   after(() => {
-    cy.task('esArchiverLoad', 'auditbeat');
+    cy.task('esArchiverLoad', { archiveName: 'auditbeat' });
   });
 
   it('Splash screen should be here', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
@@ -24,7 +24,7 @@ import { goToTablePage, sortFirstTableColumn } from '../../../tasks/table_pagina
 describe('Pagination', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('Host uncommon processes table)', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'host_uncommon_processes');
+      cy.task('esArchiverLoad', { archiveName: 'host_uncommon_processes' });
     });
 
     beforeEach(() => {
@@ -100,7 +100,7 @@ describe('Pagination', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   describe('All users and all Hosts tables', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'all_users');
+      cy.task('esArchiverLoad', { archiveName: 'all_users' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/users/users_tabs.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/users/users_tabs.cy.ts
@@ -22,9 +22,9 @@ import { USERS_URL } from '../../../urls/navigation';
 describe('Users stats and tables', () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'users');
+    cy.task('esArchiverLoad', { archiveName: 'users' });
 
-    cy.task('esArchiverLoad', 'risk_users');
+    cy.task('esArchiverLoad', { archiveName: 'risk_users' });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/inspect/inspect_button.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/inspect/inspect_button.cy.ts
@@ -25,8 +25,8 @@ const DATA_VIEW = 'auditbeat-*';
 
 describe('Inspect Explore pages', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
-    cy.task('esArchiverLoad', 'risk_users');
-    cy.task('esArchiverLoad', 'risk_hosts');
+    cy.task('esArchiverLoad', { archiveName: 'risk_users' });
+    cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });
 
     login();
     // Create and select data view

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_action_column.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alert_table_action_column.cy.ts
@@ -19,7 +19,9 @@ import { ALERTS_URL } from '../../../urls/navigation';
 describe('Alerts Table Action column', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'process_ancestry');
+    cy.task('esArchiverLoad', {
+      archiveName: 'process_ancestry',
+    });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_details.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_details.cy.ts
@@ -60,7 +60,7 @@ describe('Alert details flyout', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('With unmapped fields', () => {
     before(() => {
       cleanKibana();
-      cy.task('esArchiverLoad', 'unmapped_fields');
+      cy.task('esArchiverLoad', { archiveName: 'unmapped_fields' });
       createRule(getUnmappedRule());
     });
 
@@ -126,7 +126,7 @@ describe('Alert details flyout', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('Url state management', () => {
     before(() => {
       cleanKibana();
-      cy.task('esArchiverLoad', 'query_alert');
+      cy.task('esArchiverLoad', { archiveName: 'query_alert' });
     });
 
     beforeEach(() => {
@@ -172,7 +172,7 @@ describe('Alert details flyout', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   describe('Localstorage management', () => {
     before(() => {
       cleanKibana();
-      cy.task('esArchiverLoad', 'query_alert');
+      cy.task('esArchiverLoad', { archiveName: 'query_alert' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/building_block_alerts.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/building_block_alerts.cy.ts
@@ -28,7 +28,7 @@ describe(
   { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] },
   () => {
     before(() => {
-      cy.task('esArchiverLoad', 'auditbeat_big');
+      cy.task('esArchiverLoad', { archiveName: 'auditbeat_big' });
       cleanKibana();
       login();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/changing_alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/changing_alert_status.cy.ts
@@ -41,7 +41,7 @@ import { ALERTS_URL } from '../../../urls/navigation';
 
 describe('Changing alert status', { tags: [tag.ESS, tag.BROKEN_IN_SERVERLESS] }, () => {
   before(() => {
-    cy.task('esArchiverLoad', 'auditbeat_big');
+    cy.task('esArchiverLoad', { archiveName: 'auditbeat_big' });
     cleanKibana();
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/bulk_add_to_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/bulk_add_to_timeline.cy.ts
@@ -26,7 +26,7 @@ import { ALERTS_URL, HOSTS_URL } from '../../../urls/navigation';
 describe('Bulk Investigate in Timeline', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'bulk_process');
+    cy.task('esArchiverLoad', { archiveName: 'bulk_process' });
     login();
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/pagination.cy.ts
@@ -27,7 +27,7 @@ const defaultPageSize = 25;
 describe('Pagination', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
   before(() => {
     cleanKibana();
-    cy.task('esArchiverLoad', 'timeline');
+    cy.task('esArchiverLoad', { archiveName: 'timeline' });
   });
 
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/overview/cti_link_panel.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/overview/cti_link_panel.cy.ts
@@ -33,7 +33,7 @@ describe('CTI Link Panel', { tags: [tag.ESS, tag.SERVERLESS] }, () => {
 
   describe('enabled threat intel module', () => {
     before(() => {
-      cy.task('esArchiverLoad', 'threat_indicator');
+      cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });
     });
 
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
+++ b/x-pack/test/security_solution_cypress/cypress/support/es_archiver.ts
@@ -34,7 +34,8 @@ export const esArchiver = (
   });
 
   on('task', {
-    esArchiverLoad: async (archiveName) => esArchiverInstance.load(archiveName),
+    esArchiverLoad: async ({ archiveName, ...options }) =>
+      esArchiverInstance.load(archiveName, options),
     esArchiverUnload: async (archiveName) => esArchiverInstance.unload(archiveName),
     esArchiverResetKibana: async () => esArchiverInstance.emptyKibanaIndex(),
   });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[security_solution_cypress] Add support for options in EsArchiver.load (#164988)](https://github.com/elastic/kibana/pull/164988)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Patryk Kopyciński","email":"contact@patrykkopycinski.com"},"sourceCommit":{"committedDate":"2023-08-28T18:21:43Z","message":"[security_solution_cypress] Add support for options in EsArchiver.load (#164988)\n\n## Summary\r\n\r\nNeeded for\r\nhttps://github.com/elastic/kibana/pull/160572#issuecomment-1695775316","sha":"f8ad13ae1f078aa5f0cb6e1190e3c167dec168c8","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","v8.11.0"],"number":164988,"url":"https://github.com/elastic/kibana/pull/164988","mergeCommit":{"message":"[security_solution_cypress] Add support for options in EsArchiver.load (#164988)\n\n## Summary\r\n\r\nNeeded for\r\nhttps://github.com/elastic/kibana/pull/160572#issuecomment-1695775316","sha":"f8ad13ae1f078aa5f0cb6e1190e3c167dec168c8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164988","number":164988,"mergeCommit":{"message":"[security_solution_cypress] Add support for options in EsArchiver.load (#164988)\n\n## Summary\r\n\r\nNeeded for\r\nhttps://github.com/elastic/kibana/pull/160572#issuecomment-1695775316","sha":"f8ad13ae1f078aa5f0cb6e1190e3c167dec168c8"}}]}] BACKPORT-->