### PR TITLE
[Fleet] Make integrations sidebar sticky again

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/components/package_list_grid/index.tsx
@@ -8,6 +8,7 @@
 import type { ReactNode, FunctionComponent } from 'react';
 import { useMemo } from 'react';
 import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
 
 import {
   EuiFlexGroup,
@@ -41,6 +42,11 @@ import { ControlsColumn } from './controls';
 import { GridColumn } from './grid';
 import { MissingIntegrationContent } from './missing_integrations';
 import { SearchBox } from './search_box';
+
+const StickySidebar = styled(EuiFlexItem)`
+  position: sticky;
+  top: 120px;
+`;
 
 export interface Props {
   isLoading?: boolean;
@@ -168,9 +174,9 @@ export const PackageListGrid: FunctionComponent<Props> = ({
       gutterSize="xl"
       data-test-subj="epmList.integrationCards"
     >
-      <EuiFlexItem data-test-subj="epmList.controlsSideColumn" grow={1}>
+      <StickySidebar data-test-subj="epmList.controlsSideColumn" grow={1}>
         <ControlsColumn controls={controls} title={title} />
-      </EuiFlexItem>
+      </StickySidebar>
       <EuiFlexItem grow={5} data-test-subj="epmList.mainColumn" style={{ alignSelf: 'stretch' }}>
         <EuiFlexItem grow={false}>
           <SearchBox


### PR DESCRIPTION
## Summary
[Latest upgrade of EUI](https://github.com/elastic/kibana/pull/165790) removed the `isSticky` property that we were using in Integrations sidebar. 

This PR is adding it back with some css properties.

https://github.com/elastic/kibana/assets/16084106/ffe0e1ed-cf70-45b7-8d8d-cb0c5f53e843


