### PR TITLE
[Security Solution] Prevent rules table auto-refreshing on window focus when auto-refresh disabled

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
@@ -296,8 +296,8 @@ export const RulesTableContextProvider = ({ children }: RulesTableContextProvide
     },
     {
       // We don't need refreshes on windows focus and reconnects if auto-refresh if off
-      refetchOnWindowFocus: isRefreshOn,
-      refetchOnReconnect: isRefreshOn,
+      refetchOnWindowFocus: isRefreshOn && !isActionInProgress,
+      refetchOnReconnect: isRefreshOn && !isActionInProgress,
       refetchInterval: isRefreshOn && !isActionInProgress && autoRefreshSettings.value,
       keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
     }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
@@ -295,7 +295,9 @@ export const RulesTableContextProvider = ({ children }: RulesTableContextProvide
       pagination,
     },
     {
-      enabled: isRefreshOn, // We don't need refreshes on windows focus and reconnects if auto-refresh if off
+      // We don't need refreshes on windows focus and reconnects if auto-refresh if off
+      refetchOnWindowFocus: isRefreshOn,
+      refetchOnReconnect: isRefreshOn,
       refetchInterval: isRefreshOn && !isActionInProgress && autoRefreshSettings.value,
       keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
     }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/components/rules_table/rules_table/rules_table_context.tsx
@@ -295,6 +295,7 @@ export const RulesTableContextProvider = ({ children }: RulesTableContextProvide
       pagination,
     },
     {
+      enabled: isRefreshOn, // We don't need refreshes on windows focus and reconnects if auto-refresh if off
       refetchInterval: isRefreshOn && !isActionInProgress && autoRefreshSettings.value,
       keepPreviousData: true, // Use this option so that the state doesn't jump between "success" and "loading" on page change
     }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -50,7 +50,7 @@ describe(
       login();
     });
 
