### PR TITLE
[Logs Onboarding] Implement Observability Onboarding locator

### DIFF
--- a/x-pack/plugins/observability_onboarding/kibana.jsonc
+++ b/x-pack/plugins/observability_onboarding/kibana.jsonc
@@ -7,7 +7,7 @@
     "server": true,
     "browser": true,
     "configPath": ["xpack", "observability_onboarding"],
-    "requiredPlugins": ["data", "observability", "observabilityShared", "discover"],
+    "requiredPlugins": ["data", "observability", "observabilityShared", "discover", "share"],
     "optionalPlugins": ["cloud", "usageCollection"],
     "requiredBundles": ["kibanaReact"],
     "extraPublicDirs": ["common"]

--- a/x-pack/plugins/observability_onboarding/public/index.ts
+++ b/x-pack/plugins/observability_onboarding/public/index.ts
@@ -17,6 +17,8 @@ import {
   ObservabilityOnboardingPluginStart,
 } from './plugin';
 
+export { OBSERVABILITY_ONBOARDING_LOCATOR } from './locators/onboarding_locator/locator_definition';
+
 export interface ConfigSchema {
   ui: {
     enabled: boolean;

--- a/x-pack/plugins/observability_onboarding/public/locators/index.ts
+++ b/x-pack/plugins/observability_onboarding/public/locators/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObservabilityOnboardingLocator } from './onboarding_locator/types';
+
+export interface ObservabilityOnboardingPluginLocators {
+  onboarding: ObservabilityOnboardingLocator;
+}

--- a/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/get_location.ts
+++ b/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/get_location.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObservabilityOnboardingLocatorParams } from './types';
+import { PLUGIN_ID } from '../../../common';
+
+export function getLocation(params: ObservabilityOnboardingLocatorParams) {
+  const { source } = params;
+
+  const path = ['/', source].filter(Boolean).join('');
+
+  return {
+    app: PLUGIN_ID,
+    path,
+    state: {},
+  };
+}

--- a/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/locator_definition.test.ts
+++ b/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/locator_definition.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ObservabilityOnboardingLocatorDefinition } from './locator_definition';
+
+describe('Observability onboarding locator', () => {
+  test('should create a link to the overview page', async () => {
+    const locator = new ObservabilityOnboardingLocatorDefinition();
+    const location = await locator.getLocation();
+
+    expect(location).toMatchObject({
+      app: 'observabilityOnboarding',
+      path: '/',
+      state: {},
+    });
+  });
+
+  test('should create a link to specified log source onboarding', async () => {
+    const locator = new ObservabilityOnboardingLocatorDefinition();
+    const systemLocation = await locator.getLocation({ source: 'systemLogs' });
+
+    expect(systemLocation).toMatchObject({
+      app: 'observabilityOnboarding',
+      path: '/systemLogs',
+      state: {},
+    });
+  });
+});

--- a/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/locator_definition.ts
+++ b/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/locator_definition.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LocatorDefinition } from '@kbn/share-plugin/public';
+import type { ObservabilityOnboardingLocatorParams } from './types';
+
+export const OBSERVABILITY_ONBOARDING_LOCATOR =
+  'OBSERVABILITY_ONBOARDING_LOCATOR' as const;
+
+export class ObservabilityOnboardingLocatorDefinition
+  implements LocatorDefinition<ObservabilityOnboardingLocatorParams>
+{
+  public readonly id = OBSERVABILITY_ONBOARDING_LOCATOR;
+
+  public readonly getLocation = async (
+    params: ObservabilityOnboardingLocatorParams = {}
+  ) => {
+    const { getLocation } = await import('./get_location');
+    return getLocation(params);
+  };
+}

--- a/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/types.ts
+++ b/x-pack/plugins/observability_onboarding/public/locators/onboarding_locator/types.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { LocatorPublic } from '@kbn/share-plugin/public';
+import { SerializableRecord } from '@kbn/utility-types';
+
+export interface ObservabilityOnboardingLocatorParams
+  extends SerializableRecord {
+  /** If given, it will load the given map else will load the create a new map page. */
+  source?: 'customLogs' | 'systemLogs';
+}
+
+export type ObservabilityOnboardingLocator =
+  LocatorPublic<ObservabilityOnboardingLocatorParams>;

