### PR TITLE
[Cases] Backend validation custom fields

### DIFF
--- a/x-pack/plugins/cases/common/types/api/case/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/case/v1.test.ts
@@ -276,7 +276,7 @@ describe('CasePostRequestRt', () => {
     });
   });
 
-  it('limits customFields to 5', () => {
+  it(`limits customFields to ${MAX_CUSTOM_FIELDS_PER_CASE}`, () => {
     const customFields = Array(MAX_CUSTOM_FIELDS_PER_CASE + 1).fill({
       key: 'first_custom_field_key',
       type: 'text',
@@ -290,7 +290,9 @@ describe('CasePostRequestRt', () => {
           customFields,
         })
       )
-    ).toContain('The length of the field customFields is too long. Array must be of length <= 5.');
+    ).toContain(
+      `The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
+    );
   });
 
   it('does not throw an error with undefined customFields', async () => {
@@ -660,7 +662,7 @@ describe('CasePatchRequestRt', () => {
     ).toContain('The length of the category is too long. The maximum length is 50.');
   });
 
-  it('limits customFields to 5', () => {
+  it(`limits customFields to ${MAX_CUSTOM_FIELDS_PER_CASE}`, () => {
     const customFields = Array(MAX_CUSTOM_FIELDS_PER_CASE + 1).fill({
       key: 'first_custom_field_key',
       type: 'text',
@@ -674,7 +676,9 @@ describe('CasePatchRequestRt', () => {
           customFields,
         })
       )
-    ).toContain('The length of the field customFields is too long. Array must be of length <= 5.');
+    ).toContain(
+      `The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
+    );
   });
 });
 

--- a/x-pack/plugins/cases/common/types/api/case/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/case/v1.ts
@@ -42,6 +42,13 @@ import { CaseConnectorRt } from '../../domain/connector/v1';
 import { CaseUserProfileRt, UserRt } from '../../domain/user/v1';
 import { CasesStatusResponseRt } from '../stats/v1';
 
+const CustomFieldsRt = limitedArraySchema({
+  codec: CustomFieldRt,
+  fieldName: 'customFields',
+  min: 0,
+  max: MAX_CUSTOM_FIELDS_PER_CASE,
+});
+
 /**
  * Create case
  */
@@ -108,12 +115,7 @@ export const CasePostRequestRt = rt.intersection([
       /**
        * The list of custom field values of the case.
        */
-      customFields: limitedArraySchema({
-        codec: CustomFieldRt,
-        fieldName: 'customFields',
-        min: 0,
-        max: MAX_CUSTOM_FIELDS_PER_CASE,
-      }),
+      customFields: CustomFieldsRt,
     })
   ),
 ]);
@@ -371,12 +373,7 @@ export const CasePatchRequestRt = rt.intersection([
       /**
        * Custom fields of the case
        */
-      customFields: limitedArraySchema({
-        codec: CustomFieldRt,
-        fieldName: 'customFields',
-        min: 0,
-        max: MAX_CUSTOM_FIELDS_PER_CASE,
-      }),
+      customFields: CustomFieldsRt,
     })
   ),
   /**
@@ -467,3 +464,4 @@ export type GetReportersResponse = rt.TypeOf<typeof GetReportersResponseRt>;
 export type CasesBulkGetRequest = rt.TypeOf<typeof CasesBulkGetRequestRt>;
 export type CasesBulkGetResponse = rt.TypeOf<typeof CasesBulkGetResponseRt>;
 export type GetRelatedCasesByAlertResponse = rt.TypeOf<typeof GetRelatedCasesByAlertResponseRt>;
+export type CaseRequestCustomFields = rt.TypeOf<typeof CustomFieldsRt>;

--- a/x-pack/plugins/cases/common/types/api/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.ts
@@ -6,8 +6,12 @@
  */
 
 import * as rt from 'io-ts';
-import { MAX_CUSTOM_FIELD_KEY_LENGTH, MAX_CUSTOM_FIELD_LABEL_LENGTH } from '../../../constants';
-import { limitedStringSchema } from '../../../schema';
+import {
+  MAX_CUSTOM_FIELDS_PER_CASE,
+  MAX_CUSTOM_FIELD_KEY_LENGTH,
+  MAX_CUSTOM_FIELD_LABEL_LENGTH,
+} from '../../../constants';
+import { limitedArraySchema, limitedStringSchema } from '../../../schema';
 import { CustomFieldTextTypeRt, CustomFieldToggleTypeRt } from '../../domain';
 import type { Configurations, Configuration } from '../../domain/configure/v1';
 import { ConfigurationBasicWithoutOwnerRt, ClosureTypeRt } from '../../domain/configure/v1';
@@ -38,9 +42,12 @@ export const ToggleCustomFieldConfigurationRt = rt.intersection([
   CustomFieldConfigurationRt,
 ]);
 
