### PR TITLE
[Infra UI] Fix node details page re-render

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/metric_detail/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/metric_detail/index.tsx
@@ -19,7 +19,7 @@ export const MetricDetail = () => {
     params: { type: nodeType, node: nodeName },
   } = useRouteMatch<{ type: InventoryItemType; node: string }>();
 
-  const PageContent = () => (nodeType === 'host' ? <AssetDetailPage /> : <MetricDetailPage />);
+  const pageContent = nodeType === 'host' ? <AssetDetailPage /> : <MetricDetailPage />;
 
   useMetricsBreadcrumbs([
     {
@@ -29,9 +29,7 @@ export const MetricDetail = () => {
 
   return (
     <EuiErrorBoundary>
-      <MetricsTimeProvider>
-        <PageContent />
-      </MetricsTimeProvider>
+      <MetricsTimeProvider>{pageContent}</MetricsTimeProvider>
     </EuiErrorBoundary>
   );
 };


### PR DESCRIPTION
fixes [#165287](https://github.com/elastic/kibana/issues/165287)

## Summary

This PR fixes the page re-rendering that happened when switching the Asset Details tabs.



https://github.com/elastic/kibana/assets/2767137/2fc257a2-3f5c-41b9-90ea-64b237a66484



### How to tests
- Start a local Kibana instance
- Navigate to Infrastructure > Hosts
- Click on a host name to be redirected to the Node Details page click on the tabs.
