### PR TITLE
chore(NA): reduce parallelism number on Serverless Security Cypress Tests

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -140,7 +140,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 40
-    parallelism: 16
+    parallelism: 12
     soft_fail: true
     retry:
       automatic:

--- a/.buildkite/pipelines/serverless.yml
+++ b/.buildkite/pipelines/serverless.yml
@@ -105,7 +105,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 40
-    parallelism: 16
+    parallelism: 12
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
This PR reduces the parallel number of workers that will run the Serverless Security Cypress Tests as at least for now I don't think we need `16`.