### PR TITLE
[ResponseOps][Alerting] Failing ES Promotion: max_queued_actions_circuit_breaker.ts test

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
@@ -14,10 +14,10 @@ import { FtrProviderContext } from '../../../common/ftr_provider_context';
 export default function createActionTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
 
-  // Failing ES Promotion: See https://github.com/elastic/kibana/issues/166770
-  describe.skip('max queued actions circuit breaker', () => {
+  describe('max queued actions circuit breaker', () => {
     const objectRemover = new ObjectRemover(supertest);
     const retry = getService('retry');
+    const logger = getService('log');
 
     after(() => objectRemover.removeAll());
 
@@ -92,6 +92,7 @@ export default function createActionTests({ getService }: FtrProviderContext) {
 
       // check that there's a warning in the execute event
       const executeEvent = events[0];
+      logger.info(`execute event - ${JSON.stringify(executeEvent)}`);
       expect(executeEvent?.event?.outcome).to.eql('success');
       expect(executeEvent?.event?.reason).to.eql('maxQueuedActions');
       expect(executeEvent?.kibana?.alerting?.status).to.eql('warning');

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
-import { getEventLog, getTestRuleData, ObjectRemover } from '../../../common/lib';
+import { ESTestIndexTool, ES_TEST_INDEX_NAME } from '@kbn/alerting-api-integration-helpers';
+import { getEventLog, ObjectRemover } from '../../../common/lib';
 import { FtrProviderContext } from '../../../common/ftr_provider_context';
 
 // eslint-disable-next-line import/no-default-export
@@ -17,9 +17,18 @@ export default function createActionTests({ getService }: FtrProviderContext) {
   describe('max queued actions circuit breaker', () => {
     const objectRemover = new ObjectRemover(supertest);
     const retry = getService('retry');
-    const logger = getService('log');
+    const es = getService('es');
+    const esTestIndexTool = new ESTestIndexTool(es, retry);
 
-    after(() => objectRemover.removeAll());
+    beforeEach(async () => {
+      await esTestIndexTool.destroy();
+      await esTestIndexTool.setup();
+    });
+
+    afterEach(async () => {
+      objectRemover.removeAll();
+      await esTestIndexTool.destroy();
+    });
 
     it('completes execution and reports back whether it reached the limit', async () => {
       const response = await supertest
@@ -44,7 +53,7 @@ export default function createActionTests({ getService }: FtrProviderContext) {
       for (let i = 0; i < 510; i++) {
         actions.push({
           id: actionId,
-          group: 'default',
+          group: 'query matched',
           params: {
             index: ES_TEST_INDEX_NAME,
             reference: 'test',
@@ -61,19 +70,25 @@ export default function createActionTests({ getService }: FtrProviderContext) {
       const resp = await supertest
         .post('/api/alerting/rule')
         .set('kbn-xsrf', 'foo')
-        .send(
-          getTestRuleData({
-            rule_type_id: 'test.always-firing-alert-as-data',
-            schedule: { interval: '1h' },
-            throttle: undefined,
-            notify_when: undefined,
-            params: {
-              index: ES_TEST_INDEX_NAME,
-              reference: 'test',
-            },
-            actions,
-          })
-        );
+        .send({
+          name: 'abc',
+          consumer: 'alertsFixture',
+          enabled: true,
+          rule_type_id: '.es-query',
+          schedule: { interval: '1h' },
+          actions,
+          notify_when: undefined,
+          params: {
+            size: 100,
+            timeWindowSize: 20,
+            timeWindowUnit: 's',
+            thresholdComparator: '>',
+            threshold: [-1],
+            esQuery: `{\n  \"query\":{\n    \"match_all\" : {}\n  }\n}`,
+            timeField: 'date',
+            index: [ES_TEST_INDEX_NAME],
+          },
+        });
 
       expect(resp.status).to.eql(200);
       const ruleId = resp.body.id;
@@ -92,7 +107,6 @@ export default function createActionTests({ getService }: FtrProviderContext) {
 
       // check that there's a warning in the execute event
       const executeEvent = events[0];
-      logger.info(`execute event - ${JSON.stringify(executeEvent)}`);
       expect(executeEvent?.event?.outcome).to.eql('success');
       expect(executeEvent?.event?.reason).to.eql('maxQueuedActions');
       expect(executeEvent?.kibana?.alerting?.status).to.eql('warning');


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166770

## Summary

The test was failing for this reason: "illegal_argument_exception: can't merge a non object mapping [ruleInfo.actions] with an object mapping". I switched to es query rule so that we can use ESTestIndexTool that defines a mapping for the es test index.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### To verify

Run the functional test runner with the following command and verify it passes:
```
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.11.0/archives/20230919-155242_b9970223/manifest.json" node scripts/functional_tests_server.js --config x-pack/test/alerting_api_integration/spaces_only/tests/actions/config.ts
```
