### PR TITLE
Fix a typo in `roles.yml` of the `kbn-es` package.

### DIFF
--- a/packages/kbn-es/src/ess_resources/roles.yml
+++ b/packages/kbn-es/src/ess_resources/roles.yml
@@ -1,4 +1,3 @@
----
 system_indices_superuser:
   cluster: ['all']
   indices:


### PR DESCRIPTION
## Summary

Luckily ES ignores invalid role definitions in `roles.yml`, but it still logs the following error:
```
node scripts/functional_tests_server.js --config x-pack/test_serverless/api_integration/test_suites/search/config.ts
----
docker logs -f es01
....
[2023-08-31T09:36:55,775][ERROR][o.e.x.s.a.s.FileRolesStore] [es01] invalid role definition [null] in roles file [/usr/share/elasticsearch/config/roles.yml]. skipping role..
```