### PR TITLE
[APM] Require `_meta` in APM Telemetry Schema

### DIFF
--- a/src/plugins/usage_collection/server/collector/types.ts
+++ b/src/plugins/usage_collection/server/collector/types.ts
@@ -21,7 +21,7 @@ export type {
 /**
  * Helper to find out whether to keep recursively looking or if we are on an end value
  */
-export type RecursiveMakeSchemaFrom<U> = U extends object
+export type RecursiveMakeSchemaFrom<U, RequireMeta> = U extends object
   ? Record<string, unknown> extends U
     ?
         | {
@@ -31,19 +31,21 @@ export type RecursiveMakeSchemaFrom<U> = U extends object
               description: string; // Intentionally enforcing the descriptions here
             } & SchemaMetaOptional<U>;
           }
-        | MakeSchemaFrom<U> // But still allow being explicit in the definition if they want to.
-    : MakeSchemaFrom<U>
+        | MakeSchemaFrom<U, RequireMeta> // But still allow being explicit in the definition if they want to.
+    : MakeSchemaFrom<U, RequireMeta>
+  : RequireMeta extends true
+  ? { type: PossibleSchemaTypes<U>; _meta: { description: string } }
   : { type: PossibleSchemaTypes<U>; _meta?: { description: string } };
 
 /**
  * The `schema` property in {@link CollectorOptions} must match the output of
  * the `fetch` method. This type helps ensure that is correct
  */
