### PR TITLE
[Security Solution] Fix junit report transformation

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -96,8 +96,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
     label: 'Osquery Cypress Tests'
@@ -110,8 +108,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-osquery/**/*"
 
   - command: .buildkite/scripts/steps/functional/synthetics_plugin.sh
     label: 'Synthetics @elastic/synthetics Tests'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -146,8 +146,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"
 
   # status_exception: Native role management is not enabled in this Elasticsearch instance
   # - command: .buildkite/scripts/steps/functional/security_serverless_defend_workflows.sh
@@ -161,8 +159,6 @@ steps:
   #     automatic:
   #       - exit_status: '*'
   #         limit: 1
-  #   artifact_paths:
-  #     - "target/kibana-security-solution/**/*"
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Security Investigations Cypress Tests'
@@ -176,8 +172,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Security Explore Cypress Tests'
@@ -191,8 +185,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"
 
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'

--- a/.buildkite/pipelines/pull_request/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/defend_workflows.yml
@@ -10,8 +10,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"
 
   - command: .buildkite/scripts/steps/functional/defend_workflows_vagrant.sh
     label: 'Defend Workflows Endpoint Cypress Tests'
@@ -24,5 +22,3 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"

--- a/.buildkite/pipelines/pull_request/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/osquery_cypress.yml
@@ -10,8 +10,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-osquery/**/*"
 
   - command: .buildkite/scripts/steps/functional/osquery_cypress_burn.sh
     label: 'Osquery Cypress Tests, burning changed specs'
@@ -22,8 +20,6 @@ steps:
     soft_fail: true
     retry:
       automatic: false
-    artifact_paths:
-      - "target/kibana-osquery/**/*"
 
   # Error: self-signed certificate in certificate chain
   # - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
@@ -37,5 +33,3 @@ steps:
   #     automatic:
   #       - exit_status: '*'
   #         limit: 1
-  #   artifact_paths:
-  #     - "target/kibana-osquery/**/*"

--- a/.buildkite/pipelines/pull_request/response_ops.yml
+++ b/.buildkite/pipelines/pull_request/response_ops.yml
@@ -10,5 +10,3 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"

--- a/.buildkite/pipelines/pull_request/response_ops_cases.yml
+++ b/.buildkite/pipelines/pull_request/response_ops_cases.yml
@@ -9,5 +9,3 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-solution/**/*"

--- a/.buildkite/pipelines/pull_request/security_solution.yml
+++ b/.buildkite/pipelines/pull_request/security_solution.yml
@@ -10,8 +10,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - 'target/kibana-security-solution/**/*'
 
   - command: .buildkite/scripts/steps/functional/security_solution_explore.sh
     label: 'Explore - Security Solution Cypress Tests'
@@ -24,8 +22,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - 'target/kibana-security-solution/**/*'
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'
@@ -38,8 +34,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - 'target/kibana-security-solution/**/*'
 
   - command: .buildkite/scripts/steps/functional/security_solution_burn.sh
     label: 'Security Solution Cypress tests, burning changed specs'
@@ -51,8 +45,6 @@ steps:
     retry:
       automatic: false
     soft_fail: true
-    artifact_paths:
-      - 'target/kibana-security-solution/**/*'
 
   - command: .buildkite/scripts/steps/code_generation/security_solution_codegen.sh
     label: 'Security Solution OpenAPI codegen'

--- a/.buildkite/pipelines/pull_request/threat_intelligence.yml
+++ b/.buildkite/pipelines/pull_request/threat_intelligence.yml
@@ -10,5 +10,3 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-threat-intelligence/**/*"

--- a/.buildkite/pipelines/serverless.yml
+++ b/.buildkite/pipelines/serverless.yml
@@ -110,8 +110,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-serverless/**/*"
 
   - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
     label: 'Serverless Explore - Security Solution Cypress Tests'
@@ -124,8 +122,6 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-serverless/**/*"
 
   - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
     label: 'Serverless Investigations - Security Solution Cypress Tests'
@@ -138,5 +134,3 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-    artifact_paths:
-      - "target/kibana-security-serverless/**/*"

