### PR TITLE
[Security solution] GenAI - update response schema

### DIFF
--- a/x-pack/plugins/stack_connectors/common/gen_ai/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/gen_ai/schema.ts
@@ -35,12 +35,13 @@ export const GenAiStreamActionParamsSchema = schema.object({
 });
 
 export const GenAiStreamingResponseSchema = schema.any();
+
 export const GenAiRunActionResponseSchema = schema.object(
   {
-    id: schema.string(),
-    object: schema.string(),
-    created: schema.number(),
-    model: schema.string(),
+    id: schema.maybe(schema.string()),
+    object: schema.maybe(schema.string()),
+    created: schema.maybe(schema.number()),
+    model: schema.maybe(schema.string()),
     usage: schema.object(
       {
         prompt_tokens: schema.number(),


### PR DESCRIPTION
## Summary

Loosen strictness on the GenAI Response Schema. We are only using `usage` and `choices`, so updated the schema to reflect that

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->