### PR TITLE
[ML] AIOps: Enable `event_generating_elements_should_be_instrumented` eslint rule.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -908,6 +908,7 @@ module.exports = {
     },
     {
       files: [
+        'x-pack/plugins/aiops/**/*.{js,mjs,ts,tsx}',
         'x-pack/plugins/apm/**/*.{js,mjs,ts,tsx}',
         'x-pack/plugins/exploratory_view/**/*.{js,mjs,ts,tsx}',
         'x-pack/plugins/infra/**/*.{js,mjs,ts,tsx}',

--- a/x-pack/plugins/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/fields_config.tsx
@@ -356,6 +356,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
               <EuiSpacer size={'m'} />
 
               <EuiButton
+                data-test-subj="aiopsChangePointDetectionSubmitDashboardAttachButton"
                 fill
                 type={'submit'}
                 fullWidth
@@ -441,6 +442,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
           <EuiFlexGroup alignItems={'center'} gutterSize={'s'}>
             <EuiFlexItem grow={false}>
               <EuiButtonIcon
+                data-test-subj="aiopsChangePointDetectionExpandConfigButton"
                 iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
                 onClick={setIsExpanded.bind(null, (prevState) => !prevState)}
                 aria-label={i18n.translate('xpack.aiops.changePointDetection.expandConfigLabel', {
@@ -480,6 +482,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                 id={`panelContextMenu_${panelIndex}`}
                 button={
                   <EuiButtonIcon
+                    data-test-subj="aiopsChangePointDetectionContextMenuButton"
                     aria-label={i18n.translate(
                       'xpack.aiops.changePointDetection.configActionsLabel',
                       {

--- a/x-pack/plugins/aiops/public/components/change_point_detection/max_series_control.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/max_series_control.tsx
@@ -42,6 +42,7 @@ export const MaxSeriesControl: FC<{
       label={inline ? undefined : label}
     >
       <EuiFieldNumber
+        data-test-subj="aiopsMaxSeriesControlFieldNumber"
         disabled={disabled}
         prepend={inline ? label : undefined}
         append={

--- a/x-pack/plugins/aiops/public/components/log_categorization/category_table/table_header.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/category_table/table_header.tsx
@@ -51,6 +51,7 @@ export const TableHeader: FC<Props> = ({
           <>
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty
+                data-test-subj="aiopsLogPatternAnalysisOpenInDiscoverIncludeButton"
                 size="s"
                 onClick={() => openInDiscover(QUERY_MODE.INCLUDE)}
                 iconType="plusInCircle"
@@ -61,6 +62,7 @@ export const TableHeader: FC<Props> = ({
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiButtonEmpty
+                data-test-subj="aiopsLogPatternAnalysisOpenInDiscoverExcludeButton"
                 size="s"
                 onClick={() => openInDiscover(QUERY_MODE.EXCLUDE)}
                 iconType="minusInCircle"

--- a/x-pack/plugins/aiops/public/components/log_categorization/loading_categorization.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/loading_categorization.tsx
@@ -43,7 +43,12 @@ export const LoadingCategorization: FC<Props> = ({ onClose }) => (
           <EuiFlexItem>
             <EuiFlexGroup justifyContent="spaceAround">
               <EuiFlexItem grow={false} css={{ textAlign: 'center' }}>
-                <EuiButton onClick={() => onClose()}>Cancel</EuiButton>
+                <EuiButton
+                  data-test-subj="aiopsLoadingCategorizationCancelButton"
+                  onClick={() => onClose()}
+                >
+                  Cancel
+                </EuiButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>

--- a/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/log_categorization_page.tsx
@@ -322,7 +322,12 @@ export const LogCategorizationPage: FC = () => {
               />
             </EuiButton>
           ) : (
-            <EuiButton onClick={() => cancelRequest()}>Cancel</EuiButton>
+            <EuiButton
+              data-test-subj="aiopsLogCategorizationPageCancelButton"
+              onClick={() => cancelRequest()}
+            >
+              Cancel
+            </EuiButton>
           )}
         </EuiFlexItem>
         <EuiFlexItem />

--- a/x-pack/plugins/aiops/public/components/log_categorization/sampling_menu/random_sampler_range_slider.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/sampling_menu/random_sampler_range_slider.tsx
@@ -92,6 +92,7 @@ export const RandomSamplerRangeSlider = ({
           data-test-subj="dvRandomSamplerProbabilityRange"
           append={
             <EuiButton
+              data-test-subj="aiopsRandomSamplerRangeSliderApplyButton"
               disabled={isInvalidSamplingProbabilityInput}
               onClick={() => {
                 if (setSamplingProbability && isDefined(samplingProbabilityInput)) {

--- a/x-pack/plugins/aiops/public/components/log_categorization/sampling_menu/sampling_menu.tsx
+++ b/x-pack/plugins/aiops/public/components/log_categorization/sampling_menu/sampling_menu.tsx
@@ -118,6 +118,7 @@ export const SamplingMenu: FC<Props> = ({ randomSampler, reload }) => {
       id="aiopsSamplingOptions"
       button={
         <EuiButtonEmpty
+          data-test-subj="aiopsLogPatternAnalysisShowSamplingOptionsButton"
           onClick={() => setShowSamplingOptionsPopover(!showSamplingOptionsPopover)}
           iconSide="right"
           iconType="arrowDown"

--- a/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
+++ b/x-pack/plugins/aiops/public/components/log_rate_analysis/log_rate_analysis_results.tsx
@@ -409,7 +409,11 @@ export const LogRateAnalysisResults: FC<LogRateAnalysisResultsProps> = ({
               )}
               {overrides !== undefined ? (
                 <p>
-                  <EuiButton size="s" onClick={() => startHandler(true)}>
+                  <EuiButton
+                    data-test-subj="aiopsLogRateAnalysisResultsTryToContinueAnalysisButton"
+                    size="s"
+                    onClick={() => startHandler(true)}
+                  >
                     <FormattedMessage
                       id="xpack.aiops.logRateAnalysis.page.tryToContinueAnalysisButtonText"
                       defaultMessage="Try to continue analysis"


### PR DESCRIPTION
## Summary

Implements #153108.

This enables the `@kbn/telemetry/event_generating_elements_should_be_instrumented` eslint rule for the `aiops` plugin to enforce `data-test-subj` attributes on actionable EUI components so they are auto-instrumented by telemetry.

The ids were first auto-created using `node scripts/eslint --fix x-pack/plugins/aiops` and then adapted.

----

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
