### PR TITLE
[DOCS] Adds shards object to Create pack and Update pack API

### DIFF
--- a/docs/api/osquery-manager/packs/create.asciidoc
+++ b/docs/api/osquery-manager/packs/create.asciidoc
@@ -33,6 +33,8 @@ experimental[] Create packs.
 
 `policy_ids`:: (Optional, array) A list of agents policy IDs.
 
+`shards`:: (Required, object) An object with shard configuration for policies included in the pack. For each policy, set the shard configuration to a percentage (1–100) of target hosts.
+
 `queries`:: (Required, object) An object of queries.
 
 
@@ -56,8 +58,13 @@ $ curl -X POST api/osquery/packs \
   "description": "My pack",
   "enabled": true,
   "policy_ids": [
-    "my_policy_id"
+    "my_policy_id",
+    "fleet-server-policy"
   ],
+  "shards": {
+    "my_policy_id": 35,
+    "fleet-server-policy": 58
+  },
   "queries": {
     "my_query": {
       "query": "SELECT * FROM listening_ports;",
@@ -67,7 +74,10 @@ $ curl -X POST api/osquery/packs \
           "field": "port"
         },
         "tags": {
-          "value": ["tag1", "tag2"]
+          "value": [
+            "tag1",
+            "tag2"
+          ]
         }
       }
     }

--- a/docs/api/osquery-manager/packs/update.asciidoc
+++ b/docs/api/osquery-manager/packs/update.asciidoc
@@ -38,6 +38,8 @@ WARNING: You are unable to update a prebuilt pack (`read_only = true`).
 
 `policy_ids`:: (Optional, array) A list of agent policy IDs.
 
+`shards`:: (Optional, object) An object with shard configuration for policies included in the pack. For each policy, set the shard configuration to a percentage (1–100) of target hosts.
+
 `queries`:: (Required, object) An object of queries.
 
 


### PR DESCRIPTION
## Summary

- Resolves https://github.com/elastic/security-docs/issues/3822 

Adds the `shards` object schema definition to Create pack and Update pack API, and to the Create pack request example.

- Related dev PR: https://github.com/elastic/kibana/pull/143948


<!--ONMERGE {"backportTargets":["8.10","8.6","8.7","8.8","8.9"]} ONMERGE-->