### PR TITLE
Removing the double quotes from the build.filter

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -151,7 +151,7 @@ spec:
         build_pull_request_forks: false
         build_tags: true
         # https://regex101.com/r/tY52jo/1
-        filter_condition: 'build.tag =~ "/^deploy@\d+\$/"'
+        filter_condition: 'build.tag =~ /^deploy@\d+\$/'
         filter_enabled: true
       teams:
         kibana-operations:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -151,7 +151,7 @@ spec:
         build_pull_request_forks: false
         build_tags: true
         # https://regex101.com/r/tY52jo/1
-        filter_condition: 'build.tag =~ /^deploy@\d+\$/'
+        filter_condition: 'build.tag =~ /^deploy@\d+$/'
         filter_enabled: true
       teams:
         kibana-operations:


### PR DESCRIPTION
@brianseeders figured this out. We tried out this change by modifying the pipeline directly, and it triggered the pipeline: https://buildkite.com/elastic/kibana-serverless-release