### PR TITLE
[Security Solution] Add missing version headers for Fleet test utility functions

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/fleet.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/fleet.ts
@@ -25,13 +25,21 @@ const deleteAgentPolicies = () => {
   return rootRequest<{ items: Array<{ id: string }> }>({
     method: 'GET',
     url: 'api/fleet/agent_policies',
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
   }).then((response) => {
     response.body.items.forEach((item: { id: string }) => {
       rootRequest({
         method: 'POST',
         url: `api/fleet/agent_policies/delete`,
-        headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+        headers: {
+          'kbn-xsrf': 'cypress-creds',
+          'x-elastic-internal-origin': 'security-solution',
+          'elastic-api-version': '2023-10-31',
+        },
         body: {
           agentPolicyId: item.id,
         },
@@ -44,12 +52,20 @@ const deletePackagePolicies = () => {
   return rootRequest<{ items: Array<{ id: string }> }>({
     method: 'GET',
     url: 'api/fleet/package_policies',
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
   }).then((response) => {
     rootRequest({
       method: 'POST',
       url: `api/fleet/package_policies/delete`,
-      headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+      headers: {
+        'kbn-xsrf': 'cypress-creds',
+        'x-elastic-internal-origin': 'security-solution',
+        'elastic-api-version': '2023-10-31',
+      },
       body: {
         packagePolicyIds: response.body.items.map((item: { id: string }) => item.id),
       },
@@ -61,7 +77,11 @@ const deletePackages = () => {
   return rootRequest<{ items: Array<{ status: string; name: string; version: string }> }>({
     method: 'GET',
     url: 'api/fleet/epm/packages',
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
   }).then((response) => {
     response.body.items.forEach((item) => {
       if (item.status === 'installed') {
@@ -71,6 +91,7 @@ const deletePackages = () => {
           headers: {
             'kbn-xsrf': 'cypress-creds',
             'x-elastic-internal-origin': 'security-solution',
+            'elastic-api-version': '2023-10-31',
           },
         });
       }


### PR DESCRIPTION
## Summary

This PR adds missing version header for Fleet test utility functions. Tests work normally in CI without explicitly specified version headers but fail locally making running and debugging tests impossible.

