### PR TITLE
fix(slo): burn rate lookback window component

### DIFF
--- a/x-pack/plugins/observability/public/components/burn_rate_rule_editor/long_window_duration.tsx
+++ b/x-pack/plugins/observability/public/components/burn_rate_rule_editor/long_window_duration.tsx
@@ -5,12 +5,12 @@
  * 2.0.
  */
 
-import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIconTip } from '@elastic/eui';
+import { EuiFieldNumber, EuiFormRow, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React, { ChangeEvent, useState } from 'react';
 
-import { toMinutes } from '../../utils/slo/duration';
 import { Duration } from '../../typings';
+import { toMinutes } from '../../utils/slo/duration';
 
 interface Props {
   shortWindowDuration: Duration;
@@ -36,22 +36,18 @@ export function LongWindowDuration({
 
   return (
     <EuiFormRow label={getRowLabel(shortWindowDuration)} fullWidth isInvalid={hasError}>
-      <EuiFlexGroup direction="row">
-        <EuiFlexItem>
-          <EuiFieldNumber
-            isInvalid={hasError}
-            min={1}
-            max={72}
-            step={1}
-            value={String(durationValue)}
-            onChange={onDurationValueChange}
-            aria-label={i18n.translate('xpack.observability.slo.rules.longWindow.valueLabel', {
-              defaultMessage: 'Lookback period in hours',
-            })}
-            data-test-subj="durationValueInput"
-          />
-        </EuiFlexItem>
-      </EuiFlexGroup>
+      <EuiFieldNumber
+        isInvalid={hasError}
+        min={1}
+        max={72}
+        step={1}
+        value={String(durationValue)}
+        onChange={onDurationValueChange}
+        aria-label={i18n.translate('xpack.observability.slo.rules.longWindow.valueLabel', {
+          defaultMessage: 'Lookback period in hours',
+        })}
+        data-test-subj="durationValueInput"
+      />
     </EuiFormRow>
   );
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166071 (kind of)

## Summary

The forementioned issue suggests to open the tooltip when the row title is clicked, but that's not how the [EuiFormRow is working](https://eui.elastic.co/#/forms/form-layouts#form-and-form-rows). That being said, the lookback component was wrapping the EuiFieldNumber within an extra FlexItem which was breaking the auto focus.

This PR fixes the `lookback window` form row so when the title is clicked, the input below is focused.
