### PR TITLE
[FullStory] Add projectId to the context

### DIFF
--- a/packages/analytics/shippers/fullstory/src/fullstory_shipper.ts
+++ b/packages/analytics/shippers/fullstory/src/fullstory_shipper.ts
@@ -32,6 +32,7 @@ const PAGE_VARS_KEYS = [
   'buildNum', // May be useful for Serverless
   'cloudId',
   'deploymentId',
+  'projectId', // projectId and deploymentId are mutually exclusive. They shouldn't be sent in the same offering.
   'cluster_name',
   'cluster_uuid',
   'cluster_version',


### PR DESCRIPTION
## Summary

Follow up to https://github.com/elastic/kibana/pull/166527. It exposes the contextual EBT field `projectId` to FullStory as well.

EBT context fields follow an opt-in mechanism when sharing them to FullStory because it has a short limit in the number of fields we can provide to the `setVars` calls. This addition shouldn't increase the count because `deploymentId` (already present) is not present in Serverless projects, and the opposite applies to ESS deployments.

cc @shahinakmal 

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
