### PR TITLE
[Security Solution] fix projectId not populating for metering records

### DIFF
--- a/x-pack/plugins/security_solution_serverless/server/endpoint/constants/metering.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/constants/metering.ts
@@ -14,4 +14,5 @@ export const METERING_TASK = {
   SAMPLE_PERIOD_SECONDS: 3600,
   THRESHOLD_MINUTES: 30,
   USAGE_TYPE_PREFIX: 'security_solution_',
+  MISSING_PROJECT_ID: 'missing_project_id',
 };

--- a/x-pack/plugins/security_solution_serverless/server/endpoint/services/metering_service.test.ts
+++ b/x-pack/plugins/security_solution_serverless/server/endpoint/services/metering_service.test.ts
@@ -96,7 +96,7 @@ describe('EndpointMeteringService', () => {
       const usageRecords = await endpointMeteringService.getUsageRecords(args);
 
       expect(usageRecords[0]).toEqual({
-        id: `endpoint-${agentId}-${timestamp}`,
+        id: `endpoint-${agentId}-${timestamp.toISOString()}`,
         usage_timestamp: heartbeatDocSrc!.event.ingested,
         creation_timestamp: heartbeatDocSrc!.event.ingested,
         usage: {
@@ -140,7 +140,7 @@ describe('EndpointMeteringService', () => {
           : `${ProductLine.cloud}_${ProductLine.endpoint}`;
 
       expect(usageRecords[0]).toEqual({
-        id: `endpoint-${agentId}-${timestamp}`,
+        id: `endpoint-${agentId}-${timestamp.toISOString()}`,
         usage_timestamp: heartbeatDocSrc!.event.ingested,
         creation_timestamp: heartbeatDocSrc!.event.ingested,
         usage: {

--- a/x-pack/plugins/security_solution_serverless/server/plugin.ts
+++ b/x-pack/plugins/security_solution_serverless/server/plugin.ts
@@ -72,7 +72,7 @@ export class SecuritySolutionServerlessPlugin
       logFactory: this.initializerContext.logger,
       config: this.config,
       taskManager: pluginsSetup.taskManager,
-      cloudSetup: pluginsSetup.cloudSetup,
+      cloudSetup: pluginsSetup.cloud,
       taskType: cloudSecurityMetringTaskProperties.taskType,
       taskTitle: cloudSecurityMetringTaskProperties.taskTitle,
       version: cloudSecurityMetringTaskProperties.version,
@@ -88,7 +88,7 @@ export class SecuritySolutionServerlessPlugin
       version: ENDPOINT_METERING_TASK.VERSION,
       meteringCallback: endpointMeteringService.getUsageRecords,
       taskManager: pluginsSetup.taskManager,
-      cloudSetup: pluginsSetup.cloudSetup,
+      cloudSetup: pluginsSetup.cloud,
     });
 
     pluginsSetup.serverless.setupProjectSettings(SECURITY_PROJECT_SETTINGS);

--- a/x-pack/plugins/security_solution_serverless/server/types.ts
+++ b/x-pack/plugins/security_solution_serverless/server/types.ts
@@ -38,7 +38,7 @@ export interface SecuritySolutionServerlessPluginSetupDeps {
   features: PluginSetupContract;
   ml: MlPluginSetup;
   taskManager: TaskManagerSetupContract;
-  cloudSetup: CloudSetup;
+  cloud: CloudSetup;
 }
 
 export interface SecuritySolutionServerlessPluginStartDeps {


### PR DESCRIPTION
## Summary

fix `cloud.serverless.projectId` not populating for serverless security solution metering records.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
