### PR TITLE
[Security Solution] remove unused flyoutSize property

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.test.tsx
@@ -53,7 +53,6 @@ describe('CaseUI View Page activity tab', () => {
             values: ['alert-id-1'],
           },
         },
-        flyoutSize: 'm',
         showExpandToDetails: true,
         showAlertStatusWithFlapping: false,
       });
@@ -83,7 +82,6 @@ describe('CaseUI View Page activity tab', () => {
             values: ['alert-id-1'],
           },
         },
-        flyoutSize: 's',
         showExpandToDetails: false,
         showAlertStatusWithFlapping: true,
       });

--- a/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/case_view_alerts.tsx
@@ -7,7 +7,6 @@
 
 import React, { useMemo } from 'react';
 
-import type { EuiFlyoutSize } from '@elastic/eui';
 import { EuiFlexItem, EuiFlexGroup, EuiProgress } from '@elastic/eui';
 import { SECURITY_SOLUTION_OWNER } from '../../../../common/constants';
 import type { CaseUI } from '../../../../common';
@@ -47,7 +46,6 @@ export const CaseViewAlerts = ({ caseData }: CaseViewAlertsProps) => {
     alertsTableConfigurationRegistry: triggersActionsUi.alertsTableConfigurationRegistry,
     configurationId: configId,
     id: `case-details-alerts-${caseData.owner}`,
-    flyoutSize: (alertFeatureIds?.includes('siem') ? 'm' : 's') as EuiFlyoutSize,
     featureIds: alertFeatureIds ?? [],
     query: alertIdsQuery,
     showExpandToDetails: Boolean(alertFeatureIds?.includes('siem')),

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/alerts/alerts_tab_content.tsx
@@ -51,7 +51,6 @@ export const AlertsTabContent = () => {
               alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
               configurationId={AlertConsumers.OBSERVABILITY}
               featureIds={infraAlertFeatureIds}
-              flyoutSize="s"
               id={ALERTS_TABLE_ID}
               pageSize={ALERTS_PER_PAGE}
               query={alertsEsQueryByStatus}

--- a/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
@@ -220,7 +220,6 @@ function InternalAlertsPage() {
                 alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
                 configurationId={AlertConsumers.OBSERVABILITY}
                 id={ALERTS_TABLE_ID}
-                flyoutSize="s"
                 featureIds={observabilityAlertFeatureIds}
                 query={esQuery}
                 showExpandToDetails={false}

--- a/x-pack/plugins/observability/public/pages/overview/overview.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/overview.tsx
@@ -189,7 +189,6 @@ export function OverviewPage() {
             <AlertsStateTable
               alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
               configurationId={AlertConsumers.OBSERVABILITY}
-              flyoutSize="s"
               featureIds={observabilityAlertFeatureIds}
               hideLazyLoader
               id={ALERTS_TABLE_ID}

--- a/x-pack/plugins/observability/public/pages/rule_details/components/rule_details_tabs.tsx
+++ b/x-pack/plugins/observability/public/pages/rule_details/components/rule_details_tabs.tsx
@@ -108,7 +108,6 @@ export function RuleDetailsTabs({
                   configurationId={observabilityFeatureId}
                   id={RULE_DETAILS_PAGE_ID}
                   featureIds={featureIds}
-                  flyoutSize="s"
                   query={esQuery}
                   showAlertStatusWithFlapping
                   showExpandToDetails={false}

--- a/x-pack/plugins/observability/public/pages/slo_details/components/slo_detail_alerts.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/slo_detail_alerts.tsx
@@ -31,7 +31,6 @@ export function SloDetailsAlerts({ slo }: Props) {
             alertsTableConfigurationRegistry={alertsTableConfigurationRegistry}
             configurationId={AlertConsumers.OBSERVABILITY}
             id={ALERTS_TABLE_ID}
-            flyoutSize="s"
             data-test-subj="alertTable"
             featureIds={[AlertConsumers.SLO]}
             query={{

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_details_ui/pages/rule_details/index.tsx
@@ -505,7 +505,6 @@ const RuleDetailsPageComponent: React.FC<DetectionEngineComponentProps> = ({
       return (
         <AlertsTableComponent
           configId={ALERTS_TABLE_REGISTRY_CONFIG_IDS.RULE_DETAILS}
-          flyoutSize="m"
           inputFilters={[...alertMergedFilters, ...groupingFilters]}
           tableId={TableId.alertsOnRuleDetailsPage}
           onRuleChange={refreshRule}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { EuiDataGridRowHeightsOptions, EuiDataGridStyle, EuiFlyoutSize } from '@elastic/eui';
+import type { EuiDataGridRowHeightsOptions, EuiDataGridStyle } from '@elastic/eui';
 import { EuiFlexGroup } from '@elastic/eui';
 import type { Filter } from '@kbn/es-query';
 import type { FC } from 'react';
@@ -86,7 +86,6 @@ const EuiDataGridContainer = styled.div<GridContainerProps>`
 `;
 interface DetectionEngineAlertTableProps {
   configId: string;
-  flyoutSize: EuiFlyoutSize;
   inputFilters: Filter[];
   tableId: TableId;
   sourcererScope?: SourcererScopeName;
@@ -96,7 +95,6 @@ interface DetectionEngineAlertTableProps {
 
 export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
   configId,
-  flyoutSize,
   inputFilters,
   tableId = TableId.alertsOnAlertsPage,
   sourcererScope = SourcererScopeName.detections,
@@ -258,7 +256,6 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       configurationId: configId,
       // stores saperate configuration based on the view of the table
       id: `detection-engine-alert-table-${configId}-${tableView}`,
-      flyoutSize,
       featureIds: ['siem'],
       query: finalBoolQuery,
       showExpandToDetails: false,
@@ -278,7 +275,6 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
       triggersActionsUi.alertsTableConfigurationRegistry,
       configId,
       tableView,
-      flyoutSize,
       finalBoolQuery,
       gridStyle,
       rowHeightsOptions,

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -382,7 +382,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
       return (
         <AlertsTableComponent
           configId={ALERTS_TABLE_REGISTRY_CONFIG_IDS.ALERTS_PAGE}
-          flyoutSize="m"
           inputFilters={[...alertsTableDefaultFilters, ...groupingFilters]}
           tableId={TableId.alertsOnAlertsPage}
           isLoading={isAlertTableLoading}

--- a/x-pack/plugins/security_solution/public/explore/components/risk_score/top_risk_score_contributors_alerts/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/components/risk_score/top_risk_score_contributors_alerts/index.tsx
@@ -82,7 +82,6 @@ export const TopRiskScoreContributorsAlerts: React.FC<TopRiskScoreContributorsAl
       return (
         <AlertsTableComponent
           configId={ALERTS_TABLE_REGISTRY_CONFIG_IDS.RISK_INPUTS}
-          flyoutSize="m"
           inputFilters={[...inputFilters, ...filters, ...groupingFilters]}
           tableId={TableId.alertsRiskInputs}
         />

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.tsx
@@ -14,7 +14,6 @@ import {
   EuiFlexItem,
   EuiPagination,
   EuiProgress,
-  EuiFlyoutSize,
 } from '@elastic/eui';
 import type { Alert, AlertsTableConfigurationRegistry } from '../../../../types';
 
@@ -40,7 +39,6 @@ interface AlertsFlyoutProps {
   alert: Alert;
   alertsTableConfiguration: AlertsTableConfigurationRegistry;
   flyoutIndex: number;
-  flyoutSize?: EuiFlyoutSize;
   alertsCount: number;
   isLoading: boolean;
   onClose: () => void;
@@ -51,7 +49,6 @@ export const AlertsFlyout: React.FunctionComponent<AlertsFlyoutProps> = ({
   alert,
   alertsTableConfiguration,
   flyoutIndex,
-  flyoutSize = 'm',
   alertsCount,
   isLoading,
   onClose,
@@ -109,7 +106,7 @@ export const AlertsFlyout: React.FunctionComponent<AlertsFlyoutProps> = ({
   );
 
   return (
-    <EuiFlyout onClose={onClose} size={flyoutSize} data-test-subj="alertsFlyout" ownFocus={false}>
+    <EuiFlyout onClose={onClose} size="m" data-test-subj="alertsFlyout" ownFocus={false}>
       {isLoading && <EuiProgress size="xs" color="accent" data-test-subj="alertsFlyoutLoading" />}
       <EuiFlyoutHeader hasBorder>
         <Suspense fallback={null}>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table_state.tsx
@@ -12,7 +12,6 @@ import {
   EuiProgress,
   EuiDataGridSorting,
   EuiEmptyPrompt,
-  EuiFlyoutSize,
   EuiDataGridProps,
   EuiDataGridToolBarVisibilityOptions,
 } from '@elastic/eui';
@@ -64,7 +63,6 @@ export type AlertsTableStateProps = {
   configurationId: string;
   id: string;
   featureIds: ValidFeatureId[];
-  flyoutSize?: EuiFlyoutSize;
   query: Pick<QueryDslQueryContainer, 'bool' | 'ids'>;
   pageSize?: number;
   showExpandToDetails: boolean;
@@ -148,7 +146,6 @@ const AlertsTableStateWithQueryProvider = ({
   configurationId,
   id,
   featureIds,
-  flyoutSize,
   query,
   pageSize,
   showExpandToDetails,
@@ -378,7 +375,6 @@ const AlertsTableStateWithQueryProvider = ({
       bulkActions: [],
       deletedEventIds: [],
       disabledCellActions: [],
-      flyoutSize,
       pageSize: pagination.pageSize,
       pageSizeOptions: [10, 20, 50, 100],
       id,
@@ -409,7 +405,6 @@ const AlertsTableStateWithQueryProvider = ({
       memoizedCases,
       memoizedMaintenanceWindows,
       columns,
-      flyoutSize,
       pagination.pageSize,
       id,
       leadingControlColumns,

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -15,7 +15,6 @@ import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type {
   IconType,
-  EuiFlyoutSize,
   RecursivePartial,
   EuiDataGridCellValueElementProps,
   EuiDataGridToolBarAdditionalControlsOptions,
@@ -537,7 +536,6 @@ export type AlertsTableProps = {
   // defaultCellActions: TGridCellAction[];
   deletedEventIds: string[];
   disabledCellActions: string[];
-  flyoutSize?: EuiFlyoutSize;
   pageSize: number;
   pageSizeOptions: number[];
   id?: string;


### PR DESCRIPTION
## Summary

This PR is a first of few that aim at removing the _old_ Security Solution alert details flyout, and replacing it by the new Security Solution expandable flyout alert details flyout.

Before actually removing the old code, I encountered some challenges, and doing some code cleanup first will make the switch a bit easier later.

Therefore, this PR cleans up an unused property of the Security Solution alert table: `flyoutSize`. The value was set in a bunch of places, but wasn't actually passed to the flyout at all. [Here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx#L473) is where the flyout is being used in the alerts table. The size is actually defaulted defaulted to `m` [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_flyout/alerts_flyout.tsx#L54).

All the places I checked in the UI indeed always display a medium size flyout (despite having the `small` size set in the code). The observability pages actually do not use the flyout (unless I'm mistaken).

https://github.com/elastic/security-team/issues/7461