### PR TITLE
[8.10] [Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)

### DIFF
--- a/x-pack/plugins/security_solution/public/management/links.test.ts
+++ b/x-pack/plugins/security_solution/public/management/links.test.ts
@@ -93,7 +93,8 @@ describe('links', () => {
         SecurityPageName.hostIsolationExceptions,
         SecurityPageName.policies,
         SecurityPageName.responseActionsHistory,
-        SecurityPageName.trustedApps
+        SecurityPageName.trustedApps,
+        SecurityPageName.cloudDefendPolicies
       )
     );
   });
@@ -234,7 +235,9 @@ describe('links', () => {
 
       const filteredLinks = await getManagementFilteredLinks(coreMockStarted, getPlugins());
 
-      expect(filteredLinks).toEqual(getLinksWithout(SecurityPageName.policies));
+      expect(filteredLinks).toEqual(
+        getLinksWithout(SecurityPageName.policies, SecurityPageName.cloudDefendPolicies)
+      );
     });
   });
 

--- a/x-pack/plugins/security_solution/public/management/links.ts
+++ b/x-pack/plugins/security_solution/public/management/links.ts
@@ -235,6 +235,7 @@ export const getManagementFilteredLinks = async (
 
   if (!canReadPolicyManagement) {
     linksToExclude.push(SecurityPageName.policies);
+    linksToExclude.push(SecurityPageName.cloudDefendPolicies);
   }
 
   if (!canReadActionsLogManagement) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)](https://github.com/elastic/kibana/pull/165376)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Karl Godard","email":"karl.godard@elastic.co"},"sourceCommit":{"committedDate":"2023-09-05T14:44:54Z","message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Cloud Security","backport:prev-minor","v8.10.0","v8.11.0"],"number":165376,"url":"https://github.com/elastic/kibana/pull/165376","mergeCommit":{"message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/165376","number":165376,"mergeCommit":{"message":"[Cloud Security] added missing bits for backend route check (similar to csp), also add… (#165376)\n\n…ed d4c manage policies link to the list of excluded links when user\r\ndoes not have permission to read policies in security solution\r\n\r\n## Summary\r\n\r\nFixes: https://github.com/elastic/kibana/issues/163562","sha":"7e826077c450d8e32a87629177055e214d5c77f2"}}]}] BACKPORT-->