### PR TITLE
[Security Solution][Endpoint] Transition to fleet versioned APIs on Management pages

### DIFF
--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy.ts
@@ -9,6 +9,7 @@ import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
 import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { useQuery } from '@tanstack/react-query';
 import { packagePolicyRouteService } from '@kbn/fleet-plugin/common';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import {
   DefaultPolicyNotificationMessage,
   DefaultPolicyRuleNotificationMessage,
@@ -46,7 +47,7 @@ export const useFetchEndpointPolicy = (
     queryFn: async () => {
       const apiResponse = await http.get<GetPolicyResponse>(
         packagePolicyRouteService.getInfoPath(policyId),
-        { version: '2023-10-31' }
+        { version: API_VERSIONS.public.v1 }
       );
 
       applyDefaultsToPolicyIfNeeded(apiResponse.item);

--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy.ts
@@ -45,7 +45,8 @@ export const useFetchEndpointPolicy = (
     ...options,
     queryFn: async () => {
       const apiResponse = await http.get<GetPolicyResponse>(
-        packagePolicyRouteService.getInfoPath(policyId)
+        packagePolicyRouteService.getInfoPath(policyId),
+        { version: '2023-10-31' }
       );
 
       applyDefaultsToPolicyIfNeeded(apiResponse.item);

--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy_agent_summary.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy_agent_summary.ts
@@ -10,6 +10,7 @@ import type { IHttpFetchError } from '@kbn/core-http-browser';
 import type { GetAgentStatusResponse } from '@kbn/fleet-plugin/common';
 import { useQuery } from '@tanstack/react-query';
 import { agentRouteService } from '@kbn/fleet-plugin/common';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import { useHttp } from '../../../common/lib/kibana';
 
 type EndpointPolicyAgentSummary = GetAgentStatusResponse['results'];
@@ -30,7 +31,7 @@ export const useFetchAgentByAgentPolicySummary = (
       return (
         await http.get<GetAgentStatusResponse>(agentRouteService.getStatusPath(), {
           query: { policyId: agentPolicyId },
-          version: '2023-10-31',
+          version: API_VERSIONS.public.v1,
         })
       ).results;
     },

--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy_agent_summary.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_fetch_endpoint_policy_agent_summary.ts
@@ -30,6 +30,7 @@ export const useFetchAgentByAgentPolicySummary = (
       return (
         await http.get<GetAgentStatusResponse>(agentRouteService.getStatusPath(), {
           query: { policyId: agentPolicyId },
+          version: '2023-10-31',
         })
       ).results;
     },

--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_update_endpoint_policy.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_update_endpoint_policy.ts
@@ -9,6 +9,7 @@ import type { UseMutationOptions, UseMutationResult } from '@tanstack/react-quer
 import type { IHttpFetchError } from '@kbn/core-http-browser';
 import { useMutation } from '@tanstack/react-query';
 import { packagePolicyRouteService } from '@kbn/fleet-plugin/common';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import { getPolicyDataForUpdate } from '../../../../common/endpoint/service/policy';
 import { useHttp } from '../../../common/lib/kibana';
 import type { PolicyData } from '../../../../common/endpoint/types';
@@ -39,7 +40,7 @@ export const useUpdateEndpointPolicy = (
 
     return http.put(packagePolicyRouteService.getUpdatePath(policy.id), {
       body: JSON.stringify(update),
-      version: '2023-10-31',
+      version: API_VERSIONS.public.v1,
     });
   }, options);
 };

--- a/x-pack/plugins/security_solution/public/management/hooks/policy/use_update_endpoint_policy.ts
+++ b/x-pack/plugins/security_solution/public/management/hooks/policy/use_update_endpoint_policy.ts
@@ -39,6 +39,7 @@ export const useUpdateEndpointPolicy = (
 
     return http.put(packagePolicyRouteService.getUpdatePath(policy.id), {
       body: JSON.stringify(update),
+      version: '2023-10-31',
     });
   }, options);
 };

--- a/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
@@ -12,6 +12,7 @@ import type {
   GetInfoResponse,
 } from '@kbn/fleet-plugin/common';
 import { epmRouteService } from '@kbn/fleet-plugin/common';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 
 import type { NewPolicyData } from '../../../../common/endpoint/types';
 import type { GetPolicyResponse, UpdatePolicyResponse } from '../../pages/policy/types';
@@ -36,7 +37,7 @@ export const sendGetPackagePolicy = (
 ) => {
   return http.get<GetPolicyResponse>(`${INGEST_API_PACKAGE_POLICIES}/${packagePolicyId}`, {
     ...options,
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
   });
 };
 
@@ -53,7 +54,7 @@ export const sendBulkGetPackagePolicies = (
 ) => {
   return http.post<GetPackagePoliciesResponse>(`${INGEST_API_PACKAGE_POLICIES}/_bulk_get`, {
     ...options,
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
     body: JSON.stringify({
       ids: packagePolicyIds,
       ignoreMissing: true,
@@ -77,7 +78,7 @@ export const sendPutPackagePolicy = (
 ): Promise<UpdatePolicyResponse> => {
   return http.put(`${INGEST_API_PACKAGE_POLICIES}/${packagePolicyId}`, {
     ...options,
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
     body: JSON.stringify(packagePolicy),
   });
 };
@@ -97,7 +98,7 @@ export const sendGetFleetAgentStatusForPolicy = (
 ): Promise<GetAgentStatusResponse> => {
   return http.get(INGEST_API_FLEET_AGENT_STATUS, {
     ...options,
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
     query: {
       policyId,
     },
@@ -112,7 +113,7 @@ export const sendGetEndpointSecurityPackage = async (
 ): Promise<GetInfoResponse['item']> => {
   const path = epmRouteService.getInfoPath('endpoint');
   const endpointPackageResponse = await http.get<GetInfoResponse>(path, {
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
   });
   const endpointPackageInfo = endpointPackageResponse.item;
   if (!endpointPackageInfo) {

--- a/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/ingest.ts
@@ -34,7 +34,10 @@ export const sendGetPackagePolicy = (
   packagePolicyId: string,
   options?: HttpFetchOptions
 ) => {
-  return http.get<GetPolicyResponse>(`${INGEST_API_PACKAGE_POLICIES}/${packagePolicyId}`, options);
+  return http.get<GetPolicyResponse>(`${INGEST_API_PACKAGE_POLICIES}/${packagePolicyId}`, {
+    ...options,
+    version: '2023-10-31',
+  });
 };
 
 /**
@@ -50,6 +53,7 @@ export const sendBulkGetPackagePolicies = (
 ) => {
   return http.post<GetPackagePoliciesResponse>(`${INGEST_API_PACKAGE_POLICIES}/_bulk_get`, {
     ...options,
+    version: '2023-10-31',
     body: JSON.stringify({
       ids: packagePolicyIds,
       ignoreMissing: true,
@@ -73,6 +77,7 @@ export const sendPutPackagePolicy = (
 ): Promise<UpdatePolicyResponse> => {
   return http.put(`${INGEST_API_PACKAGE_POLICIES}/${packagePolicyId}`, {
     ...options,
+    version: '2023-10-31',
     body: JSON.stringify(packagePolicy),
   });
 };
@@ -92,6 +97,7 @@ export const sendGetFleetAgentStatusForPolicy = (
 ): Promise<GetAgentStatusResponse> => {
   return http.get(INGEST_API_FLEET_AGENT_STATUS, {
     ...options,
+    version: '2023-10-31',
     query: {
       policyId,
     },
@@ -105,7 +111,9 @@ export const sendGetEndpointSecurityPackage = async (
   http: HttpStart
 ): Promise<GetInfoResponse['item']> => {
   const path = epmRouteService.getInfoPath('endpoint');
-  const endpointPackageResponse = await http.get<GetInfoResponse>(path);
+  const endpointPackageResponse = await http.get<GetInfoResponse>(path, {
+    version: '2023-10-31',
+  });
   const endpointPackageInfo = endpointPackageResponse.item;
   if (!endpointPackageInfo) {
     throw new Error('Endpoint package was not found.');

--- a/x-pack/plugins/security_solution/public/management/services/policies/policies.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/policies.ts
@@ -8,6 +8,7 @@
 import type { HttpFetchOptions, HttpStart } from '@kbn/core/public';
 import type { GetPackagePoliciesRequest } from '@kbn/fleet-plugin/common';
 import { PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
+import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import type { GetPolicyListResponse } from '../../pages/policy/types';
 import { INGEST_API_PACKAGE_POLICIES } from './ingest';
 
@@ -29,6 +30,6 @@ export const sendGetEndpointSpecificPackagePolicies = (
         options?.query?.kuery ? `${options.query.kuery} and ` : ''
       }${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
     },
-    version: '2023-10-31',
+    version: API_VERSIONS.public.v1,
   });
 };

--- a/x-pack/plugins/security_solution/public/management/services/policies/policies.ts
+++ b/x-pack/plugins/security_solution/public/management/services/policies/policies.ts
@@ -29,5 +29,6 @@ export const sendGetEndpointSpecificPackagePolicies = (
         options?.query?.kuery ? `${options.query.kuery} and ` : ''
       }${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name: endpoint`,
     },
+    version: '2023-10-31',
   });
 };


### PR DESCRIPTION
## Summary

adding version header to API calls towards Fleet on Management pages, as Fleet requires version since PR: elastic/kibana/pull/163570