-export type MakeSchemaFrom<Base> = {
+export type MakeSchemaFrom<Base, RequireMeta = false> = {
   // Using Required to enforce all optional keys in the object
   [Key in keyof Required<Base>]: Required<Base>[Key] extends Array<infer U>
-    ? { type: 'array'; items: RecursiveMakeSchemaFrom<U> }
-    : RecursiveMakeSchemaFrom<Required<Base>[Key]>;
+    ? { type: 'array'; items: RecursiveMakeSchemaFrom<U, RequireMeta> }
+    : RecursiveMakeSchemaFrom<Required<Base>[Key], RequireMeta>;
 };
 
 /**

--- a/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
@@ -14,76 +14,148 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                     "services_per_agent": {
                       "properties": {
                         "android/java": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the android/java agent within the last day"
+                          }
                         },
                         "dotnet": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the dotnet (.Net) agent within the last day"
+                          }
                         },
                         "iOS/swift": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the iOS/swift agent within the last day"
+                          }
                         },
                         "go": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the go agent within the last day"
+                          }
                         },
                         "java": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the Java agent within the last day"
+                          }
                         },
                         "js-base": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the js-base agent within the last day"
+                          }
                         },
                         "nodejs": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the nodeJS agent within the last day"
+                          }
                         },
                         "php": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the PHH agent within the last day"
+                          }
                         },
                         "python": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the Python agent within the last day"
+                          }
                         },
                         "ruby": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the Ruby agent within the last day"
+                          }
                         },
                         "rum-js": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the rum-js agent within the last day"
+                          }
                         },
                         "otlp": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the otlp agent within the last day"
+                          }
                         },
                         "opentelemetry/cpp": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/cpp agent within the last day"
+                          }
                         },
                         "opentelemetry/dotnet": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/dotnet agent within the last day"
+                          }
                         },
                         "opentelemetry/erlang": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/erlang agent within the last day"
+                          }
                         },
                         "opentelemetry/go": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/go agent within the last day"
+                          }
                         },
                         "opentelemetry/java": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/java agent within the last day"
+                          }
                         },
                         "opentelemetry/nodejs": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/nodejs agent within the last day"
+                          }
                         },
                         "opentelemetry/php": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/php agent within the last day"
+                          }
                         },
                         "opentelemetry/python": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/python agent within the last day"
+                          }
                         },
                         "opentelemetry/ruby": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/ruby agent within the last day"
+                          }
                         },
                         "opentelemetry/rust": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/rust agent within the last day"
+                          }
                         },
                         "opentelemetry/swift": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/swift agent within the last day"
+                          }
                         },
                         "opentelemetry/webjs": {
-                          "type": "long"
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of services utilizing the opentelemetry/webjs agent within the last day"
+                          }
                         }
                       }
                     },
@@ -1140,60 +1212,96 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                         "current_implementation": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         },
                         "no_observer_name": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         },
                         "no_rum": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         },
                         "no_rum_no_observer_name": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         },
                         "only_rum": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         },
                         "only_rum_no_observer_name": {
                           "properties": {
                             "expected_metric_document_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             },
                             "transaction_count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": ""
+                              }
                             }
                           }
                         }
@@ -1366,10 +1474,10 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                         "services": {
                           "properties": {
                             "1d": {
-                              "type": "long"
-                            },
-                            "all": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": "Total number of unique services within the last day"
+                              }
                             }
                           }
                         },
@@ -1552,7 +1660,10 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                             "shards": {
                               "properties": {
                                 "total": {
-                                  "type": "long"
+                                  "type": "long",
+                                  "_meta": {
+                                    "description": "Total number of shards for metric indices"
+                                  }
                                 }
                               }
                             },
@@ -1563,14 +1674,20 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                                     "docs": {
                                       "properties": {
                                         "count": {
-                                          "type": "long"
+                                          "type": "long",
+                                          "_meta": {
+                                            "description": "Total number of metric documents overall"
+                                          }
                                         }
                                       }
                                     },
                                     "store": {
                                       "properties": {
                                         "size_in_bytes": {
-                                          "type": "long"
+                                          "type": "long",
+                                          "_meta": {
+                                            "description": "Size of the metric indicess in byte units overall."
+                                          }
                                         }
                                       }
                                     }
@@ -1587,7 +1704,7 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                                 "total": {
                                   "type": "long",
                                   "_meta": {
-                                    "description": "Total number of shards overall"
+                                    "description": "Total number of shards for span and trasnaction indices"
                                   }
                                 }
                               }
@@ -1819,7 +1936,10 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                             "pod": {
                               "properties": {
                                 "name": {
-                                  "type": "keyword"
+                                  "type": "keyword",
+                                  "_meta": {
+                                    "description": "Kuberneted pod name "
+                                  }
                                 }
                               }
                             }
@@ -1828,7 +1948,10 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                         "container": {
                           "properties": {
                             "id": {
-                              "type": "keyword"
+                              "type": "keyword",
+                              "_meta": {
+                                "description": "Container id"
+                              }
                             }
                           }
                         }

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -6,164 +6,157 @@
  */
 
 import { MakeSchemaFrom } from '@kbn/usage-collection-plugin/server';
-import {
-  AggregatedTransactionsCounts,
-  APMUsage,
-  TimeframeMap,
-  TimeframeMap1d,
-  TimeframeMapAll,
-  APMPerService,
-} from './types';
+import { AggregatedTransactionsCounts, APMUsage, APMPerService } from './types';
 import { ElasticAgentName } from '../../../typings/es_schemas/ui/fields/agent';
 
 const long: { type: 'long' } = { type: 'long' };
 
 const keyword: { type: 'keyword' } = { type: 'keyword' };
 
-const aggregatedTransactionCountSchema: MakeSchemaFrom<AggregatedTransactionsCounts> =
+const aggregatedTransactionCountSchema: MakeSchemaFrom<
+  AggregatedTransactionsCounts,
+  true
+> = {
+  expected_metric_document_count: {
+    type: 'long',
+    _meta: {
+      description: '',
+    },
+  },
+  transaction_count: {
+    type: 'long',
+    _meta: {
+      description: '',
+    },
+  },
+};
+
+const agentSchema: MakeSchemaFrom<APMUsage, true>['agents'][ElasticAgentName] =
   {
-    expected_metric_document_count: long,
-    transaction_count: long,
+    agent: {
+      version: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description:
+              'An array of the top 3 agent versions within the last day',
+          },
+        },
+      },
+      activation_method: {
+        type: 'array',
+        items: {
+          type: 'keyword',
+          _meta: {
+            description:
+              'An array of the top 3 agent activation methods within the last day',
+          },
+        },
+      },
+    },
+    service: {
+      framework: {
+        name: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service framework name  within the last day',
+            },
+          },
+        },
+        version: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service framework version within the last day',
+            },
+          },
+        },
+        composite: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'Composite field containing service framework and version sorted by doc count',
+            },
+          },
+        },
+      },
+      language: {
+        name: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service language name within the last day',
+            },
+          },
+        },
+        version: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service language version within the last day',
+            },
+          },
+        },
+        composite: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'Composite field containing service language name and version sorted by doc count.',
+            },
+          },
+        },
+      },
+      runtime: {
+        name: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service runtime name within the last day',
+            },
+          },
+        },
+        version: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'An array of the top 3 service runtime version within the last day',
+            },
+          },
+        },
+        composite: {
+          type: 'array',
+          items: {
+            type: 'keyword',
+            _meta: {
+              description:
+                'Composite field containing service runtime name and version sorted by doc count.',
+            },
+          },
+        },
+      },
+    },
   };
 
