### PR TITLE
[Discover] Switch to Inter font for the grid and doc viewer

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.scss
+++ b/packages/kbn-unified-data-table/src/components/data_table.scss
@@ -6,7 +6,7 @@
 }
 
 .unifiedDataTable__cellValue {
-  font-family: $euiCodeFontFamily;
+  font-variant-numeric: tabular-nums;
 }
 
 .unifiedDataTable__cellPopover {
@@ -18,7 +18,7 @@
 }
 
 .unifiedDataTable__cellPopoverValue {
-  font-family: $euiCodeFontFamily;
+  font-variant-numeric: tabular-nums;
   font-size: $euiFontSizeS;
 }
 

--- a/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.scss
+++ b/src/plugins/unified_doc_viewer/public/components/doc_viewer_table/table.scss
@@ -5,8 +5,8 @@
 }
 
 .kbnDocViewer__tableRow {
+  font-variant-numeric: tabular-nums;
   font-size: $euiFontSizeXS;
-  font-family: $euiCodeFontFamily;
 
   // set min-width for each column except actions
   .euiTableRowCell:nth-child(n+2) {


### PR DESCRIPTION
Part of Discover redesign v1.

This PR changes the font to `Inter` for the grid and doc viewer. Numeric values will still be well aligned.

<img width="600" alt="Screenshot 2023-09-13 at 17 40 53" src="https://github.com/elastic/kibana/assets/1415710/bdc344d9-ea59-4903-bf70-d13aa25800d7">
<img width="600" alt="Screenshot 2023-09-13 at 17 41 04" src="https://github.com/elastic/kibana/assets/1415710/f5926057-cf0c-4fdb-b6cb-9122febefde8">
