### PR TITLE
POC Adding a global saved query feature permission

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -211,7 +211,7 @@ export const DiscoverTopNav = ({
   const showSaveQuery =
     !isPlainRecord &&
     (Boolean(services.capabilities.discover.saveQuery) ||
-      Boolean(services.capabilities.globalSavedQueries.edit));
+      Boolean(services.capabilities.savedQueryManagement.edit));
 
   return (
     <SearchBar

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -208,6 +208,11 @@ export const DiscoverTopNav = ({
     [searchBarCustomization?.CustomSearchBar, AggregateQueryTopNavMenu]
   );
 
+  const showSaveQuery =
+    !isPlainRecord &&
+    (Boolean(services.capabilities.discover.saveQuery) ||
+      Boolean(services.capabilities.globalSavedQueries.edit));
+
   return (
     <SearchBar
       appName="discover"
@@ -220,7 +225,7 @@ export const DiscoverTopNav = ({
       savedQueryId={savedQuery}
       screenTitle={savedSearch.title}
       showDatePicker={showDatePicker}
-      showSaveQuery={!isPlainRecord && Boolean(services.capabilities.discover.saveQuery)}
+      showSaveQuery={showSaveQuery}
       showSearchBar={true}
       useDefaultBehaviors={true}
       dataViewPickerOverride={

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -212,7 +212,9 @@ export function createSearchBar({
             showFilterBar={props.showFilterBar}
             showQueryMenu={props.showQueryMenu}
             showQueryInput={props.showQueryInput}
-            showSaveQuery={props.showSaveQuery}
+            showSaveQuery={
+              Boolean(core.application.capabilities.globalSavedQueries?.edit) || props.showSaveQuery
+            }
             showSubmitButton={props.showSubmitButton}
             submitButtonStyle={props.submitButtonStyle}
             isDisabled={props.isDisabled}

--- a/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/create_search_bar.tsx
@@ -15,6 +15,7 @@ import type { QueryStart, SavedQuery, DataPublicPluginStart } from '@kbn/data-pl
 import type { Query, AggregateQuery } from '@kbn/es-query';
 import type { Filter, TimeRange } from '@kbn/es-query';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import { SearchBar } from '.';
 import type { SearchBarOwnProps } from '.';
 import { useFilterManager } from './lib/use_filter_manager';
@@ -193,6 +194,9 @@ export function createSearchBar({
         true
       );
     }, [query, timeRange, useDefaultBehaviors]);
+    const showSaveQuery =
+      !isOfAggregateQueryType(query) &&
+      (Boolean(core.application.capabilities.savedQueryManagement?.edit) || props.showSaveQuery);
 
     return (
       <KibanaContextProvider
@@ -212,9 +216,7 @@ export function createSearchBar({
             showFilterBar={props.showFilterBar}
             showQueryMenu={props.showQueryMenu}
             showQueryInput={props.showQueryInput}
-            showSaveQuery={
-              Boolean(core.application.capabilities.globalSavedQueries?.edit) || props.showSaveQuery
-            }
+            showSaveQuery={showSaveQuery}
             showSubmitButton={props.showSubmitButton}
             submitButtonStyle={props.submitButtonStyle}
             isDisabled={props.isDisabled}

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -68,7 +68,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   dateRangeTo?: string;
   // Query bar - should be in SearchBarInjectedDeps
   query?: QT | Query;
-  // Show when user has privileges to save or when globalSavedQueries.edit privilege is true
+  // Show when user has privileges to save or when savedQueryManagement.edit privilege is true
   showSaveQuery?: boolean;
   savedQuery?: SavedQuery;
   onQueryChange?: (payload: { dateRange: TimeRange; query?: QT | Query }) => void;

--- a/src/plugins/unified_search/public/search_bar/search_bar.tsx
+++ b/src/plugins/unified_search/public/search_bar/search_bar.tsx
@@ -68,7 +68,7 @@ export interface SearchBarOwnProps<QT extends AggregateQuery | Query = Query> {
   dateRangeTo?: string;
   // Query bar - should be in SearchBarInjectedDeps
   query?: QT | Query;
-  // Show when user has privileges to save
+  // Show when user has privileges to save or when globalSavedQueries.edit privilege is true
   showSaveQuery?: boolean;
   savedQuery?: SavedQuery;
   onQueryChange?: (payload: { dateRange: TimeRange; query?: QT | Query }) => void;

--- a/x-pack/plugins/features/server/oss_features.ts
+++ b/x-pack/plugins/features/server/oss_features.ts
@@ -20,17 +20,17 @@ export const buildOSSFeatures = ({
 }: BuildOSSFeaturesParams): KibanaFeatureConfig[] => {
   return [
     {
-      id: 'globalSavedQueries',
-      name: i18n.translate('xpack.features.globalSavedQueriesFeatureName', {
-        defaultMessage: 'Global Saved Queries',
+      id: 'savedQueryManagement',
+      name: i18n.translate('xpack.features.savedQueryManagementFeatureName', {
+        defaultMessage: 'Saved Query Management',
       }),
-      order: 101,
-      category: DEFAULT_APP_CATEGORIES.kibana,
+      order: 1700,
+      category: DEFAULT_APP_CATEGORIES.management,
       app: ['kibana'],
       catalogue: [],
-      privilegesTooltip: i18n.translate('xpack.features.globalSavedQueriesTooltip', {
+      privilegesTooltip: i18n.translate('xpack.features.savedQueryManagementTooltip', {
         defaultMessage:
-          'If this is enabled saved queries can be edited or changed across Kibana. When set to None, this depends on the consuming plugin.',
+          'If "All" is set saved queries can be edited or changed across Kibana. This will overwrite any other privileges related to saved queries.',
       }),
       privileges: {
         all: {

--- a/x-pack/plugins/features/server/oss_features.ts
+++ b/x-pack/plugins/features/server/oss_features.ts
@@ -20,6 +20,31 @@ export const buildOSSFeatures = ({
 }: BuildOSSFeaturesParams): KibanaFeatureConfig[] => {
   return [
     {
+      id: 'globalSavedQueries',
+      name: i18n.translate('xpack.features.globalSavedQueriesFeatureName', {
+        defaultMessage: 'Global Saved Queries',
+      }),
+      order: 101,
+      category: DEFAULT_APP_CATEGORIES.kibana,
+      app: ['kibana'],
+      catalogue: [],
+      privilegesTooltip: i18n.translate('xpack.features.globalSavedQueriesTooltip', {
+        defaultMessage:
+          'If this is enabled saved queries can be edited or changed across Kibana. When set to None, this depends on the consuming plugin.',
+      }),
+      privileges: {
+        all: {
+          app: ['kibana'],
+          catalogue: [],
+          savedObject: {
+            all: ['query'],
+            read: ['query'],
+          },
+          ui: ['edit'],
+        },
+      },
+    },
+    {
       id: 'discover',
       name: i18n.translate('xpack.features.discoverFeatureName', {
         defaultMessage: 'Discover',


### PR DESCRIPTION
## Summary

WIP

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
