### PR TITLE
[8.9] [DOCS] Fix Kibana home page link

### DIFF
--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -71,8 +71,8 @@
       </a>
     </p>
     <p>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.7/whats-new.html">What's new</a>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.7/release-notes.html">Release notes</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.9/whats-new.html">What's new</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.9/release-notes.html">Release notes</a>
       <a class="inline-block mr-3" href="install.html">Install</a>
     </p>
   </div>


### PR DESCRIPTION
Fixes the links on the Kibana landing page for `8.9`.