### PR TITLE
[Graph] Fix settings tabs when in dark mode

### DIFF
--- a/x-pack/plugins/graph/public/components/workspace_layout/workspace_top_nav_menu.tsx
+++ b/x-pack/plugins/graph/public/components/workspace_layout/workspace_top_nav_menu.tsx
@@ -12,7 +12,6 @@ import { AppMountParameters, Capabilities, CoreStart } from '@kbn/core/public';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Start as InspectorPublicPluginStart, RequestAdapter } from '@kbn/inspector-plugin/public';
 import { NavigationPublicPluginStart as NavigationStart } from '@kbn/navigation-plugin/public';
-// import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { datasourceSelector, hasFieldsSelector } from '../../state_management';
 import { GraphSavePolicy, GraphWorkspaceSavedObject, Workspace } from '../../types';

--- a/x-pack/plugins/graph/public/components/workspace_layout/workspace_top_nav_menu.tsx
+++ b/x-pack/plugins/graph/public/components/workspace_layout/workspace_top_nav_menu.tsx
@@ -12,7 +12,8 @@ import { AppMountParameters, Capabilities, CoreStart } from '@kbn/core/public';
 import { useHistory, useLocation } from 'react-router-dom';
 import { Start as InspectorPublicPluginStart, RequestAdapter } from '@kbn/inspector-plugin/public';
 import { NavigationPublicPluginStart as NavigationStart } from '@kbn/navigation-plugin/public';
-import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
+// import { toMountPoint, wrapWithTheme } from '@kbn/kibana-react-plugin/public';
+import { toMountPoint } from '@kbn/react-kibana-mount';
 import { datasourceSelector, hasFieldsSelector } from '../../state_management';
 import { GraphSavePolicy, GraphWorkspaceSavedObject, Workspace } from '../../types';
 import { AsObservable, Settings, SettingsWorkspaceProps } from '../settings';
@@ -162,12 +163,10 @@ export const WorkspaceTopNavMenu = (props: WorkspaceTopNavMenuProps) => {
 
       props.coreStart.overlays.openFlyout(
         toMountPoint(
-          wrapWithTheme(
-            <Provider store={store}>
-              <Settings observable={settingsObservable} />
-            </Provider>,
-            props.coreStart.theme.theme$
-          )
+          <Provider store={store}>
+            <Settings observable={settingsObservable} />
+          </Provider>,
+          { theme: props.coreStart.theme, i18n: props.coreStart.i18n }
         ),
         {
           size: 'm',

--- a/x-pack/plugins/graph/tsconfig.json
+++ b/x-pack/plugins/graph/tsconfig.json
@@ -46,6 +46,7 @@
     "@kbn/content-management-table-list-view-table",
     "@kbn/content-management-table-list-view",
     "@kbn/core-ui-settings-browser",
+    "@kbn/react-kibana-mount",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Fixes #165354 

Dark mode set at space level/Advanced settings

<img width="456" alt="Screenshot 2023-09-04 at 17 56 38" src="https://github.com/elastic/kibana/assets/924948/09b8bf12-cb05-4766-aa91-3b30328997f0">

Light mode set at space level

<img width="465" alt="Screenshot 2023-09-04 at 17 57 06" src="https://github.com/elastic/kibana/assets/924948/ec83372c-ff97-4825-bca4-b58a5b0e5cc5">

Dark mode set as profile setting:

<img width="451" alt="Screenshot 2023-09-04 at 17 55 40" src="https://github.com/elastic/kibana/assets/924948/0d3065ed-099b-4b10-9008-4330345bb452">

Light mode set as profile setting:

<img width="440" alt="Screenshot 2023-09-04 at 17 56 05" src="https://github.com/elastic/kibana/assets/924948/85a05df5-405f-494c-b14e-096d5e8d9a41">

