### PR TITLE
[8.10] [Dashboard] Unskips the by value lens tests (#165798)

### DIFF
--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -1368,15 +1368,14 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
       await dashboardAddPanel.clickCreateNewLink();
       await this.goToTimeRange();
       await this.configureDimension({
-        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
-        operation: 'date_histogram',
-        field: '@timestamp',
-      });
-
-      await this.configureDimension({
         dimension: 'lnsXY_yDimensionPanel > lns-empty-dimension',
         operation: 'average',
         field: 'bytes',
+      });
+      await this.configureDimension({
+        dimension: 'lnsXY_xDimensionPanel > lns-empty-dimension',
+        operation: 'date_histogram',
+        field: '@timestamp',
       });
 
       await this.configureDimension({


### PR DESCRIPTION
# Backport

Closes https://github.com/elastic/kibana/issues/165461

This will backport the following commits from `main` to `8.10`:
 - [[Dashboard] Unskips the by value lens tests (#165798)](https://github.com/elastic/kibana/pull/165798)