### PR TITLE
Skip flaky serverless cases status test suite

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cases/list_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cases/list_view.ts
@@ -53,7 +53,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         });
       });
 
-      describe('status', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/166027
+      describe.skip('status', () => {
         createNCasesBeforeDeleteAllAfter(2, getPageObject, getService);
 
         it('change the status of cases to in-progress correctly', async () => {


### PR DESCRIPTION
This PR skips a flaky serverless security cases list view test suite.

#166027 already listed out the flakiness and skipped the corresponding stateful test.