### PR TITLE
GitHub create-deploy-tag workflow: Misc changes

### DIFF
--- a/.github/workflows/create-deploy-tag.yml
+++ b/.github/workflows/create-deploy-tag.yml
@@ -87,50 +87,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Expected Staging promotion date:"
-                  },
-                  "accessory": {
-                    "type": "datepicker",
-                    "placeholder": {
-                      "type": "plain_text",
-                      "text": "Select a date",
-                      "emoji": true
-                    },
-                    "action_id": "datepicker-action"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Useful links:*\n\n • <https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>\n • <https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|GitHub Workflow run>\n • <https://buildkite.com/elastic/kibana-tests/builds?branch=main|Quality Gate pipeline>\n • <https://argo-workflows.us-central1.gcp.qa.cld.elstc.co/workflows?label=hash%3D${{ env.COMMIT }}|Argo Workflow>\n • <https://platform-logging.kb.us-central1.gcp.foundit.no/app/dashboards#/view/f710d7d0-00b9-11ee-93d2-8df4bca5a4c9?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&service-name=kibana&_a=(controlGroupInput:(chainingSystem:HIERARCHICAL,controlStyle:oneLine,ignoreParentSettings:(ignoreFilters:!f,ignoreQuery:!f,ignoreTimerange:!f,ignoreValidations:!f),panels:('18201b8e-3aae-4459-947d-21e007b6a3a5':(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:commit-hash,id:'18201b8e-3aae-4459-947d-21e007b6a3a5',selectedOptions:!('${{ env.COMMIT }}'),title:commit-hash),grow:!t,order:1,type:optionsListControl,width:medium),'41060e65-ce4c-414e-b8cf-492ccb19245f':(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:service-name,id:'41060e65-ce4c-414e-b8cf-492ccb19245f',selectedOptions:!(kibana),title:service-name),grow:!t,order:0,type:optionsListControl,width:medium),ed96828e-efe9-43ad-be3f-0e04218f79af:(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:to-env,id:ed96828e-efe9-43ad-be3f-0e04218f79af,selectedOptions:!(qa),title:to-env),grow:!t,order:2,type:optionsListControl,width:medium))))|GPCTL Logs dashboard>"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Day 1 to-do list*"
-                  },
-                  "accessory": {
-                    "type": "checkboxes",
-                    "options": [
-                      {
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "Verify successful promotion to QA"
-                        },
-                        "value": "value-0"
-                      },
-                      {
-                        "text": {
-                          "type": "mrkdwn",
-                          "text": "Notify Security Solution team to beging manual testing"
-                        },
-                        "value": "value-1"
-                      }
-                    ],
-                    "action_id": "checkboxes-action"
+                    "text": "${{ join(fromJSON(env.JSON_USEFUL_LINKS_ARRAY), '\n • ') }}"
                   }
                 }
               ]
@@ -138,6 +95,16 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_TAGGER_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JSON_USEFUL_LINKS_ARRAY: |
+            [
+              "*Useful links:*\\n",
+              "<https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>",
+              "<https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|GitHub Workflow run>",
+              "<https://buildkite.com/elastic/kibana-serverless-release/builds?branch=${{ env.TAG_NAME }}|Kibana Serverless Release pipeline>",
+              "<https://argo-workflows.us-central1.gcp.qa.cld.elstc.co/workflows?label=hash%3D${{ env.COMMIT }}|Argo Workflow>",
+              "<https://platform-logging.kb.us-central1.gcp.foundit.no/app/dashboards#/view/f710d7d0-00b9-11ee-93d2-8df4bca5a4c9?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&service-name=kibana&_a=(controlGroupInput:(chainingSystem:HIERARCHICAL,controlStyle:oneLine,ignoreParentSettings:(ignoreFilters:!f,ignoreQuery:!f,ignoreTimerange:!f,ignoreValidations:!f),panels:('18201b8e-3aae-4459-947d-21e007b6a3a5':(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:commit-hash,id:'18201b8e-3aae-4459-947d-21e007b6a3a5',selectedOptions:!('${{ env.COMMIT }}'),title:commit-hash),grow:!t,order:1,type:optionsListControl,width:medium),'41060e65-ce4c-414e-b8cf-492ccb19245f':(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:service-name,id:'41060e65-ce4c-414e-b8cf-492ccb19245f',selectedOptions:!(kibana),title:service-name),grow:!t,order:0,type:optionsListControl,width:medium),ed96828e-efe9-43ad-be3f-0e04218f79af:(explicitInput:(dataViewId:'logs-*',enhancements:(),fieldName:to-env,id:ed96828e-efe9-43ad-be3f-0e04218f79af,selectedOptions:!(qa),title:to-env),grow:!t,order:2,type:optionsListControl,width:medium))))|GPCTL Deployment Status dashboard>",
+              "<https://buildkite.com/elastic/kibana-tests/builds?branch=main|Quality Gate pipeline>"
+            ]
       - name: Post Slack failure message
         if: failure()
         uses: slackapi/slack-github-action@v1.24.0
@@ -169,7 +136,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "*Useful links:*\n\n • <https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>\n • <https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|GitHub Workflow run>"
+                    "text": "${{ join(fromJSON(env.JSON_USEFUL_LINKS_ARRAY), '\n • ') }}"
                   }
                 }
               ]
@@ -177,3 +144,9 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.DEPLOY_TAGGER_SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          JSON_USEFUL_LINKS_ARRAY: |
+            [
+              "*Useful links:*\\n",
+              "<https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>",
+              "<https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|GitHub Workflow run>"
+            ]


### PR DESCRIPTION
This PR changes multiple things in the `create-deploy-tag` workflow:

- Improve maintainability by moving the "useful links" to an array with one item per line
- Add link to Kibana Serverless Release pipeline
- Remove "Day 1 to-do list"
- Remove "Expected staging promotion date" date-picker

## Note to reviewers

I tried several ways to make the list of useful links into an array so that it would be easier to maintain. The approach used in this PR was the only way I could find that worked. You can see the test run here (expand the `Run slackapi/slack-github-action@v1.24.0` line): https://github.com/watson/kibana/actions/runs/6220952029/job/16881998080#step:8:1