-const timeframeMap1dSchema: MakeSchemaFrom<TimeframeMap1d> = {
-  '1d': long,
-};
-
-const timeframeMapAllSchema: MakeSchemaFrom<TimeframeMapAll> = {
-  all: long,
-};
-
-const timeframeMapSchema: MakeSchemaFrom<TimeframeMap> = {
-  ...timeframeMap1dSchema,
-  ...timeframeMapAllSchema,
-};
-
-const agentSchema: MakeSchemaFrom<APMUsage>['agents'][ElasticAgentName] = {
-  agent: {
-    version: {
-      type: 'array',
-      items: {
-        type: 'keyword',
-        _meta: {
-          description:
-            'An array of the top 3 agent versions within the last day',
-        },
-      },
-    },
-    activation_method: {
-      type: 'array',
-      items: {
-        type: 'keyword',
-        _meta: {
-          description:
-            'An array of the top 3 agent activation methods within the last day',
-        },
-      },
-    },
-  },
-  service: {
-    framework: {
-      name: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service framework name  within the last day',
-          },
-        },
-      },
-      version: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service framework version within the last day',
-          },
-        },
-      },
-      composite: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'Composite field containing service framework and version sorted by doc count',
-          },
-        },
-      },
-    },
-    language: {
-      name: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service language name within the last day',
-          },
-        },
-      },
-      version: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service language version within the last day',
-          },
-        },
-      },
-      composite: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'Composite field containing service language name and version sorted by doc count.',
-          },
-        },
-      },
-    },
-    runtime: {
-      name: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service runtime name within the last day',
-          },
-        },
-      },
-      version: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'An array of the top 3 service runtime version within the last day',
-          },
-        },
-      },
-      composite: {
-        type: 'array',
-        items: {
-          type: 'keyword',
-          _meta: {
-            description:
-              'Composite field containing service runtime name and version sorted by doc count.',
-          },
-        },
-      },
-    },
-  },
-};
-
 const apmPerAgentSchema: Pick<
