### PR TITLE
[Cloud Security] add api version to fleet call

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/common/api/use_cis_kubernetes_integration.tsx
@@ -10,6 +10,7 @@ import {
   epmRouteService,
   type GetInfoResponse,
   type DefaultPackagesInstallationError,
+  API_VERSIONS,
 } from '@kbn/fleet-plugin/common';
 import { CLOUD_SECURITY_POSTURE_PACKAGE_NAME } from '../../../common/constants';
 import { useKibana } from '../hooks/use_kibana';
@@ -21,6 +22,8 @@ export const useCisKubernetesIntegration = () => {
   const { http } = useKibana().services;
 
   return useQuery<GetInfoResponse, DefaultPackagesInstallationError>(['integrations'], () =>
-    http.get<GetInfoResponse>(epmRouteService.getInfoPath(CLOUD_SECURITY_POSTURE_PACKAGE_NAME))
+    http.get<GetInfoResponse>(epmRouteService.getInfoPath(CLOUD_SECURITY_POSTURE_PACKAGE_NAME), {
+      version: API_VERSIONS.public.v1,
+    })
   );
 };


### PR DESCRIPTION
## Summary
fixes
- https://github.com/elastic/security-team/issues/7623

adding version to the fleet call


