### PR TITLE
[Security Solution] Prevent junit tranformation command from breaking a build step

### DIFF
--- a/.buildkite/scripts/steps/functional/defend_workflows.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows.sh
@@ -13,4 +13,4 @@ echo "--- Defend Workflows Cypress tests"
 cd x-pack/plugins/security_solution
 
 set +e
-yarn cypress:dw:run; status=$?; yarn junit:merge && exit $status
+yarn cypress:dw:run; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/defend_workflows_vagrant.sh
+++ b/.buildkite/scripts/steps/functional/defend_workflows_vagrant.sh
@@ -13,4 +13,4 @@ echo "--- Defend Workflows Endpoint Cypress tests"
 cd x-pack/plugins/security_solution
 
 set +e
-yarn cypress:dw:endpoint:run; status=$?; yarn junit:merge && exit $status
+yarn cypress:dw:endpoint:run; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/response_ops.sh
+++ b/.buildkite/scripts/steps/functional/response_ops.sh
@@ -13,4 +13,4 @@ echo "--- Response Ops Cypress Tests on Security Solution"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:run:respops:ess; status=$?; yarn junit:merge && exit $status
+yarn cypress:run:respops:ess; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/response_ops_cases.sh
+++ b/.buildkite/scripts/steps/functional/response_ops_cases.sh
@@ -13,4 +13,4 @@ echo "--- Response Ops Cases Cypress Tests on Security Solution"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:run:cases:ess; status=$?; yarn junit:merge && exit $status
+yarn cypress:run:cases:ess; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless.sh
@@ -13,4 +13,4 @@ echo "--- Security Serverless Cypress Tests"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:run:serverless; status=$?; yarn junit:merge && exit $status
+yarn cypress:run:serverless; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_explore.sh
@@ -13,4 +13,4 @@ echo "--- Explore - Security Solution Cypress Tests"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:explore:run:serverless; status=$?; yarn junit:merge && exit $status
+yarn cypress:explore:run:serverless; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_serverless_investigations.sh
@@ -13,4 +13,4 @@ echo "--- Investigations Cypress Tests on Serverless"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:investigations:run:serverless; status=$?; yarn junit:merge && exit $status
+yarn cypress:investigations:run:serverless; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_solution.sh
+++ b/.buildkite/scripts/steps/functional/security_solution.sh
@@ -13,4 +13,4 @@ echo "--- Security Solution Cypress tests (Chrome)"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:run:ess; status=$?; yarn junit:merge && exit $status
+yarn cypress:run:ess; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_explore.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_explore.sh
@@ -13,4 +13,4 @@ echo "--- Explore Cypress Tests on Security Solution"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:explore:run:ess; status=$?; yarn junit:merge && exit $status
+yarn cypress:explore:run:ess; status=$?; yarn junit:merge || :; exit $status

--- a/.buildkite/scripts/steps/functional/security_solution_investigations.sh
+++ b/.buildkite/scripts/steps/functional/security_solution_investigations.sh
@@ -13,4 +13,4 @@ echo "--- Investigations - Security Solution Cypress Tests"
 cd x-pack/test/security_solution_cypress
 
 set +e
-yarn cypress:investigations:run:ess; status=$?; yarn junit:merge && exit $status
+yarn cypress:investigations:run:ess; status=$?; yarn junit:merge || :; exit $status


### PR DESCRIPTION
## Summary

This PR implements a temporary fix to prevent `yarn junit:merge` command from breaking a build step by returning non zero code. `yarn junit:merge` fails in case if it can't find reports or folders it operates on weren't created beforehand.

