### PR TITLE
[Security Solution] Detection engine metrics logging improvements

### DIFF
--- a/x-pack/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_metrics.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/rule_monitoring/model/execution_metrics.ts
@@ -25,4 +25,5 @@ export const RuleExecutionMetrics = t.partial({
   total_indexing_duration_ms: DurationMetric,
   total_enrichment_duration_ms: DurationMetric,
   execution_gap_duration_s: DurationMetric,
+  total_value_list_filtering_duration_ms: DurationMetric,
 });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_assets/prebuilt_rule_assets_client.ts
@@ -30,7 +30,7 @@ export const createPrebuiltRuleAssetsClient = (
 ): IPrebuiltRuleAssetsClient => {
   return {
     fetchLatestAssets: () => {
-      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestAssets', async () => {
+      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestAssets', [], async () => {
         const findResult = await savedObjectsClient.find<
           PrebuiltRuleAsset,
           {
@@ -73,7 +73,7 @@ export const createPrebuiltRuleAssetsClient = (
     },
 
     fetchLatestVersions: (): Promise<RuleVersionSpecifier[]> => {
-      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestVersions', async () => {
+      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchLatestVersions', [], async () => {
         const findResult = await savedObjectsClient.find<
           PrebuiltRuleAsset,
           {
@@ -125,7 +125,7 @@ export const createPrebuiltRuleAssetsClient = (
     },
 
     fetchAssetsByVersion: (versions: RuleVersionSpecifier[]): Promise<PrebuiltRuleAsset[]> => {
-      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchAssetsByVersion', async () => {
+      return withSecuritySpan('IPrebuiltRuleAssetsClient.fetchAssetsByVersion', [], async () => {
         if (versions.length === 0) {
           // NOTE: without early return it would build incorrect filter and fetch all existing saved objects
           return [];

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/create_prebuilt_rules.ts
@@ -13,7 +13,7 @@ import { createRules } from '../../../rule_management/logic/crud/create_rules';
 import type { PrebuiltRuleAsset } from '../../model/rule_assets/prebuilt_rule_asset';
 
 export const createPrebuiltRules = (rulesClient: RulesClient, rules: PrebuiltRuleAsset[]) =>
-  withSecuritySpan('createPrebuiltRules', async () => {
+  withSecuritySpan('createPrebuiltRules', [], async () => {
     const result = await initPromisePool({
       concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
       items: rules,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/prebuilt_rule_objects_client.ts
@@ -25,27 +25,31 @@ export const createPrebuiltRuleObjectsClient = (
 ): IPrebuiltRuleObjectsClient => {
   return {
     fetchAllInstalledRules: (): Promise<RuleResponse[]> => {
-      return withSecuritySpan('IPrebuiltRuleObjectsClient.fetchInstalledRules', async () => {
+      return withSecuritySpan('IPrebuiltRuleObjectsClient.fetchInstalledRules', [], async () => {
         const rulesData = await getExistingPrepackagedRules({ rulesClient });
         const rules = rulesData.map((rule) => internalRuleToAPIResponse(rule));
         return rules;
       });
     },
     fetchInstalledRulesByIds: (ruleIds: RuleSignatureId[]): Promise<RuleResponse[]> => {
-      return withSecuritySpan('IPrebuiltRuleObjectsClient.fetchInstalledRulesByIds', async () => {
-        const { data } = await findRules({
-          rulesClient,
-          perPage: ruleIds.length,
-          page: 1,
-          sortField: 'createdAt',
-          sortOrder: 'desc',
-          fields: undefined,
-          filter: `alert.attributes.params.ruleId:(${ruleIds.join(' or ')})`,
-        });
+      return withSecuritySpan(
+        'IPrebuiltRuleObjectsClient.fetchInstalledRulesByIds',
+        [],
+        async () => {
+          const { data } = await findRules({
+            rulesClient,
+            perPage: ruleIds.length,
+            page: 1,
+            sortField: 'createdAt',
+            sortOrder: 'desc',
+            fields: undefined,
+            filter: `alert.attributes.params.ruleId:(${ruleIds.join(' or ')})`,
+          });
 
-        const rules = data.map((rule) => internalRuleToAPIResponse(rule));
-        return rules;
-      });
+          const rules = data.map((rule) => internalRuleToAPIResponse(rule));
+          return rules;
+        }
+      );
     },
   };
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/upgrade_prebuilt_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/prebuilt_rules/logic/rule_objects/upgrade_prebuilt_rules.ts
@@ -27,7 +27,7 @@ import type { PrebuiltRuleAsset } from '../../model/rule_assets/prebuilt_rule_as
  * @param rules The rules to apply the update for
  */
 export const upgradePrebuiltRules = async (rulesClient: RulesClient, rules: PrebuiltRuleAsset[]) =>
-  withSecuritySpan('upgradePrebuiltRules', async () => {
+  withSecuritySpan('upgradePrebuiltRules', [], async () => {
     const result = await initPromisePool({
       concurrency: MAX_RULES_TO_UPDATE_IN_PARALLEL,
       items: rules,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/crud/read_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/crud/read_rules.ts
@@ -38,7 +38,7 @@ export const readRules = async ({
 }: ReadRuleOptions): Promise<
   SanitizedRule<RuleParams> | ResolvedSanitizedRule<RuleParams> | null
 > => {
-  return withSecuritySpan('readRules', async () => {
+  return withSecuritySpan('readRules', [], async () => {
     if (id != null) {
       try {
         const rule = await rulesClient.resolve({ id });

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/logic/search/get_existing_prepackaged_rules.ts
@@ -32,7 +32,7 @@ export const getRulesCount = async ({
   rulesClient: RulesClient;
   filter: string;
 }): Promise<number> => {
-  return withSecuritySpan('getRulesCount', async () => {
+  return withSecuritySpan('getRulesCount', [], async () => {
     const { total } = await findRules({
       rulesClient,
       filter,
@@ -53,7 +53,7 @@ export const getRules = async ({
   rulesClient: RulesClient;
   filter: string;
 }): Promise<RuleAlertType[]> =>
-  withSecuritySpan('getRules', async () => {
+  withSecuritySpan('getRules', [], async () => {
     const rules = await findRules({
       rulesClient,
       filter,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -251,6 +251,9 @@ const normalizeStatusChangeArgs = (args: StatusChangeArgs): NormalizedStatusChan
           total_indexing_duration_ms: normalizeDurations(metrics.indexingDurations),
           total_enrichment_duration_ms: normalizeDurations(metrics.enrichmentDurations),
           execution_gap_duration_s: normalizeGap(metrics.executionGap),
+          total_value_list_filtering_duration_ms: normalizeDurations(
+            metrics.valueListFilteringDurations
+          ),
         }
       : undefined,
   };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client.ts
@@ -80,23 +80,27 @@ export const createRuleExecutionLogClientForExecutors = (
     },
 
     async logStatusChange(args: StatusChangeArgs): Promise<void> {
-      await withSecuritySpan('IRuleExecutionLogForExecutors.logStatusChange', async () => {
-        const correlationIds = baseCorrelationIds.withStatus(args.newStatus);
-        const logMeta = correlationIds.getLogMeta();
+      await withSecuritySpan(
+        'IRuleExecutionLogForExecutors.logStatusChange',
+        args.metrics?.durationMetrics ?? [],
+        async () => {
+          const correlationIds = baseCorrelationIds.withStatus(args.newStatus);
+          const logMeta = correlationIds.getLogMeta();
 
-        try {
-          const normalizedArgs = normalizeStatusChangeArgs(args);
+          try {
+            const normalizedArgs = normalizeStatusChangeArgs(args);
 
-          await Promise.all([
-            writeStatusChangeToConsole(normalizedArgs, logMeta),
-            writeStatusChangeToRuleObject(normalizedArgs),
-            writeStatusChangeToEventLog(normalizedArgs),
-          ]);
-        } catch (e) {
-          const logMessage = `Error changing rule status to "${args.newStatus}"`;
-          writeExceptionToConsole(e, logMessage, logMeta);
+            await Promise.all([
+              writeStatusChangeToConsole(normalizedArgs, logMeta),
+              writeStatusChangeToRuleObject(normalizedArgs),
+              writeStatusChangeToEventLog(normalizedArgs),
+            ]);
+          } catch (e) {
+            const logMessage = `Error changing rule status to "${args.newStatus}"`;
+            writeExceptionToConsole(e, logMessage, logMeta);
+          }
         }
-      });
+      );
     },
   };
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -7,6 +7,7 @@
 
 import type { Duration } from 'moment';
 import type { RuleExecutionStatus } from '../../../../../../../common/api/detection_engine/rule_monitoring';
+import type { DurationMetrics, RulePhase } from '../../../../rule_types/types';
 
 /**
  * Used from rule executors to log various information about the rule execution:
@@ -125,6 +126,10 @@ export interface MetricsArgs {
   searchDurations?: string[];
   indexingDurations?: string[];
   enrichmentDurations?: string[];
-  valueListFilteringDurations?: string[];
+  durationMetrics?: DurationMetrics[];
   executionGap?: Duration;
 }
+
+export type DurationMetricReturn = {
+  [key in RulePhase]?: number;
+};

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_executors/client_interface.ts
@@ -125,5 +125,6 @@ export interface MetricsArgs {
   searchDurations?: string[];
   indexingDurations?: string[];
   enrichmentDurations?: string[];
+  valueListFilteringDurations?: string[];
   executionGap?: Duration;
 }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/client.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/client_for_routes/client.ts
@@ -27,7 +27,7 @@ export const createRuleExecutionLogClientForRoutes = (
 ): IRuleExecutionLogForRoutes => {
   return {
     getExecutionEvents: (args: GetExecutionEventsArgs): Promise<GetRuleExecutionEventsResponse> => {
-      return withSecuritySpan('IRuleExecutionLogForRoutes.getExecutionEvents', async () => {
+      return withSecuritySpan('IRuleExecutionLogForRoutes.getExecutionEvents', [], async () => {
         const { ruleId } = args;
         try {
           return await eventLog.getExecutionEvents(args);
@@ -48,7 +48,7 @@ export const createRuleExecutionLogClientForRoutes = (
     getExecutionResults: (
       args: GetExecutionResultsArgs
     ): Promise<GetRuleExecutionResultsResponse> => {
-      return withSecuritySpan('IRuleExecutionLogForRoutes.getExecutionResults', async () => {
+      return withSecuritySpan('IRuleExecutionLogForRoutes.getExecutionResults', [], async () => {
         const { ruleId } = args;
         try {
           return await eventLog.getExecutionResults(args);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/event_log/event_log_reader.ts
@@ -68,7 +68,7 @@ export const createEventLogReader = (eventLog: IEventLogClient): IEventLogReader
       const soType = RULE_SAVED_OBJECT_TYPE;
       const soIds = [ruleId];
 
-      const findResult = await withSecuritySpan('findEventsBySavedObjectIds', () => {
+      const findResult = await withSecuritySpan('findEventsBySavedObjectIds', [], () => {
         return eventLog.findEventsBySavedObjectIds(soType, soIds, {
           // TODO: include Framework events
           filter: buildEventLogKqlFilter({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/execution_settings/fetch_rule_execution_settings.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/rule_execution_log/execution_settings/fetch_rule_execution_settings.ts
@@ -24,18 +24,26 @@ export const fetchRuleExecutionSettings = async (
   savedObjectsClient: SavedObjectsClientContract
 ): Promise<RuleExecutionSettings> => {
   try {
-    const ruleExecutionSettings = await withSecuritySpan('fetchRuleExecutionSettings', async () => {
-      const [coreStart] = await withSecuritySpan('getCoreStartServices', () =>
-        core.getStartServices()
-      );
+    const ruleExecutionSettings = await withSecuritySpan(
+      'fetchRuleExecutionSettings',
+      [],
+      async () => {
+        const [coreStart] = await withSecuritySpan('getCoreStartServices', [], () =>
+          core.getStartServices()
+        );
 
-      const kibanaAdvancedSettings = await withSecuritySpan('getKibanaAdvancedSettings', () => {
-        const settingsClient = coreStart.uiSettings.asScopedToClient(savedObjectsClient);
-        return settingsClient.getAll();
-      });
+        const kibanaAdvancedSettings = await withSecuritySpan(
+          'getKibanaAdvancedSettings',
+          [],
+          () => {
+            const settingsClient = coreStart.uiSettings.asScopedToClient(savedObjectsClient);
+            return settingsClient.getAll();
+          }
+        );
 
-      return getRuleExecutionSettingsFrom(config, kibanaAdvancedSettings);
-    });
+        return getRuleExecutionSettingsFrom(config, kibanaAdvancedSettings);
+      }
+    );
 
     return ruleExecutionSettings;
   } catch (e) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/service.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_monitoring/logic/service.ts
@@ -104,6 +104,7 @@ export const createRuleMonitoringService = (
     ): Promise<IRuleExecutionLogForExecutors> => {
       return withSecuritySpan(
         'IRuleMonitoringService.createRuleExecutionLogClientForExecutors',
+        [],
         async () => {
           const { savedObjectsClient, context, ruleMonitoringService, ruleResultService } = params;
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -426,7 +426,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   success: result.success && runResult.success,
                   warning: warningMessages.length > 0,
                   warningMessages,
-                  metrics: result.metrics.concat(runResult.metrics),
+                  durationMetrics: result.durationMetrics.concat(runResult.durationMetrics),
                 };
                 runState = runResult.state;
               }
@@ -442,7 +442,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 success: true,
                 warning: false,
                 warningMessages: [],
-                metrics: [],
+                durationMetrics: [],
               };
             }
 
@@ -475,6 +475,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                     searchDurations: result.searchAfterTimes,
                     indexingDurations: result.bulkCreateTimes,
                     enrichmentDurations: result.enrichmentTimes,
+                    durationMetrics: result.durationMetrics,
                   },
                 });
               }
@@ -486,6 +487,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   searchDurations: result.searchAfterTimes,
                   indexingDurations: result.bulkCreateTimes,
                   enrichmentDurations: result.enrichmentTimes,
+                  durationMetrics: result.durationMetrics,
                 },
               });
             }
@@ -499,6 +501,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 searchDurations: result.searchAfterTimes,
                 indexingDurations: result.bulkCreateTimes,
                 enrichmentDurations: result.enrichmentTimes,
+                durationMetrics: result.durationMetrics,
               },
             });
           }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/create_security_rule_type_wrapper.ts
@@ -426,6 +426,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                   success: result.success && runResult.success,
                   warning: warningMessages.length > 0,
                   warningMessages,
+                  metrics: result.metrics.concat(runResult.metrics),
                 };
                 runState = runResult.state;
               }
@@ -441,6 +442,7 @@ export const createSecurityRuleTypeWrapper: CreateSecurityRuleTypeWrapper =
                 success: true,
                 warning: false,
                 warningMessages: [],
+                metrics: [],
               };
             }
 

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/eql.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/eql/eql.ts
@@ -24,6 +24,7 @@ import type {
   RuleRangeTuple,
   SearchAfterAndBulkCreateReturnType,
   SignalSource,
+  DurationMetrics,
 } from '../types';
 import {
   addToSearchAfterReturn,
@@ -56,6 +57,7 @@ export const eqlExecutor = async ({
   secondaryTimestamp,
   exceptionFilter,
   unprocessedExceptions,
+  durationMetrics,
 }: {
   inputIndex: string[];
   runtimeMappings: estypes.MappingRuntimeFields | undefined;
@@ -71,10 +73,11 @@ export const eqlExecutor = async ({
   secondaryTimestamp?: string;
   exceptionFilter: Filter | undefined;
   unprocessedExceptions: ExceptionListItemSchema[];
+  durationMetrics: DurationMetrics[];
 }): Promise<SearchAfterAndBulkCreateReturnType> => {
   const ruleParams = completeRule.ruleParams;
 
-  return withSecuritySpan('eqlExecutor', async () => {
+  return withSecuritySpan('eqlExecutor', durationMetrics, async () => {
     const result = createSearchAfterReturnType();
 
     const request = buildEqlSearchRequest({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/indicator_match.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/indicator_match.ts
@@ -15,7 +15,7 @@ import type {
 } from '@kbn/alerting-plugin/server';
 import type { ListClient } from '@kbn/lists-plugin/server';
 import type { Filter, DataViewFieldBase } from '@kbn/es-query';
-import type { RuleRangeTuple, BulkCreate, WrapHits } from '../types';
+import type { RuleRangeTuple, BulkCreate, WrapHits, DurationMetrics } from '../types';
 import type { ITelemetryEventsSender } from '../../../telemetry/sender';
 import { createThreatSignals } from './threat_mapping/create_threat_signals';
 import type { CompleteRule, ThreatRuleParams } from '../../rule_schema';
@@ -41,6 +41,7 @@ export const indicatorMatchExecutor = async ({
   exceptionFilter,
   unprocessedExceptions,
   inputIndexFields,
+  durationMetrics,
 }: {
   inputIndex: string[];
   runtimeMappings: estypes.MappingRuntimeFields | undefined;
@@ -59,10 +60,11 @@ export const indicatorMatchExecutor = async ({
   exceptionFilter: Filter | undefined;
   unprocessedExceptions: ExceptionListItemSchema[];
   inputIndexFields: DataViewFieldBase[];
+  durationMetrics: DurationMetrics[];
 }) => {
   const ruleParams = completeRule.ruleParams;
 
-  return withSecuritySpan('indicatorMatchExecutor', async () => {
+  return withSecuritySpan('indicatorMatchExecutor', durationMetrics, async () => {
     return createThreatSignals({
       alertId: completeRule.alertId,
       bulkCreate,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_event_signal.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_event_signal.ts
@@ -137,7 +137,6 @@ export const createEventSignal = async ({
       ruleExecutionLogger,
       services,
       sortOrder: 'desc',
-      trackTotalHits: false,
       tuple,
       wrapHits,
       runtimeMappings,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signal.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signal.ts
@@ -111,7 +111,6 @@ export const createThreatSignal = async ({
       ruleExecutionLogger,
       services,
       sortOrder: 'desc',
-      trackTotalHits: false,
       tuple,
       wrapHits,
       runtimeMappings,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
@@ -90,6 +90,7 @@ export const createThreatSignals = async ({
     createdSignals: [],
     errors: [],
     warningMessages: [],
+    durationMetrics: [],
   };
 
   const { eventMappingFilter, indicatorMappingFilter } = getMappingFilters(threatMapping);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/get_event_count.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/get_event_count.ts
@@ -10,6 +10,7 @@ import type { EventCountOptions, EventsOptions, EventDoc } from './types';
 import { getQueryFilter } from '../../utils/get_query_filter';
 import { singleSearchAfter } from '../../utils/single_search_after';
 import { buildEventsSearchQuery } from '../../utils/build_events_query';
+import { getTotalHitsValue } from '../../utils/utils';
 
 export const MAX_PER_PAGE = 9000;
 
@@ -60,10 +61,13 @@ export const getEventList = async ({
     primaryTimestamp,
     secondaryTimestamp,
     sortOrder: 'desc',
-    trackTotalHits: false,
+    trackTotalHits: true,
     runtimeMappings,
     overrideBody: eventListConfig,
   });
+
+  const totalHits = getTotalHitsValue(searchResult.hits.total);
+  ruleExecutionLogger.debug(`totalHits: ${totalHits}`);
 
   ruleExecutionLogger.debug(`Retrieved events items of size: ${searchResult.hits.hits.length}`);
   return searchResult;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
@@ -19,7 +19,7 @@ import type { CompleteRule, MachineLearningRuleParams } from '../../rule_schema'
 import { bulkCreateMlSignals } from './bulk_create_ml_signals';
 import { filterEventsAgainstList } from '../utils/large_list_filters/filter_events_against_list';
 import { findMlSignals } from './find_ml_signals';
-import type { BulkCreate, RuleRangeTuple, WrapHits } from '../types';
+import type { BulkCreate, DurationMetrics, RuleRangeTuple, WrapHits } from '../types';
 import { RulePhase } from '../types';
 import {
   addToSearchAfterReturn,
@@ -44,6 +44,7 @@ export const mlExecutor = async ({
   wrapHits,
   exceptionFilter,
   unprocessedExceptions,
+  durationMetrics,
 }: {
   completeRule: CompleteRule<MachineLearningRuleParams>;
   tuple: RuleRangeTuple;
@@ -55,11 +56,12 @@ export const mlExecutor = async ({
   wrapHits: WrapHits;
   exceptionFilter: Filter | undefined;
   unprocessedExceptions: ExceptionListItemSchema[];
+  durationMetrics: DurationMetrics[];
 }) => {
   const result = createSearchAfterReturnType();
   const ruleParams = completeRule.ruleParams;
 
-  return withSecuritySpan('mlExecutor', async () => {
+  return withSecuritySpan('mlExecutor', durationMetrics, async () => {
     if (ml == null) {
       throw new Error('ML plugin unavailable during rule execution');
     }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
@@ -25,6 +25,7 @@ import {
   createErrorsFromShard,
   createSearchAfterReturnType,
   getMaxSignalsWarning,
+  makeFloatString,
   mergeReturns,
 } from '../utils/utils';
 import type { SetupPlugins } from '../../../../plugin';
@@ -115,12 +116,15 @@ export const mlExecutor = async ({
       result.warningMessages.push(getMaxSignalsWarning());
     }
 
+    const start = performance.now();
     const [filteredAnomalyHits, _] = await filterEventsAgainstList({
       listClient,
       ruleExecutionLogger,
       exceptionsList: unprocessedExceptions,
       events: anomalyResults.hits.hits,
     });
+    const end = performance.now();
+    result.metrics.valueListFilteringTimes.push(makeFloatString(end - start));
 
     const anomalyCount = filteredAnomalyHits.length;
     if (anomalyCount) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/ml/ml.ts
@@ -20,6 +20,7 @@ import { bulkCreateMlSignals } from './bulk_create_ml_signals';
 import { filterEventsAgainstList } from '../utils/large_list_filters/filter_events_against_list';
 import { findMlSignals } from './find_ml_signals';
 import type { BulkCreate, RuleRangeTuple, WrapHits } from '../types';
+import { RulePhase } from '../types';
 import {
   addToSearchAfterReturn,
   createErrorsFromShard,
@@ -124,7 +125,10 @@ export const mlExecutor = async ({
       events: anomalyResults.hits.hits,
     });
     const end = performance.now();
-    result.metrics.valueListFilteringTimes.push(makeFloatString(end - start));
+    result.durationMetrics.push({
+      phaseName: RulePhase.ValueListFiltering,
+      duration: makeFloatString(end - start),
+    });
 
     const anomalyCount = filteredAnomalyHits.length;
     if (anomalyCount) {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/new_terms/create_new_terms_alert_type.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/new_terms/create_new_terms_alert_type.ts
@@ -7,6 +7,7 @@
 
 import { validateNonExact } from '@kbn/securitysolution-io-ts-utils';
 import { NEW_TERMS_RULE_TYPE_ID } from '@kbn/securitysolution-rules';
+import { withSecuritySpan } from '../../../../utils/with_security_span';
 import { SERVER_APP_ID } from '../../../../../common/constants';
 
 import type { NewTermsRuleParams } from '../../rule_schema';
@@ -111,6 +112,7 @@ export const createNewTermsAlertType = (
           alertTimestampOverride,
           publicBaseUrl,
           inputIndexFields,
+          durationMetrics,
         },
         services,
         params,
@@ -135,6 +137,7 @@ export const createNewTermsAlertType = (
         query: params.query,
         exceptionFilter,
         fields: inputIndexFields,
+        durationMetrics,
       });
 
       const parsedHistoryWindowSize = parseDateString({
@@ -163,55 +166,57 @@ export const createNewTermsAlertType = (
         // PHASE 1: Fetch a page of terms using a composite aggregation. This will collect a page from
         // all of the terms seen over the last rule interval. In the next phase we'll determine which
         // ones are new.
-        const { searchResult, searchDuration, searchErrors } = await singleSearchAfter({
-          aggregations: buildRecentTermsAgg({
-            fields: params.newTermsFields,
-            after: afterKey,
-          }),
-          searchAfterSortIds: undefined,
-          index: inputIndex,
-          // The time range for the initial composite aggregation is the rule interval, `from` and `to`
-          from: tuple.from.toISOString(),
-          to: tuple.to.toISOString(),
-          services,
-          ruleExecutionLogger,
-          filter: esFilter,
-          pageSize: 0,
-          primaryTimestamp,
-          secondaryTimestamp,
-          runtimeMappings,
-          trackTotalHits,
+        await withSecuritySpan('phase 1', durationMetrics, async () => {
+          const { searchResult, searchDuration, searchErrors } = await singleSearchAfter({
+            aggregations: buildRecentTermsAgg({
+              fields: params.newTermsFields,
+              after: afterKey,
+            }),
+            searchAfterSortIds: undefined,
+            index: inputIndex,
+            // The time range for the initial composite aggregation is the rule interval, `from` and `to`
+            from: tuple.from.toISOString(),
+            to: tuple.to.toISOString(),
+            services,
+            ruleExecutionLogger,
+            filter: esFilter,
+            pageSize: 0,
+            primaryTimestamp,
+            secondaryTimestamp,
+            runtimeMappings,
+            trackTotalHits,
+            durationMetrics,
+          });
+          const searchResultWithAggs = searchResult as RecentTermsAggResult;
+          if (!searchResultWithAggs.aggregations) {
+            throw new Error('Aggregations were missing on recent terms search result');
+          }
+          logger.debug(`Time spent on composite agg: ${searchDuration}`);
+          if (trackTotalHits) {
+            const totalHits = getTotalHitsValue(searchResult.hits.total);
+            ruleExecutionLogger.debug(`Recent terms search totalHits: ${totalHits}`);
+          }
+
+          result.searchAfterTimes.push(searchDuration);
+          result.errors.push(...searchErrors);
+
+          afterKey = searchResultWithAggs.aggregations.new_terms.after_key;
+
+          // If the aggregation returns no after_key it signals that we've paged through all results
+          // and the current page is empty so we can immediately break.
+          if (afterKey == null) {
+            break;
+          }
+          const bucketsForField = searchResultWithAggs.aggregations.new_terms.buckets;
+          ruleExecutionLogger.debug(
+            `Recent terms search unique terms count: ${bucketsForField.length}`
+          );
+          const includeValues = transformBucketsToValues(params.newTermsFields, bucketsForField);
+          const newTermsRuntimeMappings = getNewTermsRuntimeMappings(
+            params.newTermsFields,
+            bucketsForField
+          );
         });
-        const searchResultWithAggs = searchResult as RecentTermsAggResult;
-        if (!searchResultWithAggs.aggregations) {
-          throw new Error('Aggregations were missing on recent terms search result');
-        }
-        logger.debug(`Time spent on composite agg: ${searchDuration}`);
-        if (trackTotalHits) {
-          const totalHits = getTotalHitsValue(searchResult.hits.total);
-          ruleExecutionLogger.debug(`Recent terms search totalHits: ${totalHits}`);
-        }
-
-        result.searchAfterTimes.push(searchDuration);
-        result.errors.push(...searchErrors);
-
-        afterKey = searchResultWithAggs.aggregations.new_terms.after_key;
-
-        // If the aggregation returns no after_key it signals that we've paged through all results
-        // and the current page is empty so we can immediately break.
-        if (afterKey == null) {
-          break;
-        }
-        const bucketsForField = searchResultWithAggs.aggregations.new_terms.buckets;
-        ruleExecutionLogger.debug(
-          `Recent terms search unique terms count: ${bucketsForField.length}`
-        );
-        const includeValues = transformBucketsToValues(params.newTermsFields, bucketsForField);
-        const newTermsRuntimeMappings = getNewTermsRuntimeMappings(
-          params.newTermsFields,
-          bucketsForField
-        );
-
         // PHASE 2: Take the page of results from Phase 1 and determine if each term exists in the history window.
         // The aggregation filters out buckets for terms that exist prior to `tuple.from`, so the buckets in the
         // response correspond to each new term.
@@ -242,6 +247,7 @@ export const createNewTermsAlertType = (
           pageSize: 0,
           primaryTimestamp,
           secondaryTimestamp,
+          durationMetrics,
         });
         result.searchAfterTimes.push(pageSearchDuration);
         result.errors.push(...pageSearchErrors);
@@ -291,6 +297,7 @@ export const createNewTermsAlertType = (
             pageSize: 0,
             primaryTimestamp,
             secondaryTimestamp,
+            durationMetrics,
           });
           result.searchAfterTimes.push(docFetchSearchDuration);
           result.errors.push(...docFetchSearchErrors);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
@@ -149,9 +149,7 @@ export const groupAndBulkCreate = async ({
       state: {
         suppressionGroupHistory: filteredBucketHistory,
       },
-      metrics: {
-        valueListFilteringTimes: [],
-      },
+      durationMetrics: [],
     };
 
     const exceptionsWarning = getUnprocessedExceptionsWarnings(runOpts.unprocessedExceptions);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
@@ -17,6 +17,7 @@ import {
   getUnprocessedExceptionsWarnings,
   getMaxSignalsWarning,
   mergeReturns,
+  getTotalHitsValue,
 } from '../../utils/utils';
 import type { SuppressionBucket } from './wrap_suppressed_alerts';
 import { wrapSuppressedAlerts } from './wrap_suppressed_alerts';
@@ -148,6 +149,9 @@ export const groupAndBulkCreate = async ({
       state: {
         suppressionGroupHistory: filteredBucketHistory,
       },
+      metrics: {
+        valueListFilteringTimes: [],
+      },
     };
 
     const exceptionsWarning = getUnprocessedExceptionsWarnings(runOpts.unprocessedExceptions);
@@ -194,10 +198,14 @@ export const groupAndBulkCreate = async ({
         secondaryTimestamp: runOpts.secondaryTimestamp,
         runtimeMappings: runOpts.runtimeMappings,
         additionalFilters: bucketHistoryFilter,
+        trackTotalHits: true,
       };
       const { searchResult, searchDuration, searchErrors } = await singleSearchAfter(
         eventsSearchParams
       );
+
+      const totalHits = getTotalHitsValue(searchResult.hits.total);
+      runOpts.ruleExecutionLogger.debug(`totalHits: ${totalHits}`);
 
       toReturn.searchAfterTimes.push(searchDuration);
       toReturn.errors.push(...searchErrors);

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/alert_suppression/group_and_bulk_create.ts
@@ -127,7 +127,7 @@ export const groupAndBulkCreate = async ({
   groupByFields,
   eventsTelemetry,
 }: GroupAndBulkCreateParams): Promise<GroupAndBulkCreateReturnType> => {
-  return withSecuritySpan('groupAndBulkCreate', async () => {
+  return withSecuritySpan('groupAndBulkCreate', runOpts.durationMetrics, async () => {
     const tuple = runOpts.tuple;
 
     const filteredBucketHistory = filterBucketHistory({
@@ -197,6 +197,7 @@ export const groupAndBulkCreate = async ({
         runtimeMappings: runOpts.runtimeMappings,
         additionalFilters: bucketHistoryFilter,
         trackTotalHits: true,
+        durationMetrics: runOpts.durationMetrics,
       };
       const { searchResult, searchDuration, searchErrors } = await singleSearchAfter(
         eventsSearchParams

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/query.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/query/query.ts
@@ -48,7 +48,7 @@ export const queryExecutor = async ({
   const completeRule = runOpts.completeRule;
   const ruleParams = completeRule.ruleParams;
 
-  return withSecuritySpan('queryExecutor', async () => {
+  return withSecuritySpan('queryExecutor', runOpts.durationMetrics, async () => {
     const esFilter = await getFilter({
       type: ruleParams.type,
       filters: ruleParams.filters,
@@ -59,6 +59,7 @@ export const queryExecutor = async ({
       index: runOpts.inputIndex,
       exceptionFilter: runOpts.exceptionFilter,
       fields: runOpts.inputIndexFields,
+      durationMetrics: runOpts.durationMetrics,
     });
 
     const license = await firstValueFrom(licensing.license$);
@@ -93,6 +94,7 @@ export const queryExecutor = async ({
               runtimeMappings: runOpts.runtimeMappings,
               primaryTimestamp: runOpts.primaryTimestamp,
               secondaryTimestamp: runOpts.secondaryTimestamp,
+              durationMetrics: runOpts.durationMetrics,
             })),
             state: {},
           };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/get_threshold_bucket_filters.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/get_threshold_bucket_filters.ts
@@ -13,13 +13,13 @@ import type { ThresholdSignalHistory, ThresholdSignalHistoryRecord } from './typ
  * Returns a filter to exclude events that have already been included in a
  * previous threshold signal. Uses the threshold signal history to achieve this.
  */
-export const getThresholdBucketFilters = async ({
+export const getThresholdBucketFilters = ({
   signalHistory,
   aggregatableTimestampField,
 }: {
   signalHistory: ThresholdSignalHistory;
   aggregatableTimestampField: string;
-}): Promise<Filter[]> => {
+}): Filter[] => {
   const filters = Object.values(signalHistory).reduce(
     (acc: ESFilter[], bucket: ThresholdSignalHistoryRecord): ESFilter[] => {
       const filter = {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -164,7 +164,6 @@ export const thresholdExecutor = async ({
     result.errors.push(...searchErrors);
     result.warningMessages.push(...warnings);
     result.searchAfterTimes = searchDurations;
-    result.metrics.thresholdSignalHistorySearchTime = searchDuration;
 
     const createdAlerts = createResult.createdItems.map((alert) => {
       const { _id, _index, ...source } = alert;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -90,8 +90,12 @@ export const thresholdExecutor = async ({
     }
 
     // Get state or build initial state (on upgrade)
-    const { signalHistory, searchErrors: previousSearchErrors } = state.initialized
-      ? { signalHistory: state.signalHistory, searchErrors: [] }
+    const {
+      signalHistory,
+      searchErrors: previousSearchErrors,
+      searchDuration,
+    } = state.initialized
+      ? { signalHistory: state.signalHistory, searchErrors: [], searchDuration: undefined }
       : await getThresholdSignalHistory({
           from: tuple.from.toISOString(),
           to: tuple.to.toISOString(),
@@ -102,7 +106,7 @@ export const thresholdExecutor = async ({
 
     const validSignalHistory = getSignalHistory(state, signalHistory, tuple);
     // Eliminate dupes
-    const bucketFilters = await getThresholdBucketFilters({
+    const bucketFilters = getThresholdBucketFilters({
       signalHistory: validSignalHistory,
       aggregatableTimestampField,
     });
@@ -160,6 +164,7 @@ export const thresholdExecutor = async ({
     result.errors.push(...searchErrors);
     result.warningMessages.push(...warnings);
     result.searchAfterTimes = searchDurations;
+    result.metrics.thresholdSignalHistorySearchTime = searchDuration;
 
     const createdAlerts = createResult.createdItems.map((alert) => {
       const { _id, _index, ...source } = alert;

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -26,6 +26,7 @@ import { getThresholdSignalHistory } from './get_threshold_signal_history';
 
 import type {
   BulkCreate,
+  DurationMetrics,
   RuleRangeTuple,
   SearchAfterAndBulkCreateReturnType,
   WrapHits,
@@ -60,6 +61,7 @@ export const thresholdExecutor = async ({
   exceptionFilter,
   unprocessedExceptions,
   inputIndexFields,
+  durationMetrics,
 }: {
   inputIndex: string[];
   runtimeMappings: estypes.MappingRuntimeFields | undefined;
@@ -79,11 +81,12 @@ export const thresholdExecutor = async ({
   exceptionFilter: Filter | undefined;
   unprocessedExceptions: ExceptionListItemSchema[];
   inputIndexFields: DataViewFieldBase[];
+  durationMetrics: DurationMetrics[];
 }): Promise<SearchAfterAndBulkCreateReturnType & { state: ThresholdAlertState }> => {
   const result = createSearchAfterReturnType();
   const ruleParams = completeRule.ruleParams;
 
-  return withSecuritySpan('thresholdExecutor', async () => {
+  return withSecuritySpan('thresholdExecutor', durationMetrics, async () => {
     const exceptionsWarning = getUnprocessedExceptionsWarnings(unprocessedExceptions);
     if (exceptionsWarning) {
       result.warningMessages.push(exceptionsWarning);
@@ -122,6 +125,7 @@ export const thresholdExecutor = async ({
       index: inputIndex,
       exceptionFilter,
       fields: inputIndexFields,
+      durationMetrics,
     });
 
     // Look for new events over threshold

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -73,6 +73,7 @@ export interface SecurityAlertTypeReturnValue<TState extends RuleTypeState> {
   success: boolean;
   warning: boolean;
   warningMessages: string[];
+  metrics: SearchAfterAndBulkCreateMetrics[];
 }
 
 export interface RunOpts<TParams extends RuleParams> {
@@ -374,6 +375,11 @@ export interface SearchAfterAndBulkCreateParams {
   additionalFilters?: estypes.QueryDslQueryContainer[];
 }
 
+export interface SearchAfterAndBulkCreateMetrics {
+  valueListFilteringTimes: string[];
+  thresholdSignalHistorySearchTime?: string;
+}
+
 export interface SearchAfterAndBulkCreateReturnType {
   success: boolean;
   warning: boolean;
@@ -385,6 +391,7 @@ export interface SearchAfterAndBulkCreateReturnType {
   createdSignals: unknown[];
   errors: string[];
   warningMessages: string[];
+  metrics: SearchAfterAndBulkCreateMetrics;
 }
 
 // the new fields can be added later if needed

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -73,7 +73,7 @@ export interface SecurityAlertTypeReturnValue<TState extends RuleTypeState> {
   success: boolean;
   warning: boolean;
   warningMessages: string[];
-  metrics: SearchAfterAndBulkCreateMetrics[];
+  durationMetrics: DurationMetrics[];
 }
 
 export interface RunOpts<TParams extends RuleParams> {
@@ -375,9 +375,16 @@ export interface SearchAfterAndBulkCreateParams {
   additionalFilters?: estypes.QueryDslQueryContainer[];
 }
 
-export interface SearchAfterAndBulkCreateMetrics {
-  valueListFilteringTimes: string[];
-  thresholdSignalHistorySearchTime?: string;
+export enum RulePhase {
+  CompositeAgg = 'composite_agg',
+  BulkCreate = 'bulk_create',
+  AlertEnrichment = 'alert_enrichment',
+  ValueListFiltering = 'value_list_filtering',
+}
+
+export interface DurationMetrics {
+  phaseName: RulePhase;
+  duration: string;
 }
 
 export interface SearchAfterAndBulkCreateReturnType {
@@ -391,7 +398,7 @@ export interface SearchAfterAndBulkCreateReturnType {
   createdSignals: unknown[];
   errors: string[];
   warningMessages: string[];
-  metrics: SearchAfterAndBulkCreateMetrics;
+  durationMetrics: DurationMetrics[];
 }
 
 // the new fields can be added later if needed

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/types.ts
@@ -84,6 +84,7 @@ export interface RunOpts<TParams extends RuleParams> {
     maxSignals: number;
   };
   ruleExecutionLogger: IRuleExecutionLogForExecutors;
+  durationMetrics: DurationMetrics[];
   listClient: ListClient;
   searchAfterSize: number;
   bulkCreate: BulkCreate;
@@ -373,11 +374,17 @@ export interface SearchAfterAndBulkCreateParams {
   primaryTimestamp: string;
   secondaryTimestamp?: string;
   additionalFilters?: estypes.QueryDslQueryContainer[];
+  durationMetrics: DurationMetrics[];
 }
 
 export enum RulePhase {
-  CompositeAgg = 'composite_agg',
-  BulkCreate = 'bulk_create',
+  RecentTermsCompositeAgg = 'recent_terms_composite_agg',
+  HistoryWindowCompositeAgg = 'history_window_composite_agg',
+  DocumentSearchCompositeAgg = 'document_search_composite_agg',
+  DocumentSearch = 'document_search',
+  ThresholdCompositeAgg = 'threshold_composite_agg',
+  ThresholdSignalHistory = 'threshold_signal_history',
+  BulkCreate = 'bulk_create', // Difference between suppressed/unsuppressed/others?
   AlertEnrichment = 'alert_enrichment',
   ValueListFiltering = 'value_list_filtering',
 }

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/get_filter.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/get_filter.ts
@@ -27,6 +27,7 @@ import type { PartialFilter } from '../../types';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
 import type { ESBoolQuery } from '../../../../../common/typed_json';
 import { getQueryFilter } from './get_query_filter';
+import type { DurationMetrics } from '../types';
 
 interface GetFilterArgs {
   type: Type;
@@ -38,6 +39,7 @@ interface GetFilterArgs {
   index: IndexPatternArray | undefined;
   exceptionFilter: Filter | undefined;
   fields?: DataViewFieldBase[];
+  durationMetrics: DurationMetrics[];
 }
 
 interface QueryAttributes {
@@ -59,6 +61,7 @@ export const getFilter = async ({
   query,
   exceptionFilter,
   fields = [],
+  durationMetrics,
 }: GetFilterArgs): Promise<ESBoolQuery> => {
   const queryFilter = () => {
     if (query != null && language != null && index != null) {
@@ -79,7 +82,7 @@ export const getFilter = async ({
     if (savedId != null && index != null) {
       try {
         // try to get the saved object first
-        const savedObject = await withSecuritySpan('getSavedFilter', () =>
+        const savedObject = await withSecuritySpan('getSavedFilter', durationMetrics, () =>
           services.savedObjectsClient.get<QueryAttributes>('query', savedId)
         );
         return getQueryFilter({

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/get_input_output_index.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/get_input_output_index.ts
@@ -16,6 +16,7 @@ import type { Logger } from '@kbn/core/server';
 
 import { DEFAULT_INDEX_KEY, DEFAULT_INDEX_PATTERN } from '../../../../../common/constants';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
+import type { DurationMetrics } from '../types';
 
 export interface GetInputIndex {
   index: string[] | null | undefined;
@@ -25,6 +26,7 @@ export interface GetInputIndex {
   // the rule's rule_id
   ruleId: string;
   dataViewId?: string;
+  durationMetrics: DurationMetrics[];
 }
 
 export interface GetInputIndexReturn {
@@ -43,6 +45,7 @@ export const getInputIndex = async ({
   logger,
   ruleId,
   dataViewId,
+  durationMetrics,
 }: GetInputIndex): Promise<GetInputIndexReturn> => {
   // If data views defined, use it
   if (dataViewId != null && dataViewId !== '') {
@@ -85,7 +88,7 @@ export const getInputIndex = async ({
       runtimeMappings: {},
     };
   } else {
-    const configuration = await withSecuritySpan('getDefaultIndex', () =>
+    const configuration = await withSecuritySpan('getDefaultIndex', durationMetrics, () =>
       services.savedObjectsClient.get<{
         'securitySolution:defaultIndex': string[];
       }>('config', version)

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
@@ -21,6 +21,7 @@ export const createResultObject = <TState extends RuleTypeState>(state: TState) 
     success: true,
     warning: false,
     warningMessages: [],
+    metrics: [],
   };
   return result;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/index.ts
@@ -21,7 +21,7 @@ export const createResultObject = <TState extends RuleTypeState>(state: TState) 
     success: true,
     warning: false,
     warningMessages: [],
-    metrics: [],
+    durationMetrics: [],
   };
   return result;
 };

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
@@ -47,8 +47,9 @@ export const searchAfterAndBulkCreate = async ({
   primaryTimestamp,
   secondaryTimestamp,
   additionalFilters,
+  durationMetrics,
 }: SearchAfterAndBulkCreateParams): Promise<SearchAfterAndBulkCreateReturnType> => {
-  return withSecuritySpan('searchAfterAndBulkCreate', async () => {
+  return withSecuritySpan('searchAfterAndBulkCreate', durationMetrics, async () => {
     let toReturn = createSearchAfterReturnType();
     let searchingIteration = 0;
 
@@ -94,6 +95,7 @@ export const searchAfterAndBulkCreate = async ({
             trackTotalHits,
             sortOrder,
             additionalFilters,
+            durationMetrics,
           });
           mergedSearchResults = mergeSearchResults([mergedSearchResults, searchResult]);
           toReturn = mergeReturns([

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
@@ -20,6 +20,7 @@ import {
   getSafeSortIds,
   addToSearchAfterReturn,
   getMaxSignalsWarning,
+  makeFloatString,
 } from './utils';
 import type { SearchAfterAndBulkCreateParams, SearchAfterAndBulkCreateReturnType } from '../types';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
@@ -39,7 +40,6 @@ export const searchAfterAndBulkCreate = async ({
   ruleExecutionLogger,
   services,
   sortOrder,
-  trackTotalHits,
   tuple,
   wrapHits,
   runtimeMappings,
@@ -54,7 +54,7 @@ export const searchAfterAndBulkCreate = async ({
     // sortId tells us where to start our next consecutive search_after query
     let sortIds: estypes.SortResults | undefined;
     let hasSortId = true; // default to true so we execute the search on initial run
-
+    let trackTotalHits = true; // default to true so we track on initial run
     if (tuple == null || tuple.to == null || tuple.from == null) {
       ruleExecutionLogger.error(
         `missing run options fields: ${!tuple.to ? '"tuple.to"' : ''}, ${
@@ -109,6 +109,10 @@ export const searchAfterAndBulkCreate = async ({
 
           // determine if there are any candidate signals to be processed
           const totalHits = getTotalHitsValue(mergedSearchResults.hits.total);
+          if (trackTotalHits) {
+            trackTotalHits = false;
+            ruleExecutionLogger.debug(`totalHits: ${totalHits}`);
+          }
           const lastSortIds = getSafeSortIds(
             searchResult.hits.hits[searchResult.hits.hits.length - 1]?.sort
           );
@@ -141,13 +145,22 @@ export const searchAfterAndBulkCreate = async ({
         // filter out the search results that match with the values found in the list.
         // the resulting set are signals to be indexed, given they are not duplicates
         // of signals already present in the signals index.
+        const start = performance.now();
         const [includedEvents, _] = await filterEventsAgainstList({
           listClient,
           exceptionsList,
           ruleExecutionLogger,
           events: mergedSearchResults.hits.hits,
         });
-
+        const end = performance.now();
+        mergeReturns([
+          toReturn,
+          createSearchAfterReturnType({
+            metrics: {
+              valueListFilteringTimes: [makeFloatString(end - start)],
+            },
+          }),
+        ]);
         // only bulk create if there are filteredEvents leftover
         // if there isn't anything after going through the value list filter
         // skip the call to bulk create and proceed to the next search_after,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/search_after_bulk_create.ts
@@ -23,6 +23,7 @@ import {
   makeFloatString,
 } from './utils';
 import type { SearchAfterAndBulkCreateParams, SearchAfterAndBulkCreateReturnType } from '../types';
+import { RulePhase } from '../types';
 import { withSecuritySpan } from '../../../../utils/with_security_span';
 import { createEnrichEventsFunction } from './enrichments';
 
@@ -156,9 +157,9 @@ export const searchAfterAndBulkCreate = async ({
         mergeReturns([
           toReturn,
           createSearchAfterReturnType({
-            metrics: {
-              valueListFilteringTimes: [makeFloatString(end - start)],
-            },
+            durationMetrics: [
+              { phaseName: RulePhase.ValueListFiltering, duration: makeFloatString(end - start) },
+            ],
           }),
         ]);
         // only bulk create if there are filteredEvents leftover

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/single_search_after.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/single_search_after.ts
@@ -11,7 +11,12 @@ import type {
   AlertInstanceState,
   RuleExecutorServices,
 } from '@kbn/alerting-plugin/server';
-import type { SignalSearchResponse, SignalSource, OverrideBodyQuery } from '../types';
+import type {
+  SignalSearchResponse,
+  SignalSource,
+  OverrideBodyQuery,
+  DurationMetrics,
+} from '../types';
 import { buildEventsSearchQuery } from './build_events_query';
 import { createErrorsFromShard, makeFloatString } from './utils';
 import type { TimestampOverride } from '../../../../../common/api/detection_engine/model/rule_schema';
@@ -35,6 +40,7 @@ export interface SingleSearchAfterParams {
   runtimeMappings: estypes.MappingRuntimeFields | undefined;
   additionalFilters?: estypes.QueryDslQueryContainer[];
   overrideBody?: OverrideBodyQuery;
+  durationMetrics: DurationMetrics[];
 }
 
 // utilize search_after for paging results into bulk.
@@ -57,12 +63,13 @@ export const singleSearchAfter = async <
   trackTotalHits,
   additionalFilters,
   overrideBody,
+  durationMetrics,
 }: SingleSearchAfterParams): Promise<{
   searchResult: SignalSearchResponse<TAggregations>;
   searchDuration: string;
   searchErrors: string[];
 }> => {
-  return withSecuritySpan('singleSearchAfter', async () => {
+  return withSecuritySpan('singleSearchAfter', durationMetrics, async () => {
     try {
       const searchAfterQuery = buildEventsSearchQuery({
         aggregations,

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -169,6 +169,7 @@ export const checkPrivilegesFromEsClient = async (
 ): Promise<Privilege> =>
   withSecuritySpan(
     'checkPrivilegesFromEsClient',
+    [],
     async () =>
       (await esClient.transport.request({
         path: '/_security/user/_has_privileges',

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/utils/utils.ts
@@ -45,6 +45,7 @@ import type {
   SignalSourceHit,
   SimpleHit,
   WrappedEventHit,
+  SearchAfterAndBulkCreateMetrics,
 } from '../types';
 import type { ShardError } from '../../../types';
 import type {
@@ -656,6 +657,7 @@ export const createSearchAfterReturnType = ({
   createdSignals,
   errors,
   warningMessages,
+  metrics,
 }: {
   success?: boolean | undefined;
   warning?: boolean;
@@ -667,6 +669,7 @@ export const createSearchAfterReturnType = ({
   createdSignals?: unknown[] | undefined;
   errors?: string[] | undefined;
   warningMessages?: string[] | undefined;
+  metrics?: SearchAfterAndBulkCreateMetrics;
 } = {}): SearchAfterAndBulkCreateReturnType => {
   return {
     success: success ?? true,
@@ -679,6 +682,7 @@ export const createSearchAfterReturnType = ({
     createdSignals: createdSignals ?? [],
     errors: errors ?? [],
     warningMessages: warningMessages ?? [],
+    metrics: metrics ?? { valueListFilteringTimes: [] },
   };
 };
 
@@ -737,6 +741,10 @@ export const mergeReturns = (
       createdSignals: existingCreatedSignals,
       errors: existingErrors,
       warningMessages: existingWarningMessages,
+      metrics: {
+        thresholdSignalHistorySearchTime: existingThresholdSignalHistorySearchTime,
+        valueListFilteringTimes: existingValueListFilteringTimes,
+      },
     }: SearchAfterAndBulkCreateReturnType = prev;
 
     const {
@@ -750,6 +758,10 @@ export const mergeReturns = (
       createdSignals: newCreatedSignals,
       errors: newErrors,
       warningMessages: newWarningMessages,
+      metrics: {
+        thresholdSignalHistorySearchTime: newThresholdSignalHistorySearchTime,
+        valueListFilteringTimes: newValueListFilteringTimes,
+      },
     }: SearchAfterAndBulkCreateReturnType = next;
 
     return {
@@ -763,6 +775,14 @@ export const mergeReturns = (
       createdSignals: [...existingCreatedSignals, ...newCreatedSignals],
       errors: [...new Set([...existingErrors, ...newErrors])],
       warningMessages: [...existingWarningMessages, ...newWarningMessages],
+      metrics: {
+        thresholdSignalHistorySearchTime:
+          newThresholdSignalHistorySearchTime ?? existingThresholdSignalHistorySearchTime,
+        valueListFilteringTimes: [
+          ...existingValueListFilteringTimes,
+          ...newValueListFilteringTimes,
+        ],
+      },
     };
   });
 };

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/calculate_risk_scores.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/calculate_risk_scores.ts
@@ -38,6 +38,7 @@ import type {
   CalculateScoresResponse,
   RiskScoreBucket,
 } from './types';
+import type { DurationMetrics } from '../detection_engine/rule_types/types';
 
 const bucketToResponse = ({
   bucket,
@@ -206,11 +207,13 @@ export const calculateRiskScores = async ({
   range,
   runtimeMappings,
   weights,
+  durationMetrics,
 }: {
   esClient: ElasticsearchClient;
   logger: Logger;
+  durationMetrics: DurationMetrics[];
 } & CalculateScoresParams): Promise<CalculateScoresResponse> =>
-  withSecuritySpan('calculateRiskScores', async () => {
+  withSecuritySpan('calculateRiskScores', durationMetrics, async () => {
     const now = new Date().toISOString();
 
     const filter = [{ exists: { field: ALERT_RISK_SCORE } }, filterFromRange(range)];


### PR DESCRIPTION
## Summary

_WIP_

Adds telemetry and metrics logs for the Detection engine to help debug and visualize internal rule execution performance

In this PR:
- Adds "documents of interest" debug logging with `trackTotalHits` ES param passed programmatically per rule execution to visualize documents the rule is parsing over to create candidate alerts. Also helps track if there are any late arriving documents by comparing the initial rule run to later runs with the same params. Implemented on all rule types. Example: `Recent terms search totalHits: 40`
- Adds "unique terms count" logging for New Terms rule type to help visualize amount of unique terms rule is parsing over in both its Stage 1 and Stage 2 search after steps
- Creates `valueListFilteringDuration` metric to log the aggregated amount of time the rule spends filtering against our defined "large" value lists
- Modifies detection engine metrics to track rule metrics in a unified object so that multiple different phases of rule runs can be tracked rather than just total durations. This will help keep more detailed track of rule runs for rule types that have multiple different search phases (new terms, threat match, etc)

**Example**
```js
[{
  phaseName: 'alert_enrichment',
  duration: '12345'
},
{
  phaseName: 'composite_agg',
  duration: '67890'
}]
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
