### PR TITLE
[8.10] [Logs onboarding] Getting elastic-agent state in a more reliably way (#165205)

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
+++ b/x-pack/plugins/observability_onboarding/public/assets/standalone_agent_setup.sh
@@ -124,14 +124,20 @@ waitForElasticAgentStatus
 if [ "$?" -ne 0 ]; then
   updateStepProgress "ea-status" "warning" "Unable to determine agent status"
 fi
-ELASTIC_AGENT_STATE="$(elastic-agent status | grep -m1 State | sed 's/State: //')"
-ELASTIC_AGENT_MESSAGE="$(elastic-agent status | grep -m1 Message | sed 's/Message: //')"
-if [ "${ELASTIC_AGENT_STATE}" = "HEALTHY" ] && [ "${ELASTIC_AGENT_MESSAGE}" = "Running" ]; then
+
+# https://www.elastic.co/guide/en/fleet/current/elastic-agent-cmd-options.html#elastic-agent-status-command
+ELASTIC_AGENT_STATES=(STARTING CONFIGURING HEALTHY DEGRADED FAILED STOPPING UPGRADING ROLLBACK)
+
+# Get elastic-agent status in json format | removing extra states in the json | finding "state":value | removing , | removing "state": | trimming the result
+ELASTIC_AGENT_STATE="$(elastic-agent status --output json | sed -n '/components/q;p' | grep state | sed 's/\(.*\),/\1 /' | sed 's/"state": //' | sed 's/\s//g')"
+# Get elastic-agent status in json format | removing extra states in the json | finding "message":value | removing , | removing "message": | trimming the result | removing ""
+ELASTIC_AGENT_MESSAGE="$(elastic-agent status --output json | sed -n '/components/q;p' | grep message | sed 's/\(.*\),/\1 /' | sed 's/"message": //' | sed 's/\s//g' | sed 's/\"//g')"
+if [ "${ELASTIC_AGENT_STATE}" = "2" ] && [ "${ELASTIC_AGENT_MESSAGE}" = "Running" ]; then
   echo "Elastic Agent running"
   echo "Download and save configuration to ${cfg}"
   updateStepProgress "ea-status" "complete"
 else
-  updateStepProgress "ea-status" "warning" "Expected agent status HEALTHY / Running but got ${ELASTIC_AGENT_STATE} / ${ELASTIC_AGENT_MESSAGE}"
+  updateStepProgress "ea-status" "warning" "Expected agent status HEALTHY / Running but got ${ELASTIC_AGENT_STATES[ELASTIC_AGENT_STATE]} / ${ELASTIC_AGENT_MESSAGE}"
 fi
 
 downloadElasticAgentConfig() {


### PR DESCRIPTION
{defaultPrDescription}

<!--BACKPORT {commits} BACKPORT-->