### PR TITLE
[8.10] fix(slo): date range filter format (#166989)

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -24,7 +24,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -130,7 +130,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -163,7 +163,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -277,7 +277,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -391,7 +391,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -505,7 +505,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -765,7 +765,7 @@ Object {
           Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },
@@ -1039,7 +1039,7 @@ Object {
           Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -20,7 +20,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -122,7 +122,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -151,7 +151,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -261,7 +261,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -371,7 +371,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -481,7 +481,7 @@ Object {
       Object {
         "range": Object {
           "@timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -730,7 +730,7 @@ Object {
           Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },
@@ -993,7 +993,7 @@ Object {
           Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -51,7 +51,7 @@ Object {
       Object {
         "range": Object {
           "log_timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -232,7 +232,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },
@@ -488,7 +488,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -92,7 +92,7 @@ Object {
       Object {
         "range": Object {
           "log_timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -247,7 +247,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },
@@ -477,7 +477,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -63,7 +63,7 @@ Object {
       Object {
         "range": Object {
           "log_timestamp": Object {
-            "gte": "now-7d",
+            "gte": "now-7d/d",
           },
         },
       },
@@ -256,7 +256,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },
@@ -524,7 +524,7 @@ Object {
           Object {
             "range": Object {
               "log_timestamp": Object {
-                "gte": "now-7d",
+                "gte": "now-7d/d",
               },
             },
           },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_duration.ts
@@ -72,7 +72,7 @@ export class ApmTransactionDurationTransformGenerator extends TransformGenerator
       {
         range: {
           '@timestamp': {
-            gte: `now-${slo.timeWindow.duration.format()}`,
+            gte: `now-${slo.timeWindow.duration.format()}/d`,
           },
         },
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/apm_transaction_error_rate.ts
@@ -72,7 +72,7 @@ export class ApmTransactionErrorRateTransformGenerator extends TransformGenerato
       {
         range: {
           '@timestamp': {
-            gte: `now-${slo.timeWindow.duration.format()}`,
+            gte: `now-${slo.timeWindow.duration.format()}/d`,
           },
         },
       },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/histogram.ts
@@ -54,7 +54,7 @@ export class HistogramTransformGenerator extends TransformGenerator {
             {
               range: {
                 [indicator.params.timestampField]: {
-                  gte: `now-${slo.timeWindow.duration.format()}`,
+                  gte: `now-${slo.timeWindow.duration.format()}/d`,
                 },
               },
             },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/kql_custom.ts
@@ -49,7 +49,7 @@ export class KQLCustomTransformGenerator extends TransformGenerator {
             {
               range: {
                 [indicator.params.timestampField]: {
-                  gte: `now-${slo.timeWindow.duration.format()}`,
+                  gte: `now-${slo.timeWindow.duration.format()}/d`,
                 },
               },
             },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/metric_custom.ts
@@ -52,7 +52,7 @@ export class MetricCustomTransformGenerator extends TransformGenerator {
             {
               range: {
                 [indicator.params.timestampField]: {
-                  gte: `now-${slo.timeWindow.duration.format()}`,
+                  gte: `now-${slo.timeWindow.duration.format()}/d`,
                 },
               },
             },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [fix(slo): date range filter format (#166989)](https://github.com/elastic/kibana/pull/166989)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2023-09-25T17:09:03Z","message":"fix(slo): date range filter format (#166989)","sha":"5b24da796d3a992cd0e3eeb0262bd37564ba995b","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["backport","release_note:skip","backport:skip","Team: Actionable Observability","v8.11.0","Feature:SLO"],"number":166989,"url":"https://github.com/elastic/kibana/pull/166989","mergeCommit":{"message":"fix(slo): date range filter format (#166989)","sha":"5b24da796d3a992cd0e3eeb0262bd37564ba995b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166989","number":166989,"mergeCommit":{"message":"fix(slo): date range filter format (#166989)","sha":"5b24da796d3a992cd0e3eeb0262bd37564ba995b"}}]}] BACKPORT-->