-  MakeSchemaFrom<APMUsage>,
+  MakeSchemaFrom<APMUsage, true>,
   'services_per_agent' | 'agents'
 > = {
   // services_per_agent: AGENT_NAMES.reduce(
@@ -177,30 +170,174 @@ const apmPerAgentSchema: Pick<
   // TODO: Find a way for `@kbn/telemetry-tools` to understand and evaluate expressions.
   //  In the meanwhile, we'll have to maintain these lists up to date (TS will remind us to update)
   services_per_agent: {
-    'android/java': long,
-    dotnet: long,
-    'iOS/swift': long,
-    go: long,
-    java: long,
-    'js-base': long,
-    nodejs: long,
-    php: long,
-    python: long,
-    ruby: long,
-    'rum-js': long,
-    otlp: long,
-    'opentelemetry/cpp': long,
-    'opentelemetry/dotnet': long,
-    'opentelemetry/erlang': long,
-    'opentelemetry/go': long,
-    'opentelemetry/java': long,
-    'opentelemetry/nodejs': long,
-    'opentelemetry/php': long,
-    'opentelemetry/python': long,
-    'opentelemetry/ruby': long,
-    'opentelemetry/rust': long,
-    'opentelemetry/swift': long,
-    'opentelemetry/webjs': long,
+    'android/java': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the android/java agent within the last day',
+      },
+    },
+    dotnet: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the dotnet (.Net) agent within the last day',
+      },
+    },
+    'iOS/swift': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the iOS/swift agent within the last day',
+      },
+    },
+    go: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the go agent within the last day',
+      },
+    },
+    java: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the Java agent within the last day',
+      },
+    },
+    'js-base': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the js-base agent within the last day',
+      },
+    },
+    nodejs: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the nodeJS agent within the last day',
+      },
+    },
+    php: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the PHH agent within the last day',
+      },
+    },
+    python: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the Python agent within the last day',
+      },
+    },
+    ruby: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the Ruby agent within the last day',
+      },
+    },
+    'rum-js': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the rum-js agent within the last day',
+      },
+    },
+    otlp: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the otlp agent within the last day',
+      },
+    },
+    'opentelemetry/cpp': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/cpp agent within the last day',
+      },
+    },
+    'opentelemetry/dotnet': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/dotnet agent within the last day',
+      },
+    },
+    'opentelemetry/erlang': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/erlang agent within the last day',
+      },
+    },
+    'opentelemetry/go': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/go agent within the last day',
+      },
+    },
+    'opentelemetry/java': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/java agent within the last day',
+      },
+    },
+    'opentelemetry/nodejs': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/nodejs agent within the last day',
+      },
+    },
+    'opentelemetry/php': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/php agent within the last day',
+      },
+    },
+    'opentelemetry/python': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/python agent within the last day',
+      },
+    },
+    'opentelemetry/ruby': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/ruby agent within the last day',
+      },
+    },
+    'opentelemetry/rust': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/rust agent within the last day',
+      },
+    },
+    'opentelemetry/swift': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/swift agent within the last day',
+      },
+    },
+    'opentelemetry/webjs': {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of services utilizing the opentelemetry/webjs agent within the last day',
+      },
+    },
   },
   agents: {
     'android/java': agentSchema,
@@ -217,7 +354,7 @@ const apmPerAgentSchema: Pick<
   },
 };
 
-export const apmPerServiceSchema: MakeSchemaFrom<APMPerService> = {
+export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
   service_id: {
     ...keyword,
     _meta: {
@@ -367,16 +504,26 @@ export const apmPerServiceSchema: MakeSchemaFrom<APMPerService> = {
   // No data found
   kubernetes: {
     pod: {
-      name: keyword,
+      name: {
+        type: 'keyword',
+        _meta: {
+          description: 'Kuberneted pod name ',
+        },
+      },
     },
   },
   // No data found
   container: {
-    id: keyword,
+    id: {
+      type: 'keyword',
+      _meta: {
+        description: 'Container id',
+      },
+    },
   },
 };
 
-export const apmSchema: MakeSchemaFrom<APMUsage> = {
+export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   ...apmPerAgentSchema,
   has_any_services: {
     type: 'boolean',
@@ -433,7 +580,6 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
       },
     },
   },
-  // #NOTE No task identified for extracting the following information
   aggregated_transactions: {
     current_implementation: aggregatedTransactionCountSchema,
     no_observer_name: aggregatedTransactionCountSchema,
@@ -602,8 +748,14 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
         },
       },
     },
