### PR TITLE
[8.10] [Security Solution] Fix tab navigation scrolling to top (#166655)

### DIFF
--- a/x-pack/packages/security-solution/navigation/src/navigation.test.ts
+++ b/x-pack/packages/security-solution/navigation/src/navigation.test.ts
@@ -7,6 +7,7 @@
 import { useGetAppUrl, useNavigateTo } from './navigation';
 import { mockGetUrlForApp, mockNavigateToApp, mockNavigateToUrl } from '../mocks/context';
 import { renderHook } from '@testing-library/react-hooks';
+import { fireEvent } from '@testing-library/dom';
 
 jest.mock('./context');
 
@@ -60,6 +61,23 @@ describe('yourFile', () => {
       // Verify dependencies were called with correct parameters
       expect(mockNavigateToApp).not.toHaveBeenCalled();
       expect(mockNavigateToUrl).toHaveBeenCalledWith(URL);
+    });
+
+    it('navigates restoring the scroll', async () => {
+      const { result } = renderHook(useNavigateTo);
+      const { navigateTo } = result.current;
+
+      const currentScrollY = 100;
+      window.scrollY = currentScrollY;
+      window.scrollTo = jest.fn();
+
+      navigateTo({ url: URL, restoreScroll: true });
+
+      // Simulates the browser scroll reset event
+      fireEvent(window, new Event('scroll'));
+
+      expect(window.scrollTo).toHaveBeenCalledTimes(1);
+      expect(window.scrollTo).toHaveBeenCalledWith(0, currentScrollY);
     });
   });
 });

