### PR TITLE
[Cloud plugin] Add `projectId` to the telemetry streams

### DIFF
--- a/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.test.ts
+++ b/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.test.ts
@@ -42,4 +42,19 @@ describe('registerCloudDeploymentIdAnalyticsContext', () => {
       deploymentId: 'uuid-of-my-deployment',
     });
   });
+
+  test('it registers the context provider and emits the cloudId and projectId', async () => {
+    registerCloudDeploymentMetadataAnalyticsContext(analytics, {
+      id: 'cloud_id',
+      serverless: {
+        project_id: 'a-project-id',
+      },
+    });
+    expect(analytics.registerContextProvider).toHaveBeenCalledTimes(1);
+    const [{ context$ }] = analytics.registerContextProvider.mock.calls[0];
+    await expect(firstValueFrom(context$)).resolves.toEqual({
+      cloudId: 'cloud_id',
+      projectId: 'a-project-id',
+    });
+  });
 });

--- a/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
+++ b/x-pack/plugins/cloud/common/register_cloud_deployment_id_analytics_context.ts
@@ -14,6 +14,9 @@ export interface CloudDeploymentMetadata {
   trial_end_date?: string;
   is_elastic_staff_owned?: boolean;
   deployment_url?: string;
+  serverless?: {
+    project_id?: string;
+  };
 }
 
 export function registerCloudDeploymentMetadataAnalyticsContext(
@@ -27,6 +30,7 @@ export function registerCloudDeploymentMetadataAnalyticsContext(
     id: cloudId,
     trial_end_date: cloudTrialEndDate,
     is_elastic_staff_owned: cloudIsElasticStaffOwned,
+    serverless: { project_id: projectId } = {},
   } = cloudMetadata;
 
   analytics.registerContextProvider({
@@ -36,6 +40,7 @@ export function registerCloudDeploymentMetadataAnalyticsContext(
       deploymentId: parseDeploymentIdFromDeploymentUrl(cloudMetadata.deployment_url),
       cloudTrialEndDate,
       cloudIsElasticStaffOwned,
+      projectId,
     }),
     schema: {
       cloudId: {
@@ -56,6 +61,10 @@ export function registerCloudDeploymentMetadataAnalyticsContext(
           description: '`true` if the owner of the deployment is an Elastician',
           optional: true,
         },
+      },
+      projectId: {
+        type: 'keyword',
+        _meta: { description: 'The Serverless Project ID', optional: true },
       },
     },
   });

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
@@ -35,6 +35,8 @@ describe('createCloudUsageCollector', () => {
         isCloudEnabled: true,
         isElasticStaffOwned: undefined,
         trialEndDate: undefined,
+        deploymentId: undefined,
+        projectId: undefined,
       });
     });
 
