### PR TITLE
[7.17] [Logger] Strip ANSI escape codes from the message (#164337)

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,7 @@
     "@turf/length": "^6.0.2",
     "@types/react-is": "^16.7.2",
     "JSONStream": "1.3.5",
+    "ansi-regex": "^5.0.1",
     "antlr4ts": "^0.5.0-alpha.3",
     "archiver": "^5.2.0",
     "axios": "^1.4.0",

--- a/src/core/server/logging/layouts/conversions/message.test.ts
+++ b/src/core/server/logging/layouts/conversions/message.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { LogLevel, LogRecord } from '@kbn/logging';
+import { MessageConversion } from './message';
+
+const baseRecord: LogRecord = {
+  pid: 1,
+  timestamp: new Date(),
+  level: LogLevel.Info,
+  context: '',
+  message: '',
+};
+
+describe('MessageConversion', () => {
+  test('it should keep break lines', () => {
+    expect(
+      MessageConversion.convert({ ...baseRecord, message: 'Hi!\nHow are you?' }, false)
+    ).toEqual('Hi!\nHow are you?');
+  });
+
+  test('it should remove ANSI chars lines from the message', () => {
+    expect(
+      MessageConversion.convert(
+        { ...baseRecord, message: 'Blinking...\u001b[5;7;6mThis is Fine\u001b[27m' },
+        false
+      )
+    ).toEqual('Blinking...This is Fine');
+  });
+
+  test('it should remove any unicode injection from the message', () => {
+    expect(
+      MessageConversion.convert(
+        {
+          ...baseRecord,
+          message:
+            '\u001b[31mESC-INJECTION-LFUNICODE:\u001b[32mSUCCESSFUL\u001b[0m\u0007\n\nInjecting 10.000 lols 😂\u001b[10000;b\u0007',
+        },
+        false
+      )
+    ).toEqual('ESC-INJECTION-LFUNICODE:SUCCESSFUL\n\nInjecting 10.000 lols 😂');
+  });
+});

--- a/src/core/server/logging/layouts/conversions/message.ts
+++ b/src/core/server/logging/layouts/conversions/message.ts
@@ -6,13 +6,20 @@
  * Side Public License, v 1.
  */
 
+import ansiRegex from 'ansi-regex';
 import { LogRecord } from '@kbn/logging';
 import { Conversion } from './type';
+
+// Defining it globally because it's more performant than creating for each log entry
+// We can reuse the same global RegExp here because `.replace()` automatically resets the `.lastIndex` of the RegExp.
+const ANSI_ESCAPE_CODES_REGEXP = ansiRegex();
 
 export const MessageConversion: Conversion = {
   pattern: /%message/g,
   convert(record: LogRecord) {
     // Error stack is much more useful than just the message.
-    return (record.error && record.error.stack) || record.message;
+    const str = record.error?.stack || record.message;
+    // We need to validate it's a string because, despite types, there are use case where it's not a string :/
+    return typeof str === 'string' ? str.replace(ANSI_ESCAPE_CODES_REGEXP, '') : str;
   },
 };


### PR DESCRIPTION
## Summary

Backporting to 7.17 the changes from #164337



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
