### PR TITLE
Add autocomplete for knn in search query

### DIFF
--- a/src/plugins/console/server/lib/spec_definitions/js/search.ts
+++ b/src/plugins/console/server/lib/spec_definitions/js/search.ts
@@ -222,6 +222,37 @@ export const search = (specService: SpecDefinitionsService) => {
       timeout: '1s',
       version: { __one_of: [true, false] },
       track_total_hits: { __one_of: [true, false] },
+      knn: {
+        __template: {
+          field: '',
+          k: 10,
+          num_candidates: 100,
+        },
+        __one_of: [
+          {
+            field: '{field}',
+            filter: { __scope_link: 'GLOBAL.filter' },
+            k: 10,
+            num_candidates: 100,
+            query_vector: [],
+            query_vector_builder: {},
+            similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product'] },
+            boost: 1.0,
+          },
+          [
+            {
+              field: '{field}',
+              filter: { __scope_link: 'GLOBAL.filter' },
+              k: 10,
+              num_candidates: 100,
+              query_vector: [],
+              query_vector_builder: {},
+              similarity: { __one_of: ['l2_norm', 'cosine', 'dot_product'] },
+              boost: 1.0,
+            },
+          ],
+        ],
+      },
     },
   });
 


### PR DESCRIPTION
## Summary

This PR adds autocomplete for knn in search query.

![autocomplete-for-knn](https://github.com/elastic/kibana/assets/721858/3e185db5-f132-4865-9ca0-245af71ea9bd)

Closes #165529

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Improves autocomplete to suggest knn in search query