### PR TITLE
[RAM] Correct renamed function after a race-condition merge

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/get_action_error_log.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/get_action_error_log.ts
@@ -14,7 +14,7 @@ import {
   ObjectRemover,
   getTestRuleData,
   getEventLog,
-  getConsumerUnauthorizedErrorMessage,
+  getUnauthorizedErrorMessage,
 } from '../../../../common/lib';
 import { FtrProviderContext } from '../../../../common/ftr_provider_context';
 
@@ -101,7 +101,7 @@ export default function createGetActionErrorLogTests({ getService }: FtrProvider
               expect(response.statusCode).to.eql(403);
               expect(response.body).to.eql({
                 error: 'Forbidden',
-                message: getConsumerUnauthorizedErrorMessage(
+                message: getUnauthorizedErrorMessage(
                   'get',
                   'test.cumulative-firing',
                   'alertsFixture'


### PR DESCRIPTION
## Summary
There was an accidental race-condition on a variable re-name and usage between https://github.com/elastic/kibana/pull/166032 & https://github.com/elastic/kibana/pull/166603.

This PR intends to correct that. 

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->