### PR TITLE
change quality gates notifications

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
@@ -1,4 +1,17 @@
+# This pipeline serves as the entry point for your service's quality gates definitions. When
+# properly configured, it will be invoked automatically as part of the automated
+# promotion process once a new version was rolled out in one of the various cloud stages.
+#
+# The updated environment is provided via ENVIRONMENT variable. The seedling
+# step will branch and execute pipeline snippets at the following location:
+# pipeline.tests-qa.yaml
+# pipeline.tests-staging.yaml
+# pipeline.tests-production.yaml
+#
+# Docs: https://docs.elastic.dev/serverless/qualitygates
+
 env:
+  TEAM_CHANNEL: "#kibana-mission-control"
   ENVIRONMENT: ${ENVIRONMENT?}
 
 steps:
@@ -8,3 +21,7 @@ steps:
     command: "make -C /agent run-environment-tests"
     agents:
       image: "docker.elastic.co/ci-agent-images/quality-gate-seedling:0.0.2"
+
+notify:
+  - slack: "${TEAM_CHANNEL?}"
+    if: build.branch == "main" && build.state == "failed"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -1,6 +1,6 @@
-env:
-  TEAM_CHANNEL: "#kibana-serverless-release"
-  ENVIRONMENT: "production"
+# These pipeline steps constitute the quality gate for your service within the production
+# environment. Incorporate any necessary additional logic to validate the service's integrity.
+# A failure in this pipeline build will prevent further progression to the subsequent stage.
 
 steps:
   - label: ":pipeline::fleet::seedling: Trigger Observability Kibana Tests for ${ENVIRONMENT}"
@@ -13,9 +13,17 @@ steps:
     agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
+  - label: ":rocket: Run cp e2e tests"
+    trigger: "ess-k8s-production-e2e-tests"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      env:
+        REGION_ID: aws-us-east-1
+        NAME_PREFIX: ci_test_${SERVICE}-promotion_
+
   - wait: ~
 
   - label: ":judge::seedling: Trigger Manual Tests Phase"
     command: "make -C /agent trigger-manual-verification-phase"
     agents:
-      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.1"
+      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.2"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -1,6 +1,6 @@
-env:
-  TEAM_CHANNEL: "#kibana-serverless-release"
-  ENVIRONMENT: "qa"
+# These pipeline steps constitute the quality gate for your service within the QA environment.
+# Incorporate any necessary additional logic to validate the service's integrity. A failure in
+# this pipeline build will prevent further progression to the subsequent stage.
 
 steps:
   - label: ":pipeline::kibana::seedling: Trigger Kibana Tests for ${ENVIRONMENT}"
@@ -23,9 +23,17 @@ steps:
     agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
+  - label: ":rocket: Run cp e2e tests"
+    trigger: "ess-k8s-qa-e2e-tests-daily"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      env:
+        REGION_ID: aws-eu-west-1
+        NAME_PREFIX: ci_test_kibana-promotion_
+
   - wait: ~
 
   - label: ":judge::seedling: Trigger Manual Tests Phase"
     command: "make -C /agent trigger-manual-verification-phase"
     agents:
-      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.1"
+      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.2"

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-staging.yaml
@@ -1,6 +1,6 @@
-env:
-  TEAM_CHANNEL: "#kibana-serverless-release"
-  ENVIRONMENT: "staging"
+# These pipeline steps constitute the quality gate for your service within the staging environment.
+# Incorporate any necessary additional logic to validate the service's integrity. A failure in
+# this pipeline build will prevent further progression to the subsequent stage.
 
 steps:
   - label: ":pipeline::fleet::seedling: Trigger Observability Kibana Tests for ${ENVIRONMENT}"
@@ -13,9 +13,17 @@ steps:
     agents:
       image: "docker.elastic.co/ci-agent-images/basic-buildkite-agent:1688566364"
 
+  - label: ":rocket: Run cp e2e tests"
+    trigger: "ess-k8s-staging-e2e-tests"
+    build:
+      message: "${BUILDKITE_MESSAGE}"
+      env:
+        REGION_ID: aws-us-east-1
+        NAME_PREFIX: ci_test_kibana-promotion_
+
   - wait: ~
 
   - label: ":judge::seedling: Trigger Manual Tests Phase"
     command: "make -C /agent trigger-manual-verification-phase"
     agents:
-      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.1"
+      image: "docker.elastic.co/ci-agent-images/manual-verification-agent:0.0.2"


### PR DESCRIPTION
## Summary
This redirects release notification to `#kibana-mission-controle`.
Adds a set of minimum smoke tests in each environment. 
They basically check wether kibana boots, can connect to ES and subsystems are availble.
They are however broadly scoped as they require CP components functionality, 
so we have to see how it goes with them. 
=>They may block kibana releases on CP service failures