### PR TITLE
[8.8] [DOCS] Fix `welcome-to-elastic` link (#166357)

### DIFF
--- a/docs/landing-page.asciidoc
+++ b/docs/landing-page.asciidoc
@@ -259,7 +259,7 @@
     </a>
   </div>
   <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html">
       <div class="card h-100">
         <h4 class="mt-3">
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Fix `welcome-to-elastic` link (#166357)](https://github.com/elastic/kibana/pull/166357)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"James Rodewig","email":"james.rodewig@elastic.co"},"sourceCommit":{"committedDate":"2023-09-14T10:08:35Z","message":"[DOCS] Fix `welcome-to-elastic` link (#166357)\n\n**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the \"Welcome to Elastic Docs\" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix\r\n\r\n**Solution:** Update an outdated link.","sha":"94219bd1e9c4ad868d5e57a303b45e84c1b2e6bb","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","v8.5.4","v8.6.3","v8.7.2","v8.8.3","v8.11.0","v8.9.3","v8.10.1"],"number":166357,"url":"https://github.com/elastic/kibana/pull/166357","mergeCommit":{"message":"[DOCS] Fix `welcome-to-elastic` link (#166357)\n\n**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the \"Welcome to Elastic Docs\" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix\r\n\r\n**Solution:** Update an outdated link.","sha":"94219bd1e9c4ad868d5e57a303b45e84c1b2e6bb"}},"sourceBranch":"main","suggestedTargetBranches":["8.5","8.6","8.7","8.8","8.9","8.10"],"targetPullRequestStates":[{"branch":"8.5","label":"v8.5.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.6","label":"v8.6.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.7","label":"v8.7.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.8","label":"v8.8.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166357","number":166357,"mergeCommit":{"message":"[DOCS] Fix `welcome-to-elastic` link (#166357)\n\n**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the \"Welcome to Elastic Docs\" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix\r\n\r\n**Solution:** Update an outdated link.","sha":"94219bd1e9c4ad868d5e57a303b45e84c1b2e6bb"}},{"branch":"8.9","label":"v8.9.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.10","label":"v8.10.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->