### PR TITLE
Revert to using the old GPG key

### DIFF
--- a/src/dev/build/tasks/fleet/download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet/download_elastic_gpg_key.ts
@@ -15,7 +15,7 @@ import { downloadToDisk } from '../../lib';
 const ARTIFACTS_URL = 'https://artifacts.elastic.co/';
 const GPG_KEY_NAME = 'GPG-KEY-elasticsearch';
 const GPG_KEY_SHA512 =
-  '62a567354286deb02baf5fc6b82ddf6c7067898723463da9ae65b132b8c6d6f064b2874e390885682376228eed166c1c82fe7f11f6c9a69f0c157029c548fa3d';
+  '84ee193cc337344d9a7da9021daf3f5ede83f5f1ab049d169f3634921529dcd096abf7a91eec7f26f3a6913e5e38f88f69a5e2ce79ad155d46edc75705a648c6';
 
 export async function downloadElasticGpgKey(pkgDir: string, log: ToolingLog) {
   const gpgKeyUrl = ARTIFACTS_URL + GPG_KEY_NAME;

--- a/src/dev/build/tasks/fleet/download_elastic_gpg_key.ts
+++ b/src/dev/build/tasks/fleet/download_elastic_gpg_key.ts
@@ -13,7 +13,7 @@ import { ToolingLog } from '@kbn/tooling-log';
 import { downloadToDisk } from '../../lib';
 
 const ARTIFACTS_URL = 'https://artifacts.elastic.co/';
-const GPG_KEY_NAME = 'GPG-KEY-elasticsearch';
+const GPG_KEY_NAME = 'GPG-KEY-elasticsearch.sha1';
 const GPG_KEY_SHA512 =
   '84ee193cc337344d9a7da9021daf3f5ede83f5f1ab049d169f3634921529dcd096abf7a91eec7f26f3a6913e5e38f88f69a5e2ce79ad155d46edc75705a648c6';
 


### PR DESCRIPTION
## Summary
Context: 
- there was a gpg key signature change (https://elastic.slack.com/archives/C0D8P2XK5/p1695621791855459)
- we updated the code to reflect the new key file's hash
- tests started to fail in various, fleet-related test suites
- we didn't manage to fix forward: https://github.com/elastic/kibana/pull/167149
- so we decided to fix backward (using the old key, giving time for a proper fix in a single pr)

<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->