### PR TITLE
FTR - Adjust check for successful navigation

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -299,7 +299,7 @@ export class CommonPageObject extends FtrService {
         const navSuccessful = currentUrl
           .replace(':80/', '/')
           .replace(':443/', '/')
-          .startsWith(appUrl);
+          .startsWith(appUrl.replace(':80/', '/').replace(':443/', '/'));
 
         if (!navSuccessful) {
           const msg = `App failed to load: ${appName} in ${this.defaultFindTimeout}ms appUrl=${appUrl} currentUrl=${currentUrl}`;


### PR DESCRIPTION
## Summary

This PR adjusts the FTR check for successful navigation to also take ports on the `appUrl` into account when comparing to `currentUrl` that already had the ports removed for the comparison.
