### PR TITLE
[Security Solution] [Elastic AI Assistant] Amends Assistant Avatar

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/assistant_title/index.tsx
@@ -10,6 +10,7 @@ import {
   EuiButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiLink,
   EuiModalHeaderTitle,
   EuiPopover,
@@ -18,10 +19,10 @@ import {
 } from '@elastic/eui';
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import * as i18n from '../translations';
 import type { Conversation } from '../../..';
 import { ConnectorSelectorInline } from '../../connectorland/connector_selector_inline/connector_selector_inline';
-import { AssistantAvatar } from '../assistant_avatar/assistant_avatar';
 
 /**
  * Renders a header title, a tooltip button, and a popover with
@@ -73,8 +74,13 @@ export const AssistantTitle: React.FC<{
   return (
     <EuiModalHeaderTitle>
       <EuiFlexGroup gutterSize="m">
-        <EuiFlexItem grow={false}>
-          <AssistantAvatar data-test-subj="titleIcon" size={'m'} />
+        <EuiFlexItem
+          grow={false}
+          css={css`
+            margin-top: 3px;
+          `}
+        >
+          <EuiIcon data-test-subj="titleIcon" type="logoSecurity" size="xl" />
         </EuiFlexItem>
         <EuiFlexGroup direction="column" gutterSize="none" justifyContent="center">
           <EuiFlexItem grow={false}>

--- a/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/connectorland/connector_setup/index.tsx
@@ -25,7 +25,6 @@ import { clearPresentationData, conversationHasNoPresentationData } from './help
 import * as i18n from '../translations';
 import { useAssistantContext } from '../../assistant_context';
 import { useLoadConnectors } from '../use_load_connectors';
-import { AssistantAvatar } from '../../assistant/assistant_avatar/assistant_avatar';
 import { getGenAiConfig } from '../helpers';
 
 const ConnectorButtonWrapper = styled.div`
@@ -180,7 +179,7 @@ export const useConnectorSetup = ({
               name={i18n.CONNECTOR_SETUP_USER_ASSISTANT}
               size="l"
               color="subdued"
-              iconType={AssistantAvatar}
+              iconType="logoSecurity"
             />
           ),
           timestamp: `${i18n.CONNECTOR_SETUP_TIMESTAMP_AT}: ${message.timestamp}`,

--- a/x-pack/plugins/security_solution/public/app/home/global_header/assistant_header_link.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/global_header/assistant_header_link.tsx
@@ -5,12 +5,11 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiToolTip } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiIcon, EuiToolTip } from '@elastic/eui';
 import React, { useCallback } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { useAssistantContext } from '@kbn/elastic-assistant/impl/assistant_context';
-import { AssistantAvatar } from '@kbn/elastic-assistant';
 
 const isMac = navigator.platform.toLowerCase().indexOf('mac') >= 0;
 
@@ -40,7 +39,7 @@ export const AssistantHeaderLink = React.memo(() => {
       <EuiHeaderLink data-test-subj="assistantHeaderLink" color="primary" onClick={showOverlay}>
         <EuiFlexGroup gutterSize="s" alignItems="center">
           <EuiFlexItem grow={false}>
-            <AssistantAvatar size="xs" />
+            <EuiIcon data-test-subj="titleIcon" type="logoSecurity" size="m" />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             {i18n.translate('xpack.securitySolution.globalHeader.assistantHeaderLink', {

--- a/x-pack/plugins/security_solution/public/assistant/get_comments/index.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/get_comments/index.tsx
@@ -10,7 +10,6 @@ import type { Conversation } from '@kbn/elastic-assistant';
 import { EuiAvatar, EuiMarkdownFormat, EuiText } from '@elastic/eui';
 import React from 'react';
 
-import { AssistantAvatar } from '@kbn/elastic-assistant';
 import { CommentActions } from '../comment_actions';
 import * as i18n from './translations';
 
@@ -58,7 +57,7 @@ export const getComments = ({
       timelineAvatar: isUser ? (
         <EuiAvatar name="user" size="l" color="subdued" iconType="userAvatar" />
       ) : (
-        <EuiAvatar name="machine" size="l" color="subdued" iconType={AssistantAvatar} />
+        <EuiAvatar name="machine" size="l" color="subdued" iconType="logoSecurity" />
       ),
       timestamp: i18n.AT(
         message.timestamp.length === 0 ? new Date().toLocaleString() : message.timestamp


### PR DESCRIPTION
> [!WARNING]
> This PR is waiting on confirmation from @elastic/security-design. Please contact @dimadavid before merging or closing this PR. Thank you! 

## Summary

Amends Assistant avatar to be `logoSecurity` within the Assistant `title`, `conversation avatar`, and within the new global header action button. 



##### Assistant

<p align="center">
  <img width="500" src="https://github.com/elastic/kibana/assets/2946766/2af38869-dc08-4686-9c9d-4908a7a685c1" />
</p> 

##### Global Header Action Button

<p align="center">
  <img width="500" src="https://github.com/elastic/kibana/assets/2946766/2ef9bf70-6bde-44d9-90f1-132710fa7d02" />
</p> 
