### PR TITLE
[Cloud Security] Fix first item flyout wont open in vuln table

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/vulnerabilities/vulnerabilities.tsx
@@ -279,9 +279,7 @@ const VulnerabilitiesDataGrid = ({
     [pageSize, setUrlQuery]
   );
 
-  const showVulnerabilityFlyout = flyoutVulnerabilityIndex
-    ? flyoutVulnerabilityIndex > invalidIndex
-    : undefined;
+  const showVulnerabilityFlyout = flyoutVulnerabilityIndex > invalidIndex;
 
   if (data?.page.length === 0) {
     return <EmptyState onResetFilters={onResetFilters} />;


### PR DESCRIPTION
Reverted the logic change for the function that opens the flyout


https://github.com/elastic/kibana/assets/51442161/fadad616-4302-40dc-b04a-4d75018cf5dc



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->