### PR TITLE
[kbn/es] Always guide user to auth for Docker pull errors

### DIFF
--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -103,11 +103,6 @@ export const SERVERLESS_REPO = `${DOCKER_REGISTRY}/elasticsearch-ci/elasticsearc
 export const SERVERLESS_TAG = 'latest';
 export const SERVERLESS_IMG = `${SERVERLESS_REPO}:${SERVERLESS_TAG}`;
 
-const DOCKER_AUTH_ERRORS = [
-  'unauthorized: authentication required', // Bad credentials
-  'denied: requested access to the resource is denied', // No credentials
-];
-
 // See for default cluster settings
 // https://github.com/elastic/elasticsearch-serverless/blob/main/serverless-build-tools/src/main/kotlin/elasticsearch.serverless-run.gradle.kts
 const SHARED_SERVERLESS_PARAMS = [
@@ -340,11 +335,12 @@ export async function maybePullDockerImage(log: ToolingLog, image: string) {
   await execa('docker', ['pull', image], {
     // inherit is required to show Docker pull output
     stdio: ['ignore', 'inherit', 'pipe'],
-  }).catch(({ message, stderr }) => {
+  }).catch(({ message }) => {
     throw createCliError(
-      DOCKER_AUTH_ERRORS.some((msg) => stderr.includes(msg))
-        ? `Error authenticating with ${DOCKER_REGISTRY}. Visit https://docker-auth.elastic.co/github_auth to login.`
-        : message
+      `Error pulling image. This is likely an issue authenticating with ${DOCKER_REGISTRY}.      
+Visit ${chalk.bold.cyan('https://docker-auth.elastic.co/github_auth')} to login.
+
+${message}`
     );
   });
 }

--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -103,6 +103,11 @@ export const SERVERLESS_REPO = `${DOCKER_REGISTRY}/elasticsearch-ci/elasticsearc
 export const SERVERLESS_TAG = 'latest';
 export const SERVERLESS_IMG = `${SERVERLESS_REPO}:${SERVERLESS_TAG}`;
 
+const DOCKER_AUTH_ERRORS = [
+  'unauthorized: authentication required', // Bad credentials
+  'denied: requested access to the resource is denied', // No credentials
+];
+
 // See for default cluster settings
 // https://github.com/elastic/elasticsearch-serverless/blob/main/serverless-build-tools/src/main/kotlin/elasticsearch.serverless-run.gradle.kts
 const SHARED_SERVERLESS_PARAMS = [
@@ -337,7 +342,7 @@ export async function maybePullDockerImage(log: ToolingLog, image: string) {
     stdio: ['ignore', 'inherit', 'pipe'],
   }).catch(({ message, stderr }) => {
     throw createCliError(
-      stderr.includes('unauthorized: authentication required')
+      DOCKER_AUTH_ERRORS.some((msg) => stderr.includes(msg))
         ? `Error authenticating with ${DOCKER_REGISTRY}. Visit https://docker-auth.elastic.co/github_auth to login.`
         : message
     );


### PR DESCRIPTION
## Summary
Expands on #165422 to always guide towards Docker auth for pull issues.

## Testing
- No credentials (error `denied: requested access to the resource is denied`)
  1. Run `docker logout docker.elastic.co`
  2. Run  `yarn es serverless`
- Bad credentials (error `unauthorized: authentication required`)
  1. Visit https://docker-auth.elastic.co/github_auth and login to invalidate current token
  2. Run `yarn es serverless`  