### PR TITLE
Log more information on requests that fail at global router level

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/router.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { Router, type RouterOptions } from './router';
+import { queryString, Router, type RouterOptions } from './router';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { schema } from '@kbn/config-schema';
 
@@ -86,4 +86,18 @@ describe('Router', () => {
       expect(route.options).toEqual({});
     });
   });
+});
+
+describe('queryString', () => {
+  it('returns empty string if the provided RequestQuery is undefined', () => {
+    expect(queryString()).toEqual('');
+  });
+
+  it('returns empty string if there are no query parameters', () => {
+    expect(queryString({})).toEqual('');
+  });
+
+  it('converts a RequestQuery to the appropriate string', () => {
+    expect(queryString({ a: true, b: 'foo'})).toEqual('?a=true&b=foo');
+  })
 });

--- a/packages/core/http/core-http-router-server-internal/src/router.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.test.ts
@@ -98,6 +98,6 @@ describe('queryString', () => {
   });
 
   it('converts a RequestQuery to the appropriate string', () => {
-    expect(queryString({ a: true, b: 'foo'})).toEqual('?a=true&b=foo');
-  })
+    expect(queryString({ a: true, b: 'foo' })).toEqual('?a=true&b=foo');
+  });
 });

--- a/packages/core/http/core-http-router-server-internal/src/router.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { queryString, Router, type RouterOptions } from './router';
+import { Router, type RouterOptions } from './router';
 import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
 import { schema } from '@kbn/config-schema';
 
@@ -85,19 +85,5 @@ describe('Router', () => {
       const [route] = router.getRoutes();
       expect(route.options).toEqual({});
     });
-  });
-});
-
-describe('queryString', () => {
-  it('returns empty string if the provided RequestQuery is undefined', () => {
-    expect(queryString()).toEqual('');
-  });
-
-  it('returns empty string if there are no query parameters', () => {
-    expect(queryString({})).toEqual('');
-  });
-
-  it('converts a RequestQuery to the appropriate string', () => {
-    expect(queryString({ a: true, b: 'foo' })).toEqual('?a=true&b=foo');
   });
 });

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import type { Request, ResponseToolkit, RequestQuery } from '@hapi/hapi';
+import type { Request, ResponseToolkit } from '@hapi/hapi';
 import apm from 'elastic-apm-node';
 import { isConfigSchema } from '@kbn/config-schema';
 import type { Logger } from '@kbn/logging';
@@ -200,10 +200,10 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
     try {
       kibanaRequest = CoreKibanaRequest.from(request, routeSchemas);
     } catch (error) {
-      this.log.error(
-        `400 Bad Request - ${request.path}`,
-        { error, http: { response: { status_code: 400 } } }
-      );
+      this.log.error(`400 Bad Request - ${request.path}`, {
+        error,
+        http: { response: { status_code: 400 } },
+      });
 
       return hapiResponseAdapter.toBadRequest(error.message);
     }
@@ -217,20 +217,20 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
 
       // forward 401 errors from ES client
       if (isElasticsearchUnauthorizedError(error)) {
-        this.log.error(
-          `401 Unauthorized - ${request.path}`,
-          { error, http: { response: { status_code: 401 } } }
-        );
+        this.log.error(`401 Unauthorized - ${request.path}`, {
+          error,
+          http: { response: { status_code: 401 } },
+        });
         return hapiResponseAdapter.handle(
           kibanaResponseFactory.unauthorized(convertEsUnauthorized(error))
         );
       }
 
       // return a generic 500 to avoid error info / stack trace surfacing
