### PR TITLE
[DOCS] Makes shards optional in Create pack API

### DIFF
--- a/docs/api/osquery-manager/packs/create.asciidoc
+++ b/docs/api/osquery-manager/packs/create.asciidoc
@@ -33,7 +33,7 @@ experimental[] Create packs.
 
 `policy_ids`:: (Optional, array) A list of agents policy IDs.
 
-`shards`:: (Required, object) An object with shard configuration for policies included in the pack. For each policy, set the shard configuration to a percentage (1–100) of target hosts.
+`shards`:: (Optional, object) An object with shard configuration for policies included in the pack. For each policy, set the shard configuration to a percentage (1–100) of target hosts.
 
 `queries`:: (Required, object) An object of queries.
 


### PR DESCRIPTION
## Summary

* Resolves https://github.com/elastic/security-docs/issues/3822.  

* Updates the `shards` object in Create pack API to optional for 8.10.1 and 8.11.0 onwards, per https://github.com/elastic/kibana/pull/166178 

* Related to changes made in https://github.com/elastic/kibana/pull/166363. 





<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->