### PR TITLE
[Lens] Use keyword icon instead of text for field selection dropdown

### DIFF
--- a/packages/kbn-event-annotation-components/components/annotation_editor_controls/tooltip_annotation_panel.tsx
+++ b/packages/kbn-event-annotation-components/components/annotation_editor_controls/tooltip_annotation_panel.tsx
@@ -9,7 +9,7 @@
 import { htmlIdGenerator, EuiFlexItem, EuiPanel, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { useCallback, useMemo } from 'react';
-import { useExistingFieldsReader } from '@kbn/unified-field-list/src/hooks/use_existing_fields';
+import { useExistingFieldsReader, getFieldIconType } from '@kbn/unified-field-list';
 import {
   FieldOption,
   FieldOptionValue,
@@ -139,7 +139,7 @@ export function TooltipSection({
           value: {
             type: 'field',
             field: field.name,
-            dataType: field.type,
+            dataType: getFieldIconType(field),
           },
           exists: dataView.id ? hasFieldData(dataView.id, field.name) : false,
           compatible: true,

--- a/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/field_select.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/dimension_panel/field_select.tsx
@@ -12,11 +12,11 @@ import { i18n } from '@kbn/i18n';
 import { EuiComboBoxOptionOption, EuiComboBoxProps } from '@elastic/eui';
 import { useExistingFieldsReader } from '@kbn/unified-field-list/src/hooks/use_existing_fields';
 import { FieldOption, FieldOptionValue, FieldPicker } from '@kbn/visualization-ui-components';
+import { getFieldIconType } from '@kbn/unified-field-list';
 import type { OperationType } from '../form_based';
 import type { OperationSupportMatrix } from './operation_support';
 import { fieldContainsData } from '../../../shared_components';
 import type { IndexPattern } from '../../../types';
-import { getFieldType } from '../pure_utils';
 
 export type FieldChoiceWithOperationType = FieldOptionValue & {
   operationType: OperationType;
@@ -89,7 +89,7 @@ export function FieldSelect({
             value: {
               type: 'field' as const,
               field,
-              dataType: fieldInstance ? getFieldType(fieldInstance) : undefined,
+              dataType: fieldInstance ? getFieldIconType(fieldInstance) : undefined,
               // Use the operation directly, or choose the first compatible operation.
               // All fields are guaranteed to have at least one operation because they
               // won't appear in the list otherwise


### PR DESCRIPTION
## Summary

Fix #165216 

Fixed for any dimension panel:

<img width="269" alt="Screenshot 2023-08-31 at 14 22 24" src="https://github.com/elastic/kibana/assets/924948/2a8eb2c0-747f-4918-997b-1b059339a242">
<img width="275" alt="Screenshot 2023-08-31 at 14 37 46" src="https://github.com/elastic/kibana/assets/924948/0ef218b3-1400-4eb9-8f4b-65eee814e0ac">

This has been addressed also in the annotation panel:
<img width="262" alt="Screenshot 2023-08-31 at 14 37 00" src="https://github.com/elastic/kibana/assets/924948/22967182-b9bb-49c4-bfb8-48f25babd128">
