### PR TITLE
Remove version from EventLog index name

### DIFF
--- a/x-pack/plugins/event_log/README.md
+++ b/x-pack/plugins/event_log/README.md
@@ -44,7 +44,7 @@ prior releases, it was an alias with an initial index set up, with the
 alias used to deal with rolled over indices from ILM.  With the data stream,
 there's a little less set up, and the bulk writing is slightly different.
 
-The default data stream / alias name is `.kibana-event-log-${kibanaVersion}`.
+The default data stream / alias name is `.kibana-event-log-ds`.
 To search across all versions' event logs, use `.kibana-event-log-*`; 
 it will search over data streams and aliases as expected.
 

--- a/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
+++ b/x-pack/plugins/event_log/server/es/cluster_client_adapter.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   clusterClientAdapter = new ClusterClientAdapter({
     logger,
     elasticsearchClientPromise: Promise.resolve(clusterClient),
-    esNames: getEsNames('kibana', '1.2.3'),
+    esNames: getEsNames('kibana'),
     wait: () => Promise.resolve(true),
   });
 });
@@ -50,7 +50,7 @@ describe('indexDocument', () => {
 
     expect(clusterClient.bulk).toHaveBeenCalledWith({
       body: [{ create: {} }, { message: 'foo' }],
-      index: 'kibana-event-log-1.2.3',
+      index: 'kibana-event-log-ds',
     });
   });
 
@@ -103,7 +103,7 @@ describe('buffering documents', () => {
 
     expect(clusterClient.bulk).toHaveBeenCalledWith({
       body: expectedBody,
-      index: 'kibana-event-log-1.2.3',
+      index: 'kibana-event-log-ds',
     });
   });
 
@@ -124,12 +124,12 @@ describe('buffering documents', () => {
 
     expect(clusterClient.bulk).toHaveBeenNthCalledWith(1, {
       body: expectedBody,
-      index: 'kibana-event-log-1.2.3',
+      index: 'kibana-event-log-ds',
     });
 
     expect(clusterClient.bulk).toHaveBeenNthCalledWith(2, {
       body: [{ create: {} }, { message: `foo 100` }],
-      index: 'kibana-event-log-1.2.3',
+      index: 'kibana-event-log-ds',
     });
   });
 
@@ -158,7 +158,7 @@ describe('buffering documents', () => {
       }
 
       expect(clusterClient.bulk).toHaveBeenNthCalledWith(i + 1, {
-        index: 'kibana-event-log-1.2.3',
+        index: 'kibana-event-log-ds',
         body: expectedBody,
       });
     }

--- a/x-pack/plugins/event_log/server/es/context.test.ts
+++ b/x-pack/plugins/event_log/server/es/context.test.ts
@@ -36,7 +36,6 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test0',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
 
@@ -51,16 +50,15 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test-index',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
 
     const esNames = context.esNames;
     expect(esNames).toStrictEqual({
       base: 'test-index',
-      dataStream: 'test-index-event-log-1.2.3',
+      dataStream: 'test-index-event-log-ds',
       indexPattern: 'test-index-event-log-*',
-      indexTemplate: 'test-index-event-log-1.2.3-template',
+      indexTemplate: 'test-index-event-log-template',
     });
   });
 
@@ -69,7 +67,6 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test1',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
 
@@ -91,7 +88,6 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test2',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
     elasticsearchClient.indices.existsTemplate.mockResponse(true);
@@ -123,7 +119,6 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test2',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
     expect(mockCreateReadySignal).toBeCalledTimes(1);
@@ -141,7 +136,6 @@ describe('createEsContext', () => {
       logger,
       shouldSetExistingAssetsToHidden: true,
       indexNameRoot: 'test2',
-      kibanaVersion: '1.2.3',
       elasticsearchClientPromise: Promise.resolve(elasticsearchClient),
     });
     context.initialize();

