### PR TITLE
[Security Solution] expandable flyout - increase line-height for session preview

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/right/components/session_preview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/session_preview.tsx
@@ -8,6 +8,7 @@
 import { EuiCode, EuiIcon, useEuiTheme } from '@elastic/eui';
 import type { ReactElement } from 'react';
 import React, { useMemo, type FC } from 'react';
+import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SESSION_PREVIEW_TEST_ID } from './test_ids';
 import { useRightPanelContext } from '../context';
@@ -127,7 +128,12 @@ export const SessionPreview: FC = () => {
   }, [command, workdir]);
 
   return (
-    <div data-test-subj={SESSION_PREVIEW_TEST_ID}>
+    <div
+      css={css`
+        line-height: 1.5;
+      `}
+      data-test-subj={SESSION_PREVIEW_TEST_ID}
+    >
       <ValueContainer>
         <EuiIcon type="user" />
         &nbsp;


### PR DESCRIPTION
## Summary

This PR fixes a very small UI issue visible in some scenarios where the Security Solution expandable flyout right panel session preview component has its row overlapping.

I could not really reproduce the issue locally to the extend of the screenshot found in [the ticket](https://github.com/elastic/security-team/issues/7665). As you can see in the screenhost below, the rendering seems correct, but on the limit.
<img width="348" alt="Screenshot 2023-09-21 at 2 57 07 PM" src="https://github.com/elastic/kibana/assets/17276605/b6a0e124-c1f1-4ba3-86b1-d4310e81bcff">

 The `line-height :1.25` could have worked but using `1.5` is safer and will work in more scenarios.
<img width="348" alt="Screenshot 2023-09-21 at 2 58 22 PM" src="https://github.com/elastic/kibana/assets/17276605/82c15828-c122-447e-956f-3d6cf81bf1eb">

https://github.com/elastic/security-team/issues/7665


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->