### PR TITLE
[DOCS] Remove 'coming in 8.10' from changelog

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -51,8 +51,6 @@ Review important information about the {kib} 8.x releases.
 [[release-notes-8.10.0]]
 == {kib} 8.10.0
 
-coming::[8.10.0]
-
 For information about the {kib} 8.10.0 release, review the following information.
 
 [float]


### PR DESCRIPTION
Removes the 'coming in 8.10' notice from the release notes