### PR TITLE
[8.10] [Search] Fix broken Search plugin on unauthenticated user (#167171)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/__mocks__/kea_logic/kibana_logic.mock.ts
@@ -61,7 +61,6 @@ export const mockKibanaValues = {
   setDocTitle: jest.fn(),
   share: sharePluginMock.createStartContract(),
   uiSettings: uiSettingsServiceMock.createStartContract(),
-  userProfile: {},
 };
 
 jest.mock('../../shared/kibana', () => ({

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_overview/components/product_selector/product_selector.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useValues } from 'kea';
 
@@ -20,6 +20,8 @@ import {
 import { Chat } from '@kbn/cloud-chat-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { WelcomeBanner } from '@kbn/search-api-panels';
+
+import { AuthenticatedUser } from '@kbn/security-plugin/common';
 
 import { ErrorStateCallout } from '../../../shared/error_state';
 import { HttpLogic } from '../../../shared/http';
@@ -40,8 +42,23 @@ import { IngestionSelector } from './ingestion_selector';
 import './product_selector.scss';
 
 export const ProductSelector: React.FC = () => {
-  const { config, userProfile } = useValues(KibanaLogic);
+  const { config, security } = useValues(KibanaLogic);
   const { errorConnectingMessage } = useValues(HttpLogic);
+
+  const [user, setUser] = useState<AuthenticatedUser | {}>({});
+
+  useEffect(() => {
+    try {
+      security.authc
+        .getCurrentUser()
+        .then(setUser)
+        .catch(() => {
+          setUser({});
+        });
+    } catch {
+      setUser({});
+    }
+  }, [security.authc]);
 
   const showErrorConnecting = !!(config.host && errorConnectingMessage);
   // The create index flow does not work without ent-search, when content is updated
@@ -53,7 +70,7 @@ export const ProductSelector: React.FC = () => {
         <TrialCallout />
         <EuiPageTemplate.Section alignment="top" className="entSearchProductSelectorHeader">
           <EuiText color="ghost">
-            <WelcomeBanner userProfile={userProfile} image={headerImage} showDescription={false} />
+            <WelcomeBanner userProfile={{ user }} image={headerImage} showDescription={false} />
           </EuiText>
         </EuiPageTemplate.Section>
 

--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -66,7 +66,7 @@ export const renderApp = (
   const { history } = params;
   const { application, chrome, http, uiSettings } = core;
   const { capabilities, navigateToUrl } = application;
-  const { charts, cloud, guidedOnboarding, lens, security, share, userProfile } = plugins;
+  const { charts, cloud, guidedOnboarding, lens, security, share } = plugins;
 
   const entCloudHost = getCloudEnterpriseSearchHost(plugins.cloud);
   externalUrl.enterpriseSearchUrl = publicUrl || entCloudHost || config.host || '';
@@ -108,7 +108,6 @@ export const renderApp = (
     setDocTitle: chrome.docTitle.change,
     share,
     uiSettings,
-    userProfile,
   });
   const unmountLicensingLogic = mountLicensingLogic({
     canManageLicense: core.application.capabilities.management?.stack?.license_management,

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana/kibana_logic.ts
@@ -21,7 +21,6 @@ import {
 import { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
-import { GetUserProfileResponse, UserProfileData } from '@kbn/security-plugin/common';
 import { SecurityPluginStart } from '@kbn/security-plugin/public';
 import { SharePluginStart } from '@kbn/share-plugin/public';
 
@@ -54,7 +53,6 @@ interface KibanaLogicProps {
   setDocTitle(title: string): void;
   share: SharePluginStart;
   uiSettings: IUiSettingsClient;
-  userProfile: GetUserProfileResponse<UserProfileData>;
 }
 
 export interface KibanaValues extends Omit<KibanaLogicProps, 'cloud'> {
@@ -95,7 +93,6 @@ export const KibanaLogic = kea<MakeLogicType<KibanaValues>>({
     setDocTitle: [props.setDocTitle, {}],
     share: [props.share, {}],
     uiSettings: [props.uiSettings, {}],
-    userProfile: [props.userProfile, {}],
   }),
   selectors: ({ selectors }) => ({
     isCloud: [() => [selectors.cloud], (cloud?: Partial<CloudSetup>) => !!cloud?.isCloudEnabled],

--- a/x-pack/plugins/enterprise_search/public/plugin.ts
+++ b/x-pack/plugins/enterprise_search/public/plugin.ts
@@ -22,7 +22,6 @@ import { GuidedOnboardingPluginStart } from '@kbn/guided-onboarding-plugin/publi
 import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { LicensingPluginStart } from '@kbn/licensing-plugin/public';
-import { GetUserProfileResponse, UserProfileData } from '@kbn/security-plugin/common';
 import { SecurityPluginSetup, SecurityPluginStart } from '@kbn/security-plugin/public';
 import { SharePluginStart } from '@kbn/share-plugin/public';
 
@@ -66,7 +65,6 @@ export interface PluginsStart {
   licensing: LicensingPluginStart;
   security: SecurityPluginStart;
   share: SharePluginStart;
-  userProfile: GetUserProfileResponse<UserProfileData>;
 }
 
 export class EnterpriseSearchPlugin implements Plugin {
@@ -102,8 +100,7 @@ export class EnterpriseSearchPlugin implements Plugin {
       cloudSetup && (pluginsStart as PluginsStart).cloud
         ? { ...cloudSetup, ...(pluginsStart as PluginsStart).cloud }
         : undefined;
-    const userProfile = await (pluginsStart as PluginsStart).security.userProfiles.getCurrent();
-    const plugins = { ...pluginsStart, cloud, userProfile } as PluginsStart;
+    const plugins = { ...pluginsStart, cloud } as PluginsStart;
 
     coreStart.chrome
       .getChromeStyle$()


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Search] Fix broken Search plugin on unauthenticated user (#167171)](https://github.com/elastic/kibana/pull/167171)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-09-26T11:10:22Z","message":"[Search] Fix broken Search plugin on unauthenticated user (#167171)\n\n## Summary\r\n\r\nThis fixes an issue where the Search plugin was inaccessible for\r\nunauthenticated user, eg. for Kibana in read-only demo setups.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9198475715c1ec0f02a5a0db40f3e3d7168acf08","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:EnterpriseSearch","v8.10.0","v8.11.0"],"number":167171,"url":"https://github.com/elastic/kibana/pull/167171","mergeCommit":{"message":"[Search] Fix broken Search plugin on unauthenticated user (#167171)\n\n## Summary\r\n\r\nThis fixes an issue where the Search plugin was inaccessible for\r\nunauthenticated user, eg. for Kibana in read-only demo setups.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9198475715c1ec0f02a5a0db40f3e3d7168acf08"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/167171","number":167171,"mergeCommit":{"message":"[Search] Fix broken Search plugin on unauthenticated user (#167171)\n\n## Summary\r\n\r\nThis fixes an issue where the Search plugin was inaccessible for\r\nunauthenticated user, eg. for Kibana in read-only demo setups.\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"9198475715c1ec0f02a5a0db40f3e3d7168acf08"}}]}] BACKPORT-->