### PR TITLE
feat(slo): Add range filter to slo indicators by default

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -47,11 +47,24 @@ Object {
 exports[`Histogram Transform Generator filters the source using the kql query 1`] = `
 Object {
   "bool": Object {
-    "minimum_should_match": 1,
-    "should": Array [
+    "filter": Array [
       Object {
-        "match": Object {
-          "labels.groupId": "group-4",
+        "range": Object {
+          "log_timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "bool": Object {
+          "minimum_should_match": 1,
+          "should": Array [
+            Object {
+              "match": Object {
+                "labels.groupId": "group-4",
+              },
+            },
+          ],
         },
       },
     ],
@@ -215,11 +228,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],
@@ -458,11 +484,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -88,11 +88,24 @@ Object {
 exports[`KQL Custom Transform Generator filters the source using the kql query 1`] = `
 Object {
   "bool": Object {
-    "minimum_should_match": 1,
-    "should": Array [
+    "filter": Array [
       Object {
-        "match": Object {
-          "labels.groupId": "group-4",
+        "range": Object {
+          "log_timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "bool": Object {
+          "minimum_should_match": 1,
+          "should": Array [
+            Object {
+              "match": Object {
+                "labels.groupId": "group-4",
+              },
+            },
+          ],
         },
       },
     ],
@@ -230,11 +243,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],
@@ -447,11 +473,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -59,11 +59,24 @@ Object {
 exports[`Metric Custom Transform Generator filters the source using the kql query 1`] = `
 Object {
   "bool": Object {
-    "minimum_should_match": 1,
-    "should": Array [
+    "filter": Array [
       Object {
-        "match": Object {
-          "labels.groupId": "group-4",
+        "range": Object {
+          "log_timestamp": Object {
+            "gte": "now-7d",
+          },
+        },
+      },
+      Object {
+        "bool": Object {
+          "minimum_should_match": 1,
+          "should": Array [
+            Object {
+              "match": Object {
+                "labels.groupId": "group-4",
+              },
+            },
+          ],
         },
       },
     ],
@@ -239,11 +252,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],
@@ -494,11 +520,24 @@ Object {
     ],
     "query": Object {
       "bool": Object {
-        "minimum_should_match": 1,
-        "should": Array [
+        "filter": Array [
           Object {
-            "match": Object {
-              "labels.groupId": "group-3",
+            "range": Object {
+              "log_timestamp": Object {
+                "gte": "now-7d",
+              },
+            },
+          },
+          Object {
+            "bool": Object {
+              "minimum_should_match": 1,
+              "should": Array [
+                Object {
+                  "match": Object {
+                    "labels.groupId": "group-3",
+                  },
+                },
+              ],
             },
           },
         ],

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
@@ -45,11 +45,23 @@ export class HistogramTransformGenerator extends TransformGenerator {
   }
 
   private buildSource(slo: SLO, indicator: HistogramIndicator) {
-    const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
       index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
-      query: filter,
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                [indicator.params.timestampField]: {
+                  gte: `now-${slo.timeWindow.duration.format()}`,
+                },
+              },
+            },
+            getElastichsearchQueryOrThrow(indicator.params.filter),
+          ],
+        },
+      },
     };
   }
 

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -40,11 +40,23 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
   }
 
   private buildSource(slo: SLO, indicator: KQLCustomIndicator) {
-    const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
       index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
-      query: filter,
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                [indicator.params.timestampField]: {
+                  gte: `now-${slo.timeWindow.duration.format()}`,
+                },
+              },
+            },
+            getElastichsearchQueryOrThrow(indicator.params.filter),
+          ],
+        },
+      },
     };
   }
 

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
@@ -43,11 +43,23 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
   }
 
   private buildSource(slo: SLO, indicator: MetricCustomIndicator) {
-    const filter = getElastichsearchQueryOrThrow(indicator.params.filter);
     return {
       index: parseIndex(indicator.params.index),
       runtime_mappings: this.buildCommonRuntimeMappings(slo),
-      query: filter,
+      query: {
+        bool: {
+          filter: [
+            {
+              range: {
+                [indicator.params.timestampField]: {
+                  gte: `now-${slo.timeWindow.duration.format()}`,
+                },
+              },
+            },
+            getElastichsearchQueryOrThrow(indicator.params.filter),
+          ],
+        },
+      },
     };
   }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166389

## 🍒 Summary

This PR adds a range filter for the custom kql, custom metric and histogram indicators based on the SLO time window duration.

We noticed during our testing on large cluster that it could become very slow for the transform to index the initial data if no range filter was set, and not useful since data older than a time window duration are not actively used by the product. 
The user had the possibility to set a custom filter on these indicator, but this was a workaround not known by everyone.