### PR TITLE
[Cloud Security] fix "Install Agent" link from empty states

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration_policies.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/navigation/use_navigate_to_cis_integration_policies.ts
@@ -8,17 +8,34 @@
 import { pagePathGetters, pkgKeyFromPackageInfo } from '@kbn/fleet-plugin/public';
 import { useCisKubernetesIntegration } from '../api/use_cis_kubernetes_integration';
 import { useKibana } from '../hooks/use_kibana';
+import { useCspBenchmarkIntegrations } from '../../pages/benchmarks/use_csp_benchmark_integrations';
+import { PostureTypes } from '../../../common/types';
 
 export const useCISIntegrationPoliciesLink = ({
-  addAgentToPolicyId = '',
-  integration = '',
+  postureType,
 }: {
-  addAgentToPolicyId?: string;
-  integration?: string;
+  postureType: PostureTypes;
 }): string | undefined => {
   const { http } = useKibana().services;
   const cisIntegration = useCisKubernetesIntegration();
+  // using an existing hook to get agent id and package policy id
+  const cspBenchmarkIntegrations = useCspBenchmarkIntegrations({
+    name: '',
+    page: 1,
+    perPage: 100,
+    sortField: 'package_policy.name',
+    sortOrder: 'asc',
+  });
   if (!cisIntegration.isSuccess) return;
+
+  const intergrations = cspBenchmarkIntegrations.data?.items;
+  const matchedIntegration = intergrations?.find(
+    (integration) =>
+      integration?.package_policy?.inputs?.find((input) => input?.enabled)?.policy_template ===
+      postureType
+  );
+  const addAgentToPolicyId = matchedIntegration?.agent_policy.id || '';
+  const integration = matchedIntegration?.package_policy.id || '';
 
   const path = pagePathGetters
     .integration_details_policies({

--- a/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_findings_states.tsx
@@ -22,7 +22,6 @@ import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { CSPM_POLICY_TEMPLATE, KSPM_POLICY_TEMPLATE } from '../../common/constants';
 import { FullSizeCenteredPage } from './full_size_centered_page';
-import { useCspBenchmarkIntegrations } from '../pages/benchmarks/use_csp_benchmark_integrations';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
 import {
   CSPM_NOT_INSTALLED_ACTION_SUBJ,
@@ -37,21 +36,9 @@ import noDataIllustration from '../assets/illustrations/no_data_illustration.svg
 import { useCspIntegrationLink } from '../common/navigation/use_csp_integration_link';
 import { NO_FINDINGS_STATUS_REFRESH_INTERVAL_MS } from '../common/constants';
 
-const NotDeployed = () => {
-  // using an existing hook to get agent id and package policy id
-  const benchmarks = useCspBenchmarkIntegrations({
-    name: '',
-    page: 1,
-    perPage: 1,
-    sortField: 'package_policy.name',
-    sortOrder: 'asc',
-  });
-
-  // the ids are not a must, but as long as we have them we can open the add agent flyout
-  const firstBenchmark = benchmarks.data?.items?.[0];
+const NotDeployed = ({ postureType }: { postureType: PostureTypes }) => {
   const integrationPoliciesLink = useCISIntegrationPoliciesLink({
-    addAgentToPolicyId: firstBenchmark?.agent_policy.id || '',
-    integration: firstBenchmark?.package_policy.id || '',
+    postureType,
   });
 
   return (
@@ -280,7 +267,7 @@ export const NoFindingsStates = ({ posturetype }: { posturetype: PostureTypes })
       .map((idxDetails: IndexDetails) => idxDetails.index)
       .sort((a, b) => a.localeCompare(b));
   const render = () => {
-    if (status === 'not-deployed') return <NotDeployed />; // integration installed, but no agents added
+    if (status === 'not-deployed') return <NotDeployed postureType={posturetype} />; // integration installed, but no agents added
     if (status === 'indexing' || status === 'waiting_for_results') return <Indexing />; // agent added, index timeout hasn't passed since installation
     if (status === 'index-timeout') return <IndexTimeout />; // agent added, index timeout has passed
     if (status === 'unprivileged')

--- a/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/no_vulnerabilities_states.tsx
@@ -33,7 +33,7 @@ import {
 import noDataIllustration from '../assets/illustrations/no_data_illustration.svg';
 import { useCspIntegrationLink } from '../common/navigation/use_csp_integration_link';
 import { useCISIntegrationPoliciesLink } from '../common/navigation/use_navigate_to_cis_integration_policies';
-import { useCspBenchmarkIntegrations } from '../pages/benchmarks/use_csp_benchmark_integrations';
+import { PostureTypes } from '../../common/types';
 
 const REFETCH_INTERVAL_MS = 20000;
 
@@ -191,21 +191,9 @@ const Unprivileged = ({ unprivilegedIndices }: { unprivilegedIndices: string[] }
     }
   />
 );
-const AgentNotDeployedEmptyPrompt = () => {
-  // using an existing hook to get agent id and package policy id
-  const benchmarks = useCspBenchmarkIntegrations({
-    name: '',
-    page: 1,
-    perPage: 1,
-    sortField: 'package_policy.name',
-    sortOrder: 'asc',
-  });
-
-  // the ids are not a must, but as long as we have them we can open the add agent flyout
-  const firstBenchmark = benchmarks.data?.items?.[0];
+const AgentNotDeployedEmptyPrompt = ({ postureType }: { postureType: PostureTypes }) => {
   const integrationPoliciesLink = useCISIntegrationPoliciesLink({
-    addAgentToPolicyId: firstBenchmark?.agent_policy.id || '',
-    integration: firstBenchmark?.package_policy.id || '',
+    postureType,
   });
 
   return (
@@ -268,7 +256,8 @@ export const NoVulnerabilitiesStates = () => {
       return (
         <CnvmIntegrationNotInstalledEmptyPrompt vulnMgmtIntegrationLink={vulnMgmtIntegrationLink} />
       );
-    if (status === 'not-deployed') return <AgentNotDeployedEmptyPrompt />;
+    if (status === 'not-deployed')
+      return <AgentNotDeployedEmptyPrompt postureType={VULN_MGMT_POLICY_TEMPLATE} />;
     if (status === 'unprivileged')
       return <Unprivileged unprivilegedIndices={unprivilegedIndices || []} />; // user has no privileges for our indices
   };


### PR DESCRIPTION
## Summary
A part of Quick Wins day

fixes
- https://github.com/elastic/kibana/issues/160286

The fix is to load more CSP integrations and pick the one that matches the posture type of the current empty state



