### PR TITLE
[PoC] Show non text-based ad hoc data views in list when using ES|QL

### DIFF
--- a/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
+++ b/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
@@ -34,6 +34,7 @@ export async function getDataViewByTextBasedQueryLang(
   ) {
     const dataViewObj = await services.dataViews.create({
       title: indexPatternFromQuery,
+      name: generateTextBasedDataViewName(),
     });
 
     if (dataViewObj.fields.getByName('@timestamp')?.type === 'date') {
@@ -43,3 +44,11 @@ export async function getDataViewByTextBasedQueryLang(
   }
   return currentDataView;
 }
+
+const textBasedDataViewPrefix = '__TEXT_BASED_DATA_VIEW__';
+let textBasedDataViewCount = 0;
+
+export const generateTextBasedDataViewName = () => {
+  textBasedDataViewCount++;
+  return `${textBasedDataViewPrefix}${textBasedDataViewCount}`;
+};

--- a/src/plugins/discover/public/application/view_alert/view_alert_utils.tsx
+++ b/src/plugins/discover/public/application/view_alert/view_alert_utils.tsx
@@ -19,6 +19,7 @@ import { MarkdownSimple } from '@kbn/kibana-react-plugin/public';
 import { toMountPoint } from '@kbn/react-kibana-mount';
 import { Filter } from '@kbn/es-query';
 import { DiscoverAppLocatorParams } from '../../../common/locator';
+import { generateTextBasedDataViewName } from '../main/utils/get_data_view_by_text_based_query_lang';
 
 export interface SearchThresholdAlertParams extends RuleTypeParams {
   searchConfiguration: SerializedSearchSourceFields;
@@ -137,6 +138,7 @@ export const getAlertUtils = (
       dataView = await dataViews.create({
         title: indexPattern,
         timeFieldName: alert.params.timeField,
+        name: generateTextBasedDataViewName(),
       });
     }
 

--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
@@ -111,7 +111,9 @@ export function ChangeDataView({
         : await data.dataViews.getIdsWithTitle();
       // not propagate the adHoc dataviews on the list for text based languages
       const adHocDataViewRefs: DataViewListItemEnhanced[] =
-        (!isTextBasedLangSelected && adHocDataViews?.map(mapAdHocDataView)) || [];
+        adHocDataViews
+          ?.filter((dataView) => !dataView.name.startsWith('__TEXT_BASED_DATA_VIEW__'))
+          ?.map(mapAdHocDataView) || [];
 
       setDataViewsList(savedDataViewRefs.concat(adHocDataViewRefs));
     };


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)