### PR TITLE
[ES|QL] Fixes error in new metric when breakdown is a number

### DIFF
--- a/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
+++ b/src/plugins/chart_expressions/expression_metric/public/components/metric_vis.tsx
@@ -184,7 +184,7 @@ export const MetricVis = ({
     const baseMetric: MetricWNumber = {
       value,
       valueFormatter: formatPrimaryMetric,
-      title,
+      title: String(title),
       subtitle,
       icon: config.metric?.icon ? getIcon(config.metric?.icon) : undefined,
       extra: (


### PR DESCRIPTION
## Summary

In ES|QL we don't have field formatters. We just have the type of the field (number/date etc).

If you are in Discover and write a query which returns only one column/row then the new metric is suggested.

<img width="1990" alt="image" src="https://github.com/elastic/kibana/assets/17003240/79650d4b-f0c9-476b-b050-617653ccc993">

If for whatever reason the user goes to breakdown and selects the same number variable (try_new) the chart will fail to render and you will see in the console an error.

This happens because EC wait the title to be string but here as we don't have field formatters this is number and fails.