### PR TITLE
GitHub create-deploy-tag workflow: Allow kibana-operations team to trigger

### DIFF
--- a/.github/workflows/create-deploy-tag.yml
+++ b/.github/workflows/create-deploy-tag.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   create-deploy-tag:
     # Temporary, we need a way to limit this to a GitHub team instead of specific users
-    if: contains('["watson","clintandrewhall","kobelb","lukeelmers","thomasneirynck"]', github.triggering_actor)
+    if: contains('["watson","clintandrewhall","kobelb","lukeelmers","thomasneirynck","jbudz","mistic","delanni","Ikuni17"]', github.triggering_actor)
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Adds the individual members of the @elastic/kibana-operations team to the list of GitHub users who are allowed to trigger this workflow