### PR TITLE
[CM] Change network mode to behave correctly

### DIFF
--- a/src/plugins/content_management/public/content_client/content_client.tsx
+++ b/src/plugins/content_management/public/content_client/content_client.tsx
@@ -96,7 +96,7 @@ export class ContentClient {
     private readonly crudClientProvider: (contentType?: string) => CrudClient,
     private readonly contentTypeRegistry: ContentTypeRegistry
   ) {
-    this.queryClient = new QueryClient();
+    this.queryClient = new QueryClient({ defaultOptions: { queries: { networkMode: 'always' } } });
     this.queryOptionBuilder = createQueryOptionBuilder({
       crudClientProvider: this.crudClientProvider,
       contentTypeRegistry: this.contentTypeRegistry,


### PR DESCRIPTION
## Summary

Fixes #165323 

This was a tricky one-liner fix: Lens/Maps/Discover/Visualize List are all using the DataViews service, which in turns is leveraging the ContentManagement plugin to get the default DataView in Kibana.
The ContentManagement plugin is using a third party library `react-query`, which by default behaves in [`"online"` Network mode](https://tanstack.com/query/v4/docs/react/guides/network-mode), which it means that in case of offline sets in pause all requests optimistically waiting for the connection to get back.
This has the side effect of producing a `Promise` which remains in `pending` state forever in an air-gapped environment.

```mermaid
sequenceDiagram
    participant Apps as "Lens/Discover/etc"
    participant DataViews
    participant ContentManagement
    participant lib as "react-query"
    Apps->>DataViews: getDefaultDataView()
    DataViews->>ContentManagement: client.get(id)
    ContentManagement->>lib: fetchFn
    lib-->>ContentManagement: Promise<pending>
    Note over lib, ContentManagement: Promise will be pending forever

```

The solution is to force the `"always"` Network mode which is what it regularly happens without any smart handling.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->