### PR TITLE
[ES|QL] Adds more tests in unified histogram component

### DIFF
--- a/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.test.ts
+++ b/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.test.ts
@@ -1,0 +1,178 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import { renderHook } from '@testing-library/react-hooks';
+import { dataPluginMock } from '@kbn/data-plugin/public/mocks';
+import { calculateBounds } from '@kbn/data-plugin/public';
+import { deepMockedFields, buildDataViewMock } from '@kbn/discover-utils/src/__mocks__';
+import { allSuggestionsMock } from '../../__mocks__/suggestions';
+import { useLensSuggestions } from './use_lens_suggestions';
+
+describe('useLensSuggestions', () => {
+  const dataMock = dataPluginMock.createStartContract();
+  dataMock.query.timefilter.timefilter.calculateBounds = (timeRange) => {
+    return calculateBounds(timeRange);
+  };
+  const dataViewMock = buildDataViewMock({
+    name: 'the-data-view',
+    fields: deepMockedFields,
+    timeFieldName: '@timestamp',
+  });
+
+  test('should return empty suggestions for non aggregate query', async () => {
+    const { result } = renderHook(() => {
+      return useLensSuggestions({
+        dataView: dataViewMock,
+        query: undefined,
+        isPlainRecord: false,
+        data: dataMock,
+        lensSuggestionsApi: jest.fn(),
+      });
+    });
+    const current = result.current;
+    expect(current).toStrictEqual({
+      allSuggestions: [],
+      currentSuggestion: undefined,
+      isOnHistogramMode: false,
+      suggestionUnsupported: false,
+    });
+  });
+
+  test('should return suggestions for aggregate query', async () => {
+    const { result } = renderHook(() => {
+      return useLensSuggestions({
+        dataView: dataViewMock,
+        query: { esql: 'from the-data-view | stats maxB = max(bytes)' },
+        isPlainRecord: true,
+        columns: [
+          {
+            id: 'var0',
+            name: 'var0',
+            meta: {
+              type: 'number',
+            },
+          },
+        ],
+        data: dataMock,
+        lensSuggestionsApi: jest.fn(() => allSuggestionsMock),
+      });
+    });
+    const current = result.current;
+    expect(current).toStrictEqual({
+      allSuggestions: allSuggestionsMock,
+      currentSuggestion: allSuggestionsMock[0],
+      isOnHistogramMode: false,
+      suggestionUnsupported: false,
+    });
+  });
+
+  test('should return suggestionUnsupported if no timerange is provided and no suggestions returned by the api', async () => {
+    const { result } = renderHook(() => {
+      return useLensSuggestions({
+        dataView: dataViewMock,
+        query: { esql: 'from the-data-view | stats maxB = max(bytes)' },
+        isPlainRecord: true,
+        columns: [
+          {
+            id: 'var0',
+            name: 'var0',
+            meta: {
+              type: 'number',
+            },
+          },
+        ],
+        data: dataMock,
+        lensSuggestionsApi: jest.fn(),
+      });
+    });
+    const current = result.current;
+    expect(current).toStrictEqual({
+      allSuggestions: [],
+      currentSuggestion: undefined,
+      isOnHistogramMode: false,
+      suggestionUnsupported: true,
+    });
+  });
+
+  test('should return histogramSuggestion if no suggestions returned by the api', async () => {
+    const firstMockReturn = undefined;
+    const secondMockReturn = allSuggestionsMock;
+    const lensSuggestionsApi = jest
+      .fn()
+      .mockReturnValueOnce(firstMockReturn) // will return to firstMockReturn object firstly
+      .mockReturnValueOnce(secondMockReturn); // will return to secondMockReturn object secondly
+
+    const { result } = renderHook(() => {
+      return useLensSuggestions({
+        dataView: dataViewMock,
+        query: { esql: 'from the-data-view | limit 100' },
+        isPlainRecord: true,
+        columns: [
+          {
+            id: 'var0',
+            name: 'var0',
+            meta: {
+              type: 'number',
+            },
+          },
+        ],
+        data: dataMock,
+        lensSuggestionsApi,
+        timeRange: {
+          from: '2023-09-03T08:00:00.000Z',
+          to: '2023-09-04T08:56:28.274Z',
+        },
+      });
+    });
+    const current = result.current;
+    expect(current).toStrictEqual({
+      allSuggestions: [],
+      currentSuggestion: allSuggestionsMock[0],
+      isOnHistogramMode: true,
+      suggestionUnsupported: false,
+    });
+  });
+
+  test('should not return histogramSuggestion if no suggestions returned by the api and transformational commands', async () => {
+    const firstMockReturn = undefined;
+    const secondMockReturn = allSuggestionsMock;
+    const lensSuggestionsApi = jest
+      .fn()
+      .mockReturnValueOnce(firstMockReturn) // will return to firstMockReturn object firstly
+      .mockReturnValueOnce(secondMockReturn); // will return to secondMockReturn object secondly
+
+    const { result } = renderHook(() => {
+      return useLensSuggestions({
+        dataView: dataViewMock,
+        query: { esql: 'from the-data-view | limit 100 | keep @timestamp' },
+        isPlainRecord: true,
+        columns: [
+          {
+            id: 'var0',
+            name: 'var0',
+            meta: {
+              type: 'number',
+            },
+          },
+        ],
+        data: dataMock,
+        lensSuggestionsApi,
+        timeRange: {
+          from: '2023-09-03T08:00:00.000Z',
+          to: '2023-09-04T08:56:28.274Z',
+        },
+      });
+    });
+    const current = result.current;
+    expect(current).toStrictEqual({
+      allSuggestions: [],
+      currentSuggestion: undefined,
+      isOnHistogramMode: false,
+      suggestionUnsupported: true,
+    });
+  });
+});

--- a/src/plugins/unified_histogram/tsconfig.json
+++ b/src/plugins/unified_histogram/tsconfig.json
@@ -24,6 +24,7 @@
     "@kbn/ui-actions-plugin",
     "@kbn/kibana-utils-plugin",
     "@kbn/visualizations-plugin",
+    "@kbn/discover-utils",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/165431

Adds more unit tests in unified_histogram plugin, as a follow up from ES|QL

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
