### PR TITLE
[DOCS] Fix Kibana landing page links

### DIFF
--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -71,8 +71,8 @@
       </a>
     </p>
     <p>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.7/whats-new.html">What's new</a>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.7/release-notes.html">Release notes</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.10/whats-new.html">What's new</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.10/release-notes.html">Release notes</a>
       <a class="inline-block mr-3" href="install.html">Install</a>
     </p>
   </div>


### PR DESCRIPTION
Fixes the links on the Kibana landing page for `main` and `8.10`.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->