### PR TITLE
[ResponseOps] [POC] resolve conflicts when updating alert docs after rule execution

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -48,7 +48,6 @@ import {
   getLifecycleAlertsQueries,
   getContinualAlertsQuery,
 } from './lib';
-import { resolveAlertConflicts } from './lib/alert_conflict_resolver';
 
 // Term queries can take up to 10,000 terms
 const CHUNK_SIZE = 10000;
@@ -413,11 +412,11 @@ export class AlertsClient<
             } alerts - ${JSON.stringify(errorsInResponse)}`
           );
 
-          //resolveAlertConflicts({
+          // resolveAlertConflicts({
           //  bulkRequest: bulkBody,
           //  bulkResponse: response,
           //  esClient,
-          //});
+          // });
         }
       } catch (err) {
         this.options.logger.error(

--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -48,6 +48,7 @@ import {
   getLifecycleAlertsQueries,
   getContinualAlertsQuery,
 } from './lib';
+import { resolveAlertConflicts } from './lib/alert_conflict_resolver';
 
 // Term queries can take up to 10,000 terms
 const CHUNK_SIZE = 10000;
@@ -411,6 +412,12 @@ export class AlertsClient<
               alertsToIndex.length
             } alerts - ${JSON.stringify(errorsInResponse)}`
           );
+
+          //resolveAlertConflicts({
+          //  bulkRequest: bulkBody,
+          //  bulkResponse: response,
+          //  esClient,
+          //});
         }
       } catch (err) {
         this.options.logger.error(

--- a/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { zip } from 'lodash';
+
+import {
+  BulkRequest,
+  BulkResponse,
+  BulkOperationContainer,
+} from '@elastic/elasticsearch/lib/api/types';
+
+import { ElasticsearchClient } from '@kbn/core/server';
+
+interface ResolveAlertConflictsParams {
+  esClient: ElasticsearchClient;
+  bulkRequest: BulkRequest;
+  bulkResponse: BulkResponse;
+}
+
+interface ResolveAlertConfictsResult {
+  bulkRequest: BulkRequest;
+}
+
+interface NormalizedBulkRequest {
+  op: BulkOperationContainer;
+  doc: unknown;
+}
+
+export async function resolveAlertConflicts(
+  params: ResolveAlertConflictsParams
+): Promise<ResolveAlertConfictsResult> {
+  const conflictRequest = getConflictRequest(params);
+  await updateOCC(params.esClient, conflictRequest);
+
+  const bulkRequest = {
+    operations: conflictRequest.map((req) => [req.op, req.doc]).flat(),
+  }
+  return { bulkRequest };
+}
+
+
+// change this to do the mget separately from applying the OCC,
+// so we can also use the mget to get the current ad-hoc fields of the alert
+
+
+
+/** Update the OCC info in the request via mget. */
+async function updateOCC(esClient: ElasticsearchClient, conflictRequests: NormalizedBulkRequest[]) {
+  const docs: Array<{ _id: string; _index: string }> = [];
+
+  conflictRequests.forEach((req) => {
+    const [id, index] = [req.op.index?._id, req.op.index?._index];
+    if (!id || !index) return;
+
+    docs.push({ _id: id, _index: index });
+  });
+
+  const mgetRes = await esClient.mget<unknown>({ docs, _source: false });
+
+  if (mgetRes.docs.length !== docs.length) {
+    throw new Error('Unexpected number of mget response docs');
+  }
+
+  for (const [req, doc] of zip(conflictRequests, mgetRes.docs)) {
+    if (!req?.op.index || !doc) continue;
+
+    // @ts-expect-error @elastic/elasticsearch _seq_no is not in the type!
+    const seqNo: number | undefined = doc._seq_no;
+    // @ts-expect-error @elastic/elasticsearch _primary_term is not in the type!
+    const primaryTerm: number | undefined = doc._primary_term;
+
+    if (seqNo === undefined) throw new Error('Unexpected undefined seqNo');
+    if (primaryTerm === undefined) throw new Error('Unexpected undefined primaryTerm');
+
+    req.op.index.if_seq_no = seqNo;
+    req.op.index.if_seq_no = primaryTerm;
+  }
+}
+
+/** Return the bulk request, filtered to those requests that had conflicts. */
+function getConflictRequest(params: ResolveAlertConflictsParams): NormalizedBulkRequest[] {
+  const { bulkRequest, bulkResponse } = params;
+
+  const request = normalizeRequest(bulkRequest);
+
+  if (request.length !== bulkResponse.items.length) {
+    throw new Error('Unexpected number of bulk response items');
+  }
+
+  if (request.length === 0) return [];
+
+  const conflictRequest = zip(request, bulkResponse.items)
+    .filter(([req, resp]) => req && resp?.index?.status === 409)
+    .map(([req, _]) => req!);
+
+  return conflictRequest;
+}
+
+/** Convert a bulk request (op | doc)[] to an array of { op, doc }[] for index op */
+function normalizeRequest(bulkRequest: BulkRequest) {
+  if (!bulkRequest.operations) return [];
+  const result: NormalizedBulkRequest[] = [];
+
+  let index = 0;
+  while (index < bulkRequest.operations.length) {
+    const op = bulkRequest.operations[index] as BulkOperationContainer;
+
+    if (op.create || op.index || op.update) {
+      index++;
+      if (op.index) {
+        const doc = bulkRequest.operations[index];
+        result.push({ op, doc });
+      }
+    } else if (op.delete) {
+      // no doc for delete op
+    } else {
+      throw new Error(`Unsupported bulk operation: ${JSON.stringify(op)}`);
+    }
+
+    index++;
+  }
+
+  return result;
+}

--- a/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/lib/alert_conflict_resolver.ts
@@ -38,15 +38,12 @@ export async function resolveAlertConflicts(
 
   const bulkRequest = {
     operations: conflictRequest.map((req) => [req.op, req.doc]).flat(),
-  }
+  };
   return { bulkRequest };
 }
 
-
 // change this to do the mget separately from applying the OCC,
 // so we can also use the mget to get the current ad-hoc fields of the alert
-
-
 
 /** Update the OCC info in the request via mget. */
 async function updateOCC(esClient: ElasticsearchClient, conflictRequests: NormalizedBulkRequest[]) {


### PR DESCRIPTION
resolves: https://github.com/elastic/kibana/issues/158403

## Summary

Current approach is to `mget()` the conflicting docs, to get their new OCC values (`_seq_no`, `_primary_term`) as well as "ad hoc" updated fields like case assignment, workflow status etc.  Then re-try the bulk update.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
