### PR TITLE
[Search] Fix platinum license for cloud connectors

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
@@ -228,7 +228,7 @@ export const SelectConnector: React.FC = () => {
                 {filteredConnectors.map((connector) => (
                   <EuiFlexItem key={connector.serviceType} grow>
                     <ConnectorCheckable
-                      disabled={connector.platinumOnly && !hasPlatinumLicense}
+                      disabled={connector.platinumOnly && (!hasPlatinumLicense || !isCloud)}
                       icon={connector.icon}
                       isBeta={connector.isBeta}
                       isTechPreview={Boolean(connector.isTechPreview)}


### PR DESCRIPTION
## Summary

This makes platinum license connectors accessible on cloud regardless of license.

<!--ONMERGE {"backportTargets":["8.10","8.9"]} ONMERGE-->