--- a/.buildkite/scripts/steps/functional/defend_workflows.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows.sh
@@ -12,4 +12,5 @@ echo "--- Defend Workflows Cypress tests"
 
 cd x-pack/plugins/security_solution
 
+set +e
 yarn cypress:dw:run; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/defend_workflows_vagrant.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows_vagrant.sh
@@ -12,4 +12,5 @@ echo "--- Defend Workflows Endpoint Cypress tests"
 
 cd x-pack/plugins/security_solution
 
+set +e
 yarn cypress:dw:endpoint:run; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/osquery_cypress.sh
+++ b/.buildkite/scripts/steps/functional/osquery_cypress.sh
@@ -12,4 +12,7 @@ export JOB=kibana-osquery-cypress
 
 echo "--- Osquery Cypress tests"
 
-yarn --cwd x-pack/plugins/osquery cypress:run
+cd x-pack/plugins/osquery
+
+set +e
+yarn cypress:run; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/osquery_cypress_burn.sh
+++ b/.buildkite/scripts/steps/functional/osquery_cypress_burn.sh
@@ -14,4 +14,5 @@ buildkite-agent meta-data set "${BUILDKITE_JOB_ID}_is_test_execution_step" 'fals
 
 echo "--- Osquery Cypress tests, burning changed specs (Chrome)"
 
-yarn --cwd x-pack/plugins/osquery cypress:changed-specs-only
+set +e
+yarn cypress:changed-specs-only; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/response_ops.sh
+++ b/.buildkite/scripts/steps/functional/response_ops.sh
@@ -12,4 +12,5 @@ echo "--- Response Ops Cypress Tests on Security Solution"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:run:respops:ess; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/response_ops_cases.sh
+++ b/.buildkite/scripts/steps/functional/response_ops_cases.sh
@@ -12,4 +12,5 @@ echo "--- Response Ops Cases Cypress Tests on Security Solution"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:run:cases:ess; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless.sh
@@ -12,4 +12,5 @@ echo "--- Security Serverless Cypress Tests"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:run:serverless; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_explore.sh
@@ -12,4 +12,5 @@ echo "--- Explore - Security Solution Cypress Tests"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:explore:run:serverless; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
@@ -12,4 +12,5 @@ echo "--- Investigations Cypress Tests on Serverless"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:investigations:run:serverless; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_solution.sh
+++ b/.buildkite/scripts/steps/functional/security_solution.sh
@@ -12,4 +12,5 @@ echo "--- Security Solution Cypress tests (Chrome)"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:run:ess; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_explore.sh
@@ -12,4 +12,5 @@ echo "--- Explore Cypress Tests on Security Solution"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:explore:run:ess; status=$?; yarn junit:merge && exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_investigations.sh
@@ -12,4 +12,5 @@ echo "--- Investigations - Security Solution Cypress Tests"
 
 cd x-pack/test/security_solution_cypress
 
+set +e
 yarn cypress:investigations:run:ess; status=$?; yarn junit:merge && exit $status


### PR DESCRIPTION
**Fixes:** https://github.com/elastic/kibana/issues/165546

## Summary

This PR fixes junit report transformation for Security Solution build steps (Cypress writes reports in `mochawesome` format and `yarn junit:transform` transforms it to junit format).

## Details

After refactoring it turned out `yarn junit:merge` was moved from `cypress:*` yarn scripts to build step `*.sh` files in `.buildkite/scripts/steps/functional` folder. This way a command to run Cypress tests changed from

```sh
yarn cypress:run:ess
```

to

```sh
yarn cypress:run:ess; status=$?; yarn junit:merge && exit $status
```

In first case any test failure do not lead to early exist and all following commands are executed as yarn runs scripts without preserving shell settings. In the second case failing tests lead to `yarn cypress:run:ess` exit with non-zero exit code so the shell script exits immediately without giving a chance for `yarn junit:merge` to execute.

This problem is solved by disabling early exit on error via `set +e`.

On top of that using of `artifact_paths` config option is redundant as [post command script](https://github.com/elastic/kibana/blob/main/.buildkite/scripts/lifecycle/post_command.sh#L16) upload build artefact via a bildkite agent.

#### [Failed build example](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3049#_)