### PR TITLE
[Lens] Prevent user to use decimals for custom Percentile rank function in Top values

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.test.tsx
@@ -359,5 +359,73 @@ describe('percentile ranks', () => {
           .prop('value')
       ).toEqual('miaou');
     });
+
+    it('should support decimals on dimension edit', () => {
+      const updateLayerSpy = jest.fn();
+      const instance = mount(
+        <InlineOptions
+          {...defaultProps}
+          layer={layer}
+          paramEditorUpdater={updateLayerSpy}
+          columnId="col2"
+          currentColumn={layer.columns.col2 as PercentileRanksIndexPatternColumn}
+        />
+      );
+
+      const input = instance
+        .find('[data-test-subj="lns-indexPattern-percentile_ranks-input"]')
+        .find(EuiFieldNumber);
+
+      act(() => {
+        input.prop('onChange')!({
+          currentTarget: { value: '10.5' },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      instance.update();
+
+      expect(updateLayerSpy).toHaveBeenCalled();
+    });
+
+    it('should not support decimals on inline edit', () => {
+      const updateLayerSpy = jest.fn();
+      const instance = mount(
+        <InlineOptions
+          {...defaultProps}
+          layer={layer}
+          paramEditorUpdater={updateLayerSpy}
+          columnId="col2"
+          currentColumn={layer.columns.col2 as PercentileRanksIndexPatternColumn}
+          paramEditorCustomProps={{ isInline: true }}
+        />
+      );
+
+      const input = instance
+        .find('[data-test-subj="lns-indexPattern-percentile_ranks-input"]')
+        .find(EuiFieldNumber);
+
+      act(() => {
+        input.prop('onChange')!({
+          currentTarget: { value: '10.5' },
+        } as React.ChangeEvent<HTMLInputElement>);
+      });
+
+      instance.update();
+
+      expect(updateLayerSpy).not.toHaveBeenCalled();
+
+      expect(
+        instance
+          .find('[data-test-subj="lns-indexPattern-percentile_ranks-form"]')
+          .first()
+          .prop('isInvalid')
+      ).toEqual(true);
+      expect(
+        instance
+          .find('[data-test-subj="lns-indexPattern-percentile_ranks-input"]')
+          .find(EuiFieldNumber)
+          .prop('value')
+      ).toEqual('10.5');
+    });
   });
 });

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/percentile_ranks.tsx
@@ -189,7 +189,7 @@ export const percentileRanksOperation: OperationDefinition<
       });
     const onChange = useCallback(
       (value) => {
-        if (!isValidNumber(value) || Number(value) === currentColumn.params.value) {
+        if (!isValidNumber(value, isInline) || Number(value) === currentColumn.params.value) {
           return;
         }
         paramEditorUpdater({
@@ -209,7 +209,7 @@ export const percentileRanksOperation: OperationDefinition<
           },
         } as PercentileRanksIndexPatternColumn);
       },
-      [paramEditorUpdater, currentColumn, indexPattern]
+      [isInline, currentColumn, paramEditorUpdater, indexPattern]
     );
     const { inputValue, handleInputChange: handleInputChangeWithoutValidation } = useDebouncedValue<
       string | undefined
@@ -220,7 +220,7 @@ export const percentileRanksOperation: OperationDefinition<
       },
       { allowFalsyValue: true }
     );
-    const inputValueIsValid = isValidNumber(inputValue);
+    const inputValueIsValid = isValidNumber(inputValue, isInline);
 
     const handleInputChange: EuiFieldNumberProps['onChange'] = useCallback(
       (e) => {
@@ -250,7 +250,7 @@ export const percentileRanksOperation: OperationDefinition<
           compressed
           value={inputValue ?? ''}
           onChange={handleInputChange}
-          step="any"
+          step={isInline ? 1 : 'any'}
           aria-label={percentileRanksLabel}
         />
       </FormRow>


### PR DESCRIPTION
## Summary

Fixes #165001 

Decimals are still allowed as dimension column:

<img width="336" alt="Screenshot 2023-09-04 at 18 20 30" src="https://github.com/elastic/kibana/assets/924948/c35206ce-7413-4a26-b785-46d088322f3a">

But considered invalid values when used inline in Top values as custom ranking function:

<img width="343" alt="Screenshot 2023-09-04 at 18 20 44" src="https://github.com/elastic/kibana/assets/924948/aff26496-bf99-4a06-9c10-0ffe9e9e6219">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios