### PR TITLE
[Cases] Validate custom field keys

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/client.ts
+++ b/x-pack/plugins/cases/server/client/cases/client.ts
@@ -102,13 +102,13 @@ export const createCasesSubClient = (
   casesClientInternal: CasesClientInternal
 ): CasesSubClient => {
   const casesSubClient: CasesSubClient = {
-    create: (data: CasePostRequest) => create(data, clientArgs),
+    create: (data: CasePostRequest) => create(data, clientArgs, casesClient),
     find: (params: CasesFindRequest) => find(params, clientArgs),
     get: (params: GetParams) => get(params, clientArgs),
     resolve: (params: GetParams) => resolve(params, clientArgs),
     bulkGet: (params) => bulkGet(params, clientArgs),
     push: (params: PushParams) => push(params, clientArgs, casesClient),
-    update: (cases: CasesPatchRequest) => update(cases, clientArgs),
+    update: (cases: CasesPatchRequest) => update(cases, clientArgs, casesClient),
     delete: (ids: string[]) => deleteCases(ids, clientArgs),
     getTags: (params: AllTagsFindRequest) => getTags(params, clientArgs),
     getCategories: (params: AllCategoriesFindRequest) => getCategories(params, clientArgs),

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -13,7 +13,8 @@ import {
   MAX_ASSIGNEES_PER_CASE,
   MAX_CUSTOM_FIELDS_PER_CASE,
 } from '../../../common/constants';
-import { CasePostRequest, SECURITY_SOLUTION_OWNER } from '../../../common';
+import type { CasePostRequest } from '../../../common';
+import { SECURITY_SOLUTION_OWNER } from '../../../common';
 import { mockCases } from '../../mocks';
 import { createCasesClientMock, createCasesClientMockArgs } from '../mocks';
 import { create, throwIfCustomFieldKeysInvalid } from './create';

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -388,15 +388,38 @@ describe('create', () => {
   describe('Custom Fields', () => {
     const clientArgs = createCasesClientMockArgs();
     clientArgs.services.caseService.postNewCase.mockResolvedValue(caseSO);
+    clientArgs.services.caseConfigureService.find.mockResolvedValue({
+      saved_objects: [
+        {
+          attributes: {
+            owner: theCase.owner,
+            customFields: [
+              {
+                key: 'first_key',
+                type: CustomFieldTypes.TEXT,
+                label: 'foo',
+                required: false,
+              },
+              {
+                key: 'second_key',
+                type: CustomFieldTypes.TOGGLE,
+                label: 'foo',
+                required: false,
+              },
+            ],
+          },
+        },
+      ],
+    });
 
     const theCustomFields: CaseCustomFields = [
       {
-        key: 'first_customField_key',
+        key: 'first_key',
         type: CustomFieldTypes.TEXT,
         field: { value: ['this is a text field value', 'this is second'] },
       },
       {
-        key: 'second_customField_key',
+        key: 'second_key',
         type: CustomFieldTypes.TOGGLE,
         field: { value: [true] },
       },

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -682,7 +682,7 @@ describe('create', () => {
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"Invalid custom field keys: invalid_key"`);
     });
 
-    it('throws if no configuration found when trying to update custom fields', async () => {
+    it('throws if no configuration found when trying to create custom fields', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([]);
 
       await expect(

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -391,6 +391,7 @@ describe('create', () => {
     clientArgs.services.caseConfigureService.find.mockResolvedValue({
       saved_objects: [
         {
+          // @ts-ignore: incomplete attributes
           attributes: {
             owner: theCase.owner,
             customFields: [

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -27,7 +27,7 @@ import { compareCustomFieldKeysAgainstConfiguration } from './utils';
 /**
  * Throws if any of the custom field keys in the request does not exist in the case configuration.
  */
-async function throwIfCustomFieldKeysInvalid({
+export async function throwIfCustomFieldKeysInvalid({
   casePostRequest,
   casesClient,
 }: {

--- a/x-pack/plugins/cases/server/client/cases/create.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.ts
@@ -57,10 +57,14 @@ async function throwIfCustomFieldKeysInvalid({
     options: { filter: ownerFilter },
   });
 
+  if (configuration.saved_objects.length === 0) {
+    throw Boom.badRequest('Invalid custom fields passed in request.');
+  }
+
   customFields.forEach((customField) => {
     let validKey = false;
 
-    configuration.saved_objects[0].attributes.customFields.every(({ key }) => {
+    configuration.saved_objects[0].attributes.customFields?.every(({ key }) => {
       if (key === customField.key) {
         validKey = true;
       }

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -18,7 +18,7 @@ import {
   MAX_CUSTOM_FIELDS_PER_CASE,
 } from '../../../common/constants';
 import { mockCases } from '../../mocks';
-import { createCasesClientMockArgs } from '../mocks';
+import { createCasesClientMock, createCasesClientMockArgs } from '../mocks';
 import { update } from './update';
 
 describe('update', () => {
@@ -31,6 +31,8 @@ describe('update', () => {
       },
     ],
   };
+  const casesClientMock = createCasesClientMock();
+  casesClientMock.configure.get = jest.fn().mockResolvedValue([]);
 
   describe('Assignees', () => {
     const clientArgs = createCasesClientMockArgs();
@@ -51,7 +53,7 @@ describe('update', () => {
     });
 
     it('notifies an assignee', async () => {
-      await update(cases, clientArgs);
+      await update(cases, clientArgs, casesClientMock);
 
       expect(clientArgs.services.notificationService.bulkNotifyAssignees).toHaveBeenCalledWith([
         {
@@ -78,7 +80,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"not-exists","version":"123"}]: Error: These cases not-exists do not exist. Please check you have the correct ids.'
@@ -99,7 +102,7 @@ describe('update', () => {
         ],
       });
 
-      await expect(update(cases, clientArgs)).rejects.toThrow(
+      await expect(update(cases, clientArgs, casesClientMock)).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: All update fields are identical to current version.'
       );
 
@@ -135,7 +138,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.notificationService.bulkNotifyAssignees).toHaveBeenCalledWith([
@@ -176,7 +180,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.notificationService.bulkNotifyAssignees).toHaveBeenCalledWith([]);
@@ -214,7 +219,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.notificationService.bulkNotifyAssignees).toHaveBeenCalledWith([
@@ -251,7 +257,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       /**
@@ -276,7 +283,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: invalid keys \\"foo\\""`
@@ -297,7 +305,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the field assignees is too long. Array must be of length <= 10.'
@@ -335,7 +344,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).resolves.not.toThrow();
     });
@@ -352,7 +362,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the category is too long. The maximum length is ${MAX_CATEGORY_LENGTH}.,Invalid value \"A very long category with more than fifty characters!\" supplied to \"cases,category\"`
@@ -371,7 +382,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The category field cannot be an empty string.,Invalid value "" supplied to "cases,category"'
@@ -390,7 +402,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The category field cannot be an empty string.,Invalid value "   " supplied to "cases,category"'
@@ -408,7 +421,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.caseService.patchCases).toHaveBeenCalledWith(
@@ -463,7 +477,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).resolves.not.toThrow();
     });
@@ -481,7 +496,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the title is too long. The maximum length is ${MAX_TITLE_LENGTH}.`
@@ -500,7 +516,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The title field cannot be an empty string.'
@@ -519,7 +536,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The title field cannot be an empty string.'
@@ -537,7 +555,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.caseService.patchCases).toHaveBeenCalledWith(
@@ -592,7 +611,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).resolves.not.toThrow();
     });
@@ -613,7 +633,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the description is too long. The maximum length is ${MAX_DESCRIPTION_LENGTH}.`
@@ -632,7 +653,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The description field cannot be an empty string.'
@@ -651,7 +673,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The description field cannot be an empty string.'
@@ -669,7 +692,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.caseService.patchCases).toHaveBeenCalledWith(
@@ -724,7 +748,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).resolves.not.toThrow();
     });
@@ -745,7 +770,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).resolves.not.toThrow();
     });
@@ -764,7 +790,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the field tags is too long. Array must be of length <= ${MAX_TAGS_PER_CASE}.`
@@ -787,7 +814,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the tag is too long. The maximum length is ${MAX_LENGTH_PER_TAG}.`
@@ -806,7 +834,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The tag field cannot be an empty string.'
@@ -825,7 +854,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The tag field cannot be an empty string.'
@@ -843,7 +873,8 @@ describe('update', () => {
             },
           ],
         },
-        clientArgs
+        clientArgs,
+        casesClientMock
       );
 
       expect(clientArgs.services.caseService.patchCases).toHaveBeenCalledWith(
@@ -870,6 +901,7 @@ describe('update', () => {
 
   describe('Custom Fields', () => {
     const clientArgs = createCasesClientMockArgs();
+    const casesClient = createCasesClientMock();
 
     beforeEach(() => {
       jest.clearAllMocks();
@@ -880,30 +912,26 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
-      clientArgs.services.caseConfigureService.find.mockResolvedValue({
-        saved_objects: [
-          {
-            // @ts-ignore: incomplete attributes
-            attributes: {
-              owner: mockCases[0].attributes.owner,
-              customFields: [
-                {
-                  key: 'first_key',
-                  type: CustomFieldTypes.TEXT,
-                  label: 'foo',
-                  required: false,
-                },
-                {
-                  key: 'second_key',
-                  type: CustomFieldTypes.TOGGLE,
-                  label: 'foo',
-                  required: false,
-                },
-              ],
+
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: mockCases[0].attributes.owner,
+          customFields: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TEXT,
+              label: 'foo',
+              required: false,
             },
-          },
-        ],
-      });
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TOGGLE,
+              label: 'foo',
+              required: false,
+            },
+          ],
+        },
+      ]);
     });
 
     it('can update customFields', async () => {
@@ -935,7 +963,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClient
         )
       ).resolves.not.toThrow();
 
