### PR TITLE
Serverless test readme - link to kbn-es readme

### DIFF
--- a/x-pack/test_serverless/README.md
+++ b/x-pack/test_serverless/README.md
@@ -5,6 +5,9 @@ The tests and helper methods (services, page objects) defined here in
  `serverless`, `serverless_observability`, `serverless_search` and
  `serverless_security` plugins.
 
+ For how to set up Docker for serverless ES images, please refer to
+ [packages/kbn-es/README](https://github.com/elastic/kibana/blob/main/packages/kbn-es/README.mdx).
+
 ## Serverless testing structure and conventions
 
 ### Overview


### PR DESCRIPTION
## Summary

This PR updates the serverless test readme and adds a link to the @kbn-es readme.
