### PR TITLE
Fix exceptions flyout disappearing

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -233,6 +233,7 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
     detailName: string;
     tabName: string;
   }>();
+
   const {
     rule: maybeRule,
     refresh: refreshRule,
@@ -382,19 +383,21 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
     [clearEventsLoading, clearEventsDeleted, clearSelected, setFilterGroup]
   );
 
+  const isBuildingBlockTypeNotNull = rule?.building_block_type != null;
   // Set showBuildingBlockAlerts if rule is a Building Block Rule otherwise we won't show alerts
   useEffect(() => {
-    setShowBuildingBlockAlerts(rule?.building_block_type != null);
-  }, [rule, setShowBuildingBlockAlerts]);
+    setShowBuildingBlockAlerts(isBuildingBlockTypeNotNull);
+  }, [isBuildingBlockTypeNotNull, setShowBuildingBlockAlerts]);
 
+  const ruleRuleId = rule?.rule_id ?? '';
   const alertDefaultFilters = useMemo(
     () => [
-      ...buildAlertsFilter(rule?.rule_id ?? ''),
+      ...buildAlertsFilter(ruleRuleId ?? ''),
       ...buildShowBuildingBlockFilter(showBuildingBlockAlerts),
       ...buildAlertStatusFilter(filterGroup),
       ...buildThreatMatchFilter(showOnlyThreatIndicatorAlerts),
     ],
-    [rule, showBuildingBlockAlerts, showOnlyThreatIndicatorAlerts, filterGroup]
+    [ruleRuleId, showBuildingBlockAlerts, showOnlyThreatIndicatorAlerts, filterGroup]
   );
 
   const alertMergedFilters = useMemo(


### PR DESCRIPTION
## Summary
fix: [https://github.com/elastic/kibana/issues/166616](https://github.com/elastic/kibana/issues/166616)

When we open exception flyout we do request a rule
Then in the rule details page,  `alertDefaultFilters` was memoized based on whole rule object
And if the rule changes it rerenders the whole alerts table. 

In the attached video it rule changes because of rule execution time.

I make `useMemo` and `use effect` for these cases really on rule property, but not full object



https://github.com/elastic/kibana/assets/7609147/eba7c3ce-84b9-47a7-8bc9-a15bc0179e2c