@@ -978,7 +1007,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClient
         )
       ).rejects.toThrow(
         `Failed to update case, ids: [{"id":"mock-id-1","version":"WzAsMV0="}]: Error: The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
@@ -1008,7 +1038,8 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClient
         )
       ).rejects.toThrow('Error: Invalid duplicated custom field keys in request: duplicated_key');
     });
@@ -1036,13 +1067,18 @@ describe('update', () => {
               },
             ],
           },
-          clientArgs
+          clientArgs,
+          casesClient
         )
-      ).rejects.toThrow('Error: Invalid custom field keys: missing_key');
+      ).rejects.toThrow(
+        'Error: The case with case id mock-id-1 has the following invalid custom field keys: missing_key'
+      );
     });
   });
 
   describe('Validation', () => {
+    const clientArgsMock = createCasesClientMockArgs();
+
     beforeEach(() => {
       jest.clearAllMocks();
     });
@@ -1057,7 +1093,8 @@ describe('update', () => {
               title: 'This is a test case!!',
             }),
           },
-          createCasesClientMockArgs()
+          clientArgsMock,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Error: The length of the field cases is too long. Array must be of length <= 100.'
@@ -1070,7 +1107,8 @@ describe('update', () => {
           {
             cases: [],
           },
-          createCasesClientMockArgs()
+          clientArgsMock,
+          casesClientMock
         )
       ).rejects.toThrow(
         'Error: The length of the field cases is too short. Array must be of length >= 1.'
@@ -1078,14 +1116,12 @@ describe('update', () => {
     });
 
     describe('Validate max user actions per page', () => {
-      const casesClient = createCasesClientMockArgs();
-
       beforeEach(() => {
         jest.clearAllMocks();
-        casesClient.services.caseService.getCases.mockResolvedValue({
+        clientArgsMock.services.caseService.getCases.mockResolvedValue({
           saved_objects: [{ ...mockCases[0] }, { ...mockCases[1] }],
         });
-        casesClient.services.caseService.getAllCaseComments.mockResolvedValue({
+        clientArgsMock.services.caseService.getAllCaseComments.mockResolvedValue({
           saved_objects: [],
           total: 0,
           per_page: 10,
@@ -1094,16 +1130,18 @@ describe('update', () => {
       });
 
       it('passes validation if max user actions per case is not reached', async () => {
-        casesClient.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
-          [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE - 1,
-        });
+        clientArgsMock.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue(
+          {
+            [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE - 1,
+          }
+        );
 
         // @ts-ignore: only the array length matters here
-        casesClient.services.userActionService.creator.buildUserActions.mockReturnValue({
+        clientArgsMock.services.userActionService.creator.buildUserActions.mockReturnValue({
           [mockCases[0].id]: [1],
         });
 
-        casesClient.services.caseService.patchCases.mockResolvedValue({
+        clientArgsMock.services.caseService.patchCases.mockResolvedValue({
           saved_objects: [{ ...mockCases[0] }],
         });
 
@@ -1118,18 +1156,21 @@ describe('update', () => {
                 },
               ],
             },
-            casesClient
+            clientArgsMock,
+            casesClientMock
           )
         ).resolves.not.toThrow();
       });
 
       it(`throws an error when the user actions to be created will reach ${MAX_USER_ACTIONS_PER_CASE}`, async () => {
-        casesClient.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
-          [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE,
-        });
+        clientArgsMock.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue(
+          {
+            [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE,
+          }
+        );
 
         // @ts-ignore: only the array length matters here
-        casesClient.services.userActionService.creator.buildUserActions.mockReturnValue({
+        clientArgsMock.services.userActionService.creator.buildUserActions.mockReturnValue({
           [mockCases[0].id]: [1, 2, 3],
         });
 
@@ -1144,7 +1185,8 @@ describe('update', () => {
                 },
               ],
             },
-            casesClient
+            clientArgsMock,
+            casesClientMock
           )
         ).rejects.toThrow(
           `Error: The case with case id ${mockCases[0].id} has reached the limit of ${MAX_USER_ACTIONS_PER_CASE} user actions.`
@@ -1152,13 +1194,15 @@ describe('update', () => {
       });
 
       it('throws an error when trying to update multiple cases and one of them is expected to fail', async () => {
-        casesClient.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue({
-          [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE,
-          [mockCases[1].id]: 0,
-        });
+        clientArgsMock.services.userActionService.getMultipleCasesUserActionsTotal.mockResolvedValue(
+          {
+            [mockCases[0].id]: MAX_USER_ACTIONS_PER_CASE,
+            [mockCases[1].id]: 0,
+          }
+        );
 
         // @ts-ignore: only the array length matters here
-        casesClient.services.userActionService.creator.buildUserActions.mockReturnValue({
+        clientArgsMock.services.userActionService.creator.buildUserActions.mockReturnValue({
           [mockCases[0].id]: [1, 2, 3],
           [mockCases[1].id]: [1],
         });
@@ -1180,7 +1224,8 @@ describe('update', () => {
                 },
               ],
             },
-            casesClient
+            clientArgsMock,
+            casesClientMock
           )
         ).rejects.toThrow(
           `Error: The case with case id ${mockCases[0].id} has reached the limit of ${MAX_USER_ACTIONS_PER_CASE} user actions.`

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -880,28 +880,42 @@ describe('update', () => {
         per_page: 10,
         page: 1,
       });
+      clientArgs.services.caseConfigureService.find.mockResolvedValue({
+        saved_objects: [
+          {
+            // @ts-ignore: incomplete attributes
+            attributes: {
+              owner: mockCases[0].attributes.owner,
+              customFields: [
+                {
+                  key: 'first_key',
+                  type: CustomFieldTypes.TEXT,
+                  label: 'foo',
+                  required: false,
+                },
+                {
+                  key: 'second_key',
+                  type: CustomFieldTypes.TOGGLE,
+                  label: 'foo',
+                  required: false,
+                },
+              ],
+            },
+          },
+        ],
+      });
     });
 
     it('can update customFields', async () => {
       const customFields = [
         {
-          key: 'string_custom_field_1',
+          key: 'first_key',
           type: CustomFieldTypes.TEXT as const,
           field: { value: ['this is a text field value', 'this is second'] },
         },
         {
-          key: 'string_custom_field_2',
+          key: 'second_key',
           type: CustomFieldTypes.TEXT as const,
-          field: { value: null },
-        },
-        {
-          key: 'boolean_custom_field_1',
-          type: CustomFieldTypes.TOGGLE as const,
-          field: { value: [true] },
-        },
-        {
-          key: 'boolean_custom_field_2',
-          type: CustomFieldTypes.TOGGLE as const,
           field: { value: null },
         },
       ];
@@ -997,6 +1011,34 @@ describe('update', () => {
           clientArgs
         )
       ).rejects.toThrow('Error: Invalid duplicated custom field keys in request: duplicated_key');
+    });
+
+    it('throws when customFields keys are not present in configuration', async () => {
+      await expect(
+        update(
+          {
+            cases: [
+              {
+                id: mockCases[0].id,
+                version: mockCases[0].version ?? '',
+                customFields: [
+                  {
+                    key: 'first_key',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: ['this is a text field value', 'this is second'] },
+                  },
+                  {
+                    key: 'missing_key',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: null },
+                  },
+                ],
+              },
+            ],
+          },
+          clientArgs
+        )
+      ).rejects.toThrow('Error: Invalid custom field keys: missing_key');
     });
   });
 

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -124,7 +124,7 @@ async function throwIfCustomFieldKeysInvalid({
   const configurationMap: Record<string, ConfigurationTransformedAttributes> = {};
   const invalidCustomFieldKeys: string[] = [];
 
-  configurations.saved_objects.forEach((e) => {
+  configurations?.saved_objects.forEach((e) => {
     if (!(e.attributes.owner in configurationMap)) {
       configurationMap[e.attributes.owner] = e.attributes;
     }
@@ -137,7 +137,7 @@ async function throwIfCustomFieldKeysInvalid({
       if (owner in configurationMap) {
         let validKey = false;
 
-        configurationMap[owner].customFields.every(({ key }) => {
+        configurationMap[owner]?.customFields?.every(({ key }) => {
           if (key === customField.key) {
             validKey = true;
           }

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -110,7 +110,7 @@ async function throwIfMaxUserActionsReached({
 /**
  * Throws if any of the custom field keys in the request does not exist in the case configuration.
  */
-async function throwIfCustomFieldKeysInvalid({
+export async function throwIfCustomFieldKeysInvalid({
   casesToUpdate,
   casesClient,
 }: {
@@ -338,7 +338,7 @@ function partitionPatchRequest(
   };
 }
 
-interface UpdateRequestWithOriginalCase {
+export interface UpdateRequestWithOriginalCase {
   updateReq: CasePatchRequest;
   originalCase: CaseSavedObjectTransformed;
 }

--- a/x-pack/plugins/cases/server/client/cases/update.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.ts
@@ -117,7 +117,6 @@ export async function throwIfCustomFieldKeysInvalid({
   casesToUpdate: UpdateRequestWithOriginalCase[];
   casesClient: CasesClient;
 }) {
-  // const configurations = await caseConfigureService.find({ unsecuredSavedObjectsClient });
   const configurations = await casesClient.configure.get({});
 
   const configurationMap: Record<string, CustomFieldsConfiguration> = {};

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -27,8 +27,10 @@ import {
   mapCaseFieldsToExternalSystemFields,
   formatComments,
   addKibanaInformationToDescription,
+  validateCustomFieldKeysAgainstConfiguration,
 } from './utils';
-import { CaseStatuses, UserActionActions } from '../../../common/types/domain';
+import type { CaseCustomFields } from '../../../common/types/domain';
+import { CaseStatuses, CustomFieldTypes, UserActionActions } from '../../../common/types/domain';
 import { flattenCaseSavedObject } from '../../common/utils';
 import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { casesConnectors } from '../../connectors';
@@ -1339,6 +1341,78 @@ describe('utils', () => {
           userProfilesMapNoFullNames
         )
       ).toEqual(userProfiles[0].user.username);
+    });
+  });
+
+  describe('validateCustomFieldKeysAgainstConfiguration', () => {
+    const requestCustomFields: CaseCustomFields = [
+      {
+        key: 'first_key',
+        type: CustomFieldTypes.TEXT,
+        field: { value: ['this is a text field value', 'this is second'] },
+      },
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        field: { value: [true] },
+      },
+    ];
+    const configurationCustomFields = [
+      {
+        key: 'first_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'foo',
+        required: false,
+      },
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        label: 'foo',
+        required: false,
+      },
+    ];
+
+    it('returns empty array when no key is missing', () => {
+      expect(
+        validateCustomFieldKeysAgainstConfiguration({
+          requestCustomFields,
+          configurationCustomFields,
+        })
+      ).toEqual([]);
+    });
+
+    it('does not throw when requestCustomFields is empty', () => {
+      expect(
+        validateCustomFieldKeysAgainstConfiguration({
+          requestCustomFields: [],
+          configurationCustomFields,
+        })
+      ).toEqual([]);
+    });
+
+    it('returns missing keys', () => {
+      expect(
+        validateCustomFieldKeysAgainstConfiguration({
+          requestCustomFields: [
+            ...requestCustomFields,
+            {
+              key: 'missing_key',
+              type: CustomFieldTypes.TOGGLE,
+              field: { value: [true] },
+            },
+          ],
+          configurationCustomFields,
+        })
+      ).toEqual(['missing_key']);
+    });
+
+    it('returns every key if no configurationCustomFields', () => {
+      expect(
+        validateCustomFieldKeysAgainstConfiguration({
+          requestCustomFields,
+          configurationCustomFields: [],
+        })
+      ).toEqual(['first_key', 'second_key']);
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -27,7 +27,7 @@ import {
   mapCaseFieldsToExternalSystemFields,
   formatComments,
   addKibanaInformationToDescription,
-  validateCustomFieldKeysAgainstConfiguration,
+  compareCustomFieldKeysAgainstConfiguration,
 } from './utils';
 import type { CaseCustomFields } from '../../../common/types/domain';
 import { CaseStatuses, CustomFieldTypes, UserActionActions } from '../../../common/types/domain';
@@ -1344,7 +1344,7 @@ describe('utils', () => {
     });
   });
 
-  describe('validateCustomFieldKeysAgainstConfiguration', () => {
+  describe('compareCustomFieldKeysAgainstConfiguration', () => {
     const requestCustomFields: CaseCustomFields = [
       {
         key: 'first_key',
@@ -1374,16 +1374,16 @@ describe('utils', () => {
 
     it('returns empty array when no key is missing', () => {
       expect(
-        validateCustomFieldKeysAgainstConfiguration({
+        compareCustomFieldKeysAgainstConfiguration({
           requestCustomFields,
           configurationCustomFields,
         })
       ).toEqual([]);
     });
 
-    it('does not throw when requestCustomFields is empty', () => {
+    it('returns an empty array if request has no custom fields', () => {
       expect(
-        validateCustomFieldKeysAgainstConfiguration({
+        compareCustomFieldKeysAgainstConfiguration({
           requestCustomFields: [],
           configurationCustomFields,
         })
@@ -1392,7 +1392,7 @@ describe('utils', () => {
 
     it('returns missing keys', () => {
       expect(
-        validateCustomFieldKeysAgainstConfiguration({
+        compareCustomFieldKeysAgainstConfiguration({
           requestCustomFields: [
             ...requestCustomFields,
             {
@@ -1408,7 +1408,7 @@ describe('utils', () => {
 
     it('returns every key if no configurationCustomFields', () => {
       expect(
-        validateCustomFieldKeysAgainstConfiguration({
+        compareCustomFieldKeysAgainstConfiguration({
           requestCustomFields,
           configurationCustomFields: [],
         })

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { uniqBy, isEmpty } from 'lodash';
+import { uniqBy, isEmpty, differenceWith } from 'lodash';
 import type { UserProfile } from '@kbn/security-plugin/common';
 import type { IBasePath } from '@kbn/core-http-browser';
 import type { SecurityPluginStart } from '@kbn/security-plugin/server';
@@ -458,29 +458,16 @@ export const getUserProfiles = async (
   }, new Map());
 };
 
-export const validateCustomFieldKeysAgainstConfiguration = ({
+export const compareCustomFieldKeysAgainstConfiguration = ({
   requestCustomFields,
   configurationCustomFields = [],
 }: {
   requestCustomFields: CaseRequestCustomFields;
   configurationCustomFields?: CustomFieldsConfiguration;
 }): string[] => {
-  const invalidCustomFieldKeys: string[] = [];
-
-  requestCustomFields.forEach((customField) => {
-    let validKey = false;
-    configurationCustomFields.every(({ key: keyInConfiguration }) => {
-      if (keyInConfiguration === customField.key) {
-        validKey = true;
-      }
-
-      return !validKey;
-    });
-
-    if (!validKey) {
-      invalidCustomFieldKeys.push(customField.key);
-    }
-  });
-
-  return invalidCustomFieldKeys;
+  return differenceWith(
+    requestCustomFields,
+    configurationCustomFields,
+    (requestVal, configurationVal) => requestVal.key === configurationVal.key
+  ).map((e) => e.key);
 };

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -19,11 +19,15 @@ import type {
   ConnectorMappings,
   ConnectorMappingSource,
   ConnectorMappingTarget,
+  CustomFieldsConfiguration,
   ExternalService,
   User,
 } from '../../../common/types/domain';
 import { CaseStatuses, UserActionTypes, AttachmentType } from '../../../common/types/domain';
-import type { CaseUserActionsDeprecatedResponse } from '../../../common/types/api';
+import type {
+  CaseRequestCustomFields,
+  CaseUserActionsDeprecatedResponse,
+} from '../../../common/types/api';
 import { CASE_VIEW_PAGE_TABS } from '../../../common/types';
 import { isPushedUserAction } from '../../../common/utils/user_actions';
 import type { CasesClientGetAlertsResponse } from '../alerts/types';
@@ -452,4 +456,31 @@ export const getUserProfiles = async (
     acc.set(profile.uid, profile);
     return acc;
   }, new Map());
+};
+
+export const validateCustomFieldKeysAgainstConfiguration = ({
+  requestCustomFields,
+  configurationCustomFields = [],
+}: {
+  requestCustomFields: CaseRequestCustomFields;
+  configurationCustomFields?: CustomFieldsConfiguration;
+}): string[] => {
+  const invalidCustomFieldKeys: string[] = [];
+
+  requestCustomFields.forEach((customField) => {
+    let validKey = false;
+    configurationCustomFields.every(({ key: keyInConfiguration }) => {
+      if (keyInConfiguration === customField.key) {
+        validKey = true;
+      }
+
+      return !validKey;
+    });
+
+    if (!validKey) {
+      invalidCustomFieldKeys.push(customField.key);
+    }
+  });
+
+  return invalidCustomFieldKeys;
 };

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -38,6 +38,8 @@ import {
   calculateDuration,
   getCaseUserActions,
   removeServerGeneratedPropertiesFromUserAction,
+  createConfiguration,
+  getConfigurationRequest,
 } from '../../../../common/lib/api';
 import {
   createSignalsIndex,
@@ -75,6 +77,21 @@ export default ({ getService }: FtrProviderContext): void => {
 
     describe('happy path', () => {
       it('should patch a case', async () => {
+        await createConfiguration(
+          supertest,
+          getConfigurationRequest({
+            overrides: {
+              customFields: [
+                {
+                  key: 'test_custom_field',
+                  label: 'text',
+                  type: CustomFieldTypes.TEXT,
+                  required: false,
+                },
+              ],
+            },
+          })
+        );
         const postedCase = await createCase(supertest, postCaseReq);
         const patchedCases = await updateCase({
           supertest,
@@ -97,7 +114,7 @@ export default ({ getService }: FtrProviderContext): void => {
         });
       });
 
-      it('should closes the case correctly', async () => {
+      it('should close the case correctly', async () => {
         const postedCase = await createCase(supertest, postCaseReq);
         const patchedCases = await updateCase({
           supertest,
@@ -285,6 +302,62 @@ export default ({ getService }: FtrProviderContext): void => {
             type: '.jira',
             fields: { issueType: 'Task', priority: null, parent: null },
           },
+          updated_by: defaultUser,
+        });
+      });
+
+      it('should patch a case with customFields', async () => {
+        await createConfiguration(
+          supertest,
+          getConfigurationRequest({
+            overrides: {
+              customFields: [
+                {
+                  key: 'test_custom_field_1',
+                  label: 'text',
+                  type: CustomFieldTypes.TEXT,
+                  required: false,
+                },
+                {
+                  key: 'test_custom_field_2',
+                  label: 'toggle',
+                  type: CustomFieldTypes.TOGGLE,
+                  required: true,
+                },
+              ],
+            },
+          })
+        );
+
+        const postedCase = await createCase(supertest, postCaseReq);
+        const patchedCases = await updateCase({
+          supertest,
+          params: {
+            cases: [
+              {
+                id: postedCase.id,
+                version: postedCase.version,
+                customFields: [
+                  {
+                    key: 'test_custom_field_1',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: ['this is a text field value'] },
+                  },
+                  {
+                    key: 'test_custom_field_2',
+                    type: CustomFieldTypes.TOGGLE,
+                    field: { value: [true] },
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+        const data = removeServerGeneratedPropertiesFromCase(patchedCases[0]);
+        expect(data).to.eql({
+          ...postCaseResp(),
+          title: 'new title',
           updated_by: defaultUser,
         });
       });
@@ -847,6 +920,31 @@ export default ({ getService }: FtrProviderContext): void => {
             },
             expectedHttpCode: 400,
           });
+        });
+      });
+
+      it('400s when trying to patch with a non existent custom field key', async () => {
+        await createConfiguration(supertest);
+        const postedCase = await createCase(supertest, postCaseReq);
+
+        await updateCase({
+          supertest,
+          params: {
+            cases: [
+              {
+                id: postedCase.id,
+                version: postedCase.version,
+                customFields: [
+                  {
+                    key: 'key_does_not_exist',
+                    type: CustomFieldTypes.TEXT,
+                    field: { value: ['this is a text field value'] },
+                  },
+                ],
+              },
+            ],
+          },
+          expectedHttpCode: 400,
         });
       });
     });

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -924,7 +924,21 @@ export default ({ getService }: FtrProviderContext): void => {
       });
 
       it('400s when trying to patch with a non existent custom field key', async () => {
-        await createConfiguration(supertest);
+        await createConfiguration(
+          supertest,
+          getConfigurationRequest({
+            overrides: {
+              customFields: [
+                {
+                  key: 'test_custom_field',
+                  label: 'text',
+                  type: CustomFieldTypes.TEXT,
+                  required: false,
+                },
+              ],
+            },
+          })
+        );
         const postedCase = await createCase(supertest, postCaseReq);
 
         await updateCase({

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -396,7 +396,21 @@ export default ({ getService }: FtrProviderContext): void => {
         });
 
         it('400s when trying to create case with non existant customField key', async () => {
-          await createConfiguration(supertest);
+          await createConfiguration(
+            supertest,
+            getConfigurationRequest({
+              overrides: {
+                customFields: [
+                  {
+                    key: 'test_custom_field',
+                    label: 'text',
+                    type: CustomFieldTypes.TEXT,
+                    required: false,
+                  },
+                ],
+              },
+            })
+          );
           await createCase(
             supertest,
             getPostCaseRequest({


### PR DESCRIPTION
## Summary

This PR implements the following validation:

- **Custom Field Keys need to exist in configuration when creating or updating cases**
  - Where:
    - Cases Client
      - `create`
      - `update` 
  - Tests:
    - x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
    - x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts