### PR TITLE
[DOCS] Make landing page links relative

### DIFF
--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -71,8 +71,8 @@
       </a>
     </p>
     <p>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.10/whats-new.html">What's new</a>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/kibana/8.10/release-notes.html">Release notes</a>
+      <a class="inline-block mr-3" href="whats-new.html">What's new</a>
+      <a class="inline-block mr-3" href="release-notes.html">Release notes</a>
       <a class="inline-block mr-3" href="install.html">Install</a>
     </p>
   </div>


### PR DESCRIPTION
**Problem:**
The below links on the Kibana docs landing page must be updated each major/minor release. We often forget this chore.

<img width="1137" alt="Screenshot 2023-09-12 at 7 30 21 PM" src="https://github.com/elastic/kibana/assets/40268737/62bc881c-85ac-4a55-9a2f-d3a6f04bae14">

**Solution:**
Make the links relative so they always stay updated.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->