### PR TITLE
[7.17] [Infra UI] Unskip alerts flyout test (#163919)

### DIFF
--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -15,9 +15,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
   const pageObjects = getPageObjects(['common', 'infraHome', 'infraSavedViews']);
 
-  // Failing: See https://github.com/elastic/kibana/issues/164452
-  // Failing: See https://github.com/elastic/kibana/issues/157767
-  describe.skip('Home page', function () {
+  describe('Home page', function () {
     this.tags('includeFirefox');
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/empty_kibana');

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -75,7 +75,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.infraHome.closeAlertFlyout();
       });
 
-      it('should open and close inventory alert flyout', async () => {
+      it('should open and close metrics threshold alert flyout', async () => {
         await pageObjects.infraHome.openMetricsThresholdAlertFlyout();
         await pageObjects.infraHome.closeAlertFlyout();
       });

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -216,20 +216,40 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await testSubjects.missingOrFail('metrics-alert-menu');
     },
 
+    async dismissDatePickerTooltip() {
+      const isTooltipOpen = await testSubjects.exists(`waffleDatePickerIntervalTooltip`, {
+        timeout: 1000,
+      });
+
+      if (isTooltipOpen) {
+        await testSubjects.click(`waffleDatePickerIntervalTooltip`);
+      }
+    },
+
     async openInventoryAlertFlyout() {
+      await this.dismissDatePickerTooltip();
       await testSubjects.click('infrastructure-alerts-and-rules');
       await testSubjects.click('inventory-alerts-menu-option');
-      await testSubjects.click('inventory-alerts-create-rule');
-      await testSubjects.missingOrFail('inventory-alerts-create-rule');
-      await testSubjects.find('euiFlyoutCloseButton');
+
+      // forces date picker tooltip to close in case it pops up after Alerts and rules opens
+      await testSubjects.moveMouseTo('contextMenuPanelTitleButton');
+
+      await retry.tryForTime(1000, () => testSubjects.click('inventory-alerts-create-rule'));
+      await testSubjects.missingOrFail('inventory-alerts-create-rule', { timeout: 30000 });
     },
 
     async openMetricsThresholdAlertFlyout() {
+      await this.dismissDatePickerTooltip();
       await testSubjects.click('infrastructure-alerts-and-rules');
       await testSubjects.click('metrics-threshold-alerts-menu-option');
-      await testSubjects.click('metrics-threshold-alerts-create-rule');
-      await testSubjects.missingOrFail('metrics-threshold-alerts-create-rule');
-      await testSubjects.find('euiFlyoutCloseButton');
+
+      // forces date picker tooltip to close in case it pops up after Alerts and rules opens
+      await testSubjects.moveMouseTo('contextMenuPanelTitleButton');
+
+      await retry.tryForTime(1000, () =>
+        testSubjects.click('metrics-threshold-alerts-create-rule')
+      );
+      await testSubjects.missingOrFail('metrics-threshold-alerts-create-rule', { timeout: 30000 });
     },
 
     async closeAlertFlyout() {


### PR DESCRIPTION
closes [#157767](https://github.com/elastic/kibana/issues/157767)

# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Infra UI] Unskip alerts flyout test (#163919)](https://github.com/elastic/kibana/pull/163919)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-08-16T12:13:22Z","message":"[Infra UI] Unskip alerts flyout test (#163919)\n\ncloses [#157712](https://github.com/elastic/kibana/issues/157712)\r\ncloses [#157767](https://github.com/elastic/kibana/issues/157767)\r\ncloses [#157711](https://github.com/elastic/kibana/issues/157711)\r\n\r\n## Summary\r\n\r\nUnskips \"alerts flyouts\" test. What cause the test to fail was possibly\r\nsolved by https://github.com/elastic/kibana/pull/162896\r\n\r\n\r\n### How to test\r\n\r\n```\r\nyarn test:ftr:server --config x-pack/test/functional/apps/infra/config.ts     \r\n```\r\n```\r\nnode scripts/functional_test_runner --config=x-pack/test/functional/apps/infra/config.ts --include x-pack/test/functional/apps/infra/home_page.ts  \r\n```\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2888\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1240d332502605657bf4a2b01f92f599557deab","branchLabelMapping":{"^v8.10.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Metrics UI","Team:Infra Monitoring UI","release_note:skip","backport:skip","v8.10.0","v8.11.0"],"number":163919,"url":"https://github.com/elastic/kibana/pull/163919","mergeCommit":{"message":"[Infra UI] Unskip alerts flyout test (#163919)\n\ncloses [#157712](https://github.com/elastic/kibana/issues/157712)\r\ncloses [#157767](https://github.com/elastic/kibana/issues/157767)\r\ncloses [#157711](https://github.com/elastic/kibana/issues/157711)\r\n\r\n## Summary\r\n\r\nUnskips \"alerts flyouts\" test. What cause the test to fail was possibly\r\nsolved by https://github.com/elastic/kibana/pull/162896\r\n\r\n\r\n### How to test\r\n\r\n```\r\nyarn test:ftr:server --config x-pack/test/functional/apps/infra/config.ts     \r\n```\r\n```\r\nnode scripts/functional_test_runner --config=x-pack/test/functional/apps/infra/config.ts --include x-pack/test/functional/apps/infra/home_page.ts  \r\n```\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2888\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1240d332502605657bf4a2b01f92f599557deab"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.10.0","labelRegex":"^v8.10.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/163919","number":163919,"mergeCommit":{"message":"[Infra UI] Unskip alerts flyout test (#163919)\n\ncloses [#157712](https://github.com/elastic/kibana/issues/157712)\r\ncloses [#157767](https://github.com/elastic/kibana/issues/157767)\r\ncloses [#157711](https://github.com/elastic/kibana/issues/157711)\r\n\r\n## Summary\r\n\r\nUnskips \"alerts flyouts\" test. What cause the test to fail was possibly\r\nsolved by https://github.com/elastic/kibana/pull/162896\r\n\r\n\r\n### How to test\r\n\r\n```\r\nyarn test:ftr:server --config x-pack/test/functional/apps/infra/config.ts     \r\n```\r\n```\r\nnode scripts/functional_test_runner --config=x-pack/test/functional/apps/infra/config.ts --include x-pack/test/functional/apps/infra/home_page.ts  \r\n```\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/2888\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d1240d332502605657bf4a2b01f92f599557deab"}},{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->