### PR TITLE
[Security Solution] expandable flyout - add tooltip to expandable panel link titles

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/right/components/analyzer_preview_container.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/analyzer_preview_container.tsx
@@ -64,7 +64,17 @@ export const AnalyzerPreviewContainer: React.FC = () => {
           />
         ),
         iconType: 'timeline',
-        ...(isEnabled && { callback: goToAnalyzerTab }),
+        ...(isEnabled && {
+          link: {
+            callback: goToAnalyzerTab,
+            tooltip: (
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.right.visualizations.analyzerPreview.analyzerPreviewTooltip"
+                defaultMessage="Show analyzer graph"
+              />
+            ),
+          },
+        }),
       }}
       data-test-subj={ANALYZER_PREVIEW_TEST_ID}
     >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/correlations_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/correlations_overview.tsx
@@ -90,7 +90,15 @@ export const CorrelationsOverview: React.FC = () => {
             defaultMessage="Correlations"
           />
         ),
-        callback: goToCorrelationsTab,
+        link: {
+          callback: goToCorrelationsTab,
+          tooltip: (
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.right.insights.correlations.overviewTooltip"
+              defaultMessage="Show all correlations"
+            />
+          ),
+        },
         iconType: 'arrowStart',
       }}
       data-test-subj={INSIGHTS_CORRELATIONS_TEST_ID}

--- a/x-pack/plugins/security_solution/public/flyout/right/components/entities_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/entities_overview.tsx
@@ -57,7 +57,7 @@ export const EntitiesOverview: React.FC = () => {
             tooltip: (
               <FormattedMessage
                 id="xpack.securitySolution.flyout.right.insights.entities.entitiesTooltip"
-                defaultMessage="View all entities"
+                defaultMessage="Show all entities"
               />
             ),
           },

--- a/x-pack/plugins/security_solution/public/flyout/right/components/entities_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/entities_overview.tsx
@@ -52,7 +52,15 @@ export const EntitiesOverview: React.FC = () => {
               defaultMessage="Entities"
             />
           ),
