### PR TITLE
[Lens] Axis label formatting independent from axis visibility

### DIFF
--- a/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
+++ b/src/plugins/chart_expressions/expression_heatmap/public/components/heatmap_component.tsx
@@ -762,24 +762,20 @@ export const HeatmapComponent: FC<HeatmapRenderProps> = memo(
               xAxisTitle={args.gridConfig.isXAxisTitleVisible ? xAxisTitle : undefined}
               yAxisTitle={args.gridConfig.isYAxisTitleVisible ? yAxisTitle : undefined}
               xAxisLabelFormatter={(v) =>
-                args.gridConfig.isXAxisLabelVisible
-                  ? `${
-                      xAccessor && formattedTable.formattedColumns[xAccessor]
-                        ? v
-                        : xValuesFormatter.convert(v)
-                    }`
-                  : ''
+                `${
+                  xAccessor && formattedTable.formattedColumns[xAccessor]
+                    ? v
+                    : xValuesFormatter.convert(v)
+                }`
               }
               yAxisLabelFormatter={
                 yAxisColumn
                   ? (v) =>
-                      args.gridConfig.isYAxisLabelVisible
-                        ? `${
-                            yAccessor && formattedTable.formattedColumns[yAccessor]
-                              ? v
-                              : yValuesFormatter.convert(v) ?? ''
-                          }`
-                        : ''
+                      `${
+                        yAccessor && formattedTable.formattedColumns[yAccessor]
+                          ? v
+                          : yValuesFormatter.convert(v) ?? ''
+                      }`
                   : undefined
               }
             />


### PR DESCRIPTION
## Summary
Due to an existing (but already resolved) [bug](https://github.com/elastic/elastic-charts/issues/1581) in elastic-chart, the Lens Heatmap introduced a workaround to avoid a reduction in the size of the heatmap chart in the suggestions panel due to the length of the axis labels.

After the fix was resolved in elastic-charts, the workaround was not removed and left a [bug](https://github.com/elastic/kibana/issues/164847) in the interface.

This PR removes the workaround introduced in https://github.com/elastic/kibana/pull/124542

fix https://github.com/elastic/kibana/issues/164847
