### PR TITLE
[Fleet] Support registry filtering with spec.min and spec.max

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -27,7 +27,11 @@ xpack.fleet.agentIdVerificationEnabled: false
 xpack.apm.serverlessOnboarding: true
 
 # Fleet specific configuration
-xpack.fleet.internal.capabilities: ['apm', 'observability']
+xpack.fleet.internal.registry.capabilities: ['apm', 'observability']
+xpack.fleet.internal.registry.spec.max: '3.0.0'
+# Disabled until packages implement the new spec TODO github issue
+# xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
+# xpack.fleet.internal.registry.spec.min: '3.0.0'
 
 ## Required for force installation of APM Package
 xpack.fleet.packages:

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -28,10 +28,10 @@ xpack.apm.serverlessOnboarding: true
 
 # Fleet specific configuration
 xpack.fleet.internal.registry.capabilities: ['apm', 'observability']
-xpack.fleet.internal.registry.spec.max: '3.0.0'
+xpack.fleet.internal.registry.spec.max: '3.0'
 # Disabled until packages implement the new spec https://github.com/elastic/kibana/issues/166742
 # xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
-# xpack.fleet.internal.registry.spec.min: '3.0.0'
+# xpack.fleet.internal.registry.spec.min: '3.0'
 
 ## Required for force installation of APM Package
 xpack.fleet.packages:

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -29,7 +29,7 @@ xpack.apm.serverlessOnboarding: true
 # Fleet specific configuration
 xpack.fleet.internal.registry.capabilities: ['apm', 'observability']
 xpack.fleet.internal.registry.spec.max: '3.0.0'
-# Disabled until packages implement the new spec TODO github issue
+# Disabled until packages implement the new spec https://github.com/elastic/kibana/issues/166742
 # xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 # xpack.fleet.internal.registry.spec.min: '3.0.0'
 

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -27,10 +27,10 @@ telemetry.labels.serverless: security
 
 # Fleet specific configuration
 xpack.fleet.internal.registry.capabilities: ['security']
-xpack.fleet.internal.registry.spec.max: '3.0.0'
+xpack.fleet.internal.registry.spec.max: '3.0'
 # Disabled until packages implement the new spec https://github.com/elastic/kibana/issues/166742
 # xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
-# xpack.fleet.internal.registry.spec.min: '3.0.0'
+# xpack.fleet.internal.registry.spec.min: '3.0'
 
 # Serverless security specific options
 xpack.securitySolution.enableExperimental:

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -26,7 +26,11 @@ xpack.serverless.plugin.developer.projectSwitcher.currentType: 'security'
 telemetry.labels.serverless: security
 
 # Fleet specific configuration
-xpack.fleet.internal.capabilities: ['security']
+xpack.fleet.internal.registry.capabilities: ['security']
+xpack.fleet.internal.registry.spec.max: '3.0.0'
+# Disabled until packages implement the new spec TODO github issue
+# xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
+# xpack.fleet.internal.registry.spec.min: '3.0.0'
 
 # Serverless security specific options
 xpack.securitySolution.enableExperimental:

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -28,7 +28,7 @@ telemetry.labels.serverless: security
 # Fleet specific configuration
 xpack.fleet.internal.registry.capabilities: ['security']
 xpack.fleet.internal.registry.spec.max: '3.0.0'
-# Disabled until packages implement the new spec TODO github issue
+# Disabled until packages implement the new spec https://github.com/elastic/kibana/issues/166742
 # xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 # xpack.fleet.internal.registry.spec.min: '3.0.0'
 

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -9,7 +9,7 @@ xpack.fleet.internal.activeAgentsSoftLimit: 25000
 xpack.fleet.internal.onlyAllowAgentUpgradeToKnownVersions: true
 
 # Cloud links
-xpack.cloud.base_url: "https://cloud.elastic.co"
+xpack.cloud.base_url: 'https://cloud.elastic.co'
 
 # Enable ZDT migration algorithm
 migrations.algorithm: zdt
@@ -86,7 +86,7 @@ xpack.spaces.allowFeatureVisibility: false
 console.autocompleteDefinitions.endpointsAvailability: serverless
 
 # Allow authentication via the Elasticsearch JWT realm with the `shared_secret` client authentication type.
