### PR TITLE
[DOCS] Cross-link to ES CCS docs

### DIFF
--- a/docs/concepts/data-views.asciidoc
+++ b/docs/concepts/data-views.asciidoc
@@ -153,6 +153,10 @@ To exclude a cluster with the name `cluster_one`:
 Once you configure a {data-source} to use the {ccs} syntax, all searches and
 aggregations using that {data-source} in {kib} take advantage of {ccs}.
 
+For more information, refer to
+{ref}/modules-cross-cluster-search.html#exclude-problematic-clusters[Excluding
+clusters or indicies from cross-cluster search].
+
 [float]
 [[delete-data-view]]
 === Delete a {data-source}


### PR DESCRIPTION
## Summary

Cross-links to [Excluding clusters or indices from cross-cluster search](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-cross-cluster-search.html#exclude-problematic-clusters) from [Use data views with cross-cluster search](https://www.elastic.co/guide/en/kibana/current/data-views.html#management-cross-cluster-search).

This was originally part of https://github.com/elastic/kibana/pull/164904

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->