### PR TITLE
[8.10] [Fleet] Show snapshot version in agent upgrade modal + allow custom values (but not in serverless) (#165978)

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -6,6 +6,7 @@ xpack.fleet.internal.fleetServerStandalone: true
 xpack.fleet.internal.disableILMPolicies: true
 xpack.fleet.internal.disableProxies: true
 xpack.fleet.internal.activeAgentsSoftLimit: 25000
+xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions: true
 
 # Cloud links
 xpack.cloud.base_url: "https://cloud.elastic.co"

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -233,6 +233,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.fleet.internal.activeAgentsSoftLimit (number)',
         'xpack.fleet.internal.disableProxies (boolean)',
         'xpack.fleet.internal.fleetServerStandalone (boolean)',
+        'xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions (boolean)',
         'xpack.fleet.developer.maxAgentPoliciesWithInactivityTimeout (number)',
         'xpack.global_search.search_timeout (duration)',
         'xpack.graph.canEditDrillDownUrls (boolean)',

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -49,6 +49,7 @@ export interface FleetConfigType {
     disableILMPolicies: boolean;
     disableProxies: boolean;
     fleetServerStandalone: boolean;
+    onlyAllowAgentUpgradeToKnownVersions: boolean;
     activeAgentsSoftLimit?: number;
     capabilities: string[];
   };

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -43,6 +43,7 @@ export const config: PluginConfigDescriptor = {
       fleetServerStandalone: true,
       disableProxies: true,
       activeAgentsSoftLimit: true,
+      onlyAllowAgentUpgradeToKnownVersions: true,
     },
   },
   deprecations: ({ renameFromRoot, unused, unusedFromRoot }) => [
@@ -174,6 +175,9 @@ export const config: PluginConfigDescriptor = {
           defaultValue: false,
         }),
         fleetServerStandalone: schema.boolean({
+          defaultValue: false,
+        }),
+        onlyAllowAgentUpgradeToKnownVersions: schema.boolean({
           defaultValue: false,
         }),
         activeAgentsSoftLimit: schema.maybe(

--- a/x-pack/plugins/fleet/server/routes/agent/handlers.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/handlers.test.ts
@@ -11,12 +11,15 @@ import { coreMock, httpServerMock } from '@kbn/core/server/mocks';
 
 import { getAvailableVersionsHandler } from './handlers';
 
+let mockKibanaVersion = '300.0.0';
+let mockConfig = {};
 jest.mock('../../services/app_context', () => {
   const { loggerMock } = jest.requireActual('@kbn/logging-mocks');
   return {
     appContextService: {
       getLogger: () => loggerMock.create(),
-      getKibanaVersion: () => '300.0.0',
+      getKibanaVersion: () => mockKibanaVersion,
+      getConfig: () => mockConfig,
     },
   };
 });
@@ -27,6 +30,7 @@ const mockedReadFile = readFile as jest.MockedFunction<typeof readFile>;
 
 describe('getAvailableVersionsHandler', () => {
   it('should return available version and filter version < 7.17', async () => {
+    mockKibanaVersion = '300.0.0';
     const ctx = coreMock.createCustomRequestHandlerContext(coreMock.createRequestHandlerContext());
     const response = httpServerMock.createResponseFactory();
 
@@ -37,6 +41,41 @@ describe('getAvailableVersionsHandler', () => {
     expect(response.ok).toBeCalled();
     expect(response.ok.mock.calls[0][0]?.body).toEqual({
       items: ['300.0.0', '8.1.0', '8.0.0', '7.17.0'],
+    });
+  });
+
+  it('should not strip -SNAPSHOT from kibana version', async () => {
+    mockKibanaVersion = '300.0.0-SNAPSHOT';
+    const ctx = coreMock.createCustomRequestHandlerContext(coreMock.createRequestHandlerContext());
+    const response = httpServerMock.createResponseFactory();
+
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+
+    await getAvailableVersionsHandler(ctx, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toBeCalled();
+    expect(response.ok.mock.calls[0][0]?.body).toEqual({
+      items: ['300.0.0-SNAPSHOT', '8.1.0', '8.0.0', '7.17.0'],
+    });
+  });
+
+  it('should not include the current version if onlyAllowAgentUpgradeToKnownVersions = true', async () => {
+    mockKibanaVersion = '300.0.0-SNAPSHOT';
+    mockConfig = {
+      internal: {
+        onlyAllowAgentUpgradeToKnownVersions: true,
+      },
+    };
+    const ctx = coreMock.createCustomRequestHandlerContext(coreMock.createRequestHandlerContext());
+    const response = httpServerMock.createResponseFactory();
+
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+
+    await getAvailableVersionsHandler(ctx, httpServerMock.createKibanaRequest(), response);
+
+    expect(response.ok).toBeCalled();
+    expect(response.ok.mock.calls[0][0]?.body).toEqual({
+      items: ['8.1.0', '8.0.0', '7.17.0'],
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
@@ -124,6 +124,7 @@ describe('_installPackage', () => {
           disableILMPolicies: true,
           disableProxies: false,
           fleetServerStandalone: false,
+          onlyAllowAgentUpgradeToKnownVersions: false,
           capabilities: [],
         },
       })
@@ -177,6 +178,7 @@ describe('_installPackage', () => {
           disableProxies: false,
           disableILMPolicies: false,
           fleetServerStandalone: false,
+          onlyAllowAgentUpgradeToKnownVersions: false,
           capabilities: [],
         },
       })


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Fleet] Show snapshot version in agent upgrade modal + allow custom values (but not in serverless) (#165978)](https://github.com/elastic/kibana/pull/165978)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mark Hopkin","email":"mark.hopkin@elastic.co"},"sourceCommit":{"committedDate":"2023-09-11T10:56:39Z","message":"[Fleet] Show snapshot version in agent upgrade modal + allow custom values (but not in serverless) (#165978)\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"238428076cd07994d843f798d51238fbdbc2cf53","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v8.11.0"],"number":165978,"url":"https://github.com/elastic/kibana/pull/165978","mergeCommit":{"message":"[Fleet] Show snapshot version in agent upgrade modal + allow custom values (but not in serverless) (#165978)\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"238428076cd07994d843f798d51238fbdbc2cf53"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/165978","number":165978,"mergeCommit":{"message":"[Fleet] Show snapshot version in agent upgrade modal + allow custom values (but not in serverless) (#165978)\n\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"238428076cd07994d843f798d51238fbdbc2cf53"}}]}] BACKPORT-->