### PR TITLE
[ES|QL] Adds initial telemetry events

### DIFF
--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
@@ -27,6 +27,7 @@ import {
   EuiButtonEmpty,
   EuiToolTip,
 } from '@elastic/eui';
+import { METRIC_TYPE } from '@kbn/analytics';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { AggregateQuery, getLanguageDisplayName } from '@kbn/es-query';
 import type { DataView } from '@kbn/data-views-plugin/public';
@@ -92,7 +93,9 @@ export function ChangeDataView({
   const [selectedDataViewId, setSelectedDataViewId] = useState(currentDataViewId);
 
   const kibana = useKibana<IUnifiedSearchPluginServices>();
-  const { application, data, storage, dataViews, dataViewEditor } = kibana.services;
+  const { application, data, storage, dataViews, dataViewEditor, appName, usageCollection } =
+    kibana.services;
+  const reportUiCounter = usageCollection?.reportUiCounter.bind(usageCollection, appName);
   const styles = changeDataViewStyles({ fullWidth: trigger.fullWidth });
   const [isTextLangTransitionModalDismissed, setIsTextLangTransitionModalDismissed] = useState(() =>
     Boolean(storage.get(TEXT_LANG_TRANSITION_MODAL_KEY))
@@ -366,8 +369,9 @@ export function ChangeDataView({
     (q: AggregateQuery) => {
       onTextLangQuerySubmit?.(q);
       setPopoverIsOpen(false);
+      reportUiCounter?.(METRIC_TYPE.CLICK, `esql:unified_search_clicked`);
     },
-    [onTextLangQuerySubmit]
+    [onTextLangQuerySubmit, reportUiCounter]
   );
 
   const cleanup = useCallback(

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { CoreStart } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
-import type { AggregateQuery } from '@kbn/es-query';
+import { AggregateQuery, isOfAggregateQueryType, getAggregateQueryMode } from '@kbn/es-query';
 import type { SavedObjectReference } from '@kbn/core/public';
 import { EuiFormRow } from '@elastic/eui';
 import type { ExpressionsStart } from '@kbn/expressions-plugin/public';
@@ -371,6 +371,12 @@ export function getTextBasedDatasource({
     },
 
     getRenderEventCounters(state: TextBasedPrivateState): string[] {
+      const context = state?.initialContext;
+      if (context && 'query' in context && context.query && isOfAggregateQueryType(context.query)) {
+        const language = getAggregateQueryMode(context.query);
+        // it will eventually log render_lens_esql_chart
+        return [`${language}_chart`];
+      }
       return [];
     },
 


### PR DESCRIPTION
## Summary

Adds initial counters for ES|QL

1. When the Try ES|QL option in dataview picker is clicked
2. When a Lens chart with text based languages is rendered