@@ -49,6 +51,27 @@ describe('createCloudUsageCollector', () => {
         isElasticStaffOwned: undefined,
         trialEndDate: '2020-10-01T14:30:16Z',
         inTrial: false,
+        deploymentId: undefined,
+        projectId: undefined,
+      });
+    });
+
+    it('pass-through properties are copied as expected', async () => {
+      const collector = createCloudUsageCollector(usageCollection, {
+        isCloudEnabled: true,
+        trialEndDate: '2020-10-01T14:30:16Z',
+        isElasticStaffOwned: true,
+        deploymentId: 'a-deployment-id',
+        projectId: 'a-project-id',
+      });
+
+      expect(await collector.fetch(collectorFetchContext)).toStrictEqual({
+        isCloudEnabled: true,
+        trialEndDate: '2020-10-01T14:30:16Z',
+        inTrial: false,
+        isElasticStaffOwned: true,
+        deploymentId: 'a-deployment-id',
+        projectId: 'a-project-id',
       });
     });
   });

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
@@ -11,6 +11,8 @@ interface Config {
   isCloudEnabled: boolean;
   trialEndDate?: string;
   isElasticStaffOwned?: boolean;
+  deploymentId?: string;
+  projectId?: string;
 }
 
 interface CloudUsage {
@@ -18,10 +20,12 @@ interface CloudUsage {
   trialEndDate?: string;
   inTrial?: boolean;
   isElasticStaffOwned?: boolean;
+  deploymentId?: string;
+  projectId?: string;
 }
 
 export function createCloudUsageCollector(usageCollection: UsageCollectionSetup, config: Config) {
-  const { isCloudEnabled, trialEndDate, isElasticStaffOwned } = config;
+  const { isCloudEnabled, trialEndDate, isElasticStaffOwned, deploymentId, projectId } = config;
   const trialEndDateMs = trialEndDate ? new Date(trialEndDate).getTime() : undefined;
   return usageCollection.makeUsageCollector<CloudUsage>({
     type: 'cloud',
@@ -31,6 +35,14 @@ export function createCloudUsageCollector(usageCollection: UsageCollectionSetup,
       trialEndDate: { type: 'date' },
       inTrial: { type: 'boolean' },
       isElasticStaffOwned: { type: 'boolean' },
+      deploymentId: {
+        type: 'keyword',
+        _meta: { description: 'The ESS Deployment ID' },
+      },
+      projectId: {
+        type: 'keyword',
+        _meta: { description: 'The Serverless Project ID' },
+      },
     },
     fetch: () => {
       return {
@@ -38,6 +50,8 @@ export function createCloudUsageCollector(usageCollection: UsageCollectionSetup,
         isElasticStaffOwned,
         trialEndDate,
         ...(trialEndDateMs ? { inTrial: Date.now() <= trialEndDateMs } : {}),
+        deploymentId,
+        projectId,
       };
     },
   });

--- a/x-pack/plugins/cloud/server/plugin.ts
+++ b/x-pack/plugins/cloud/server/plugin.ts
@@ -147,13 +147,17 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
 
   public setup(core: CoreSetup, { usageCollection }: PluginsSetup): CloudSetup {
     const isCloudEnabled = getIsCloudEnabled(this.config.id);
-    const isServerlessEnabled = !!this.config.serverless?.project_id;
+    const projectId = this.config.serverless?.project_id;
+    const isServerlessEnabled = !!projectId;
+    const deploymentId = parseDeploymentIdFromDeploymentUrl(this.config.deployment_url);
 
     registerCloudDeploymentMetadataAnalyticsContext(core.analytics, this.config);
     registerCloudUsageCollector(usageCollection, {
       isCloudEnabled,
       trialEndDate: this.config.trial_end_date,
       isElasticStaffOwned: this.config.is_elastic_staff_owned,
+      deploymentId,
+      projectId,
     });
 
     let decodedId: DecodedCloudId | undefined;
@@ -165,7 +169,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       ...this.getCloudUrls(),
       cloudId: this.config.id,
       instanceSizeMb: readInstanceSizeMb(),
-      deploymentId: parseDeploymentIdFromDeploymentUrl(this.config.deployment_url),
+      deploymentId,
       elasticsearchUrl: decodedId?.elasticsearchUrl,
       kibanaUrl: decodedId?.kibanaUrl,
       cloudHost: decodedId?.host,
@@ -179,7 +183,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       },
       isServerlessEnabled,
       serverless: {
-        projectId: this.config.serverless?.project_id,
+        projectId,
         projectName: this.config.serverless?.project_name,
       },
     };

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -6179,6 +6179,18 @@
         },
         "isElasticStaffOwned": {
           "type": "boolean"
+        },
+        "deploymentId": {
+          "type": "keyword",
+          "_meta": {
+            "description": "The ESS Deployment ID"
+          }
+        },
+        "projectId": {
+          "type": "keyword",
+          "_meta": {
+            "description": "The Serverless Project ID"
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

We need `projectId` in our telemetry streams so that we can see the evolution of the usage per project.

cc @shahinakmal 


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
