### PR TITLE
Skip flaky serverless oblt cases status test suite

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/observability/cases/list_view.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/cases/list_view.ts
@@ -53,7 +53,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         });
       });
 
-      describe('status', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/166027
+      describe.skip('status', () => {
         createNCasesBeforeDeleteAllAfter(2, getPageObject, getService);
 
         it('change the status of cases to in-progress correctly', async () => {


### PR DESCRIPTION
This PR skips a flaky serverless observability cases list view test suite.

Follow-up on #166093, where the `security` version of these serverless test suite has been skipped.
