### PR TITLE
[Cloud Security] [Dashboard Navigation] Fix edit filter when navigating from dashboard

### DIFF
--- a/x-pack/plugins/cloud_security_posture/common/constants.ts
+++ b/x-pack/plugins/cloud_security_posture/common/constants.ts
@@ -65,6 +65,8 @@ export const LATEST_VULNERABILITIES_RETENTION_POLICY = '3d';
 
 export const DATA_VIEW_INDEX_PATTERN = 'logs-*';
 
+export const SECURITY_DEFAULT_DATA_VIEW_ID = 'security-solution-default';
+
 export const CSP_INGEST_TIMESTAMP_PIPELINE = 'cloud_security_posture_add_ingest_timestamp_pipeline';
 export const CSP_LATEST_FINDINGS_INGEST_TIMESTAMP_PIPELINE =
   'cloud_security_posture_latest_index_add_ingest_timestamp_pipeline';

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.test.ts
@@ -6,7 +6,11 @@
  */
 
 import { renderHook, act } from '@testing-library/react-hooks/dom';
-import { useNavigateFindings, useNavigateFindingsByResource } from './use_navigate_findings';
+import {
+  useNavigateFindings,
+  useNavigateFindingsByResource,
+  useNavigateVulnerabilities,
+} from './use_navigate_findings';
 import { useHistory } from 'react-router-dom';
 
 jest.mock('react-router-dom', () => ({
@@ -39,7 +43,7 @@ jest.mock('../api/use_latest_findings_data_view', () => ({
 }));
 
 describe('useNavigateFindings', () => {
-  it('creates a URL to findings page with correct path and filter', () => {
+  it('creates a URL to findings page with correct path, filter and dataViewId', () => {
     const push = jest.fn();
     (useHistory as jest.Mock).mockReturnValueOnce({ push });
 
@@ -89,6 +93,24 @@ describe('useNavigateFindings', () => {
       pathname: '/cloud_security_posture/findings/resource',
       search:
         "cspq=(filters:!((meta:(alias:!n,disabled:!f,index:data-view-id,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
+    });
+    expect(push).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a URL to vulnerabilities page with correct path, filter and dataViewId', () => {
+    const push = jest.fn();
+    (useHistory as jest.Mock).mockReturnValueOnce({ push });
+
+    const { result } = renderHook(() => useNavigateVulnerabilities());
+
+    act(() => {
+      result.current({ foo: 1 });
+    });
+
+    expect(push).toHaveBeenCalledWith({
+      pathname: '/cloud_security_posture/findings/vulnerabilities',
+      search:
+        "cspq=(filters:!((meta:(alias:!n,disabled:!f,index:security-solution-default,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
     });
     expect(push).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.test.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.test.ts
@@ -29,6 +29,14 @@ jest.mock('./use_kibana', () => ({
     },
   }),
 }));
+jest.mock('../api/use_latest_findings_data_view', () => ({
+  useLatestFindingsDataView: jest.fn().mockReturnValue({
+    status: 'success',
+    data: {
+      id: 'data-view-id',
+    },
+  }),
+}));
 
 describe('useNavigateFindings', () => {
   it('creates a URL to findings page with correct path and filter', () => {
@@ -44,7 +52,7 @@ describe('useNavigateFindings', () => {
     expect(push).toHaveBeenCalledWith({
       pathname: '/cloud_security_posture/findings/configurations',
       search:
-        "cspq=(filters:!((meta:(alias:!n,disabled:!f,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
+        "cspq=(filters:!((meta:(alias:!n,disabled:!f,index:data-view-id,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
     });
     expect(push).toHaveBeenCalledTimes(1);
   });
@@ -62,7 +70,7 @@ describe('useNavigateFindings', () => {
     expect(push).toHaveBeenCalledWith({
       pathname: '/cloud_security_posture/findings/configurations',
       search:
-        "cspq=(filters:!((meta:(alias:!n,disabled:!f,key:foo,negate:!t,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
+        "cspq=(filters:!((meta:(alias:!n,disabled:!f,index:data-view-id,key:foo,negate:!t,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
     });
     expect(push).toHaveBeenCalledTimes(1);
   });
@@ -80,7 +88,7 @@ describe('useNavigateFindings', () => {
     expect(push).toHaveBeenCalledWith({
       pathname: '/cloud_security_posture/findings/resource',
       search:
-        "cspq=(filters:!((meta:(alias:!n,disabled:!f,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
+        "cspq=(filters:!((meta:(alias:!n,disabled:!f,index:data-view-id,key:foo,negate:!f,type:phrase),query:(match_phrase:(foo:1)))),query:(language:kuery,query:''))",
     });
     expect(push).toHaveBeenCalledTimes(1);
   });

--- a/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/common/hooks/use_navigate_findings.ts
@@ -8,9 +8,14 @@
 import { useCallback } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Filter } from '@kbn/es-query';
+import {
+  LATEST_FINDINGS_INDEX_PATTERN,
+  SECURITY_DEFAULT_DATA_VIEW_ID,
+} from '../../../common/constants';
 import { findingsNavigation } from '../navigation/constants';
 import { encodeQuery } from '../navigation/query_utils';
 import { useKibana } from './use_kibana';
+import { useLatestFindingsDataView } from '../api/use_latest_findings_data_view';
 
 interface NegatedValue {
   value: string | number;
@@ -21,7 +26,7 @@ type FilterValue = string | number | NegatedValue;
 
 export type NavFilter = Record<string, FilterValue>;
 
-const createFilter = (key: string, filterValue: FilterValue): Filter => {
+const createFilter = (key: string, filterValue: FilterValue, dataViewId: string): Filter => {
   let negate = false;
   let value = filterValue;
   if (typeof filterValue === 'object') {
@@ -32,7 +37,7 @@ const createFilter = (key: string, filterValue: FilterValue): Filter => {
   if (value === '*') {
     return {
       query: { exists: { field: key } },
-      meta: { type: 'exists' },
+      meta: { type: 'exists', index: dataViewId },
     };
   }
   return {
@@ -42,18 +47,19 @@ const createFilter = (key: string, filterValue: FilterValue): Filter => {
       disabled: false,
       type: 'phrase',
       key,
+      index: dataViewId,
     },
     query: { match_phrase: { [key]: value } },
   };
 };
-const useNavigate = (pathname: string) => {
+const useNavigate = (pathname: string, dataViewId = SECURITY_DEFAULT_DATA_VIEW_ID) => {
   const history = useHistory();
   const { services } = useKibana();
 
   return useCallback(
     (filterParams: NavFilter = {}) => {
       const filters = Object.entries(filterParams).map(([key, filterValue]) =>
-        createFilter(key, filterValue)
+        createFilter(key, filterValue, dataViewId)
       );
 
       history.push({
@@ -65,14 +71,19 @@ const useNavigate = (pathname: string) => {
         }),
       });
     },
-    [pathname, history, services.data.query.queryString]
+    [pathname, history, services.data.query.queryString, dataViewId]
   );
 };
 
-export const useNavigateFindings = () => useNavigate(findingsNavigation.findings_default.path);
+export const useNavigateFindings = () => {
+  const { data } = useLatestFindingsDataView(LATEST_FINDINGS_INDEX_PATTERN);
+  return useNavigate(findingsNavigation.findings_default.path, data?.id);
+};
 
-export const useNavigateFindingsByResource = () =>
-  useNavigate(findingsNavigation.findings_by_resource.path);
+export const useNavigateFindingsByResource = () => {
+  const { data } = useLatestFindingsDataView(LATEST_FINDINGS_INDEX_PATTERN);
+  return useNavigate(findingsNavigation.findings_by_resource.path, data?.id);
+};
 
 export const useNavigateVulnerabilities = () =>
   useNavigate(findingsNavigation.vulnerabilities.path);


### PR DESCRIPTION
## Summary

This is part of a [Quick Wins](https://github.com/elastic/security-team/issues/7436) ticket

This PR fixes [this](https://github.com/elastic/kibana/issues/165954) issue, by adding the `dataViewId` to the `createFilter` method called by the `useNavigation` hook according to the respective findings page (Misconfigurations, Vulnerabilities).

It falls back to the `security-solution-default` data view if a data view can not be found (in case it's manually deleted by the user for example).

## Recording


https://github.com/elastic/kibana/assets/19270322/74a3cd2b-c6ce-4fe4-9bed-ba0d8604c509

