### PR TITLE
Revert 165293

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -273,8 +273,7 @@ type RequestHandlerEnhanced<P, Q, B, Method extends RouteMethod> = WithoutHeadAr
   RequestHandler<P, Q, B, RequestHandlerContextBase, Method>
 >;
 
-// headers that may contain PII
-const SENSITIVE_HEADERS = [
+const FORBIDDEN_HEADERS = [
   'authorization',
   'cookie',
   'set-cookie',
@@ -286,11 +285,11 @@ const REDACTED_HEADER_TEXT = '[REDACTED]';
 
 const redactSensitiveHeaders = (data: any) => {
   // keep the original Error object, but deep clone all its properties
-  // this allows redacting PII without modifying the original objects,
+  // this allows redacting some fields without modifying the original objects,
   // and at the same time preserving the original Error object
   Object.entries(data).forEach(([key, value]) => {
     data[key] = cloneDeepWith(value, (v, k) =>
-      typeof k === 'string' && SENSITIVE_HEADERS.includes(k) ? REDACTED_HEADER_TEXT : undefined
+      typeof k === 'string' && FORBIDDEN_HEADERS.includes(k) ? REDACTED_HEADER_TEXT : undefined
     );
   });
   return data;

--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -26,6 +26,7 @@ import type {
   VersionedRouter,
 } from '@kbn/core-http-server';
 import { validBodyOutput } from '@kbn/core-http-server';
+import { cloneDeepWith } from 'lodash';
 import { RouteValidator } from './validator';
 import { CoreVersionedRouter } from './versioned_router';
 import { CoreKibanaRequest } from './request';
@@ -201,7 +202,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
       kibanaRequest = CoreKibanaRequest.from(request, routeSchemas);
     } catch (error) {
       this.log.error(`400 Bad Request - ${request.path}`, {
-        error,
+        error: redactSensitiveHeaders(error),
         http: { response: { status_code: 400 } },
       });
 
@@ -218,7 +219,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
       // forward 401 errors from ES client
       if (isElasticsearchUnauthorizedError(error)) {
         this.log.error(`401 Unauthorized - ${request.path}`, {
-          error,
+          error: redactSensitiveHeaders(error),
           http: { response: { status_code: 401 } },
         });
         return hapiResponseAdapter.handle(
@@ -228,7 +229,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
 
       // return a generic 500 to avoid error info / stack trace surfacing
       this.log.error(`500 Server Error - ${request.path}`, {
-        error,
+        error: redactSensitiveHeaders(error),
         http: { response: { status_code: 500 } },
       });
       return hapiResponseAdapter.toInternalError();
@@ -271,3 +272,26 @@ type WithoutHeadArgument<T> = T extends (first: any, ...rest: infer Params) => i
 type RequestHandlerEnhanced<P, Q, B, Method extends RouteMethod> = WithoutHeadArgument<
   RequestHandler<P, Q, B, RequestHandlerContextBase, Method>
 >;
+
+// headers that may contain PII
+const SENSITIVE_HEADERS = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-elastic-app-auth',
+  'es-client-authentication',
+];
+
+const REDACTED_HEADER_TEXT = '[REDACTED]';
+
+const redactSensitiveHeaders = (data: any) => {
+  // keep the original Error object, but deep clone all its properties
+  // this allows redacting PII without modifying the original objects,
+  // and at the same time preserving the original Error object
+  Object.entries(data).forEach(([key, value]) => {
+    data[key] = cloneDeepWith(value, (v, k) =>
+      typeof k === 'string' && SENSITIVE_HEADERS.includes(k) ? REDACTED_HEADER_TEXT : undefined
+    );
+  });
+  return data;
+};

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -608,35 +608,7 @@ describe('Handler', () => {
     expect(message).toEqual('500 Server Error - /');
 
     // unwrap all error properties
-    expect(Object.assign({}, meta!.error)).toMatchInlineSnapshot(`
-      Object {
-        "meta": Object {
-          "headers": Object {
-            "authorization": "[REDACTED]",
-            "randomHeader": "randomValue",
-          },
-          "request": Object {
-            "options": Object {
-              "headers": Object {
-                "authorization": "[REDACTED]",
-                "cookie": "[REDACTED]",
-                "user-agent": "Kibana/8.11.0",
-              },
-            },
-            "params": Object {
-              "headers": Object {
-                "authorization": "[REDACTED]",
-                "cookie": "[REDACTED]",
-                "es-client-authentication": "[REDACTED]",
-                "queryParam": "aValue",
-                "set-cookie": "[REDACTED]",
-                "x-elastic-app-auth": "[REDACTED]",
-              },
-            },
-          },
-        },
-      }
-    `);
+    expect(Object.assign({}, meta!.error)).toMatchInlineSnapshot(`Object {}`);
   });
 
   it('captures the error if handler throws', async () => {
@@ -674,7 +646,6 @@ describe('Handler', () => {
         Array [
           "500 Server Error - /",
           Object {
-            "error": [Error: Unauthorized],
             "http": Object {
               "response": Object {
                 "status_code": 500,
@@ -704,7 +675,6 @@ describe('Handler', () => {
         Array [
           "500 Server Error - /",
           Object {
-            "error": [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
             "http": Object {
               "response": Object {
                 "status_code": 500,
@@ -749,7 +719,6 @@ describe('Handler', () => {
         Array [
           "400 Bad Request - /",
           Object {
-            "error": [Error: [request query.page]: expected value of type [number] but got [string]],
             "http": Object {
               "response": Object {
                 "status_code": 400,
@@ -1234,7 +1203,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: expected 'location' header to be set],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1648,7 +1616,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1725,7 +1692,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: expected 'location' header to be set],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1873,7 +1839,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: expected error message to be provided],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1907,7 +1872,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: expected error message to be provided],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1940,7 +1904,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: options.statusCode is expected to be set. given options: undefined],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1973,7 +1936,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error - /",
             Object {
-              "error": [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
               "http": Object {
                 "response": Object {
                   "status_code": 500,

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -577,11 +577,8 @@ describe('Handler', () => {
       'An internal server error occurred. Check Kibana server logs for details.'
     );
 
-    const [message, meta] = loggingSystemMock.collect(logger).error[0];
+    const [message] = loggingSystemMock.collect(logger).error[0];
     expect(message).toEqual('500 Server Error - /');
-
-    // unwrap all error properties
-    expect(Object.assign({}, meta!.error)).toMatchInlineSnapshot(`Object {}`);
   });
 
   it('captures the error if handler throws', async () => {

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -569,6 +569,10 @@ describe('Handler', () => {
       // simulate the enriched error that we get for an actual request
       throw Object.assign(new Error('unexpected error'), {
         meta: {
+          headers: {
+            authorization: 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
+            randomHeader: 'randomValue',
+          },
           request: {
             options: {
               headers: {
@@ -577,10 +581,21 @@ describe('Handler', () => {
                 cookie: '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
               },
             },
+            params: {
+              headers: {
+                queryParam: 'aValue',
+                authorization: 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
+                cookie: '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
+                'set-cookie': '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
+                'x-elastic-app-auth': 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
+                'es-client-authentication': '5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
+              },
+            },
           },
         },
       });
     });
+
     await server.start();
 
     const result = await supertest(innerServer.listener).get('/').expect(500);
@@ -596,12 +611,26 @@ describe('Handler', () => {
     expect(Object.assign({}, meta!.error)).toMatchInlineSnapshot(`
       Object {
         "meta": Object {
+          "headers": Object {
+            "authorization": "[REDACTED]",
+            "randomHeader": "randomValue",
+          },
           "request": Object {
             "options": Object {
               "headers": Object {
                 "authorization": "[REDACTED]",
                 "cookie": "[REDACTED]",
                 "user-agent": "Kibana/8.11.0",
+              },
+            },
+            "params": Object {
+              "headers": Object {
+                "authorization": "[REDACTED]",
+                "cookie": "[REDACTED]",
+                "es-client-authentication": "[REDACTED]",
+                "queryParam": "aValue",
+                "set-cookie": "[REDACTED]",
+                "x-elastic-app-auth": "[REDACTED]",
               },
             },
           },

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -561,39 +561,12 @@ describe('Cache-Control', () => {
 });
 
 describe('Handler', () => {
-  it("Doesn't expose sensitive nor uninteresting error details if handler throws", async () => {
+  it("Doesn't expose error details if handler throws", async () => {
     const { server: innerServer, createRouter } = await server.setup(setupDeps);
     const router = createRouter('/');
 
     router.get({ path: '/', validate: false }, (context, req, res) => {
-      // simulate the enriched error that we get for an actual request
-      throw Object.assign(new Error('unexpected error'), {
-        meta: {
-          headers: {
-            authorization: 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
-            randomHeader: 'randomValue',
-          },
-          request: {
-            options: {
-              headers: {
-                'user-agent': 'Kibana/8.11.0',
-                authorization: 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
-                cookie: '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
-              },
-            },
-            params: {
-              headers: {
-                queryParam: 'aValue',
-                authorization: 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
-                cookie: '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
-                'set-cookie': '5eaGBBijbDxx someCookie RfK7IcNAkAAAA=',
-                'x-elastic-app-auth': 'Bearer 5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
-                'es-client-authentication': '5eaGBBijbDxx someToken RfK7IcNAkAAAA=',
-              },
-            },
-          },
-        },
-      });
+      throw new Error('unexpected error');
     });
 
     await server.start();

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -592,7 +592,7 @@ describe('Handler', () => {
     const [message, meta] = loggingSystemMock.collect(logger).error[0];
     expect(message).toEqual('500 Server Error - /');
 
-    // unwrap all Error's properties (assert PII has been redacted)
+    // unwrap all error properties
     expect(Object.assign({}, meta!.error)).toMatchInlineSnapshot(`
       Object {
         "meta": Object {


### PR DESCRIPTION
## Summary

Let's revert https://github.com/elastic/kibana/pull/165293 until we agree on the attributes of the error object that we want to log. Should they be based on the `EcsError` interface?

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->