-    // No tasks found
-    services: timeframeMapSchema,
+    services: {
+      '1d': {
+        ...long,
+        _meta: {
+          description: 'Total number of unique services within the last day',
+        },
+      },
+    },
     environments: {
       '1d': {
         ...long,
@@ -746,23 +898,44 @@ export const apmSchema: MakeSchemaFrom<APMUsage> = {
   },
 
   indices: {
-    // cannot find related data
     metric: {
-      shards: { total: long },
+      shards: {
+        total: {
+          type: 'long',
+          _meta: {
+            description: 'Total number of shards for metric indices',
+          },
+        },
+      },
       all: {
         total: {
-          docs: { count: long },
-          store: { size_in_bytes: long },
+          docs: {
+            count: {
+              ...long,
+              _meta: {
+                description: 'Total number of metric documents overall',
+              },
+            },
+          },
+          store: {
+            size_in_bytes: {
+              ...long,
+              _meta: {
+                description:
+                  'Size of the metric indicess in byte units overall.',
+              },
+            },
+          },
         },
       },
     },
-    // cannot find related data
     traces: {
       shards: {
         total: {
           ...long,
           _meta: {
-            description: 'Total number of shards overall',
+            description:
+              'Total number of shards for span and trasnaction indices',
           },
         },
       },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -9,10 +9,6 @@ import { MakeSchemaFrom } from '@kbn/usage-collection-plugin/server';
 import { AggregatedTransactionsCounts, APMUsage, APMPerService } from './types';
 import { ElasticAgentName } from '../../../typings/es_schemas/ui/fields/agent';
 
-const long: { type: 'long' } = { type: 'long' };
-
-const keyword: { type: 'keyword' } = { type: 'keyword' };
-
 const aggregatedTransactionCountSchema: MakeSchemaFrom<
   AggregatedTransactionsCounts,
   true
@@ -356,21 +352,21 @@ const apmPerAgentSchema: Pick<
 
 export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
   service_id: {
-    ...keyword,
+    type: 'keyword',
     _meta: {
       description:
         'Unique identifier that combines the SHA256 hashed representation of the service name and environment',
     },
   },
   num_service_nodes: {
-    ...long,
+    type: 'long',
     _meta: {
       description:
         'Total number of the unique service instances that served the transaction within an hour',
     },
   },
   num_transaction_types: {
-    ...long,
+    type: 'long',
     _meta: {
       description:
         'Total number of the unique transaction types within an hour',
@@ -430,21 +426,21 @@ export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
   },
   agent: {
     name: {
-      ...keyword,
+      type: 'keyword',
       _meta: {
         description:
           'The top value of agent name for the service from transaction documents within an hour. Sorted by _score',
       },
     },
     version: {
-      ...keyword,
+      type: 'keyword',
       _meta: {
         description:
           'The top value of agent version for the service from transaction documents within an hour. Sorted by _score',
       },
     },
     activation_method: {
-      ...keyword,
+      type: 'keyword',
       _meta: {
         description:
           'The top value of agent activation method for the service from transaction documents within an hour. Sorted by _score',
@@ -454,14 +450,14 @@ export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
   service: {
     language: {
       name: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of language name for the service from transaction documents within an hour. Sorted by _score',
         },
       },
       version: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of language version for the service from transaction documents within an hour. Sorted by _score',
@@ -470,14 +466,14 @@ export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
     },
     framework: {
       name: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of service framework name from transaction documents within an hour. Sorted by _score. Example AWS Lambda',
         },
       },
       version: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of service framework version from transaction documents within an hour. Sorted by _score',
@@ -486,14 +482,14 @@ export const apmPerServiceSchema: MakeSchemaFrom<APMPerService, true> = {
     },
     runtime: {
       name: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of service runtime name from transaction documents within an hour. Sorted by _score',
         },
       },
       version: {
-        ...keyword,
+        type: 'keyword',
         _meta: {
           description:
             'The top value of service runtime version version from transaction documents within an hour. Sorted by _score',
@@ -535,19 +531,19 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   version: {
     apm_server: {
       major: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'The major version of the APM server. Example: 7',
         },
       },
       minor: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'The minor version of the APM server. Example: 17',
         },
       },
       patch: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'The patch version of the APM server. Example 3',
         },
@@ -556,14 +552,14 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   },
   environments: {
     services_without_environment: {
-      ...long,
+      type: 'long',
       _meta: {
         description:
           'Number of services without an assigned environment within the last day. This is determined by checking the "service.environment" field and counting instances where it is null',
       },
     },
     services_with_multiple_environments: {
-      ...long,
+      type: 'long',
       _meta: {
         description:
           'Number of services with more than one assigned environment within the last day',
@@ -637,14 +633,14 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   counts: {
     transaction: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of transaction documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of transaction documents overall',
         },
@@ -652,13 +648,13 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     span: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of span documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of span documents overall',
         },
@@ -666,13 +662,13 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     error: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of error documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of error documents overall',
         },
@@ -680,13 +676,13 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     metric: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of metric documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of metric documents overall',
         },
@@ -694,14 +690,14 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     onboarding: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of onboarding documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of onboarding documents overall',
         },
@@ -709,7 +705,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     agent_configuration: {
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of apm-agent-configuration documents overall',
@@ -718,7 +714,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     max_transaction_groups_per_service: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of distinct transaction groups for the top service for the last 24 hours',
@@ -727,7 +723,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     max_error_groups_per_service: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of distinct error groups for the top service for the last 24 hours',
@@ -736,13 +732,13 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     traces: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of trace documents within the last day',
         },
       },
       all: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of trace documents overall',
         },