-      this.log.error(
-        `500 Server Error - ${request.path}`,
-        { error, http: { response: { status_code: 500 } } }
-      );
+      this.log.error(`500 Server Error - ${request.path}`, {
+        error,
+        http: { response: { status_code: 500 } },
+      });
       return hapiResponseAdapter.toInternalError();
     }
   }

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -199,31 +199,38 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
     const hapiResponseAdapter = new HapiResponseAdapter(responseToolkit);
     try {
       kibanaRequest = CoreKibanaRequest.from(request, routeSchemas);
-    } catch (e) {
-      this.log.error(`400 Bad Request - ${request.path}${queryString(request.query)}`);
-      this.log.error(e);
-      return hapiResponseAdapter.toBadRequest(e.message);
+    } catch (error) {
+      this.log.error(
+        `400 Bad Request - ${request.path}`,
+        { error, http: { response: { status_code: 400 } } }
+      );
+
+      return hapiResponseAdapter.toBadRequest(error.message);
     }
 
     try {
       const kibanaResponse = await handler(kibanaRequest, kibanaResponseFactory);
       return hapiResponseAdapter.handle(kibanaResponse);
-    } catch (e) {
+    } catch (error) {
       // capture error
-      apm.captureError(e);
+      apm.captureError(error);
 
       // forward 401 errors from ES client
-      if (isElasticsearchUnauthorizedError(e)) {
-        this.log.error(`401 Unauthorized - ${request.path}${queryString(request.query)}`);
-        this.log.error(e);
+      if (isElasticsearchUnauthorizedError(error)) {
+        this.log.error(
+          `401 Unauthorized - ${request.path}`,
+          { error, http: { response: { status_code: 401 } } }
+        );
         return hapiResponseAdapter.handle(
-          kibanaResponseFactory.unauthorized(convertEsUnauthorized(e))
+          kibanaResponseFactory.unauthorized(convertEsUnauthorized(error))
         );
       }
 
       // return a generic 500 to avoid error info / stack trace surfacing
-      this.log.error(`500 Server Error - ${request.path}${queryString(request.query)}`);
-      this.log.error(e);
+      this.log.error(
+        `500 Server Error - ${request.path}`,
+        { error, http: { response: { status_code: 500 } } }
+      );
       return hapiResponseAdapter.toInternalError();
     }
   }
@@ -264,13 +271,3 @@ type WithoutHeadArgument<T> = T extends (first: any, ...rest: infer Params) => i
 type RequestHandlerEnhanced<P, Q, B, Method extends RouteMethod> = WithoutHeadArgument<
   RequestHandler<P, Q, B, RequestHandlerContextBase, Method>
 >;
-
-export function queryString(requestQuery?: RequestQuery): string {
-  const entries = Object.entries(requestQuery ?? {});
-
-  if (!entries?.length) {
-    return '';
-  }
-
-  return `?` + entries.map(([key, value]) => `${key}=${value}`).join('&');
-}

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -576,11 +576,14 @@ describe('Handler', () => {
       'An internal server error occurred. Check Kibana server logs for details.'
     );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
+      Array [
         Array [
-          Array [
-            [Error: unexpected error],
-          ],
-        ]
+          "500 Server Error - /",
+        ],
+        Array [
+          [Error: unexpected error],
+        ],
+      ]
     `);
   });
 
@@ -617,6 +620,9 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
+          "500 Server Error - /",
+        ],
+        Array [
           [Error: Unauthorized],
         ],
       ]
@@ -638,6 +644,9 @@ describe('Handler', () => {
     );
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
+        Array [
+          "500 Server Error - /",
+        ],
         Array [
           [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
         ],
@@ -672,6 +681,17 @@ describe('Handler', () => {
       message: '[request query.page]: expected value of type [number] but got [string]',
       statusCode: 400,
     });
+
+    expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "400 Bad Request - /?page=one",
+        ],
+        Array [
+          [Error: [request query.page]: expected value of type [number] but got [string]],
+        ],
+      ]
+    `);
   });
 
   it('accept to receive an array payload', async () => {
@@ -1145,6 +1165,9 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
+            "500 Server Error - /",
+          ],
+          Array [
             [Error: expected 'location' header to be set],
           ],
         ]
@@ -1551,6 +1574,9 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
+            "500 Server Error - /",
+          ],
+          Array [
             [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
           ],
         ]
