### PR TITLE
[Security Solution] expandable flyout - prevalence details datepicker displayed in full width

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
@@ -363,6 +363,7 @@ export const PrevalenceDetails: React.FC = () => {
           end={end}
           onTimeChange={onTimeChange}
           data-test-subj={PREVALENCE_DETAILS_DATE_PICKER_TEST_ID}
+          width="full"
         />
         <EuiSpacer size="m" />
         {data.length > 0 ? (


### PR DESCRIPTION
## Summary

This PR makes a tiny change to the Security Solution expandable flyout left panel prevalence details date picker to make it displayed in full width, identical to the table below it.

| Befire  | After |
| ------------- | ------------- |
| <img width="792" alt="Screenshot 2023-09-19 at 2 12 04 PM" src="https://github.com/elastic/kibana/assets/17276605/48b66a9f-f3c1-43f6-99ef-3183c4ec402e">  | <img width="786" alt="Screenshot 2023-09-19 at 2 21 07 PM" src="https://github.com/elastic/kibana/assets/17276605/6993f555-f088-44f2-a480-48d21b5bbebb">  |

https://github.com/elastic/security-team/issues/7668