### PR TITLE
[Infra UI] Fix redirection to Node Details page from Inventory UI

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
@@ -78,7 +78,7 @@ export const NodeContextMenu: React.FC<Props & { theme?: EuiTheme }> = withTheme
 
     const nodeDetailMenuItemLinkProps = useLinkProps({
       ...getNodeDetailUrl({
-        assetType: node.type,
+        assetType: nodeType,
         assetId: node.id,
         search: {
           from: nodeDetailFrom,

--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/waffle/node_context_menu.tsx
@@ -171,7 +171,10 @@ export const NodeContextMenu: React.FC<Props & { theme?: EuiTheme }> = withTheme
             )}
             <SectionLinks>
               <SectionLink data-test-subj="viewLogsContextMenuItem" {...nodeLogsMenuItem} />
-              <SectionLink {...nodeDetailMenuItem} />
+              <SectionLink
+                data-test-subj="viewAssetDetailsContextMenuItem"
+                {...nodeDetailMenuItem}
+              />
               <SectionLink data-test-subj="viewApmTracesContextMenuItem" {...apmTracesMenuItem} />
               <SectionLink {...uptimeMenuItem} color={'primary'} />
             </SectionLinks>

--- a/x-pack/test/functional/apps/infra/constants.ts
+++ b/x-pack/test/functional/apps/infra/constants.ts
@@ -29,6 +29,9 @@ export const DATES = {
       kubernetesSectionStartDate: '2023-09-19T07:20:00.000Z',
       kubernetesSectionEndDate: '2023-09-19T07:21:00.000Z',
     },
+    pods: {
+      withData: '01/20/2022 5:10:00 PM',
+    },
     stream: {
       startWithData: '2018-10-17T19:42:22.000Z',
       endWithData: '2018-10-17T19:57:21.000Z',
@@ -47,6 +50,7 @@ export const ML_JOB_IDS = [
 
 export const HOSTS_LINK_LOCAL_STORAGE_KEY = 'inventoryUI:hostsLinkClicked';
 
+export const INVENTORY_PATH = 'metrics/inventory';
 export const NODE_DETAILS_PATH = 'detail/host';
 export const HOSTS_VIEW_PATH = 'metrics/hosts';
 

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -223,11 +223,12 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHome.clickOnFirstNode();
           await pageObjects.infraHome.clickOnNodeDetailsFlyoutOpenAsPage();
 
-          const documentTitle = await browser.getTitle();
-
-          expect(documentTitle).to.contain(
-            'demo-stack-redis-01 - Infrastructure - Observability - Elastic'
-          );
+          await retry.tryForTime(3 * 1000, async () => {
+            const documentTitle = await browser.getTitle();
+            expect(documentTitle).to.contain(
+              'demo-stack-redis-01 - Infrastructure - Observability - Elastic'
+            );
+          });
 
           await returnTo(INVENTORY_PATH);
         });
@@ -238,10 +239,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHome.clickOnFirstNode();
           await pageObjects.infraHome.clickOnGoToNodeDetails();
 
-          const documentTitle = await browser.getTitle();
-          expect(documentTitle).to.contain(
-            'ed01e3a3-4787-42f6-b73e-ac9e97294e9d - Infrastructure - Observability - Elastic'
-          );
+          await retry.tryForTime(3 * 1000, async () => {
+            const documentTitle = await browser.getTitle();
+            expect(documentTitle).to.contain('pod-0 - Infrastructure - Observability - Elastic');
+          });
 
           await returnTo(INVENTORY_PATH);
         });

--- a/x-pack/test/functional/apps/infra/home_page.ts
+++ b/x-pack/test/functional/apps/infra/home_page.ts
@@ -8,10 +8,11 @@
 import expect from '@kbn/expect';
 import { KUBERNETES_TOUR_STORAGE_KEY } from '@kbn/infra-plugin/public/pages/metrics/inventory_view/components/kubernetes_tour';
 import { FtrProviderContext } from '../../ftr_provider_context';
-import { DATES } from './constants';
+import { DATES, INVENTORY_PATH } from './constants';
 
 const DATE_WITH_DATA = DATES.metricsAndLogs.hosts.withData;
 const DATE_WITHOUT_DATA = DATES.metricsAndLogs.hosts.withoutData;
+const DATE_WITH_POD_WITH_DATA = DATES.metricsAndLogs.pods.withData;
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const esArchiver = getService('esArchiver');
@@ -21,8 +22,15 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const kibanaServer = getService('kibanaServer');
   const testSubjects = getService('testSubjects');
 
-  // Failing: See https://github.com/elastic/kibana/issues/164164
-  describe.skip('Home page', function () {
+  const returnTo = async (path: string, timeout = 2000) =>
+    retry.waitForWithTimeout('returned to inventory', timeout, async () => {
+      await browser.goBack();
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      const currentUrl = await browser.getCurrentUrl();
+      return !!currentUrl.match(path);
+    });
+
+  describe('Home page', function () {
     this.tags('includeFirefox');
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
@@ -51,20 +59,19 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         );
         await pageObjects.infraHome.waitForLoading();
         await pageObjects.header.waitUntilLoadingHasFinished();
-
-        const documentTitle = await browser.getTitle();
-        expect(documentTitle).to.contain('Uh oh - Observability - Elastic');
       });
     });
 
     describe('with metrics present', () => {
       before(async () => {
         await esArchiver.load('x-pack/test/functional/es_archives/infra/metrics_and_logs');
+        await esArchiver.load('x-pack/test/functional/es_archives/infra/8.0.0/pods_only');
         await pageObjects.common.navigateToApp('infraOps');
         await pageObjects.infraHome.waitForLoading();
       });
       after(async () => {
         await esArchiver.unload('x-pack/test/functional/es_archives/infra/metrics_and_logs');
+        await esArchiver.unload('x-pack/test/functional/es_archives/infra/8.0.0/pods_only');
         await browser.removeLocalStorageItem(KUBERNETES_TOUR_STORAGE_KEY);
       });
 
@@ -202,6 +209,42 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
       it('toggles the inventory switcher', async () => {
         await pageObjects.infraHome.toggleInventorySwitcher();
+      });
+
+      describe('Redirect to Node Details page', () => {
+        before(async () => {
+          await pageObjects.common.navigateToApp('infraOps');
+          await pageObjects.infraHome.waitForLoading();
+        });
+
+        it('Should redirect to Host Details page', async () => {
+          await pageObjects.infraHome.goToTime(DATE_WITH_DATA);
+          await pageObjects.infraHome.goToHost();
+          await pageObjects.infraHome.clickOnFirstNode();
+          await pageObjects.infraHome.clickOnNodeDetailsFlyoutOpenAsPage();
+
+          const documentTitle = await browser.getTitle();
+
+          expect(documentTitle).to.contain(
+            'demo-stack-redis-01 - Infrastructure - Observability - Elastic'
+          );
+
+          await returnTo(INVENTORY_PATH);
+        });
+
+        it('Should redirect to Node Details page', async () => {
+          await pageObjects.infraHome.goToTime(DATE_WITH_POD_WITH_DATA);
+          await pageObjects.infraHome.goToPods();
+          await pageObjects.infraHome.clickOnFirstNode();
+          await pageObjects.infraHome.clickOnGoToNodeDetails();
+
+          const documentTitle = await browser.getTitle();
+          expect(documentTitle).to.contain(
+            'ed01e3a3-4787-42f6-b73e-ac9e97294e9d - Infrastructure - Observability - Elastic'
+          );
+
+          await returnTo(INVENTORY_PATH);
+        });
       });
     });
 

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -87,6 +87,28 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       return Promise.all(promises);
     },
 
