### PR TITLE
[8.10] [Security Solution] Fix a build step when there are no tests to execute (#165929)

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -31,8 +31,10 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   buildkite-agent artifact upload '.es/**/*.hprof'
   buildkite-agent artifact upload 'data/es_debug_*.tar.gz'
 
-  echo "--- Run Failed Test Reporter"
-  node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" 'target/junit/**/*.xml'
+  if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then
+    echo "--- Run Failed Test Reporter"
+    node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" 'target/junit/**/*.xml'
+  fi
 
   if [[ -d 'target/test_failures' ]]; then
     buildkite-agent artifact upload 'target/test_failures/**/*'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Security Solution] Fix a build step when there are no tests to execute (#165929)](https://github.com/elastic/kibana/pull/165929)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maxim Palenov","email":"maxim.palenov@elastic.co"},"sourceCommit":{"committedDate":"2023-09-07T16:02:16Z","message":"[Security Solution] Fix a build step when there are no tests to execute (#165929)\n\n## Summary\r\n\r\nFixes failed build steps when there are no tests to execute and hence no\r\nreports.\r\n\r\n## Details\r\n\r\nDespite this [PR](https://github.com/elastic/kibana/pull/165824) fixes\r\ntests failure when there are no reports but `yarn junit:merge` tries to\r\nconvert them to junit format the problem is partially stays as `Failed\r\nTest Reporter` runs for every build step meaning also for successful\r\nbuild steps. We don't need to handle failed test reports for successful\r\nbuild steps. There are cases when there are no tests to run so Cypress\r\ndoesn't produce reports and nothing is converted to junit format so\r\n`Failed Test Reporter` fails and causes a build step to fails. It could\r\nbe solved by defining an environment variable\r\n`DISABLE_MISSING_TEST_REPORT_ERRORS=true` but we need to make sure\r\nreports exist for failed tests. Taking this into account we can rely on\r\n`BUILDKITE_COMMAND_EXIT_STATUS` to avoid running `Failed Test Reporter`\r\nif the build step successed.\r\n\r\nOne may ask why don't skip `Upload Artifacts` too. We may need some\r\nbuild artifacts for successful build steps.\r\n\r\n---------\r\n\r\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"369d2fe367d105a8786a26e332fac1f68bc81666","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","ci:all-cypress-suites","v8.11.0"],"number":165929,"url":"https://github.com/elastic/kibana/pull/165929","mergeCommit":{"message":"[Security Solution] Fix a build step when there are no tests to execute (#165929)\n\n## Summary\r\n\r\nFixes failed build steps when there are no tests to execute and hence no\r\nreports.\r\n\r\n## Details\r\n\r\nDespite this [PR](https://github.com/elastic/kibana/pull/165824) fixes\r\ntests failure when there are no reports but `yarn junit:merge` tries to\r\nconvert them to junit format the problem is partially stays as `Failed\r\nTest Reporter` runs for every build step meaning also for successful\r\nbuild steps. We don't need to handle failed test reports for successful\r\nbuild steps. There are cases when there are no tests to run so Cypress\r\ndoesn't produce reports and nothing is converted to junit format so\r\n`Failed Test Reporter` fails and causes a build step to fails. It could\r\nbe solved by defining an environment variable\r\n`DISABLE_MISSING_TEST_REPORT_ERRORS=true` but we need to make sure\r\nreports exist for failed tests. Taking this into account we can rely on\r\n`BUILDKITE_COMMAND_EXIT_STATUS` to avoid running `Failed Test Reporter`\r\nif the build step successed.\r\n\r\nOne may ask why don't skip `Upload Artifacts` too. We may need some\r\nbuild artifacts for successful build steps.\r\n\r\n---------\r\n\r\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"369d2fe367d105a8786a26e332fac1f68bc81666"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/165929","number":165929,"mergeCommit":{"message":"[Security Solution] Fix a build step when there are no tests to execute (#165929)\n\n## Summary\r\n\r\nFixes failed build steps when there are no tests to execute and hence no\r\nreports.\r\n\r\n## Details\r\n\r\nDespite this [PR](https://github.com/elastic/kibana/pull/165824) fixes\r\ntests failure when there are no reports but `yarn junit:merge` tries to\r\nconvert them to junit format the problem is partially stays as `Failed\r\nTest Reporter` runs for every build step meaning also for successful\r\nbuild steps. We don't need to handle failed test reports for successful\r\nbuild steps. There are cases when there are no tests to run so Cypress\r\ndoesn't produce reports and nothing is converted to junit format so\r\n`Failed Test Reporter` fails and causes a build step to fails. It could\r\nbe solved by defining an environment variable\r\n`DISABLE_MISSING_TEST_REPORT_ERRORS=true` but we need to make sure\r\nreports exist for failed tests. Taking this into account we can rely on\r\n`BUILDKITE_COMMAND_EXIT_STATUS` to avoid running `Failed Test Reporter`\r\nif the build step successed.\r\n\r\nOne may ask why don't skip `Upload Artifacts` too. We may need some\r\nbuild artifacts for successful build steps.\r\n\r\n---------\r\n\r\nCo-authored-by: Tiago Costa <tiago.costa@elastic.co>","sha":"369d2fe367d105a8786a26e332fac1f68bc81666"}}]}] BACKPORT-->