### PR TITLE
[Data Views] Do not overflow notification card with long data view name

### DIFF
--- a/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
@@ -68,7 +68,7 @@ const DataViewFlyoutContentContainer = ({
 
         if (persist) {
           const title = i18n.translate('indexPatternEditor.saved', {
-            defaultMessage: "Saved",
+            defaultMessage: 'Saved',
           });
           const text = `'${saveResponse.getName()}'`;
           notifications.toasts.addSuccess({

--- a/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_flyout_content_container.tsx
@@ -67,11 +67,14 @@ const DataViewFlyoutContentContainer = ({
         await dataViews.refreshFields(saveResponse);
 
         if (persist) {
-          const message = i18n.translate('indexPatternEditor.saved', {
-            defaultMessage: "Saved '{indexPatternName}'",
-            values: { indexPatternName: saveResponse.getName() },
+          const title = i18n.translate('indexPatternEditor.saved', {
+            defaultMessage: "Saved",
           });
-          notifications.toasts.addSuccess(message);
+          const text = `'${saveResponse.getName()}'`;
+          notifications.toasts.addSuccess({
+            title,
+            text,
+          });
         }
         await onSave(saveResponse);
       }

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4164,7 +4164,7 @@
     "indexPatternEditor.rollupDataView.warning.textParagraphOne": "Kibana 基于汇总/打包为数据视图提供公测版支持。将这些视图用于已保存搜索、可视化以及仪表板可能会遇到问题。某些高级功能，如 Timelion 和 Machine Learning，不支持这些模式。",
     "indexPatternEditor.rollupDataView.warning.textParagraphTwo": "可以根据一个汇总/打包索引和零个或更多常规索引匹配汇总/打包数据视图。汇总/打包数据视图的指标、字段、时间间隔和聚合有限。汇总/打包索引仅限于具有一个作业配置或多个作业配置兼容的索引。",
     "indexPatternEditor.rollupIndexPattern.warning.title": "公测版功能",
-    "indexPatternEditor.saved": "已保存“{indexPatternName}”",
+    "indexPatternEditor.saved": "已保存",
     "indexPatternEditor.status.noSystemIndicesLabel": "没有数据流、索引或索引别名匹配您的索引模式。",
     "indexPatternEditor.status.noSystemIndicesWithPromptLabel": "没有数据流、索引或索引别名匹配您的索引模式。",
     "indexPatternEditor.status.notMatchLabel.notMatchNoIndicesDetail": "输入的索引模式不匹配任何数据流、索引或索引别名。",


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/163330

Data view names are now rendered as body, instead of title, hence long titles overflow, like so:

<img width="366" alt="Screenshot 2023-09-13 at 15 06 16" src="https://github.com/elastic/kibana/assets/82822460/388479c4-9908-4887-94eb-e59298bd2cc1">

