### PR TITLE
[Security solution] Another GenAI response schema update

### DIFF
--- a/x-pack/plugins/stack_connectors/common/gen_ai/schema.ts
+++ b/x-pack/plugins/stack_connectors/common/gen_ai/schema.ts
@@ -60,8 +60,8 @@ export const GenAiRunActionResponseSchema = schema.object(
             },
             { unknowns: 'ignore' }
           ),
-          finish_reason: schema.string(),
-          index: schema.number(),
+          finish_reason: schema.maybe(schema.string()),
+          index: schema.maybe(schema.number()),
         },
         { unknowns: 'ignore' }
       )


### PR DESCRIPTION
## Summary

Follow up from https://github.com/elastic/kibana/pull/166300

We are only using `messages` from `choices`, so I made the other `choices` properties `maybe` as well

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->