### PR TITLE
[Cloud Security][Fleet] fix broken k8s manifest link

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.test.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getManifestDownloadLink } from './kubernetes_instructions';
+
+describe('getManifestDownloadLink', () => {
+  it('should return the correct link', () => {
+    expect(getManifestDownloadLink('https://fleet.host', 'enrollmentToken')).toEqual(
+      '/api/fleet/kubernetes/download?fleetServer=https%3A%2F%2Ffleet.host&enrolToken=enrollmentToken'
+    );
+    expect(getManifestDownloadLink('https://fleet.host')).toEqual(
+      '/api/fleet/kubernetes/download?fleetServer=https%3A%2F%2Ffleet.host'
+    );
+    expect(getManifestDownloadLink(undefined, 'enrollmentToken')).toEqual(
+      '/api/fleet/kubernetes/download?enrolToken=enrollmentToken'
+    );
+  });
+});

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/kubernetes_instructions.tsx
@@ -31,6 +31,15 @@ interface Props {
   fleetServerHost?: string;
 }
 
+export const getManifestDownloadLink = (fleetServerHost?: string, enrollmentAPIKey?: string) => {
+  const searchParams = new URLSearchParams({
+    ...(fleetServerHost && { fleetServer: fleetServerHost }),
+    ...(enrollmentAPIKey && { enrolToken: enrollmentAPIKey }),
+  });
+
+  return `${agentPolicyRouteService.getK8sFullDownloadPath()}?${searchParams.toString()}`;
+};
+
 export const KubernetesInstructions: React.FunctionComponent<Props> = ({
   enrollmentAPIKey,
   onCopy,
@@ -111,13 +120,8 @@ export const KubernetesInstructions: React.FunctionComponent<Props> = ({
     </EuiCopy>
   );
 
-  const searchParams = new URLSearchParams({
-    ...(fleetServerHost && { fleetServer: fleetServerHost }),
-    ...(enrollmentAPIKey && { enrolToken: enrollmentAPIKey }),
-  });
-
   const downloadLink = core.http.basePath.prepend(
-    `${agentPolicyRouteService.getK8sFullDownloadPath()}${searchParams.toString()}`
+    getManifestDownloadLink(fleetServerHost, enrollmentAPIKey)
   );
 
   const k8sDownloadYaml = (


### PR DESCRIPTION
## Summary

fixes:
- https://github.com/elastic/kibana/issues/166931

The issue was introduced in https://github.com/elastic/kibana/pull/165127/files#diff-276f84c47e09954d668b83d633d87edc09406b69603dac7e63964b70e2342af1R120

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->