### PR TITLE
[Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
@@ -154,6 +154,35 @@ describe('PrevalenceDetails', () => {
     );
   });
 
+  it('should render multiple values in value column', () => {
+    (usePrevalence as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [
+        {
+          field: 'field1',
+          values: ['value1', 'value2'],
+          alertCount: 1000,
+          docCount: 2000000,
+          hostPrevalence: 0.05,
+          userPrevalence: 0.1,
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <LeftPanelContext.Provider value={panelContextValue}>
+          <PrevalenceDetails />
+        </LeftPanelContext.Provider>
+      </TestProviders>
+    );
+
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value1');
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value2');
+  });
+
   it('should render the table with only basic columns if license is not platinum', () => {
     const field1 = 'field1';
     const field2 = 'field2';

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
@@ -79,7 +79,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -87,7 +87,7 @@ describe('PrevalenceDetails', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,
@@ -124,7 +124,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: 'field1',
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1000,
           docCount: 2000000,
           hostPrevalence: 0.05,
@@ -163,7 +163,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -171,7 +171,7 @@ describe('PrevalenceDetails', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
@@ -88,7 +88,7 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     render: (values: string[]) => (
       <EuiFlexGroup direction="column" gutterSize="none">
         {values.map((value) => (
-          <EuiFlexItem>
+          <EuiFlexItem key={value}>
             <EuiText size="xs">{value}</EuiText>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
@@ -77,7 +77,7 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     width: '20%',
   },
   {
-    field: 'value',
+    field: 'values',
     name: (
       <FormattedMessage
         id="xpack.securitySolution.flyout.left.insights.prevalence.valueColumnLabel"
@@ -85,7 +85,15 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
       />
     ),
     'data-test-subj': PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
-    render: (value: string) => <EuiText size="xs">{value}</EuiText>,
+    render: (values: string[]) => (
+      <EuiFlexGroup direction="column" gutterSize="none">
+        {values.map((value) => (
+          <EuiFlexItem>
+            <EuiText size="xs">{value}</EuiText>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    ),
     width: '20%',
   },
   {
@@ -116,9 +124,9 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     ),
     'data-test-subj': PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
     render: (data: PrevalenceDetailsRow) => {
-      const dataProviders = [
-        getDataProvider(data.field, `timeline-indicator-${data.field}-${data.value}`, data.value),
-      ];
+      const dataProviders = data.values.map((value) =>
+        getDataProvider(data.field, `timeline-indicator-${data.field}-${value}`, value)
+      );
       return data.alertCount > 0 ? (
         <InvestigateInTimelineButton
           asEmptyButton={true}
@@ -162,24 +170,18 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     ),
     'data-test-subj': PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
     render: (data: PrevalenceDetailsRow) => {
-      const dataProviders = [
-        {
-          ...getDataProvider(
-            data.field,
-            `timeline-indicator-${data.field}-${data.value}`,
-            data.value
+      const dataProviders = data.values.map((value) => ({
+        ...getDataProvider(data.field, `timeline-indicator-${data.field}-${value}`, value),
+        and: [
+          getDataProviderAnd(
+            'event.kind',
+            `timeline-indicator-event.kind-not-signal`,
+            'signal',
+            IS_OPERATOR,
+            true
           ),
-          and: [
-            getDataProviderAnd(
-              'event.kind',
-              `timeline-indicator-event.kind-not-signal`,
-              'signal',
-              IS_OPERATOR,
-              true
-            ),
-          ],
-        },
-      ];
+        ],
+      }));
       return data.docCount > 0 ? (
         <InvestigateInTimelineButton
           asEmptyButton={true}

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
@@ -99,7 +99,7 @@ describe('<PrevalenceOverview />', () => {
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -107,7 +107,7 @@ describe('<PrevalenceOverview />', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,
@@ -141,7 +141,7 @@ describe('<PrevalenceOverview />', () => {
       data: [
         {
           field: 'field1',
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
@@ -93,6 +93,7 @@ describe('<PrevalenceOverview />', () => {
   it('should render only data with prevalence less than 10%', () => {
     const field1 = 'field1';
     const field2 = 'field2';
+    const field3 = 'field3';
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
       error: false,
@@ -107,7 +108,15 @@ describe('<PrevalenceOverview />', () => {
         },
         {
           field: field2,
-          values: ['value2'],
+          values: ['value2', 'value22'],
+          alertCount: 1,
+          docCount: 1,
+          hostPrevalence: 0.06,
+          userPrevalence: 0.2,
+        },
+        {
+          field: field3,
+          values: ['value3'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,
@@ -128,8 +137,14 @@ describe('<PrevalenceOverview />', () => {
 
     const iconDataTestSubj2 = `${PREVALENCE_TEST_ID}${field2}Icon`;
     const valueDataTestSubj2 = `${PREVALENCE_TEST_ID}${field2}Value`;
-    expect(queryByTestId(iconDataTestSubj2)).not.toBeInTheDocument();
-    expect(queryByTestId(valueDataTestSubj2)).not.toBeInTheDocument();
+    expect(getByTestId(iconDataTestSubj2)).toBeInTheDocument();
+    expect(getByTestId(valueDataTestSubj2)).toBeInTheDocument();
+    expect(getByTestId(valueDataTestSubj2)).toHaveTextContent('field2, value2,value22 is uncommon');
+
+    const iconDataTestSubj3 = `${PREVALENCE_TEST_ID}${field3}Icon`;
+    const valueDataTestSubj3 = `${PREVALENCE_TEST_ID}${field3}Value`;
+    expect(queryByTestId(iconDataTestSubj3)).not.toBeInTheDocument();
+    expect(queryByTestId(valueDataTestSubj3)).not.toBeInTheDocument();
 
     expect(queryByTestId(PREVALENCE_NO_DATA_TEST_ID)).not.toBeInTheDocument();
   });

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
@@ -99,7 +99,7 @@ export const PrevalenceOverview: FC = () => {
                 <FormattedMessage
                   id="xpack.securitySolution.flyout.right.insights.prevalence.rowDescription"
                   defaultMessage="{field}, {value} is uncommon"
-                  values={{ field: d.field, value: d.value }}
+                  values={{ field: d.field, value: d.values.toString() }}
                 />
               }
               data-test-subj={`${PREVALENCE_TEST_ID}${d.field}`}

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.test.tsx
@@ -124,7 +124,7 @@ describe('usePrevalence', () => {
     expect(hookResult.result.current.data).toEqual([
       {
         field: 'host.name',
-        value: 'host-1',
+        values: ['host-1'],
         alertCount: 1,
         docCount: 1,
         hostPrevalence: 0.1,

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.ts
@@ -6,7 +6,6 @@
  */
 
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
-import { isArray } from 'lodash/fp';
 import { useMemo } from 'react';
 import { useHighlightedFields } from './use_highlighted_fields';
 import { convertHighlightedFieldsToPrevalenceFilters } from '../utils/highlighted_fields_helpers';
@@ -24,7 +23,7 @@ import { EventKind } from '../constants/event_kinds';
 
 export interface PrevalenceData {
   field: string;
-  value: string;
+  values: string[];
   alertCount: number;
   docCount: number;
   hostPrevalence: number;
@@ -91,7 +90,7 @@ export const usePrevalence = ({
     const fieldNames = Object.keys(data.aggregations[FIELD_NAMES_AGG_KEY].buckets);
 
     fieldNames.forEach((fieldName: string) => {
-      const fieldValue = highlightedFields[fieldName].values;
+      const fieldValues = highlightedFields[fieldName].values;
 
       // retrieves the number of signals for the current field/value pair
       const alertCount =
@@ -131,7 +130,7 @@ export const usePrevalence = ({
 
       items.push({
         field: fieldName,
-        value: isArray(fieldValue) ? fieldValue[0] : fieldValue,
+        values: fieldValues,
         alertCount,
         docCount,
         hostPrevalence,

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
@@ -58,12 +58,12 @@ describe('convertHighlightedFieldsToPrevalenceFilters', () => {
         values: ['host-1'],
       },
       'user.name': {
-        values: ['user-1'],
+        values: ['user-1', 'user-2'],
       },
     };
     expect(convertHighlightedFieldsToPrevalenceFilters(highlightedFields)).toEqual({
-      'host.name': { match: { 'host.name': 'host-1' } },
-      'user.name': { match: { 'user.name': 'user-1' } },
+      'host.name': { terms: { 'host.name': ['host-1'] } },
+      'user.name': { terms: { 'user.name': ['user-1', 'user-2'] } },
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
@@ -48,7 +48,7 @@ export const convertHighlightedFieldsToPrevalenceFilters = (
 
     return {
       ...acc,
-      [curr]: { match: { [curr]: Array.isArray(values) ? values[0] : values } },
+      [curr]: { terms: { [curr]: values } },
     };
   }, []) as unknown as Record<string, QueryDslQueryContainer>;
 };


### PR DESCRIPTION
## Summary

This PR fixes an issue with the prevalence query: for fields with multiple values, we were only keeping the first value of the array. This PR makes the following changes:
- use all values for the highlighted fields fetched
- displays all the values in the prevalence table and in the prevalence overview
- use all the values when opening up timeline

Opening timeline

https://github.com/elastic/kibana/assets/17276605/a20292e3-aac6-44a4-ae2d-615d0a881968

Fetching prevalence data

https://github.com/elastic/kibana/assets/17276605/7a8986b1-d0fa-4f86-8eab-8099c8c60b87

https://github.com/elastic/security-team/issues/7546

### How to reproduce

- find an alert that has a field with 2 or more values
- edit the rule that was used to create the alert, or if the rule cannot be edited, create a new rule with a custom highlighted field for the field that has 2 or more values

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->