### PR TITLE
[Security Solution][PoC] Discover table in Explore pages

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -7,10 +7,11 @@
 
 import {
   dataTableActions,
-  DataTableComponent,
   defaultHeaders,
   getEventIdToDataMapping,
 } from '@kbn/securitysolution-data-table';
+import { DataView } from '@kbn/data-views-plugin/public';
+
 import type {
   SubsetDataTableModel,
   TableId,
@@ -23,16 +24,13 @@ import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { ThemeContext } from 'styled-components';
 import type { Filter } from '@kbn/es-query';
-import type {
-  DeprecatedCellValueElementProps,
-  DeprecatedRowRenderer,
-  Direction,
-  EntityType,
-} from '@kbn/timelines-plugin/common';
+import type { Direction, EntityType, TimelineItem } from '@kbn/timelines-plugin/common';
 import { isEmpty } from 'lodash';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
-import type { EuiDataGridRowHeightsOptions } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { DataLoadingState } from '@kbn/unified-data-table';
+import { UnifiedDataTable } from '../unified_data_table';
 import { ALERTS_TABLE_VIEW_SELECTION_KEY } from '../../../../common/constants';
 import type { Sort } from '../../../timelines/components/timeline/body/sort';
 import type {
@@ -68,7 +66,7 @@ import {
   StyledEuiPanel,
 } from './styles';
 import { getDefaultViewSelection, getCombinedFilterQuery } from './helpers';
-import { useTimelineEvents } from './use_timelines_events';
+import { useDataTableRows } from './use_data_table_rows';
 import { TableContext, EmptyTable, TableLoading } from './shared';
 import type { AlertWorkflowStatus } from '../../types';
 import { useQueryInspector } from '../page/manage_query';
@@ -77,12 +75,11 @@ import { checkBoxControlColumn, transformControlColumns } from '../control_colum
 import { RightTopMenu } from './right_top_menu';
 import { useAlertBulkActions } from './use_alert_bulk_actions';
 import type { BulkActionsProp } from '../toolbar/bulk_actions/types';
-import { StatefulEventContext } from './stateful_event_context';
 import { defaultUnit } from '../toolbar/unit';
-import { useGetFieldSpec } from '../../hooks/use_get_field_spec';
 
 const storage = new Storage(localStorage);
-
+const REQUEST_SIZE = 50;
+const SAMPLE_SIZE = 1000;
 const SECURITY_ALERTS_CONSUMERS = [AlertConsumers.SIEM];
 
 export interface EventsViewerProps {
@@ -151,7 +148,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
       itemsPerPage,
       itemsPerPageOptions,
       sessionViewConfig,
-      showCheckboxes,
+      // showCheckboxes,
       sort,
       queryFields,
       selectAll,
@@ -162,10 +159,15 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     } = defaultModel,
   } = useSelector((state: State) => eventsViewerSelector(state, tableId));
 
+  const showCheckboxes = false; // checkboxes are handled inside the unified data table
+
   const {
     uiSettings,
     data,
-    triggersActionsUi: { getFieldBrowser },
+    fieldFormats,
+    theme: themeService,
+    dataViewFieldEditor,
+    notifications: { toasts: toastNotifications },
   } = useKibana().services;
 
   const [tableView, setTableView] = useState<ViewSelection>(
@@ -181,28 +183,22 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     indexPattern,
     runtimeMappings,
     selectedPatterns,
-    dataViewId: selectedDataViewId,
     loading: isLoadingIndexPattern,
+    sourcererDataView,
   } = useSourcererDataView(sourcererScope);
 
-  const getFieldSpec = useGetFieldSpec(sourcererScope);
+  const dataView = useMemo(() => {
+    if (sourcererDataView != null) {
+      return new DataView({ spec: sourcererDataView, fieldFormats });
+    } else {
+      return null;
+    }
+  }, [sourcererDataView, fieldFormats]);
 
   const { globalFullScreen } = useGlobalFullScreen();
 
   const editorActionsRef = useRef<FieldEditorActions>(null);
   useEffect(() => {
-    dispatch(
-      dataTableActions.createDataTable({
-        columns,
-        dataViewId: selectedDataViewId,
-        defaultColumns,
-        id: tableId,
-        indexNames: indexNames ?? selectedPatterns,
-        itemsPerPage,
-        showCheckboxes,
-        sort,
-      })
-    );
     return () => {
       dispatch(inputsActions.deleteOneQuery({ id: tableId, inputId: InputsModelId.global }));
       if (editorActionsRef.current) {
@@ -303,8 +299,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     [sort]
   );
 
-  const [loading, { events, loadPage, pageInfo, refetch, totalCount = 0, inspect }] =
-    useTimelineEvents({
+  const [loading, { rows, loadMore, pageInfo, refetch, totalCount = 0, inspect }] =
+    useDataTableRows({
       // We rely on entityType to determine Events vs Alerts
       alertConsumers: SECURITY_ALERTS_CONSUMERS,
       data,
@@ -315,7 +311,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
       filterQuery,
       id: tableId,
       indexNames: indexNames ?? selectedPatterns,
-      limit: itemsPerPage,
+      limit: REQUEST_SIZE,
       runtimeMappings,
       skip: !canQueryTimeline,
       sort: sortField,
@@ -356,38 +352,20 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
   const showFullLoading = loading && !hasAlerts;
 
   const nonDeletedEvents = useMemo(
-    () => events.filter((e) => !deletedEventIds.includes(e._id)),
-    [deletedEventIds, events]
+    () => rows.filter((e) => !deletedEventIds.includes(e._id)),
+    [deletedEventIds, rows]
   );
   useEffect(() => {
     setQuery({ id: tableId, inspect, loading, refetch });
   }, [inspect, loading, refetch, setQuery, tableId]);
 
-  // Clear checkbox selection when new events are fetched
-  useEffect(() => {
-    dispatch(dataTableActions.clearSelected({ id: tableId }));
-    dispatch(
-      dataTableActions.setDataTableSelectAll({
-        id: tableId,
-        selectAll: false,
-      })
-    );
-  }, [nonDeletedEvents, dispatch, tableId]);
-
   const onChangeItemsPerPage = useCallback(
-    (itemsChangedPerPage) => {
+    (itemsChangedPerPage: number) => {
       dispatch(
         dataTableActions.updateItemsPerPage({ id: tableId, itemsPerPage: itemsChangedPerPage })
       );
     },
     [tableId, dispatch]
-  );
-
-  const onChangePage = useCallback(
-    (page) => {
-      loadPage(page);
-    },
-    [loadPage]
   );
 
   const setEventsLoading = useCallback<SetEventsLoading>(
@@ -507,39 +485,6 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     selectedCount,
   });
 
-  // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
-  const [activeStatefulEventContext] = useState({
-    timelineID: tableId,
-    tabType: 'query',
-    enableHostDetailsFlyout: true,
-    enableIpDetailsFlyout: true,
-  });
-
-  const unitCountText = useMemo(
-    () => `${totalCountMinusDeleted.toLocaleString()} ${unit(totalCountMinusDeleted)}`,
-    [totalCountMinusDeleted, unit]
-  );
-
-  const rowHeightsOptions: EuiDataGridRowHeightsOptions | undefined = useMemo(() => {
-    if (tableView === 'eventRenderedView') {
-      return {
-        defaultHeight: 'auto' as const,
-      };
-    }
-    return undefined;
-  }, [tableView]);
-
-  const pagination = useMemo(
-    () => ({
-      pageIndex: pageInfo.activePage,
-      pageSize: itemsPerPage,
-      pageSizeOptions: itemsPerPageOptions,
-      onChangeItemsPerPage,
-      onChangePage,
-    }),
-    [itemsPerPage, itemsPerPageOptions, onChangeItemsPerPage, onChangePage, pageInfo.activePage]
-  );
-
   return (
     <>
       <FullScreenContainer $isFullScreen={globalFullScreen}>
@@ -573,41 +518,53 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
                   />
 
                   {!hasAlerts && !loading && !graphOverlay && <EmptyTable />}
-                  {hasAlerts && (
+                  {hasAlerts && dataView && (
                     <FullWidthFlexGroupTable
                       $visible={!graphEventId && graphOverlay == null}
                       gutterSize="none"
                     >
                       <ScrollableFlexItem grow={1}>
-                        <StatefulEventContext.Provider value={activeStatefulEventContext}>
-                          <DataTableComponent
-                            cellActionsTriggerId={cellActionsTriggerId}
-                            additionalControls={alertBulkActions}
-                            unitCountText={unitCountText}
-                            browserFields={browserFields}
-                            data={nonDeletedEvents}
-                            id={tableId}
-                            loadPage={loadPage}
-                            // TODO: migrate away from deprecated type
-                            renderCellValue={
-                              renderCellValue as (
-                                props: DeprecatedCellValueElementProps
-                              ) => React.ReactNode
-                            }
-                            // TODO: migrate away from deprecated type
-                            rowRenderers={rowRenderers as unknown as DeprecatedRowRenderer[]}
-                            totalItems={totalCountMinusDeleted}
-                            bulkActions={bulkActions}
-                            fieldBrowserOptions={fieldBrowserOptions}
-                            hasCrudPermissions={hasCrudPermissions}
-                            leadingControlColumns={transformedLeadingControlColumns}
-                            pagination={pagination}
-                            isEventRenderedView={tableView === 'eventRenderedView'}
-                            rowHeightsOptions={rowHeightsOptions}
-                            getFieldBrowser={getFieldBrowser}
-                            getFieldSpec={getFieldSpec}
-                          />
-                        </StatefulEventContext.Provider>
+                        <UnifiedDataTable
+                          ariaLabelledBy="events-viewer"
+                          loadingState={
+                            loading ? DataLoadingState.loadingMore : DataLoadingState.loaded
+                          }
+                          cellActionsTriggerId={cellActionsTriggerId}
+                          externalAdditionalControls={alertBulkActions}
+                          dataView={dataView}
+                          columns={columns.map(({ id }) => id)}
+                          rows={timelineItemsToTableRecords(nonDeletedEvents)}
+                          onFilter={() => {}}
+                          onSetColumns={() => {}}
+                          onFetchMoreRecords={loadMore}
+                          sampleSize={SAMPLE_SIZE}
+                          showTimeCol={false}
+                          sort={[]}
+                          useNewFieldsApi={false}
+                          onUpdateRowsPerPage={onChangeItemsPerPage}
+                          rowsPerPageState={itemsPerPage}
+                          rowsPerPageOptions={itemsPerPageOptions}
+                          // TODO: migrate away from deprecated type
+                          // renderCellValue={
+                          //   renderCellValue as (
+                          //     props: DeprecatedCellValueElementProps
+                          //   ) => React.ReactNode
+                          // }
+                          // TODO: migrate away from deprecated type
+                          // rowRenderers={rowRenderers as unknown as DeprecatedRowRenderer[]}
+                          totalHits={totalCountMinusDeleted}
+                          externalControlColumns={transformedLeadingControlColumns}
+                          rowHeightState={2}
+                          services={{
+                            theme: themeService,
+                            fieldFormats,
+                            uiSettings,
+                            dataViewFieldEditor,
+                            toastNotifications,
+                            storage,
+                            data,
+                          }}
+                        />
                       </ScrollableFlexItem>
                     </FullWidthFlexGroupTable>
                   )}
@@ -634,3 +591,22 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 export const StatefulEventsViewer: React.FunctionComponent<EventsViewerProps> = connector(
   StatefulEventsViewerComponent
 );
+
+function timelineItemsToTableRecords(events: TimelineItem[]): DataTableRecord[] {
+  return events.map((event) => {
+    const dataRecord = event.data.reduce<Record<string, unknown>>((acc, { field, value }) => {
+      acc[field] = value;
+      return acc;
+    }, {});
+
+    return {
+      id: event._id,
+      raw: {
+        _id: event._id,
+        _index: event._index ?? '',
+        _source: dataRecord,
+      },
+      flattened: dataRecord,
+    };
+  });
+}

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/use_data_table_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/use_data_table_rows.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
+import {
+  useTimelineEvents,
+  type TimelineArgs,
+  type UseTimelineEventsProps,
+} from './use_timelines_events';
+
+type UseDataTable = [
+  boolean,
+  Omit<TimelineArgs, 'loadPage' | 'events'> & { rows: TimelineItem[]; loadMore: () => void }
+];
+
+export const useDataTableRows = (props: UseTimelineEventsProps): UseDataTable => {
+  const [loading, result] = useTimelineEvents(props);
+  const { events, loadPage, pageInfo, ...rest } = result;
+
+  const [pageRows, setPageRows] = useState<TimelineItem[][]>([]);
+
+  const loadMore = () => {
+    loadPage(pageInfo.activePage + 1);
+  };
+
+  useEffect(() => {
+    setPageRows((currentPageRows) => {
+      if (currentPageRows[pageInfo.activePage]?.length) {
+        return currentPageRows;
+      }
+      const newPageRows = [...currentPageRows];
+      newPageRows[pageInfo.activePage] = events;
+      return newPageRows;
+    });
+  }, [events, pageInfo.activePage]);
+
+  const rows = useMemo(() => pageRows.flat(), [pageRows]);
+
+  return [loading, { ...rest, rows, loadMore, pageInfo }];
+};

--- a/x-pack/plugins/security_solution/public/common/components/unified_data_table/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/unified_data_table/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export { UnifiedDataTable, type UnifiedDataTableProps } from './unified_data_table';

--- a/x-pack/plugins/security_solution/public/common/components/unified_data_table/unified_data_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/unified_data_table/unified_data_table.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiLoadingSpinner } from '@elastic/eui';
+import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import React from 'react';
+
+export type { UnifiedDataTableProps };
+
+const UnifiedDataTableLazy = React.lazy(() =>
+  import('@kbn/unified-data-table').then(({ UnifiedDataTable }) => ({
+    default: UnifiedDataTable,
+  }))
+);
+
+const UnifiedDataTableLazyWithSuspense = (props: UnifiedDataTableProps) => (
+  <React.Suspense fallback={<EuiLoadingSpinner size="m" />}>
+    <UnifiedDataTableLazy {...props} />
+  </React.Suspense>
+);
+
+export const UnifiedDataTable = React.memo(UnifiedDataTableLazyWithSuspense);

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -172,6 +172,8 @@
     "@kbn/core-lifecycle-browser",
     "@kbn/security-solution-features",
     "@kbn/handlebars",
-    "@kbn/content-management-plugin"
+    "@kbn/content-management-plugin",
+    "@kbn/discover-utils",
+    "@kbn/unified-data-table"
   ]
 }


### PR DESCRIPTION
## Summary

PoC that implements the integration the `@kbn/unified-data-table` (Discover grid) in all the event tables of Explore pages (Hosts, Network, Users)

<img width="1701" alt="Captura de pantalla 2023-09-08 a les 18 37 02" src="https://github.com/elastic/kibana/assets/17747913/bf4ac452-6db9-47bb-adfc-ef6261e6205e">


- [x] Data fetching
- [x] Data convertion
- [ ] Extend bulk actions with security bulk actions
- [ ] Configure row renderers correctly
- [ ] Add Field Browser
- [ ] Column order changes
