### PR TITLE
[EDR Workflows] Fix osquery test 

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/roles/alert_test.cy.ts
@@ -21,6 +21,12 @@ describe('Alert Test', { tags: ['@ess'] }, () => {
   });
 
   describe('t1_analyst role', () => {
+    before(() => {
+      cy.login(ServerlessRoleName.SOC_MANAGER);
+
+      cy.visit('/app/security/rules');
+      clickRuleName(ruleName);
+    });
     beforeEach(() => {
       cy.login(ServerlessRoleName.T1_ANALYST);
 


### PR DESCRIPTION
Not sure what changed, but we were missing privileges to index.