### PR TITLE
[8.10] [Security Solution][Endpoint] Adds new unit test case for exceptions deduplication logic in manifest manager (#164290)

### DIFF
--- a/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/services/artifacts/manifest_manager/manifest_manager.test.ts
@@ -43,6 +43,7 @@ import type { EndpointArtifactClientInterface } from '../artifact_client';
 import { InvalidInternalManifestError } from '../errors';
 import { EndpointError } from '../../../../../common/endpoint/errors';
 import type { Artifact } from '@kbn/fleet-plugin/server';
+import type { ExceptionListItemSchema } from '@kbn/securitysolution-io-ts-list-types/src/response/exception_list_item_schema';
 
 const getArtifactObject = (artifact: InternalArtifactSchema) =>
   JSON.parse(Buffer.from(artifact.body!, 'base64').toString());
@@ -517,6 +518,138 @@ describe('ManifestManager', () => {
         expect(manifest.isDefaultArtifact(artifact)).toBe(true);
         expect(manifest.getArtifactTargetPolicies(artifact)).toStrictEqual(
           new Set([TEST_POLICY_ID_1])
+        );
+      }
+    });
+
+    test('Builds fully new manifest with single entries when they are duplicated', async () => {
+      const exceptionListItem = getExceptionListItemSchemaMock({ os_types: ['macos'] });
+      const trustedAppListItem = getExceptionListItemSchemaMock({
+        os_types: ['linux'],
+        tags: ['policy:all'],
+      });
+      const eventFiltersListItem = getExceptionListItemSchemaMock({
+        os_types: ['windows'],
+        tags: [`policy:${TEST_POLICY_ID_1}`],
+      });
+      const hostIsolationExceptionsItem = getExceptionListItemSchemaMock({
+        os_types: ['linux'],
+        tags: ['policy:all'],
+      });
+      const blocklistsListItem = getExceptionListItemSchemaMock({
+        os_types: ['macos'],
+        tags: ['policy:all'],
+      });
+      const context = buildManifestManagerContextMock({});
+      const manifestManager = new ManifestManager(context);
+
+      const duplicatedEventFilterInDifferentPolicy = {
+        ...eventFiltersListItem,
+        tags: [`policy:${TEST_POLICY_ID_2}`],
+      };
+      const duplicatedEndpointExceptionInDifferentOS: ExceptionListItemSchema = {
+        ...exceptionListItem,
+        os_types: ['windows'],
+      };
+      context.exceptionListClient.findExceptionListItem = mockFindExceptionListItemResponses({
+        [ENDPOINT_LIST_ID]: {
+          macos: [exceptionListItem, exceptionListItem],
+          windows: [duplicatedEndpointExceptionInDifferentOS],
+        },
+        [ENDPOINT_TRUSTED_APPS_LIST_ID]: { linux: [trustedAppListItem, trustedAppListItem] },
+        [ENDPOINT_EVENT_FILTERS_LIST_ID]: {
+          windows: [eventFiltersListItem, duplicatedEventFilterInDifferentPolicy],
+        },
+        [ENDPOINT_HOST_ISOLATION_EXCEPTIONS_LIST_ID]: {
+          linux: [
+            hostIsolationExceptionsItem,
+            { ...hostIsolationExceptionsItem, tags: [`policy:${TEST_POLICY_ID_2}`] },
+          ],
+        },
+        [ENDPOINT_BLOCKLISTS_LIST_ID]: { macos: [blocklistsListItem, blocklistsListItem] },
+      });
+      context.savedObjectsClient.create = jest
+        .fn()
+        .mockImplementation((_type: string, object: InternalManifestSchema) => ({
+          attributes: object,
+        }));
+      context.packagePolicyService.listIds = mockPolicyListIdsResponse([
+        TEST_POLICY_ID_1,
+        TEST_POLICY_ID_2,
+      ]);
+
+      const manifest = await manifestManager.buildNewManifest();
+
+      expect(manifest?.getSchemaVersion()).toStrictEqual('v1');
+      expect(manifest?.getSemanticVersion()).toStrictEqual('1.0.0');
+      expect(manifest?.getSavedObjectVersion()).toBeUndefined();
+
+      const artifacts = manifest.getAllArtifacts();
+
+      expect(artifacts.length).toBe(16);
+      expect(getArtifactIds(artifacts)).toStrictEqual(SUPPORTED_ARTIFACT_NAMES);
+
+      expect(getArtifactObject(artifacts[0])).toStrictEqual({
+        entries: translateToEndpointExceptions([exceptionListItem], 'v1'),
+      });
+      expect(getArtifactObject(artifacts[1])).toStrictEqual({
+        entries: translateToEndpointExceptions([duplicatedEndpointExceptionInDifferentOS], 'v1'),
+      });
+      expect(getArtifactObject(artifacts[2])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[3])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[4])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[5])).toStrictEqual({
+        entries: translateToEndpointExceptions([trustedAppListItem], 'v1'),
+      });
+      expect(getArtifactObject(artifacts[6])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[7])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[8])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[9])).toStrictEqual({
+        entries: translateToEndpointExceptions(
+          [eventFiltersListItem, duplicatedEventFilterInDifferentPolicy],
+          'v1'
+        ),
+      });
+      expect(getArtifactObject(artifacts[10])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[11])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[12])).toStrictEqual({
+        entries: translateToEndpointExceptions([hostIsolationExceptionsItem], 'v1'),
+      });
+      expect(getArtifactObject(artifacts[13])).toStrictEqual({
+        entries: translateToEndpointExceptions([blocklistsListItem], 'v1'),
+      });
+      expect(getArtifactObject(artifacts[14])).toStrictEqual({ entries: [] });
+      expect(getArtifactObject(artifacts[15])).toStrictEqual({ entries: [] });
+
+      // Default artifacts used by both policies
+      for (const artifact of artifacts.slice(0, 7)) {
+        expect(manifest.isDefaultArtifact(artifact)).toBe(true);
+        expect(manifest.getArtifactTargetPolicies(artifact)).toStrictEqual(
+          new Set([TEST_POLICY_ID_1, TEST_POLICY_ID_2])
+        );
+      }
+
+      // Default event filters artifact for windows not used by test policies
+      expect(manifest.isDefaultArtifact(artifacts[7])).toBe(true);
+      expect(manifest.getArtifactTargetPolicies(artifacts[7])).toStrictEqual(new Set([]));
+
+      // Default event filters artifact for linux used by both policies
+      expect(manifest.isDefaultArtifact(artifacts[8])).toBe(true);
+      expect(manifest.getArtifactTargetPolicies(artifacts[8])).toStrictEqual(
+        new Set([TEST_POLICY_ID_1, TEST_POLICY_ID_2])
+      );
+
+      // Policy specific event filters artifact for windows used by both policies
+      expect(manifest.isDefaultArtifact(artifacts[9])).toBe(false);
+      expect(manifest.getArtifactTargetPolicies(artifacts[9])).toStrictEqual(
+        new Set([TEST_POLICY_ID_1, TEST_POLICY_ID_2])
+      );
+
+      // Default artifacts used by both policies
+      for (const artifact of artifacts.slice(10)) {
+        expect(manifest.isDefaultArtifact(artifact)).toBe(true);
+        expect(manifest.getArtifactTargetPolicies(artifact)).toStrictEqual(
+          new Set([TEST_POLICY_ID_1, TEST_POLICY_ID_2])
         );
       }
     });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Security Solution][Endpoint] Adds new unit test case for exceptions deduplication logic in manifest manager (#164290)](https://github.com/elastic/kibana/pull/164290)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"David Sánchez","email":"david.sanchezsoler@elastic.co"},"sourceCommit":{"committedDate":"2023-08-29T14:43:57Z","message":"[Security Solution][Endpoint] Adds new unit test case for exceptions deduplication logic in manifest manager (#164290)\n\n## Summary\r\n\r\nAdds new unit test case for exceptions deduplication logic in manifest\r\nmanager.\r\nIt tests a scenario with duplicated exceptions in different/same\r\npolicies and different/same OS's\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9b39c83a3dcd642068a6ed6f6a3acbc77d86833a","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.10.0","v8.11.0"],"number":164290,"url":"https://github.com/elastic/kibana/pull/164290","mergeCommit":{"message":"[Security Solution][Endpoint] Adds new unit test case for exceptions deduplication logic in manifest manager (#164290)\n\n## Summary\r\n\r\nAdds new unit test case for exceptions deduplication logic in manifest\r\nmanager.\r\nIt tests a scenario with duplicated exceptions in different/same\r\npolicies and different/same OS's\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9b39c83a3dcd642068a6ed6f6a3acbc77d86833a"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/164290","number":164290,"mergeCommit":{"message":"[Security Solution][Endpoint] Adds new unit test case for exceptions deduplication logic in manifest manager (#164290)\n\n## Summary\r\n\r\nAdds new unit test case for exceptions deduplication logic in manifest\r\nmanager.\r\nIt tests a scenario with duplicated exceptions in different/same\r\npolicies and different/same OS's\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9b39c83a3dcd642068a6ed6f6a3acbc77d86833a"}}]}] BACKPORT-->