### PR TITLE
[Ops] Fix serverless startup issue around importing @kbn/dev-utils 

### DIFF
--- a/src/cli/serve/serve.js
+++ b/src/cli/serve/serve.js
@@ -15,10 +15,12 @@ import { isKibanaDistributable } from '@kbn/repo-info';
 import { readKeystore } from '../keystore/read_keystore';
 import { compileConfigStack } from './compile_config_stack';
 import { getConfigFromFiles } from '@kbn/config';
-import { kibanaDevServiceAccount } from '@kbn/dev-utils';
 
 const DEV_MODE_PATH = '@kbn/cli-dev-mode';
 const DEV_MODE_SUPPORTED = canRequire(DEV_MODE_PATH);
+const KIBANA_DEV_SERVICE_ACCOUNT_TOKEN =
+  process.env.TEST_KIBANA_SERVICE_ACCOUNT_TOKEN ||
+  'AAEAAWVsYXN0aWMva2liYW5hL2tpYmFuYS1kZXY6VVVVVVVVTEstKiBaNA';
 
 function canRequire(path) {
   try {
@@ -70,7 +72,7 @@ export function applyConfigOverrides(rawConfig, opts, extraCliOptions) {
 
   if (opts.dev) {
     if (opts.serverless) {
-      set('elasticsearch.serviceAccountToken', kibanaDevServiceAccount.token);
+      set('elasticsearch.serviceAccountToken', KIBANA_DEV_SERVICE_ACCOUNT_TOKEN);
     }
 
     if (!has('elasticsearch.serviceAccountToken') && opts.devCredentials !== false) {
@@ -103,7 +105,6 @@ export function applyConfigOverrides(rawConfig, opts, extraCliOptions) {
       ensureNotDefined('server.ssl.truststore.path');
       ensureNotDefined('server.ssl.certificateAuthorities');
       ensureNotDefined('elasticsearch.ssl.certificateAuthorities');
-
       const elasticsearchHosts = (
         (customElasticsearchHosts.length > 0 && customElasticsearchHosts) || [
           'https://localhost:9200',


### PR DESCRIPTION
## Summary
Fixes kibana-serverless issues of this nature: https://elastic.slack.com/archives/C04L3JE8LV6/p1693450827486199 or https://elastic.slack.com/archives/C04L3JE8LV6/p1693473384616049

After #162673 - serverless images started breaking:  https://github.com/elastic/serverless-gitops/commits/main/services/kibana/versions.yaml
The issue is probably that the library `@kbn/dev-utils` is a devDependency, thus it doesn't show up in the serverless image, but it's required for the serve script. This doesn't show up locally (or probably in other kibana distros) because dev/prod dependencies are also installed together.

To solve this, I inlined the token (as it doesn't depend on anything else, it's just saved in a central place for code deduplication) - if it's a better solution, we can just move the `@kbn/dev-utils` to the prod dependencies, but I don't know enough about the context to make that decision.

- fix(kibana-serverless): inline dev service account token - in the serverless images the @kbn/dev-utils package is not linked
