### PR TITLE
[8.10] [Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)

### DIFF
--- a/x-pack/packages/security-solution/features/src/constants.ts
+++ b/x-pack/packages/security-solution/features/src/constants.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Same as the plugin id defined by Security Solution
+export const APP_ID = 'securitySolution' as const;
+export const SERVER_APP_ID = 'siem' as const;
+
+export const CASES_FEATURE_ID = 'securitySolutionCases' as const;
+export const ASSISTANT_FEATURE_ID = 'securitySolutionAssistant' as const;
+
+// Same as the plugin id defined by Cloud Security Posture
+export const CLOUD_POSTURE_APP_ID = 'csp' as const;
+
+// Same as the plugin id defined by Defend for containers (cloud_defend)
+export const CLOUD_DEFEND_APP_ID = 'cloudDefend' as const;
+
+/**
+ * Id for the notifications alerting type
+ * @deprecated Once we are confident all rules relying on side-car actions SO's have been migrated to SO references we should remove this function
+ */
+export const LEGACY_NOTIFICATIONS_ID = `siem.notifications` as const;

--- a/x-pack/packages/security-solution/features/src/security/kibana_features.ts
+++ b/x-pack/packages/security-solution/features/src/security/kibana_features.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
+import {
+  EQL_RULE_TYPE_ID,
+  INDICATOR_RULE_TYPE_ID,
+  ML_RULE_TYPE_ID,
+  NEW_TERMS_RULE_TYPE_ID,
+  QUERY_RULE_TYPE_ID,
+  SAVED_QUERY_RULE_TYPE_ID,
+  THRESHOLD_RULE_TYPE_ID,
+} from '@kbn/securitysolution-rules';
+import type { BaseKibanaFeatureConfig } from '../types';
+import {
+  APP_ID,
+  SERVER_APP_ID,
+  LEGACY_NOTIFICATIONS_ID,
+  CLOUD_POSTURE_APP_ID,
+  CLOUD_DEFEND_APP_ID,
+} from '../constants';
+import type { SecurityFeatureParams } from './types';
+
+const SECURITY_RULE_TYPES = [
+  LEGACY_NOTIFICATIONS_ID,
+  EQL_RULE_TYPE_ID,
+  INDICATOR_RULE_TYPE_ID,
+  ML_RULE_TYPE_ID,
+  QUERY_RULE_TYPE_ID,
+  SAVED_QUERY_RULE_TYPE_ID,
+  THRESHOLD_RULE_TYPE_ID,
+  NEW_TERMS_RULE_TYPE_ID,
+];
+
+export const getSecurityBaseKibanaFeature = ({
+  savedObjects,
+}: SecurityFeatureParams): BaseKibanaFeatureConfig => ({
+  id: SERVER_APP_ID,
+  name: i18n.translate(
+    'securitySolutionPackages.features.featureRegistry.linkSecuritySolutionTitle',
+    {
+      defaultMessage: 'Security',
+    }
+  ),
+  order: 1100,
+  category: DEFAULT_APP_CATEGORIES.security,
+  app: [APP_ID, CLOUD_POSTURE_APP_ID, CLOUD_DEFEND_APP_ID, 'kibana'],
+  catalogue: [APP_ID],
+  management: {
+    insightsAndAlerting: ['triggersActions'],
+  },
+  alerting: SECURITY_RULE_TYPES,
+  privileges: {
+    all: {
+      app: [APP_ID, CLOUD_POSTURE_APP_ID, CLOUD_DEFEND_APP_ID, 'kibana'],
+      catalogue: [APP_ID],
+      api: [
+        APP_ID,
+        'lists-all',
+        'lists-read',
+        'lists-summary',
+        'rac',
+        'cloud-security-posture-all',
+        'cloud-security-posture-read',
+        'cloud-defend-all',
+        'cloud-defend-read',
+      ],
+      savedObject: {
+        all: ['alert', ...savedObjects],
+        read: [],
+      },
+      alerting: {
+        rule: {
+          all: SECURITY_RULE_TYPES,
+        },
+        alert: {
+          all: SECURITY_RULE_TYPES,
+        },
+      },
+      management: {
+        insightsAndAlerting: ['triggersActions'],
+      },
+      ui: ['show', 'crud'],
+    },
+    read: {
+      app: [APP_ID, CLOUD_POSTURE_APP_ID, CLOUD_DEFEND_APP_ID, 'kibana'],
+      catalogue: [APP_ID],
+      api: [APP_ID, 'lists-read', 'rac', 'cloud-security-posture-read', 'cloud-defend-read'],
+      savedObject: {
+        all: [],
+        read: [...savedObjects],
+      },
+      alerting: {
+        rule: {
+          read: SECURITY_RULE_TYPES,
+        },
+        alert: {
+          all: SECURITY_RULE_TYPES,
+        },
+      },
+      management: {
+        insightsAndAlerting: ['triggersActions'],
+      },
+      ui: ['show'],
+    },
+  },
+});

--- a/x-pack/plugins/security_solution/public/management/links.test.ts
+++ b/x-pack/plugins/security_solution/public/management/links.test.ts
@@ -93,7 +93,8 @@ describe('links', () => {
         SecurityPageName.hostIsolationExceptions,
         SecurityPageName.policies,
         SecurityPageName.responseActionsHistory,
-        SecurityPageName.trustedApps
+        SecurityPageName.trustedApps,
+        SecurityPageName.cloudDefendPolicies
       )
     );
   });
@@ -234,7 +235,9 @@ describe('links', () => {
 
       const filteredLinks = await getManagementFilteredLinks(coreMockStarted, getPlugins());
 
-      expect(filteredLinks).toEqual(getLinksWithout(SecurityPageName.policies));
+      expect(filteredLinks).toEqual(
+        getLinksWithout(SecurityPageName.policies, SecurityPageName.cloudDefendPolicies)
+      );
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -235,6 +235,7 @@ export const getManagementFilteredLinks = async (
 
   if (!canReadPolicyManagement) {
     linksToExclude.push(SecurityPageName.policies);
+    linksToExclude.push(SecurityPageName.cloudDefendPolicies);
   }
 
   if (!canReadActionsLogManagement) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)](https://github.com/elastic/kibana/pull/165376)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Karl Godard","email":"karl.godard@elastic.co"},"sourceCommit":{"committedDate":"2023-09-05T14:44:54Z","message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security","backport:prev-minor","v8.10.0","v8.11.0"],"number":165376,"url":"https://github.com/elastic/kibana/pull/165376","mergeCommit":{"message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/165376","number":165376,"mergeCommit":{"message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2"}}]}] BACKPORT-->