### PR TITLE
[Profiling] Fix set up process

### DIFF
--- a/x-pack/plugins/profiling_data_access/common/fleet_policies.ts
+++ b/x-pack/plugins/profiling_data_access/common/fleet_policies.ts
@@ -7,6 +7,7 @@
 
 import { SavedObjectsClientContract } from '@kbn/core/server';
 import type { PackagePolicyClient } from '@kbn/fleet-plugin/server';
+import { PACKAGE_POLICY_SAVED_OBJECT_TYPE, PackagePolicy } from '@kbn/fleet-plugin/common';
 import { getApmPolicy } from './get_apm_policy';
 import { PartialSetupState, ProfilingSetupOptions } from './setup';
 
@@ -21,9 +22,11 @@ async function getPackagePolicy({
   packagePolicyClient: PackagePolicyClient;
   soClient: SavedObjectsClientContract;
   packageName: string;
-}) {
-  const packagePolicies = await packagePolicyClient.list(soClient, {});
-  return packagePolicies.items.find((pkg) => pkg.name === packageName);
+}): Promise<PackagePolicy | undefined> {
+  const packagePolicies = await packagePolicyClient.list(soClient, {
+    kuery: `${PACKAGE_POLICY_SAVED_OBJECT_TYPE}.name:${packageName}`,
+  });
+  return packagePolicies.items[0];
 }
 
 export async function getCollectorPolicy({


### PR DESCRIPTION
So clients reported that they got stuck in the set up screen In the Universal Profling UI. And when the set up button was clicked an error happened:

```
An integration policy with the name elastic-universal-profiling-collector already exists. Please rename it or choose a different name.
```

This happens because when we were checking if the Collector and Symbolizer integrations were installed we weren't taking into consideration that the Fleet API is paginated. So if neither integration was available on the first page we just assumed the Profiling wasn't set up.

This PR fixes it by adding a kuery filter in the Fleet API call to only look for out integrations. So we don't need to worry about paginating.