### PR TITLE
fix(slo): search bar

### DIFF
--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
@@ -21,7 +21,7 @@ export function SloList({ autoRefresh }: Props) {
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<SortField | undefined>('status');
 
-  const { isInitialLoading, isLoading, isRefetching, isError, sloList, refetch } = useFetchSloList({
+  const { isLoading, isRefetching, isError, sloList } = useFetchSloList({
     page: activePage + 1,
     kqlQuery: query,
     sortBy: sort,
@@ -38,19 +38,16 @@ export function SloList({ autoRefresh }: Props) {
 
   const handlePageClick = (pageNumber: number) => {
     setActivePage(pageNumber);
-    refetch();
   };
 
   const handleChangeQuery = (newQuery: string) => {
     setActivePage(0);
     setQuery(newQuery);
-    refetch();
   };
 
   const handleChangeSort = (newSort: SortField | undefined) => {
     setActivePage(0);
     setSort(newSort);
-    refetch();
   };
 
   return (

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
@@ -54,15 +54,7 @@ export function SloList({ autoRefresh }: Props) {
     <EuiFlexGroup direction="column" gutterSize="m" data-test-subj="sloList">
       <EuiFlexItem grow>
         <SloListSearchFilterSortBar
-          loading={
-            isInitialLoading ||
-            isLoading ||
-            isRefetching ||
-            isCreatingSlo ||
-            isCloningSlo ||
-            isUpdatingSlo ||
-            isDeletingSlo
-          }
+          loading={isLoading || isCreatingSlo || isCloningSlo || isUpdatingSlo || isDeletingSlo}
           onChangeQuery={handleChangeQuery}
           onChangeSort={handleChangeSort}
         />

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
@@ -16,6 +16,7 @@ import {
   EuiSelectableOption,
 } from '@elastic/eui';
 import { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
+import { Query } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { QueryStringInput } from '@kbn/unified-search-plugin/public';
 import React, { useState } from 'react';
@@ -103,9 +104,13 @@ export function SloListSearchFilterSortBar({
             unifiedSearch,
           }}
           disableAutoFocus
-          onSubmit={() => onChangeQuery(query)}
+          onSubmit={(value: Query) => {
+            setQuery(String(value.query));
+            onChangeQuery(String(value.query));
+          }}
           disableLanguageSwitcher
           isDisabled={loading}
+          autoSubmit
           indexPatterns={dataView ? [dataView] : []}
           placeholder={i18n.translate('xpack.observability.slo.list.search', {
             defaultMessage: 'Search your SLOs...',


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166689
Resolves https://github.com/elastic/kibana/issues/166683

## 🍒 Summary

This PR fixes two bugs:
1. When the auto refetch was triggered, the search bar was disabled, resulting in a lost of focus if the user was actively typing in the search bar.
2. When submitting a search query, we were forcing `refetch` but doing so was using the previous state of the query. Instead, we only update the query state, and let react react hook query trigger a refetch based on the state update.

