### PR TITLE
[Logs onboarding] Making onboarding boxes clickable

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
@@ -139,6 +139,7 @@ export function Home() {
               paddingSize="l"
               display="plain"
               hasBorder
+              onClick={handleClickSystemLogs}
             >
               <EuiSpacer size="s" />
               <EuiBadge color="hollow">{elasticAgentLabel}</EuiBadge>
@@ -177,6 +178,7 @@ export function Home() {
               paddingSize="l"
               display="plain"
               hasBorder
+              onClick={handleClickCustomLogs}
             >
               <EuiSpacer size="s" />
               <EuiBadge color="hollow">{elasticAgentLabel}</EuiBadge>
@@ -263,6 +265,7 @@ export function Home() {
               paddingSize="m"
               display="plain"
               hasBorder
+              onClick={handleClickKubernetesSetupGuide}
             />
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -355,6 +358,7 @@ export function Home() {
           paddingSize="none"
           display="plain"
           hasBorder
+          onClick={handleClickIntegrations}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
@@ -358,7 +358,6 @@ export function Home() {
           paddingSize="none"
           display="plain"
           hasBorder
-          onClick={handleClickIntegrations}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
@@ -144,7 +144,7 @@ export function Home() {
               <EuiSpacer size="s" />
               <EuiBadge color="hollow">{elasticAgentLabel}</EuiBadge>
               <EuiSpacer size="m" />
-              <EuiText color="subdued" size="s" textAlign="left">
+              <EuiText color="subdued" size="s" textAlign="center">
                 <p>
                   {i18n.translate(
                     'xpack.observability_onboarding.card.systemLogs.description1',
@@ -183,7 +183,7 @@ export function Home() {
               <EuiSpacer size="s" />
               <EuiBadge color="hollow">{elasticAgentLabel}</EuiBadge>
               <EuiSpacer size="m" />
-              <EuiText color="subdued" size="s" textAlign="left">
+              <EuiText color="subdued" size="s" textAlign="center">
                 <p>
                   {i18n.translate(
                     'xpack.observability_onboarding.card.customLogs.description.text',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/166000.

### Before
![image](https://github.com/elastic/kibana/assets/1313018/cbb66ff5-3a84-4ad6-88de-14e8f98c0c6a)

### After
<img width="936" alt="image" src="https://github.com/elastic/kibana/assets/1313018/ba886167-c073-45da-99b0-36607a81b50c">

### How to test
1. Go to[ logs onboarding](https://yngrdyn-deploy-kiban-pr166422.kb.us-west2.gcp.elastic-cloud.com/app/observabilityOnboarding) landing page
2. Verify the folllowing
    - Cards are clickable. `Get started` buttons should remain clickable as well.
    - Cards description is centered