### PR TITLE
GitHub create-deploy-tag workflow: Show commit SHA

### DIFF
--- a/.github/workflows/create-deploy-tag.yml
+++ b/.github/workflows/create-deploy-tag.yml
@@ -79,7 +79,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n<https://github.com/elastic/kibana/releases/tag/${{ env.COMMIT }}|${{ env.COMMIT }}>"
+                      "text": "*Commit:*\n<https://github.com/elastic/kibana/commit/${{ env.COMMIT }}|${{ env.COMMIT }}>"
                     },
                     {
                       "type": "mrkdwn",
@@ -169,7 +169,7 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
-                      "text": "*Commit:*\n<https://github.com/elastic/kibana/releases/tag/${{ env.COMMIT }}|${{ env.COMMIT }}>"
+                      "text": "*Commit:*\n<https://github.com/elastic/kibana/commit/${{ env.COMMIT }}|${{ env.COMMIT }}>"
                     }
                   ]
                 },

--- a/.github/workflows/create-deploy-tag.yml
+++ b/.github/workflows/create-deploy-tag.yml
@@ -79,6 +79,10 @@ jobs:
                     },
                     {
                       "type": "mrkdwn",
+                      "text": "*Commit:*\n<https://github.com/elastic/kibana/releases/tag/${{ env.COMMIT }}|${{ env.COMMIT }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
                       "text": "*Git tag:*\n<https://github.com/elastic/kibana/releases/tag/${{ env.TAG_NAME }}|${{ env.TAG_NAME }}>"
                     }
                   ]
@@ -103,7 +107,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Useful links:*\n\n • <https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>\n • <https://buildkite.com/elastic/kibana-tests/builds?branch=run-kibana-quality-gate-suites|QA Quality Gate pipeline>"
+                    "text": "*Useful links:*\n\n • <https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>\n • <https://example.com|QA Quality Gate pipeline>"
                   }
                 },
                 {
@@ -162,6 +166,10 @@ jobs:
                     {
                       "type": "mrkdwn",
                       "text": "*Workflow run:*\n<https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|${{ github.run_id }}>"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Commit:*\n<https://github.com/elastic/kibana/releases/tag/${{ env.COMMIT }}|${{ env.COMMIT }}>"
                     }
                   ]
                 },


### PR DESCRIPTION
Shows the commit SHA as part of the message in Slack (makes it easier to search for and copy):

<img width="458" alt="image" src="https://github.com/elastic/kibana/assets/10602/e675df23-8027-4f7a-b960-e7bfb1a476ae">

This PR also removes an incorrect URL that was temporary and changes it to `example.com` for now until we know the right one to use.