### PR TITLE
[Security Solution] Unskip failing tests in Policy and Metadata

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/policy_response.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/mocked_data/policy_response.cy.ts
@@ -61,8 +61,7 @@ describe.skip('Endpoint Policy Response', () => {
     login();
   });
 
-  // TODO failing test skipped https://github.com/elastic/kibana/issues/162428
-  describe.skip('from Fleet Agent Details page', () => {
+  describe('from Fleet Agent Details page', () => {
     it('should display policy response with errors', () => {
       navigateToFleetAgentDetails(endpointMetadata.agent.id);
 

--- a/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts
@@ -44,8 +44,7 @@ export default function ({ getService }: FtrProviderContext) {
   const endpointTestResources = getService('endpointTestResources');
 
   describe('test metadata apis', () => {
-    // FLAKY: https://github.com/elastic/kibana/issues/151854
-    describe.skip('list endpoints GET route', () => {
+    describe('list endpoints GET route', () => {
       const numberOfHostsInFixture = 2;
       let agent1Timestamp: number;
       let agent2Timestamp: number;


### PR DESCRIPTION
## Summary

Unskip tests that were skipped during a package release that was rolled back.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->