### PR TITLE
[DOCS] Move preconfigured Microsoft Teams connector details

### DIFF
--- a/docs/api-generated/connectors/connector-apis-passthru.asciidoc
+++ b/docs/api-generated/connectors/connector-apis-passthru.asciidoc
@@ -1097,6 +1097,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#secrets_properties_slack_api"><code>secrets_properties_slack_api</code> - Connector secrets properties for a Web API Slack connector</a></li>
     <li><a href="#secrets_properties_slack_webhook"><code>secrets_properties_slack_webhook</code> - Connector secrets properties for a Webhook Slack connector</a></li>
     <li><a href="#secrets_properties_swimlane"><code>secrets_properties_swimlane</code> - Connector secrets properties for a Swimlane connector</a></li>
+    <li><a href="#secrets_properties_teams"><code>secrets_properties_teams</code> - Connector secrets properties for a Microsoft Teams connector</a></li>
     <li><a href="#secrets_properties_webhook"><code>secrets_properties_webhook</code> - Connector secrets properties for a Webhook connector</a></li>
     <li><a href="#secrets_properties_xmatters"><code>secrets_properties_xmatters</code> - Connector secrets properties for an xMatters connector</a></li>
     <li><a href="#updateConnector_400_response"><code>updateConnector_400_response</code> - </a></li>
@@ -1112,6 +1113,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#update_connector_request_slack_api"><code>update_connector_request_slack_api</code> - Update Slack connector request</a></li>
     <li><a href="#update_connector_request_slack_webhook"><code>update_connector_request_slack_webhook</code> - Update Slack connector request</a></li>
     <li><a href="#update_connector_request_swimlane"><code>update_connector_request_swimlane</code> - Update Swimlane connector request</a></li>
+    <li><a href="#update_connector_request_teams"><code>update_connector_request_teams</code> - Update Microsoft Teams connector request</a></li>
     <li><a href="#update_connector_request_xmatters"><code>update_connector_request_xmatters</code> - Update xMatters connector request</a></li>
   </ol>
 
@@ -1737,7 +1739,8 @@ Any modifications made to this file will be overwritten.
     <h3><a name="connector_response_properties_teams"><code>connector_response_properties_teams</code> - Connector response properties for a Microsoft Teams connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'></div>
     <div class="field-items">
-      <div class="param">connector_type_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The type of connector. </div>
+      <div class="param">config (optional)</div><div class="param-desc"><span class="param-type"><a href="#">Object</a></span>  </div>
+<div class="param">connector_type_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The type of connector. </div>
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">.teams</div>
 <div class="param">id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The identifier for the connector. </div>
@@ -1985,7 +1988,7 @@ Any modifications made to this file will be overwritten.
         <div class="param-enum-header">Enum:</div>
         <div class="param-enum">.teams</div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
-<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#AnyType">map[String, oas_any_type_not_mapped]</a></span> Defines secrets for connectors when type is <code>.teams</code>. </div>
+<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_teams">secrets_properties_teams</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -2445,6 +2448,13 @@ Any modifications made to this file will be overwritten.
     </div>  <!-- field-items -->
   </div>
   <div class="model">
+    <h3><a name="secrets_properties_teams"><code>secrets_properties_teams</code> - Connector secrets properties for a Microsoft Teams connector</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'>Defines secrets for connectors when type is <code>.teams</code>.</div>
+    <div class="field-items">
+      <div class="param">webhookUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The URL of the incoming webhook. If you are using the <code>xpack.actions.allowedHosts</code> setting, add the hostname to the allowed hosts. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
     <h3><a name="secrets_properties_webhook"><code>secrets_properties_webhook</code> - Connector secrets properties for a Webhook connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>Defines secrets for connectors when type is <code>.webhook</code>.</div>
     <div class="field-items">
@@ -2574,6 +2584,14 @@ Any modifications made to this file will be overwritten.
       <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_swimlane">config_properties_swimlane</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
 <div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_swimlane">secrets_properties_swimlane</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="update_connector_request_teams"><code>update_connector_request_teams</code> - Update Microsoft Teams connector request</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
