### PR TITLE
Switch Check Types to Commit Diff for on merge pipeline

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -154,8 +154,11 @@ steps:
         - exit_status: '-1'
           limit: 3
 
-  - command: .buildkite/scripts/steps/check_types.sh
-    label: 'Check Types'
+  - command: .buildkite/scripts/steps/check_types_commits.sh
+    label: 'Check Types Commit Diff'
+    # TODO: Enable in #166813 after fixing types
+  # - command: .buildkite/scripts/steps/check_types.sh
+    # label: 'Check Types'
     agents:
       queue: n2-16-spot
     timeout_in_minutes: 60


### PR DESCRIPTION
## Summary

After merging #167060, `Check Types` is going to fail in the on merge pipeline until all type errors are triaged. For now, lets use the commit diff type check.