### PR TITLE
[ML] AIOps: Fixes render loop when using a saved search.

### DIFF
--- a/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
@@ -71,7 +71,7 @@ export const LogCategorizationPage: FC = () => {
   const [globalState, setGlobalState] = useUrlState('_g');
   const [selectedField, setSelectedField] = useState<string | undefined>();
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(null);
-  const [selectedSavedSearch, setSelectedDataView] = useState(savedSearch);
+  const [selectedSavedSearch, setSelectedSavedSearch] = useState(savedSearch);
   const [loading, setLoading] = useState(false);
   const [totalCount, setTotalCount] = useState(0);
   const [eventRate, setEventRate] = useState<EventRate>([]);
@@ -91,7 +91,7 @@ export const LogCategorizationPage: FC = () => {
 
   useEffect(() => {
     if (savedSearch) {
-      setSelectedDataView(savedSearch);
+      setSelectedSavedSearch(savedSearch);
     }
   }, [savedSearch]);
 
@@ -114,7 +114,7 @@ export const LogCategorizationPage: FC = () => {
       // When the user loads saved search and then clear or modify the query
       // we should remove the saved search and replace it with the index pattern id
       if (selectedSavedSearch !== null) {
-        setSelectedDataView(null);
+        setSelectedSavedSearch(null);
       }
 
       setUrlState({

--- a/x-pack/plugins/aiops/public/hooks/use_search.ts
+++ b/x-pack/plugins/aiops/public/hooks/use_search.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { useMemo } from 'react';
+
 import type { DataView } from '@kbn/data-views-plugin/public';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 
@@ -24,12 +26,16 @@ export const useSearch = (
     },
   } = useAiopsAppContext();
 
-  const searchData = getEsQueryFromSavedSearch({
-    dataView,
-    uiSettings,
-    savedSearch,
-    filterManager,
-  });
+  const searchData = useMemo(
+    () =>
+      getEsQueryFromSavedSearch({
+        dataView,
+        uiSettings,
+        savedSearch,
+        filterManager,
+      }),
+    [dataView, uiSettings, savedSearch, filterManager]
+  );
 
   if (searchData === undefined || (aiopsListState && aiopsListState.searchString !== '')) {
     if (aiopsListState?.filters && readOnly === false) {


### PR DESCRIPTION
## Summary

Fixes #166079.

If a user picked a saved search to investigate, the log pattern analysis page would freeze with an infinite render loop; the log rate analysis pate wouldn't freeze but repeatedly query for new data. 

This PR fixes the issue by memoizing the queries derived from the saved search information to avoid it being a new instance every time. 

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->