--- a/x-pack/packages/security-solution/navigation/src/navigation.ts
+++ b/x-pack/packages/security-solution/navigation/src/navigation.ts
@@ -34,6 +34,11 @@ export type NavigateTo = (
   param: {
     url?: string;
     appId?: string;
+    /**
+     * Browsers will reset the scroll position to 0 when navigating to a new page.
+     * This option will prevent that from happening.
+     */
+    restoreScroll?: boolean;
   } & NavigateToAppOptions
 ) => void;
 /**
@@ -44,7 +49,10 @@ export const useNavigateTo = () => {
   const { navigateToApp, navigateToUrl } = useNavigationContext().application;
 
   const navigateTo = useCallback<NavigateTo>(
-    ({ url, appId = SECURITY_UI_APP_ID, ...options }) => {
+    ({ url, appId = SECURITY_UI_APP_ID, restoreScroll, ...options }) => {
+      if (restoreScroll) {
+        addScrollRestoration();
+      }
       if (url) {
         navigateToUrl(url);
       } else {
@@ -54,6 +62,16 @@ export const useNavigateTo = () => {
     [navigateToApp, navigateToUrl]
   );
   return { navigateTo };
+};
+
+/**
+ * Expects the browser scroll reset event to be fired after the navigation,
+ * then restores the previous scroll position.
+ */
+const addScrollRestoration = () => {
+  const scrollY = window.scrollY;
+  const handler = () => window.scrollTo(0, scrollY);
+  window.addEventListener('scroll', handler, { once: true });
 };
 
 /**

--- a/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/tab_navigation.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/navigation/tab_navigation/tab_navigation.tsx
@@ -31,7 +31,7 @@ const TabNavigationItemComponent = ({
   const handleClick = useCallback(
     (ev) => {
       ev.preventDefault();
-      navigateTo({ path: hrefWithSearch });
+      navigateTo({ path: hrefWithSearch, restoreScroll: true });
       track(METRIC_TYPE.CLICK, `${TELEMETRY_EVENT.TAB_CLICKED}${id}`);
     },
     [navigateTo, hrefWithSearch, id]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Security Solution] Fix tab navigation scrolling to top (#166655)](https://github.com/elastic/kibana/pull/166655)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sergi Massaneda","email":"sergi.massaneda@elastic.co"},"sourceCommit":{"committedDate":"2023-09-19T09:32:30Z","message":"[Security Solution] Fix tab navigation scrolling to top (#166655)\n\n## Summary\r\n\r\nissue: https://github.com/elastic/kibana/issues/163606\r\n\r\nFixes the bug on the Security tab navigation component scrolling to the\r\ntop of the page when clicked.\r\n\r\n### Problem\r\n\r\nAs described in the React Router\r\n[docs](https://v5.reactrouter.com/web/guides/scroll-restoration), all\r\nbrowsers introduced scroll reset in the `history.pushState` API\r\n([spec](https://majido.github.io/scroll-restoration-proposal/history-based-api.html#web-idl)),\r\nwhich is the expected behavior on most of the regular navigation\r\nactions, however in some cases such as the tabs navigation we don't want\r\nthe scrolling to be reset to the top after pushing the URL.\r\n\r\nThe spec also defines the `window.history.scrollRestoration` API to\r\nconfigure this behavior ('manual' or 'auto'), but it does not work\r\ncorrectly when using `react-route-dom` history object to navigate.\r\n\r\nReact Router v5 also provides a `ScrollRestoration` component to solve\r\nthis problem, but it only works with _\"data router\"_ type, we use\r\n_\"browser router\"_ in Kibana, which is not supported by this tool.\r\n\r\nThere are other libraries that also solve this problem, implementing a\r\nvery similar approach, such as\r\n[react-scroll-restoration](https://github.com/nanyang24/react-scroll-restoration).\r\n\r\n### Solution\r\n\r\nInstead of loading new external modules, I implemented the same approach\r\nintegrating it into our Security navigation tools:\r\nThe `navigateTo` function now accepts a new `restoreScroll` option prop,\r\nwhen set to `true` it will prevent the scroll reset after navigating by\r\nrestoring the previous scroll position when it receives the event\r\ntriggered by the Browser.\r\n\r\nIn the case of using an old browser version that does not trigger the\r\nscroll reset after the navigation, this change will have no implication\r\nother than losing the first scroll event after the navigation, this will\r\nbe very hard to notice since many events are sent when a user scrolls\r\nmanually.\r\n\r\n## Recordings\r\n\r\nBefore:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/464f708a-f373-47b9-9826-a5cfa7473f5b\r\n\r\nAfter:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/46d99b12-69e8-410a-a700-ca9ef7f5c2a4\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"f8927dd1fe45448f0e3e4bdfdbdc6c5009a5b614","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:Threat Hunting","Team:Threat Hunting:Explore","v8.10.0","v8.11.0"],"number":166655,"url":"https://github.com/elastic/kibana/pull/166655","mergeCommit":{"message":"[Security Solution] Fix tab navigation scrolling to top (#166655)\n\n## Summary\r\n\r\nissue: https://github.com/elastic/kibana/issues/163606\r\n\r\nFixes the bug on the Security tab navigation component scrolling to the\r\ntop of the page when clicked.\r\n\r\n### Problem\r\n\r\nAs described in the React Router\r\n[docs](https://v5.reactrouter.com/web/guides/scroll-restoration), all\r\nbrowsers introduced scroll reset in the `history.pushState` API\r\n([spec](https://majido.github.io/scroll-restoration-proposal/history-based-api.html#web-idl)),\r\nwhich is the expected behavior on most of the regular navigation\r\nactions, however in some cases such as the tabs navigation we don't want\r\nthe scrolling to be reset to the top after pushing the URL.\r\n\r\nThe spec also defines the `window.history.scrollRestoration` API to\r\nconfigure this behavior ('manual' or 'auto'), but it does not work\r\ncorrectly when using `react-route-dom` history object to navigate.\r\n\r\nReact Router v5 also provides a `ScrollRestoration` component to solve\r\nthis problem, but it only works with _\"data router\"_ type, we use\r\n_\"browser router\"_ in Kibana, which is not supported by this tool.\r\n\r\nThere are other libraries that also solve this problem, implementing a\r\nvery similar approach, such as\r\n[react-scroll-restoration](https://github.com/nanyang24/react-scroll-restoration).\r\n\r\n### Solution\r\n\r\nInstead of loading new external modules, I implemented the same approach\r\nintegrating it into our Security navigation tools:\r\nThe `navigateTo` function now accepts a new `restoreScroll` option prop,\r\nwhen set to `true` it will prevent the scroll reset after navigating by\r\nrestoring the previous scroll position when it receives the event\r\ntriggered by the Browser.\r\n\r\nIn the case of using an old browser version that does not trigger the\r\nscroll reset after the navigation, this change will have no implication\r\nother than losing the first scroll event after the navigation, this will\r\nbe very hard to notice since many events are sent when a user scrolls\r\nmanually.\r\n\r\n## Recordings\r\n\r\nBefore:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/464f708a-f373-47b9-9826-a5cfa7473f5b\r\n\r\nAfter:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/46d99b12-69e8-410a-a700-ca9ef7f5c2a4\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"f8927dd1fe45448f0e3e4bdfdbdc6c5009a5b614"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166655","number":166655,"mergeCommit":{"message":"[Security Solution] Fix tab navigation scrolling to top (#166655)\n\n## Summary\r\n\r\nissue: https://github.com/elastic/kibana/issues/163606\r\n\r\nFixes the bug on the Security tab navigation component scrolling to the\r\ntop of the page when clicked.\r\n\r\n### Problem\r\n\r\nAs described in the React Router\r\n[docs](https://v5.reactrouter.com/web/guides/scroll-restoration), all\r\nbrowsers introduced scroll reset in the `history.pushState` API\r\n([spec](https://majido.github.io/scroll-restoration-proposal/history-based-api.html#web-idl)),\r\nwhich is the expected behavior on most of the regular navigation\r\nactions, however in some cases such as the tabs navigation we don't want\r\nthe scrolling to be reset to the top after pushing the URL.\r\n\r\nThe spec also defines the `window.history.scrollRestoration` API to\r\nconfigure this behavior ('manual' or 'auto'), but it does not work\r\ncorrectly when using `react-route-dom` history object to navigate.\r\n\r\nReact Router v5 also provides a `ScrollRestoration` component to solve\r\nthis problem, but it only works with _\"data router\"_ type, we use\r\n_\"browser router\"_ in Kibana, which is not supported by this tool.\r\n\r\nThere are other libraries that also solve this problem, implementing a\r\nvery similar approach, such as\r\n[react-scroll-restoration](https://github.com/nanyang24/react-scroll-restoration).\r\n\r\n### Solution\r\n\r\nInstead of loading new external modules, I implemented the same approach\r\nintegrating it into our Security navigation tools:\r\nThe `navigateTo` function now accepts a new `restoreScroll` option prop,\r\nwhen set to `true` it will prevent the scroll reset after navigating by\r\nrestoring the previous scroll position when it receives the event\r\ntriggered by the Browser.\r\n\r\nIn the case of using an old browser version that does not trigger the\r\nscroll reset after the navigation, this change will have no implication\r\nother than losing the first scroll event after the navigation, this will\r\nbe very hard to notice since many events are sent when a user scrolls\r\nmanually.\r\n\r\n## Recordings\r\n\r\nBefore:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/464f708a-f373-47b9-9826-a5cfa7473f5b\r\n\r\nAfter:\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/17747913/46d99b12-69e8-410a-a700-ca9ef7f5c2a4\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"f8927dd1fe45448f0e3e4bdfdbdc6c5009a5b614"}}]}] BACKPORT-->