### PR TITLE
[Security Solution] Unskip Serverless Threshold rule creation Cypress test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
@@ -24,7 +24,8 @@ import {
   fillScheduleRuleAndContinue,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
@@ -24,7 +24,7 @@ import {
   fillScheduleRuleAndContinue,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -59,7 +59,7 @@ describe(
       fillScheduleRuleAndContinue(rule);
       fillRuleAction(actions);
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       goToRuleDetailsOf(rule.name);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
@@ -24,8 +24,7 @@ import {
   fillScheduleRuleAndContinue,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { visit } from '../../../tasks/navigation';
-
+import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -60,6 +59,7 @@ describe(
       fillScheduleRuleAndContinue(rule);
       fillRuleAction(actions);
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
 
       goToRuleDetailsOf(rule.name);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/common_flows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/common_flows.cy.ts
@@ -21,7 +21,7 @@ import { RULE_NAME_HEADER } from '../../../screens/rule_details';
 import { createTimeline } from '../../../tasks/api_calls/timelines';
 import { deleteAlertsAndRules } from '../../../tasks/common';
 import {
-  createAndEnableRuleOnly,
+  createAndEnableRule,
   expandAdvancedSettings,
   fillCustomInvestigationFields,
   fillDescription,
@@ -93,8 +93,9 @@ describe('Common rule creation flows', { tags: ['@ess', '@serverless'] }, () => 
     cy.get(ABOUT_CONTINUE_BTN).should('exist').click();
     cy.get(SCHEDULE_CONTINUE_BUTTON).click();
 
-    createAndEnableRuleOnly();
+    createAndEnableRule();
 
+    // UI redirects to rule creation page of a created rule
     cy.get(RULE_NAME_HEADER).should('contain', ruleFields.ruleName);
   });
 });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule.cy.ts
@@ -10,10 +10,10 @@ import { RULE_NAME_HEADER } from '../../../screens/rule_details';
 
 import { deleteAlertsAndRules } from '../../../tasks/common';
 import {
-  createAndEnableRuleOnly,
   fillScheduleRuleAndContinue,
   fillAboutRuleMinimumAndContinue,
   fillDefineCustomRuleAndContinue,
+  createRuleWithoutEnabling,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
@@ -37,7 +37,7 @@ describe('Create custom query rule', { tags: ['@ess', '@serverless'] }, () => {
       fillDefineCustomRuleAndContinue(rule);
       fillAboutRuleMinimumAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
-      createAndEnableRuleOnly();
+      createRuleWithoutEnabling();
 
       cy.log('Asserting we have a new rule created');
       cy.get(RULE_NAME_HEADER).should('contain', rule.name);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
@@ -63,7 +63,7 @@ import {
 } from '../../../tasks/create_new_rule';
 
 import { login } from '../../../tasks/login';
-import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 
 import { CREATE_RULE_URL } from '../../../urls/navigation';
@@ -97,7 +97,7 @@ describe('Custom query rules', { tags: ['@ess', '@serverless', '@brokenInServerl
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 
@@ -162,7 +162,7 @@ describe('Custom query rules', { tags: ['@ess', '@serverless', '@brokenInServerl
 
       fillScheduleRuleAndContinue(rule);
       createRuleWithoutEnabling();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       goToRuleDetailsOf(rule.name);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
@@ -63,7 +63,7 @@ import {
 } from '../../../tasks/create_new_rule';
 
 import { login } from '../../../tasks/login';
-import { visit } from '../../../tasks/navigation';
+import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 
 import { CREATE_RULE_URL } from '../../../urls/navigation';
@@ -97,6 +97,7 @@ describe('Custom query rules', { tags: ['@ess', '@serverless', '@brokenInServerl
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 
@@ -161,6 +162,7 @@ describe('Custom query rules', { tags: ['@ess', '@serverless', '@brokenInServerl
 
       fillScheduleRuleAndContinue(rule);
       createRuleWithoutEnabling();
+      goBackToRulesTableViaBreadcrumbs();
 
       goToRuleDetailsOf(rule.name);
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_query_rule_data_view.cy.ts
@@ -63,7 +63,8 @@ import {
 } from '../../../tasks/create_new_rule';
 
 import { login } from '../../../tasks/login';
-import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 
 import { CREATE_RULE_URL } from '../../../urls/navigation';

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
@@ -45,7 +45,7 @@ import {
 import { createRule } from '../../../tasks/api_calls/rules';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
-import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
 
 const savedQueryName = 'custom saved query';
 const savedQueryQuery = 'process.name: test';
@@ -87,7 +87,7 @@ describe('Saved query rules', { tags: ['@ess', '@serverless', '@brokenInServerle
       fillScheduleRuleAndContinue(rule);
       cy.intercept('POST', '/api/detection_engine/rules').as('savedQueryRule');
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       cy.wait('@savedQueryRule').then(({ response }) => {
         // created rule should have saved_query type

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
@@ -43,9 +43,9 @@ import {
   visitRuleDetailsPage,
 } from '../../../tasks/rule_details';
 import { createRule } from '../../../tasks/api_calls/rules';
-
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
+import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
 
 const savedQueryName = 'custom saved query';
 const savedQueryQuery = 'process.name: test';
@@ -87,6 +87,7 @@ describe('Saved query rules', { tags: ['@ess', '@serverless', '@brokenInServerle
       fillScheduleRuleAndContinue(rule);
       cy.intercept('POST', '/api/detection_engine/rules').as('savedQueryRule');
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
 
       cy.wait('@savedQueryRule').then(({ response }) => {
         // created rule should have saved_query type

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/custom_saved_query_rule.cy.ts
@@ -45,7 +45,7 @@ import {
 import { createRule } from '../../../tasks/api_calls/rules';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
-import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 
 const savedQueryName = 'custom saved query';
 const savedQueryQuery = 'process.name: test';

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/esql_rule_create.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/esql_rule_create.cy.ts
@@ -31,8 +31,8 @@ import {
   selectEsqlRuleType,
   getDefineContinueButton,
   fillEsqlQueryBar,
-  pressRuleCreateBtn,
   fillAboutSpecificEsqlRuleAndContinue,
+  createRuleWithoutEnabling,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
@@ -68,7 +68,7 @@ describe.skip('Detection ES|QL rules, creation', { tags: ['@ess'] }, () => {
       fillDefineEsqlRuleAndContinue(rule);
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
-      pressRuleCreateBtn();
+      createRuleWithoutEnabling();
 
       // ensures after rule save ES|QL rule is displayed
       cy.get(RULE_NAME_HEADER).should('contain', `${rule.name}`);
@@ -91,7 +91,7 @@ describe.skip('Detection ES|QL rules, creation', { tags: ['@ess'] }, () => {
       fillDefineEsqlRuleAndContinue(rule);
       fillAboutSpecificEsqlRuleAndContinue({ ...rule, rule_name_override: 'test_id' });
       fillScheduleRuleAndContinue(rule);
-      pressRuleCreateBtn();
+      createRuleWithoutEnabling();
 
       // ensure rule name override is displayed on details page
       getDetails(RULE_NAME_OVERRIDE_DETAILS).should('have.text', 'test_id');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
@@ -53,7 +53,8 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
@@ -53,7 +53,7 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -84,7 +84,7 @@ describe('EQL rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, 
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 
@@ -162,7 +162,7 @@ describe('EQL rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, 
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
       goToRuleDetailsOf(rule.name);
       waitForTheRuleToBeExecuted();
       waitForAlertsToPopulate();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/event_correlation_rule.cy.ts
@@ -53,8 +53,7 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { visit } from '../../../tasks/navigation';
-
+import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -85,6 +84,7 @@ describe('EQL rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, 
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 
@@ -162,6 +162,7 @@ describe('EQL rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, 
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
       goToRuleDetailsOf(rule.name);
       waitForTheRuleToBeExecuted();
       waitForAlertsToPopulate();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
@@ -111,7 +111,7 @@ import {
 } from '../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
-import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 
 const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d/d"';
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
@@ -111,7 +111,7 @@ import {
 } from '../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
-import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
 
 const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d/d"';
 
@@ -435,7 +435,7 @@ describe('indicator match', { tags: ['@ess', '@serverless', '@brokenInServerless
         fillAboutRuleAndContinue(rule);
         fillScheduleRuleAndContinue(rule);
         createAndEnableRule();
-        goBackToRulesTableViaBreadcrumbs();
+        openRuleManagementPageViaBreadcrumbs();
 
         cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/indicator_match_rule.cy.ts
@@ -109,9 +109,9 @@ import {
   waitForTheRuleToBeExecuted,
   visitRuleDetailsPage,
 } from '../../../tasks/rule_details';
-
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
+import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
 
 const DEFAULT_THREAT_MATCH_QUERY = '@timestamp >= "now-30d/d"';
 
@@ -435,6 +435,7 @@ describe('indicator match', { tags: ['@ess', '@serverless', '@brokenInServerless
         fillAboutRuleAndContinue(rule);
         fillScheduleRuleAndContinue(rule);
         createAndEnableRule();
+        goBackToRulesTableViaBreadcrumbs();
 
         cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
@@ -50,8 +50,7 @@ import {
   selectMachineLearningRuleType,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { visit } from '../../../tasks/navigation';
-
+import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -78,6 +77,7 @@ describe('Machine Learning rules', { tags: ['@ess', '@serverless', '@brokenInSer
     fillAboutRuleAndContinue(mlRule);
     fillScheduleRuleAndContinue(mlRule);
     createAndEnableRule();
+    goBackToRulesTableViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
@@ -50,7 +50,8 @@ import {
   selectMachineLearningRuleType,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/machine_learning_rule.cy.ts
@@ -50,7 +50,7 @@ import {
   selectMachineLearningRuleType,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
@@ -77,7 +77,7 @@ describe('Machine Learning rules', { tags: ['@ess', '@serverless', '@brokenInSer
     fillAboutRuleAndContinue(mlRule);
     fillScheduleRuleAndContinue(mlRule);
     createAndEnableRule();
-    goBackToRulesTableViaBreadcrumbs();
+    openRuleManagementPageViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
@@ -56,8 +56,8 @@ import {
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
-
 import { CREATE_RULE_URL } from '../../../urls/navigation';
+import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('New Terms rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
@@ -86,6 +86,7 @@ describe('New Terms rules', { tags: ['@ess', '@serverless', '@brokenInServerless
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
+      goBackToRulesTableViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
@@ -57,7 +57,7 @@ import {
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
-import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('New Terms rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
@@ -86,7 +86,7 @@ describe('New Terms rules', { tags: ['@ess', '@serverless', '@brokenInServerless
       fillAboutRuleAndContinue(rule);
       fillScheduleRuleAndContinue(rule);
       createAndEnableRule();
-      goBackToRulesTableViaBreadcrumbs();
+      openRuleManagementPageViaBreadcrumbs();
 
       cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/new_terms_rule.cy.ts
@@ -57,7 +57,7 @@ import {
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
-import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('New Terms rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
@@ -60,7 +60,7 @@ import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
-import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('Rules override', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
@@ -82,7 +82,7 @@ describe('Rules override', { tags: ['@ess', '@serverless', '@brokenInServerless'
     fillAboutRuleWithOverrideAndContinue(rule);
     fillScheduleRuleAndContinue(rule);
     createAndEnableRule();
-    goBackToRulesTableViaBreadcrumbs();
+    openRuleManagementPageViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
@@ -59,8 +59,8 @@ import {
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
-
 import { CREATE_RULE_URL } from '../../../urls/navigation';
+import { goBackToRulesTableViaBreadcrumbs } from '../../../tasks/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('Rules override', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
@@ -82,6 +82,7 @@ describe('Rules override', { tags: ['@ess', '@serverless', '@brokenInServerless'
     fillAboutRuleWithOverrideAndContinue(rule);
     fillScheduleRuleAndContinue(rule);
     createAndEnableRule();
+    goBackToRulesTableViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/override.cy.ts
@@ -60,7 +60,7 @@ import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
 import { getDetails, waitForTheRuleToBeExecuted } from '../../../tasks/rule_details';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
-import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 describe('Rules override', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
@@ -55,12 +55,10 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { visit } from '../../../tasks/navigation';
-
+import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-describe('Threshold rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Threshold rules', { tags: ['@ess', '@serverless'] }, () => {
   const rule = getNewThresholdRule();
   const expectedUrls = rule.references?.join('');
   const expectedFalsePositives = rule.false_positives?.join('');
@@ -84,6 +82,7 @@ describe('Threshold rules', { tags: ['@ess', '@serverless', '@brokenInServerless
     fillAboutRuleAndContinue(rule);
     fillScheduleRuleAndContinue(rule);
     createAndEnableRule();
+    goBackToRulesTableViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
@@ -55,7 +55,8 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 describe('Threshold rules', { tags: ['@ess', '@serverless'] }, () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_creation/threshold_rule.cy.ts
@@ -55,7 +55,7 @@ import {
   waitForAlertsToPopulate,
 } from '../../../tasks/create_new_rule';
 import { login } from '../../../tasks/login';
-import { goBackToRulesTableViaBreadcrumbs, visit } from '../../../tasks/navigation';
+import { openRuleManagementPageViaBreadcrumbs, visit } from '../../../tasks/navigation';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
 describe('Threshold rules', { tags: ['@ess', '@serverless'] }, () => {
@@ -82,7 +82,7 @@ describe('Threshold rules', { tags: ['@ess', '@serverless'] }, () => {
     fillAboutRuleAndContinue(rule);
     fillScheduleRuleAndContinue(rule);
     createAndEnableRule();
-    goBackToRulesTableViaBreadcrumbs();
+    openRuleManagementPageViaBreadcrumbs();
 
     cy.get(CUSTOM_RULES_BTN).should('have.text', 'Custom rules (1)');
 

--- a/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const RULES_TABLE_BREADCRUMB =
+  '[data-test-subj~="breadcrumb"][title="Detection rules (SIEM)"]';
+
+export const LAST_BREADCRUMB = `[data-test-subj~="last"]`;

--- a/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export const RULES_TABLE_BREADCRUMB =
+export const RULE_MANAGEMENT_PAGE_BREADCRUMB =
   '[data-test-subj~="breadcrumb"][title="Detection rules (SIEM)"]';
 
 export const LAST_BREADCRUMB = `[data-test-subj~="last"]`;

--- a/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/breadcrumbs.ts
@@ -8,4 +8,4 @@
 export const RULE_MANAGEMENT_PAGE_BREADCRUMB =
   '[data-test-subj~="breadcrumb"][title="Detection rules (SIEM)"]';
 
-export const LAST_BREADCRUMB = `[data-test-subj~="last"]`;
+export const LAST_BREADCRUMB = `[data-test-subj~="breadcrumb"][data-test-subj~="last"]`;

--- a/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/rule_details.ts
@@ -142,8 +142,5 @@ export const THREAT_TECHNIQUE = '[data-test-subj="threatTechniqueLink"]';
 
 export const THREAT_SUBTECHNIQUE = '[data-test-subj="threatSubtechniqueLink"]';
 
-export const BACK_TO_RULES_TABLE =
-  '[data-test-subj="breadcrumbs"] a[title="Detection rules (SIEM)"]';
-
 export const HIGHLIGHTED_ROWS_IN_TABLE =
   '[data-test-subj="euiDataGridBody"] .alertsTableHighlightedRow';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/create_new_rule.ts
@@ -127,31 +127,18 @@ import { ALERTS_TABLE_COUNT } from '../screens/timeline';
 import { TIMELINE } from '../screens/timelines';
 import { EUI_FILTER_SELECT_ITEM, COMBO_BOX_INPUT } from '../screens/common/controls';
 import { ruleFields } from '../data/detection_engine';
-import { BACK_TO_RULES_TABLE } from '../screens/rule_details';
 import { waitForAlerts } from './alerts';
 import { refreshPage } from './security_header';
 import { EMPTY_ALERT_TABLE } from '../screens/alerts';
 
-export const createAndEnableRuleOnly = () => {
-  cy.get(CREATE_AND_ENABLE_BTN).click({ force: true });
-  cy.get(CREATE_AND_ENABLE_BTN).should('not.exist');
-};
-
 export const createAndEnableRule = () => {
-  cy.get(CREATE_AND_ENABLE_BTN).click({ force: true });
+  cy.get(CREATE_AND_ENABLE_BTN).click();
   cy.get(CREATE_AND_ENABLE_BTN).should('not.exist');
-  cy.get(BACK_TO_RULES_TABLE).click({ force: true });
-};
-
-export const pressRuleCreateBtn = () => {
-  cy.get(CREATE_WITHOUT_ENABLING_BTN).click();
-  cy.get(CREATE_WITHOUT_ENABLING_BTN).should('not.exist');
 };
 
 export const createRuleWithoutEnabling = () => {
-  pressRuleCreateBtn();
-  cy.get(BACK_TO_RULES_TABLE).click({ force: true });
-  cy.get(BACK_TO_RULES_TABLE).should('not.exist');
+  cy.get(CREATE_WITHOUT_ENABLING_BTN).click();
+  cy.get(CREATE_WITHOUT_ENABLING_BTN).should('not.exist');
 };
 
 export const fillAboutRule = (rule: RuleCreateProps) => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
@@ -10,6 +10,7 @@ import { encode } from '@kbn/rison';
 import type { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '@kbn/security-solution-plugin/common/constants';
 import { hostDetailsUrl, userDetailsUrl } from '../urls/navigation';
+import { LAST_BREADCRUMB, RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
 import { constructUrlWithUser, getUrlWithRoute, User } from './login';
 
 export const visit = (
@@ -90,6 +91,12 @@ export const visitHostDetailsPage = (hostName = 'suricata-iowa') => {
 export const visitUserDetailsPage = (userName = 'test') => {
   visitWithTimeRange(userDetailsUrl(userName));
 };
+
+export function goBackToRulesTableViaBreadcrumbs(): void {
+  cy.log('Navigate back to rules table via breadcrumbs');
+  cy.get(`${RULES_TABLE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
+  cy.get(`${RULES_TABLE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
+}
 
 /**
  * For all the new features tours we show in the app, this method disables them

--- a/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
@@ -92,7 +92,7 @@ export const visitUserDetailsPage = (userName = 'test') => {
   visitWithTimeRange(userDetailsUrl(userName));
 };
 
-export function goBackToRulesTableViaBreadcrumbs(): void {
+export function openRuleManagementPageViaBreadcrumbs(): void {
   cy.log('Navigate back to rules table via breadcrumbs');
   cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
   cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');

--- a/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
@@ -10,7 +10,6 @@ import { encode } from '@kbn/rison';
 import type { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '@kbn/security-solution-plugin/common/constants';
 import { hostDetailsUrl, userDetailsUrl } from '../urls/navigation';
-import { LAST_BREADCRUMB, RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
 import { constructUrlWithUser, getUrlWithRoute, User } from './login';
 
 export const visit = (
@@ -91,12 +90,6 @@ export const visitHostDetailsPage = (hostName = 'suricata-iowa') => {
 export const visitUserDetailsPage = (userName = 'test') => {
   visitWithTimeRange(userDetailsUrl(userName));
 };
-
-export function openRuleManagementPageViaBreadcrumbs(): void {
-  cy.log('Navigate back to rules table via breadcrumbs');
-  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
-  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
-}
 
 /**
  * For all the new features tours we show in the app, this method disables them

--- a/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/navigation.ts
@@ -10,7 +10,7 @@ import { encode } from '@kbn/rison';
 import type { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { NEW_FEATURES_TOUR_STORAGE_KEYS } from '@kbn/security-solution-plugin/common/constants';
 import { hostDetailsUrl, userDetailsUrl } from '../urls/navigation';
-import { LAST_BREADCRUMB, RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
+import { LAST_BREADCRUMB, RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
 import { constructUrlWithUser, getUrlWithRoute, User } from './login';
 
 export const visit = (
@@ -94,8 +94,8 @@ export const visitUserDetailsPage = (userName = 'test') => {
 
 export function goBackToRulesTableViaBreadcrumbs(): void {
   cy.log('Navigate back to rules table via breadcrumbs');
-  cy.get(`${RULES_TABLE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
-  cy.get(`${RULES_TABLE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
+  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
+  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
 }
 
 /**

--- a/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
@@ -22,7 +22,7 @@ import {
   UPGRADE_ALL_RULES_BUTTON,
   UPGRADE_SELECTED_RULES_BUTTON,
 } from '../screens/alerts_detection_rules';
-import { RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
+import { RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
 import type { SAMPLE_PREBUILT_RULE } from './api_calls/prebuilt_rules';
 
 export const addElasticRulesButtonClick = () => {
@@ -108,7 +108,7 @@ const assertInstallationSuccessOrFailure = (
       cy.get(ADD_ELASTIC_RULES_TABLE).contains(rule['security-rule'].name);
     }
   } else {
-    cy.get(RULES_TABLE_BREADCRUMB).click();
+    cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
     for (const rule of rules) {
       cy.get(RULES_MANAGEMENT_TABLE).contains(rule['security-rule'].name);
     }

--- a/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/prebuilt_rules.ts
@@ -22,7 +22,7 @@ import {
   UPGRADE_ALL_RULES_BUTTON,
   UPGRADE_SELECTED_RULES_BUTTON,
 } from '../screens/alerts_detection_rules';
-import { BACK_TO_RULES_TABLE } from '../screens/rule_details';
+import { RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
 import type { SAMPLE_PREBUILT_RULE } from './api_calls/prebuilt_rules';
 
 export const addElasticRulesButtonClick = () => {
@@ -108,7 +108,7 @@ const assertInstallationSuccessOrFailure = (
       cy.get(ADD_ELASTIC_RULES_TABLE).contains(rule['security-rule'].name);
     }
   } else {
-    cy.get(BACK_TO_RULES_TABLE).click();
+    cy.get(RULES_TABLE_BREADCRUMB).click();
     for (const rule of rules) {
       cy.get(RULES_MANAGEMENT_TABLE).contains(rule['security-rule'].name);
     }

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rule_details.ts
@@ -7,7 +7,7 @@
 
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import type { Exception } from '../objects/exception';
-import { RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
+import { RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
 import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 import { RULE_STATUS } from '../screens/create_new_rule';
 import {
@@ -152,7 +152,7 @@ export const waitForTheRuleToBeExecuted = () => {
 };
 
 export const goBackToRulesTable = () => {
-  cy.get(RULES_TABLE_BREADCRUMB).click();
+  cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).click();
 };
 
 export const getDetails = (title: string | RegExp) =>

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rule_details.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rule_details.ts
@@ -7,6 +7,7 @@
 
 import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import type { Exception } from '../objects/exception';
+import { RULES_TABLE_BREADCRUMB } from '../screens/breadcrumbs';
 import { PAGE_CONTENT_SPINNER } from '../screens/common/page';
 import { RULE_STATUS } from '../screens/create_new_rule';
 import {
@@ -30,7 +31,6 @@ import {
   EDIT_EXCEPTION_BTN,
   ENDPOINT_EXCEPTIONS_TAB,
   EDIT_RULE_SETTINGS_LINK,
-  BACK_TO_RULES_TABLE,
   EXCEPTIONS_TAB_EXPIRED_FILTER,
   EXCEPTIONS_TAB_ACTIVE_FILTER,
   RULE_NAME_HEADER,
@@ -152,7 +152,7 @@ export const waitForTheRuleToBeExecuted = () => {
 };
 
 export const goBackToRulesTable = () => {
-  cy.get(BACK_TO_RULES_TABLE).click();
+  cy.get(RULES_TABLE_BREADCRUMB).click();
 };
 
 export const getDetails = (title: string | RegExp) =>

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
@@ -18,6 +18,6 @@ export function visitRulesManagementTable(role?: ROLES): void {
 
 export function openRuleManagementPageViaBreadcrumbs(): void {
   cy.log('Navigate back to rules table via breadcrumbs');
-  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
-  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
+  cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).not(LAST_BREADCRUMB).click();
+  cy.get(RULE_MANAGEMENT_PAGE_BREADCRUMB).filter(LAST_BREADCRUMB).should('exist');
 }

--- a/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/rules_management.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ROLES } from '@kbn/security-solution-plugin/common/test';
+import { LAST_BREADCRUMB, RULE_MANAGEMENT_PAGE_BREADCRUMB } from '../screens/breadcrumbs';
 import { RULES_MANAGEMENT_URL } from '../urls/rules_management';
 import { resetRulesTableState } from './common';
 import { visit } from './navigation';
@@ -13,4 +14,10 @@ import { visit } from './navigation';
 export function visitRulesManagementTable(role?: ROLES): void {
   resetRulesTableState(); // Clear persistent rules filter data before page loading
   visit(RULES_MANAGEMENT_URL, { role });
+}
+
+export function openRuleManagementPageViaBreadcrumbs(): void {
+  cy.log('Navigate back to rules table via breadcrumbs');
+  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}:not(${LAST_BREADCRUMB})`).click();
+  cy.get(`${RULE_MANAGEMENT_PAGE_BREADCRUMB}${LAST_BREADCRUMB}`).should('exist');
 }


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/161539

## Summary

This PR unskips Threshold rule creation Cypress tests.

## Details

To unskip the test with minimal changes it required to refactor navigation via breadcrumbs and update rules table breadcrumb selectors to make navigation back to the rules table work seamlessly between ESS and Serverless.

## Flaky Test runner

Serverless [threshold_rule.cy.ts  150 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3213) 🟢

