### PR TITLE
[APM] Paginate big traces

### DIFF
--- a/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace_long.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/distributed_trace_long.ts
@@ -49,7 +49,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
           timestamp,
           children: (_) => {
             _.service({
-              repeat: 10,
+              repeat: 80,
               serviceInstance: synthNode,
               transactionName: 'GET /nodejs/products',
               latency: 100,
@@ -60,7 +60,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
                   transactionName: 'GET /go',
                   children: (_) => {
                     _.service({
-                      repeat: 20,
+                      repeat: 50,
                       serviceInstance: synthJava,
                       transactionName: 'GET /java',
                       children: (_) => {
@@ -83,7 +83,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
               serviceInstance: synthNode,
               transactionName: 'GET /nodejs/users',
               latency: 100,
-              repeat: 10,
+              repeat: 40,
               children: (_) => {
                 _.service({
                   serviceInstance: synthGo,
@@ -91,7 +91,7 @@ const scenario: Scenario<ApmFields> = async (runOptions: RunOptions) => {
                   latency: 50,
                   children: (_) => {
                     _.service({
-                      repeat: 10,
+                      repeat: 40,
                       serviceInstance: synthDotnet,
                       transactionName: 'GET /dotnet/cases/4',
                       latency: 50,

--- a/x-pack/plugins/apm/common/critical_path/get_critical_path.test.ts
+++ b/x-pack/plugins/apm/common/critical_path/get_critical_path.test.ts
@@ -23,7 +23,7 @@ describe('getCriticalPath', () => {
         errorDocs: [],
         exceedsMax: false,
         spanLinksCountById: {},
-        traceItemCount: events.length,
+        traceDocsTotal: events.length,
         maxTraceItems: 5000,
       },
       entryTransaction,

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/generate_large_trace.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/generate_large_trace.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable @typescript-eslint/no-shadow */
+import { apm, timerange, DistributedTrace } from '@kbn/apm-synthtrace-client';
+import { synthtrace } from '../../../../synthtrace';
+
+const RATE_PER_MINUTE = 1;
+
+export function generateLargeTrace({
+  start,
+  end,
+  rootTransactionName,
+  repeaterFactor,
+  environment,
+}: {
+  start: number;
+  end: number;
+  rootTransactionName: string;
+  repeaterFactor: number;
+  environment: string;
+}) {
+  const range = timerange(start, end);
+
+  const synthRum = apm
+    .service({ name: 'synth-rum', environment, agentName: 'rum-js' })
+    .instance('my-instance');
+
+  const synthNode = apm
+    .service({ name: 'synth-node', environment, agentName: 'nodejs' })
+    .instance('my-instance');
+
+  const synthGo = apm
+    .service({ name: 'synth-go', environment, agentName: 'go' })
+    .instance('my-instance');
+
+  const synthDotnet = apm
+    .service({ name: 'synth-dotnet', environment, agentName: 'dotnet' })
+    .instance('my-instance');
+
+  const synthJava = apm
+    .service({ name: 'synth-java', environment, agentName: 'java' })
+    .instance('my-instance');
+
+  const traces = range.ratePerMinute(RATE_PER_MINUTE).generator((timestamp) => {
+    return new DistributedTrace({
+      serviceInstance: synthRum,
+      transactionName: rootTransactionName,
+      timestamp,
+      children: (_) => {
+        _.service({
+          repeat: 5 * repeaterFactor,
+          serviceInstance: synthNode,
+          transactionName: 'GET /nodejs/products',
+          latency: 100,
+
+          children: (_) => {
+            _.service({
+              serviceInstance: synthGo,
+              transactionName: 'GET /go',
+              children: (_) => {
+                _.service({
+                  repeat: 5 * repeaterFactor,
+                  serviceInstance: synthJava,
+                  transactionName: 'GET /java',
+                  children: (_) => {
+                    _.external({
+                      name: 'GET telemetry.elastic.co',
+                      url: 'https://telemetry.elastic.co/ping',
+                      duration: 50,
+                    });
+                  },
+                });
+              },
+            });
+            _.db({
+              name: 'GET apm-*/_search',
+              type: 'elasticsearch',
+              duration: 400,
+            });
+            _.db({ name: 'GET', type: 'redis', duration: 500 });
+            _.db({
+              name: 'SELECT * FROM users',
+              type: 'sqlite',
+              duration: 600,
+            });
+          },
+        });
+
+        _.service({
+          serviceInstance: synthNode,
+          transactionName: 'GET /nodejs/users',
+          latency: 100,
+          repeat: 5 * repeaterFactor,
+          children: (_) => {
+            _.service({
+              serviceInstance: synthGo,
+              transactionName: 'GET /go/security',
+              latency: 50,
+              children: (_) => {
+                _.service({
+                  repeat: 5 * repeaterFactor,
+                  serviceInstance: synthDotnet,
+                  transactionName: 'GET /dotnet/cases/4',
+                  latency: 50,
+                  children: (_) =>
+                    _.db({
+                      name: 'GET apm-*/_search',
+                      type: 'elasticsearch',
+                      duration: 600,
+                      statement: JSON.stringify(
+                        {
+                          query: {
+                            query_string: {
+                              query: '(new york city) OR (big apple)',
+                              default_field: 'content',
+                            },
+                          },
+                        },
+                        null,
+                        2
+                      ),
+                    }),
+                });
+              },
+            });
+          },
+        });
+      },
+    }).getTransaction();
+  });
+
+  return synthtrace.index(traces);
+}

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/large_traces_in_waterfall.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/large_traces_in_waterfall.cy.ts
@@ -26,6 +26,10 @@ describe('Large Trace in waterfall', () => {
     });
   });
 
+  after(() => {
+    synthtrace.clean();
+  });
+
   describe('when navigating to a trace sample with default maxTraceItems', () => {
     beforeEach(() => {
       cy.loginAsViewerUser();

--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/large_traces_in_waterfall.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/transaction_details/large_trace_in_waterfall/large_traces_in_waterfall.cy.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { synthtrace } from '../../../../synthtrace';
+import { generateLargeTrace } from './generate_large_trace';
+
+const start = '2021-10-10T00:00:00.000Z';
+const end = '2021-10-10T00:01:00.000Z';
+const rootTransactionName = `Large trace`;
+
+const timeRange = { rangeFrom: start, rangeTo: end };
+
+describe('Large Trace in waterfall', () => {
+  before(() => {
+    synthtrace.clean();
+
+    generateLargeTrace({
+      start: new Date(start).getTime(),
+      end: new Date(end).getTime(),
+      rootTransactionName,
+      repeaterFactor: 10,
+      environment: 'large_trace',
+    });
+
+    cy.loginAsViewerUser();
+  });
+
+  describe('when navigating to a trace sample', () => {
+    it('shows warning about trace size', () => {
+      cy.visitKibana(
+        `/app/apm/services/synth-rum/transactions/view?${new URLSearchParams({
+          ...timeRange,
+          transactionName: rootTransactionName,
+        })}`
+      );
+
+      cy.getByTestSubj('apmWaterfallSizeWarning').should(
+        'have.text',
+        'The number of items in this trace is 15551 which is higher than the current limit of 5000. Please increase the limit via `xpack.apm.ui.maxTraceItems` to see the full trace'
+      );
+    });
+
+    it('does not show the warning about trace size', () => {
+      cy.intercept('GET', '/internal/apm/traces/**', (req) => {
+        req.query.maxTraceItems = 20000;
+      }).as('getTraces');
+
+      cy.visitKibana(
+        `/app/apm/services/synth-rum/transactions/view?${new URLSearchParams({
+          ...timeRange,
+          transactionName: rootTransactionName,
+        })}`
+      );
+
+      cy.getByTestSubj('apmWaterfallSizeWarning').should('not.exist');
+    });
+  });
+});

--- a/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/use_waterfall_fetcher.ts
@@ -16,7 +16,7 @@ const INITIAL_DATA: APIReturnType<'GET /internal/apm/traces/{traceId}'> = {
     traceDocs: [],
     exceedsMax: false,
     spanLinksCountById: {},
-    traceItemCount: 0,
+    traceDocsTotal: 0,
     maxTraceItems: 0,
   },
   entryTransaction: undefined,

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/accordion_waterfall.tsx
@@ -132,6 +132,7 @@ export function AccordionWaterfall(props: AccordionWaterfallProps) {
 
   return (
     <StyledAccordion
+      data-test-subj="waterfallItem"
       className="waterfall_accordion"
       style={{ position: 'relative' }}
       buttonClassName={`button_${item.id}`}

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -113,14 +113,15 @@ export function Waterfall({
     <Container>
       {waterfall.exceedsMax && (
         <EuiCallOut
+          data-test-subj="apmWaterfallSizeWarning"
           color="warning"
           size="s"
           iconType="warning"
           title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
             defaultMessage:
-              'The number of items in this trace is {traceItemCount} which is higher than the current limit of {maxTraceItems}. Please increase the limit via `xpack.apm.ui.maxTraceItems` to see the full trace',
+              'The number of items in this trace is {traceDocsTotal} which is higher than the current limit of {maxTraceItems}. Please increase the limit via `xpack.apm.ui.maxTraceItems` to see the full trace',
             values: {
-              traceItemCount: waterfall.traceItemCount,
+              traceDocsTotal: waterfall.traceDocsTotal,
               maxTraceItems: waterfall.maxTraceItems,
             },
           })}
@@ -161,9 +162,9 @@ export function Waterfall({
               ) => toggleFlyout({ history, item, flyoutDetailTab })}
               showCriticalPath={showCriticalPath}
               maxLevelOpen={
-                waterfall.traceItemCount > 500
+                waterfall.traceDocsTotal > 500
                   ? maxLevelOpen
-                  : waterfall.traceItemCount
+                  : waterfall.traceDocsTotal
               }
             />
           )}

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -118,7 +118,7 @@ export function Waterfall({
           iconType="warning"
           title={i18n.translate('xpack.apm.waterfall.exceedsMax', {
             defaultMessage:
-              'The number of items in this trace is {traceItemCount} which is higher than the current limit of {maxTraceItems}. Please increase the limit to see the full trace',
+              'The number of items in this trace is {traceItemCount} which is higher than the current limit of {maxTraceItems}. Please increase the limit via `xpack.apm.ui.maxTraceItems` to see the full trace',
             values: {
               traceItemCount: waterfall.traceItemCount,
               maxTraceItems: waterfall.maxTraceItems,

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.test.ts
@@ -138,7 +138,7 @@ describe('waterfall_helpers', () => {
           errorDocs,
           exceedsMax: false,
           spanLinksCountById: {},
-          traceItemCount: hits.length,
+          traceDocsTotal: hits.length,
           maxTraceItems: 5000,
         },
         entryTransaction: {
@@ -168,7 +168,7 @@ describe('waterfall_helpers', () => {
           errorDocs,
           exceedsMax: false,
           spanLinksCountById: {},
-          traceItemCount: hits.length,
+          traceDocsTotal: hits.length,
           maxTraceItems: 5000,
         },
         entryTransaction: {
@@ -271,7 +271,7 @@ describe('waterfall_helpers', () => {
           errorDocs: [],
           exceedsMax: false,
           spanLinksCountById: {},
-          traceItemCount: traceItems.length,
+          traceDocsTotal: traceItems.length,
           maxTraceItems: 5000,
         },
         entryTransaction: {
@@ -390,7 +390,7 @@ describe('waterfall_helpers', () => {
           errorDocs: [],
           exceedsMax: false,
           spanLinksCountById: {},
-          traceItemCount: traceItems.length,
+          traceDocsTotal: traceItems.length,
           maxTraceItems: 5000,
         },
         entryTransaction: {

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/waterfall_helpers/waterfall_helpers.ts
@@ -46,7 +46,7 @@ export interface IWaterfall {
   errorItems: IWaterfallError[];
   exceedsMax: boolean;
   totalErrorsCount: number;
-  traceItemCount: number;
+  traceDocsTotal: number;
   maxTraceItems: number;
 }
 
@@ -427,7 +427,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
       getErrorCount: () => 0,
       exceedsMax: false,
       totalErrorsCount: 0,
-      traceItemCount: 0,
+      traceDocsTotal: 0,
       maxTraceItems: 0,
     };
   }
@@ -476,7 +476,7 @@ export function getWaterfall(apiResponse: TraceAPIResponse): IWaterfall {
     getErrorCount: (parentId: string) => errorCountByParentId[parentId] ?? 0,
     exceedsMax: traceItems.exceedsMax,
     totalErrorsCount: traceItems.errorDocs.length,
-    traceItemCount: traceItems.traceItemCount,
+    traceDocsTotal: traceItems.traceDocsTotal,
     maxTraceItems: traceItems.maxTraceItems,
   };
 }

--- a/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.stories.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall_container.stories.tsx
@@ -83,7 +83,7 @@ export const Example: Story<any> = () => {
     traceDocs,
     errorDocs: errorDocs.map((error) => dedot(error, {}) as WaterfallError),
     spanLinksCountById: {},
-    traceItemCount: traceDocs.length,
+    traceDocsTotal: traceDocs.length,
     maxTraceItems: 5000,
   };
 

--- a/x-pack/plugins/apm/server/routes/alerts/test_utils/index.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/test_utils/index.ts
@@ -15,6 +15,7 @@ import { PluginSetupContract as AlertingPluginSetupContract } from '@kbn/alertin
 import { ObservabilityPluginSetup } from '@kbn/observability-plugin/server';
 import { DEFAULT_FLAPPING_SETTINGS } from '@kbn/alerting-plugin/common';
 import { APMConfig, APM_SERVER_FEATURE_ID } from '../../..';
+import { RegisterRuleDependencies } from '../register_apm_rule_types';
 
 export const createRuleTypeMocks = () => {
   let alertExecutor: (...args: any[]) => Promise<any>;
@@ -48,35 +49,37 @@ export const createRuleTypeMocks = () => {
     shouldWriteAlerts: () => true,
   };
 
+  const dependencies = {
+    alerting,
+    basePath: {
+      prepend: (path: string) => `http://localhost:5601/eyr${path}`,
+      publicBaseUrl: 'http://localhost:5601/eyr',
+      serverBasePath: '/eyr',
+    } as IBasePath,
+    apmConfig: { searchAggregatedTransactions: true } as any as APMConfig,
+    getApmIndices: async () => ({
+      error: 'apm-*',
+      transaction: 'apm-*',
+      span: 'apm-*',
+      metric: 'apm-*',
+      onboarding: 'apm-*',
+    }),
+    observability: {
+      getAlertDetailsConfig: jest.fn().mockReturnValue({ apm: true }),
+    } as unknown as ObservabilityPluginSetup,
+    logger: loggerMock,
+    ruleDataClient: ruleRegistryMocks.createRuleDataClient(
+      '.alerts-observability.apm.alerts'
+    ) as IRuleDataClient,
+    alertsLocator: {
+      getLocation: jest.fn().mockImplementation(() => ({
+        path: 'mockedAlertsLocator > getLocation',
+      })),
+    } as any as LocatorPublic<AlertsLocatorParams>,
+  } as unknown as RegisterRuleDependencies;
+
   return {
-    dependencies: {
-      alerting,
-      basePath: {
-        prepend: (path: string) => `http://localhost:5601/eyr${path}`,
-        publicBaseUrl: 'http://localhost:5601/eyr',
-        serverBasePath: '/eyr',
-      } as IBasePath,
-      apmConfig: { searchAggregatedTransactions: true } as any as APMConfig,
-      getApmIndices: async () => ({
-        error: 'apm-*',
-        transaction: 'apm-*',
-        span: 'apm-*',
-        metric: 'apm-*',
-        onboarding: 'apm-*',
-      }),
-      observability: {
-        getAlertDetailsConfig: jest.fn().mockReturnValue({ apm: true }),
-      } as unknown as ObservabilityPluginSetup,
-      logger: loggerMock,
-      ruleDataClient: ruleRegistryMocks.createRuleDataClient(
-        '.alerts-observability.apm.alerts'
-      ) as IRuleDataClient,
-      alertsLocator: {
-        getLocation: jest.fn().mockImplementation(() => ({
-          path: 'mockedAlertsLocator > getLocation',
-        })),
-      } as any as LocatorPublic<AlertsLocatorParams>,
-    },
+    dependencies,
     services,
     scheduleActions,
     executor: async ({ params }: { params: Record<string, any> }) => {

--- a/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
+++ b/x-pack/plugins/apm/server/routes/settings/apm_indices/get_apm_indices.ts
@@ -9,7 +9,13 @@ import { getApmIndicesSavedObject } from '@kbn/apm-data-access-plugin/server/sav
 import { APMRouteHandlerResources } from '../../apm_routes/register_apm_server_routes';
 
 export type ApmIndexSettingsResponse = Array<{
-  configurationName: 'transaction' | 'span' | 'error' | 'metric' | 'onboarding';
+  configurationName:
+    | 'transaction'
+    | 'span'
+    | 'error'
+    | 'metric'
+    | 'onboarding'
+    | 'sourcemap';
   defaultValue: string; // value defined in kibana[.dev].yml
   savedValue: string | undefined;
 }>;

--- a/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
+++ b/x-pack/plugins/apm/server/routes/traces/__snapshots__/queries.test.ts.snap
@@ -48,7 +48,7 @@ Object {
         },
       },
     },
-    "size": 5000,
+    "size": 1000,
     "track_total_hits": false,
   },
 }

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -207,7 +207,7 @@ async function getTraceDocsPerPage({
   searchAfter?: SortResults;
   hitsRetrievedCount: number;
 }) {
-  const MAX_ITEMS_PER_PAGE = 100; // 10000 is the max allowed by ES
+  const MAX_ITEMS_PER_PAGE = 10000; // 10000 is the max allowed by ES
   const hitsRemaining = maxTraceItems - hitsRetrievedCount;
   const size = Math.min(hitsRemaining, MAX_ITEMS_PER_PAGE);
 

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -270,7 +270,6 @@ async function getTraceDocsPerPage({
             order: 'desc',
           },
         },
-        // { '@timestamp': 'asc' },
         { _doc: 'asc' }, // tiebreaker
       ] as Sort,
     },

--- a/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
+++ b/x-pack/plugins/apm/server/routes/traces/get_trace_items.ts
@@ -178,7 +178,7 @@ async function getTraceDocsPaginated({
   const mergedHits = [...hits, ...response.hits];
 
   logger.debug(
-    `retrieved: ${response.hits.length}, total retrieved: ${mergedHits.length}), max: ${maxTraceItems}, total is ${response.total}`
+    `Paginating traces: retrieved: ${response.hits.length}, (total: ${mergedHits.length} of ${response.total}), maxTraceItems: ${maxTraceItems}`
   );
 
   if (
@@ -277,16 +277,8 @@ async function getTraceDocsPerPage({
           order: 'desc',
         },
       },
-      {
-        _script: {
-          type: 'string',
-          script: {
-            lang: 'painless',
-            source: `if (doc['${TRANSACTION_ID}'].size() > 0) { return doc['${TRANSACTION_ID}'].value } else { return doc['${SPAN_ID}'].value }`,
-          },
-          order: 'desc',
-        },
-      },
+      { '@timestamp': 'asc' },
+      { _doc: 'asc' },
     ] as Sort,
   };
 

--- a/x-pack/plugins/apm/server/routes/traces/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/traces/queries.test.ts
@@ -20,7 +20,13 @@ describe('trace queries', () => {
 
   it('fetches a trace', async () => {
     mock = await inspectSearchParams(({ mockConfig, mockApmEventClient }) =>
-      getTraceItems('foo', mockConfig, mockApmEventClient, 0, 50000)
+      getTraceItems({
+        traceId: 'foo',
+        config: mockConfig,
+        apmEventClient: mockApmEventClient,
+        start: 0,
+        end: 50000,
+      })
     );
 
     expect(mock.params).toMatchSnapshot();

--- a/x-pack/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/plugins/apm/server/routes/traces/route.ts
@@ -98,7 +98,13 @@ const tracesByIdRoute = createApmServerRoute({
     const { traceId } = params.path;
     const { start, end, entryTransactionId } = params.query;
     const [traceItems, entryTransaction] = await Promise.all([
-      getTraceItems(traceId, config, apmEventClient, start, end),
+      getTraceItems({
+        traceId,
+        config,
+        apmEventClient,
+        start,
+        end,
+      }),
       getTransaction({
         transactionId: entryTransactionId,
         traceId,

--- a/x-pack/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/plugins/apm/server/routes/traces/route.ts
@@ -6,7 +6,7 @@
  */
 
 import * as t from 'io-ts';
-import { nonEmptyStringRt } from '@kbn/io-ts-utils';
+import { nonEmptyStringRt, toNumberRt } from '@kbn/io-ts-utils';
 import { TraceSearchType } from '../../../common/trace_explorer';
 import { getSearchTransactionsEvents } from '../../lib/helpers/transactions';
 import { createApmServerRoute } from '../apm_routes/create_apm_server_route';
@@ -84,7 +84,11 @@ const tracesByIdRoute = createApmServerRoute({
     path: t.type({
       traceId: t.string,
     }),
-    query: t.intersection([rangeRt, t.type({ entryTransactionId: t.string })]),
+    query: t.intersection([
+      rangeRt,
+      t.type({ entryTransactionId: t.string }),
+      t.partial({ maxTraceItems: toNumberRt }),
+    ]),
   }),
   options: { tags: ['access:apm'] },
   handler: async (
@@ -104,6 +108,7 @@ const tracesByIdRoute = createApmServerRoute({
         apmEventClient,
         start,
         end,
+        maxTraceItemsFromUrlParam: params.query.maxTraceItems,
       }),
       getTransaction({
         transactionId: entryTransactionId,

--- a/x-pack/plugins/apm/server/routes/traces/route.ts
+++ b/x-pack/plugins/apm/server/routes/traces/route.ts
@@ -98,7 +98,7 @@ const tracesByIdRoute = createApmServerRoute({
     entryTransaction?: Transaction;
   }> => {
     const apmEventClient = await getApmEventClient(resources);
-    const { params, config } = resources;
+    const { params, config, logger } = resources;
     const { traceId } = params.path;
     const { start, end, entryTransactionId } = params.query;
     const [traceItems, entryTransaction] = await Promise.all([
@@ -109,6 +109,7 @@ const tracesByIdRoute = createApmServerRoute({
         start,
         end,
         maxTraceItemsFromUrlParam: params.query.maxTraceItems,
+        logger,
       }),
       getTransaction({
         transactionId: entryTransactionId,

--- a/x-pack/plugins/apm/server/utils/test_helpers.tsx
+++ b/x-pack/plugins/apm/server/utils/test_helpers.tsx
@@ -60,6 +60,7 @@ export async function inspectSearchParams(
     span: 'myIndex',
     transaction: 'myIndex',
     metric: 'myIndex',
+    sourcemap: 'myIndex',
   };
 
   const mockConfig = new Proxy(

--- a/x-pack/plugins/apm_data_access/server/saved_objects/apm_indices.ts
+++ b/x-pack/plugins/apm_data_access/server/saved_objects/apm_indices.ts
@@ -23,6 +23,7 @@ export interface APMIndicesSavedObjectBody {
     span?: string;
     transaction?: string;
     metric?: string;
+    sourcemap?: string;
   };
   isSpaceAware?: boolean;
 }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -7617,7 +7617,7 @@
     "xpack.apm.tutorial.windowsServerInstructions.textPre": "1.从[下载页面]({downloadPageLink}) 下载 APM Server Windows zip 文件。\n2.将 zip 文件的内容解压缩到 {zipFileExtractFolder}。\n3.将 {apmServerDirectory} 目录重命名为 `APM-Server`。\n4.以管理员身份打开 PowerShell 提示符（右键单击 PowerShell 图标，然后选择**以管理员身份运行**）。如果运行的是 Windows XP，则可能需要下载并安装 PowerShell。\n5.从 PowerShell 提示符处，运行以下命令以将 APM Server 安装为 Windows 服务：",
     "xpack.apm.unifiedSearchBar.placeholder": "搜索{event, select, transaction {事务} metric {指标} error {错误} other {事务、错误和指标}}（例如 {queryExample}）",
     "xpack.apm.waterfall.errorCount": "{errorCount, plural, other {查看 # 个相关错误}}",
-    "xpack.apm.waterfall.exceedsMax": "此跟踪中的项目数为 {traceItemCount}，这高于 {maxTraceItems} 的当前限值。请增加该限值以查看完整追溯信息",
+    "xpack.apm.waterfall.exceedsMax": "此跟踪中的项目数为 {traceDocsTotal}，这高于 {maxTraceItems} 的当前限值。请增加该限值以查看完整追溯信息",
     "xpack.apm.waterfall.spanLinks.badge": "{total} {total, plural, other {跨度链接}}",
     "xpack.apm.waterfall.spanLinks.tooltip.linkedChildren": "{linkedChildren} 传入",
     "xpack.apm.waterfall.spanLinks.tooltip.linkedParents": "{linkedParents} 传出",

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/generate_large_trace.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/generate_large_trace.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/* eslint-disable @typescript-eslint/no-shadow */
+
+import { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { apm, timerange, DistributedTrace } from '@kbn/apm-synthtrace-client';
+
+const RATE_PER_MINUTE = 1;
+
+export function generateLargeTrace({
+  start,
+  end,
+  rootTransactionName,
+  synthtraceEsClient,
+  repeaterFactor,
+  environment,
+}: {
+  start: number;
+  end: number;
+  rootTransactionName: string;
+  synthtraceEsClient: ApmSynthtraceEsClient;
+  repeaterFactor: number;
+  environment: string;
+}) {
+  const range = timerange(start, end);
+
+  const synthRum = apm
+    .service({ name: 'synth-rum', environment, agentName: 'rum-js' })
+    .instance('my-instance');
+
+  const synthNode = apm
+    .service({ name: 'synth-node', environment, agentName: 'nodejs' })
+    .instance('my-instance');
+
+  const synthGo = apm
+    .service({ name: 'synth-go', environment, agentName: 'go' })
+    .instance('my-instance');
+
+  const synthDotnet = apm
+    .service({ name: 'synth-dotnet', environment, agentName: 'dotnet' })
+    .instance('my-instance');
+
+  const synthJava = apm
+    .service({ name: 'synth-java', environment, agentName: 'java' })
+    .instance('my-instance');
+
+  const traces = range.ratePerMinute(RATE_PER_MINUTE).generator((timestamp) => {
+    return new DistributedTrace({
+      serviceInstance: synthRum,
+      transactionName: rootTransactionName,
+      timestamp,
+      children: (_) => {
+        _.service({
+          repeat: 5 * repeaterFactor,
+          serviceInstance: synthNode,
+          transactionName: 'GET /nodejs/products',
+          latency: 100,
+
+          children: (_) => {
+            _.service({
+              serviceInstance: synthGo,
+              transactionName: 'GET /go',
+              children: (_) => {
+                _.service({
+                  repeat: 5 * repeaterFactor,
+                  serviceInstance: synthJava,
+                  transactionName: 'GET /java',
+                  children: (_) => {
+                    _.external({
+                      name: 'GET telemetry.elastic.co',
+                      url: 'https://telemetry.elastic.co/ping',
+                      duration: 50,
+                    });
+                  },
+                });
+              },
+            });
+            _.db({
+              name: 'GET apm-*/_search',
+              type: 'elasticsearch',
+              duration: 400,
+            });
+            _.db({ name: 'GET', type: 'redis', duration: 500 });
+            _.db({
+              name: 'SELECT * FROM users',
+              type: 'sqlite',
+              duration: 600,
+            });
+          },
+        });
+
+        _.service({
+          serviceInstance: synthNode,
+          transactionName: 'GET /nodejs/users',
+          latency: 100,
+          repeat: 5 * repeaterFactor,
+          children: (_) => {
+            _.service({
+              serviceInstance: synthGo,
+              transactionName: 'GET /go/security',
+              latency: 50,
+              children: (_) => {
+                _.service({
+                  repeat: 5 * repeaterFactor,
+                  serviceInstance: synthDotnet,
+                  transactionName: 'GET /dotnet/cases/4',
+                  latency: 50,
+                  children: (_) =>
+                    _.db({
+                      name: 'GET apm-*/_search',
+                      type: 'elasticsearch',
+                      duration: 600,
+                      statement: JSON.stringify(
+                        {
+                          query: {
+                            query_string: {
+                              query: '(new york city) OR (big apple)',
+                              default_field: 'content',
+                            },
+                          },
+                        },
+                        null,
+                        2
+                      ),
+                    }),
+                });
+              },
+            });
+          },
+        });
+      },
+    }).getTransaction();
+  });
+
+  return synthtraceEsClient.index(traces);
+}

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
@@ -81,7 +81,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         it('and traceDocs is correct', () => {
-          expect(trace.traceItems.traceDocs.length).to.be(15551);
+          expect(trace.traceItems.traceDocs.length).to.within(15550, 15555);
         });
 
         it('and maxTraceItems is correct', () => {

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
@@ -43,6 +43,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
       });
 
+      after(async () => {
+        await synthtraceEsClient.clean();
+      });
+
       describe('when maxTraceItems is 5000 (default)', () => {
         let trace: APIReturnType<'GET /internal/apm/traces/{traceId}'>;
         before(async () => {

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
@@ -81,7 +81,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
 
         it('and traceDocs is correct', () => {
-          expect(trace.traceItems.traceDocs.length).to.within(15550, 15555);
+          expect(trace.traceItems.traceDocs.length).to.be(15551);
         });
 
         it('and maxTraceItems is correct', () => {

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import {
+  PROCESSOR_EVENT,
+  TRACE_ID,
+  SERVICE_ENVIRONMENT,
+  TRANSACTION_ID,
+  PARENT_ID,
+} from '@kbn/apm-plugin/common/es_fields/apm';
+import type { Client } from '@elastic/elasticsearch';
+import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import expect from '@kbn/expect';
+import { ApmApiClient } from '../../../common/config';
+import { FtrProviderContext } from '../../../common/ftr_provider_context';
+import { generateLargeTrace } from './generate_large_trace';
+
+const start = new Date('2023-01-01T00:00:00.000Z').getTime();
+const end = new Date('2023-01-01T00:01:00.000Z').getTime() - 1;
+const rootTransactionName = 'Long trace';
+const environment = 'long_trace_scenario';
+
+export default function ApiTest({ getService }: FtrProviderContext) {
+  const registry = getService('registry');
+  const apmApiClient = getService('apmApiClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+  const es = getService('es');
+
+  registry.when('Large trace', { config: 'basic', archives: [] }, () => {
+    describe('when the trace is large (>15.000 items)', () => {
+      before(async () => {
+        await synthtraceEsClient.clean();
+        await generateLargeTrace({
+          start,
+          end,
+          rootTransactionName,
+          synthtraceEsClient,
+          repeaterFactor: 10,
+          environment,
+        });
+      });
+
+      describe('when maxTraceItems is 5000 (default)', () => {
+        let trace: APIReturnType<'GET /internal/apm/traces/{traceId}'>;
+        before(async () => {
+          trace = await getTrace({ es, apmApiClient, maxTraceItems: 5000 });
+        });
+
+        it('traceDocsTotal', () => {
+          expect(trace.traceItems.traceDocsTotal).to.be(15551);
+        });
+
+        it('traceDocs', () => {
+          expect(trace.traceItems.traceDocs.length).to.be(5000);
+        });
+
+        it('maxTraceItems', () => {
+          expect(trace.traceItems.maxTraceItems).to.be(5000);
+        });
+
+        it('exceedsMax', () => {
+          expect(trace.traceItems.exceedsMax).to.be(true);
+        });
+      });
+
+      describe('when maxTraceItems is 20000', () => {
+        let trace: APIReturnType<'GET /internal/apm/traces/{traceId}'>;
+        before(async () => {
+          trace = await getTrace({ es, apmApiClient, maxTraceItems: 20000 });
+        });
+
+        it('traceDocsTotal', () => {
+          expect(trace.traceItems.traceDocsTotal).to.be(15551);
+        });
+
+        it('traceDocs', () => {
+          expect(trace.traceItems.traceDocs.length).to.be(15551);
+        });
+
+        it('maxTraceItems', () => {
+          expect(trace.traceItems.maxTraceItems).to.be(20000);
+        });
+
+        it('exceedsMax', () => {
+          expect(trace.traceItems.exceedsMax).to.be(false);
+        });
+      });
+    });
+  });
+}
+
+async function getRootTransaction(es: Client) {
+  const params = {
+    index: 'traces-apm*',
+    _source: [TRACE_ID, TRANSACTION_ID],
+    body: {
+      query: {
+        bool: {
+          filter: [
+            { term: { [PROCESSOR_EVENT]: 'transaction' } },
+            { term: { [SERVICE_ENVIRONMENT]: environment } },
+          ],
+          must_not: [{ exists: { field: PARENT_ID } }],
+        },
+      },
+    },
+  };
+
+  interface Hit {
+    trace: { id: string };
+    transaction: { id: string };
+  }
+
+  const res = await es.search<Hit>(params);
+
+  return {
+    traceId: res.hits.hits[0]?._source?.trace.id as string,
+    transactionId: res.hits.hits[0]?._source?.transaction.id as string,
+  };
+}
+
+async function getTrace({
+  es,
+  apmApiClient,
+  maxTraceItems,
+}: {
+  es: Client;
+  apmApiClient: ApmApiClient;
+  maxTraceItems?: number;
+}) {
+  const rootTransaction = await getRootTransaction(es);
+  const res = await apmApiClient.readUser({
+    endpoint: `GET /internal/apm/traces/{traceId}`,
+    params: {
+      path: { traceId: rootTransaction.traceId },
+      query: {
+        start: new Date(start).toISOString(),
+        end: new Date(end).toISOString(),
+        entryTransactionId: rootTransaction.transactionId,
+        maxTraceItems,
+      },
+    },
+  });
+
+  return res.body;
+}

--- a/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/large_trace/large_trace.spec.ts
@@ -53,19 +53,19 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           trace = await getTrace({ es, apmApiClient, maxTraceItems: 5000 });
         });
 
-        it('traceDocsTotal', () => {
+        it('and traceDocsTotal is correct', () => {
           expect(trace.traceItems.traceDocsTotal).to.be(15551);
         });
 
-        it('traceDocs', () => {
+        it('and traceDocs is correct', () => {
           expect(trace.traceItems.traceDocs.length).to.be(5000);
         });
 
-        it('maxTraceItems', () => {
+        it('and maxTraceItems is correct', () => {
           expect(trace.traceItems.maxTraceItems).to.be(5000);
         });
 
-        it('exceedsMax', () => {
+        it('and exceedsMax is correct', () => {
           expect(trace.traceItems.exceedsMax).to.be(true);
         });
       });
@@ -76,19 +76,19 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           trace = await getTrace({ es, apmApiClient, maxTraceItems: 20000 });
         });
 
-        it('traceDocsTotal', () => {
+        it('and traceDocsTotal is correct', () => {
           expect(trace.traceItems.traceDocsTotal).to.be(15551);
         });
 
-        it('traceDocs', () => {
+        it('and traceDocs is correct', () => {
           expect(trace.traceItems.traceDocs.length).to.be(15551);
         });
 
-        it('maxTraceItems', () => {
+        it('and maxTraceItems is correct', () => {
           expect(trace.traceItems.maxTraceItems).to.be(20000);
         });
 
-        it('exceedsMax', () => {
+        it('and exceedsMax is correct', () => {
           expect(trace.traceItems.exceedsMax).to.be(false);
         });
       });

--- a/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import type { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
 import { apm, timerange } from '@kbn/apm-synthtrace-client';
 import expect from '@kbn/expect';
 import { Readable } from 'stream';
@@ -17,30 +18,17 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const start = new Date('2022-01-01T00:00:00.000Z').getTime();
   const end = new Date('2022-01-01T00:15:00.000Z').getTime() - 1;
 
-  async function fetchTraces({
-    traceId,
-    query,
-  }: {
-    traceId: string;
-    query: { start: string; end: string; entryTransactionId: string };
-  }) {
-    return await apmApiClient.readUser({
-      endpoint: `GET /internal/apm/traces/{traceId}`,
-      params: {
-        path: { traceId },
-        query,
-      },
-    });
-  }
-
   registry.when('Trace does not exist', { config: 'basic', archives: [] }, () => {
     it('handles empty state', async () => {
-      const response = await fetchTraces({
-        traceId: 'foo',
-        query: {
-          start: new Date(start).toISOString(),
-          end: new Date(end).toISOString(),
-          entryTransactionId: 'foo',
+      const response = await apmApiClient.readUser({
+        endpoint: `GET /internal/apm/traces/{traceId}`,
+        params: {
+          path: { traceId: 'foo' },
+          query: {
+            start: new Date(start).toISOString(),
+            end: new Date(end).toISOString(),
+            entryTransactionId: 'foo',
+          },
         },
       });
 
@@ -51,7 +39,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
           traceDocs: [],
           errorDocs: [],
           spanLinksCountById: {},
-          traceItemCount: 0,
+          traceDocsTotal: 0,
           maxTraceItems: 5000,
         },
       });
@@ -61,6 +49,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   registry.when('Trace exists', { config: 'basic', archives: [] }, () => {
     let entryTransactionId: string;
     let serviceATraceId: string;
+
     before(async () => {
       const instanceJava = apm
         .service({ name: 'synth-apple', environment: 'production', agentName: 'java' })
@@ -106,19 +95,24 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     after(() => synthtraceEsClient.clean());
 
     describe('return trace', () => {
-      let traces: Awaited<ReturnType<typeof fetchTraces>>['body'];
+      let traces: APIReturnType<'GET /internal/apm/traces/{traceId}'>;
       before(async () => {
-        const response = await fetchTraces({
-          traceId: serviceATraceId,
-          query: {
-            start: new Date(start).toISOString(),
-            end: new Date(end).toISOString(),
-            entryTransactionId,
+        const response = await apmApiClient.readUser({
+          endpoint: `GET /internal/apm/traces/{traceId}`,
+          params: {
+            path: { traceId: serviceATraceId },
+            query: {
+              start: new Date(start).toISOString(),
+              end: new Date(end).toISOString(),
+              entryTransactionId: 'foo',
+            },
           },
         });
+
         expect(response.status).to.eql(200);
         traces = response.body;
       });
+
       it('returns some errors', () => {
         expect(traces.traceItems.errorDocs.length).to.be.greaterThan(0);
         expect(traces.traceItems.errorDocs[0].error.exception?.[0].message).to.eql(

--- a/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/traces/trace_by_id.spec.ts
@@ -104,7 +104,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
             query: {
               start: new Date(start).toISOString(),
               end: new Date(end).toISOString(),
-              entryTransactionId: 'foo',
+              entryTransactionId,
             },
           },
         });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/164937

- Add pagination support for loading big traces
- Change sort order to use duration of spans and transactions simultaneously (this is a big improvement because before we always loaded all transactions first, then spans afterwards)
- Improve error message in the UI to show correct total number of traces, and the setting to increase.

**Flaky test runner builds:**

- ~https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3068~
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3073

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->