### PR TITLE
Rename changed QA serverless pipeline name.

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -4,7 +4,7 @@
 
 steps:
   - label: ":pipeline::kibana::seedling: Trigger Kibana Serverless Tests for ${ENVIRONMENT}"
-    trigger: appex-qa-kibana-serverless-ftr-tests # https://buildkite.com/elastic/appex-qa-kibana-serverless-ftr-tests
+    trigger: appex-qa-serverless-kibana-ftr-tests # https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests
     soft_fail: true # Remove this before release or when tests stabilize
     build:
       env:


### PR DESCRIPTION
It appears that the pipeline was recently renamed from https://buildkite.com/elastic/appex-qa-kibana-serverless-ftr-tests to https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests so our QA promotion is failing.

Honestly I'm not sure if this is the only change that's required or if there are other considerations we need to be worrying about to unblock us, but figured I'd open the PR so @delanni @ramonbutter and @watson can decide what to do with it tomorrow.