### PR TITLE
feature(slo): Run transforms unattended

### DIFF
--- a/x-pack/plugins/observability/server/assets/constants.ts
+++ b/x-pack/plugins/observability/server/assets/constants.ts
@@ -6,6 +6,7 @@
  */
 
 export const SLO_RESOURCES_VERSION = 2;
+export const SLO_SUMMARY_TRANSFORMS_VERSION = 3;
 
 export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = '.slo-observability.sli-mappings';
 export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = '.slo-observability.sli-settings';

--- a/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
+++ b/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
@@ -36,6 +36,7 @@ export const getSLOTransformTemplate = (
   dest: destination,
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   sync: {
     time: {

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -36,6 +36,7 @@ export class CreateSLO {
     }
 
     try {
+      await this.transformManager.preview(sloTransformId);
       await this.transformManager.start(sloTransformId);
     } catch (err) {
       await Promise.all([

--- a/x-pack/plugins/observability/server/services/slo/mocks/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/mocks/index.ts
@@ -28,6 +28,7 @@ const createSummaryTransformInstallerMock = (): jest.Mocked<SummaryTransformInst
 const createTransformManagerMock = (): jest.Mocked<TransformManager> => {
   return {
     install: jest.fn(),
+    preview: jest.fn(),
     uninstall: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
@@ -7,7 +7,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 7 days rolling time window",
       "dest": Object {
@@ -173,6 +173,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -235,7 +236,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 30 days rolling time window",
       "dest": Object {
@@ -401,6 +402,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -463,7 +465,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 90 days rolling time window",
       "dest": Object {
@@ -629,6 +631,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -691,7 +694,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a weekly calendar aligned time window",
       "dest": Object {
@@ -870,6 +873,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -932,7 +936,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a monthly calendar aligned time window",
       "dest": Object {
@@ -1126,6 +1130,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.ts
@@ -8,7 +8,7 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import {
-  SLO_RESOURCES_VERSION,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../assets/constants';
 import { retryTransientEsErrors } from '../../../utils/retry';
@@ -32,7 +32,7 @@ export class DefaultSummaryTransformInstaller implements SummaryTransformInstall
     const alreadyInstalled =
       summaryTransforms.count === allTransformIds.length &&
       summaryTransforms.transforms.every(
-        (transform) => transform._meta?.version === SLO_RESOURCES_VERSION
+        (transform) => transform._meta?.version === SLO_SUMMARY_TRANSFORMS_VERSION
       ) &&
       summaryTransforms.transforms.every((transform) => allTransformIds.includes(transform.id));
 
@@ -46,9 +46,9 @@ export class DefaultSummaryTransformInstaller implements SummaryTransformInstall
       const transform = summaryTransforms.transforms.find((t) => t.id === transformId);
 
       const transformAlreadyInstalled =
-        !!transform && transform._meta?.version === SLO_RESOURCES_VERSION;
+        !!transform && transform._meta?.version === SLO_SUMMARY_TRANSFORMS_VERSION;
       const previousTransformAlreadyInstalled =
-        !!transform && transform._meta?.version !== SLO_RESOURCES_VERSION;
+        !!transform && transform._meta?.version !== SLO_SUMMARY_TRANSFORMS_VERSION;
 
       if (transformAlreadyInstalled) {
         this.logger.info(`SLO summary transform [${transformId}] already installed - skipping`);

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,10 +143,10 @@ export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
-    max_page_search_size: 8000,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -141,9 +141,10 @@ export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest =
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -141,9 +141,10 @@ export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = 
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -171,9 +171,10 @@ export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = 
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -156,9 +156,10 @@ export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -739,6 +739,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",
@@ -1013,6 +1014,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -708,6 +708,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",
@@ -971,6 +972,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -220,6 +220,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -476,6 +477,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -235,6 +235,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -465,6 +466,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -244,6 +244,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -512,6 +513,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
@@ -47,7 +47,7 @@ describe('TransformManager', () => {
 
         await expect(
           service.install(createSLO({ indicator: createAPMTransactionErrorRateIndicator() }))
-        ).rejects.toThrowError('Unsupported SLI type: sli.apm.transactionErrorRate');
+        ).rejects.toThrowError('Unsupported indicator type [sli.apm.transactionErrorRate]');
       });
 
       it('throws when transform generator fails', async () => {

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
@@ -80,6 +80,20 @@ describe('TransformManager', () => {
     });
   });
 
+  describe('Preview', () => {
+    it('previews the transform', async () => {
+      // @ts-ignore defining only a subset of the possible SLI
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
+        'sli.apm.transactionErrorRate': new ApmTransactionErrorRateTransformGenerator(),
+      };
+      const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
+
+      await transformManager.preview('slo-transform-id');
+
+      expect(esClientMock.transform.previewTransform).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('Start', () => {
     it('starts the transform', async () => {
       // @ts-ignore defining only a subset of the possible SLI

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.ts
@@ -31,8 +31,8 @@ export class DefaultTransformManager implements TransformManager {
   async install(slo: SLO): Promise<TransformId> {
     const generator = this.generators[slo.indicator.type];
     if (!generator) {
-      this.logger.error(`No transform generator found for ${slo.indicator.type} SLO type`);
-      throw new Error(`Unsupported SLI type: ${slo.indicator.type}`);
+      this.logger.error(`No transform generator found for indicator type [${slo.indicator.type}]`);
+      throw new Error(`Unsupported indicator type [${slo.indicator.type}]`);
     }
 
     const transformParams = generator.getTransformParams(slo);
@@ -41,7 +41,7 @@ export class DefaultTransformManager implements TransformManager {
         logger: this.logger,
       });
     } catch (err) {
-      this.logger.error(`Cannot create transform for ${slo.indicator.type} SLI type: ${err}`);
+      this.logger.error(`Cannot create SLO transform for indicator type [${slo.indicator.type}]`);
       throw err;
     }
 
@@ -51,15 +51,11 @@ export class DefaultTransformManager implements TransformManager {
   async preview(transformId: string): Promise<void> {
     try {
       await retryTransientEsErrors(
-        () =>
-          this.esClient.transform.previewTransform(
-            { transform_id: transformId },
-            { ignore: [409] }
-          ),
+        () => this.esClient.transform.previewTransform({ transform_id: transformId }),
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot preview transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot preview SLO transform [${transformId}]`);
       throw err;
     }
   }
@@ -72,7 +68,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot start transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot start SLO transform [${transformId}]`);
       throw err;
     }
   }
@@ -88,7 +84,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot stop transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot stop SLO transform [${transformId}]`);
       throw err;
     }
   }
@@ -104,7 +100,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot delete transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot delete SLO transform [${transformId}]`);
       throw err;
     }
   }

--- a/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
@@ -141,8 +141,9 @@ describe('UpdateSLO', () => {
   });
 
   function expectInstallationOfNewSLOTransform() {
-    expect(mockTransformManager.start).toBeCalled();
     expect(mockTransformManager.install).toBeCalled();
+    expect(mockTransformManager.preview).toBeCalled();
+    expect(mockTransformManager.start).toBeCalled();
   }
 
   function expectDeletionOfObsoleteSLOData(originalSlo: SLO) {

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -37,9 +37,12 @@ export class UpdateSLO {
     validateSLO(updatedSlo);
 
     await this.deleteObsoleteSLORevisionData(originalSlo);
+
+    const updatedSloTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
     await this.repository.save(updatedSlo);
     await this.transformManager.install(updatedSlo);
-    await this.transformManager.start(getSLOTransformId(updatedSlo.id, updatedSlo.revision));
+    await this.transformManager.preview(updatedSloTransformId);
+    await this.transformManager.start(updatedSloTransformId);
 
     await this.esClient.index({
       index: SLO_SUMMARY_TEMP_INDEX_NAME,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166954

## Summary

This PR creates the SLO transforms in `unattended` mode.
I've also updated the summary transform installation to use a specific version number.
