### PR TITLE
[APM] Add elastic-api-version header to Kibana API calls

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/client/apm_synthtrace_kibana_client.ts
@@ -69,5 +69,6 @@ function kibanaHeaders() {
     Accept: 'application/json',
     'Content-Type': 'application/json',
     'kbn-xsrf': 'kibana',
+    'elastic-api-version': '2023-10-31',
   };
 }


### PR DESCRIPTION
Versioned APIs in Kibana require an `elastic-api-version` header.

This PR adds the required header to Synthtrace.