### PR TITLE
[Cases] Validate length of text custom fields.

### DIFF
--- a/x-pack/plugins/cases/common/types/api/case/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/case/v1.test.ts
@@ -17,6 +17,7 @@ import {
   MAX_TITLE_LENGTH,
   MAX_CATEGORY_LENGTH,
   MAX_CUSTOM_FIELDS_PER_CASE,
+  MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
 } from '../../../constants';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import { AttachmentType } from '../../domain/attachment/v1';
@@ -299,6 +300,25 @@ describe('CasePostRequestRt', () => {
     const { customFields, ...rest } = defaultRequest;
 
     expect(PathReporter.report(CasePostRequestRt.decode(rest))).toContain('No errors!');
+  });
+
+  it(`throws an error when a text customFields is longer than ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}`, () => {
+    expect(
+      PathReporter.report(
+        CasePostRequestRt.decode({
+          ...defaultRequest,
+          customFields: [
+            {
+              key: 'first_custom_field_key',
+              type: 'text',
+              field: { value: ['#'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1)] },
+            },
+          ],
+        })
+      )
+    ).toContain(
+      `The length of the value is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}.`
+    );
   });
 });
 
@@ -678,6 +698,25 @@ describe('CasePatchRequestRt', () => {
       )
     ).toContain(
       `The length of the field customFields is too long. Array must be of length <= ${MAX_CUSTOM_FIELDS_PER_CASE}.`
+    );
+  });
+
+  it(`throws an error when a text customFields is longer than ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}`, () => {
+    expect(
+      PathReporter.report(
+        CasePatchRequestRt.decode({
+          ...defaultRequest,
+          customFields: [
+            {
+              key: 'first_custom_field_key',
+              type: 'text',
+              field: { value: ['#'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1)] },
+            },
+          ],
+        })
+      )
+    ).toContain(
+      `The length of the value is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}.`
     );
   });
 });

--- a/x-pack/plugins/cases/common/types/api/case/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/case/v1.ts
@@ -22,6 +22,7 @@ import {
   MAX_CATEGORY_FILTER_LENGTH,
   MAX_ASSIGNEES_PER_CASE,
   MAX_CUSTOM_FIELDS_PER_CASE,
+  MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
 } from '../../../constants';
 import {
   limitedStringSchema,
@@ -29,18 +30,34 @@ import {
   NonEmptyString,
   paginationSchema,
 } from '../../../schema';
+import { CustomFieldTextTypeRt } from '../../domain';
 import {
   CaseRt,
   CaseSettingsRt,
   CaseSeverityRt,
   CasesRt,
   CaseStatusRt,
+  CustomFieldToggle,
+  customFieldValue,
   RelatedCaseRt,
-  CustomFieldRt,
 } from '../../domain/case/v1';
 import { CaseConnectorRt } from '../../domain/connector/v1';
 import { CaseUserProfileRt, UserRt } from '../../domain/user/v1';
 import { CasesStatusResponseRt } from '../stats/v1';
+
+const CustomFieldText = rt.strict({
+  key: rt.string,
+  type: CustomFieldTextTypeRt,
+  field: customFieldValue(
+    limitedStringSchema({
+      fieldName: 'value',
+      min: 0,
+      max: MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
+    })
+  ),
+});
+
+const CustomFieldRt = rt.union([CustomFieldText, CustomFieldToggle]);
 
 const CustomFieldsRt = limitedArraySchema({
   codec: CustomFieldRt,

--- a/x-pack/plugins/cases/common/types/domain/case/v1.ts
+++ b/x-pack/plugins/cases/common/types/domain/case/v1.ts
@@ -52,7 +52,7 @@ export const CaseSettingsRt = rt.strict({
   syncAlerts: rt.boolean,
 });
 
-const customFieldValue = <C extends rt.Mixed>(codec: C) =>
+export const customFieldValue = <C extends rt.Mixed>(codec: C) =>
   rt.strict({ value: rt.union([rt.array(codec), rt.null]) });
 
 const CustomFieldText = rt.strict({
@@ -61,7 +61,7 @@ const CustomFieldText = rt.strict({
   field: customFieldValue(rt.string),
 });
 
-const CustomFieldToggle = rt.strict({
+export const CustomFieldToggle = rt.strict({
   key: rt.string,
   type: CustomFieldToggleTypeRt,
   field: customFieldValue(rt.boolean),


### PR DESCRIPTION
## Summary

This PR limits the length of the property value for `text` custom fields.
