### PR TITLE
chore(slo): open SLO details into new tab

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
@@ -139,7 +139,13 @@ export function SloListItem({
               <EuiFlexGroup direction="column" gutterSize="m">
                 <EuiFlexItem>
                   <EuiText size="s">
-                    {slo.summary ? <a href={sloDetailsUrl}>{slo.name}</a> : <span>{slo.name}</span>}
+                    {slo.summary ? (
+                      <a data-test-subj="o11ySloListItemLink" href={sloDetailsUrl}>
+                        {slo.name}
+                      </a>
+                    ) : (
+                      <span>{slo.name}</span>
+                    )}
                   </EuiText>
                 </EuiFlexItem>
                 <SloBadges

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_item.tsx
@@ -11,7 +11,6 @@ import {
   EuiContextMenuPanel,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiLink,
   EuiPanel,
   EuiPopover,
   EuiText,
@@ -23,6 +22,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import React, { useState } from 'react';
 import { rulesLocatorID, sloFeatureId } from '../../../../common';
 import { SLO_BURN_RATE_RULE_TYPE_ID } from '../../../../common/constants';
+import { paths } from '../../../../common/locators/paths';
 import { sloKeys } from '../../../hooks/slo/query_key_factory';
 import { useCapabilities } from '../../../hooks/slo/use_capabilities';
 import { useCloneSlo } from '../../../hooks/slo/use_clone_slo';
@@ -30,7 +30,6 @@ import { useDeleteSlo } from '../../../hooks/slo/use_delete_slo';
 import type { SloRule } from '../../../hooks/slo/use_fetch_rules_for_slo';
 import { useGetFilteredRuleTypes } from '../../../hooks/use_get_filtered_rule_types';
 import type { RulesParams } from '../../../locators/rules';
-import { paths } from '../../../../common/locators/paths';
 import { useKibana } from '../../../utils/kibana_react';
 import {
   transformCreateSLOFormToCreateSLOInput,
@@ -79,15 +78,14 @@ export function SloListItem({
     setIsActionsPopoverOpen(!isActionsPopoverOpen);
   };
 
+  const sloDetailsUrl = basePath.prepend(
+    paths.observability.sloDetails(
+      slo.id,
+      slo.groupBy !== ALL_VALUE && slo.instanceId ? slo.instanceId : undefined
+    )
+  );
   const handleViewDetails = () => {
-    navigateToUrl(
-      basePath.prepend(
-        paths.observability.sloDetails(
-          slo.id,
-          slo.groupBy !== ALL_VALUE && slo.instanceId ? slo.instanceId : undefined
-        )
-      )
-    );
+    navigateToUrl(sloDetailsUrl);
   };
 
   const handleEdit = () => {
@@ -141,13 +139,7 @@ export function SloListItem({
               <EuiFlexGroup direction="column" gutterSize="m">
                 <EuiFlexItem>
                   <EuiText size="s">
-                    {slo.summary ? (
-                      <EuiLink data-test-subj="o11ySloListItemLink" onClick={handleViewDetails}>
-                        {slo.name}
-                      </EuiLink>
-                    ) : (
-                      <span>{slo.name}</span>
-                    )}
+                    {slo.summary ? <a href={sloDetailsUrl}>{slo.name}</a> : <span>{slo.name}</span>}
                   </EuiText>
                 </EuiFlexItem>
                 <SloBadges


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166684

## 🍒 Summary

This PR allows to open the SLO details page in a new tab or in the current tab when clicking on the SLO name on the list page. Before, the SLO details page was always opened in the current page because of the usage of EuiLink.

## 🧪 Testing

Create an SLO, and while holding ctrl, click on the slo name. A new tab should be open on the slo details page.