+<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_teams">secrets_properties_teams</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/management/connectors/action-types/teams.asciidoc
+++ b/docs/management/connectors/action-types/teams.asciidoc
@@ -3,6 +3,10 @@
 ++++
 <titleabbrev>Microsoft Teams</titleabbrev>
 ++++
+:frontmatter-description: Add a connector that can send messages to a Microsoft Teams channel.
+:frontmatter-tags-products: [kibana] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [configure]
 
 The Microsoft Teams connector uses https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook[Incoming Webhooks].
 
@@ -24,28 +28,6 @@ Microsoft Teams connectors have the following configuration properties:
 
 Name::      The name of the connector.
 Webhook URL::   The URL of the incoming webhook. See https://docs.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook#add-an-incoming-webhook-to-a-teams-channel[Add Incoming Webhooks] for instructions on generating this URL. If you are using the <<action-settings, `xpack.actions.allowedHosts`>> setting, make sure the hostname is added to the allowed hosts.
-
-[float]
-[[preconfigured-teams-configuration]]
-=== Create preconfigured connectors
-
-If you are running {kib} on-prem, you can define connectors by
-adding `xpack.actions.preconfigured` settings to your `kibana.yml` file.
-For example:
-
-[source,text]
---
-xpack.actions.preconfigured:
-  my-teams:
-    name: preconfigured-teams-connector-type
-    actionTypeId: .teams
-    secrets:
-      webhookUrl: 'https://outlook.office.com/webhook/abcd@0123456/IncomingWebhook/abcdefgh/ijklmnopqrstuvwxyz'
---
-
-Secrets defines sensitive information for the connector type.
-
-`webhookUrl`:: A string that corresponds to *Webhook URL*.
 
 [float]
 [[teams-action-configuration]]

--- a/docs/management/connectors/pre-configured-connectors.asciidoc
+++ b/docs/management/connectors/pre-configured-connectors.asciidoc
@@ -159,6 +159,23 @@ xpack.actions.preconfigured:
 <4> The API authentication token for HTTP basic authentication. NOTE: This value should be stored in the <<creating-keystore,{kib} keystore>>.
 
 [float]
+[[preconfigured-teams-configuration]]
+==== Microsoft Teams connectors
+
+The following example creates a <<teams-action-type,Microsoft Teams connector>>:
+
+[source,text]
+--
+xpack.actions.preconfigured:
+  my-teams:
+    name: preconfigured-teams-connector-type
+    actionTypeId: .teams
+    secrets:
+      webhookUrl: 'https://outlook.office.com/webhook/abcd@0123456/IncomingWebhook/abcdefgh/ijklmnopqrstuvwxyz' <1>
+--
+<1> The URL of the incoming webhook.
+
+[float]
 [[preconfigured-opsgenie-configuration]]
 ==== {opsgenie} connectors
 

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -390,6 +390,11 @@ A user name secret that varies by connector:
 * For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
+`xpack.actions.preconfigured.<connector-id>.secrets.webhookUrl`::
+For a <<teams-action-type,Microsoft Teams>>, specifies the URL of the incoming webhook.
++
+NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname is added to the allowed hosts.
+
 
 [float]
 [[alert-settings]]

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -485,6 +485,9 @@
                     "$ref": "#/components/schemas/update_connector_request_swimlane"
                   },
                   {
+                    "$ref": "#/components/schemas/update_connector_request_teams"
+                  },
+                  {
                     "$ref": "#/components/schemas/update_connector_request_xmatters"
                   }
                 ]
@@ -2558,7 +2561,15 @@
         "title": "Connector secrets properties for a Microsoft Teams connector",
         "description": "Defines secrets for connectors when type is `.teams`.",
         "type": "object",
