### PR TITLE
[DOCS] Add preconfigured webhook connector settings

### DIFF
--- a/docs/api-generated/connectors/connector-apis-passthru.asciidoc
+++ b/docs/api-generated/connectors/connector-apis-passthru.asciidoc
@@ -1122,6 +1122,7 @@ Any modifications made to this file will be overwritten.
     <li><a href="#update_connector_request_slack_webhook"><code>update_connector_request_slack_webhook</code> - Update Slack connector request</a></li>
     <li><a href="#update_connector_request_swimlane"><code>update_connector_request_swimlane</code> - Update Swimlane connector request</a></li>
     <li><a href="#update_connector_request_teams"><code>update_connector_request_teams</code> - Update Microsoft Teams connector request</a></li>
+    <li><a href="#update_connector_request_webhook"><code>update_connector_request_webhook</code> - Update Webhook connector request</a></li>
     <li><a href="#update_connector_request_xmatters"><code>update_connector_request_xmatters</code> - Update xMatters connector request</a></li>
   </ol>
 
@@ -2686,6 +2687,15 @@ Any modifications made to this file will be overwritten.
     <div class="field-items">
       <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
 <div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_teams">secrets_properties_teams</a></span>  </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="update_connector_request_webhook"><code>update_connector_request_webhook</code> - Update Webhook connector request</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_webhook">config_properties_webhook</a></span>  </div>
+<div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
+<div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_webhook">secrets_properties_webhook</a></span>  </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -322,16 +322,19 @@ For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a REST API
 NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure the hostname in the URL is added to the allowed hosts. 
 
 `xpack.actions.preconfigured.<connector-id>.config.hasAuth`::
-For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration. Defaults to `true`.
+For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies whether a user and password are required inside the secrets configuration. Defaults to `true`.
 
 `xpack.actions.preconfigured.<connector-id>.config.headers`::
-For a <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request.
+For a <<webhook-action-type,webhook>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a set of key-value pairs sent as headers with the request.
 
 `xpack.actions.preconfigured.<connector-id>.config.host`::
 For an <<email-action-type,email connector>>, specifies the host name of the service provider.
 
 `xpack.actions.preconfigured.<connector-id>.config.index`::
 For an <<index-action-type,index connector>>, specifies the {es} index.
+
+`xpack.actions.preconfigured.<connector-id>.config.method`::
+For a <<webhook-action-type,webhook connector>>, specifies the HTTP request method, either `post` or `put`. Defaults to `post`.
 
 `xpack.actions.preconfigured.<connector-id>.config.orgId`::
 For an <<resilient-action-type,{ibm-r} connector>>, specifies the {ibm-r} organization identifier.
@@ -370,6 +373,7 @@ A configuration URL that varies by connector:
 +
 --
 * For a <<d3security-action-type,D3 Security conector>>, specifies the D3 Security API request URL.
+* For a <<webhook-action-type,webhook connector>>, specifies the web service request URL.
 
 NOTE: If you are using the `xpack.actions.allowedHosts` setting, make sure this hostname is added to the allowed hosts.
 --
@@ -420,7 +424,7 @@ For a <<jira-action-type,Jira connector>>, specifies the account email for HTTP 
 A password secret that varies by connector:
 +
 --
-* For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a password that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
 
@@ -445,7 +449,7 @@ A token secret that varies by connector:
 A user name secret that varies by connector:
 +
 --
-* For an <<email-action-type,email>> or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
+* For an <<email-action-type,email>>, <<webhook-action-type,webhook>>, or <<cases-webhook-action-type,{webhook-cm} connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.hasAuth` is `true`.
 * For an <<xmatters-action-type,xMatters connector>>, specifies a user name that is required when `xpack.actions.preconfigured.<connector-id>.config.usesBasic` is `true`.
 --
 

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -506,6 +506,9 @@
                     "$ref": "#/components/schemas/update_connector_request_teams"
                   },
                   {
+                    "$ref": "#/components/schemas/update_connector_request_webhook"
+                  },
+                  {
                     "$ref": "#/components/schemas/update_connector_request_xmatters"
                   }
                 ]
@@ -4174,6 +4177,27 @@
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_teams"
+          }
+        }
+      },
+      "update_connector_request_webhook": {
+        "title": "Update Webhook connector request",
+        "type": "object",
+        "required": [
+          "config",
+          "name",
+          "secrets"
+        ],
+        "properties": {
+          "config": {
+            "$ref": "#/components/schemas/config_properties_webhook"
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name for the connector."
+          },
+          "secrets": {
+            "$ref": "#/components/schemas/secrets_properties_webhook"
           }
         }
       },

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -263,6 +263,7 @@ paths:
                 - $ref: '#/components/schemas/update_connector_request_slack_webhook'
                 - $ref: '#/components/schemas/update_connector_request_swimlane'
                 - $ref: '#/components/schemas/update_connector_request_teams'
+                - $ref: '#/components/schemas/update_connector_request_webhook'
                 - $ref: '#/components/schemas/update_connector_request_xmatters'
             examples:
               updateIndexConnectorRequest:
@@ -2896,6 +2897,21 @@ components:
           description: The display name for the connector.
         secrets:
           $ref: '#/components/schemas/secrets_properties_teams'
+    update_connector_request_webhook:
+      title: Update Webhook connector request
+      type: object
+      required:
+        - config
+        - name
+        - secrets
+      properties:
+        config:
+          $ref: '#/components/schemas/config_properties_webhook'
+        name:
+          type: string
+          description: The display name for the connector.
+        secrets:
+          $ref: '#/components/schemas/secrets_properties_webhook'
     update_connector_request_xmatters:
       title: Update xMatters connector request
       type: object

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -176,7 +176,7 @@ put:
             - $ref: '../components/schemas/update_connector_request_swimlane.yaml' 
             - $ref: '../components/schemas/update_connector_request_teams.yaml'
 #            - $ref: '../components/schemas/update_connector_request_tines.yaml'
-#            - $ref: '../components/schemas/update_connector_request_webhook.yaml'
+            - $ref: '../components/schemas/update_connector_request_webhook.yaml'
             - $ref: '../components/schemas/update_connector_request_xmatters.yaml'
         examples:
           updateIndexConnectorRequest:


### PR DESCRIPTION
## Summary

This PR adds the preconfigured webhook connector settings to https://www.elastic.co/guide/en/kibana/master/alert-action-settings-kb.html#preconfigured-connector-settings and uncomments the update webhook connector details in the open API specification.