@@ -750,7 +746,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     services: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of unique services within the last day',
         },
@@ -758,7 +754,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     environments: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of unique environments within the last day',
@@ -767,7 +763,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     span_destination_service_resource: {
       '1d': {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of unique values of span.destination.service.resource within the last day',
@@ -782,7 +778,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         country_iso_code: {
           rum: {
             '1d': {
-              ...long,
+              type: 'long',
               _meta: {
                 description:
                   'Unique country iso code captured for the agents js-base, rum-js and opentelemetry/webjs within the last day',
@@ -796,7 +792,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
       original: {
         all_agents: {
           '1d': {
-            ...long,
+            type: 'long',
             _meta: {
               description:
                 'Unique user agent for all agents within the last day',
@@ -805,7 +801,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         },
         rum: {
           '1d': {
-            ...long,
+            type: 'long',
             _meta: {
               description:
                 'Unique user agent for rum agent within the last day',
@@ -818,7 +814,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
       name: {
         all_agents: {
           '1d': {
-            ...long,
+            type: 'long',
             _meta: {
               description:
                 'Unique transaction names for all agents within the last day',
@@ -827,7 +823,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         },
         rum: {
           '1d': {
-            ...long,
+            type: 'long',
             _meta: {
               description:
                 'Unique transaction names for rum agent within the last day',
@@ -841,7 +837,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   retainment: {
     span: {
       ms: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Represent the time difference in milliseconds between the current date and the date when the span document was recorded',
@@ -850,7 +846,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     transaction: {
       ms: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Represent the time difference in milliseconds between the current date and the date when the transaction document was recorded',
@@ -859,7 +855,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     error: {
       ms: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Represent the time difference in milliseconds between the current date and the date when the error document was recorded',
@@ -868,7 +864,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     metric: {
       ms: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Represent the time difference in milliseconds between the current date and the date when the metric document was recorded',
@@ -877,7 +873,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     onboarding: {
       ms: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Represent the time difference in milliseconds between the current date and the date when the onboarding document was recorded',
@@ -888,7 +884,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
   integrations: {
     ml: {
       all_jobs_count: {
-        ...long,
+        type: 'long',
         _meta: {
           description:
             'Total number of anomaly detection jobs associated with the jobs apm-*, *-high_mean_response_time',
@@ -911,7 +907,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         total: {
           docs: {
             count: {
-              ...long,
+              type: 'long',
               _meta: {
                 description: 'Total number of metric documents overall',
               },
@@ -919,7 +915,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
           },
           store: {
             size_in_bytes: {
-              ...long,
+              type: 'long',
               _meta: {
                 description:
                   'Size of the metric indicess in byte units overall.',
@@ -932,7 +928,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     traces: {
       shards: {
         total: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Total number of shards for span and trasnaction indices',
@@ -943,7 +939,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         total: {
           docs: {
             count: {
-              ...long,
+              type: 'long',
               _meta: {
                 description:
                   'Total number of transaction and span documents overall',
@@ -952,7 +948,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
           },
           store: {
             size_in_bytes: {
-              ...long,
+              type: 'long',
               _meta: {
                 description: 'Size of the index in byte units overall.',
               },
@@ -963,7 +959,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     },
     shards: {
       total: {
-        ...long,
+        type: 'long',
         _meta: {
           description: 'Total number of shards overall',
         },
@@ -973,7 +969,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
       total: {
         docs: {
           count: {
-            ...long,
+            type: 'long',
             _meta: {
               description: 'Total number of all documents overall',
             },
@@ -981,7 +977,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
         },
         store: {
           size_in_bytes: {
-            ...long,
+            type: 'long',
             _meta: {
               description: 'Size of the index in byte units overall.',
             },
@@ -1002,7 +998,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
       },
     },
     total: {
-      ...long,
+      type: 'long',
       _meta: {
         description:
           'Total number of service groups retrived from the saved object across all spaces',
@@ -1014,7 +1010,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     aggregated_transactions: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "aggregated_transactions" task',
@@ -1025,7 +1021,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     cloud: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description: 'Execution time in milliseconds for the "cloud" task',
           },
@@ -1035,7 +1031,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     host: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description: 'Execution time in milliseconds for the "host" task',
           },
@@ -1045,7 +1041,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     processor_events: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "processor_events" task',
@@ -1056,7 +1052,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     agent_configuration: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "agent_configuration" task',
@@ -1067,7 +1063,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     services: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "services" task',
@@ -1078,7 +1074,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     versions: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "versions" task',
@@ -1089,7 +1085,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     groupings: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "groupings" task',
@@ -1100,7 +1096,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     integrations: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "integrations" task',
@@ -1111,7 +1107,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     agents: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description: 'Execution time in milliseconds for the "agents" task',
           },
@@ -1121,7 +1117,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     indices_stats: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "indices_stats" task',
@@ -1132,7 +1128,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     cardinality: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "cardinality" task',
@@ -1143,7 +1139,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     environments: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "environments" task',
@@ -1154,7 +1150,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     service_groups: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "service_groups" task',
@@ -1165,7 +1161,7 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
     per_service: {
       took: {
         ms: {
-          ...long,
+          type: 'long',
           _meta: {
             description:
               'Execution time in milliseconds for the "per_service" task',

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -107,7 +107,7 @@ export interface APMUsage {
     max_transaction_groups_per_service: TimeframeMap1d;
     max_error_groups_per_service: TimeframeMap1d;
     traces: TimeframeMap;
-    services: TimeframeMap;
+    services: TimeframeMap1d;
     environments: TimeframeMap1d;
     span_destination_service_resource: TimeframeMap1d;
   };

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -2728,76 +2728,148 @@
         "services_per_agent": {
           "properties": {
             "android/java": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the android/java agent within the last day"
+              }
             },
             "dotnet": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the dotnet (.Net) agent within the last day"
+              }
             },
             "iOS/swift": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the iOS/swift agent within the last day"
+              }
             },
             "go": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the go agent within the last day"
+              }
             },
             "java": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the Java agent within the last day"
+              }
             },
             "js-base": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the js-base agent within the last day"
+              }
             },
             "nodejs": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the nodeJS agent within the last day"
+              }
             },
             "php": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the PHH agent within the last day"
+              }
             },
             "python": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the Python agent within the last day"
+              }
             },
             "ruby": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the Ruby agent within the last day"
+              }
             },
             "rum-js": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the rum-js agent within the last day"
+              }
             },
             "otlp": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the otlp agent within the last day"
+              }
             },
             "opentelemetry/cpp": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/cpp agent within the last day"
+              }
             },
             "opentelemetry/dotnet": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/dotnet agent within the last day"
+              }
             },
             "opentelemetry/erlang": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/erlang agent within the last day"
+              }
             },
             "opentelemetry/go": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/go agent within the last day"
+              }
             },
             "opentelemetry/java": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/java agent within the last day"
+              }
             },
             "opentelemetry/nodejs": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/nodejs agent within the last day"
+              }
             },
             "opentelemetry/php": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/php agent within the last day"
+              }
             },
             "opentelemetry/python": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/python agent within the last day"
+              }
             },
             "opentelemetry/ruby": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/ruby agent within the last day"
+              }
             },
             "opentelemetry/rust": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/rust agent within the last day"
+              }
             },
             "opentelemetry/swift": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/swift agent within the last day"
+              }
             },
             "opentelemetry/webjs": {
-              "type": "long"
+              "type": "long",
+              "_meta": {
+                "description": "Total number of services utilizing the opentelemetry/webjs agent within the last day"
+              }
             }
           }
         },
