### PR TITLE
[Saved Searches] Soften saved search Content Management response `sort` schema

### DIFF
--- a/src/plugins/saved_search/common/content_management/v1/cm_services.ts
+++ b/src/plugins/saved_search/common/content_management/v1/cm_services.ts
@@ -16,7 +16,7 @@ import {
   createResultSchema,
 } from '@kbn/content-management-utils';
 
-const sortSchema = schema.arrayOf(schema.string(), { minSize: 2, maxSize: 2 });
+const sortSchema = schema.arrayOf(schema.string(), { maxSize: 2 });
 
 const savedSearchAttributesSchema = schema.object(
   {


### PR DESCRIPTION
## Summary

This PR softens the saved search CM response `sort` schema to align it with the saved search SO `sort` schema from #156769 (no `minSize`).

You can import this broken saved search SO for testing:
```json
{"attributes":{"columns":["response","url","clientip","machine.os","tags"],"description":"","grid":{},"hideChart":false,"hits":0,"isTextBasedQuery":false,"kibanaSavedObjectMeta":{"searchSourceJSON":"{\"query\":{\"query\":\"\",\"language\":\"kuery\"},\"filter\":[],\"indexRefName\":\"kibanaSavedObjectMeta.searchSourceJSON.index\"}"},"sort":[[]],"timeRestore":false,"title":"test","version":1},"coreMigrationVersion":"8.8.0","created_at":"2023-09-20T20:01:37.753Z","id":"2f360f30-ea74-11eb-b4c6-3d2afc1cb389","managed":false,"references":[{"id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"kibanaSavedObjectMeta.searchSourceJSON.index","type":"index-pattern"}],"type":"search","typeMigrationVersion":"7.9.3","updated_at":"2023-09-20T20:02:12.775Z","version":"WzQwLDFd"}
{"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":1,"missingRefCount":0,"missingReferences":[]}
```

Fixes #166880.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->