### PR TITLE
Avoid running incompatible Platform Security Serverless tests on MKI.

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/security/authentication.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/security/authentication.ts
@@ -144,7 +144,8 @@ export default function ({ getService }: FtrProviderContext) {
             metadata: {},
             operator: true,
             roles: ['superuser'],
-            username: 'elastic_serverless',
+            // We use `elastic` for MKI, and `elastic_serverless` for any other testing environment.
+            username: expect.stringContaining('elastic'),
           });
           expect(status).toBe(200);
         });

--- a/x-pack/test_serverless/api_integration/test_suites/common/security/authentication_http.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/security/authentication_http.ts
@@ -12,40 +12,45 @@ export default function ({ getService }: FtrProviderContext) {
   const supertest = getService('supertestWithoutAuth');
 
   describe('security/authentication/http', function () {
-    it('allows JWT HTTP authentication only for selected routes', async () => {
-      const jsonWebToken =
-        'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2tpYmFuYS5lbGFzdGljLmNvL2p3dC8iLCJzdWIiOiJlbGFzdGljLWFnZW50IiwiYXVkIjoiZWxhc3RpY3NlYXJjaCIsIm5hbWUiOiJFbGFzdGljIEFnZW50IiwiaWF0Ijo5NDY2ODQ4MDAsImV4cCI6NDA3MDkwODgwMH0.P7RHKZlLskS5DfVRqoVO4ivoIq9rXl2-GW6hhC9NvTSkwphYivcjpTVcyENZvxTTvJJNqcyx6rF3T-7otTTIHBOZIMhZauc5dob-sqcN_mT2htqm3BpSdlJlz60TBq6diOtlNhV212gQCEJMPZj0MNj7kZRj_GsECrTaU7FU0A3HAzkbdx15vQJMKZiFbbQCVI7-X2J0bZzQKIWfMHD-VgHFwOe6nomT-jbYIXtCBDd6fNj1zTKRl-_uzjVqNK-h8YW1h6tE4xvZmXyHQ1-9yNKZIWC7iEaPkBLaBKQulLU5MvW3AtVDUhzm6--5H1J85JH5QhRrnKYRon7ZW5q1AQ';
+    describe('JWT', () => {
+      // When we run tests on MKI, JWT realm is configured differently, and we cannot handcraft valid JWTs.
+      this.tags(['skipMKI']);
 
-      // Check 5 routes that are currently known to accept JWT as a means of authentication.
-      for (const allowedPath of [
-        '/api/status',
-        '/api/stats',
-        '/api/task_manager/_background_task_utilization',
-        '/internal/task_manager/_background_task_utilization',
-        '/api/task_manager/metrics',
-      ]) {
+      it('allows JWT HTTP authentication only for selected routes', async () => {
+        const jsonWebToken =
+          'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2tpYmFuYS5lbGFzdGljLmNvL2p3dC8iLCJzdWIiOiJlbGFzdGljLWFnZW50IiwiYXVkIjoiZWxhc3RpY3NlYXJjaCIsIm5hbWUiOiJFbGFzdGljIEFnZW50IiwiaWF0Ijo5NDY2ODQ4MDAsImV4cCI6NDA3MDkwODgwMH0.P7RHKZlLskS5DfVRqoVO4ivoIq9rXl2-GW6hhC9NvTSkwphYivcjpTVcyENZvxTTvJJNqcyx6rF3T-7otTTIHBOZIMhZauc5dob-sqcN_mT2htqm3BpSdlJlz60TBq6diOtlNhV212gQCEJMPZj0MNj7kZRj_GsECrTaU7FU0A3HAzkbdx15vQJMKZiFbbQCVI7-X2J0bZzQKIWfMHD-VgHFwOe6nomT-jbYIXtCBDd6fNj1zTKRl-_uzjVqNK-h8YW1h6tE4xvZmXyHQ1-9yNKZIWC7iEaPkBLaBKQulLU5MvW3AtVDUhzm6--5H1J85JH5QhRrnKYRon7ZW5q1AQ';
+
+        // Check 5 routes that are currently known to accept JWT as a means of authentication.
+        for (const allowedPath of [
+          '/api/status',
+          '/api/stats',
+          '/api/task_manager/_background_task_utilization',
+          '/internal/task_manager/_background_task_utilization',
+          '/api/task_manager/metrics',
+        ]) {
+          await supertest
+            .get(allowedPath)
+            .set('Authorization', `Bearer ${jsonWebToken}`)
+            .set('ES-Client-Authentication', 'SharedSecret my_super_secret')
+            .set(svlCommonApi.getInternalRequestHeader())
+            .expect(200);
+        }
+
+        // Make sure it's not possible to use JWT to have interactive sessions.
         await supertest
-          .get(allowedPath)
+          .get('/')
+          .set('Authorization', `Bearer ${jsonWebToken}`)
+          .set('ES-Client-Authentication', 'SharedSecret my_super_secret')
+          .expect(401);
+
+        // Make sure it's not possible to use JWT to access any other APIs.
+        await supertest
+          .get('/internal/security/me')
           .set('Authorization', `Bearer ${jsonWebToken}`)
           .set('ES-Client-Authentication', 'SharedSecret my_super_secret')
           .set(svlCommonApi.getInternalRequestHeader())
-          .expect(200);
-      }
-
-      // Make sure it's not possible to use JWT to have interactive sessions.
-      await supertest
-        .get('/')
-        .set('Authorization', `Bearer ${jsonWebToken}`)
-        .set('ES-Client-Authentication', 'SharedSecret my_super_secret')
-        .expect(401);
-
-      // Make sure it's not possible to use JWT to access any other APIs.
-      await supertest
-        .get('/internal/security/me')
-        .set('Authorization', `Bearer ${jsonWebToken}`)
-        .set('ES-Client-Authentication', 'SharedSecret my_super_secret')
-        .set(svlCommonApi.getInternalRequestHeader())
-        .expect(401);
+          .expect(401);
+      });
     });
   });
 }

--- a/x-pack/test_serverless/api_integration/test_suites/common/security/user_profiles.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/security/user_profiles.ts
@@ -17,6 +17,10 @@ export default function ({ getService }: FtrProviderContext) {
   describe('security/user_profiles', function () {
     describe('route access', () => {
       describe('internal', () => {
+        // When we run tests on MKI, SAML realm is configured differently, and we cannot handcraft SAML responses to
+        // log in as SAML users.
+        this.tags(['skipMKI']);
+
         it('update', async () => {
           const { status } = await supertestWithoutAuth
             .post(`/internal/security/user_profile/_data`)


### PR DESCRIPTION
## Summary

When we run tests on MKI, we cannot override Elasticsearch security realm definitions. This means that any of our tests relying on a custom Elasticsearch security realm (SAML and JWT) won't work on MKI.

## How to test

See `Kibana serverless cheat sheet` on how to run tests against MKI. Until https://github.com/elastic/qaf-tests/pull/30 is merged, you'd need to also add `--exclude-tag=skipMKI` to the test runner command.

/cc @dmlemeshko 

