### PR TITLE
Only replace embeddable if type changes

### DIFF
--- a/src/plugins/controls/public/control_group/actions/edit_control_flyout.tsx
+++ b/src/plugins/controls/public/control_group/actions/edit_control_flyout.tsx
@@ -92,7 +92,11 @@ export const EditControlFlyout = ({
     }
 
     closeFlyout();
-    await controlGroup.replaceEmbeddable(embeddable.id, inputToReturn, type);
+    if (panel.type === type) {
+      controlGroup.updateInputForChild(embeddable.id, inputToReturn);
+    } else {
+      await controlGroup.replaceEmbeddable(embeddable.id, inputToReturn, type);
+    }
   };
 
   return (


### PR DESCRIPTION
This should fix one of the failing functional tests in the Dashboard Navigation PR. 

The control group editor should only call `Container.replaceEmbeddable` when the `type` has changed. If the `type` has not changed, the `newExplicitInput` are only a subset of changes. So we should call `Container.updateInputForChild`. 