### PR TITLE
[DOCS] Move preconfigured Slack connector details

### DIFF
--- a/docs/management/connectors/action-types/slack.asciidoc
+++ b/docs/management/connectors/action-types/slack.asciidoc
@@ -3,6 +3,10 @@
 ++++
 <titleabbrev>Slack</titleabbrev>
 ++++
+:frontmatter-description: Add a connector that can send Slack messages.
+:frontmatter-tags-products: [kibana] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [configure]
 
 The Slack connector uses incoming webhooks or an API method to send Slack messages.
 
@@ -27,37 +31,6 @@ If you use the latter method, you choose your channel when you create a rule act
 Thus a connector can be used in multiple rules and actions to communicate with different channels.
 
 For Slack setup details, go to <<configuring-slack>>.
-
-[float]
-[[preconfigured-slack-configuration]]
-=== Create preconfigured connectors
-
-If you are running {kib} on-prem, you can define connectors by
-adding `xpack.actions.preconfigured` settings to your `kibana.yml` file.
-
-.Example Slack connector with webhook
-[source,text]
---
-xpack.actions.preconfigured:
-  my-slack:
-    name: preconfigured-slack-webhook-connector-type
-    actionTypeId: .slack
-    secrets:
-      webhookUrl: 'https://hooks.slack.com/services/xxxx/xxxx/xxxx' <1>
---
-<1> To obtain this value, go to <<configuring-slack-webhook>>.
-
-.Example Slack connector with web API
-[source,text]
---
-xpack.actions.preconfigured:
-  my-slack:
-    name: preconfigured-slack-api-connector-type
-    actionTypeId: .slack_api
-    secrets:
-      token: 'xoxb-xxxx-xxxx-xxxx' <1>
---
-<1> To obtain this value, go to <<configuring-slack-web-api>>.
 
 [float]
 [[slack-action-configuration]]

--- a/docs/management/connectors/pre-configured-connectors.asciidoc
+++ b/docs/management/connectors/pre-configured-connectors.asciidoc
@@ -111,6 +111,7 @@ Index names must start with `kibana-alert-history-` to take advantage of the pre
 * <<preconfigured-opsgenie-configuration>>
 * <<preconfigured-pagerduty-configuration>>
 * <<preconfigured-server-log-configuration>>
+* <<preconfigured-slack-configuration>>
 * <<preconfigured-webhook-configuration>>
 * <<preconfigured-cases-webhook-configuration>>
 * <<preconfigured-xmatters-configuration>>
@@ -211,6 +212,37 @@ xpack.actions.preconfigured:
     name: preconfigured-server-log-connector-type
     actionTypeId: .server-log
 --
+
+
+[float]
+[[preconfigured-slack-configuration]]
+==== Slack connectors
+
+The following example creates a <<slack-action-type,Slack connector>> with webhook:
+
+[source,text]
+--
+xpack.actions.preconfigured:
+  my-slack:
+    name: preconfigured-slack-webhook-connector-type
+    actionTypeId: .slack
+    secrets:
+      webhookUrl: 'https://hooks.slack.com/services/xxxx/xxxx/xxxx' <1>
+--
+<1> The Slack webhook URL.
+
+The following example creates a Slack connector with web API:
+
+[source,text]
+--
+xpack.actions.preconfigured:
+  my-slack:
+    name: preconfigured-slack-api-connector-type
+    actionTypeId: .slack_api
+    secrets:
+      token: 'xoxb-xxxx-xxxx-xxxx' <1>
+--
+<1> The Slack bot user OAuth token.
 
 [float]
 [[preconfigured-webhook-configuration]]

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -383,6 +383,13 @@ It is used only when `xpack.actions.preconfigured.<connector-id>.config.usesBasi
 +
 NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts.
 
+`xpack.actions.preconfigured.<connector-id>.secrets.token`::
+A token secret that varies by connector:
++
+--
+For a <<slack-action-type,Slack connector>>, specifies the Slack bot user OAuth token.
+--
+
 `xpack.actions.preconfigured.<connector-id>.secrets.user`::
 A user name secret that varies by connector:
 +
@@ -390,6 +397,11 @@ A user name secret that varies by connector:
 * For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
+
+`xpack.actions.preconfigured.<connector-id>.secrets.webhookUrl`::
+For a <<slack-action-type,Slack connector>>, specifies the Slack webhook URL.
++
+NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname is added to the allowed hosts.
 
 [float]
 [[alert-settings]]

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -3955,6 +3955,7 @@
           ".servicenow-sir",
           ".server-log",
           ".slack",
+          ".slack_api",
           ".swimlane",
           ".teams",
           ".tines",

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -2733,6 +2733,7 @@ components:
         - .servicenow-sir
         - .server-log
         - .slack
+        - .slack_api
         - .swimlane
         - .teams
         - .tines

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_types.yaml
@@ -15,6 +15,7 @@ enum:
   - .servicenow-sir
   - .server-log
   - .slack
+  - .slack_api
   - .swimlane
   - .teams
   - .tines


### PR DESCRIPTION
## Summary

This PR:

- Moves the preconfigured connector examples from hhttps://www.elastic.co/guide/en/kibana/master/slack-action-type.html to https://www.elastic.co/guide/en/kibana/master/pre-configured-connectors.html since that functionality is only applicable if you are running Kibana on-prem and therefore won't be applicable to serverless projects.
- Adds the setting names to https://www.elastic.co/guide/en/kibana/master/alert-action-settings-kb.html
- Adds the `.slack_api` connector type in the OpenAPI specification