-elasticsearch.requestHeadersWhitelist: ["authorization", "es-client-authentication"]
+elasticsearch.requestHeadersWhitelist: ['authorization', 'es-client-authentication']
 
 # Limit maxSockets to 800 as we do in ESS, which improves reliability under high loads.
 elasticsearch.maxSockets: 800

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -51,7 +51,14 @@ export interface FleetConfigType {
     fleetServerStandalone: boolean;
     onlyAllowAgentUpgradeToKnownVersions: boolean;
     activeAgentsSoftLimit?: number;
-    capabilities: string[];
+    registry: {
+      kibanaVersionCheckEnabled: boolean;
+      capabilities: string[];
+      spec?: {
+        min?: string;
+        max?: string;
+      };
+    };
   };
   createArtifactsBulkBatchSize?: number;
 }

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -29,6 +29,8 @@ import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts'
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
+const REGISTRY_SPEC_MAX_VERSION = '3.0.0';
+
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {
     epm: true,
@@ -185,17 +187,42 @@ export const config: PluginConfigDescriptor = {
             min: 0,
           })
         ),
-        capabilities: schema.arrayOf(
-          schema.oneOf([
-            // See package-spec for the list of available capiblities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
-            schema.literal('apm'),
-            schema.literal('enterprise_search'),
-            schema.literal('observability'),
-            schema.literal('security'),
-            schema.literal('serverless_search'),
-            schema.literal('uptime'),
-          ]),
-          { defaultValue: [] }
+        registry: schema.object(
+          {
+            kibanaVersionCheckEnabled: schema.boolean({ defaultValue: true }),
+            spec: schema.object(
+              {
+                min: schema.maybe(schema.string()),
+                max: schema.string({ defaultValue: REGISTRY_SPEC_MAX_VERSION }),
+              },
+              {
+                defaultValue: {
+                  max: REGISTRY_SPEC_MAX_VERSION,
+                },
+              }
+            ),
+            capabilities: schema.arrayOf(
+              schema.oneOf([
+                // See package-spec for the list of available capiblities https://github.com/elastic/package-spec/blob/dcc37b652690f8a2bca9cf8a12fc28fd015730a0/spec/integration/manifest.spec.yml#L113
+                schema.literal('apm'),
+                schema.literal('enterprise_search'),
+                schema.literal('observability'),
+                schema.literal('security'),
+                schema.literal('serverless_search'),
+                schema.literal('uptime'),
+              ]),
+              { defaultValue: [] }
+            ),
+          },
+          {
+            defaultValue: {
+              kibanaVersionCheckEnabled: true,
+              capabilities: [],
+              spec: {
+                max: REGISTRY_SPEC_MAX_VERSION,
+              },
+            },
+          }
         ),
       })
     ),

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -29,7 +29,7 @@ import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts'
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
 
-const REGISTRY_SPEC_MAX_VERSION = '3.0.0';
+const REGISTRY_SPEC_MAX_VERSION = '3.0';
 
 export const config: PluginConfigDescriptor = {
   exposeToBrowser: {

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.test.ts
@@ -125,7 +125,10 @@ describe('_installPackage', () => {
           disableProxies: false,
           fleetServerStandalone: false,
           onlyAllowAgentUpgradeToKnownVersions: false,
-          capabilities: [],
+          registry: {
+            kibanaVersionCheckEnabled: true,
+            capabilities: [],
+          },
         },
       })
     );
@@ -179,7 +182,10 @@ describe('_installPackage', () => {
           disableILMPolicies: false,
           fleetServerStandalone: false,
           onlyAllowAgentUpgradeToKnownVersions: false,
-          capabilities: [],
+          registry: {
+            kibanaVersionCheckEnabled: true,
+            capabilities: [],
+          },
         },
       })
     );

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -316,4 +316,41 @@ describe('fetchList', () => {
     const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
     expect(callUrl.searchParams.get('capabilities')).toBeNull();
   });
