### PR TITLE
fix breadcrumbs are missing in `Devtools > Grok Debugger` `Devtools > Painless Lab` in serverless search project

### DIFF
--- a/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
+++ b/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
@@ -161,6 +161,12 @@ export interface NodeDefinition<
    * @default 'visible'
    */
   breadcrumbStatus?: 'hidden' | 'visible';
+
+  /**
+   * If should be hidden in the side nav
+   * @default 'visible'
+   */
+  sideNavStatus?: 'hidden' | 'visible';
 }
 
 /**

--- a/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
+++ b/packages/core/chrome/core-chrome-browser/src/project_navigation.ts
@@ -88,6 +88,12 @@ export interface ChromeProjectNavigationNode {
    * @default 'visible'
    */
   breadcrumbStatus?: 'hidden' | 'visible';
+
+  /**
+   * If should be hidden in the side nav
+   * @default 'visible'
+   */
+  sideNavStatus?: 'hidden' | 'visible';
 }
 
 /** @public */

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation.test.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation.test.tsx
@@ -389,6 +389,141 @@ describe('<Navigation />', () => {
       ]);
     });
 
+    test('should not render hidden item', async () => {
+      const navLinks$: Observable<ChromeNavLink[]> = of([
+        {
+          id: 'item1',
+          title: 'Title from deeplink',
+          baseUrl: '',
+          url: '',
+          href: '',
+        },
+        {
+          id: 'item2',
+          title: 'Title from deeplink',
+          baseUrl: '',
+          url: '',
+          href: '',
+        },
+      ]);
+      const onProjectNavigationChange = jest.fn();
+
+      const { queryByTestId } = render(
+        <NavigationProvider
+          {...services}
+          navLinks$={navLinks$}
+          onProjectNavigationChange={onProjectNavigationChange}
+        >
+          <Navigation>
+            <Navigation.Group id="root">
+              <Navigation.Group id="group1">
+                <Navigation.Item<any> id="item1" link="item1" sideNavStatus={'hidden'} />
+              </Navigation.Group>
+              <Navigation.Group id="group2">
+                <Navigation.Item<any> id="item2" link="item2" />
+              </Navigation.Group>
+            </Navigation.Group>
+          </Navigation>
+        </NavigationProvider>
+      );
+
+      await act(async () => {
+        jest.advanceTimersByTime(SET_NAVIGATION_DELAY);
+      });
+
+      expect(queryByTestId(/nav-group-root.group1/)).toBeNull();
+      expect(queryByTestId(/nav-item-root.group2.item2/)).toBeVisible();
+
+      expect(onProjectNavigationChange).toHaveBeenCalled();
+      const lastCall =
+        onProjectNavigationChange.mock.calls[onProjectNavigationChange.mock.calls.length - 1];
+      const [navTree] = lastCall;
+
+      expect(navTree.navigationTree).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": undefined,
+                    "deepLink": Object {
+                      "baseUrl": "",
+                      "href": "",
+                      "id": "item1",
+                      "title": "Title from deeplink",
+                      "url": "",
+                    },
+                    "href": undefined,
+                    "id": "item1",
+                    "isActive": false,
+                    "path": Array [
+                      "root",
+                      "group1",
+                      "item1",
+                    ],
+                    "renderItem": undefined,
+                    "sideNavStatus": "hidden",
+                    "title": "Title from deeplink",
+                  },
+                ],
+                "deepLink": undefined,
+                "href": undefined,
+                "id": "group1",
+                "isActive": false,
+                "path": Array [
+                  "root",
+                  "group1",
+                ],
+                "title": "",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": undefined,
+                    "deepLink": Object {
+                      "baseUrl": "",
+                      "href": "",
+                      "id": "item2",
+                      "title": "Title from deeplink",
+                      "url": "",
+                    },
+                    "href": undefined,
+                    "id": "item2",
+                    "isActive": false,
+                    "path": Array [
+                      "root",
+                      "group2",
+                      "item2",
+                    ],
+                    "renderItem": undefined,
+                    "title": "Title from deeplink",
+                  },
+                ],
+                "deepLink": undefined,
+                "href": undefined,
+                "id": "group2",
+                "isActive": false,
+                "path": Array [
+                  "root",
+                  "group2",
+                ],
+                "title": "",
+              },
+            ],
+            "deepLink": undefined,
+            "href": undefined,
+            "id": "root",
+            "isActive": false,
+            "path": Array [
+              "root",
+            ],
+            "title": "",
+          },
+        ]
+      `);
+    });
+
     test('should render custom react element', async () => {
       const navLinks$: Observable<ChromeNavLink[]> = of([
         {

--- a/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
+++ b/packages/shared-ux/chrome/navigation/src/ui/components/navigation_section_ui.tsx
@@ -89,31 +89,34 @@ export const NavigationSectionUI: FC<Props> = ({ navNode, items = [] }) => {
   // but once the user manually expand a group we don't want to close it afterward automatically.
   const [doCollapseFromActiveState, setDoCollapseFromActiveState] = useState(true);
 
-  // If the item has no link and no cildren, we don't want to render it
-  const itemHasLinkOrChildren = (item: ChromeProjectNavigationNodeEnhanced) => {
+  const shouldRenderItem = (item: ChromeProjectNavigationNodeEnhanced) => {
+    // if the item is hidden, we don't want to render it
+    if (item.sideNavStatus === 'hidden') return false;
+
+    // If the item has no link and no children, we don't want to render it
     const hasLink = Boolean(item.deepLink) || Boolean(item.href);
     if (hasLink) {
       return true;
     }
     const hasChildren = Boolean(item.children?.length);
     if (hasChildren) {
-      return item.children!.some(itemHasLinkOrChildren);
+      return item.children!.some(shouldRenderItem);
     }
     return false;
   };
 
-  const filteredItems = items.filter(itemHasLinkOrChildren).map((item) => {
+  const filteredItems = items.filter(shouldRenderItem).map((item) => {
     if (item.children) {
       return {
         ...item,
-        children: item.children.filter(itemHasLinkOrChildren),
+        children: item.children.filter(shouldRenderItem),
       };
     }
     return item;
   });
 
   const groupHasLink = Boolean(navNode.deepLink) || Boolean(navNode.href);
-  const groupHasChildren = filteredItems.some(itemHasLinkOrChildren);
+  const groupHasChildren = filteredItems.some(shouldRenderItem);
   // Group with a link and no children will be rendered as a link and not an EUI accordion
   const groupIsLink = groupHasLink && !groupHasChildren;
   const groupHref = navNode.deepLink?.url ?? navNode.href!;

--- a/packages/shared-ux/chrome/serverless_projects_documentation.mdx
+++ b/packages/shared-ux/chrome/serverless_projects_documentation.mdx
@@ -209,6 +209,7 @@ The `GroupDefinition` interface represents a group of items in the side navigati
 | `href`               | `string`                | Use `href` for absolute links only. Internal links should use "link".                                                                                                                                                              |
 | `getIsActive`        | `function`              | Optional function to control the active state. This function is called whenever the location changes.                                                                                                                              |
 | `breadcrumbStatus`   | `'hidden'\|'visible'`   | An optional flag to indicate if the breadcrumb should be hidden when this node is active. The default value is `'visible'`.                                                                                                        |
+| `sideNavStatus`      | `'hidden'\|'visible'`   | An optional flag to indicate if the item should be hidden in the side nav. The default value is `'visible'`.                                                                                                                       |
 
 ##### `RecentlyAccessedDefinition`
 

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -47,7 +47,12 @@ const navigationTree: NavigationTreeDefinition = {
           title: i18n.translate('xpack.serverlessSearch.nav.devTools', {
             defaultMessage: 'Dev Tools',
           }),
-          children: [{ link: 'dev_tools:console' }, { link: 'dev_tools:searchprofiler' }],
+          children: [
+            { link: 'dev_tools:console' },
+            { link: 'dev_tools:searchprofiler' },
+            { link: 'dev_tools:grokdebugger', sideNavStatus: 'hidden' as const },
+            { link: 'dev_tools:painless_lab', sideNavStatus: 'hidden' as const },
+          ],
         },
         {
           id: 'explore',


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/165813


Since part of the devtools breadcrumbs already worked because they were part of the navigation, I thought it would make more sense to include other tools into the nav but hide them from the side nav instead of setting deeper context imperatively from  dev tools code.
