### PR TITLE
Update transforms.alertingRules documentation link

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -506,8 +506,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
     },
     transforms: {
       guide: `${ELASTICSEARCH_DOCS}transforms.html`,
-      // TODO add valid docs URL
-      alertingRules: `${MACHINE_LEARNING_DOCS}ml-configuring-alerts.html`,
+      alertingRules: `${ELASTICSEARCH_DOCS}transform-alerts.html`,
     },
     visualize: {
       guide: `${KIBANA_DOCS}dashboard.html`,


### PR DESCRIPTION
## Summary

The "Learn more" link for the transform health alerting rule currently targets a machine learning page (https://www.elastic.co/guide/en/machine-learning/current/ml-configuring-alerts.html):

![image](https://github.com/elastic/kibana/assets/26471269/139755bf-774e-4b13-8274-c6f9abfd74c0)

This PR updates the documentation link service to target https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-alerts.html instead.

<!--ONMERGE {"backportTargets":["7.17","8.10"]} ONMERGE-->