-    it('gets disabled when any rule selected and enabled after rules unselected', () => {
+    it('gets deactivated when any rule selected and activated after rules unselected', () => {
       visit(DETECTIONS_RULE_MANAGEMENT_URL);
 
       expectNumberOfRules(RULES_MANAGEMENT_TABLE, NUM_OF_TEST_RULES);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_auto_refresh.cy.ts
@@ -42,15 +42,15 @@ describe(
       cleanKibana();
       login();
 
+      setRulesTableAutoRefreshIntervalSetting({
+        enabled: true,
+        refreshInterval: RULES_TABLE_REFRESH_INTERVAL_MS,
+      });
       createRule(getNewRule({ name: 'Test rule 1', rule_id: '1', enabled: false }));
     });
 
     beforeEach(() => {
       login();
-      setRulesTableAutoRefreshIntervalSetting({
-        enabled: true,
-        refreshInterval: RULES_TABLE_REFRESH_INTERVAL_MS,
-      });
     });
 
     it('gets deactivated when any rule selected and activated after rules unselected', () => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -519,6 +519,16 @@ const unselectRuleByName = (ruleName: string) => {
   getRuleRow(ruleName).find(EUI_CHECKBOX).should('not.be.checked');
 };
 
+/**
+ * Set Kibana `securitySolution:rulesTableRefresh` setting looking like
+ *
+ * ```
+ * { "on": true, "value": 60000 }
+ * ```
+ *
+ * @param enabled whether the auto-refresh is enabled
+ * @param refreshInterval refresh interval in milliseconds
+ */
 export const setRulesTableAutoRefreshIntervalSetting = ({
   enabled,
   refreshInterval,

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { DEFAULT_RULES_TABLE_REFRESH_SETTING } from '@kbn/security-solution-plugin/common/constants';
 import {
   COLLAPSED_ACTION_BTN,
   CUSTOM_RULES_BTN,
@@ -64,6 +65,7 @@ import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 
 import { goToRuleEditSettings } from './rule_details';
 import { goToActionsStepTab } from './create_new_rule';
+import { setKibanaSetting } from './api_calls/kibana_advanced_settings';
 
 export const getRulesManagementTableRows = () => cy.get(RULES_MANAGEMENT_TABLE).find(RULES_ROW);
 
@@ -515,4 +517,20 @@ const unselectRuleByName = (ruleName: string) => {
   getRuleRow(ruleName).find(EUI_CHECKBOX).uncheck();
   cy.log(`Make sure rule "${ruleName}" has been unselected`);
   getRuleRow(ruleName).find(EUI_CHECKBOX).should('not.be.checked');
+};
+
+export const setRulesTableAutoRefreshIntervalSetting = ({
+  enabled,
+  refreshInterval,
+}: {
+  enabled: boolean;
+  refreshInterval: number; // milliseconds
+}) => {
+  setKibanaSetting(
+    DEFAULT_RULES_TABLE_REFRESH_SETTING,
+    JSON.stringify({
+      on: enabled,
+      value: refreshInterval,
+    })
+  );
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/kibana_advanced_settings.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/kibana_advanced_settings.ts
@@ -5,30 +5,27 @@
  * 2.0.
  */
 
+import { SECURITY_SOLUTION_SHOW_RELATED_INTEGRATIONS_ID } from '@kbn/management-settings-ids';
+import { ENABLE_EXPANDABLE_FLYOUT_SETTING } from '@kbn/security-solution-plugin/common/constants';
 import { rootRequest } from '../common';
 
-const kibanaSettings = (body: Cypress.RequestBody) => {
+export const setKibanaSetting = (key: string, value: boolean | number | string) => {
   rootRequest({
     method: 'POST',
     url: 'internal/kibana/settings',
-    body,
+    body: { changes: { [key]: value } },
     headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
   });
 };
 
-const relatedIntegrationsBody = (status: boolean): Cypress.RequestBody => {
-  return { changes: { 'securitySolution:showRelatedIntegrations': status } };
-};
-
 export const enableRelatedIntegrations = () => {
-  kibanaSettings(relatedIntegrationsBody(true));
+  setKibanaSetting(SECURITY_SOLUTION_SHOW_RELATED_INTEGRATIONS_ID, true);
 };
 
 export const disableRelatedIntegrations = () => {
-  kibanaSettings(relatedIntegrationsBody(false));
+  setKibanaSetting(SECURITY_SOLUTION_SHOW_RELATED_INTEGRATIONS_ID, false);
 };
 
 export const disableExpandableFlyout = () => {
-  const body = { changes: { 'securitySolution:enableExpandableFlyout': false } };
-  kibanaSettings(body);
+  setKibanaSetting(ENABLE_EXPANDABLE_FLYOUT_SETTING, false);
 };

--- a/x-pack/test/security_solution_cypress/cypress/tsconfig.json
+++ b/x-pack/test/security_solution_cypress/cypress/tsconfig.json
@@ -37,6 +37,7 @@
     "@kbn/config-schema",
     "@kbn/lists-plugin",
     "@kbn/securitysolution-list-constants",
-    "@kbn/security-plugin"
+    "@kbn/security-plugin",
+    "@kbn/management-settings-ids"
   ]
 }


### PR DESCRIPTION
**Fixes: https://github.com/elastic/kibana/issues/165221**

## Summary

This PR prevents rules management table from being auto-refreshed on window focus or on reconnect if auto-refresh is disabled.

*Before:*

Auto-refresh is switched off

https://github.com/elastic/kibana/assets/3775283/9536cc47-27b3-424a-a0a6-b3d32d40b9e2

Auto-refresh is switched off AND a rule is selected

https://github.com/elastic/kibana/assets/3775283/dbf9c899-85cc-465b-8f78-303ebee0cece

*After:*

Auto-refresh is switched off

https://github.com/elastic/kibana/assets/3775283/e7b98d15-5f33-44dc-b064-1014ec9382f9

Auto-refresh is switched off AND a rule is selected

https://github.com/elastic/kibana/assets/3775283/39a8fa9d-a2e8-451c-879b-5c08492518c9


## Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


## Flaky test runner

[rules_table_auto_refresh.cy.ts (150 runs)](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3027) 🟢
