### PR TITLE
[Fleet] Enable using agent providers in namespace field

### DIFF
--- a/x-pack/plugins/fleet/common/services/is_valid_namespace.ts
+++ b/x-pack/plugins/fleet/common/services/is_valid_namespace.ts
@@ -20,7 +20,7 @@ export function isValidNamespace(namespace: string): { valid: boolean; error?: s
       }),
     };
   }
-  
+
   // Strip out variables that will be replaced by Agent and check if the result is valid
   const strippedNamespace = namespace.replace(/\$\{.+\}/g, '');
 

--- a/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/package_policies_to_agent_permissions.ts
@@ -171,6 +171,8 @@ export interface DataStreamMeta {
   };
 }
 
+const PROVIDER_REGEX = /\$\{.+\}/;
+
 export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: string = '*') {
   let index = dataStream.hidden ? `.${dataStream.type}-` : `${dataStream.type}-`;
 
@@ -184,7 +186,7 @@ export function getDataStreamPrivileges(dataStream: DataStreamMeta, namespace: s
   }
 
   // Determine namespace
-  if (dataStream.elasticsearch?.dynamic_namespace) {
+  if (PROVIDER_REGEX.test(namespace) || dataStream.elasticsearch?.dynamic_namespace) {
     index += `-*`;
   } else {
     index += `-${namespace}`;


### PR DESCRIPTION
## Summary

In https://github.com/elastic/kibana/issues/134971 we added package-level support for specifying a dynamic or wildcard data stream namespace. This allowed any agent running an integration that leverages this feature to get a wildcard in the namespace piece of index privileges for that package. This is only available as an option at package-development time and cannot be leveraged for an arbitrary integration policy by an end user.

Another use case is being able to use Elastic Agent's [built-in providers](https://www.elastic.co/guide/en/fleet/current/providers.html) to specify the destination index and the `data_stream.namespace` field. For example, a user may want to split the data by `${env.APP_NAME}`, `${host.platform}`, or `${kubernetes.cluster.name}`. This is what this PR adds support for by updating the API privileges to support a wildcard namespace.

State of this PR has it working for integration data, but it currently fails if used on the agent policy level due to what I _think_ is Agent not supporting providers on the `agent.monitoring` block of the policy. This is the error that is shown in the Agent logs:

```
Failed to dispatch action 'action_id: policy:21b07d40-56e8-11ee-aea9-77662636bf77:12:1, type: POLICY_CHANGE', error: could not convert the configuration from the policy: missing field accessing 'agent'
```

<img width="885" alt="image" src="https://github.com/elastic/kibana/assets/1813008/7941cc2f-9ce4-43d4-8fdf-1f4a39bd6dfa">

Privileges in the policy:

<img width="359" alt="image" src="https://github.com/elastic/kibana/assets/1813008/25d62bd4-f256-4d3b-b23b-6228bbcadf16">

I ran Agent with `APP_NAME=foo` env var and now see this data in Discover:

<img width="692" alt="image" src="https://github.com/elastic/kibana/assets/1813008/306bf96f-60ad-42a0-817b-d96841aef53b">


### TODOs
- [ ] Fix the monitoring issue in Agent
- [ ] Add warning to the UI that this enables broader API privileges?
- [ ] Prevent user from using a var with high cardinality - it will cause way too many data streams + shards to be created in Elasticsearch
    - [ ] Add warning to UI?
    - [ ] Restrict to an allowlist of supported providers/vars - eg. `env.*`, `host.platform`, `kubernetes.namespace.name`?

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