--- a/x-pack/plugins/observability_onboarding/public/plugin.ts
+++ b/x-pack/plugins/observability_onboarding/public/plugin.ts
@@ -24,15 +24,20 @@ import {
   DataPublicPluginStart,
 } from '@kbn/data-plugin/public';
 import type { DiscoverSetup } from '@kbn/discover-plugin/public';
+import { SharePluginSetup } from '@kbn/share-plugin/public';
 import type { ObservabilityOnboardingConfig } from '../server';
+import { PLUGIN_ID } from '../common';
+import { ObservabilityOnboardingLocatorDefinition } from './locators/onboarding_locator/locator_definition';
+import { ObservabilityOnboardingPluginLocators } from './locators';
 
 export type ObservabilityOnboardingPluginSetup = void;
 export type ObservabilityOnboardingPluginStart = void;
 
 export interface ObservabilityOnboardingPluginSetupDeps {
   data: DataPublicPluginSetup;
-  observability: ObservabilityPublicSetup;
   discover: DiscoverSetup;
+  observability: ObservabilityPublicSetup;
+  share: SharePluginSetup;
 }
 
 export interface ObservabilityOnboardingPluginStartDeps {
@@ -48,6 +53,8 @@ export class ObservabilityOnboardingPlugin
       ObservabilityOnboardingPluginStart
     >
 {
+  private locators?: ObservabilityOnboardingPluginLocators;
+
   constructor(private ctx: PluginInitializerContext) {}
 
   public setup(
@@ -69,7 +76,7 @@ export class ObservabilityOnboardingPlugin
         navLinkStatus: isServerlessEnabled
           ? AppNavLinkStatus.visible
           : AppNavLinkStatus.hidden,
-        id: 'observabilityOnboarding',
+        id: PLUGIN_ID,
         title: 'Observability Onboarding',
         order: 8500,
         euiIconType: 'logoObservability',
@@ -98,9 +105,23 @@ export class ObservabilityOnboardingPlugin
         },
       });
     }
+
+    this.locators = {
+      onboarding: plugins.share.url.locators.create(
+        new ObservabilityOnboardingLocatorDefinition()
+      ),
+    };
+
+    return {
+      locators: this.locators,
+    };
   }
   public start(
     core: CoreStart,
     plugins: ObservabilityOnboardingPluginStartDeps
-  ) {}
+  ) {
+    return {
+      locators: this.locators,
+    };
+  }
 }

--- a/x-pack/plugins/observability_onboarding/tsconfig.json
+++ b/x-pack/plugins/observability_onboarding/tsconfig.json
@@ -33,6 +33,8 @@
     "@kbn/data-views-plugin",
     "@kbn/es-query",
     "@kbn/use-tracked-promise",
+    "@kbn/share-plugin",
+    "@kbn/utility-types",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## 📓 Summary

In preparation for #165486 where we'll implement a call to action to bring into the logs onboarding, this PR implement the onboarding locator for the `observability_onboarding` plugin.

The locator is both returned in the plugin contract and registered in the central registry so that we'll be able to consume it without creating circular dependencies between `observability_onboarding` and `observability_log_explorer` plugins.

With this first iteration, the locator allows to navigate to the landing page or to specify a log source to onboard:
```ts
// Navigate to onboarding landing page: /app/observabilityOnboarding
plugins.share.url.locators.get(OBSERVABILITY_ONBOARDING_LOCATOR).navigate()

// Navigate to system logs onboarding: /app/observabilityOnboarding/systemLogs
plugins.share.url.locators.get(OBSERVABILITY_ONBOARDING_LOCATOR).navigate({source: 'systemLogs'})


// Navigate to custom logs onboarding: /app/observabilityOnboarding/customLogs
plugins.share.url.locators.get(OBSERVABILITY_ONBOARDING_LOCATOR).navigate({source: 'customLogs'})
```