### PR TITLE
Provide valid object types in `_find` API doc

### DIFF
--- a/docs/api/saved-objects/find.asciidoc
+++ b/docs/api/saved-objects/find.asciidoc
@@ -31,7 +31,7 @@ For the most up-to-date API details, refer to the
 ==== Query Parameters
 
 `type`::
-  (Required, array|string) The saved object types to include in the export.
+  (Required, array|string) The saved object types to include in the export. Valid options include `visualization`, `dashboard`, `search`, `index-pattern`, `config`.
 
 `per_page`::
   (Optional, number) The number of objects to return per page.


### PR DESCRIPTION
## Summary

The current [Find objects API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-find.html) documentation requires the object `type` as a query parameter:

![Screenshot 2023-09-19 at 3 53 34 PM](https://github.com/elastic/kibana/assets/111907029/54cb038c-e395-4cc0-b98c-b4d935e9795e)

To further clarify these requirements, it is requested to include within this description the valid options available, similar to the way it is included in the [Get object API](https://www.elastic.co/guide/en/kibana/current/saved-objects-api-get.html) documentation:

![Screenshot 2023-09-19 at 3 56 59 PM](https://github.com/elastic/kibana/assets/111907029/d20c95f9-f147-452f-bd78-e616870a31d7)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
