### PR TITLE
[Flaky test] Add missing `await` in infrastructure_security test suite

### DIFF
--- a/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
+++ b/x-pack/test/functional/apps/infra/feature_controls/infrastructure_security.ts
@@ -372,7 +372,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           ensureCurrentUrl: false,
           shouldLoginIfPrompted: false,
         });
-        PageObjects.error.expectForbidden();
+        await PageObjects.error.expectForbidden();
       });
     });
   });


### PR DESCRIPTION
Fixes #164250 

[Successful pipeline in the flaky test runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3191).

@crespocarlos spotted the missing `await` that might cause the `infrastructure_security` suite to still be running along `infrastructure_spaces` and cause race conditions.