### PR TITLE
[8.9] [ML] Version bump for data frame analytics tests

### DIFF
--- a/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/142100
-  describe.skip('classification creation', function () {
+  describe('classification creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/bm_classification');
       await ml.testResources.createIndexPatternIfNeeded('ft_bank_marketing');
@@ -97,7 +96,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '25mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
@@ -14,8 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/142093
-  describe.skip('outlier detection creation', function () {
+  describe('outlier detection creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
       await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier');
@@ -109,7 +108,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '2mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation_saved_search.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation_saved_search.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/166033
-  describe.skip('outlier detection saved search creation', function () {
+  describe('outlier detection saved search creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote_small');
       await ml.testResources.createIndexPatternIfNeeded('ft_farequote_small', '@timestamp');
@@ -90,7 +89,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '1mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -174,7 +173,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '1mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -258,7 +257,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '1mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -343,7 +342,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '1mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
@@ -28,8 +28,7 @@ export default function ({ getService }: FtrProviderContext) {
     },
   ];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/142096
-  describe.skip('regression creation', function () {
+  describe('regression creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/egs_regression');
       await ml.testResources.createIndexPatternIfNeeded('ft_egs_regression');
@@ -93,7 +92,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '16mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation_saved_search.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation_saved_search.ts
@@ -13,8 +13,7 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
   const editedDescription = 'Edited description';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/134671
-  describe.skip('regression saved search creation', function () {
+  describe('regression saved search creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote_small');
       await ml.testResources.createIndexPatternIfNeeded('ft_farequote_small', '@timestamp');
@@ -95,7 +94,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '10mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -184,7 +183,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '10mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -273,7 +272,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '5mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {
@@ -362,7 +361,7 @@ export default function ({ getService }: FtrProviderContext) {
                   'Model memory limit',
                   '5mb',
                   'Version',
-                  '8.9.2',
+                  '8.9.3',
                 ],
               },
               {


### PR DESCRIPTION
## Summary

Bumps the versions of the expected job state for `8.9.3` in data frame analytics functional tests and unskips the corresponding tests.

The failing tests on 8.9.3 were caused by the incomplete version bump that was done in https://github.com/elastic/kibana/pull/165689

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

Closes #166033
Closes #142100
Closes #142096
Closes #142093
Closes #134671