### PR TITLE
[8.4] [DOCS] Fix broken link in Kibana release highlights

### DIFF
--- a/docs/user/whats-new.asciidoc
+++ b/docs/user/whats-new.asciidoc
@@ -16,7 +16,7 @@ Previous versions: {kibana-ref-all}/8.3/whats-new.html[8.3] | {kibana-ref-all}/8
 [[highlights-8.4-release-docs]]
 === Elastic release docs now in one place
 With the new
-https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html[Check out the latest from Elastic] page,
+{estc-welcome-current}/new.html[Check out the latest from Elastic] page,
 you can easily find all the latest information about Elastic features and updates
 in a single location.
 This includes release highlights, breaking changes, bug fixes, and more.


### PR DESCRIPTION
**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix and name for the "Welcome to Elastic Docs" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix

**Solution:** Replace the outdated link with one that uses an attribute.