### PR TITLE
[Observability AI Assistant] Return `errorDoc` instead of `error` in GetApmErrorDocument function response

### DIFF
--- a/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_error_document/index.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/get_apm_error_document/index.ts
@@ -54,14 +54,14 @@ export async function getApmErrorDocument({
     },
   });
 
-  const error = response.hits.hits[0]?._source as APMError;
+  const errorDoc = response.hits.hits[0]?._source as APMError;
 
-  if (!error) {
+  if (!errorDoc) {
     return undefined;
   }
 
-  return pick(
-    error,
+  const formattedResponse = pick(
+    errorDoc,
     'message',
     'error',
     '@timestamp',
@@ -71,4 +71,11 @@ export async function getApmErrorDocument({
     'span.type',
     'span.subtype'
   );
+
+  const { error, ...rest } = formattedResponse;
+
+  return {
+    ...rest,
+    errorDoc: formattedResponse.error,
+  };
 }


### PR DESCRIPTION
## Summary

This is done as the Assistant implementation assumes `error` indicates a faulty response and thus renders the return as if it were an error.  

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->