@@ -1619,6 +1645,9 @@ describe('Response factory', () => {
 
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
+          Array [
+            "500 Server Error - /",
+          ],
           Array [
             [Error: expected 'location' header to be set],
           ],
@@ -1760,6 +1789,9 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
+            "500 Server Error - /",
+          ],
+          Array [
             [Error: expected error message to be provided],
           ],
         ]
@@ -1786,6 +1818,9 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
+            "500 Server Error - /",
+          ],
+          Array [
             [Error: expected error message to be provided],
           ],
         ]
@@ -1811,6 +1846,9 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
+            "500 Server Error - /",
+          ],
+          Array [
             [Error: options.statusCode is expected to be set. given options: undefined],
           ],
         ]
@@ -1835,6 +1873,9 @@ describe('Response factory', () => {
       );
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
+          Array [
+            "500 Server Error - /",
+          ],
           Array [
             [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
           ],

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -579,9 +579,14 @@ describe('Handler', () => {
       Array [
         Array [
           "500 Server Error - /",
-        ],
-        Array [
-          [Error: unexpected error],
+          Object {
+            "error": [Error: unexpected error],
+            "http": Object {
+              "response": Object {
+                "status_code": 500,
+              },
+            },
+          },
         ],
       ]
     `);
@@ -621,9 +626,14 @@ describe('Handler', () => {
       Array [
         Array [
           "500 Server Error - /",
-        ],
-        Array [
-          [Error: Unauthorized],
+          Object {
+            "error": [Error: Unauthorized],
+            "http": Object {
+              "response": Object {
+                "status_code": 500,
+              },
+            },
+          },
         ],
       ]
     `);
@@ -646,9 +656,14 @@ describe('Handler', () => {
       Array [
         Array [
           "500 Server Error - /",
-        ],
-        Array [
-          [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
+          Object {
+            "error": [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
+            "http": Object {
+              "response": Object {
+                "status_code": 500,
+              },
+            },
+          },
         ],
       ]
     `);
@@ -685,10 +700,15 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
-          "400 Bad Request - /?page=one",
-        ],
-        Array [
-          [Error: [request query.page]: expected value of type [number] but got [string]],
+          "400 Bad Request - /",
+          Object {
+            "error": [Error: [request query.page]: expected value of type [number] but got [string]],
+            "http": Object {
+              "response": Object {
+                "status_code": 400,
+              },
+            },
+          },
         ],
       ]
     `);
@@ -1166,9 +1186,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: expected 'location' header to be set],
+            Object {
+              "error": [Error: expected 'location' header to be set],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1575,9 +1600,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
+            Object {
+              "error": [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1647,9 +1677,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: expected 'location' header to be set],
+            Object {
+              "error": [Error: expected 'location' header to be set],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1790,9 +1825,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: expected error message to be provided],
+            Object {
+              "error": [Error: expected error message to be provided],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1819,9 +1859,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: expected error message to be provided],
+            Object {
+              "error": [Error: expected error message to be provided],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1847,9 +1892,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: options.statusCode is expected to be set. given options: undefined],
+            Object {
+              "error": [Error: options.statusCode is expected to be set. given options: undefined],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);
@@ -1875,9 +1925,14 @@ describe('Response factory', () => {
         Array [
           Array [
             "500 Server Error - /",
-          ],
-          Array [
-            [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
+            Object {
+              "error": [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
+              "http": Object {
+                "response": Object {
+                  "status_code": 500,
+                },
+              },
+            },
           ],
         ]
       `);


### PR DESCRIPTION
There are certain occasions where Kibana UI shows a blank page (e.g. on this [failed test](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2999)).
Blank pages can happen when browsers are not able to fetch one or more of the bootstrap resources, e.g. `/bootstrap.js`.
Sometimes, Kibana server-side logs don't contain any information at all as to what caused the failure.

This PR adds a bit more information in the logs, hoping it will help us understanding why some of these requests fail sometimes.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->