### PR TITLE
[Fleet] Fix agent upgrade version being lowercased

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/components/agent_upgrade_modal/index.tsx
@@ -257,7 +257,7 @@ export const AgentUpgradeAgentModal: React.FunctionComponent<AgentUpgradeAgentMo
   }
 
   const onCreateOption = (searchValue: string) => {
-    const normalizedSearchValue = searchValue.trim().toLowerCase();
+    const normalizedSearchValue = searchValue.trim();
 
     const newOption = {
       label: normalizedSearchValue,


### PR DESCRIPTION
## Summary

The UI was unecessarily lowercasing the agent upgrade version before sending it to the server.

Closes #166685 

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->