### PR TITLE
[Synthetics] Remove `cmd/status` from Synthetics steps query

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/queries/get_journey_steps.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/queries/get_journey_steps.test.ts
@@ -156,7 +156,6 @@ describe('getJourneySteps request module', () => {
         Object {
           "terms": Object {
             "synthetics.type": Array [
-              "cmd/status",
               "journey/browserconsole",
               "step/end",
               "step/screenshot",

--- a/x-pack/plugins/observability_solution/synthetics/server/queries/get_journey_steps.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/queries/get_journey_steps.ts
@@ -29,7 +29,6 @@ export const getJourneySteps = async ({
           {
             terms: {
               'synthetics.type': [
-                'cmd/status',
                 'journey/browserconsole',
                 'step/end',
                 'step/screenshot',


### PR DESCRIPTION
## Summary

Resolves #166530.

Remove `cmd/status` from steps query.
