### PR TITLE
[Security Solution][Endpoint] Increase buildkite `parallelism` for `defend_workflows` on pipeline `on_merge_unsupported_ftrs.yml`

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -91,7 +91,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 120
-    parallelism: 2
+    parallelism: 6
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary

- Increase the `parallelism` for `defend_workflows` to match that of PR pull request (`6`)
    - Should ( 🤞 ) fix the failures being seen in buildkite: https://buildkite.com/elastic/kibana-on-merge-unsupported-ftrs

