### PR TITLE
Pick enterprise search frontend from #166813

### DIFF
--- a/x-pack/plugins/enterprise_search/server/plugin.ts
+++ b/x-pack/plugins/enterprise_search/server/plugin.ts
@@ -94,7 +94,7 @@ interface PluginsSetup {
   usageCollection?: UsageCollectionSetup;
 }
 
-interface PluginsStart {
+export interface PluginsStart {
   data: DataPluginStart;
   security: SecurityPluginStart;
   spaces?: SpacesPluginStart;

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -17,12 +17,12 @@ import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 
 // Hiding this until page is in a better space
-const _connectorItem = {
-  link: 'serverlessConnectors',
-  title: i18n.translate('xpack.serverlessSearch.nav.connectors', {
-    defaultMessage: 'Connectors',
-  }),
-};
+// const _connectorItem = {
+//   link: 'serverlessConnectors',
+//   title: i18n.translate('xpack.serverlessSearch.nav.connectors', {
+//     defaultMessage: 'Connectors',
+//   }),
+// };
 
 const navigationTree: NavigationTreeDefinition = {
   body: [

--- a/x-pack/plugins/serverless_search/public/layout/nav.tsx
+++ b/x-pack/plugins/serverless_search/public/layout/nav.tsx
@@ -16,14 +16,6 @@ import { i18n } from '@kbn/i18n';
 import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
 
-// Hiding this until page is in a better space
-// const _connectorItem = {
-//   link: 'serverlessConnectors',
-//   title: i18n.translate('xpack.serverlessSearch.nav.connectors', {
-//     defaultMessage: 'Connectors',
-//   }),
-// };
-
 const navigationTree: NavigationTreeDefinition = {
   body: [
     { type: 'recentlyAccessed' },


### PR DESCRIPTION
## Summary

We're breaking https://github.com/elastic/kibana/pull/166813 up into smaller PRs in the interest of getting PRs through sooner for type fixes. These are the changes for Enterprise Search Frontend.