### PR TITLE
[Cloud Security] fix ingest pipeline for benchmark scores index

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_indices/create_indices.ts
@@ -77,7 +77,7 @@ const createBenchmarkScoreIndex = async (
 
     const settings: IndexTemplateSettings = {
       index: {
-        default_pipeline: latestFindingsPipelineIngestConfig.id,
+        default_pipeline: scorePipelineIngestConfig.id,
       },
       lifecycle: { name: '' },
     };


### PR DESCRIPTION
## Summary

during the [ILM fix](https://github.com/elastic/kibana/pull/165317) for serverless the default pipeline for the scores index was also changed by mistake. Reverting this change


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
