### PR TITLE
Fix isErrorResponse when cluster details are provided

### DIFF
--- a/src/plugins/data/common/search/utils.test.ts
+++ b/src/plugins/data/common/search/utils.test.ts
@@ -24,6 +24,126 @@ describe('utils', () => {
       expect(isError).toBe(true);
     });
 
+    it('returns `false` if the response is not running and partial and contains failure details', () => {
+      const isError = isErrorResponse({
+        isPartial: true,
+        isRunning: false,
+        rawResponse: {
+          is_partial: true,
+          is_running: false,
+          start_time_in_millis: 1694728107992,
+          expiration_time_in_millis: 1695160107992,
+          completion_time_in_millis: 1694728107999,
+          response: {
+            took: 7,
+            timed_out: false,
+            _shards: {
+              total: 2,
+              successful: 1,
+              skipped: 0,
+              failed: 1,
+              failures: [
+                {
+                  shard: 0,
+                  index: 'remote:tmp-00002',
+                  node: '9SNgMgppT2-6UHJNXwio3g',
+                  reason: {
+                    type: 'script_exception',
+                    reason: 'runtime error',
+                    script_stack: [
+                      'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.getFactoryForDoc(LeafDocLookup.java:148)',
+                      'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:191)',
+                      'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:32)',
+                      "doc['bar'].value < 10",
+                      '    ^---- HERE',
+                    ],
+                    script: "doc['bar'].value < 10",
+                    lang: 'painless',
+                    position: {
+                      offset: 4,
+                      start: 0,
+                      end: 21,
+                    },
+                    caused_by: {
+                      type: 'illegal_argument_exception',
+                      reason: 'No field found for [bar] in mapping',
+                    },
+                  },
+                },
+              ],
+            },
+            _clusters: {
+              total: 1,
+              successful: 1,
+              skipped: 0,
+              details: {
+                remote: {
+                  status: 'partial',
+                  indices: 'tmp-*',
+                  took: 3,
+                  timed_out: false,
+                  _shards: {
+                    total: 2,
+                    successful: 1,
+                    skipped: 0,
+                    failed: 1,
+                  },
+                  failures: [
+                    {
+                      shard: 0,
+                      index: 'remote:tmp-00002',
+                      node: '9SNgMgppT2-6UHJNXwio3g',
+                      reason: {
+                        type: 'script_exception',
+                        reason: 'runtime error',
+                        script_stack: [
+                          'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.getFactoryForDoc(LeafDocLookup.java:148)',
+                          'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:191)',
+                          'org.elasticsearch.server@8.10.0/org.elasticsearch.search.lookup.LeafDocLookup.get(LeafDocLookup.java:32)',
+                          "doc['bar'].value < 10",
+                          '    ^---- HERE',
+                        ],
+                        script: "doc['bar'].value < 10",
+                        lang: 'painless',
+                        position: {
+                          offset: 4,
+                          start: 0,
+                          end: 21,
+                        },
+                        caused_by: {
+                          type: 'illegal_argument_exception',
+                          reason: 'No field found for [bar] in mapping',
+                        },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+            hits: {
+              total: {
+                value: 1,
+                relation: 'eq',
+              },
+              max_score: 0,
+              hits: [
+                {
+                  _index: 'remote:tmp-00001',
+                  _id: 'd8JNlYoBFqAcOBVnvdqx',
+                  _score: 0,
+                  _source: {
+                    foo: 'bar',
+                    bar: 1,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+      expect(isError).toBe(false);
+    });
+
     it('returns `false` if the response is running and partial', () => {
       const isError = isErrorResponse({
         isPartial: true,

--- a/src/plugins/data/common/search/utils.ts
+++ b/src/plugins/data/common/search/utils.ts
@@ -14,7 +14,13 @@ import type { IKibanaSearchResponse } from './types';
  * @returns true if response had an error while executing in ES
  */
 export const isErrorResponse = (response?: IKibanaSearchResponse) => {
-  return !response || !response.rawResponse || (!response.isRunning && !!response.isPartial);
+  return (
+    !response ||
+    !response.rawResponse ||
+    (!response.isRunning &&
+      !!response.isPartial &&
+      !response.rawResponse?.response?._clusters?.details)
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/166528.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
