### PR TITLE
[8.10] [Discover] Fix ESQL flaky test (#166249)

### DIFF
--- a/test/functional/apps/discover/group2/_sql_view.ts
+++ b/test/functional/apps/discover/group2/_sql_view.ts
@@ -94,6 +94,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
         // here Lens suggests a heatmap so it is rendered
         expect(await testSubjects.exists('unifiedHistogramChart')).to.be(true);
         expect(await testSubjects.exists('heatmapChart')).to.be(true);
@@ -110,6 +111,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await monacoEditor.setCodeEditorValue(testQuery);
         await testSubjects.click('querySubmitButton');
         await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
         let cell = await dataGrid.getCellElement(0, 4);
         expect(await cell.getVisibleText()).to.be('2269');
         await PageObjects.timePicker.setAbsoluteRange(
@@ -117,9 +119,11 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           'Sep 19, 2015 @ 06:31:44.000'
         );
         await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
         expect(await testSubjects.exists('discoverNoResults')).to.be(true);
         await PageObjects.timePicker.setDefaultAbsoluteRange();
         await PageObjects.header.waitUntilLoadingHasFinished();
+        await PageObjects.discover.waitUntilSearchingHasFinished();
         cell = await dataGrid.getCellElement(0, 4);
         expect(await cell.getVisibleText()).to.be('2269');
       });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Discover] Fix ESQL flaky test (#166249)](https://github.com/elastic/kibana/pull/166249)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julia Rechkunova","email":"julia.rechkunova@elastic.co"},"sourceCommit":{"committedDate":"2023-09-18T07:35:12Z","message":"[Discover] Fix ESQL flaky test (#166249)\n\n- Closes https://github.com/elastic/kibana/issues/165860\r\n\r\n100x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3083","sha":"fd604538ca451b470f81f389838592dc8cf1f3ec","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:DataDiscovery","backport:prev-minor","v8.11.0"],"number":166249,"url":"https://github.com/elastic/kibana/pull/166249","mergeCommit":{"message":"[Discover] Fix ESQL flaky test (#166249)\n\n- Closes https://github.com/elastic/kibana/issues/165860\r\n\r\n100x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3083","sha":"fd604538ca451b470f81f389838592dc8cf1f3ec"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166249","number":166249,"mergeCommit":{"message":"[Discover] Fix ESQL flaky test (#166249)\n\n- Closes https://github.com/elastic/kibana/issues/165860\r\n\r\n100x\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3083","sha":"fd604538ca451b470f81f389838592dc8cf1f3ec"}}]}] BACKPORT-->