### PR TITLE
[Response Ops][Task Manager] Increasing max bucket size for task delay and overdue by histograms

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
@@ -19,7 +19,7 @@ import {
 import { TaskManagerMetrics } from './task_metrics_collector';
 import { ITaskMetricsAggregator } from './types';
 
-const HDR_HISTOGRAM_MAX = 1800; // 30 minutes
+const HDR_HISTOGRAM_MAX = 7200; // 2 hours
 const HDR_HISTOGRAM_BUCKET_SIZE = 10; // 10 seconds
 
 const OVERDUE_BY_KEY = 'overdue_by';

--- a/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.ts
@@ -19,7 +19,7 @@ import {
 import { TaskManagerMetrics } from './task_metrics_collector';
 import { ITaskMetricsAggregator } from './types';
 
-const HDR_HISTOGRAM_MAX = 7200; // 2 hours
+const HDR_HISTOGRAM_MAX = 5400; // 90 minutes
 const HDR_HISTOGRAM_BUCKET_SIZE = 10; // 10 seconds
 
 const OVERDUE_BY_KEY = 'overdue_by';

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
@@ -25,7 +25,7 @@ import {
 } from './lib';
 import { ITaskMetricsAggregator } from './types';
 
-const HDR_HISTOGRAM_MAX = 7200; // 2 hours
+const HDR_HISTOGRAM_MAX = 5400; // 90 minutes
 const HDR_HISTOGRAM_BUCKET_SIZE = 10; // 10 seconds
 
 enum TaskRunKeys {

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
@@ -25,7 +25,7 @@ import {
 } from './lib';
 import { ITaskMetricsAggregator } from './types';
 
-const HDR_HISTOGRAM_MAX = 1800; // 30 minutes
+const HDR_HISTOGRAM_MAX = 7200; // 2 hours
 const HDR_HISTOGRAM_BUCKET_SIZE = 10; // 10 seconds
 
 enum TaskRunKeys {


### PR DESCRIPTION
## Summary

With the serverless circuit breakers we're setting, we could see delays up to 64 minutes so we need to increase the max bucket allowed when capturing task run delays.
