### PR TITLE
[RAM][Security Solution] Fix rule snooze toast copy

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/notify_badge/translations.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/notify_badge/translations.tsx
@@ -10,14 +10,14 @@ import { i18n } from '@kbn/i18n';
 export const SNOOZE_SUCCESS_MESSAGE = i18n.translate(
   'xpack.triggersActionsUI.sections.rulesList.rulesListSnoozePanel.snoozeSuccess',
   {
-    defaultMessage: 'Rules noitification successfully snoozed',
+    defaultMessage: 'Rules notification successfully snoozed',
   }
 );
 
 export const UNSNOOZE_SUCCESS_MESSAGE = i18n.translate(
   'xpack.triggersActionsUI.sections.rulesList.rulesListSnoozePanel.unsnoozeSuccess',
   {
-    defaultMessage: 'Rules noitification successfully unsnoozed',
+    defaultMessage: 'Rules notification successfully unsnoozed',
   }
 );
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/notify_badge/translations.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/notify_badge/translations.tsx
@@ -10,14 +10,14 @@ import { i18n } from '@kbn/i18n';
 export const SNOOZE_SUCCESS_MESSAGE = i18n.translate(
   'xpack.triggersActionsUI.sections.rulesList.rulesListSnoozePanel.snoozeSuccess',
   {
-    defaultMessage: 'Rule successfully snoozed',
+    defaultMessage: 'Rules noitification successfully snoozed',
   }
 );
 
 export const UNSNOOZE_SUCCESS_MESSAGE = i18n.translate(
   'xpack.triggersActionsUI.sections.rulesList.rulesListSnoozePanel.unsnoozeSuccess',
   {
-    defaultMessage: 'Rule successfully unsnoozed',
+    defaultMessage: 'Rules noitification successfully unsnoozed',
   }
 );
 

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rule_snoozing.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rule_snoozing.ts
@@ -36,7 +36,7 @@ export function snoozeRule(duration: SnoozeDuration): void {
 }
 
 export function expectSnoozeSuccessToast(): void {
-  cy.get(TOASTER).should('contain', 'Rule successfully snoozed');
+  cy.get(TOASTER).should('contain', 'Rules notification successfully snoozed');
 }
 
 export function expectSnoozeErrorToast(): void {
@@ -72,7 +72,7 @@ export function unsnoozeRule(): void {
 }
 
 export function expectUnsnoozeSuccessToast(): void {
-  cy.get(TOASTER).should('contain', 'Rule successfully unsnoozed');
+  cy.get(TOASTER).should('contain', 'Rules notification successfully unsnoozed');
 }
 
 export function expectRuleUnsnoozed(): void {


### PR DESCRIPTION
## Summary

Fixes #156143

Updates toasts saying `Rule successfully snoozed` to `Rules notification successfully snoozed`. Does the same for `unsnoozed`.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
