### PR TITLE
[8.10] [DOCS] Remove 8.10 `coming` tag

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,8 +51,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.10.0]]
 == {kib} 8.10.0
 
-coming::[8.10.0]
-
 For information about the {kib} 8.10.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
Removes the `coming` tag from the 8.10 release notes.