### PR TITLE
feat(slo): limit perPage in find api

### DIFF
--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.json
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.json
@@ -160,7 +160,8 @@
             "description": "The number of SLOs to return per page",
             "schema": {
               "type": "integer",
-              "default": 25
+              "default": 25,
+              "maximum": 5000
             },
             "example": 25
           },

--- a/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/bundled.yaml
@@ -99,6 +99,7 @@ paths:
           schema:
             type: integer
             default: 25
+            maximum: 5000
           example: 25
         - name: sortBy
           in: query

--- a/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
+++ b/x-pack/plugins/observability/docs/openapi/slo/paths/s@{spaceid}@api@slos.yaml
@@ -79,6 +79,7 @@ get:
       schema:
         type: integer
         default: 25
+        maximum: 5000
       example: 25
     - name: sortBy
       in: query

--- a/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/find_slo.test.ts
@@ -138,6 +138,19 @@ describe('FindSLO', () => {
       `);
     });
   });
+
+  describe('validation', () => {
+    it("throws an error when 'perPage > 5000'", async () => {
+      const slo = createSLO();
+      mockSummarySearchClient.search.mockResolvedValueOnce(summarySearchResult(slo));
+      mockRepository.findAllByIds.mockResolvedValueOnce([slo]);
+
+      await expect(findSLO.execute({ perPage: '5000' })).resolves.not.toThrow();
+      await expect(findSLO.execute({ perPage: '5001' })).rejects.toThrowError(
+        'perPage limit to 5000'
+      );
+    });
+  });
 });
 
 function summarySearchResult(slo: SLO): Paginated<SLOSummary> {

--- a/x-pack/plugins/observability/server/services/slo/find_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/find_slo.ts
@@ -7,11 +7,13 @@
 
 import { FindSLOParams, FindSLOResponse, findSLOResponseSchema } from '@kbn/slo-schema';
 import { SLO, SLOWithSummary } from '../../domain/models';
+import { IllegalArgumentError } from '../../errors';
 import { SLORepository } from './slo_repository';
 import { Pagination, SLOSummary, Sort, SummarySearchClient } from './summary_search_client';
 
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 25;
+const MAX_PER_PAGE = 5000;
 
 export class FindSLO {
   constructor(
@@ -51,6 +53,10 @@ function mergeSloWithSummary(sloList: SLO[], sloSummaryList: SLOSummary[]): SLOW
 function toPagination(params: FindSLOParams): Pagination {
   const page = Number(params.page);
   const perPage = Number(params.perPage);
+
+  if (!isNaN(perPage) && perPage > MAX_PER_PAGE) {
+    throw new IllegalArgumentError('perPage limit to 5000');
+  }
 
   return {
     page: !isNaN(page) && page >= 1 ? page : DEFAULT_PAGE,


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/166768

## Summary

This PR fixes the find SLO api by limiting the maximum allowed perPage query parameter to 5000. 

Previously providing a perPage value greater than 5000 was producing an ES error which was caught and handled in a way that no response was returned from the API.