### PR TITLE
[Fleet] fix force delete package, updated used by agents check

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1231,6 +1231,14 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/kbn_xsrf"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "name": "force",
+            "description": "delete package even if policies used by agents",
+            "in": "query"
           }
         ],
         "requestBody": {
@@ -1238,6 +1246,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "deprecated": true,
                 "properties": {
                   "force": {
                     "type": "boolean"

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -772,11 +772,17 @@ paths:
       operationId: delete-package
       parameters:
         - $ref: '#/components/parameters/kbn_xsrf'
+        - schema:
+            type: boolean
+          name: force
+          description: delete package even if policies used by agents
+          in: query
       requestBody:
         content:
           application/json:
             schema:
               type: object
+              deprecated: true
               properties:
                 force:
                   type: boolean

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@{pkg_version}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@packages@{pkg_name}@{pkg_version}.yaml
@@ -194,11 +194,17 @@ delete:
   operationId: delete-package
   parameters:
     - $ref: ../components/headers/kbn_xsrf.yaml
+    - schema:
+        type: boolean
+      name: force
+      description: delete package even if policies used by agents
+      in: query
   requestBody:
     content:
       application/json:
         schema:
           type: object
+          deprecated: true
           properties:
             force:
               type: boolean

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -540,7 +540,7 @@ export const installPackageByUploadHandler: FleetRequestHandler<
 
 export const deletePackageHandler: FleetRequestHandler<
   TypeOf<typeof DeletePackageRequestSchema.params>,
-  undefined,
+  TypeOf<typeof DeletePackageRequestSchema.query>,
   TypeOf<typeof DeletePackageRequestSchema.body>
 > = async (context, request, response) => {
   try {
@@ -554,7 +554,7 @@ export const deletePackageHandler: FleetRequestHandler<
       pkgName,
       pkgVersion,
       esClient,
-      force: request.body?.force,
+      force: request.query?.force,
     });
     const body: DeletePackageResponse = {
       items: res,

--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.test.ts
@@ -21,7 +21,15 @@ jest.mock('../..', () => {
       }),
     },
     packagePolicyService: {
-      list: jest.fn().mockResolvedValue({ total: 1, items: [{ id: 'system-1' }] }),
+      list: jest.fn().mockImplementation((soClient, params) => {
+        if (params.kuery.includes('system'))
+          return Promise.resolve({ total: 1, items: [{ id: 'system-1', agents: 1 }] });
+        else
+          return Promise.resolve({
+            total: 2,
+            items: [{ id: 'elastic_agent-1' }, { id: 'elastic_agent-2' }],
+          });
+      }),
       delete: jest.fn(),
     },
   };
@@ -70,6 +78,17 @@ describe('removeInstallation', () => {
     ).rejects.toThrowError(
       `unable to remove package with existing package policy(s) in use by agent(s)`
     );
+  });
+
+  it('should remove package policies when not used by agents', async () => {
+    await removeInstallation({
+      savedObjectsClient: soClientMock,
+      pkgName: 'elastic_agent',
+      pkgVersion: '1.0.0',
+      esClient: esClientMock,
+      force: false,
+    });
+    expect(mockPackagePolicyService.delete).toHaveBeenCalledTimes(2);
   });
 
   it('should call audit logger', async () => {

--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.test.ts
@@ -36,6 +36,8 @@ jest.mock('../..', () => {
 });
 jest.mock('../../audit_logging');
 
+jest.mock('../../package_policies/populate_package_policy_assigned_agents_count');
+
 const mockedAuditLoggingService = auditLoggingService as jest.Mocked<typeof auditLoggingService>;
 const mockPackagePolicyService = packagePolicyService as jest.Mocked<typeof packagePolicyService>;
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
@@ -43,6 +43,8 @@ import { removeArchiveEntries } from '../archive/storage';
 
 import { auditLoggingService } from '../../audit_logging';
 
+import { populatePackagePolicyAssignedAgentsCount } from '../../package_policies/populate_package_policy_assigned_agents_count';
+
 import { getInstallation, kibanaSavedObjectTypes } from '.';
 
 export async function removeInstallation(options: {
@@ -59,9 +61,12 @@ export async function removeInstallation(options: {
   const { total, items } = await packagePolicyService.list(savedObjectsClient, {
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${pkgName}`,
     page: 1,
-    perPage: options.force ? SO_SEARCH_LIMIT : 0,
-    withAgentCount: true,
+    perPage: SO_SEARCH_LIMIT,
   });
+
+  if (!options.force) {
+    await populatePackagePolicyAssignedAgentsCount(esClient, items);
+  }
 
   if (total > 0) {
     if (options.force || items.every((item) => (item.agents ?? 0) === 0)) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/remove.ts
@@ -60,16 +60,17 @@ export async function removeInstallation(options: {
     kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.package.name:${pkgName}`,
     page: 1,
     perPage: options.force ? SO_SEARCH_LIMIT : 0,
+    withAgentCount: true,
   });
 
   if (total > 0) {
-    if (options.force) {
+    if (options.force || items.every((item) => (item.agents ?? 0) === 0)) {
       // delete package policies
       const ids = items.map((item) => item.id);
       appContextService
         .getLogger()
         .info(
-          `deleting package policies of ${pkgName} package because force flag was enabled: ${ids}`
+          `deleting package policies of ${pkgName} package because not used by agents or force flag was enabled: ${ids}`
         );
       await packagePolicyService.delete(savedObjectsClient, esClient, ids, {
         force: options.force,

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -218,6 +218,10 @@ export const DeletePackageRequestSchema = {
     pkgName: schema.string(),
     pkgVersion: schema.string(),
   }),
+  query: schema.object({
+    force: schema.maybe(schema.boolean()),
+  }),
+  // body is deprecated on delete request
   body: schema.nullable(
     schema.object({
       force: schema.boolean(),


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/126190

Found that the force flag didn't work when passed in the request body of the DELETE request (the value was undefined), it seems not supported by nodejs.
Changed it to pass the force flag as a query param, left the body as deprecated for BWC.

To test:
- add an agent policy with system integration and enroll an agent
- try to delete the package without force flag: shouldn't be allowed
- try to delete with force flag, should be allowed
- if there are no agents enrolled, the package will be deleted with package policies

```
DELETE kbn:/api/fleet/epm/packages/system/1.38.2?force=true
```


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->