### PR TITLE
[Ops] Fix typos in bk pipeline stubs

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -5,12 +5,12 @@ env:
 steps:
   - label: ":pipeline::fleet::seedling: Trigger Observability Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Observability specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - label: ":pipeline::lock::seedling: Trigger Security Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Security specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - wait: ~

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -5,22 +5,22 @@ env:
 steps:
   - label: ":pipeline::kibana::seedling: Trigger Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Kibana specific tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - label: ":pipeline::fleet::seedling: Trigger Fleet Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Fleet specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - label: ":pipeline::lock::seedling: Trigger Security Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Security specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - label: ":pipeline::lock::seedling: Trigger Control Plane Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Control Plane specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - wait: ~

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
@@ -5,12 +5,12 @@ env:
 steps:
   - label: ":pipeline::fleet::seedling: Trigger Observability Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Observability specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - label: ":pipeline::lock::seedling: Trigger Security Kibana Tests for ${ENVIRONMENT}"
     command: echo "replace me with Security specific Kibana tests"
-    agent:
+    agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
   - wait: ~


### PR DESCRIPTION
## Summary
In the created stubs, some of the buildkite steps used `agent` instead of `agents`, this failed the steps.
This PR fixes these typos.

see: https://buildkite.com/elastic/kibana-tests/builds/20#018a6109-c878-489d-a4e4-ad4db1e75e87