--- a/x-pack/plugins/event_log/server/es/context.ts
+++ b/x-pack/plugins/event_log/server/es/context.ts
@@ -38,7 +38,6 @@ export function createEsContext(params: EsContextCtorParams): EsContext {
 export interface EsContextCtorParams {
   logger: Logger;
   indexNameRoot: string;
-  kibanaVersion: string;
   shouldSetExistingAssetsToHidden: boolean;
   elasticsearchClientPromise: Promise<ElasticsearchClient>;
 }
@@ -54,7 +53,7 @@ class EsContextImpl implements EsContext {
 
   constructor(params: EsContextCtorParams) {
     this.logger = params.logger;
-    this.esNames = getEsNames(params.indexNameRoot, params.kibanaVersion);
+    this.esNames = getEsNames(params.indexNameRoot);
     this.readySignal = createReadySignal();
     this.initialized = false;
     this.retryDelay = RETRY_DELAY;

--- a/x-pack/plugins/event_log/server/es/documents.test.ts
+++ b/x-pack/plugins/event_log/server/es/documents.test.ts
@@ -9,8 +9,7 @@ import { getIndexTemplate } from './documents';
 import { getEsNames } from './names';
 
 describe('getIndexTemplate()', () => {
-  const kibanaVersion = '1.2.3';
-  const esNames = getEsNames('XYZ', kibanaVersion);
+  const esNames = getEsNames('XYZ');
 
   test('returns the correct details of the index template', () => {
     const indexTemplate = getIndexTemplate(esNames);

--- a/x-pack/plugins/event_log/server/es/names.test.ts
+++ b/x-pack/plugins/event_log/server/es/names.test.ts
@@ -14,11 +14,10 @@ jest.mock('../../../../package.json', () => ({
 describe('getEsNames()', () => {
   test('works as expected', () => {
     const base = 'XYZ';
-    const kibanaVersion = '1.2.3';
-    const esNames = getEsNames(base, kibanaVersion);
+    const esNames = getEsNames(base);
     expect(esNames.base).toEqual(base);
-    expect(esNames.dataStream).toEqual(`${base}-event-log-${kibanaVersion}`);
+    expect(esNames.dataStream).toEqual(`${base}-event-log-ds`);
     expect(esNames.indexPattern).toEqual(`${base}-event-log-*`);
-    expect(esNames.indexTemplate).toEqual(`${base}-event-log-${kibanaVersion}-template`);
+    expect(esNames.indexTemplate).toEqual(`${base}-event-log-template`);
   });
 });

--- a/x-pack/plugins/event_log/server/es/names.ts
+++ b/x-pack/plugins/event_log/server/es/names.ts
@@ -14,14 +14,12 @@ export interface EsNames {
   indexTemplate: string;
 }
 
-export function getEsNames(baseName: string, kibanaVersion: string): EsNames {
-  const EVENT_LOG_VERSION_SUFFIX = `-${kibanaVersion.toLocaleLowerCase()}`;
+export function getEsNames(baseName: string): EsNames {
   const eventLogName = `${baseName}${EVENT_LOG_NAME_SUFFIX}`;
-  const eventLogNameWithVersion = `${eventLogName}${EVENT_LOG_VERSION_SUFFIX}`;
   return {
     base: baseName,
-    dataStream: eventLogNameWithVersion,
+    dataStream: `${eventLogName}-ds`,
     indexPattern: `${eventLogName}-*`,
-    indexTemplate: `${eventLogNameWithVersion}-template`,
+    indexTemplate: `${eventLogName}-template`,
   };
 }

--- a/x-pack/plugins/event_log/server/plugin.ts
+++ b/x-pack/plugins/event_log/server/plugin.ts
@@ -71,7 +71,6 @@ export class Plugin implements CorePlugin<IEventLogService, IEventLogClientServi
       elasticsearchClientPromise: core
         .getStartServices()
         .then(([{ elasticsearch }]) => elasticsearch.client.asInternalUser),
-      kibanaVersion: this.kibanaVersion,
       // Only non-serverless deployments may have assets that need to be converted
       shouldSetExistingAssetsToHidden: !plugins.serverless,
     });


### PR DESCRIPTION
Resolves: #158679

This PR removes the stack version from the EventLog index and datastream names.

As we already use `kibana-event-log-*` as indexPattern, `kibana-event-log-ds` is used as DataStream name to avoid creating a breaking change.

**Changes:**
| Name    | Old | New |
| -------- | ------- | ------- |
| Datastream  | `kibana-event-log-<version>`   | `kibana-event-log-ds` |
| IndexPattern | `kibana-event-log-*` | `kibana-event-log-*` (No change) |
| IndexTemplate    | `kibana-event-log-<version>-template`   | `kibana-event-log-template` |

Backing indices still have `<date>-000001` suffix but i think this is expected.

## To verify:

Run Kibana and  ES in main with `-E path.data=../local-es-data` to save the data.
Create a rule and let it run and create some alerts.
See the alerts in the rule details page.
Stop ES and Kibana
Switch to this PR
Run Kibana and ES again with `-E path.data=../local-es-data`
See the all old and new alerts in the rule details page.

The old index created by the main branch should remain, therefore the both old and the new indices (with and without version) should be visible in the console.