+
+  it('does call registry with kibana.version if not explictly disabled', async () => {
+    mockGetConfig.mockReturnValue({
+      internal: {
+        registry: {
+          spec: {
+            min: '3.0.0',
+            max: '3.0.0',
+          },
+        },
+      },
+    });
+    mockFetchUrl.mockResolvedValue(JSON.stringify([]));
+    await fetchList();
+    expect(mockFetchUrl).toBeCalledTimes(1);
+    const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
+    expect(callUrl.searchParams.get('kibana.version')).not.toBeNull();
+  });
+
+  it('does not call registry with kibana.version with config internal.registry.kibanaVersionCheckEnabled:false', async () => {
+    mockGetConfig.mockReturnValue({
+      internal: {
+        registry: {
+          kibanaVersionCheckEnabled: false,
+          spec: {
+            min: '3.0.0',
+            max: '3.0.0',
+          },
+        },
+      },
+    });
+    mockFetchUrl.mockResolvedValue(JSON.stringify([]));
+    await fetchList();
+    expect(mockFetchUrl).toBeCalledTimes(1);
+    const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
+    expect(callUrl.searchParams.get('kibana.version')).toBeNull();
+  });
 });

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -230,7 +230,9 @@ describe('fetchCategories', () => {
   it('call registry with capabilities if configured', async () => {
     mockGetConfig.mockReturnValue({
       internal: {
-        capabilities: ['apm', 'security'],
+        registry: {
+          capabilities: ['apm', 'security'],
+        },
       },
     });
     mockFetchUrl.mockResolvedValue(JSON.stringify([]));
@@ -238,6 +240,25 @@ describe('fetchCategories', () => {
     expect(mockFetchUrl).toBeCalledTimes(1);
     const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
     expect(callUrl.searchParams.get('capabilities')).toBe('apm,security');
+  });
+  it('call registry with spec.min spec.max if configured', async () => {
+    mockGetConfig.mockReturnValue({
+      internal: {
+        registry: {
+          spec: {
+            min: '3.0.0',
+            max: '3.0.0',
+          },
+          capabilities: [],
+        },
+      },
+    });
+    mockFetchUrl.mockResolvedValue(JSON.stringify([]));
+    await fetchCategories();
+    expect(mockFetchUrl).toBeCalledTimes(1);
+    const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
+    expect(callUrl.searchParams.get('spec.min')).toBe('3.0.0');
+    expect(callUrl.searchParams.get('spec.max')).toBe('3.0.0');
   });
   it('does not call registry with capabilities if none are configured', async () => {
     mockGetConfig.mockReturnValue({});
@@ -257,7 +278,9 @@ describe('fetchList', () => {
   it('call registry with capabilities if configured', async () => {
     mockGetConfig.mockReturnValue({
       internal: {
-        capabilities: ['apm', 'security'],
+        registry: {
+          capabilities: ['apm', 'security'],
+        },
       },
     });
     mockFetchUrl.mockResolvedValue(JSON.stringify([]));
@@ -266,6 +289,25 @@ describe('fetchList', () => {
     const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
     expect(callUrl.searchParams.get('capabilities')).toBe('apm,security');
   });
+  it('call registry with spec.min spec.max if configured', async () => {
+    mockGetConfig.mockReturnValue({
+      internal: {
+        registry: {
+          spec: {
+            min: '3.0.0',
+            max: '3.0.0',
+          },
+        },
+      },
+    });
+    mockFetchUrl.mockResolvedValue(JSON.stringify([]));
+    await fetchList();
+    expect(mockFetchUrl).toBeCalledTimes(1);
+    const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
+    expect(callUrl.searchParams.get('spec.min')).toBe('3.0.0');
+    expect(callUrl.searchParams.get('spec.max')).toBe('3.0.0');
+  });
+
   it('does not call registry with capabilities if none are configured', async () => {
     mockGetConfig.mockReturnValue({});
     mockFetchUrl.mockResolvedValue(JSON.stringify([]));

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.test.ts
@@ -246,8 +246,8 @@ describe('fetchCategories', () => {
       internal: {
         registry: {
           spec: {
-            min: '3.0.0',
-            max: '3.0.0',
+            min: '3.0',
+            max: '3.0',
           },
           capabilities: [],
         },
@@ -257,8 +257,8 @@ describe('fetchCategories', () => {
     await fetchCategories();
     expect(mockFetchUrl).toBeCalledTimes(1);
     const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
-    expect(callUrl.searchParams.get('spec.min')).toBe('3.0.0');
-    expect(callUrl.searchParams.get('spec.max')).toBe('3.0.0');
+    expect(callUrl.searchParams.get('spec.min')).toBe('3.0');
+    expect(callUrl.searchParams.get('spec.max')).toBe('3.0');
   });
   it('does not call registry with capabilities if none are configured', async () => {
     mockGetConfig.mockReturnValue({});
@@ -294,8 +294,8 @@ describe('fetchList', () => {
       internal: {
         registry: {
           spec: {
-            min: '3.0.0',
-            max: '3.0.0',
+            min: '3.0',
+            max: '3.0',
           },
         },
       },
@@ -304,8 +304,8 @@ describe('fetchList', () => {
     await fetchList();
     expect(mockFetchUrl).toBeCalledTimes(1);
     const callUrl = new URL(mockFetchUrl.mock.calls[0][0]);
-    expect(callUrl.searchParams.get('spec.min')).toBe('3.0.0');
-    expect(callUrl.searchParams.get('spec.max')).toBe('3.0.0');
+    expect(callUrl.searchParams.get('spec.min')).toBe('3.0');
+    expect(callUrl.searchParams.get('spec.max')).toBe('3.0');
   });
 
   it('does not call registry with capabilities if none are configured', async () => {
@@ -320,12 +320,7 @@ describe('fetchList', () => {
   it('does call registry with kibana.version if not explictly disabled', async () => {
     mockGetConfig.mockReturnValue({
       internal: {
-        registry: {
-          spec: {
-            min: '3.0.0',
-            max: '3.0.0',
-          },
-        },
+        registry: {},
       },
     });
     mockFetchUrl.mockResolvedValue(JSON.stringify([]));
@@ -340,10 +335,6 @@ describe('fetchList', () => {
       internal: {
         registry: {
           kibanaVersionCheckEnabled: false,
-          spec: {
-            min: '3.0.0',
-            max: '3.0.0',
-          },
         },
       },
     });

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -225,7 +225,8 @@ function setKibanaVersion(url: URL) {
 
   const disableVersionCheck =
     (config?.developer?.disableRegistryVersionCheck ?? false) ||
-    !(config?.internal?.registry?.kibanaVersionCheckEnabled ?? true);
+    config?.internal?.registry?.kibanaVersionCheckEnabled === false;
+
   if (disableVersionCheck) {
     return;
   }

--- a/x-pack/plugins/fleet/server/services/epm/registry/index.ts
+++ b/x-pack/plugins/fleet/server/services/epm/registry/index.ts
@@ -73,8 +73,7 @@ export async function fetchList(
     }
   }
 
-  setKibanaVersion(url);
-  setCapabilities(url);
+  setConstraints(url);
 
   return fetchUrl(url.toString()).then(JSON.parse);
 }
@@ -106,8 +105,7 @@ async function _fetchFindLatestPackage(
     );
 
     if (!ignoreConstraints) {
-      setKibanaVersion(url);
-      setCapabilities(url);
+      setConstraints(url);
     }
 
     try {
@@ -223,8 +221,11 @@ export async function fetchFile(filePath: string): Promise<Response> {
 }
 
 function setKibanaVersion(url: URL) {
+  const config = appContextService.getConfig();
+
   const disableVersionCheck =
-    appContextService.getConfig()?.developer?.disableRegistryVersionCheck ?? false;
+    (config?.developer?.disableRegistryVersionCheck ?? false) ||
+    !(config?.internal?.registry?.kibanaVersionCheckEnabled ?? true);
   if (disableVersionCheck) {
     return;
   }
@@ -236,11 +237,29 @@ function setKibanaVersion(url: URL) {
   }
 }
 
+function setSpecVersion(url: URL) {
+  const specMin = appContextService.getConfig()?.internal?.registry?.spec?.min;
+  const specMax = appContextService.getConfig()?.internal?.registry?.spec?.max;
+
+  if (specMin) {
+    url.searchParams.set('spec.min', specMin);
+  }
+  if (specMax) {
+    url.searchParams.set('spec.max', specMax);
+  }
+}
+
 function setCapabilities(url: URL) {
-  const capabilities = appContextService.getConfig()?.internal?.capabilities;
+  const capabilities = appContextService.getConfig()?.internal?.registry?.capabilities;
   if (capabilities && capabilities.length > 0) {
     url.searchParams.set('capabilities', capabilities.join(','));
   }
+}
+
+function setConstraints(url: URL) {
+  setKibanaVersion(url);
+  setCapabilities(url);
+  setSpecVersion(url);
 }
 
 export async function fetchCategories(
@@ -257,8 +276,7 @@ export async function fetchCategories(
     }
   }
 
-  setKibanaVersion(url);
-  setCapabilities(url);
+  setConstraints(url);
 
   return fetchUrl(url.toString()).then(JSON.parse);
 }


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/161210 

Allow to filter packages by configuring `spec.min` and `spec.max` in kibana config file.

As package maintainer need sometime to implement 3.0.0 spec, the config file for serverless will need to be updated in a following PR. https://github.com/elastic/kibana/issues/166742

## Manual tests

You can manually check that PR and add the following config to check that package are filtered based on spec version (there is no 3.0 packages currently)

```
xpack.fleet.internal.registry.spec.min: '2.0.0'
xpack.fleet.internal.registry.spec.max: '3.0.0'
```

## Todo 

- [x] create followup issue to enable `spec.min` filtering in serverless
- [x] Unit tests