### PR TITLE
Fixes preview chart when KQL filter is not used in APM rules

### DIFF
--- a/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/error_count_rule_type/index.tsx
@@ -106,7 +106,9 @@ export function ErrorCountRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                searchConfiguration: JSON.stringify(params.searchConfiguration),
+                searchConfiguration: params.searchConfiguration?.query?.query
+                  ? JSON.stringify(params.searchConfiguration)
+                  : undefined,
               },
             },
           }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_duration_rule_type/index.tsx
@@ -136,7 +136,9 @@ export function TransactionDurationRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                searchConfiguration: JSON.stringify(params.searchConfiguration),
+                searchConfiguration: params.searchConfiguration?.query?.query
+                  ? JSON.stringify(params.searchConfiguration)
+                  : undefined,
               },
             },
           }

--- a/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
+++ b/x-pack/plugins/apm/public/components/alerting/rule_types/transaction_error_rate_rule_type/index.tsx
@@ -108,7 +108,9 @@ export function TransactionErrorRateRuleType(props: Props) {
                 start,
                 end,
                 groupBy: params.groupBy,
-                searchConfiguration: JSON.stringify(params.searchConfiguration),
+                searchConfiguration: params.searchConfiguration?.query?.query
+                  ? JSON.stringify(params.searchConfiguration)
+                  : undefined,
               },
             },
           }

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/error_count/register_error_count_rule_type.ts
@@ -117,7 +117,7 @@ export function registerErrorCountRuleType({
 
         const indices = await getApmIndices(savedObjectsClient);
 
-        const termFilterQuery = !ruleParams.searchConfiguration
+        const termFilterQuery = !ruleParams.searchConfiguration?.query?.query
           ? [
               ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
                 queryEmptyString: false,

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_duration/register_transaction_duration_rule_type.ts
@@ -135,7 +135,7 @@ export function registerTransactionDurationRuleType({
         searchAggregatedTransactions
       );
 
-      const termFilterQuery = !ruleParams.searchConfiguration
+      const termFilterQuery = !ruleParams.searchConfiguration?.query?.query
         ? [
             ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
               queryEmptyString: false,

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/transaction_error_rate/register_transaction_error_rate_rule_type.ts
@@ -137,7 +137,7 @@ export function registerTransactionErrorRateRuleType({
           ? indices.metric
           : indices.transaction;
 
-        const termFilterQuery = !ruleParams.searchConfiguration
+        const termFilterQuery = !ruleParams.searchConfiguration?.query?.query
           ? [
               ...termQuery(SERVICE_NAME, ruleParams.serviceName, {
                 queryEmptyString: false,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/165711

Fixes preview chart when normal filters are used and KQL filter is not selected in APM rules.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->