### PR TITLE
[8.10] Remove excessively verbose logs (#166525) (#166541)

### DIFF
--- a/packages/core/http/core-http-router-server-internal/src/router.ts
+++ b/packages/core/http/core-http-router-server-internal/src/router.ts
@@ -200,8 +200,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
     try {
       kibanaRequest = CoreKibanaRequest.from(request, routeSchemas);
     } catch (error) {
-      this.log.error(`400 Bad Request - ${request.path}`, {
-        error,
+      this.log.error(`400 Bad Request`, {
         http: { response: { status_code: 400 } },
       });
 
@@ -217,8 +216,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
 
       // forward 401 errors from ES client
       if (isElasticsearchUnauthorizedError(error)) {
-        this.log.error(`401 Unauthorized - ${request.path}`, {
-          error,
+        this.log.error(`401 Unauthorized`, {
           http: { response: { status_code: 401 } },
         });
         return hapiResponseAdapter.handle(
@@ -227,8 +225,7 @@ export class Router<Context extends RequestHandlerContextBase = RequestHandlerCo
       }
 
       // return a generic 500 to avoid error info / stack trace surfacing
-      this.log.error(`500 Server Error - ${request.path}`, {
-        error,
+      this.log.error(`500 Server Error`, {
         http: { response: { status_code: 500 } },
       });
       return hapiResponseAdapter.toInternalError();

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -578,9 +578,8 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
-          "500 Server Error - /",
+          "500 Server Error",
           Object {
-            "error": [Error: unexpected error],
             "http": Object {
               "response": Object {
                 "status_code": 500,
@@ -625,7 +624,7 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
-          "500 Server Error - /",
+          "500 Server Error",
           Object {
             "error": [Error: Unauthorized],
             "http": Object {
@@ -655,7 +654,7 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
-          "500 Server Error - /",
+          "500 Server Error",
           Object {
             "error": [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
             "http": Object {
@@ -700,7 +699,7 @@ describe('Handler', () => {
     expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
       Array [
         Array [
-          "400 Bad Request - /",
+          "400 Bad Request",
           Object {
             "error": [Error: [request query.page]: expected value of type [number] but got [string]],
             "http": Object {
@@ -1185,7 +1184,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: expected 'location' header to be set],
               "http": Object {
@@ -1599,7 +1598,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
               "http": Object {
@@ -1676,7 +1675,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: expected 'location' header to be set],
               "http": Object {
@@ -1824,7 +1823,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: expected error message to be provided],
               "http": Object {
@@ -1858,7 +1857,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: expected error message to be provided],
               "http": Object {
@@ -1891,7 +1890,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: options.statusCode is expected to be set. given options: undefined],
               "http": Object {
@@ -1924,7 +1923,7 @@ describe('Response factory', () => {
       expect(loggingSystemMock.collect(logger).error).toMatchInlineSnapshot(`
         Array [
           Array [
-            "500 Server Error - /",
+            "500 Server Error",
             Object {
               "error": [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
               "http": Object {

--- a/src/core/server/integration_tests/http/router.test.ts
+++ b/src/core/server/integration_tests/http/router.test.ts
@@ -626,7 +626,6 @@ describe('Handler', () => {
         Array [
           "500 Server Error",
           Object {
-            "error": [Error: Unauthorized],
             "http": Object {
               "response": Object {
                 "status_code": 500,
@@ -656,7 +655,6 @@ describe('Handler', () => {
         Array [
           "500 Server Error",
           Object {
-            "error": [Error: Unexpected result from Route Handler. Expected KibanaResponse, but given: string.],
             "http": Object {
               "response": Object {
                 "status_code": 500,
@@ -701,7 +699,6 @@ describe('Handler', () => {
         Array [
           "400 Bad Request",
           Object {
-            "error": [Error: [request query.page]: expected value of type [number] but got [string]],
             "http": Object {
               "response": Object {
                 "status_code": 400,
@@ -1186,7 +1183,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: expected 'location' header to be set],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1600,7 +1596,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: Unexpected Http status code. Expected from 400 to 599, but given: 200],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1677,7 +1672,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: expected 'location' header to be set],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1825,7 +1819,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: expected error message to be provided],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1859,7 +1852,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: expected error message to be provided],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1892,7 +1884,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: options.statusCode is expected to be set. given options: undefined],
               "http": Object {
                 "response": Object {
                   "status_code": 500,
@@ -1925,7 +1916,6 @@ describe('Response factory', () => {
           Array [
             "500 Server Error",
             Object {
-              "error": [Error: Unexpected Http status code. Expected from 100 to 599, but given: 20.],
               "http": Object {
                 "response": Object {
                   "status_code": 500,

--- a/x-pack/plugins/observability/server/services/slo/slo_installer.ts
+++ b/x-pack/plugins/observability/server/services/slo/slo_installer.ts
@@ -34,9 +34,7 @@ export class DefaultSLOInstaller implements SLOInstaller {
       await this.sloResourceInstaller.ensureCommonResourcesInstalled();
       await this.sloSummaryInstaller.installAndStart();
     } catch (error) {
-      this.logger.error('Failed to install SLO common resources and summary transforms', {
-        error,
-      });
+      this.logger.error('Failed to install SLO common resources and summary transforms');
     } finally {
       this.isInstalling = false;
       clearTimeout(installTimeout);


### PR DESCRIPTION
Applies the changes in https://github.com/elastic/kibana/pull/166541 against the 8.10.0 release commit.