### PR TITLE
[Search] Unskip flaky test #166484

### DIFF
--- a/test/examples/search/warnings.ts
+++ b/test/examples/search/warnings.ts
@@ -11,7 +11,6 @@ import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import assert from 'assert';
 import type { FtrProviderContext } from '../../functional/ftr_provider_context';
-import type { WebElementWrapper } from '../../functional/services/lib/web_element_wrapper';
 
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
@@ -153,15 +152,14 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('searchSourceWithoutOther');
 
       // wait for toasts - toasts appear after the response is rendered
-      let toasts: WebElementWrapper[] = [];
+      let toastContents: string[] = [];
       await retry.try(async () => {
-        toasts = await find.allByCssSelector(toastsSelector);
+        const toasts = await find.allByCssSelector(toastsSelector);
         expect(toasts.length).to.be(2);
+        toastContents = await Promise.all(toasts.map((t) => t.getVisibleText()));
       });
       const expects = ['The data might be incomplete or wrong.', 'Query result'];
-      await asyncForEach(toasts, async (t, index) => {
-        expect(await t.getVisibleText()).to.eql(expects[index]);
-      });
+      expect(toastContents).to.eql(expects);
 
       // warnings tab
       const warnings = await getTestJson('warningsTab', 'warningsCodeBlock');

--- a/test/examples/search/warnings.ts
+++ b/test/examples/search/warnings.ts
@@ -10,6 +10,7 @@ import type { estypes } from '@elastic/elasticsearch';
 import expect from '@kbn/expect';
 import { asyncForEach } from '@kbn/std';
 import assert from 'assert';
+import type { WebElementWrapper } from '../../functional/services/lib/web_element_wrapper';
 import type { FtrProviderContext } from '../../functional/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
@@ -24,6 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const comboBox = getService('comboBox');
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
 
   describe('handling warnings with search source fetch', function () {
     const dataViewTitle = 'sample-01,sample-01-rollup';
@@ -118,19 +120,19 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
 
       // click "see full error" button in the toast
-      const [openShardModalButton] = await testSubjects.findAll('openIncompleteResultsModalBtn');
+      const [openShardModalButton] = await testSubjects.findAll('viewWarningBtn');
       await openShardModalButton.click();
 
       // request
-      await testSubjects.click('showRequestButton');
-      const requestBlock = await testSubjects.find('incompleteResultsModalRequestBlock');
-      expect(await requestBlock.getVisibleText()).to.contain(testRollupField);
+      await testSubjects.click('inspectorRequestDetailRequest');
+      await testSubjects.click('inspectorRequestCopyClipboardButton');
+      expect(await browser.getClipboardValue()).to.contain(testRollupField);
       // response
-      await testSubjects.click('showResponseButton');
-      const responseBlock = await testSubjects.find('incompleteResultsModalResponseBlock');
-      expect(await responseBlock.getVisibleText()).to.contain(shardFailureReason);
+      await testSubjects.click('inspectorRequestDetailResponse');
+      await testSubjects.click('inspectorRequestCopyClipboardButton');
+      expect(await browser.getClipboardValue()).to.contain(shardFailureReason);
 
-      await testSubjects.click('closeIncompleteResultsModal');
+      await testSubjects.click('euiFlyoutCloseButton');
 
       // response tab
       assert(response && response._shards.failures);
@@ -152,14 +154,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await testSubjects.click('searchSourceWithoutOther');
 
       // wait for toasts - toasts appear after the response is rendered
-      let toastContents: string[] = [];
+      let toasts: WebElementWrapper[] = [];
       await retry.try(async () => {
-        const toasts = await find.allByCssSelector(toastsSelector);
+        toasts = await find.allByCssSelector(toastsSelector);
         expect(toasts.length).to.be(2);
-        toastContents = await Promise.all(toasts.map((t) => t.getVisibleText()));
       });
       const expects = ['The data might be incomplete or wrong.', 'Query result'];
-      expect(toastContents).to.eql(expects);
+      await asyncForEach(toasts, async (t, index) => {
+        expect(await t.getVisibleText()).to.eql(expects[index]);
+      });
 
       // warnings tab
       const warnings = await getTestJson('warningsTab', 'warningsCodeBlock');

--- a/test/examples/search/warnings.ts
+++ b/test/examples/search/warnings.ts
@@ -26,8 +26,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
 
-  // eslint-disable-next-line ban/ban
-  describe.only('handling warnings with search source fetch', function () {
+  describe('handling warnings with search source fetch', function () {
     const dataViewTitle = 'sample-01,sample-01-rollup';
     const fromTime = 'Jun 17, 2022 @ 00:00:00.000';
     const toTime = 'Jun 23, 2022 @ 00:00:00.000';

--- a/test/examples/search/warnings.ts
+++ b/test/examples/search/warnings.ts
@@ -26,8 +26,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
 
-  // Failing: See https://github.com/elastic/kibana/issues/166484
-  describe.skip('handling warnings with search source fetch', function () {
+  // eslint-disable-next-line ban/ban
+  describe.only('handling warnings with search source fetch', function () {
     const dataViewTitle = 'sample-01,sample-01-rollup';
     const fromTime = 'Jun 17, 2022 @ 00:00:00.000';
     const toTime = 'Jun 23, 2022 @ 00:00:00.000';


### PR DESCRIPTION
## Summary

Resolves #166484.

Flaky test runs:
- x50 (`.only`): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3139 🟢
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3152 🔴
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3157 🔴
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3451

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)