### PR TITLE
[Security Solution] Reenable rules table filtering serverless tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_filtering.cy.ts
@@ -29,9 +29,7 @@ import {
 import { disableAutoRefresh } from '../../../../tasks/alerts_detection_rules';
 import { getNewRule } from '../../../../objects/rule';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-// Flaky in serverless tests
-describe('Rules table: filtering', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Rules table: filtering', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
   });
@@ -44,11 +42,8 @@ describe('Rules table: filtering', { tags: ['@ess', '@serverless', '@skipInServe
     cy.task('esArchiverResetKibana');
   });
 
-  // TODO: https://github.com/elastic/kibana/issues/161540
-  describe.skip('Last response filter', () => {
-    // Flaky in serverless tests
-    // @brokenInServerless tag is not working so a skip was needed
-    it('Filters rules by last response', { tags: ['@brokenInServerless'] }, function () {
+  describe('Last response filter', () => {
+    it('Filters rules by last response', function () {
       deleteIndex('test_index');
 
       createIndex('test_index', {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/elasticsearch.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/elasticsearch.ts
@@ -9,7 +9,7 @@ import { rootRequest } from '../common';
 export const deleteIndex = (index: string) => {
   rootRequest({
     method: 'DELETE',
-    url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}?refresh=wait_for`,
+    url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}`,
     headers: {
       'kbn-xsrf': 'cypress-creds',
       'x-elastic-internal-origin': 'security-solution',

--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/elasticsearch.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/elasticsearch.ts
@@ -10,7 +10,11 @@ export const deleteIndex = (index: string) => {
   rootRequest({
     method: 'DELETE',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}?refresh=wait_for`,
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     failOnStatusCode: false,
   });
 };
@@ -19,7 +23,11 @@ export const deleteDataStream = (dataStreamName: string) => {
   rootRequest({
     method: 'DELETE',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/_data_stream/${dataStreamName}`,
-    headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     failOnStatusCode: false,
   });
 };
@@ -30,6 +38,11 @@ export const deleteAllDocuments = (target: string) =>
     url: `${Cypress.env(
       'ELASTICSEARCH_URL'
     )}/${target}/_delete_by_query?conflicts=proceed&scroll_size=10000&refresh`,
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     body: {
       query: {
         match_all: {},
@@ -41,6 +54,11 @@ export const createIndex = (indexName: string, properties: Record<string, unknow
   rootRequest({
     method: 'PUT',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/${indexName}`,
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     body: {
       mappings: {
         properties,
@@ -52,6 +70,11 @@ export const createDocument = (indexName: string, document: Record<string, unkno
   rootRequest({
     method: 'POST',
     url: `${Cypress.env('ELASTICSEARCH_URL')}/${indexName}/_doc?refresh=wait_for`,
+    headers: {
+      'kbn-xsrf': 'cypress-creds',
+      'x-elastic-internal-origin': 'security-solution',
+      'elastic-api-version': '2023-10-31',
+    },
     body: document,
   });
 
@@ -61,7 +84,11 @@ export const waitForNewDocumentToBeIndexed = (index: string, initialNumberOfDocu
       rootRequest<{ hits: { hits: unknown[] } }>({
         method: 'GET',
         url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_search`,
-        headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+        headers: {
+          'kbn-xsrf': 'cypress-creds',
+          'x-elastic-internal-origin': 'security-solution',
+          'elastic-api-version': '2023-10-31',
+        },
         failOnStatusCode: false,
       }).then((response) => {
         if (response.status !== 200) {
@@ -80,7 +107,11 @@ export const refreshIndex = (index: string) => {
       rootRequest({
         method: 'POST',
         url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_refresh`,
-        headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+        headers: {
+          'kbn-xsrf': 'cypress-creds',
+          'x-elastic-internal-origin': 'security-solution',
+          'elastic-api-version': '2023-10-31',
+        },
         failOnStatusCode: false,
       }).then((response) => {
         if (response.status !== 200) {


### PR DESCRIPTION
**Relates to:** https://github.com/elastic/kibana/issues/161540

## Summary

This PR unskips rules table filtering serverless tests.

Serverless [rules_table_filtering.cy.ts (100 runs)](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3205) 🟢