-        "additionalProperties": true
+        "required": [
+          "webhookUrl"
+        ],
+        "properties": {
+          "webhookUrl": {
+            "type": "string",
+            "description": "The URL of the incoming webhook. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.\n"
+          }
+        }
       },
       "create_connector_request_teams": {
         "title": "Create Microsoft Teams connector request",
@@ -3459,6 +3470,9 @@
           "name"
         ],
         "properties": {
+          "config": {
+            "type": "object"
+          },
           "connector_type_id": {
             "type": "string",
             "description": "The type of connector.",
@@ -3913,6 +3927,23 @@
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_swimlane"
+          }
+        }
+      },
+      "update_connector_request_teams": {
+        "title": "Update Microsoft Teams connector request",
+        "type": "object",
+        "required": [
+          "name",
+          "secrets"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The display name for the connector."
+          },
+          "secrets": {
+            "$ref": "#/components/schemas/secrets_properties_teams"
           }
         }
       },

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -254,6 +254,7 @@ paths:
                 - $ref: '#/components/schemas/update_connector_request_slack_api'
                 - $ref: '#/components/schemas/update_connector_request_slack_webhook'
                 - $ref: '#/components/schemas/update_connector_request_swimlane'
+                - $ref: '#/components/schemas/update_connector_request_teams'
                 - $ref: '#/components/schemas/update_connector_request_xmatters'
             examples:
               updateIndexConnectorRequest:
@@ -1713,7 +1714,13 @@ components:
       title: Connector secrets properties for a Microsoft Teams connector
       description: Defines secrets for connectors when type is `.teams`.
       type: object
-      additionalProperties: true
+      required:
+        - webhookUrl
+      properties:
+        webhookUrl:
+          type: string
+          description: |
+            The URL of the incoming webhook. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.
     create_connector_request_teams:
       title: Create Microsoft Teams connector request
       description: The Microsoft Teams connector uses Incoming Webhooks.
@@ -2395,6 +2402,8 @@ components:
         - is_preconfigured
         - name
       properties:
+        config:
+          type: object
         connector_type_id:
           type: string
           description: The type of connector.
@@ -2700,6 +2709,18 @@ components:
           example: my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_swimlane'
+    update_connector_request_teams:
+      title: Update Microsoft Teams connector request
+      type: object
+      required:
+        - name
+        - secrets
+      properties:
+        name:
+          type: string
+          description: The display name for the connector.
+        secrets:
+          $ref: '#/components/schemas/secrets_properties_teams'
     update_connector_request_xmatters:
       title: Update xMatters connector request
       type: object

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
@@ -7,6 +7,8 @@ required:
   - is_preconfigured
   - name
 properties:
+  config:
+    type: object
   connector_type_id:
     type: string
     description: The type of connector.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/secrets_properties_teams.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/secrets_properties_teams.yaml
@@ -1,5 +1,11 @@
 title: Connector secrets properties for a Microsoft Teams connector
 description: Defines secrets for connectors when type is `.teams`.
 type: object
-additionalProperties: true
-# TO-DO: Add the properties for this connector.
+required:
+  - webhookUrl
+properties:
+  webhookUrl:
+    type: string
+    description: >
+      The URL of the incoming webhook.
+      If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -172,7 +172,7 @@ put:
             - $ref: '../components/schemas/update_connector_request_slack_api.yaml'
             - $ref: '../components/schemas/update_connector_request_slack_webhook.yaml'
             - $ref: '../components/schemas/update_connector_request_swimlane.yaml' 
-#            - $ref: '../components/schemas/update_connector_request_teams.yaml'
+            - $ref: '../components/schemas/update_connector_request_teams.yaml'
 #            - $ref: '../components/schemas/update_connector_request_tines.yaml'
 #            - $ref: '../components/schemas/update_connector_request_webhook.yaml'
             - $ref: '../components/schemas/update_connector_request_xmatters.yaml'


### PR DESCRIPTION
## Summary

This PR:

- Moves the preconfigured connector examples from https://www.elastic.co/guide/en/kibana/master/teams-action-type.html to https://www.elastic.co/guide/en/kibana/master/pre-configured-connectors.html since that functionality is only applicable if you are running Kibana on-prem and therefore won't be applicable to serverless projects.
- Adds the setting names to https://www.elastic.co/guide/en/kibana/master/alert-action-settings-kb.html
- Adds the same config and secrets properties to the openAPI specification