-export const CustomFieldsConfigurationRt = rt.array(
-  rt.union([TextCustomFieldConfigurationRt, ToggleCustomFieldConfigurationRt])
-);
+export const CustomFieldsConfigurationRt = limitedArraySchema({
+  codec: rt.union([TextCustomFieldConfigurationRt, ToggleCustomFieldConfigurationRt]),
+  min: 0,
+  max: MAX_CUSTOM_FIELDS_PER_CASE,
+  fieldName: 'customFields',
+});
 
 export const ConfigurationRequestRt = rt.intersection([
   rt.strict({
@@ -79,7 +86,13 @@ export const CaseConfigureRequestParamsRt = rt.strict({
 });
 
 export const ConfigurationPatchRequestRt = rt.intersection([
-  rt.exact(rt.partial(ConfigurationBasicWithoutOwnerRt.type.props)),
+  rt.exact(
+    rt.partial({
+      closure_type: ConfigurationBasicWithoutOwnerRt.type.props.closure_type,
+      connector: ConfigurationBasicWithoutOwnerRt.type.props.connector,
+      customFields: CustomFieldsConfigurationRt,
+    })
+  ),
   rt.strict({ version: rt.string }),
 ]);
 

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -477,5 +477,28 @@ describe('create', () => {
         `Failed to create case: Error: The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
       );
     });
+
+    it('throws with duplicated customFields keys', async () => {
+      await expect(
+        create(
+          {
+            ...theCase,
+            customFields: [
+              {
+                key: 'duplicated_key',
+                type: CustomFieldTypes.TEXT,
+                field: { value: ['this is a text field value', 'this is second'] },
+              },
+              {
+                key: 'duplicated_key',
+                type: CustomFieldTypes.TOGGLE,
+                field: { value: [true] },
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow('Error: Invalid duplicated custom field keys in request: duplicated_key');
+    });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -21,6 +21,7 @@ import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import { decodeOrThrow } from '../../../common/api/runtime_types';
 import type { CasePostRequest } from '../../../common/types/api';
 import { CasePostRequestRt } from '../../../common/types/api';
+import { throwIfDuplicatedCustomFieldKeysInRequest } from './utils';
 
 /**
  * Creates a new case.
@@ -37,6 +38,8 @@ export const create = async (data: CasePostRequest, clientArgs: CasesClientArgs)
 
   try {
     const query = decodeWithExcessOrThrow(CasePostRequestRt)(data);
+
+    throwIfDuplicatedCustomFieldKeysInRequest({ customFieldsInRequest: query.customFields });
 
     const savedObjectID = SavedObjectsUtils.generateId();
 

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -21,7 +21,7 @@ import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import { decodeOrThrow } from '../../../common/api/runtime_types';
 import type { CasePostRequest } from '../../../common/types/api';
 import { CasePostRequestRt } from '../../../common/types/api';
-import { throwIfDuplicatedCustomFieldKeysInRequest } from './utils';
+import { throwIfDuplicatedCustomFieldKeysInRequest } from '../utils';
 
 /**
  * Creates a new case.

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -970,6 +970,34 @@ describe('update', () => {
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
       );
     });
+
+    it('throws with duplicated customFields keys', async () => {
+      await expect(
+        update(
+          {
+            cases: [
+              {
+                id: mockCases[0].id,
+                version: mockCases[0].version ?? '',
+                customFields: [
+                  {
+                    key: 'duplicated_key',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: ['this is a text field value', 'this is second'] },
+                  },
+                  {
+                    key: 'duplicated_key',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: ['this is a text field value', 'this is second'] },
+                  },
+                ],
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow('Error: Invalid duplicated custom field keys in request: duplicated_key');
+    });
   });
 
   describe('Validation', () => {

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -38,7 +38,12 @@ import {
   isCommentRequestTypeAlert,
 } from '../../common/utils';
 import { arraysDifference, getCaseToUpdate } from '../utils';
-import { dedupAssignees, getClosedInfoForUpdate, getDurationForUpdate } from './utils';
+import {
+  dedupAssignees,
+  getClosedInfoForUpdate,
+  getDurationForUpdate,
+  throwIfDuplicatedCustomFieldKeysInRequest,
+} from './utils';
 import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import type { LicensingService } from '../../services/licensing';
 import type { CaseSavedObjectTransformed } from '../../common/types/case';
@@ -121,6 +126,19 @@ function throwIfUpdateAssigneesWithoutValidLicense(
       )}]`
     );
   }
+}
+
+/**
+ * Throws an error if the requests has custom fields with duplicated keys.
+ */
+function throwIfDuplicatedCustomFieldKeysInCasesToUpdate({
+  casesToUpdate,
+}: {
+  casesToUpdate: UpdateRequestWithOriginalCase[];
+}) {
+  casesToUpdate.forEach(({ updateReq }) => {
+    throwIfDuplicatedCustomFieldKeysInRequest({ customFieldsInRequest: updateReq.customFields });
+  });
 }
 
 function notifyPlatinumUsage(
@@ -301,7 +319,6 @@ export const update = async (
 
   try {
     const query = decodeWithExcessOrThrow(CasesPatchRequestRt)(cases);
-
     const myCases = await caseService.getCases({
       caseIds: query.cases.map((q) => q.id),
     });
@@ -370,6 +387,7 @@ export const update = async (
     const hasPlatinumLicense = await licensingService.isAtLeastPlatinum();
 
     throwIfUpdateOwner(casesToUpdate);
+    throwIfDuplicatedCustomFieldKeysInCasesToUpdate({ casesToUpdate });
     throwIfUpdateAssigneesWithoutValidLicense(casesToUpdate, hasPlatinumLicense);
 
     const patchCasesPayload = createPatchCasesPayload({ user, casesToUpdate });

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -37,13 +37,12 @@ import {
   flattenCaseSavedObject,
   isCommentRequestTypeAlert,
 } from '../../common/utils';
-import { arraysDifference, getCaseToUpdate } from '../utils';
 import {
-  dedupAssignees,
-  getClosedInfoForUpdate,
-  getDurationForUpdate,
+  arraysDifference,
+  getCaseToUpdate,
   throwIfDuplicatedCustomFieldKeysInRequest,
-} from './utils';
+} from '../utils';
+import { dedupAssignees, getClosedInfoForUpdate, getDurationForUpdate } from './utils';
 import { LICENSING_CASE_ASSIGNMENT_FEATURE } from '../../common/constants';
 import type { LicensingService } from '../../services/licensing';
 import type { CaseSavedObjectTransformed } from '../../common/types/case';

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -27,8 +27,9 @@ import {
   mapCaseFieldsToExternalSystemFields,
   formatComments,
   addKibanaInformationToDescription,
+  throwIfDuplicatedCustomFieldKeysInRequest,
 } from './utils';
-import { CaseStatuses, UserActionActions } from '../../../common/types/domain';
+import { CaseStatuses, CustomFieldTypes, UserActionActions } from '../../../common/types/domain';
 import { flattenCaseSavedObject } from '../../common/utils';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
@@ -1339,6 +1340,63 @@ describe('utils', () => {
           userProfilesMapNoFullNames
         )
       ).toEqual(userProfiles[0].user.username);
+    });
+  });
+
+  describe('throwIfDuplicatedCustomFieldKeysInRequest', () => {
+    it('throws if customFields in request have duplicated keys', () => {
+      expect(() =>
+        throwIfDuplicatedCustomFieldKeysInRequest({
+          customFieldsInRequest: [
+            {
+              key: 'triplicated_key',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+            {
+              key: 'triplicated_key',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+            {
+              key: 'triplicated_key',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+            {
+              key: 'duplicated_key',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+            {
+              key: 'duplicated_key',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+          ],
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid duplicated custom field keys in request: triplicated_key,duplicated_key"`
+      );
+    });
+
+    it('does not throw if customFields in request has no duplicated keys', () => {
+      expect(() =>
+        throwIfDuplicatedCustomFieldKeysInRequest({
+          customFieldsInRequest: [
+            {
+              key: '1',
+              type: CustomFieldTypes.TEXT,
+              field: { value: ['this is a text field value', 'this is second'] },
+            },
+            {
+              key: '2',
+              type: CustomFieldTypes.TOGGLE,
+              field: { value: [true] },
+            },
+          ],
+        })
+      ).not.toThrowError();
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -27,9 +27,8 @@ import {
   mapCaseFieldsToExternalSystemFields,
   formatComments,
   addKibanaInformationToDescription,
-  throwIfDuplicatedCustomFieldKeysInRequest,
 } from './utils';
-import { CaseStatuses, CustomFieldTypes, UserActionActions } from '../../../common/types/domain';
+import { CaseStatuses, UserActionActions } from '../../../common/types/domain';
 import { flattenCaseSavedObject } from '../../common/utils';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
@@ -1340,63 +1339,6 @@ describe('utils', () => {
           userProfilesMapNoFullNames
         )
       ).toEqual(userProfiles[0].user.username);
-    });
-  });
-
-  describe('throwIfDuplicatedCustomFieldKeysInRequest', () => {
-    it('throws if customFields in request have duplicated keys', () => {
-      expect(() =>
-        throwIfDuplicatedCustomFieldKeysInRequest({
-          customFieldsInRequest: [
-            {
-              key: 'triplicated_key',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-            {
-              key: 'triplicated_key',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-            {
-              key: 'triplicated_key',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-            {
-              key: 'duplicated_key',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-            {
-              key: 'duplicated_key',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid duplicated custom field keys in request: triplicated_key,duplicated_key"`
-      );
-    });
-
-    it('does not throw if customFields in request has no duplicated keys', () => {
-      expect(() =>
-        throwIfDuplicatedCustomFieldKeysInRequest({
-          customFieldsInRequest: [
-            {
-              key: '1',
-              type: CustomFieldTypes.TEXT,
-              field: { value: ['this is a text field value', 'this is second'] },
-            },
-            {
-              key: '2',
-              type: CustomFieldTypes.TOGGLE,
-              field: { value: [true] },
-            },
-          ],
-        })
-      ).not.toThrowError();
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import Boom from '@hapi/boom';
 import { uniqBy, isEmpty } from 'lodash';
 import type { UserProfile } from '@kbn/security-plugin/common';
 import type { IBasePath } from '@kbn/core-http-browser';
@@ -24,10 +23,7 @@ import type {
   User,
 } from '../../../common/types/domain';
 import { CaseStatuses, UserActionTypes, AttachmentType } from '../../../common/types/domain';
-import type {
-  CaseRequestCustomFields,
-  CaseUserActionsDeprecatedResponse,
-} from '../../../common/types/api';
+import type { CaseUserActionsDeprecatedResponse } from '../../../common/types/api';
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { isPushedUserAction } from '../../../common/utils/user_actions';
 import type { CasesClientGetAlertsResponse } from '../alerts/types';
@@ -456,30 +452,4 @@ export const getUserProfiles = async (
     acc.set(profile.uid, profile);
     return acc;
   }, new Map());
-};
-
-/**
- * Throws an error if the request has custom fields with duplicated keys.
- */
-export const throwIfDuplicatedCustomFieldKeysInRequest = ({
-  customFieldsInRequest = [],
-}: {
-  customFieldsInRequest?: CaseRequestCustomFields;
-}) => {
-  const uniqueKeys = new Set();
-  const duplicatedKeys = new Set();
-
-  customFieldsInRequest.forEach((item) => {
-    if (uniqueKeys.has(item.key)) {
-      duplicatedKeys.add(item.key);
-    } else {
-      uniqueKeys.add(item.key);
-    }
-  });
-
-  if (duplicatedKeys.size) {
-    throw Boom.badRequest(
-      `Invalid duplicated custom field keys in request: ${Array.from(duplicatedKeys.values())}`
-    );
-  }
 };

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -42,38 +42,15 @@ import type { CasesClientArgs } from '../types';
 import { getMappings } from './get_mappings';
 
 import { Operations } from '../../authorization';
-import { combineAuthorizedAndOwnerFilter } from '../utils';
+import {
+  combineAuthorizedAndOwnerFilter,
+  throwIfDuplicatedCustomFieldKeysInRequest,
+} from '../utils';
 import type { MappingsArgs, CreateMappingsArgs, UpdateMappingsArgs } from './types';
 import { createMappings } from './create_mappings';
 import { updateMappings } from './update_mappings';
 import { decodeOrThrow } from '../../../common/api/runtime_types';
 import { ConfigurationRt, ConfigurationsRt } from '../../../common/types/domain';
-
-/**
- * Throws an error if the requests has custom fields with duplicated keys.
- */
-function throwIfDuplicatedCustomFieldKeysInRequest({
-  customFieldsInRequest = [],
-}: {
-  customFieldsInRequest?: Array<{ key: string }>;
-}) {
-  const uniqueKeys = new Set();
-  const duplicatedKeys = new Set();
-
-  customFieldsInRequest.forEach((item) => {
-    if (uniqueKeys.has(item.key)) {
-      duplicatedKeys.add(item.key);
-    } else {
-      uniqueKeys.add(item.key);
-    }
-  });
-
-  if (duplicatedKeys.size) {
-    throw Boom.badRequest(
-      `Invalid duplicated custom field keys in request: ${Array.from(duplicatedKeys.values())}`
-    );
-  }
-}
 
 /**
  * Defines the internal helper functions.

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -339,7 +339,7 @@ export async function update(
   }
 }
 
-async function create(
+export async function create(
   configRequest: ConfigurationRequest,
   clientArgs: CasesClientArgs,
   casesClientInternal: CasesClientInternal

--- a/x-pack/plugins/cases/server/client/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/utils.test.ts
@@ -18,6 +18,7 @@ import {
   constructQueryOptions,
   constructSearch,
   convertSortField,
+  throwIfDuplicatedCustomFieldKeysInRequest,
 } from './utils';
 import { CasePersistedSeverity, CasePersistedStatus } from '../common/types/case';
 import { CaseSeverity, CaseStatuses } from '../../common/types/domain';
@@ -882,6 +883,49 @@ describe('utils', () => {
       expect(constructSearch(undefined, DEFAULT_NAMESPACE_STRING, savedObjectsSerializer)).toEqual(
         undefined
       );
+    });
+  });
+
+  describe('throwIfDuplicatedCustomFieldKeysInRequest', () => {
+    it('throws if customFields in request have duplicated keys', () => {
+      expect(() =>
+        throwIfDuplicatedCustomFieldKeysInRequest({
+          customFieldsInRequest: [
+            {
+              key: 'triplicated_key',
+            },
+            {
+              key: 'triplicated_key',
+            },
+            {
+              key: 'triplicated_key',
+            },
+            {
+              key: 'duplicated_key',
+            },
+            {
+              key: 'duplicated_key',
+            },
+          ],
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Invalid duplicated custom field keys in request: triplicated_key,duplicated_key"`
+      );
+    });
+
+    it('does not throw if customFields in request has no duplicated keys', () => {
+      expect(() =>
+        throwIfDuplicatedCustomFieldKeysInRequest({
+          customFieldsInRequest: [
+            {
+              key: '1',
+            },
+            {
+              key: '2',
+            },
+          ],
+        })
+      ).not.toThrowError();
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/utils.ts
+++ b/x-pack/plugins/cases/server/client/utils.ts
@@ -524,3 +524,29 @@ export const constructSearch = (
 
   return { search };
 };
+
+/**
+ * Throws an error if the request has custom fields with duplicated keys.
+ */
+export const throwIfDuplicatedCustomFieldKeysInRequest = ({
+  customFieldsInRequest = [],
+}: {
+  customFieldsInRequest?: Array<{ key: string }>;
+}) => {
+  const uniqueKeys = new Set();
+  const duplicatedKeys = new Set();
+
+  customFieldsInRequest.forEach((item) => {
+    if (uniqueKeys.has(item.key)) {
+      duplicatedKeys.add(item.key);
+    } else {
+      uniqueKeys.add(item.key);
+    }
+  });
+
+  if (duplicatedKeys.size) {
+    throw badRequest(
+      `Invalid duplicated custom field keys in request: ${Array.from(duplicatedKeys.values())}`
+    );
+  }
+};

--- a/x-pack/plugins/cases/server/services/configure/index.test.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CaseConnector, ConfigurationAttributes } from '../../../common/types/domain';
-import { CustomFieldTypes, ConnectorTypes } from '../../../common/types/domain';
+import { ConnectorTypes } from '../../../common/types/domain';
 import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import type {
@@ -832,52 +832,6 @@ describe('CaseConfigureService', () => {
 
         const persistedAttributes = unsecuredSavedObjectsClient.update.mock.calls[0][2];
         expect(persistedAttributes).not.toHaveProperty('foo');
-      });
-    });
-  });
-
-  describe('Validation', () => {
-    describe('post', () => {
-      it('throws when there are duplicates custom field keys in request', async () => {
-        const attributes = {
-          ...createConfigPostParams(createJiraConnector()),
-          customFields: [
-            { key: 'foo', label: 'text', type: CustomFieldTypes.TEXT, required: false },
-            { key: 'foo', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
-            { key: 'foo', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
-            { key: 'bar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
-            { key: 'bar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
-          ],
-        };
-
-        await expect(
-          service.post({
-            unsecuredSavedObjectsClient,
-            attributes,
-            id: '1',
-          })
-        ).rejects.toThrow(`Invalid duplicated custom field keys in request: foo,bar`);
-      });
-    });
-
-    describe('patch', () => {
-      it('throws when there are duplicates custom field keys in request', async () => {
-        const updatedAttributes = {
-          ...createConfigPostParams(createJiraConnector()),
-          customFields: [
-            { key: 'foobar', label: 'text', type: CustomFieldTypes.TEXT, required: false },
-            { key: 'foobar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
-          ],
-        };
-
-        await expect(
-          service.patch({
-            configurationId: '1',
-            unsecuredSavedObjectsClient,
-            updatedAttributes,
-            originalConfiguration: {} as SavedObject<ConfigurationAttributes>,
-          })
-        ).rejects.toThrow(`Invalid duplicated custom field keys in request: foobar`);
       });
     });
   });

--- a/x-pack/plugins/cases/server/services/configure/index.test.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.test.ts
@@ -6,7 +6,7 @@
  */
 
 import type { CaseConnector, ConfigurationAttributes } from '../../../common/types/domain';
-import { ConnectorTypes } from '../../../common/types/domain';
+import { CustomFieldTypes, ConnectorTypes } from '../../../common/types/domain';
 import { CASE_CONFIGURE_SAVED_OBJECT, SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { savedObjectsClientMock } from '@kbn/core/server/mocks';
 import type {
@@ -832,6 +832,52 @@ describe('CaseConfigureService', () => {
 
         const persistedAttributes = unsecuredSavedObjectsClient.update.mock.calls[0][2];
         expect(persistedAttributes).not.toHaveProperty('foo');
+      });
+    });
+  });
+
+  describe('Validation', () => {
+    describe('post', () => {
+      it('throws when there are duplicates custom field keys in request', async () => {
+        const attributes = {
+          ...createConfigPostParams(createJiraConnector()),
+          customFields: [
+            { key: 'foo', label: 'text', type: CustomFieldTypes.TEXT, required: false },
+            { key: 'foo', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
+            { key: 'foo', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
+            { key: 'bar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
+            { key: 'bar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
+          ],
+        };
+
+        await expect(
+          service.post({
+            unsecuredSavedObjectsClient,
+            attributes,
+            id: '1',
+          })
+        ).rejects.toThrow(`Invalid duplicated custom field keys in request: foo,bar`);
+      });
+    });
+
+    describe('patch', () => {
+      it('throws when there are duplicates custom field keys in request', async () => {
+        const updatedAttributes = {
+          ...createConfigPostParams(createJiraConnector()),
+          customFields: [
+            { key: 'foobar', label: 'text', type: CustomFieldTypes.TEXT, required: false },
+            { key: 'foobar', label: 'toggle', type: CustomFieldTypes.TOGGLE, required: true },
+          ],
+        };
+
+        await expect(
+          service.patch({
+            configurationId: '1',
+            unsecuredSavedObjectsClient,
+            updatedAttributes,
+            originalConfiguration: {} as SavedObject<ConfigurationAttributes>,
+          })
+        ).rejects.toThrow(`Invalid duplicated custom field keys in request: foobar`);
       });
     });
   });

--- a/x-pack/plugins/cases/server/services/configure/index.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import Boom from '@hapi/boom';
+
 import type {
   Logger,
   SavedObject,
@@ -13,7 +15,10 @@ import type {
 } from '@kbn/core/server';
 
 import { ACTION_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server';
-import type { ConfigurationAttributes } from '../../../common/types/domain';
+import type {
+  ConfigurationAttributes,
+  CustomFieldsConfiguration,
+} from '../../../common/types/domain';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
 import { decodeOrThrow } from '../../../common/api';
 import { CASE_CONFIGURE_SAVED_OBJECT } from '../../../common/constants';
@@ -39,6 +44,32 @@ import {
   ConfigurationPartialAttributesRt,
   ConfigurationTransformedAttributesRt,
 } from '../../common/types/configure';
+
+/**
+ * Throws an error if the requests has custom fields with duplicated keys.
+ */
+function throwIfDuplicatedCustomFieldKeysInRequest({
+  customFieldsInRequest = [],
+}: {
+  customFieldsInRequest?: CustomFieldsConfiguration;
+}) {
+  const uniqueKeys = new Set();
+  const duplicatedKeys = new Set();
+
+  customFieldsInRequest.forEach((item) => {
+    if (uniqueKeys.has(item.key)) {
+      duplicatedKeys.add(item.key);
+    } else {
+      uniqueKeys.add(item.key);
+    }
+  });
+
+  if (duplicatedKeys.size) {
+    throw Boom.badRequest(
+      `Invalid duplicated custom field keys in request: ${Array.from(duplicatedKeys.values())}`
+    );
+  }
+}
 
 export class CaseConfigureService {
   constructor(private readonly log: Logger) {}
@@ -119,6 +150,11 @@ export class CaseConfigureService {
       this.log.debug(`Attempting to POST a new case configuration`);
 
       const decodedAttributes = decodeOrThrow(ConfigurationTransformedAttributesRt)(attributes);
+
+      throwIfDuplicatedCustomFieldKeysInRequest({
+        customFieldsInRequest: decodedAttributes.customFields,
+      });
+
       const esConfigInfo = transformAttributesToESModel(decodedAttributes);
 
       const createdConfig =
@@ -148,6 +184,11 @@ export class CaseConfigureService {
       this.log.debug(`Attempting to UPDATE case configuration ${configurationId}`);
 
       const decodedAttributes = decodeOrThrow(ConfigurationPartialAttributesRt)(updatedAttributes);
+
+      throwIfDuplicatedCustomFieldKeysInRequest({
+        customFieldsInRequest: updatedAttributes.customFields,
+      });
+
       const esUpdateInfo = transformAttributesToESModel(decodedAttributes);
 
       const updatedConfiguration =

--- a/x-pack/plugins/cases/server/services/configure/index.ts
+++ b/x-pack/plugins/cases/server/services/configure/index.ts
@@ -5,8 +5,6 @@
  * 2.0.
  */
 
-import Boom from '@hapi/boom';
-
 import type {
   Logger,
   SavedObject,
@@ -15,10 +13,7 @@ import type {
 } from '@kbn/core/server';
 
 import { ACTION_SAVED_OBJECT_TYPE } from '@kbn/actions-plugin/server';
-import type {
-  ConfigurationAttributes,
-  CustomFieldsConfiguration,
-} from '../../../common/types/domain';
+import type { ConfigurationAttributes } from '../../../common/types/domain';
 import { CONNECTOR_ID_REFERENCE_NAME } from '../../common/constants';
 import { decodeOrThrow } from '../../../common/api';
 import { CASE_CONFIGURE_SAVED_OBJECT } from '../../../common/constants';
@@ -44,32 +39,6 @@ import {
   ConfigurationPartialAttributesRt,
   ConfigurationTransformedAttributesRt,
 } from '../../common/types/configure';
-
-/**
- * Throws an error if the requests has custom fields with duplicated keys.
- */
-function throwIfDuplicatedCustomFieldKeysInRequest({
-  customFieldsInRequest = [],
-}: {
-  customFieldsInRequest?: CustomFieldsConfiguration;
-}) {
-  const uniqueKeys = new Set();
-  const duplicatedKeys = new Set();
-
-  customFieldsInRequest.forEach((item) => {
-    if (uniqueKeys.has(item.key)) {
-      duplicatedKeys.add(item.key);
-    } else {
-      uniqueKeys.add(item.key);
-    }
-  });
-
-  if (duplicatedKeys.size) {
-    throw Boom.badRequest(
-      `Invalid duplicated custom field keys in request: ${Array.from(duplicatedKeys.values())}`
-    );
-  }
-}
 
 export class CaseConfigureService {
   constructor(private readonly log: Logger) {}
@@ -151,10 +120,6 @@ export class CaseConfigureService {
 
       const decodedAttributes = decodeOrThrow(ConfigurationTransformedAttributesRt)(attributes);
 
-      throwIfDuplicatedCustomFieldKeysInRequest({
-        customFieldsInRequest: decodedAttributes.customFields,
-      });
-
       const esConfigInfo = transformAttributesToESModel(decodedAttributes);
 
       const createdConfig =
@@ -184,10 +149,6 @@ export class CaseConfigureService {
       this.log.debug(`Attempting to UPDATE case configuration ${configurationId}`);
 
       const decodedAttributes = decodeOrThrow(ConfigurationPartialAttributesRt)(updatedAttributes);
-
-      throwIfDuplicatedCustomFieldKeysInRequest({
-        customFieldsInRequest: updatedAttributes.customFields,
-      });
 
       const esUpdateInfo = transformAttributesToESModel(decodedAttributes);
 

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -15,6 +15,7 @@ import {
   CaseSeverity,
   CaseStatuses,
   ConnectorTypes,
+  CustomFieldTypes,
 } from '@kbn/cases-plugin/common/types/domain';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import {
@@ -810,6 +811,37 @@ export default ({ getService }: FtrProviderContext): void => {
                   id: postedCase.id,
                   version: postedCase.version,
                   tags: ['  '],
+                },
+              ],
+            },
+            expectedHttpCode: 400,
+          });
+        });
+      });
+
+      describe('customFields', async () => {
+        it('400s when trying to patch with duplicated custom field keys', async () => {
+          const postedCase = await createCase(supertest, postCaseReq);
+
+          await updateCase({
+            supertest,
+            params: {
+              cases: [
+                {
+                  id: postedCase.id,
+                  version: postedCase.version,
+                  customFields: [
+                    {
+                      key: 'duplicated_key',
+                      type: CustomFieldTypes.TEXT,
+                      field: { value: ['this is a text field value'] },
+                    },
+                    {
+                      key: 'duplicated_key',
+                      type: CustomFieldTypes.TEXT,
+                      field: { value: ['this is a text field value'] },
+                    },
+                  ],
                 },
               ],
             },

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -8,7 +8,11 @@
 import expect from '@kbn/expect';
 
 import { CASES_URL } from '@kbn/cases-plugin/common/constants';
-import { CaseStatuses, CaseSeverity } from '@kbn/cases-plugin/common/types/domain';
+import {
+  CaseStatuses,
+  CaseSeverity,
+  CustomFieldTypes,
+} from '@kbn/cases-plugin/common/types/domain';
 import { ConnectorJiraTypeFields, ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
 import { getPostCaseRequest, postCaseResp, defaultUser } from '../../../../common/lib/mock';
 import {
@@ -319,6 +323,29 @@ export default ({ getService }: FtrProviderContext): void => {
             supertest,
             getPostCaseRequest({
               category: '   ',
+            }),
+            400
+          );
+        });
+      });
+
+      describe('customFields', async () => {
+        it('400s when trying to patch with duplicated custom field keys', async () => {
+          await createCase(
+            supertest,
+            getPostCaseRequest({
+              customFields: [
+                {
+                  key: 'duplicated_key',
+                  type: CustomFieldTypes.TEXT,
+                  field: { value: ['this is a text field value'] },
+                },
+                {
+                  key: 'duplicated_key',
+                  type: CustomFieldTypes.TEXT,
+                  field: { value: ['this is a text field value'] },
+                },
+              ],
             }),
             400
           );

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
@@ -6,7 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import { ConnectorTypes } from '@kbn/cases-plugin/common/types/domain';
+import { ConnectorTypes, CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 import { ObjectRemover as ActionsRemover } from '../../../../../alerting_api_integration/common/lib';
 
@@ -54,6 +54,31 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(data).to.eql({ ...getConfigurationOutput(true), closure_type: 'close-by-pushing' });
     });
 
+    it('should patch a configuration with customFields', async () => {
+      const customFields = [
+        {
+          key: 'text_field',
+          label: '#1',
+          type: CustomFieldTypes.TEXT,
+          required: false,
+        },
+        {
+          key: 'toggle_field',
+          label: '#2',
+          type: CustomFieldTypes.TOGGLE,
+          required: false,
+        },
+      ];
+      const configuration = await createConfiguration(supertest);
+      const newConfiguration = await updateConfiguration(supertest, configuration.id, {
+        version: configuration.version,
+        customFields,
+      });
+
+      const data = removeServerGeneratedPropertiesFromSavedObject(newConfiguration);
+      expect(data).to.eql({ ...getConfigurationOutput(true), customFields });
+    });
+
     it('should update mapping when changing connector', async () => {
       const configuration = await createConfiguration(supertest);
       await updateConfiguration(supertest, configuration.id, {
@@ -87,80 +112,114 @@ export default ({ getService }: FtrProviderContext): void => {
       ]);
     });
 
-    it('should not patch a configuration with unsupported connector type', async () => {
-      const configuration = await createConfiguration(supertest);
-      await updateConfiguration(
-        supertest,
-        configuration.id,
-        // @ts-expect-error
-        getConfigurationRequest({ type: '.unsupported' }),
-        400
-      );
-    });
-
-    it('should not patch a configuration with unsupported connector fields', async () => {
-      const configuration = await createConfiguration(supertest);
-      await updateConfiguration(
-        supertest,
-        configuration.id,
-        // @ts-expect-error
-        getConfigurationRequest({ type: '.jira', fields: { unsupported: 'value' } }),
-        400
-      );
-    });
-
-    it('should handle patch request when there is no configuration', async () => {
-      const error = await updateConfiguration(
-        supertest,
-        'not-exist',
-        { closure_type: 'close-by-pushing', version: 'no-version' },
-        404
-      );
-
-      expect(error).to.eql({
-        error: 'Not Found',
-        message: 'Saved object [cases-configure/not-exist] not found',
-        statusCode: 404,
+    describe('validation', () => {
+      it('should not patch a configuration with unsupported connector type', async () => {
+        const configuration = await createConfiguration(supertest);
+        await updateConfiguration(
+          supertest,
+          configuration.id,
+          // @ts-expect-error
+          getConfigurationRequest({ type: '.unsupported' }),
+          400
+        );
       });
-    });
 
-    it('should handle patch request when versions are different', async () => {
-      const configuration = await createConfiguration(supertest);
-      const error = await updateConfiguration(
-        supertest,
-        configuration.id,
-        { closure_type: 'close-by-pushing', version: 'no-version' },
-        409
-      );
-
-      expect(error).to.eql({
-        error: 'Conflict',
-        message:
-          'This configuration has been updated. Please refresh before saving additional updates.',
-        statusCode: 409,
+      it('should not patch a configuration with unsupported connector fields', async () => {
+        const configuration = await createConfiguration(supertest);
+        await updateConfiguration(
+          supertest,
+          configuration.id,
+          // @ts-expect-error
+          getConfigurationRequest({ type: '.jira', fields: { unsupported: 'value' } }),
+          400
+        );
       });
-    });
 
-    it('should not allow to change the owner of the configuration', async () => {
-      const configuration = await createConfiguration(supertest);
-      await updateConfiguration(
-        supertest,
-        configuration.id,
-        // @ts-expect-error
-        { owner: 'observabilityFixture', version: configuration.version },
-        400
-      );
-    });
+      it('should handle patch request when there is no configuration', async () => {
+        const error = await updateConfiguration(
+          supertest,
+          'not-exist',
+          { closure_type: 'close-by-pushing', version: 'no-version' },
+          404
+        );
 
-    it('should not allow excess attributes', async () => {
-      const configuration = await createConfiguration(supertest);
-      await updateConfiguration(
-        supertest,
-        configuration.id,
-        // @ts-expect-error
-        { notExist: 'not-exist', version: configuration.version },
-        400
-      );
+        expect(error).to.eql({
+          error: 'Not Found',
+          message: 'Saved object [cases-configure/not-exist] not found',
+          statusCode: 404,
+        });
+      });
+
+      it('should handle patch request when versions are different', async () => {
+        const configuration = await createConfiguration(supertest);
+        const error = await updateConfiguration(
+          supertest,
+          configuration.id,
+          { closure_type: 'close-by-pushing', version: 'no-version' },
+          409
+        );
+
+        expect(error).to.eql({
+          error: 'Conflict',
+          message:
+            'This configuration has been updated. Please refresh before saving additional updates.',
+          statusCode: 409,
+        });
+      });
+
+      it('should not allow to change the owner of the configuration', async () => {
+        const configuration = await createConfiguration(supertest);
+        await updateConfiguration(
+          supertest,
+          configuration.id,
+          // @ts-expect-error
+          { owner: 'observabilityFixture', version: configuration.version },
+          400
+        );
+      });
+
+      it('should not allow excess attributes', async () => {
+        const configuration = await createConfiguration(supertest);
+        await updateConfiguration(
+          supertest,
+          configuration.id,
+          // @ts-expect-error
+          { notExist: 'not-exist', version: configuration.version },
+          400
+        );
+      });
+
+      it('should not patch a configuration with duplicated custom field keys', async () => {
+        const configuration = await createConfiguration(supertest);
+        await updateConfiguration(
+          supertest,
+          configuration.id,
+          {
+            version: configuration.version,
+            customFields: [
+              {
+                key: 'triplicated_key',
+                label: '#1',
+                type: CustomFieldTypes.TEXT,
+                required: false,
+              },
+              {
+                key: 'triplicated_key',
+                label: '#2',
+                type: CustomFieldTypes.TOGGLE,
+                required: false,
+              },
+              {
+                key: 'triplicated_key',
+                label: '#2',
+                type: CustomFieldTypes.TOGGLE,
+                required: false,
+              },
+            ],
+          },
+          400
+        );
+      });
     });
 
     describe('rbac', () => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
@@ -367,20 +367,20 @@ export default ({ getService }: FtrProviderContext): void => {
         );
       });
 
-      it.skip('should not create a configuration with duplicated keys', async () => {
+      it('should not create a configuration with duplicated keys', async () => {
         await createConfiguration(
           supertest,
           getConfigurationRequest({
             overrides: {
               customFields: [
                 {
-                  key: 'hello',
+                  key: 'duplicated_key',
                   label: '#1',
                   type: CustomFieldTypes.TEXT,
                   required: false,
                 },
                 {
-                  key: 'hello',
+                  key: 'duplicated_key',
                   label: '#2',
                   type: CustomFieldTypes.TEXT,
                   required: false,


### PR DESCRIPTION
## Summary

This PR implements the following validation:

- **Custom field keys should be unique**
  - Where:
    - `CaseConfigureService` - x-pack/plugins/cases/server/services/configure/index.ts
      - `post`
      - `patch` 
  - Tests:
    - x-pack/plugins/cases/server/services/configure/index.test.ts
- **Limit custom fields to 5**
  - Where:
    - `ConfigurationRequestRt` (POST)
    - `ConfigurationPatchRequestRt`
    - `CasePostRequestRt` - done in a previous PR
    - `CasePatchRequestRt` - done in a previous PR
  - Tests:
    - x-pack/plugins/cases/server/client/configure/client.test.ts
    - x-pack/plugins/cases/common/types/api/configure/v1.test.ts
    - x-pack/plugins/cases/server/client/cases/create.test.ts
    - x-pack/plugins/cases/server/client/cases/update.test.ts
