### PR TITLE
Add serverless doc link for connectors

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -564,6 +564,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       slackApiAction: `${KIBANA_DOCS}slack-action-type.html#configuring-slack-web-api`,
       teamsAction: `${KIBANA_DOCS}teams-action-type.html#configuring-teams`,
       connectors: `${KIBANA_DOCS}action-types.html`,
+      serverlessConnectors: `${SERVERLESS_DOCS}action-connectors`,
     },
     taskManager: {
       healthMonitoring: `${KIBANA_DOCS}task-manager-health-monitoring.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -438,6 +438,7 @@ export interface DocLinks {
     slackApiAction: string;
     teamsAction: string;
     connectors: string;
+    serverlessConnectors: string;
   }>;
   readonly taskManager: Readonly<{
     healthMonitoring: string;

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_home.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_home.tsx
@@ -99,7 +99,7 @@ export const ActionsConnectorsHome: React.FunctionComponent<RouteComponentProps<
           <EuiButtonEmpty
             data-test-subj="documentationButton"
             key="documentation-button"
-            href={docLinks.links.alerting.actionTypes}
+            href={docLinks.links.alerting.serverlessConnectors}
             iconType="help"
           >
             <FormattedMessage


### PR DESCRIPTION
## Summary

This PR tests the addition of a serverless-specific documentation link in the Connectors app.

It updates the Connectors UI to point to the new serverless docs URL, which works (or will when the docs are live):

![image](https://github.com/elastic/kibana/assets/26471269/c84cc960-964d-4bf7-b6e8-287a29162db1)

However, this also affects the non-serverless build, which means it's an incorrect URL in that context:

![image](https://github.com/elastic/kibana/assets/26471269/b36e03ec-959b-4e65-9e16-d9f6f063714b)

It is unclear what the recommended method is for ensuring that we use the appropriate link for each context.

I was trying to follow what was done for the `console.guide` and `console.serverlessGuide` [keywords](https://github.com/elastic/kibana/blob/bafb23580b18781e711575cd8c0e17a6e3f4f740/packages/kbn-doc-links/src/get_doc_links.ts#L72), but they don't seem to be used as alternative options in the code.