### PR TITLE
Change to not prompt autocomplete in the end triple quotes

### DIFF
--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -1057,7 +1057,7 @@ export default function ({
     }
 
     const t = editor.getTokenAt(pos);
-    if (t && t.type == 'punctuation.end_triple_quote' && pos.column !== t.position.column + 3) {
+    if (t && t.type === 'punctuation.end_triple_quote' && pos.column !== t.position.column + 3) {
       // skip to populate context as the current position is not on the edge of end_triple_quote
       return context;
     }

--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -1056,6 +1056,12 @@ export default function ({
       return context;
     }
 
+    const t = editor.getTokenAt(pos);
+    if (t && t.type == 'punctuation.end_triple_quote' && pos.column !== t.position.column + 3) {
+      // skip to populate context as the current position is not on the edge of end_triple_quote
+      return context;
+    }
+
     // needed for scope linking + global term resolving
     context.endpointComponentResolver = getEndpointBodyCompleteComponents;
     context.globalComponentResolver = getGlobalAutocompleteComponents;


### PR DESCRIPTION
## Summary

This PR stops prompting autocomplete in the middle of the end triple quotes.

![not-prompt-autocomplete-in-triple-quotes](https://github.com/elastic/kibana/assets/721858/14a74b6e-985c-4739-99a9-4f3232c305b5)

Closes #124084

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

`backport:skip` because the bug is trivial.

## Release note

Fixes autocomplete not to be prompt between the triple quotes