-          callback: goToEntitiesTab,
+          link: {
+            callback: goToEntitiesTab,
+            tooltip: (
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.right.insights.entities.entitiesTooltip"
+                defaultMessage="View all entities"
+              />
+            ),
+          },
           iconType: 'arrowStart',
         }}
         data-test-subj={INSIGHTS_ENTITIES_TEST_ID}

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
@@ -31,7 +31,7 @@ export const PrevalenceOverview: FC = () => {
     useRightPanelContext();
   const { openLeftPanel } = useExpandableFlyoutContext();
 
-  const goToCorrelationsTab = useCallback(() => {
+  const goPrevalenceTab = useCallback(() => {
     openLeftPanel({
       id: LeftPanelKey,
       path: {
@@ -76,7 +76,15 @@ export const PrevalenceOverview: FC = () => {
             defaultMessage="Prevalence"
           />
         ),
-        callback: goToCorrelationsTab,
+        link: {
+          callback: goPrevalenceTab,
+          tooltip: (
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.right.insights.prevalence.prevalenceTooltip"
+              defaultMessage="Show all prevalence"
+            />
+          ),
+        },
         iconType: 'arrowStart',
       }}
       content={{ loading, error }}

--- a/x-pack/plugins/security_solution/public/flyout/right/components/session_preview_container.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/session_preview_container.tsx
@@ -130,7 +130,17 @@ export const SessionPreviewContainer: FC = () => {
           />
         ),
         iconType: 'timeline',
-        ...(isEnabled && { callback: goToSessionViewTab }),
+        ...(isEnabled && {
+          link: {
+            callback: goToSessionViewTab,
+            tooltip: (
+              <FormattedMessage
+                id="xpack.securitySolution.flyout.right.visualizations.sessionPreview.sessionPreviewTooltip"
+                defaultMessage="Show session viewer"
+              />
+            ),
+          },
+        }),
       }}
       data-test-subj={SESSION_PREVIEW_TEST_ID}
     >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/threat_intelligence_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/threat_intelligence_overview.tsx
@@ -55,7 +55,15 @@ export const ThreatIntelligenceOverview: FC = () => {
             defaultMessage="Threat intelligence"
           />
         ),
-        callback: goToThreatIntelligenceTab,
+        link: {
+          callback: goToThreatIntelligenceTab,
+          tooltip: (
+            <FormattedMessage
+              id="xpack.securitySolution.flyout.right.insights.threatIntelligence.threatIntelligenceTooltip"
+              defaultMessage="Show all threat intelligence"
+            />
+          ),
+        },
         iconType: 'arrowStart',
       }}
       data-test-subj={INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.tsx
@@ -18,6 +18,7 @@ import {
   EuiText,
   EuiLoadingSpinner,
   useEuiTheme,
+  EuiToolTip,
 } from '@elastic/eui';
 import type { IconType } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -28,10 +29,16 @@ export interface ExpandablePanelPanelProps {
      * String value of the title to be displayed in the header of panel
      */
     title: string | React.ReactNode;
-    /**
-     * Callback function to be called when the title is clicked
-     */
-    callback?: () => void;
+    link?: {
+      /**
+       * Callback function to be called when the title is clicked
+       */
+      callback: () => void;
+      /**
+       * Tooltip text to be displayed around the title link
+       */
+      tooltip: React.ReactNode;
+    };
     /**
      * Icon string for displaying the specified icon in the header
      */
@@ -74,7 +81,7 @@ export interface ExpandablePanelPanelProps {
  * The component can be expanded or collapsed by clicking on the chevron icon on the left of the title.
  */
 export const ExpandablePanel: React.FC<ExpandablePanelPanelProps> = ({
-  header: { title, callback, iconType, headerContent },
+  header: { title, link, iconType, headerContent },
   content: { loading, error } = { loading: false, error: false },
   expand: { expandable, expandedOnFirstRender } = {
     expandable: false,
@@ -116,7 +123,7 @@ export const ExpandablePanel: React.FC<ExpandablePanelPanelProps> = ({
           <EuiFlexItem grow={false}>{expandable && children && toggleIcon}</EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiIcon
-              color={callback ? 'primary' : 'text'}
+              color={link?.callback ? 'primary' : 'text'}
               type={iconType}
               css={css`
                 margin: ${euiTheme.size.s} 0;
@@ -125,17 +132,19 @@ export const ExpandablePanel: React.FC<ExpandablePanelPanelProps> = ({
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            {callback ? (
-              <EuiLink
-                css={css`
-                  font-size: 12px;
-                  font-weight: 700;
-                `}
-                data-test-subj={`${dataTestSubj}TitleLink`}
-                onClick={callback}
-              >
-                {title}
-              </EuiLink>
+            {link?.callback ? (
+              <EuiToolTip content={link?.tooltip}>
+                <EuiLink
+                  css={css`
+                    font-size: 12px;
+                    font-weight: 700;
+                  `}
+                  data-test-subj={`${dataTestSubj}TitleLink`}
+                  onClick={link?.callback}
+                >
+                  {title}
+                </EuiLink>
+              </EuiToolTip>
             ) : (
               <EuiTitle size="xxxs">
                 <EuiText data-test-subj={`${dataTestSubj}TitleText`}>{title}</EuiText>
@@ -145,7 +154,17 @@ export const ExpandablePanel: React.FC<ExpandablePanelPanelProps> = ({
         </EuiFlexGroup>
       </EuiFlexItem>
     ),
-    [dataTestSubj, expandable, children, toggleIcon, callback, iconType, euiTheme.size.s, title]
+    [
+      dataTestSubj,
+      expandable,
+      children,
+      toggleIcon,
+      link?.callback,
+      iconType,
+      euiTheme.size.s,
+      link?.tooltip,
+      title,
+    ]
   );
 
   const headerRightSection = useMemo(


### PR DESCRIPTION
## Summary

This PR adds the ability to show a tooltip wrapping the title of the ExpandablePanel shared component. This component is used in a few places in the Security Solution expandable flyout:
- session view preview
- analyzer graph preview
- insights entities
- insights threat intelligence
- insights prevalence
- insights correlations

Visually, the only difference is that when the user mouses over the titles, a tooltip is displayed. This tooltip is only visible when the title is a link, and not plain text.

https://github.com/elastic/kibana/assets/17276605/a4586ed4-1f03-4732-bff5-d55b22a9b35f

https://github.com/elastic/security-team/issues/7669

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)