### PR TITLE
[Defend] add advanced policy for API events

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config.ts
@@ -31,7 +31,7 @@ export const policyFactory = (
     global_manifest_version: 'latest',
     windows: {
       events: {
-        credential_access: true,
+        api: true,
         dll_and_driver_load: true,
         dns: true,
         file: true,

--- a/x-pack/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/models/policy_config_helpers.test.ts
@@ -84,7 +84,7 @@ describe('Policy Config helpers', () => {
       const defaultPolicy: PolicyConfig = policyFactory();
 
       const windowsEvents: typeof defaultPolicy.windows.events = {
-        credential_access: false,
+        api: false,
         dll_and_driver_load: false,
         dns: false,
         file: false,
@@ -203,7 +203,7 @@ export const eventsOnlyPolicy = (): PolicyConfig => ({
   },
   windows: {
     events: {
-      credential_access: true,
+      api: true,
       dll_and_driver_load: true,
       dns: true,
       file: true,

--- a/x-pack/plugins/security_solution/common/endpoint/types/index.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/types/index.ts
@@ -962,7 +962,7 @@ export interface PolicyConfig {
       };
     };
     events: {
-      credential_access: boolean;
+      api: boolean;
       dll_and_driver_load: boolean;
       dns: boolean;
       file: boolean;

--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -866,16 +866,6 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
-    key: 'windows.advanced.events.etw',
-    first_supported_version: '8.1',
-    documentation: i18n.translate(
-      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.etw',
-      {
-        defaultMessage: 'Enable collection of ETW events. Default: true',
-      }
-    ),
-  },
-  {
     key: 'windows.advanced.diagnostic.rollback_telemetry_enabled',
     first_supported_version: '8.1',
     documentation: i18n.translate(
@@ -1265,13 +1255,46 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
     ),
   },
   {
-    key: 'windows.advanced.events.api',
-    first_supported_version: '8.8',
+    key: 'windows.advanced.events.api.credential_access',
+    first_supported_version: '8.11',
     documentation: i18n.translate(
-      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api',
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api.credential_access',
       {
         defaultMessage:
-          'Controls whether API events are enabled. Set to false to disable API event collection. Default: true',
+          'Controls whether Credential Access API events are enabled. Set to false to disable just this event collection. Default: true',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.api.etw_threat_intelligence',
+    first_supported_version: '8.11',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api.etw_threat_intelligence',
+      {
+        defaultMessage:
+          'Controls whether Microsoft-Windows-Threat-Intelligence API events are enabled. Set to false to disable just this event collection. Default: true',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.api.disabled',
+    first_supported_version: '8.11',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api.disbaled',
+      {
+        defaultMessage:
+          'A comma separated list of Threat-Intelligence API names to selectively disable.',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.api.verbose',
+    first_supported_version: '8.11',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api.verbose',
+      {
+        defaultMessage:
+          'Controls whether high volume in-process and parent-child API events are enabled. Event filtering is recommended if enabled. Default: false',
       }
     ),
   },

--- a/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/store/policy_details/index.test.ts
@@ -280,7 +280,7 @@ describe('policy details: ', () => {
                   },
                   windows: {
                     events: {
-                      credential_access: true,
+                      api: true,
                       dll_and_driver_load: true,
                       dns: false,
                       file: true,

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.test.tsx
@@ -42,7 +42,7 @@ describe('Policy Windows Event Collection Card', () => {
     expect(
       getByTestId(testSubj.optionsContainer).querySelectorAll('input[type="checkbox"]')
     ).toHaveLength(8);
-    expect(getByTestId(testSubj.credentialsCheckbox)).toBeChecked();
+    expect(getByTestId(testSubj.apiCheckbox)).toBeChecked();
     expect(getByTestId(testSubj.dllCheckbox)).toBeChecked();
     expect(getByTestId(testSubj.dnsCheckbox)).toBeChecked();
     expect(getByTestId(testSubj.fileCheckbox)).toBeChecked();

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
@@ -14,12 +14,9 @@ import type { PolicyFormComponentCommonProps } from '../../types';
 
 const OPTIONS: ReadonlyArray<EventFormOption<OperatingSystem.WINDOWS>> = [
   {
-    name: i18n.translate(
-      'xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.api',
-      {
-        defaultMessage: 'API',
-      }
-    ),
+    name: i18n.translate('xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.api', {
+      defaultMessage: 'API',
+    }),
     protectionField: 'api',
   },
   {

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
@@ -15,12 +15,12 @@ import type { PolicyFormComponentCommonProps } from '../../types';
 const OPTIONS: ReadonlyArray<EventFormOption<OperatingSystem.WINDOWS>> = [
   {
     name: i18n.translate(
-      'xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.credentialAccess',
+      'xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.api',
       {
-        defaultMessage: 'Credential Access',
+        defaultMessage: 'API',
       }
     ),
-    protectionField: 'credential_access',
+    protectionField: 'api',
   },
   {
     name: i18n.translate(

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/mocks.ts
@@ -113,7 +113,7 @@ export const getPolicySettingsFormTestSubjects = (
       card: windowsEventsTestSubj(),
       osValueContainer: windowsEventsTestSubj('osValueContainer'),
       optionsContainer: windowsEventsTestSubj('options'),
-      credentialsCheckbox: windowsEventsTestSubj('credential_access'),
+      credentialsCheckbox: windowsEventsTestSubj('api'),
       dllCheckbox: windowsEventsTestSubj('dll_and_driver_load'),
       dnsCheckbox: windowsEventsTestSubj('dns'),
       fileCheckbox: windowsEventsTestSubj('file'),


### PR DESCRIPTION
## Summary

New policy and advanced policy options for Defend.

The Windows Events Policy `Credential Access` has been renamed to `API`.
Migration note - the previous boolean value should be migrated to `windows.advanced.events.api.credential_access`

`windows.advanced.events.api` was superseded by more granular configuration  -
* `windows.advanced.events.api.credential_access` - boolean
* `windows.advanced.events.api.etw_threat_intelligence` - boolean
* `windows.advanced.events.api.etw_win32k` - boolean
* `windows.advanced.events.api.disabled` - comma separated list
* `windows.advanced.events.api.verbose` - boolean
Migration note - the old `api` boolean value can be mitigated to both `etw_threat_intelligence` and `etw_win32k`.

❓ How do we implement the migration logic?

Also `windows.advanced.events.etw` has been removed. This feature was never implemented.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