+    async getFirstNode() {
+      const nodes = await testSubjects.findAll('nodeContainer');
+      return nodes[0];
+    },
+
+    async clickOnFirstNode() {
+      const firstNode = await this.getFirstNode();
+      firstNode.click();
+    },
+
+    async clickOnGoToNodeDetails() {
+      await retry.try(async () => {
+        await testSubjects.click('viewAssetDetailsContextMenuItem');
+      });
+    },
+
+    async clickOnNodeDetailsFlyoutOpenAsPage() {
+      await retry.try(async () => {
+        await testSubjects.click('infraNodeContextPopoverOpenAsPageButton');
+      });
+    },
+
     async sortNodesBy(sort: string) {
       await testSubjects.click('waffleSortByDropdown');
       if (sort === 'value') {
@@ -175,9 +197,7 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await testSubjects.click('openInventorySwitcher');
       await testSubjects.find('goToHost');
       await testSubjects.click('openInventorySwitcher');
-      return retry.tryForTime(2 * 1000, async () => {
-        return testSubjects.missingOrFail('goToHost');
-      });
+      await testSubjects.missingOrFail('goToHost', { timeout: 10 * 1000 });
     },
 
     async goToHost() {


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/166818
fixes https://github.com/elastic/kibana/issues/164164

## Summary

This PR fixes the redirection to Node Details page from the Inventory UI


https://github.com/elastic/kibana/assets/2767137/38fcc79c-12e4-42ed-8230-712227815731

flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3202

### How to test
- Setup a local Kibana instance, pointing to a oblt cluster
- Navigate to `Infrastructure`
- Change the node type to `Kubernetes Pods`
- Click on a pod and from the context menu, click on `Kubernetes Pod metrics`