### PR TITLE
[Dashboard Navigation] Make changes to empty state

### DIFF
--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor.tsx
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor.tsx
@@ -124,13 +124,16 @@ const NavigationEmbeddablePanelEditor = ({
           setOrderedLinks(
             orderedLinks.map((link) => {
               if (link.id === linkToEdit.id) {
-                return { ...newLink, order: linkToEdit.order };
+                return { ...newLink, order: linkToEdit.order } as NavigationEmbeddableLink;
               }
               return link;
             })
           );
         } else {
-          setOrderedLinks([...orderedLinks, { ...newLink, order: orderedLinks.length }]);
+          setOrderedLinks([
+            ...orderedLinks,
+            { ...newLink, order: orderedLinks.length } as NavigationEmbeddableLink,
+          ]);
         }
       }
     },
@@ -166,25 +169,25 @@ const NavigationEmbeddablePanelEditor = ({
       </EuiFlyoutHeader>
       <EuiFlyoutBody>
         <EuiForm fullWidth>
-          {hasZeroLinks ? (
-            <NavigationEmbeddablePanelEditorEmptyPrompt addLink={() => addOrEditLink()} />
-          ) : (
-            <>
-              <EuiFormRow label={NavEmbeddableStrings.editor.panelEditor.getLayoutSettingsTitle()}>
-                <EuiButtonGroup
-                  options={layoutOptions}
-                  buttonSize="compressed"
-                  idSelected={currentLayout}
-                  onChange={(id) => {
-                    setCurrentLayout(id as NavigationLayoutType);
-                  }}
-                  legend={NavEmbeddableStrings.editor.panelEditor.getLayoutSettingsLegend()}
-                />
-              </EuiFormRow>
-              <EuiFormRow label={NavEmbeddableStrings.editor.panelEditor.getLinksTitle()}>
-                {/* Needs to be surrounded by a div rather than a fragment so the EuiFormRow can respond
+          <EuiFormRow label={NavEmbeddableStrings.editor.panelEditor.getLayoutSettingsTitle()}>
+            <EuiButtonGroup
+              options={layoutOptions}
+              buttonSize="compressed"
+              idSelected={currentLayout}
+              onChange={(id) => {
+                setCurrentLayout(id as NavigationLayoutType);
+              }}
+              legend={NavEmbeddableStrings.editor.panelEditor.getLayoutSettingsLegend()}
+            />
+          </EuiFormRow>
+          <EuiFormRow label={NavEmbeddableStrings.editor.panelEditor.getLinksTitle()}>
+            {/* Needs to be surrounded by a div rather than a fragment so the EuiFormRow can respond
                     to the focus of the inner elements */}
-                <div>
+            <div>
+              {hasZeroLinks ? (
+                <NavigationEmbeddablePanelEditorEmptyPrompt addLink={() => addOrEditLink()} />
+              ) : (
+                <>
                   <EuiDragDropContext onDragEnd={onDragEnd}>
                     <EuiDroppable
                       className="navEmbeddableDroppableLinksArea"
@@ -220,10 +223,10 @@ const NavigationEmbeddablePanelEditor = ({
                   >
                     {NavEmbeddableStrings.editor.getAddButtonLabel()}
                   </EuiButtonEmpty>
-                </div>
-              </EuiFormRow>
-            </>
-          )}
+                </>
+              )}
+            </div>
+          </EuiFormRow>
         </EuiForm>
       </EuiFlyoutBody>
       <EuiFlyoutFooter>

--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_empty_prompt.tsx
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_empty_prompt.tsx
@@ -7,47 +7,23 @@
  */
 
 import React from 'react';
-import useObservable from 'react-use/lib/useObservable';
 
-import {
-  EuiText,
-  EuiImage,
-  EuiPanel,
-  EuiSpacer,
-  EuiButton,
-  EuiEmptyPrompt,
-  EuiFormRow,
-} from '@elastic/eui';
+import { EuiText, EuiPanel, EuiSpacer, EuiButton, EuiEmptyPrompt, EuiFormRow } from '@elastic/eui';
 
-import { coreServices } from '../../services/kibana_services';
 import { NavEmbeddableStrings } from '../navigation_embeddable_strings';
-
-import noLinksIllustrationDark from '../../assets/empty_links_dark.svg';
-import noLinksIllustrationLight from '../../assets/empty_links_light.svg';
-
-import './navigation_embeddable_editor.scss';
 
 export const NavigationEmbeddablePanelEditorEmptyPrompt = ({
   addLink,
 }: {
   addLink: () => Promise<void>;
 }) => {
-  const isDarkTheme = useObservable(coreServices.theme.theme$)?.darkMode;
-
   return (
     <EuiFormRow>
       <EuiPanel paddingSize="m" hasBorder={true}>
         <EuiEmptyPrompt
-          paddingSize="none"
-          hasShadow={false}
           color="plain"
-          icon={
-            <EuiImage
-              alt="alt"
-              size="s"
-              src={isDarkTheme ? noLinksIllustrationDark : noLinksIllustrationLight}
-            />
-          }
+          hasShadow={false}
+          paddingSize="none"
           body={
             <>
               <EuiText size="s">

--- a/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_link.tsx
+++ b/src/plugins/navigation_embeddable/public/components/editor/navigation_embeddable_panel_editor_link.tsx
@@ -49,7 +49,7 @@ export const NavigationEmbeddablePanelEditorLink = ({
 
   const { value: linkLabel, loading: linkLabelLoading } = useAsync(async () => {
     if (!link.destination) {
-      setDestinationError(DashboardLinkStrings.getDashboardErrorLabel());
+      setDestinationError(new Error(DashboardLinkStrings.getDashboardErrorLabel()));
       return;
     }
 

--- a/src/plugins/navigation_embeddable/public/components/navigation_embeddable_strings.ts
+++ b/src/plugins/navigation_embeddable/public/components/navigation_embeddable_strings.ts
@@ -9,6 +9,10 @@
 import { i18n } from '@kbn/i18n';
 
 export const NavEmbeddableStrings = {
+  getDescription: () =>
+    i18n.translate('navigationEmbeddable.description', {
+      defaultMessage: 'Use links to navigate to commonly used dashboards and websites.',
+    }),
   editor: {
     getAddButtonLabel: () =>
       i18n.translate('navigationEmbeddable.editor.addButtonLabel', {
@@ -37,7 +41,7 @@ export const NavEmbeddableStrings = {
         }),
       getEmptyLinksMessage: () =>
         i18n.translate('navigationEmbeddable.panelEditor.emptyLinksMessage', {
-          defaultMessage: 'Use links to navigate to commonly used dashboards and websites.',
+          defaultMessage: "You haven't added any links yet.",
         }),
       getEmptyLinksTooltip: () =>
         i18n.translate('navigationEmbeddable.panelEditor.emptyLinksTooltip', {

--- a/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_factory.ts
+++ b/src/plugins/navigation_embeddable/public/embeddable/navigation_embeddable_factory.ts
@@ -23,17 +23,17 @@ import {
 import { UiActionsPresentableGrouping } from '@kbn/ui-actions-plugin/public';
 import { DASHBOARD_GRID_COLUMN_COUNT } from '@kbn/dashboard-plugin/public';
 import {
+  NavigationEmbeddableInput,
   NavigationEmbeddableByReferenceInput,
   NavigationEmbeddableEditorFlyoutReturn,
-  NavigationEmbeddableInput,
 } from './types';
+import { extract, inject } from '../../common/embeddable';
 import { APP_ICON, APP_NAME, CONTENT_ID } from '../../common';
 import type { NavigationEmbeddable } from './navigation_embeddable';
+import { NavigationEmbeddableAttributes } from '../../common/content_management';
+import { NavEmbeddableStrings } from '../components/navigation_embeddable_strings';
 import { getNavigationEmbeddableAttributeService } from '../services/attribute_service';
 import { coreServices, untilPluginStartServicesReady } from '../services/kibana_services';
-import { extract, inject } from '../../common/embeddable';
-
-import { NavigationEmbeddableAttributes } from '../../common/content_management';
 
 export type NavigationEmbeddableFactory = EmbeddableFactory;
 
@@ -156,6 +156,10 @@ export class NavigationEmbeddableFactoryDefinition
 
   public getIconType() {
     return 'link';
+  }
+
+  public getDescription() {
+    return NavEmbeddableStrings.getDescription();
   }
 
   inject = inject;


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/165416

## Summary

This PR makes two changes to the empty state of the link creation flyout:
1. It moves the layout options to the top of the flyout **regardless** of if there are links or not - we are hoping that this will aid in the discoverability of this feature, which we found to be a problem in user testing.
2. Based on @andreadelrio's feedback in the attached issue, I decided to move the original empty state text into the embeddable's **description** instead (which means this text will show up as a tooltip in the `Add panel` popover) and simplified the text in the empty state.

| Before | After |
|--------|--------|
| Hovering the `Links` option did not show any sort of description previously: <br><br> ![image](https://github.com/elastic/kibana/assets/8698078/577621f4-0d13-450f-87df-541440cdaf3d) | Now, the user is given some context for what the Links panel does when hovering: <br><br>  ![image](https://github.com/elastic/kibana/assets/8698078/d2ae614b-70fa-44d7-a3dc-bcf061182273) |
| The layout options were not shown and the empty prompt had a larger footprint:<br><br>![image](https://github.com/elastic/kibana/assets/8698078/7ca466ec-f0d0-4f58-8b2d-5bfecc5a3fbf) | The layout options now show in the empty state, and I simplified the empty prompt:<br><br>![image](https://github.com/elastic/kibana/assets/8698078/cf3f0507-f347-4902-83c4-831e72287132) | 

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
