### PR TITLE
[Ops] Fix scoped type check

### DIFF
--- a/.buildkite/scripts/steps/check_types_commits.sh
+++ b/.buildkite/scripts/steps/check_types_commits.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 
 if [[ "${CI-}" == "true" ]]; then
   .buildkite/scripts/bootstrap.sh
-  
-  sha1="${GITHUB_PR_TARGET_BRANCH-}"
+
+  sha1=$(git merge-base $GITHUB_PR_TARGET_BRANCH $GITHUB_PR_TRIGGERED_SHA)
   sha2="${GITHUB_PR_TRIGGERED_SHA-}"
 else
   # Script take between 0 and 2 arguments representing two commit SHA's:


### PR DESCRIPTION
## Problem

The `.buildkite/scripts/steps/check_types_commits.sh` script (introduced in #167060) is comparing the latest commit of the PR against the target branch (usually `main`). But if the PR is not fully up to date with the target branch, the diff is also going to contain any changes that has landed in the target branch since the PR was branched off. This is going to include a lot of extra `tsconfig.json` files not related to the PR and will make solving the TypeScript errors a lot harder for the PR author.

## Solution

Limit diff to just the files contained in the PR by finding the closest common ancestor between the target branch and the current `HEAD`.

(This PR also makes the `.buildkite/scripts/steps/check_types_commits.sh` file executable.)