### PR TITLE
[OAS] Add defaultModel to generative AI connector

### DIFF
--- a/docs/api-generated/connectors/connector-apis-passthru.asciidoc
+++ b/docs/api-generated/connectors/connector-apis-passthru.asciidoc
@@ -1005,6 +1005,8 @@ Any modifications made to this file will be overwritten.
     <li><a href="#config_properties_d3security"><code>config_properties_d3security</code> - Connector request properties for a D3 Security connector</a></li>
     <li><a href="#config_properties_email"><code>config_properties_email</code> - Connector request properties for an email connector</a></li>
     <li><a href="#config_properties_genai"><code>config_properties_genai</code> - Connector request properties for a generative AI connector</a></li>
+    <li><a href="#config_properties_genai_oneOf"><code>config_properties_genai_oneOf</code> - </a></li>
+    <li><a href="#config_properties_genai_oneOf_1"><code>config_properties_genai_oneOf_1</code> - </a></li>
     <li><a href="#config_properties_index"><code>config_properties_index</code> - Connector request properties for an index connector</a></li>
     <li><a href="#config_properties_jira"><code>config_properties_jira</code> - Connector request properties for a Jira connector</a></li>
     <li><a href="#config_properties_opsgenie"><code>config_properties_opsgenie</code> - Connector request properties for an Opsgenie connector</a></li>
@@ -1352,6 +1354,9 @@ Any modifications made to this file will be overwritten.
       <div class="param">config </div><div class="param-desc"><span class="param-type"><a href="#config_properties_xmatters">config_properties_xmatters</a></span>  </div>
 <div class="param">name </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The display name for the connector. </div>
 <div class="param">secrets </div><div class="param-desc"><span class="param-type"><a href="#secrets_properties_xmatters">secrets_properties_xmatters</a></span>  </div>
+<div class="param">connector_type_id </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The type of connector. </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">.gen-ai</div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">
@@ -1422,8 +1427,32 @@ Any modifications made to this file will be overwritten.
     <h3><a name="config_properties_genai"><code>config_properties_genai</code> - Connector request properties for a generative AI connector</a> <a class="up" href="#__Models">Up</a></h3>
     <div class='model-description'>Defines properties for connectors when type is <code>.gen-ai</code>.</div>
     <div class="field-items">
