### PR TITLE
[Security Solution] expandable flyout - add tooltip to correlations table cells

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/correlations_details_alerts_table.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/correlations_details_alerts_table.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
-import React, { type FC, useMemo, useCallback } from 'react';
+import React, { type VFC, useMemo, useCallback } from 'react';
 import { type Criteria, EuiBasicTable, formatDate } from '@elastic/eui';
 import { Severity } from '@kbn/securitysolution-io-ts-alerting-types';
 import type { Filter } from '@kbn/es-query';
@@ -14,6 +14,7 @@ import { isRight } from 'fp-ts/lib/Either';
 import { ALERT_REASON, ALERT_RULE_NAME } from '@kbn/rule-data-utils';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { CellTooltipWrapper } from '../../shared/components/cell_tooltip_wrapper';
 import type { DataProvider } from '../../../../common/types';
 import { SeverityBadge } from '../../../detections/components/rules/severity_badge';
 import { usePaginatedAlerts } from '../hooks/use_paginated_alerts';
@@ -36,7 +37,14 @@ export const columns = [
     ),
     truncateText: true,
     dataType: 'date' as const,
-    render: (value: string) => formatDate(value, TIMESTAMP_DATE_FORMAT),
+    render: (value: string) => {
+      const date = formatDate(value, TIMESTAMP_DATE_FORMAT);
+      return (
+        <CellTooltipWrapper tooltip={date}>
+          <span>{date}</span>
+        </CellTooltipWrapper>
+      );
+    },
   },
   {
     field: ALERT_RULE_NAME,
@@ -47,6 +55,11 @@ export const columns = [
       />
     ),
     truncateText: true,
+    render: (value: string) => (
+      <CellTooltipWrapper tooltip={value}>
+        <span>{value}</span>
+      </CellTooltipWrapper>
+    ),
   },
   {
     field: ALERT_REASON,
@@ -57,6 +70,11 @@ export const columns = [
       />
     ),
     truncateText: true,
+    render: (value: string) => (
+      <CellTooltipWrapper tooltip={value} anchorPosition="left">
+        <span>{value}</span>
+      </CellTooltipWrapper>
+    ),
   },
   {
     field: 'kibana.alert.severity',
@@ -69,7 +87,12 @@ export const columns = [
     truncateText: true,
     render: (value: string) => {
       const decodedSeverity = Severity.decode(value);
-      return isRight(decodedSeverity) ? <SeverityBadge value={decodedSeverity.right} /> : value;
+      const renderValue = isRight(decodedSeverity) ? (
+        <SeverityBadge value={decodedSeverity.right} />
+      ) : (
+        <p>{value}</p>
+      );
+      return <CellTooltipWrapper tooltip={value}>{renderValue}</CellTooltipWrapper>;
     },
   },
 ];
@@ -108,7 +131,7 @@ export interface CorrelationsDetailsAlertsTableProps {
 /**
  * Renders paginated alert array based on the provided alertIds
  */
-export const CorrelationsDetailsAlertsTable: FC<CorrelationsDetailsAlertsTableProps> = ({
+export const CorrelationsDetailsAlertsTable: VFC<CorrelationsDetailsAlertsTableProps> = ({
   title,
   loading,
   alertIds,

--- a/x-pack/plugins/security_solution/public/flyout/left/components/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/related_cases.tsx
@@ -10,6 +10,7 @@ import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiInMemoryTable, EuiSkeletonText } from '@elastic/eui';
 import type { RelatedCase } from '@kbn/cases-plugin/common';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { CellTooltipWrapper } from '../../shared/components/cell_tooltip_wrapper';
 import { CaseDetailsLink } from '../../../common/components/links';
 import {
   CORRELATIONS_DETAILS_CASES_SECTION_TABLE_TEST_ID,
@@ -29,11 +30,12 @@ const columns: Array<EuiBasicTableColumn<RelatedCase>> = [
         defaultMessage="Name"
       />
     ),
-    truncateText: true,
     render: (value: string, caseData: RelatedCase) => (
-      <CaseDetailsLink detailName={caseData.id} title={caseData.title}>
-        {caseData.title}
-      </CaseDetailsLink>
+      <CellTooltipWrapper tooltip={caseData.title}>
+        <CaseDetailsLink detailName={caseData.id} title={caseData.title}>
+          {caseData.title}
+        </CaseDetailsLink>
+      </CellTooltipWrapper>
     ),
   },
   {
@@ -45,6 +47,7 @@ const columns: Array<EuiBasicTableColumn<RelatedCase>> = [
       />
     ),
     truncateText: true,
+    width: '25%',
   },
 ];
 

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CellTooltipWrapper } from './cell_tooltip_wrapper';
+
+const TEST_ID = 'test-id';
+const children = <p data-test-subj={TEST_ID}>{'test content'}</p>;
+
+describe('<CellTooltipWrapper />', () => {
+  it('should render non-expandable panel by default', () => {
+    const { getByTestId } = render(
+      <CellTooltipWrapper tooltip="test tooltip">{children}</CellTooltipWrapper>
+    );
+    expect(getByTestId(TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { VFC, ReactElement } from 'react';
+import React from 'react';
+import { EuiToolTip } from '@elastic/eui';
+
+export interface CellTooltipWrapperProps {
+  /**
+   * Value displayed in the tooltip and in the cell itself
+   */
+  tooltip: string | ReactElement;
+  /**
+   * Tooltip anchor position
+   */
+  anchorPosition?: 'left' | 'right' | 'top' | 'bottom';
+  /**
+   * React components to render
+   */
+  children: React.ReactElement;
+}
+
+export const CellTooltipWrapper: VFC<CellTooltipWrapperProps> = ({
+  tooltip,
+  anchorPosition = 'top',
+  children,
+}) => (
+  <EuiToolTip content={tooltip} position={anchorPosition}>
+    {children}
+  </EuiToolTip>
+);


### PR DESCRIPTION
## Summary

This PR adds a tooltip to the table cells for the Security Solution expandable flyout left panel correlations tables:
- related cases
- related alerts by ancestry
- related alerts by source event
- related alerts by session

https://github.com/elastic/kibana/assets/17276605/d64d7744-0e5c-4f29-9674-e8c4e0a09d03

https://github.com/elastic/kibana/issues/164983

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->