### PR TITLE
fix(slo): use comma separarted list of source index for transform

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/fixtures/slo.ts
@@ -58,7 +58,7 @@ export const createKQLCustomIndicator = (
 ): Indicator => ({
   type: 'sli.kql.custom',
   params: {
-    index: 'my-index*',
+    index: 'my-index*,my-other-index*',
     filter: 'labels.groupId: group-3',
     good: 'latency < 300',
     total: '',
@@ -72,7 +72,7 @@ export const createMetricCustomIndicator = (
 ): MetricCustomIndicator => ({
   type: 'sli.metric.custom',
   params: {
-    index: 'my-index*',
+    index: 'my-index*,my-other-index*',
     filter: 'labels.groupId: group-3',
     good: {
       metrics: [
@@ -95,7 +95,7 @@ export const createHistogramIndicator = (
 ): HistogramIndicator => ({
   type: 'sli.histogram.custom',
   params: {
-    index: 'my-index*',
+    index: 'my-index*,my-other-index*',
     filter: 'labels.groupId: group-3',
     good: {
       field: 'latency',

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -209,7 +209,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,
@@ -449,7 +452,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -224,7 +224,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,
@@ -438,7 +441,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -233,7 +233,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,
@@ -485,7 +488,10 @@ Object {
     "deduce_mappings": false,
   },
   "source": Object {
-    "index": "my-index*",
+    "index": Array [
+      "my-index*",
+      "my-other-index*",
+    ],
     "query": Object {
       "bool": Object {
         "minimum_should_match": 1,

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
@@ -14,7 +14,7 @@ import {
 
 import { InvalidTransformError } from '../../../errors';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
-import { getElastichsearchQueryOrThrow, TransformGenerator } from '.';
+import { getElastichsearchQueryOrThrow, parseIndex, TransformGenerator } from '.';
 import {
   SLO_DESTINATION_INDEX_NAME,
   SLO_INGEST_PIPELINE_NAME,
@@ -47,7 +47,7 @@ export class HistogramTransformGenerator extends TransformGenerator {
   private buildSource(slo: SLO, indicator: HistogramIndicator) {
     const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
-      index: indicator.params.index,
+      index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: filter,
     };

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -10,7 +10,7 @@ import { kqlCustomIndicatorSchema, timeslicesBudgetingMethodSchema } from '@kbn/
 
 import { InvalidTransformError } from '../../../errors';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
-import { getElastichsearchQueryOrThrow, TransformGenerator } from '.';
+import { getElastichsearchQueryOrThrow, parseIndex, TransformGenerator } from '.';
 import {
   SLO_DESTINATION_INDEX_NAME,
   SLO_INGEST_PIPELINE_NAME,
@@ -42,7 +42,7 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
   private buildSource(slo: SLO, indicator: KQLCustomIndicator) {
     const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
-      index: indicator.params.index,
+      index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: filter,
     };

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
@@ -10,7 +10,7 @@ import { metricCustomIndicatorSchema, timeslicesBudgetingMethodSchema } from '@k
 
 import { InvalidTransformError } from '../../../errors';
 import { getSLOTransformTemplate } from '../../../assets/transform_templates/slo_transform_template';
-import { getElastichsearchQueryOrThrow, TransformGenerator } from '.';
+import { getElastichsearchQueryOrThrow, parseIndex, TransformGenerator } from '.';
 import {
   SLO_DESTINATION_INDEX_NAME,
   SLO_INGEST_PIPELINE_NAME,
@@ -45,7 +45,7 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
   private buildSource(slo: SLO, indicator: MetricCustomIndicator) {
     const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
-      index: indicator.params.index,
+      index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
       query: filter,
     };


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166347

## 🍒 Summary

This PR fixes an issue we have with transform when providing many indices separated by a comma. It seems that transform requires to specify many indices by a list of index, instead of one string as we can do with es query.

I've reproduced this issue by creating 3 identical transforms, with only difference the source index. The only transform that was running and indexing correctly was the one using the comma separated list of indices, e.g. `index: ["index-one*", "index-two*"]`
I've [asked the ml team](https://elastic.slack.com/archives/C2AJLJHMM/p1694549031164839) to get their input on this.

We are going to include this into 8.10.1 if possible, but the workaround for version 8.10 or lower is to use a dataview or index pattern containing only one index. This is obviously not always possible.


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->