-      <div class="param">apiProvider (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API provider. </div>
-<div class="param">apiUrl (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API endpoint. </div>
+      <div class="param">apiProvider </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API provider. </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">OpenAI</div>
+<div class="param">apiUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API endpoint. </div>
+<div class="param">defaultModel (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The default model to use for requests. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="config_properties_genai_oneOf"><code>config_properties_genai_oneOf</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">apiProvider </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API provider. </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">Azure OpenAI</div>
+<div class="param">apiUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API endpoint. </div>
+    </div>  <!-- field-items -->
+  </div>
+  <div class="model">
+    <h3><a name="config_properties_genai_oneOf_1"><code>config_properties_genai_oneOf_1</code> - </a> <a class="up" href="#__Models">Up</a></h3>
+    <div class='model-description'></div>
+    <div class="field-items">
+      <div class="param">apiProvider </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API provider. </div>
+        <div class="param-enum-header">Enum:</div>
+        <div class="param-enum">OpenAI</div>
+<div class="param">apiUrl </div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The OpenAI API endpoint. </div>
+<div class="param">defaultModel (optional)</div><div class="param-desc"><span class="param-type"><a href="#string">String</a></span> The default model to use for requests. </div>
     </div>  <!-- field-items -->
   </div>
   <div class="model">

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -470,6 +470,9 @@
                     "$ref": "#/components/schemas/update_connector_request_email"
                   },
                   {
+                    "$ref": "#/components/schemas/create_connector_request_genai"
+                  },
+                  {
                     "$ref": "#/components/schemas/update_connector_request_index"
                   },
                   {
@@ -1755,16 +1758,54 @@
       "config_properties_genai": {
         "title": "Connector request properties for a generative AI connector",
         "description": "Defines properties for connectors when type is `.gen-ai`.",
-        "type": "object",
-        "properties": {
-          "apiProvider": {
-            "type": "string",
-            "description": "The OpenAI API provider."
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "apiProvider",
+              "apiUrl"
+            ],
+            "properties": {
+              "apiProvider": {
+                "type": "string",
+                "description": "The OpenAI API provider.",
+                "enum": [
+                  "Azure OpenAI"
+                ]
+              },
+              "apiUrl": {
+                "type": "string",
+                "description": "The OpenAI API endpoint."
+              }
+            }
           },
-          "apiUrl": {
-            "type": "string",
-            "description": "The OpenAI API endpoint."
+          {
+            "type": "object",
+            "required": [
+              "apiProvider",
+              "apiUrl"
+            ],
+            "properties": {
+              "apiProvider": {
+                "type": "string",
+                "description": "The OpenAI API provider.",
+                "enum": [
+                  "OpenAI"
+                ]
+              },
+              "apiUrl": {
+                "type": "string",
+                "description": "The OpenAI API endpoint."
+              },
+              "defaultModel": {
+                "type": "string",
+                "description": "The default model to use for requests."
+              }
+            }
           }
+        ],
+        "discriminator": {
+          "propertyName": "apiProvider"
         }
       },
       "secrets_properties_genai": {

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -251,6 +251,7 @@ paths:
                 - $ref: '#/components/schemas/update_connector_request_cases_webhook'
                 - $ref: '#/components/schemas/update_connector_request_d3security'
                 - $ref: '#/components/schemas/update_connector_request_email'
+                - $ref: '#/components/schemas/create_connector_request_genai'
                 - $ref: '#/components/schemas/update_connector_request_index'
                 - $ref: '#/components/schemas/update_connector_request_jira'
                 - $ref: '#/components/schemas/update_connector_request_opsgenie'
@@ -1100,14 +1101,38 @@ components:
     config_properties_genai:
       title: Connector request properties for a generative AI connector
       description: Defines properties for connectors when type is `.gen-ai`.
-      type: object
-      properties:
-        apiProvider:
-          type: string
-          description: The OpenAI API provider.
-        apiUrl:
-          type: string
-          description: The OpenAI API endpoint.
+      oneOf:
+        - type: object
+          required:
+            - apiProvider
+            - apiUrl
+          properties:
+            apiProvider:
+              type: string
+              description: The OpenAI API provider.
+              enum:
+                - Azure OpenAI
+            apiUrl:
+              type: string
+              description: The OpenAI API endpoint.
+        - type: object
+          required:
+            - apiProvider
+            - apiUrl
+          properties:
+            apiProvider:
+              type: string
+              description: The OpenAI API provider.
+              enum:
+                - OpenAI
+            apiUrl:
+              type: string
+              description: The OpenAI API endpoint.
+            defaultModel:
+              type: string
+              description: The default model to use for requests.
+      discriminator:
+        propertyName: apiProvider
     secrets_properties_genai:
       title: Connector secrets properties for a generative AI connector
       description: Defines secrets for connectors when type is `.gen-ai`.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_genai.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_genai.yaml
@@ -1,10 +1,32 @@
 title: Connector request properties for a generative AI connector
 description: Defines properties for connectors when type is `.gen-ai`.
-type: object
-properties:
-    apiProvider:
+oneOf:
+  - type: object
+    required:
+      - apiProvider
+      - apiUrl
+    properties:
+      apiProvider:
         type: string
         description: The OpenAI API provider.
-    apiUrl:
+        enum: ['Azure OpenAI']
+      apiUrl:
         type: string
         description: The OpenAI API endpoint.
+  - type: object
+    required:
+      - apiProvider
+      - apiUrl
+    properties:
+      apiProvider:
+        type: string
+        description: The OpenAI API provider.
+        enum: ['OpenAI']
+      apiUrl:
+        type: string
+        description: The OpenAI API endpoint.
+      defaultModel:
+        type: string
+        description: The default model to use for requests.
+discriminator:
+  propertyName: apiProvider

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_genai.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_genai.yaml
@@ -1,0 +1,13 @@
+title: Update generative AI connector request
+type: object
+required:
+  - config
+  - name
+properties:
+  config:
+    $ref: 'config_properties_genai.yaml'
+  name:
+    type: string
+    description: The display name for the connector.
+  secrets:
+    $ref: 'secrets_properties_genai.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -162,7 +162,7 @@ put:
             - $ref: '../components/schemas/update_connector_request_cases_webhook.yaml'
             - $ref: '../components/schemas/update_connector_request_d3security.yaml'
             - $ref: '../components/schemas/update_connector_request_email.yaml'
-#            - $ref: '../components/schemas/create_connector_request_genai.yaml'
+            - $ref: '../components/schemas/create_connector_request_genai.yaml'
             - $ref: '../components/schemas/update_connector_request_index.yaml'  
             - $ref: '../components/schemas/update_connector_request_jira.yaml'
             - $ref: '../components/schemas/update_connector_request_opsgenie.yaml'


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/162204

This PR updates the open API specification so that it has the optional `defaultModel` property for the generative AI connector, which is only supported for the `OpenAI` type of AI provider.

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->