### PR TITLE
[Lens] Inline editor fix for activeData

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/get_edit_lens_configuration.tsx
@@ -91,8 +91,9 @@ export async function getEditLensConfiguration(
     closeFlyout,
     wrapInFlyout,
     datasourceId,
-    adaptersTables,
     panelId,
+    inspector,
+    output$,
   }: EditLensConfigurationProps) => {
     if (!lensServices || !datasourceMap || !visualizationMap || !dataView.id) {
       return <LoadingSpinnerWithOverlay />;
@@ -154,11 +155,12 @@ export async function getEditLensConfiguration(
       updateAll,
       closeFlyout,
       datasourceId,
-      adaptersTables,
       coreStart,
       startDependencies,
       visualizationMap,
       datasourceMap,
+      output$,
+      inspector,
     };
 
     return getWrapper(

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -799,8 +799,9 @@ export class Embeddable
           dataView={dataView}
           updateAll={this.updateVisualization.bind(this)}
           datasourceId={datasourceId}
-          adaptersTables={this.lensInspector.adapters.tables?.tables}
+          inspector={this.lensInspector}
           panelId={this.id}
+          output$={this.getOutput$()}
         />
       );
     }


### PR DESCRIPTION
## Summary

Use the `inspector` reference rather than the table to get fresh data on config updates.
I suspect the `cloneElement` is preventing the panel to be updated on visualization changes, but this way it is always possible to navigate thru the stable `inspector` instance to get always fresh data.

Listen to the `output$` is required as on data changes a new update is dispatched in the embeddable, so it knows data has changed for sure.

Other things I've tried that didn't work:
* use the `inspector` from `lensServices` ❌ 
* use the `this.activeData` from the embeddable ❌ 


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
