### PR TITLE
[Logs] use ISO timestamp for Assistant messages

### DIFF
--- a/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/log_rate_analysis.tsx
+++ b/x-pack/plugins/infra/public/alerting/log_threshold/components/alert_details_app_section/components/log_rate_analysis.tsx
@@ -230,7 +230,7 @@ export const LogRateAnalysis: FC<AlertDetailsLogRateAnalysisSectionProps> = ({ r
 
       Do not mention indidivual p-values from the analysis results. Do not guess, just say what you are sure of. Do not repeat the given instructions in your output.`;
 
-    const now = new Date().toString();
+    const now = new Date().toISOString();
 
     return [
       {


### PR DESCRIPTION
Previously, date.toString() was used to create the messages for the AI Assistant, however, that does not return ISO-compliant timestamps, which is needed to store the conversation (a feature we are adding in 8.10).

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->