### PR TITLE
[APM] Add permissions for "input-only" package

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/common/types/models/agent_policy.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import type { agentPolicyStatuses } from '../../constants';
 import type { MonitoringType, PolicySecretReference, ValueOf } from '..';
 
@@ -77,15 +79,7 @@ export interface FullAgentPolicyInput {
   [key: string]: any;
 }
 
-export interface FullAgentPolicyOutputPermissions {
-  [packagePolicyName: string]: {
-    cluster?: string[];
-    indices?: Array<{
-      names: string[];
-      privileges: string[];
-    }>;
-  };
-}
+export type FullAgentPolicyOutputPermissions = Record<string, SecurityRoleDescriptor>;
 
 export type FullAgentPolicyOutput = Pick<Output, 'type' | 'hosts' | 'ca_sha256'> & {
   proxy_url?: string;

--- a/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/cloud_preconfiguration.test.ts
@@ -312,31 +312,11 @@ describe('Fleet preconfiguration reset', () => {
                   cluster: ['cluster:monitor/main'],
                   indices: [
                     {
-                      names: ['logs-apm.app-default'],
+                      names: ['traces-*', 'logs-*', 'metrics-*'],
                       privileges: ['auto_configure', 'create_doc'],
                     },
                     {
-                      names: ['metrics-apm.app.*-default'],
-                      privileges: ['auto_configure', 'create_doc'],
-                    },
-                    {
-                      names: ['logs-apm.error-default'],
-                      privileges: ['auto_configure', 'create_doc'],
-                    },
-                    {
-                      names: ['metrics-apm.internal-default'],
-                      privileges: ['auto_configure', 'create_doc'],
-                    },
-                    {
-                      names: ['metrics-apm.profiling-default'],
-                      privileges: ['auto_configure', 'create_doc'],
-                    },
-                    {
-                      names: ['traces-apm.rum-default'],
-                      privileges: ['auto_configure', 'create_doc'],
-                    },
-                    {
-                      names: ['traces-apm.sampled-default'],
+                      names: ['traces-apm.sampled-*'],
                       privileges: [
                         'auto_configure',
                         'create_doc',
@@ -344,10 +324,6 @@ describe('Fleet preconfiguration reset', () => {
                         'monitor',
                         'read',
                       ],
-                    },
-                    {
-                      names: ['traces-apm-default'],
-                      privileges: ['auto_configure', 'create_doc'],
                     },
                   ],
                 },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -619,18 +619,15 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
 
     expect(permissions).toMatchObject({
       'package-policy-uuid-test-123': {
+        cluster: ['cluster:monitor/main'],
         indices: [
           {
             names: ['traces-*', 'logs-*', 'metrics-*'],
-            privileges: [
-              'auto_configure',
-              'read',
-              'create_doc',
-              'create',
-              'write',
-              'index',
-              'view_index_metadata',
-            ],
+            privileges: ['auto_configure', 'create_doc'],
+          },
+          {
+            names: ['traces-apm.sampled-*'],
+            privileges: ['auto_configure', 'create_doc', 'maintenance', 'monitor', 'read'],
           },
         ],
       },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -287,20 +287,18 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
     expect(permissions).toBeUndefined();
   });
 
-  it('Throw an error if package policies is not an array', async () => {
-    await expect(() =>
-      storedPackagePoliciesToAgentPermissions(packageInfoCache, undefined)
-    ).rejects.toThrow(
+  it('Throw an error if package policies is not an array', () => {
+    expect(() => storedPackagePoliciesToAgentPermissions(packageInfoCache, undefined)).toThrow(
       /storedPackagePoliciesToAgentPermissions should be called with a PackagePolicy/
     );
   });
 
-  it('Returns the default permissions if a package policy does not have a package', async () => {
-    await expect(() =>
+  it('Returns the default permissions if a package policy does not have a package', () => {
+    expect(() =>
       storedPackagePoliciesToAgentPermissions(packageInfoCache, [
         { name: 'foo', package: undefined } as PackagePolicy,
       ])
-    ).rejects.toThrow(/No package for package policy foo/);
+    ).toThrow(/No package for package policy foo/);
   });
 
   it('Returns the permissions for the enabled inputs', async () => {

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.test.ts
@@ -239,6 +239,48 @@ packageInfoCache.set('profiler_collector-8.9.0-preview', {
   },
 });
 
+packageInfoCache.set('apm-8.9.0-preview', {
+  format_version: '2.7.0',
+  name: 'apm',
+  title: 'APM',
+  version: '8.9.0-preview',
+  license: 'basic',
+  description: 'APM Server integration',
+  type: 'integration',
+  release: 'beta',
+  categories: ['observability'],
+  icons: [],
+  owner: { github: 'elastic/apm-server' },
+  data_streams: [],
+  latestVersion: '8.9.0-preview',
+  status: 'not_installed',
+  assets: {
+    kibana: {
+      csp_rule_template: [],
+      dashboard: [],
+      visualization: [],
+      search: [],
+      index_pattern: [],
+      map: [],
+      lens: [],
+      security_rule: [],
+      ml_module: [],
+      tag: [],
+      osquery_pack_asset: [],
+      osquery_saved_query: [],
+    },
+    elasticsearch: {
+      component_template: [],
+      ingest_pipeline: [],
+      ilm_policy: [],
+      transform: [],
+      index_template: [],
+      data_stream_ilm_policy: [],
+      ml_model: [],
+    },
+  },
+});
+
 describe('storedPackagePoliciesToAgentPermissions()', () => {
   it('Returns `undefined` if there are no package policies', async () => {
     const permissions = await storedPackagePoliciesToAgentPermissions(packageInfoCache, []);
@@ -540,6 +582,55 @@ describe('storedPackagePoliciesToAgentPermissions()', () => {
           {
             names: ['profiling-*'],
             privileges: UNIVERSAL_PROFILING_PERMISSIONS,
+          },
+        ],
+      },
+    });
+  });
+
+  it('returns the correct permissions for the APM package', async () => {
+    const packagePolicies: PackagePolicy[] = [
+      {
+        id: 'package-policy-uuid-test-123',
+        name: 'test-policy',
+        namespace: '',
+        enabled: true,
+        package: { name: 'apm', version: '8.9.0-preview', title: 'Test Package' },
+        inputs: [
+          {
+            type: 'pf-elastic-collector',
+            enabled: true,
+            streams: [],
+          },
+        ],
+        created_at: '',
+        updated_at: '',
+        created_by: '',
+        updated_by: '',
+        revision: 1,
+        policy_id: '',
+      },
+    ];
+
+    const permissions = await storedPackagePoliciesToAgentPermissions(
+      packageInfoCache,
+      packagePolicies
+    );
+
+    expect(permissions).toMatchObject({
+      'package-policy-uuid-test-123': {
+        indices: [
+          {
+            names: ['traces-*', 'logs-*', 'metrics-*'],
+            privileges: [
+              'auto_configure',
+              'read',
+              'create_doc',
+              'create',
+              'write',
+              'index',
+              'view_index_metadata',
+            ],
           },
         ],
       },

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import type {
+  SecurityIndicesPrivileges,
+  SecurityRoleDescriptor,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
 import {
   FLEET_APM_PACKAGE,
@@ -37,10 +40,10 @@ export const UNIVERSAL_PROFILING_PERMISSIONS = [
   'view_index_metadata',
 ];
 
-export async function storedPackagePoliciesToAgentPermissions(
+export function storedPackagePoliciesToAgentPermissions(
   packageInfoCache: Map<string, PackageInfo>,
   packagePolicies?: PackagePolicy[]
-): Promise<FullAgentPolicyOutputPermissions | undefined> {
+): FullAgentPolicyOutputPermissions | undefined {
   // I'm not sure what permissions to return for this case, so let's return the defaults
   if (!packagePolicies) {
     throw new Error(
@@ -52,7 +55,7 @@ export async function storedPackagePoliciesToAgentPermissions(
     return;
   }
 
-  const permissionEntries = (packagePolicies as PackagePolicy[]).map(async (packagePolicy) => {
+  const permissionEntries = packagePolicies.map((packagePolicy) => {
     if (!packagePolicy.package) {
       throw new Error(`No package for package policy ${packagePolicy.name ?? packagePolicy.id}`);
     }
@@ -161,7 +164,7 @@ export async function storedPackagePoliciesToAgentPermissions(
     ];
   });
 
-  return Object.fromEntries(await Promise.all(permissionEntries));
+  return Object.fromEntries(permissionEntries);
 }
 
 export interface DataStreamMeta {
@@ -176,7 +179,10 @@ export interface DataStreamMeta {
   };
 }
 
-export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: string = '*') {
+export function getDataStreamPrivileges(
+  dataStream: DataStreamMeta,
+  namespace: string = '*'
+): SecurityIndicesPrivileges {
   let index = dataStream.hidden ? `.${dataStream.type}-` : `${dataStream.type}-`;
 
   // Determine dataset

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  FLEET_APM_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE,
 } from '../../../common/constants';
@@ -49,112 +50,114 @@ export async function storedPackagePoliciesToAgentPermissions(
     return;
   }
 
-  const permissionEntries = (packagePolicies as PackagePolicy[]).map<Promise<[string, any]>>(
-    async (packagePolicy) => {
-      if (!packagePolicy.package) {
-        throw new Error(`No package for package policy ${packagePolicy.name ?? packagePolicy.id}`);
-      }
-
-      const pkg = packageInfoCache.get(pkgToPkgKey(packagePolicy.package))!;
-
-      // Special handling for Universal Profiling packages, as it does not use data streams _only_,
-      // but also indices that do not adhere to the convention.
-      if (
-        pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE ||
-        pkg.name === FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE
-      ) {
-        return Promise.resolve(universalProfilingPermissions(packagePolicy.id));
-      }
-
-      const dataStreams = getNormalizedDataStreams(pkg);
-      if (!dataStreams || dataStreams.length === 0) {
-        return [packagePolicy.name, undefined];
-      }
-
-      let dataStreamsForPermissions: DataStreamMeta[];
-
-      switch (pkg.name) {
-        case 'endpoint':
-          // - Endpoint doesn't store the `data_stream` metadata in
-          // `packagePolicy.inputs`, so we will use _all_ data_streams from the
-          // package.
-          dataStreamsForPermissions = dataStreams;
-          break;
-
-        case 'apm':
-          // - APM doesn't store the `data_stream` metadata in
-          //   `packagePolicy.inputs`, so we will use _all_ data_streams from
-          //   the package.
-          dataStreamsForPermissions = dataStreams;
-          break;
-
-        case 'osquery_manager':
-          // - Osquery manager doesn't store the `data_stream` metadata in
-          //   `packagePolicy.inputs`, so we will use _all_ data_streams from
-          //   the package.
-          dataStreamsForPermissions = dataStreams;
-          break;
-
-        default:
-          // - Normal packages store some of the `data_stream` metadata in
-          //   `packagePolicy.inputs[].streams[].data_stream`
-          // - The rest of the metadata needs to be fetched from the
-          //   `data_stream` object in the package. The link is
-          //   `packagePolicy.inputs[].type == dataStreams.streams[].input`
-          // - Some packages (custom logs) have a compiled dataset, stored in
-          //   `input.streams.compiled_stream.data_stream.dataset`
-          dataStreamsForPermissions = packagePolicy.inputs
-            .filter((i) => i.enabled)
-            .flatMap((input) => {
-              if (!input.streams) {
-                return [];
-              }
-
-              const dataStreams_: DataStreamMeta[] = [];
-
-              input.streams
-                .filter((s) => s.enabled)
-                .forEach((stream) => {
-                  if (!('data_stream' in stream)) {
-                    return;
-                  }
-
-                  const ds: DataStreamMeta = {
-                    type: stream.data_stream.type,
-                    dataset:
-                      stream.compiled_stream?.data_stream?.dataset ?? stream.data_stream.dataset,
-                  };
-
-                  if (stream.data_stream.elasticsearch) {
-                    ds.elasticsearch = stream.data_stream.elasticsearch;
-                  }
-
-                  dataStreams_.push(ds);
-                });
-
-              return dataStreams_;
-            });
-      }
-
-      let clusterRoleDescriptor = {};
-      const cluster = packagePolicy?.elasticsearch?.privileges?.cluster ?? [];
-      if (cluster.length > 0) {
-        clusterRoleDescriptor = {
-          cluster,
-        };
-      }
-
-      return [
-        packagePolicy.id,
-        {
-          indices: dataStreamsForPermissions.map((ds) =>
-            getDataStreamPrivileges(ds, packagePolicy.namespace)
-          ),
-          ...clusterRoleDescriptor,
-        },
-      ];
+  const permissionEntries = (packagePolicies as PackagePolicy[]).map(async (packagePolicy) => {
+    if (!packagePolicy.package) {
+      throw new Error(`No package for package policy ${packagePolicy.name ?? packagePolicy.id}`);
     }
-  );
+
+    const pkg = packageInfoCache.get(pkgToPkgKey(packagePolicy.package))!;
+
+    // Special handling for Universal Profiling packages, as it does not use data streams _only_,
+    // but also indices that do not adhere to the convention.
+    if (
+      pkg.name === FLEET_UNIVERSAL_PROFILING_SYMBOLIZER_PACKAGE ||
+      pkg.name === FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE
+    ) {
+      return universalProfilingPermissions(packagePolicy.id);
+    }
+
+    if (pkg.name === FLEET_APM_PACKAGE) {
+      return apmPermissions(packagePolicy.id);
+    }
+
+    const dataStreams = getNormalizedDataStreams(pkg);
+    if (!dataStreams || dataStreams.length === 0) {
+      return [packagePolicy.name, undefined];
+    }
+
+    let dataStreamsForPermissions: DataStreamMeta[];
+
+    switch (pkg.name) {
+      case 'endpoint':
+        // - Endpoint doesn't store the `data_stream` metadata in
+        // `packagePolicy.inputs`, so we will use _all_ data_streams from the
+        // package.
+        dataStreamsForPermissions = dataStreams;
+        break;
+
+      case 'apm':
+        // - APM doesn't store the `data_stream` metadata in
+        //   `packagePolicy.inputs`, so we will use _all_ data_streams from
+        //   the package.
+        dataStreamsForPermissions = dataStreams;
+        break;
+
+      case 'osquery_manager':
+        // - Osquery manager doesn't store the `data_stream` metadata in
+        //   `packagePolicy.inputs`, so we will use _all_ data_streams from
+        //   the package.
+        dataStreamsForPermissions = dataStreams;
+        break;
+
+      default:
+        // - Normal packages store some of the `data_stream` metadata in
+        //   `packagePolicy.inputs[].streams[].data_stream`
+        // - The rest of the metadata needs to be fetched from the
+        //   `data_stream` object in the package. The link is
+        //   `packagePolicy.inputs[].type == dataStreams.streams[].input`
+        // - Some packages (custom logs) have a compiled dataset, stored in
+        //   `input.streams.compiled_stream.data_stream.dataset`
+        dataStreamsForPermissions = packagePolicy.inputs
+          .filter((i) => i.enabled)
+          .flatMap((input) => {
+            if (!input.streams) {
+              return [];
+            }
+
+            const dataStreams_: DataStreamMeta[] = [];
+
+            input.streams
+              .filter((s) => s.enabled)
+              .forEach((stream) => {
+                if (!('data_stream' in stream)) {
+                  return;
+                }
+
+                const ds: DataStreamMeta = {
+                  type: stream.data_stream.type,
+                  dataset:
+                    stream.compiled_stream?.data_stream?.dataset ?? stream.data_stream.dataset,
+                };
+
+                if (stream.data_stream.elasticsearch) {
+                  ds.elasticsearch = stream.data_stream.elasticsearch;
+                }
+
+                dataStreams_.push(ds);
+              });
+
+            return dataStreams_;
+          });
+    }
+
+    let clusterRoleDescriptor = {};
+    const cluster = packagePolicy?.elasticsearch?.privileges?.cluster ?? [];
+    if (cluster.length > 0) {
+      clusterRoleDescriptor = {
+        cluster,
+      };
+    }
+
+    return [
+      packagePolicy.id,
+      {
+        indices: dataStreamsForPermissions.map((ds) =>
+          getDataStreamPrivileges(ds, packagePolicy.namespace)
+        ),
+        ...clusterRoleDescriptor,
+      },
+    ];
+  });
 
   return Object.fromEntries(await Promise.all(permissionEntries));
 }
@@ -200,7 +203,7 @@ export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: s
   };
 }
 
-async function universalProfilingPermissions(packagePolicyId: string): Promise<[string, any]> {
+function universalProfilingPermissions(packagePolicyId: string) {
   const profilingIndexPattern = 'profiling-*';
   return [
     packagePolicyId,
@@ -211,6 +214,26 @@ async function universalProfilingPermissions(packagePolicyId: string): Promise<[
           privileges: UNIVERSAL_PROFILING_PERMISSIONS,
         },
       ],
+    },
+  ];
+}
+
+function apmPermissions(packagePolicyId: string) {
+  const APM_PERMISSIONS = [
+    'auto_configure',
+    'read',
+    'create_doc',
+    'create',
+    'write',
+    'index',
+    'view_index_metadata',
+  ];
+
+  const APM_INDICES = ['traces-*', 'logs-*', 'metrics-*'];
+  return [
+    packagePolicyId,
+    {
+      indices: [{ names: APM_INDICES, privileges: APM_PERMISSIONS }],
     },
   ];
 }

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import type { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+
 import {
   FLEET_APM_PACKAGE,
   FLEET_UNIVERSAL_PROFILING_COLLECTOR_PACKAGE,
@@ -203,7 +205,7 @@ export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: s
   };
 }
 
-function universalProfilingPermissions(packagePolicyId: string) {
+function universalProfilingPermissions(packagePolicyId: string): [string, SecurityRoleDescriptor] {
   const profilingIndexPattern = 'profiling-*';
   return [
     packagePolicyId,
@@ -218,7 +220,7 @@ function universalProfilingPermissions(packagePolicyId: string) {
   ];
 }
 
-function apmPermissions(packagePolicyId: string) {
+function apmPermissions(packagePolicyId: string): [string, SecurityRoleDescriptor] {
   return [
     packagePolicyId,
     {

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -219,21 +219,20 @@ function universalProfilingPermissions(packagePolicyId: string) {
 }
 
 function apmPermissions(packagePolicyId: string) {
-  const APM_PERMISSIONS = [
-    'auto_configure',
-    'read',
-    'create_doc',
-    'create',
-    'write',
-    'index',
-    'view_index_metadata',
-  ];
-
-  const APM_INDICES = ['traces-*', 'logs-*', 'metrics-*'];
   return [
     packagePolicyId,
     {
-      indices: [{ names: APM_INDICES, privileges: APM_PERMISSIONS }],
+      cluster: ['cluster:monitor/main'],
+      indices: [
+        {
+          names: ['traces-*', 'logs-*', 'metrics-*'],
+          privileges: ['auto_configure', 'create_doc'],
+        },
+        {
+          names: ['traces-apm.sampled-*'],
+          privileges: ['auto_configure', 'create_doc', 'maintenance', 'monitor', 'read'],
+        },
+      ],
     },
   ];
 }

--- a/x-pack/test/apm_api_integration/common/bettertest.ts
+++ b/x-pack/test/apm_api_integration/common/bettertest.ts
@@ -11,20 +11,32 @@ import request from 'superagent';
 
 type HttpMethod = 'get' | 'post' | 'put' | 'delete';
 
-export type BetterTest = <T extends any>(options: {
+export type BetterTest = <T>(options: BetterTestOptions) => Promise<BetterTestResponse<T>>;
+
+interface BetterTestOptions {
   pathname: string;
   query?: Record<string, any>;
   method?: HttpMethod;
   body?: any;
-}) => Promise<{ status: number; body: T }>;
+}
+
+interface BetterTestResponse<T> {
+  status: number;
+  body: T;
+}
 
 /*
  * This is a wrapper around supertest that throws an error if the response status is not 200.
  * This is useful for tests that expect a 200 response
  * It also makes it easier to debug tests that fail because of a 500 response.
  */
-export function getBettertest(st: supertest.SuperTest<supertest.Test>): BetterTest {
-  return async ({ pathname, method = 'get', query, body }) => {
+export function getBettertest(st: supertest.SuperTest<supertest.Test>) {
+  return async <T>({
+    pathname,
+    method = 'get',
+    query,
+    body,
+  }: BetterTestOptions): Promise<BetterTestResponse<T>> => {
     const url = format({ pathname, query });
 
     let res: request.Response;

--- a/x-pack/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
@@ -30,7 +30,7 @@ import {
   deletePackagePolicy,
   getPackagePolicy,
   setupFleet,
-} from './apm_package_policy_setup';
+} from './helpers';
 import { getBettertest } from '../../common/bettertest';
 import { expectToReject } from '../../common/utils/expect_to_reject';
 
@@ -120,8 +120,8 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
 
     before(async () => {
       await setupFleet(bettertest);
-      agentPolicyId = await createAgentPolicy(bettertest);
-      packagePolicyId = await createPackagePolicy(bettertest, agentPolicyId);
+      agentPolicyId = await createAgentPolicy({ bettertest });
+      packagePolicyId = await createPackagePolicy({ bettertest, agentPolicyId });
       apmPackagePolicy = await getPackagePolicy(bettertest, packagePolicyId); // make sure to get the latest package policy
     });
 

--- a/x-pack/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/fleet/apm_package_policy.spec.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import * as Url from 'url';
 import { PackagePolicy } from '@kbn/fleet-plugin/common';
 import {
   AGENT_CONFIG_PATH,
@@ -17,7 +16,7 @@ import expect from '@kbn/expect';
 import { get } from 'lodash';
 import type { SourceMap } from '@kbn/apm-plugin/server/routes/source_maps/route';
 import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
-import { createEsClientForTesting } from '@kbn/test';
+import { createEsClientForFtrConfig } from '@kbn/test';
 import {
   APM_AGENT_CONFIGURATION_INDEX,
   APM_SOURCE_MAP_INDEX,
@@ -41,14 +40,10 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
   const supertest = getService('supertest');
   const es = getService('es');
   const bettertest = getBettertest(supertest);
+  const configService = getService('config');
 
   function createEsClientWithApiKeyAuth({ id, apiKey }: { id: string; apiKey: string }) {
-    const config = getService('config');
-    return createEsClientForTesting({
-      esUrl: Url.format(config.get('servers.elasticsearch')),
-      requestTimeout: config.get('timeouts.esRequestTimeout'),
-      auth: { apiKey: { id, api_key: apiKey } },
-    });
+    return createEsClientForFtrConfig(configService, { auth: { apiKey: { id, api_key: apiKey } } });
   }
 
   async function createConfiguration(configuration: any) {

--- a/x-pack/test/apm_api_integration/tests/fleet/input_only_package.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/fleet/input_only_package.spec.ts
@@ -115,7 +115,6 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       });
 
       it('has permissions in the agent policy', async () => {
-        console.log({ permissions });
         expect(permissions).to.eql({
           cluster: ['cluster:monitor/main'],
           indices: [

--- a/x-pack/test/apm_api_integration/tests/fleet/input_only_package.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/fleet/input_only_package.spec.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { apm, timerange } from '@kbn/apm-synthtrace-client';
+import { ApmSynthtraceEsClient, createLogger, LogLevel } from '@kbn/apm-synthtrace';
+import expect from '@kbn/expect';
+import { createEsClientForTesting } from '@kbn/test';
+import * as Url from 'url';
+import { ApmDocumentType } from '@kbn/apm-plugin/common/document_type';
+import { RollupInterval } from '@kbn/apm-plugin/common/rollup';
+import { SecurityRoleDescriptor } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import pRetry from 'p-retry';
+import { FtrProviderContext } from '../../common/ftr_provider_context';
+import { getBettertest } from '../../common/bettertest';
+import {
+  createAgentPolicy,
+  createPackagePolicy,
+  deleteAgentPolicyAndPackagePolicyByName,
+  setupFleet,
+} from './helpers';
+import { ApmApiClient } from '../../common/config';
+
+export default function ApiTest(ftrProviderContext: FtrProviderContext) {
+  const { getService } = ftrProviderContext;
+  const registry = getService('registry');
+  const apmApiClient = getService('apmApiClient');
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const log = getService('log');
+  const bettertest = getBettertest(supertest);
+  const config = getService('config');
+  const synthtraceKibanaClient = getService('synthtraceKibanaClient');
+  const synthtraceEsClient = getService('synthtraceEsClient');
+
+  function createEsClientWithApiKeyAuth({ id, apiKey }: { id: string; apiKey: string }) {
+    return createEsClientForTesting({
+      esUrl: Url.format(config.get('servers.elasticsearch')),
+      requestTimeout: config.get('timeouts.esRequestTimeout'),
+      auth: { apiKey: { id, api_key: apiKey } },
+    });
+  }
+
+  async function getSynthtraceClientForApiKey({
+    id,
+    api_key: apiKey,
+  }: {
+    id: string;
+    api_key: string;
+  }) {
+    const esClient = createEsClientWithApiKeyAuth({ id, apiKey });
+    const kibanaVersion = await synthtraceKibanaClient.fetchLatestApmPackageVersion();
+    return new ApmSynthtraceEsClient({
+      client: esClient,
+      logger: createLogger(LogLevel.info),
+      version: kibanaVersion,
+      refreshAfterIndex: true,
+    });
+  }
+
+  registry.when('APM package policy', { config: 'basic', archives: [] }, () => {
+    async function getAgentPolicyPermissions(agentPolicyId: string, packagePolicyId: string) {
+      const res = await bettertest<{
+        item: { output_permissions: { default: Record<string, SecurityRoleDescriptor> } };
+      }>({
+        pathname: `/api/fleet/agent_policies/${agentPolicyId}/full`,
+        method: 'get',
+      });
+
+      return res.body.item.output_permissions.default[packagePolicyId];
+    }
+
+    describe('input only package', () => {
+      // let apmPackagePolicy: PackagePolicy;
+      let agentPolicyId: string;
+      let packagePolicyId: string;
+      let permissions: SecurityRoleDescriptor;
+      const API_KEY_NAME = 'apm_api_key_testing';
+      const APM_AGENT_POLICY_NAME = 'apm_agent_policy_testing';
+      const APM_PACKAGE_POLICY_NAME = 'apm_package_policy_testing';
+
+      async function cleanAll() {
+        try {
+          await synthtraceEsClient.clean();
+          await es.security.invalidateApiKey({ name: API_KEY_NAME });
+          await deleteAgentPolicyAndPackagePolicyByName({
+            bettertest,
+            agentPolicyName: APM_AGENT_POLICY_NAME,
+            packagePolicyName: APM_PACKAGE_POLICY_NAME,
+          });
+        } catch (e) {
+          // log.info('Could not clean', e.message);
+        }
+      }
+
+      before(async () => {
+        await cleanAll();
+
+        await setupFleet(bettertest);
+        agentPolicyId = await createAgentPolicy({ bettertest, name: APM_AGENT_POLICY_NAME });
+        packagePolicyId = await createPackagePolicy({
+          bettertest,
+          agentPolicyId,
+          name: APM_PACKAGE_POLICY_NAME,
+        });
+
+        permissions = await getAgentPolicyPermissions(agentPolicyId, packagePolicyId);
+      });
+
+      after(async () => {
+        await cleanAll();
+      });
+
+      it('has permissions in the agent policy', async () => {
+        console.log({ permissions });
+        expect(permissions).to.eql({
+          cluster: ['cluster:monitor/main'],
+          indices: [
+            {
+              names: ['traces-*', 'logs-*', 'metrics-*'],
+              privileges: ['auto_configure', 'create_doc'],
+            },
+            {
+              names: ['traces-apm.sampled-*'],
+              privileges: ['auto_configure', 'create_doc', 'maintenance', 'monitor', 'read'],
+            },
+          ],
+        });
+      });
+
+      it('can ingest APM data given the privileges specified in the agent policy', async () => {
+        const apiKeyRes = await es.security.createApiKey({
+          body: {
+            name: API_KEY_NAME,
+            role_descriptors: {
+              apmFleetPermissions: permissions,
+            },
+          },
+        });
+
+        const scenario = getSynthtraceScenario();
+        const customSynthtraceEsClient = await getSynthtraceClientForApiKey(apiKeyRes);
+        await customSynthtraceEsClient.index(scenario.events);
+        const apmServices = await getApmServices(apmApiClient, scenario.start, scenario.end);
+
+        expect(apmServices).to.eql([
+          {
+            serviceName: 'opbeans-java',
+            transactionType: 'request',
+            environments: ['production'],
+            agentName: 'java',
+            latency: 5000000,
+            transactionErrorRate: 0,
+            throughput: 1.0000083334027785,
+          },
+        ]);
+      });
+    });
+  });
+}
+
+function getApmServices(apmApiClient: ApmApiClient, start: string, end: string) {
+  return pRetry(async () => {
+    const services = await apmApiClient.readUser({
+      endpoint: 'GET /internal/apm/services',
+      params: {
+        query: {
+          start,
+          end,
+          probability: 1,
+          environment: 'ENVIRONMENT_ALL',
+          kuery: '',
+          documentType: ApmDocumentType.TransactionMetric,
+          rollupInterval: RollupInterval.OneMinute,
+        },
+      },
+    });
+
+    if (services.body.items.length === 0) {
+      throw new Error(`Timed-out: No APM Services were found`);
+    }
+
+    return services.body.items;
+  });
+}
+
+function getSynthtraceScenario() {
+  const start = new Date('2023-09-01T00:00:00.000Z').getTime();
+  const end = new Date('2023-09-01T00:02:00.000Z').getTime() - 1;
+
+  const opbeansJava = apm
+    .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
+    .instance('instance');
+
+  const events = timerange(start, end)
+    .ratePerMinute(1)
+    .generator((timestamp) => {
+      return [
+        opbeansJava
+          .transaction({ transactionName: 'tx-java' })
+          .timestamp(timestamp)
+          .duration(5000)
+          .success(),
+      ];
+    });
+
+  return {
+    start: new Date(start).toISOString(),
+    end: new Date(end).toISOString(),
+    events,
+  };
+}

--- a/x-pack/test/apm_api_integration/tests/fleet/migration_check.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/fleet/migration_check.spec.ts
@@ -13,7 +13,7 @@ import {
   deleteAgentPolicy,
   deletePackagePolicy,
   setupFleet,
-} from './apm_package_policy_setup';
+} from './helpers';
 import { getBettertest } from '../../common/bettertest';
 
 export default function ApiTest(ftrProviderContext: FtrProviderContext) {
@@ -76,7 +76,7 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       });
       describe('with Cloud agent policy', () => {
         before(async () => {
-          await createAgentPolicy(bettertest, 'policy-elastic-agent-on-cloud');
+          await createAgentPolicy({ bettertest, id: 'policy-elastic-agent-on-cloud' });
         });
         after(async () => {
           await deleteAgentPolicy(bettertest, 'policy-elastic-agent-on-cloud');
@@ -92,7 +92,7 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
 
     describe('has_cloud_apm_package_policy', () => {
       before(async () => {
-        await createAgentPolicy(bettertest, 'policy-elastic-agent-on-cloud');
+        await createAgentPolicy({ bettertest, id: 'policy-elastic-agent-on-cloud' });
       });
       after(async () => {
         await deleteAgentPolicy(bettertest, 'policy-elastic-agent-on-cloud');
@@ -107,7 +107,11 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       });
       describe('with Cloud APM package policy', () => {
         before(async () => {
-          await createPackagePolicy(bettertest, 'policy-elastic-agent-on-cloud', 'apm');
+          await createPackagePolicy({
+            bettertest,
+            agentPolicyId: 'policy-elastic-agent-on-cloud',
+            id: 'apm',
+          });
         });
         after(async () => {
           await deletePackagePolicy(bettertest, 'apm');
@@ -125,7 +129,7 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
 
     describe('has_apm_integrations', () => {
       before(async () => {
-        await createAgentPolicy(bettertest, 'test-agent-policy');
+        await createAgentPolicy({ bettertest, id: 'test-agent-policy' });
       });
       after(async () => {
         await deleteAgentPolicy(bettertest, 'test-agent-policy');
@@ -139,7 +143,11 @@ export default function ApiTest(ftrProviderContext: FtrProviderContext) {
       });
       describe('with custom APM package policy', () => {
         before(async () => {
-          await createPackagePolicy(bettertest, 'test-agent-policy', 'test-apm-package-policy');
+          await createPackagePolicy({
+            bettertest,
+            agentPolicyId: 'test-agent-policy',
+            id: 'test-apm-package-policy',
+          });
         });
         after(async () => {
           await deletePackagePolicy(bettertest, 'test-apm-package-policy');


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/164936

This grants the necessary permissions to APM Server when running under fleet. 