### PR TITLE
[Cloud Security]fix json tab overflow content

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/json_tab.tsx
@@ -10,10 +10,11 @@ import { CodeEditor } from '@kbn/kibana-react-plugin/public';
 import { XJsonLang } from '@kbn/monaco';
 import { CspFinding } from '../../../../common/schemas/csp_finding';
 
-const offsetHeight = 120;
+const offsetTopHeight = 120;
+const offsetBottomHeight = 72;
 
 export const JsonTab = ({ data }: { data: CspFinding }) => (
-  <div style={{ position: 'absolute', inset: 0, top: offsetHeight }}>
+  <div style={{ position: 'absolute', inset: 0, top: offsetTopHeight, bottom: offsetBottomHeight }}>
     <CodeEditor
       isCopyable
       allowFullScreen


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.
[Quick Wins](https://github.com/elastic/security-team/issues/7436)
 Applied offset Bottom height so JSON Tab  content inside this absolute `div` element is scrollable and doesn't get cut off by the sticky bar: