### PR TITLE
[Cases] Required custom fields in the create case API

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -752,7 +752,7 @@ describe('create', () => {
       ).resolves.not.toThrow();
     });
 
-    it('does not throw if no custom fields are in request', async () => {
+    it('does not throw if there are only optional custom fields in configuration', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: mockCases[0].attributes.owner,
@@ -760,6 +760,12 @@ describe('create', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
+              label: 'foo',
+              required: false,
+            },
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TOGGLE,
               label: 'foo',
               required: false,
             },

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -17,7 +17,7 @@ import type { CasePostRequest } from '../../../common';
 import { SECURITY_SOLUTION_OWNER } from '../../../common';
 import { mockCases } from '../../mocks';
 import { createCasesClientMock, createCasesClientMockArgs } from '../mocks';
-import { create, throwIfCustomFieldKeysInvalid } from './create';
+import { create, throwIfCustomFieldKeysInvalid, throwIfMissingRequiredCustomField } from './create';
 import {
   CaseSeverity,
   CaseStatuses,
@@ -700,6 +700,127 @@ describe('create', () => {
           casesClient,
         })
       ).rejects.toThrowErrorMatchingInlineSnapshot(`"No custom fields configured."`);
+    });
+  });
+
+  describe('throwIfMissingRequiredCustomField', () => {
+    const casesClient = createCasesClientMock();
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('does not throw if all required custom fields are in the request', async () => {
+      const customFields = [
+        {
+          key: 'first_key',
+          type: CustomFieldTypes.TEXT as const,
+          field: { value: ['this is a text field value', 'this is second'] },
+        },
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE as const,
+          field: { value: null },
+        },
+      ];
+
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: mockCases[0].attributes.owner,
+          customFields: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TEXT,
+              label: 'foo',
+            },
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TOGGLE,
+              label: 'foo',
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        throwIfMissingRequiredCustomField({
+          casePostRequest: {
+            customFields,
+          } as unknown as CasePostRequest,
+          casesClient,
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('does not throw if no custom fields are in request', async () => {
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: mockCases[0].attributes.owner,
+          customFields: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TEXT,
+              label: 'foo',
+              required: false,
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        throwIfMissingRequiredCustomField({
+          casePostRequest: {} as unknown as CasePostRequest,
+          casesClient,
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('does not throw if no configuration found', async () => {
+      casesClient.configure.get = jest.fn().mockResolvedValue([]);
+
+      await expect(
+        throwIfMissingRequiredCustomField({
+          casePostRequest: {} as unknown as CasePostRequest,
+          casesClient,
+        })
+      ).resolves.not.toThrow();
+    });
+
+    it('throws if the request has missing required custom fields', async () => {
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: mockCases[0].attributes.owner,
+          customFields: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TEXT,
+              label: 'foo',
+              required: true,
+            },
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TOGGLE,
+              label: 'foo',
+              required: true,
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        throwIfMissingRequiredCustomField({
+          casePostRequest: {
+            customFields: [
+              {
+                key: 'second_key',
+                type: CustomFieldTypes.TOGGLE,
+                label: 'foo',
+              },
+            ],
+          } as unknown as CasePostRequest,
+          casesClient,
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"Missing required custom fields: first_key"`);
     });
   });
 });

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -425,6 +425,43 @@ export default ({ getService }: FtrProviderContext): void => {
             400
           );
         });
+
+        it('400s when trying to create case with a missing required custom field', async () => {
+          await createConfiguration(
+            supertest,
+            getConfigurationRequest({
+              overrides: {
+                customFields: [
+                  {
+                    key: 'test_custom_field',
+                    label: 'text',
+                    type: CustomFieldTypes.TEXT,
+                    required: true,
+                  },
+                  {
+                    key: 'toggle_custom_field',
+                    label: 'toggle',
+                    type: CustomFieldTypes.TOGGLE,
+                    required: true,
+                  },
+                ],
+              },
+            })
+          );
+          await createCase(
+            supertest,
+            getPostCaseRequest({
+              customFields: [
+                {
+                  key: 'toggle_custom_field',
+                  type: CustomFieldTypes.TOGGLE,
+                  field: { value: [true] },
+                },
+              ],
+            }),
+            400
+          );
+        });
       });
     });
 


### PR DESCRIPTION
## Summary

This PR checks for missing required custom fields in the create case API.

(In my next PR I am thinking of moving `casesClient.configure.get({ owner: casePostRequest.owner });` outside of the validation functions.)