### PR TITLE
[Security Solution] Unskip custom query rule serverless tests

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_breadcrumbs.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/header/header_breadcrumbs.tsx
@@ -25,15 +25,22 @@ export function HeaderBreadcrumbs({ breadcrumbs$ }: Props) {
     crumbs = [{ text: 'Kibana' }];
   }
 
-  crumbs = crumbs.map((breadcrumb, i) => ({
-    ...breadcrumb,
-    'data-test-subj': classNames(
-      'breadcrumb',
-      breadcrumb['data-test-subj'],
-      i === 0 && 'first',
-      i === breadcrumbs.length - 1 && 'last'
-    ),
-  }));
+  crumbs = crumbs.map((breadcrumb, i) => {
+    const isLast = i === breadcrumbs.length - 1;
+
+    return {
+      ...breadcrumb,
+      // Last element represents the current page and expected to be inactive
+      href: isLast ? undefined : breadcrumb.href,
+      onClick: isLast ? undefined : breadcrumb.onClick,
+      'data-test-subj': classNames(
+        'breadcrumb',
+        breadcrumb['data-test-subj'],
+        i === 0 && 'first',
+        isLast && 'last'
+      ),
+    };
+  });
 
   return <EuiHeaderBreadcrumbs breadcrumbs={crumbs} max={10} data-test-subj="breadcrumbs" />;
 }

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -115,8 +115,7 @@ import {
 import { enablesRule, getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 import { ruleDetailsUrl, ruleEditUrl, RULE_CREATION } from '../../../urls/navigation';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-describe('Custom query rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Custom query rules', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     deleteAlertsAndRules();
   });

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -142,7 +142,7 @@ export const THREAT_TECHNIQUE = '[data-test-subj="threatTechniqueLink"]';
 
 export const THREAT_SUBTECHNIQUE = '[data-test-subj="threatSubtechniqueLink"]';
 
-export const BACK_TO_RULES_TABLE = '[data-test-subj="breadcrumb"][title="Detection rules (SIEM)"]';
+export const BACK_TO_RULES_TABLE = '[data-test-subj~="breadcrumb"][title="Detection rules (SIEM)"]';
 
 export const HIGHLIGHTED_ROWS_IN_TABLE =
   '[data-test-subj="euiDataGridBody"] .alertsTableHighlightedRow';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -125,26 +125,33 @@ import { BACK_TO_RULES_TABLE } from '../screens/rule_details';
 import { waitForAlerts } from './alerts';
 import { refreshPage } from './security_header';
 import { EMPTY_ALERT_TABLE } from '../screens/alerts';
+import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 
 export const createAndEnableRule = () => {
-  cy.get(CREATE_AND_ENABLE_BTN).click({ force: true });
+  cy.get(CREATE_AND_ENABLE_BTN).click();
   cy.get(CREATE_AND_ENABLE_BTN).should('not.exist');
-  cy.get(BACK_TO_RULES_TABLE).click({ force: true });
-  cy.get(BACK_TO_RULES_TABLE).should('not.exist');
+
+  // Wait for page to be loaded before performing any actions
+  // Serverless breadcrumbs don't work until the page is loaded
+  cy.get(PAGE_CONTENT_SPINNER).should('be.visible');
+  cy.get(PAGE_CONTENT_SPINNER).should('not.exist');
+
+  cy.get(BACK_TO_RULES_TABLE).click();
+  cy.get(BACK_TO_RULES_TABLE).should('have.attr', 'data-test-subj').and('match', /last/);
 };
 
 export const createRuleWithoutEnabling = () => {
-  cy.get(CREATE_WITHOUT_ENABLING_BTN).click({ force: true });
+  cy.get(CREATE_WITHOUT_ENABLING_BTN).click();
   cy.get(CREATE_WITHOUT_ENABLING_BTN).should('not.exist');
-  cy.get(BACK_TO_RULES_TABLE).click({ force: true });
+  cy.get(BACK_TO_RULES_TABLE).click();
   cy.get(BACK_TO_RULES_TABLE).should('not.exist');
 };
 
 export const fillAboutRule = (rule: RuleCreateProps) => {
-  cy.get(RULE_NAME_INPUT).clear({ force: true });
-  cy.get(RULE_NAME_INPUT).type(rule.name, { force: true });
-  cy.get(RULE_DESCRIPTION_INPUT).clear({ force: true });
-  cy.get(RULE_DESCRIPTION_INPUT).type(rule.description, { force: true });
+  cy.get(RULE_NAME_INPUT).clear();
+  cy.get(RULE_NAME_INPUT).type(rule.name);
+  cy.get(RULE_DESCRIPTION_INPUT).clear();
+  cy.get(RULE_DESCRIPTION_INPUT).type(rule.description);
 
   if (rule.severity) {
     fillSeverity(rule.severity);


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/161539

## Summary

This PR unskips custom query rule serverless tests.

## Details

It turned out serverless breadcrumbs behave a bit differently. The last element is active in serverless. Usually it's expected the last element represents the current page and shouldn't be an active link and it's done in ESS. Serverless implementation required a small fix to make the breadcrumbs to conform an expected behavior.

The test required fixing breadcrumb selectors as behavior differs under the hood a bit

- `title` attribute at the last breadcrumb element is always set in serverless breadcrumbs while removed in ESS Security Solution
- `data-test-subj` contains extra deep link related value making selectors like `[data-test-subj="breadcrumb"]` unable to select an element. Replacing it with `[data-test-subj~="breadcrumb"]` solves the problem.

