### PR TITLE
Set Certificate Authority in Serverless FTR base config based on MKI

### DIFF
--- a/x-pack/test_serverless/shared/config.base.ts
+++ b/x-pack/test_serverless/shared/config.base.ts
@@ -25,7 +25,7 @@ export default async () => {
     kibana: {
       ...kbnTestConfig.getUrlParts(kibanaTestSuperuserServerless),
       protocol: 'https',
-      certificateAuthorities: [Fs.readFileSync(CA_CERT_PATH)],
+      certificateAuthorities: process.env.TEST_CLOUD ? undefined : [Fs.readFileSync(CA_CERT_PATH)],
     },
     elasticsearch: { ...esTestConfig.getUrlParts(), protocol: 'https' },
   };

--- a/x-pack/test_serverless/shared/services/supertest.ts
+++ b/x-pack/test_serverless/shared/services/supertest.ts
@@ -14,7 +14,7 @@ export function SupertestProvider({ getService }: FtrProviderContext) {
   const kbnUrl = formatUrl(config.get('servers.kibana'));
   const ca = config.get('servers.kibana').certificateAuthorities;
 
-  return supertest.agent(kbnUrl, { ca } );
+  return supertest.agent(kbnUrl, { ca });
 }
 
 export function SupertestWithoutAuthProvider({ getService }: FtrProviderContext) {

--- a/x-pack/test_serverless/shared/services/supertest.ts
+++ b/x-pack/test_serverless/shared/services/supertest.ts
@@ -12,9 +12,9 @@ import { FtrProviderContext } from '../../functional/ftr_provider_context';
 export function SupertestProvider({ getService }: FtrProviderContext) {
   const config = getService('config');
   const kbnUrl = formatUrl(config.get('servers.kibana'));
-  const cAuthorities = config.get('servers.kibana').certificateAuthorities;
+  const ca = config.get('servers.kibana').certificateAuthorities;
 
-  return supertest.agent(kbnUrl, process.env.TEST_CLOUD ? {} : { ca: cAuthorities });
+  return supertest.agent(kbnUrl, { ca } );
 }
 
 export function SupertestWithoutAuthProvider({ getService }: FtrProviderContext) {
@@ -23,7 +23,7 @@ export function SupertestWithoutAuthProvider({ getService }: FtrProviderContext)
     ...config.get('servers.kibana'),
     auth: false,
   });
-  const cAuthorities = config.get('servers.kibana').certificateAuthorities;
+  const ca = config.get('servers.kibana').certificateAuthorities;
 
-  return supertest.agent(kbnUrl, process.env.TEST_CLOUD ? {} : { ca: cAuthorities });
+  return supertest.agent(kbnUrl, { ca });
 }


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/elastic/kibana/pull/165846

Moves the check for cloud/MKI to the base serverless FTR config. We found three use cases where the Kibana server configuration was providing a CA override:

1. In the [serverless supertest](https://github.com/elastic/kibana/blob/49ff1f152e43bc19fbdeb426fd28be372e50b3e4/x-pack/test_serverless/shared/services/supertest.ts#L15)
2. In the [APM API supertest](https://github.com/elastic/kibana/blob/49ff1f152e43bc19fbdeb426fd28be372e50b3e4/x-pack/test_serverless/api_integration/test_suites/observability/apm_api_integration/common/apm_api_supertest.ts#L107C2-L107C2)
3. In the FTR KIbana server's [Kibana client instantiation](https://github.com/elastic/kibana/blob/49ff1f152e43bc19fbdeb426fd28be372e50b3e4/packages/kbn-ftr-common-functional-services/services/kibana_server/kibana_server.ts#L24C1-L24C1)

Locally, CA certs should be overridden to our self-singed certs, while on MKI we should default to the Mozilla well-known CAs. Moving the check to the test config (if it proves successful) handles all three cases without the need for adding environment variable checks in multiple places.

cc @kc13greiner 