### PR TITLE
[ResponseOps] [Alerting] race condition at startup accessing AaD documents

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
+++ b/x-pack/plugins/alerting/server/alerts_client/alerts_client.ts
@@ -369,7 +369,7 @@ export class AlertsClient<
               })
         );
       } else {
-        this.options.logger.warn(
+        this.options.logger.debug(
           `Could not find alert document to update for recovered alert with id ${id} and uuid ${recoveredAlerts[
             id
           ].getUuid()}`


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166418

## Summary

Change from `warn` to `debug`. Was able to replicate this error when migrating an es query rule from 8.9 to 8.10 where es query uses AAD.
