### PR TITLE
[Security Solution] expandable flyout - fix footer not always visible

### DIFF
--- a/packages/kbn-expandable-flyout/src/components/left_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/left_section.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { LEFT_SECTION } from './test_ids';
 
@@ -31,7 +31,7 @@ export const LeftSection: React.FC<LeftSectionProps> = ({ component, width }: Le
   );
   return (
     <EuiFlexItem grow data-test-subj={LEFT_SECTION} style={style}>
-      <EuiFlexGroup direction="column">{component}</EuiFlexGroup>
+      {component}
     </EuiFlexItem>
   );
 };

--- a/packages/kbn-expandable-flyout/src/components/left_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/left_section.tsx
@@ -26,7 +26,7 @@ interface LeftSectionProps {
  */
 export const LeftSection: React.FC<LeftSectionProps> = ({ component, width }: LeftSectionProps) => {
   const style = useMemo<React.CSSProperties>(
-    () => ({ height: '100%', width: `${width * 100}%`, overflowY: 'scroll' }),
+    () => ({ height: '100%', width: `${width * 100}%` }),
     [width]
   );
   return (

--- a/packages/kbn-expandable-flyout/src/components/right_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/right_section.tsx
@@ -29,7 +29,7 @@ export const RightSection: React.FC<RightSectionProps> = ({
   width,
 }: RightSectionProps) => {
   const style = useMemo<React.CSSProperties>(
-    () => ({ height: '100%', width: `${width * 100}%`, overflowY: 'scroll' }),
+    () => ({ height: '100%', width: `${width * 100}%` }),
     [width]
   );
 

--- a/packages/kbn-expandable-flyout/src/components/right_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/right_section.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiFlexItem } from '@elastic/eui';
 import React, { useMemo } from 'react';
 import { RIGHT_SECTION } from './test_ids';
 
@@ -35,7 +35,7 @@ export const RightSection: React.FC<RightSectionProps> = ({
 
   return (
     <EuiFlexItem grow={false} style={style} data-test-subj={RIGHT_SECTION}>
-      <EuiFlexGroup direction="column">{component}</EuiFlexGroup>
+      {component}
     </EuiFlexItem>
   );
 };

--- a/x-pack/plugins/security_solution/public/flyout/left/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/content.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlyoutBody, useEuiTheme } from '@elastic/eui';
+import { EuiFlyoutBody, useEuiBackgroundColor } from '@elastic/eui';
 import type { VFC } from 'react';
 import React, { useMemo } from 'react';
 import { css } from '@emotion/react';
@@ -24,8 +24,6 @@ export interface PanelContentProps {
  * Displays the content of investigation and insights tabs (visualize is hidden for 8.9).
  */
 export const PanelContent: VFC<PanelContentProps> = ({ selectedTabId }) => {
-  const { euiTheme } = useEuiTheme();
-
   const selectedTabContent = useMemo(() => {
     return tabs.filter((tab) => tab.visible).find((tab) => tab.id === selectedTabId)?.content;
   }, [selectedTabId]);
@@ -33,7 +31,7 @@ export const PanelContent: VFC<PanelContentProps> = ({ selectedTabId }) => {
   return (
     <EuiFlyoutBody
       css={css`
-        background-color: ${euiTheme.colors.lightestShade};
+        background-color: ${useEuiBackgroundColor('subdued')};
       `}
     >
       {selectedTabContent}

--- a/x-pack/plugins/security_solution/public/flyout/left/content.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/content.tsx
@@ -5,9 +5,10 @@
  * 2.0.
  */
 
-import { EuiFlyoutBody } from '@elastic/eui';
+import { EuiFlyoutBody, useEuiTheme } from '@elastic/eui';
 import type { VFC } from 'react';
 import React, { useMemo } from 'react';
+import { css } from '@emotion/react';
 import type { LeftPanelPaths } from '.';
 import { tabs } from './tabs';
 
@@ -23,11 +24,21 @@ export interface PanelContentProps {
  * Displays the content of investigation and insights tabs (visualize is hidden for 8.9).
  */
 export const PanelContent: VFC<PanelContentProps> = ({ selectedTabId }) => {
+  const { euiTheme } = useEuiTheme();
+
   const selectedTabContent = useMemo(() => {
     return tabs.filter((tab) => tab.visible).find((tab) => tab.id === selectedTabId)?.content;
   }, [selectedTabId]);
 
-  return <EuiFlyoutBody>{selectedTabContent}</EuiFlyoutBody>;
+  return (
+    <EuiFlyoutBody
+      css={css`
+        background-color: ${euiTheme.colors.lightestShade};
+      `}
+    >
+      {selectedTabContent}
+    </EuiFlyoutBody>
+  );
 };
 
 PanelContent.displayName = 'PanelContent';

--- a/x-pack/plugins/security_solution/public/flyout/left/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/header.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlyoutHeader, EuiTab, EuiTabs, useEuiTheme } from '@elastic/eui';
+import { EuiFlyoutHeader, EuiTab, EuiTabs, useEuiBackgroundColor } from '@elastic/eui';
 import type { VFC } from 'react';
 import React, { memo } from 'react';
 import { css } from '@emotion/react';
@@ -29,8 +29,6 @@ export interface PanelHeaderProps {
  * Displays the investigation and insights tabs (visualize is hidden for 8.9).
  */
 export const PanelHeader: VFC<PanelHeaderProps> = memo(({ selectedTabId, setSelectedTabId }) => {
-  const { euiTheme } = useEuiTheme();
-
   const onSelectedTabChanged = (id: LeftPanelPaths) => setSelectedTabId(id);
   const renderTabs = tabs
     .filter((tab) => tab.visible)
@@ -49,7 +47,7 @@ export const PanelHeader: VFC<PanelHeaderProps> = memo(({ selectedTabId, setSele
     <EuiFlyoutHeader
       hasBorder
       css={css`
-        background-color: ${euiTheme.colors.lightestShade};
+        background-color: ${useEuiBackgroundColor('subdued')};
         padding-bottom: 0 !important;
         border-block-end: none !important;
       `}

--- a/x-pack/plugins/security_solution/public/flyout/left/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/header.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { EuiFlyoutHeader, EuiTab, EuiTabs } from '@elastic/eui';
+import { EuiFlyoutHeader, EuiTab, EuiTabs, useEuiTheme } from '@elastic/eui';
 import type { VFC } from 'react';
 import React, { memo } from 'react';
 import { css } from '@emotion/react';
@@ -29,6 +29,8 @@ export interface PanelHeaderProps {
  * Displays the investigation and insights tabs (visualize is hidden for 8.9).
  */
 export const PanelHeader: VFC<PanelHeaderProps> = memo(({ selectedTabId, setSelectedTabId }) => {
+  const { euiTheme } = useEuiTheme();
+
   const onSelectedTabChanged = (id: LeftPanelPaths) => setSelectedTabId(id);
   const renderTabs = tabs
     .filter((tab) => tab.visible)
@@ -44,14 +46,15 @@ export const PanelHeader: VFC<PanelHeaderProps> = memo(({ selectedTabId, setSele
     ));
 
   return (
-    <EuiFlyoutHeader hasBorder>
-      <EuiTabs
-        size="l"
-        expand
-        css={css`
-          margin-bottom: -25px;
-        `}
-      >
+    <EuiFlyoutHeader
+      hasBorder
+      css={css`
+        background-color: ${euiTheme.colors.lightestShade};
+        padding-bottom: 0 !important;
+        border-block-end: none !important;
+      `}
+    >
+      <EuiTabs size="l" expand>
         {renderTabs}
       </EuiTabs>
     </EuiFlyoutHeader>

--- a/x-pack/plugins/security_solution/public/flyout/left/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/index.tsx
@@ -7,8 +7,6 @@
 
 import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
-import { useEuiBackgroundColor } from '@elastic/eui';
-import { css } from '@emotion/react';
 import type { FlyoutPanelProps, PanelPath } from '@kbn/expandable-flyout';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
 import { PanelHeader } from './header';
@@ -60,15 +58,10 @@ export const LeftPanel: FC<Partial<LeftPanelProps>> = memo(({ path }) => {
   };
 
   return (
-    <div
-      css={css`
-        height: 100%;
-        background: ${useEuiBackgroundColor('subdued')};
-      `}
-    >
+    <>
       <PanelHeader selectedTabId={selectedTabId} setSelectedTabId={setSelectedTabId} />
       <PanelContent selectedTabId={selectedTabId} />
-    </div>
+    </>
   );
 });
 

--- a/x-pack/plugins/security_solution/public/flyout/right/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/header.tsx
@@ -49,12 +49,7 @@ export const PanelHeader: VFC<PanelHeaderProps> = memo(
     ));
 
     return (
-      <EuiFlyoutHeader
-        hasBorder
-        css={css`
-          margin-bottom: ${flyoutIsExpandable ? '-24px' : '0px'};
-        `}
-      >
+      <EuiFlyoutHeader hasBorder>
         {flyoutIsExpandable && (
           <div
             // moving the buttons up in the header


### PR DESCRIPTION
## Summary

This PR fixes the issue with the `Take action` dropdown button in the Security Solution expandable flyout right panel wasn't always visible.  The button is now always visible and the body of the flyout is scrolling, which is the correct behavior provided by the EuiFlyout.

Some very small code changes to the `klbn-expandable-flyout` package to simplify and get rid of an unwanted `EuiFlexGroup` that was preventing the correct rendering.
Some other small changes to the Security Solution flyout code to simplify a bit some css and add background color to the left panel header and content.

https://github.com/elastic/kibana/assets/17276605/ebb928d7-e819-49b8-9c53-e26b6c2579b1

https://github.com/elastic/security-team/issues/7667