### PR TITLE
[ML] Trained model testing: only show indices with supported fields

### DIFF
--- a/x-pack/plugins/ml/public/application/model_management/test_models/models/inference_base.ts
+++ b/x-pack/plugins/ml/public/application/model_management/test_models/models/inference_base.ts
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 
 import { map } from 'rxjs/operators';
 import { SupportedPytorchTasksType } from '@kbn/ml-trained-models-utils';
+import { ES_FIELD_TYPES } from '@kbn/field-types';
 import type { MLHttpFetchError } from '@kbn/ml-error-utils';
 import { trainedModelsApiProvider } from '../../../services/ml_api_service/trained_models';
 import { getInferenceInfoComponent } from './inference_info';
@@ -70,6 +71,7 @@ export abstract class InferenceBase<TInferResponse> {
   private runningState$ = new BehaviorSubject<RUNNING_STATE>(RUNNING_STATE.STOPPED);
   private isValid$ = new BehaviorSubject<boolean>(false);
   private pipeline$ = new BehaviorSubject<estypes.IngestPipeline>({});
+  private supportedFieldTypes: ES_FIELD_TYPES[] = [ES_FIELD_TYPES.TEXT];
 
   protected readonly info: string[] = [];
 
@@ -239,6 +241,10 @@ export abstract class InferenceBase<TInferResponse> {
 
   public getPipeline(): estypes.IngestPipeline {
     return this.pipeline$.getValue();
+  }
+
+  public getSupportedFieldTypes(): ES_FIELD_TYPES[] {
+    return this.supportedFieldTypes;
   }
 
   protected getBasicProcessors(


### PR DESCRIPTION
## Summary

Related comment in issue: https://github.com/elastic/kibana/pull/159150#discussion_r1288694083

This PR adds a `supportedFields` property to the inferrer class and, when creating the index options, filters to those containing supported fields.

For now, the supported fields default to 'text' as all inferrer types require that. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


