### PR TITLE
Add synthetics-stack-e2e workflows

### DIFF
--- a/.github/workflows/oblt-github-commands.yml
+++ b/.github/workflows/oblt-github-commands.yml
@@ -52,7 +52,7 @@ jobs:
               - \`/oblt-deploy\` : Deploy a Kibana instance using the Observability test environments.
               - \`/oblt-deploy-serverless\` : Deploy a serverless Kibana instance using the Observability test environments.
               - \`run\` \`elasticsearch-ci/docs\` : Re-trigger the docs validation. (use unformatted text in the comment!)
-
+              - \`/synthetics-stack-e2e\` : Run the synthetics stack e2e tests.
               </p>
               </details>
             `.replace(/  +/g, '')

--- a/.github/workflows/synthetics-stack-e2e-init.yml
+++ b/.github/workflows/synthetics-stack-e2e-init.yml
@@ -1,18 +1,36 @@
+---
 #
 # This workflow sets the status check `synthetics-stack-e2e` instantly to 'failure'
 # the synthetics-stack-e2e.yml is triggered with a PR comment and is responsible for setting it to success or failure.
 #
-name: synthetics # This name needs to be the same as in synthetic-stack-e2e.yml
+name: synthetics
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - "x-pack/plugins/synthetics/**"
 
 jobs:
-  synthetics-stack-e2e: # This name needs to be the same as in synthetic-stack-e2e.yml
+  init-synthetics-stack-e2e:
+    permissions:
+      statuses: write  # Needed to set the commit status
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the synthetics stack e2e workflow. That workflow is responsible for setting this status check to success or failure."'
-          exit 1
+      - name: Create commit status
+        uses: actions/github-script@v6
+        env:
+          SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              context: "synthetics-stack-e2e",
+              sha: process.env.SHA,
+              state: 'failure',
+              description: "Comment \"/synthetics-stack-e2e\" to run the synthetics stack e2e tests",
+            });
+      - name: Help
+        run: |
+          echo "Comment \"/synthetics-stack-e2e\" to run the synthetics stack e2e tests"

--- a/.github/workflows/synthetics-stack-e2e-init.yml
+++ b/.github/workflows/synthetics-stack-e2e-init.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the\ synthetics stack e2e workflow. That job workflow is responsible for setting this status check to success or failure."'
+          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the synthetics stack e2e workflow. That job workflow is responsible for setting this status check to success or failure."'
           exit 1

--- a/.github/workflows/synthetics-stack-e2e-init.yml
+++ b/.github/workflows/synthetics-stack-e2e-init.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the synthetics stack e2e workflow. That job workflow is responsible for setting this status check to success or failure."'
+          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the synthetics stack e2e workflow. That workflow is responsible for setting this status check to success or failure."'
           exit 1

--- a/.github/workflows/synthetics-stack-e2e-init.yml
+++ b/.github/workflows/synthetics-stack-e2e-init.yml
@@ -1,0 +1,18 @@
+#
+# This workflow sets the status check `synthetics-stack-e2e` instantly to 'failure'
+# the synthetics-stack-e2e.yml is triggered with a PR comment and is responsible for setting it to success or failure.
+#
+name: synthetics # This name needs to be the same as in synthetic-stack-e2e.yml
+
+on:
+  pull_request:
+    paths:
+      - "x-pack/plugins/synthetics/**"
+
+jobs:
+  synthetics-stack-e2e: # This name needs to be the same as in synthetic-stack-e2e.yml
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo 'Comment "/synthetics-stack-e2e" on the PR to trigger the\ synthetics stack e2e workflow. That job workflow is responsible for setting this status check to success or failure."'
+          exit 1

--- a/.github/workflows/synthetics-stack-e2e.yml
+++ b/.github/workflows/synthetics-stack-e2e.yml
@@ -4,23 +4,73 @@
 # which was set to failure by the synthetics-stack-e2e-init.yml workflow.
 #
 ---
-name: synthetics # This name needs to be the same as in synthetic-stack-e2e-init.yml
+name: synthetics-check-run
 
 on:
   issue_comment:
     types:
       - created
 
-permissions:
-  issues: write
-
 jobs:
-  synthetics-stack-e2e: # This name needs to be the same as in synthetic-stack-e2e-init.yml
+  run-synthetics-stack-e2e:
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/synthetics-stack-e2e') }}
     runs-on: ubuntu-latest
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?pr=${{ github.event.issue.number }}
+    permissions:
+      statuses: write # Needed to set the commit status
+      pull-requests: write # Needed to react to the comment
     steps:
+      - name: Get PR head SHA
+        id: get-pr-head-sha
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const { owner, repo } = context.repo;
+            const pull = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: context.issue.number,
+            });
+            return pull.data.head.sha;
+      - name: Create commit status
+        uses: actions/github-script@v6
+        env:
+          SHA: ${{ steps.get-pr-head-sha.outputs.result }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              context: "synthetics-stack-e2e",
+              sha: process.env.SHA,
+              state: 'pending',
+              description: "Running synthetics-stack-e2e",
+              target_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            });
       - uses: elastic/apm-pipeline-library/.github/actions/run-synthetics-stack-e2e@current
         with:
-          vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.OBLT_VAULT_ADDR }}
+          vault-role-id: ${{ secrets.OBLT_VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.OBLT_VAULT_SECRET_ID }}
+      - if: always()
+        name: Create commit status
+        uses: actions/github-script@v6
+        env:
+          SHA: ${{ steps.get-pr-head-sha.outputs.result }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              context: "synthetics-stack-e2e",
+              sha: process.env.SHA,
+              state: process.env.JOB_STATUS == 'success' ? 'success' : 'failure',
+              description: process.env.JOB_STATUS == 'success' ? "The synthetics-stack-e2e tests succeeded" : "synthetics-stack-e2e tests failed",
+              target_url: process.env.RUN_URL,
+            });

--- a/.github/workflows/synthetics-stack-e2e.yml
+++ b/.github/workflows/synthetics-stack-e2e.yml
@@ -1,0 +1,23 @@
+#
+# This workflow is triggered by a comment on a PR and runs the synthetics stack e2e tests
+# It is responsible for setting the status check `synthetics-stack-e2e` to success or failure,
+# which was set to failure by the synthetics-stack-e2e-init.yml workflow.
+#
+---
+name: synthetics # This name needs to be the same as in synthetic-stack-e2e-init.yml
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  synthetics-stack-e2e: # This name needs to be the same as in synthetic-stack-e2e-init.yml
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/synthetics-stack-e2e') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: elastic/apm-pipeline-library/.github/actions/run-synthetics-stack-e2e@current
+        with:
+          vaultUrl: ${{ secrets.OBLT_VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.OBLT_VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.OBLT_VAULT_SECRET_ID }}

--- a/.github/workflows/synthetics-stack-e2e.yml
+++ b/.github/workflows/synthetics-stack-e2e.yml
@@ -11,6 +11,9 @@ on:
     types:
       - created
 
+permissions:
+  issues: write
+
 jobs:
   synthetics-stack-e2e: # This name needs to be the same as in synthetic-stack-e2e-init.yml
     if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/synthetics-stack-e2e') }}


### PR DESCRIPTION
## Summary

Add workflows for the synthetics-stack-e2e tests.

The workflow synthetics-stack-e2e-init.yml will instantly set a failure status check if there are changes in `x-pack/plugins/synthetics/**`.

The workflow synthetics-stack-e2e.yml is triggered based on a comment and is responsible for setting the status check to success, if appropriate.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