@@ -4220,60 +4292,96 @@
             "current_implementation": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             },
             "no_observer_name": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             },
             "no_rum": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             },
             "no_rum_no_observer_name": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             },
             "only_rum": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             },
             "only_rum_no_observer_name": {
               "properties": {
                 "expected_metric_document_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 },
                 "transaction_count": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": ""
+                  }
                 }
               }
             }
@@ -4458,10 +4566,10 @@
             "services": {
               "properties": {
                 "1d": {
-                  "type": "long"
-                },
-                "all": {
-                  "type": "long"
+                  "type": "long",
+                  "_meta": {
+                    "description": "Total number of unique services within the last day"
+                  }
                 }
               }
             },
@@ -4644,7 +4752,10 @@
                 "shards": {
                   "properties": {
                     "total": {
-                      "type": "long"
+                      "type": "long",
+                      "_meta": {
+                        "description": "Total number of shards for metric indices"
+                      }
                     }
                   }
                 },
@@ -4655,14 +4766,20 @@
                         "docs": {
                           "properties": {
                             "count": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": "Total number of metric documents overall"
+                              }
                             }
                           }
                         },
                         "store": {
                           "properties": {
                             "size_in_bytes": {
-                              "type": "long"
+                              "type": "long",
+                              "_meta": {
+                                "description": "Size of the metric indicess in byte units overall."
+                              }
                             }
                           }
                         }
@@ -4679,7 +4796,7 @@
                     "total": {
                       "type": "long",
                       "_meta": {
-                        "description": "Total number of shards overall"
+                        "description": "Total number of shards for span and trasnaction indices"
                       }
                     }
                   }
@@ -4928,7 +5045,10 @@
                   "pod": {
                     "properties": {
                       "name": {
-                        "type": "keyword"
+                        "type": "keyword",
+                        "_meta": {
+                          "description": "Kuberneted pod name "
+                        }
                       }
                     }
                   }
@@ -4937,7 +5057,10 @@
               "container": {
                 "properties": {
                   "id": {
-                    "type": "keyword"
+                    "type": "keyword",
+                    "_meta": {
+                      "description": "Container id"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary

1. Update type to accept `RequireMeta` and make it required for apm telemetry schmea
2. Add missing descriptions 
3. Cleaning up apm schema a bit

### Related 
- https://github.com/elastic/kibana/pull/157529

