### PR TITLE
[APM] Add an environment param to the service metadata details endpoint

### DIFF
--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -90,7 +90,7 @@ function TemplateWithContext({
   const {
     path: { serviceName },
     query,
-    query: { rangeFrom, rangeTo },
+    query: { rangeFrom, rangeTo, environment },
   } = useApmParams('/services/{serviceName}/*');
   const history = useHistory();
   const location = useLocation();
@@ -140,6 +140,7 @@ function TemplateWithContext({
                 <EuiFlexItem grow={false}>
                   <ServiceIcons
                     serviceName={serviceName}
+                    environment={environment}
                     start={start}
                     end={end}
                   />

--- a/x-pack/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/mobile_service_template/index.tsx
@@ -57,7 +57,7 @@ function TemplateWithContext({
   const {
     path: { serviceName },
     query,
-    query: { rangeFrom, rangeTo },
+    query: { rangeFrom, rangeTo, environment },
   } = useApmParams('/mobile-services/{serviceName}/*');
 
   const { start, end } = useTimeRange({ rangeFrom, rangeTo });
@@ -116,6 +116,7 @@ function TemplateWithContext({
                 <EuiFlexItem grow={false}>
                   <ServiceIcons
                     serviceName={serviceName}
+                    environment={environment}
                     start={start}
                     end={end}
                   />

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.test.tsx
@@ -64,6 +64,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -87,6 +88,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -112,6 +114,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -138,6 +141,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -165,6 +169,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -212,6 +217,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -256,6 +262,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -308,6 +315,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />
@@ -366,6 +374,7 @@ describe('ServiceIcons', () => {
           <EuiThemeProvider>
             <ServiceIcons
               serviceName="foo"
+              environment="dev"
               start="2021-08-20T10:00:00.000Z"
               end="2021-08-20T10:15:00.000Z"
             />

--- a/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/index.tsx
@@ -25,6 +25,7 @@ import openTelemetryIcon from '../agent_icon/icons/opentelemetry.svg';
 
 interface Props {
   serviceName: string;
+  environment: string;
   start: string;
   end: string;
 }
@@ -92,7 +93,7 @@ export interface PopoverItem {
   component: ReactChild;
 }
 
-export function ServiceIcons({ start, end, serviceName }: Props) {
+export function ServiceIcons({ start, end, serviceName, environment }: Props) {
   const [selectedIconPopover, setSelectedIconPopover] =
     useState<Icons | null>();
 
@@ -117,20 +118,20 @@ export function ServiceIcons({ start, end, serviceName }: Props) {
 
   const { data: details, status: detailsFetchStatus } = useFetcher(
     (callApmApi) => {
-      if (selectedIconPopover && serviceName && start && end) {
+      if (selectedIconPopover && serviceName && start && end && environment) {
         return callApmApi(
           'GET /internal/apm/services/{serviceName}/metadata/details',
           {
             isCachable: true,
             params: {
               path: { serviceName },
-              query: { start, end },
+              query: { start, end, environment },
             },
           }
         );
       }
     },
-    [selectedIconPopover, serviceName, start, end]
+    [selectedIconPopover, serviceName, start, end, environment]
   );
 
   const isLoading = !icons && iconsFetchStatus === FETCH_STATUS.LOADING;

--- a/x-pack/plugins/apm/public/components/shared/service_icons/service_icons.stories.tsx
+++ b/x-pack/plugins/apm/public/components/shared/service_icons/service_icons.stories.tsx
@@ -22,6 +22,7 @@ type ServiceIconsReturnType =
 
 interface Args {
   serviceName: string;
+  environment: string;
   start: string;
   end: string;
   icons: ServiceIconsReturnType;
@@ -64,7 +65,12 @@ const stories: Meta<Args> = {
 };
 export default stories;
 
-export const Example: Story<Args> = ({ serviceName, start, end }) => {
+export const Example: Story<Args> = ({
+  serviceName,
+  environment,
+  start,
+  end,
+}) => {
   return (
     <EuiFlexGroup>
       <EuiFlexItem>
@@ -83,6 +89,7 @@ export const Example: Story<Args> = ({ serviceName, start, end }) => {
                   <EuiFlexItem grow={false}>
                     <ServiceIcons
                       serviceName={serviceName}
+                      environment={environment}
                       start={start}
                       end={end}
                     />
@@ -98,6 +105,7 @@ export const Example: Story<Args> = ({ serviceName, start, end }) => {
 };
 Example.args = {
   serviceName: 'opbeans-java',
+  environment: 'dev',
   start: '2021-09-10T13:59:00.000Z',
   end: '2021-09-10T14:14:04.789Z',
   icons: {

--- a/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
+++ b/x-pack/plugins/apm/server/routes/services/get_service_metadata_details.ts
@@ -7,6 +7,7 @@
 
 import { rangeQuery } from '@kbn/observability-plugin/server';
 import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { environmentQuery } from '../../../common/utils/environment_query';
 import {
   AGENT,
   CONTAINER,
@@ -86,17 +87,20 @@ export interface ServiceMetadataDetails {
 
 export async function getServiceMetadataDetails({
   serviceName,
+  environment,
   apmEventClient,
   start,
   end,
 }: {
   serviceName: string;
+  environment: string;
   apmEventClient: APMEventClient;
   start: number;
   end: number;
 }): Promise<ServiceMetadataDetails> {
   const filter = [
     { term: { [SERVICE_NAME]: serviceName } },
+    ...environmentQuery(environment),
     ...rangeQuery(start, end),
   ];
 

--- a/x-pack/plugins/apm/server/routes/services/route.ts
+++ b/x-pack/plugins/apm/server/routes/services/route.ts
@@ -234,17 +234,18 @@ const serviceMetadataDetailsRoute = createApmServerRoute({
   endpoint: 'GET /internal/apm/services/{serviceName}/metadata/details',
   params: t.type({
     path: t.type({ serviceName: t.string }),
-    query: rangeRt,
+    query: t.intersection([rangeRt, environmentRt]),
   }),
   options: { tags: ['access:apm'] },
   handler: async (resources): Promise<ServiceMetadataDetails> => {
     const apmEventClient = await getApmEventClient(resources);
     const { params } = resources;
     const { serviceName } = params.path;
-    const { start, end } = params.query;
+    const { start, end, environment } = params.query;
 
     const serviceMetadataDetails = await getServiceMetadataDetails({
       serviceName,
+      environment,
       apmEventClient,
       start,
       end,

--- a/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/feature_controls.spec.ts
@@ -184,7 +184,7 @@ export default function featureControlsTests({ getService }: FtrProviderContext)
     },
     {
       req: {
-        url: `/internal/apm/services/foo/metadata/details?start=${start}&end=${end}`,
+        url: `/internal/apm/services/foo/metadata/details?start=${start}&end=${end}&environment=dev`,
       },
       expectForbidden: expect403,
       expectResponse: expect200,

--- a/x-pack/test/apm_api_integration/tests/services/service_details/service_details.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_details/service_details.spec.ts
@@ -32,6 +32,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         query: {
           start: new Date(start).toISOString(),
           end: new Date(end).toISOString(),
+          environment: 'production',
         },
       },
     });

--- a/x-pack/test/apm_api_integration/tests/services/service_details/service_infra_metrics.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/services/service_details/service_infra_metrics.spec.ts
@@ -6,6 +6,7 @@
  */
 import expect from '@kbn/expect';
 import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
+import { ENVIRONMENT_ALL } from '@kbn/apm-plugin/common/environment_filter_values';
 import { FtrProviderContext } from '../../../common/ftr_provider_context';
 import archives_metadata from '../../../common/fixtures/es_archiver/archives_metadata';
 
@@ -94,6 +95,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               query: {
                 start,
                 end,
+                environment: ENVIRONMENT_ALL.value,
               },
             },
           });
@@ -124,6 +126,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               query: {
                 start,
                 end,
+                environment: ENVIRONMENT_ALL.value,
               },
             },
           });
@@ -151,6 +154,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               query: {
                 start,
                 end,
+                environment: ENVIRONMENT_ALL.value,
               },
             },
           });


### PR DESCRIPTION
Adds a query param for the environment to the `GET /internal/apm/services/{serviceName}/metadata/details` endpoint.

### Before
https://github.com/elastic/kibana/assets/5831975/01865a3a-f312-4356-aafd-b21b88045487

### After
https://github.com/elastic/kibana/assets/5831975/e1f2fd00-4b44-4f86-8221-775ec6494913

Closes https://github.com/elastic/kibana/issues/167146