### PR TITLE
[Security Solution] expandable flyout - fix prevalence details not working when streaming mode

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/fetch_data.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/fetch_data.ts
@@ -15,10 +15,14 @@ export const createFetchData = async <TResponse, T = {}>(
   searchService: ISearchStart,
   req: IEsSearchRequest
 ): Promise<TResponse> => {
+  let rawResponse: TResponse;
   return new Promise((resolve, reject) => {
     searchService.search<IEsSearchRequest, IKibanaSearchResponse<TResponse>>(req).subscribe({
       next: (response) => {
-        resolve(response.rawResponse);
+        rawResponse = response.rawResponse;
+      },
+      complete: () => {
+        resolve(rawResponse);
       },
       error: (error) => {
         reject(error);


### PR DESCRIPTION
## Summary

This PR fixes a bug with the way the Security Solution expandable flyout fetches prevalence data. Both the right panel prevalence overview and left panel prevalence details components use the same hook, which fetches the data using ReactQuery. When the call takes a bit of time and the frontend makes multiple queries, the data wasn't being shown on the UI at all.

This PR makes sure that the fetch logic waits for the call to complete before sending data to ReactQuery then to the UI.

### How to reproduce the bug

- add `data.search.aggs.shardDelay.enabled: true` to `kibana.yml` file
- add `delay: { shard_delay: { value: '5s' } },` to the `use_fetch_prevalence.ts` file, inside the top level `aggs` property (right [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_prevalence.ts#L174))

The code above adds a delay to the call, which mimics the behavior we're seeing on siem.dev.

#### Calls that terminate without multiple requests

Before

https://github.com/elastic/kibana/assets/17276605/9fd6aa40-9874-40a1-8f11-ddac43fb33c5

After

https://github.com/elastic/kibana/assets/17276605/62ed28ff-f105-4b1d-a270-c7e9b335da62

#### Calls that terminate at the end of multiple requests

Before

https://github.com/elastic/kibana/assets/17276605/b7a34de0-b2b3-42ca-87c7-43c571822bb7

After

https://github.com/elastic/kibana/assets/17276605/2ece6139-9872-4aa0-8172-56cade08a378

https://github.com/elastic/kibana/issues/166194


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->