### PR TITLE
[8.10] [DOCS] Fix 8.10 RNs

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -183,7 +183,8 @@ Observability::
 
 For more information about the features introduced in 8.10.0, refer to <<whats-new,What's new in 8.10>>.
 
-[[enhancements-and-bug-fixes-v8.10.0]]
+[discrete]
+[[enhancements-and-bug-fixes-v8.10.0-revised]]
 === Enhancements and bug fixes
 
 For detailed information about the 8.10.0 release, review the enhancements and bug fixes.

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -421,4 +421,4 @@ This page has been deleted. Refer to <<alerting-getting-started>>.
 [role="exclude",id="enhancements-and-bug-fixes-v8.10.0"]
 == Enhancements and bug fixes for 8.10.0
 
-This content has moved. Refer to <<release-notes-8.10.0>>.
+This content has moved. Refer to <<enhancements-and-bug-fixes-v8.10.0-revised>> for 8.10.0.

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -291,7 +291,7 @@ This page has been moved. Refer to <<dashboard-drilldowns>>.
 [[development-plugin-localization]]
 === Localization for plugins
 
-This page has been moved. PRefer to <<external-plugin-localization>>.
+This page has been moved. Refer to <<external-plugin-localization>>.
 
 [role="exclude",id="visualize"]
 == Visualize
@@ -417,3 +417,8 @@ This page has been deleted. Refer to <<machine-learning-api-sync>>.
 == Alerts and Actions
 
 This page has been deleted. Refer to <<alerting-getting-started>>.
+
+[role="exclude",id="enhancements-and-bug-fixes-v8.10.0"]
+== Enhancements and bug fixes for 8.10.0
+
+This content has moved. Refer to <<release-notes-8.10.0>>.


### PR DESCRIPTION
**Problem:**
The 8.10 Kibana release notes currently has enhancements and bug fixes on a separate page. This is due to a missing `[discrete]` tag.

**Solution:**
- Add the missing `[discrete]` tag.
- Add a redirect for the removed page.