### PR TITLE
[8.10] [Fleet] Fix bulk action dropdown (#166475)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { createFleetTestRendererMock } from '../../../../../../mock';
+
+import { AgentsSelectionStatus } from './agents_selection_status';
+
+function render(props: any) {
+  const renderer = createFleetTestRendererMock();
+
+  return renderer.render(<AgentsSelectionStatus {...props} />);
+}
+
+const defaultProps = {
+  totalAgents: 30,
+  selectableAgents: 20,
+  managedAgentsOnCurrentPage: 0,
+  selectionMode: 'manual',
+  setSelectionMode: jest.fn(),
+  selectedAgents: [],
+  setSelectedAgents: jest.fn(),
+};
+
+function generateAgents(n: number) {
+  return [...Array(n).keys()].map((i) => ({
+    id: `agent${i}`,
+    active: true,
+  }));
+}
+
+describe('AgentsSelectionStatus', () => {
+  describe('when selection mode is manual', () => {
+    describe('when there are no selected agents', () => {
+      it('should not show any selection options', () => {
+        const res = render(defaultProps);
+        expect(res.queryByTestId('selectedAgentCountLabel')).toBeNull();
+        expect(res.queryByTestId('clearAgentSelectionButton')).toBeNull();
+        expect(res.queryByTestId('selectedEverythingOnAllPagesButton')).toBeNull();
+      });
+    });
+
+    describe('when there are selected agents', () => {
+      it('should show the number of selected agents and the Clear selection button', () => {
+        const res = render({ ...defaultProps, selectedAgents: generateAgents(2) });
+        expect(res.queryByTestId('selectedAgentCountLabel')).not.toBeNull();
+        expect(res.queryByTestId('clearAgentSelectionButton')).not.toBeNull();
+      });
+
+      it('should not show the Select everything on all pages button if not all agents are selected', () => {
+        const res = render({ ...defaultProps, selectedAgents: generateAgents(2) });
+        expect(res.queryByTestId('selectedEverythingOnAllPagesButton')).toBeNull();
+      });
+
+      it('should not show the Select everything on all pages button if all agents are selected but there are no more selectable agents', () => {
+        const res = render({
+          ...defaultProps,
+          totalAgents: 20,
+          selectableAgents: 19,
+          managedAgentsOnCurrentPage: 1,
+          selectedAgents: generateAgents(19),
+        });
+        expect(res.queryByTestId('selectedEverythingOnAllPagesButton')).toBeNull();
+      });
+
+      it('should show the Select everything on all pages button if all agents are selected and there are more selectable agents', () => {
+        const res = render({ ...defaultProps, selectedAgents: generateAgents(20) });
+        expect(res.queryByTestId('selectedEverythingOnAllPagesButton')).not.toBeNull();
+      });
+    });
+  });
+
+  describe('when selection mode is query', () => {
+    describe('when there are agents', () => {
+      it('should show the number of selected agents and the Clear selection button', () => {
+        const res = render({
+          ...defaultProps,
+          selectionMode: 'query',
+          selectedAgents: generateAgents(2),
+        });
+        expect(res.queryByTestId('selectedAgentCountLabel')).not.toBeNull();
+        expect(res.queryByTestId('clearAgentSelectionButton')).not.toBeNull();
+      });
+
+      it('should not show the Select everything on all pages button', () => {
+        const res = render({
+          ...defaultProps,
+          selectionMode: 'query',
+          selectedAgents: generateAgents(20),
+        });
+        expect(res.queryByTestId('selectedEverythingOnAllPagesButton')).toBeNull();
+      });
+    });
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agents_selection_status.tsx
@@ -34,6 +34,7 @@ const Button = styled(EuiButtonEmpty)`
 export const AgentsSelectionStatus: React.FunctionComponent<{
   totalAgents: number;
   selectableAgents: number;
+  managedAgentsOnCurrentPage: number;
   selectionMode: SelectionMode;
   setSelectionMode: (mode: SelectionMode) => void;
   selectedAgents: Agent[];
@@ -41,15 +42,19 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
 }> = ({
   totalAgents,
   selectableAgents,
+  managedAgentsOnCurrentPage,
   selectionMode,
   setSelectionMode,
   selectedAgents,
   setSelectedAgents,
 }) => {
+  const showSelectionInfoAndOptions =
+    (selectionMode === 'manual' && selectedAgents.length > 0) ||
+    (selectionMode === 'query' && totalAgents > 0);
   const showSelectEverything =
     selectionMode === 'manual' &&
     selectedAgents.length === selectableAgents &&
-    selectableAgents < totalAgents;
+    selectableAgents < totalAgents - managedAgentsOnCurrentPage;
 
   return (
     <>
@@ -74,14 +79,13 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
             )}
           </EuiText>
         </EuiFlexItem>
-        {(selectionMode === 'manual' && selectedAgents.length) ||
-        (selectionMode === 'query' && totalAgents > 0) ? (
+        {showSelectionInfoAndOptions ? (
           <>
             <FlexItem grow={false}>
               <Divider />
             </FlexItem>
             <EuiFlexItem grow={false}>
-              <EuiText size="xs" color="subdued">
+              <EuiText size="xs" color="subdued" data-test-subj="selectedAgentCountLabel">
                 <FormattedMessage
                   id="xpack.fleet.agentBulkActions.agentsSelected"
                   defaultMessage="{count, plural, one {# agent} other {# agents} =all {All agents}} selected"
@@ -97,7 +101,12 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
                   <Divider />
                 </FlexItem>
                 <EuiFlexItem grow={false}>
-                  <Button size="xs" flush="left" onClick={() => setSelectionMode('query')}>
+                  <Button
+                    size="xs"
+                    flush="left"
+                    data-test-subj="selectedEverythingOnAllPagesButton"
+                    onClick={() => setSelectionMode('query')}
+                  >
                     <FormattedMessage
                       id="xpack.fleet.agentBulkActions.selectAll"
                       defaultMessage="Select everything on all pages"
@@ -113,6 +122,7 @@ export const AgentsSelectionStatus: React.FunctionComponent<{
               <Button
                 size="xs"
                 flush="left"
+                data-test-subj="clearAgentSelectionButton"
                 onClick={() => {
                   setSelectionMode('manual');
                   setSelectedAgents([]);

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.test.tsx
@@ -76,7 +76,6 @@ describe('AgentBulkActions', () => {
       expect(results.getByText('Upgrade 2 agents').closest('button')!).toBeDisabled();
       expect(results.getByText('Schedule upgrade for 2 agents').closest('button')!).toBeDisabled();
       expect(results.queryByText('Request diagnostics for 2 agents')).toBeNull();
-      expect(results.getByText('Restart upgrade 2 agents').closest('button')!).toBeDisabled();
     });
 
     it('should show available actions for 2 selected agents if they are active', async () => {
@@ -98,7 +97,6 @@ describe('AgentBulkActions', () => {
       expect(results.getByText('Unenroll 2 agents').closest('button')!).toBeEnabled();
       expect(results.getByText('Upgrade 2 agents').closest('button')!).toBeEnabled();
       expect(results.getByText('Schedule upgrade for 2 agents').closest('button')!).toBeDisabled();
-      expect(results.getByText('Restart upgrade 2 agents').closest('button')!).toBeEnabled();
     });
 
     it('should add actions if mockedExperimentalFeaturesService is enabled', async () => {
@@ -145,7 +143,6 @@ describe('AgentBulkActions', () => {
       expect(
         results.getByText('Request diagnostics for 10 agents').closest('button')!
       ).toBeEnabled();
-      expect(results.getByText('Restart upgrade 10 agents').closest('button')!).toBeEnabled();
     });
 
     it('should show correct actions for the active agents and exclude the managed agents from the count', async () => {
@@ -168,7 +165,6 @@ describe('AgentBulkActions', () => {
       expect(
         results.getByText('Request diagnostics for 8 agents').closest('button')!
       ).toBeEnabled();
-      expect(results.getByText('Restart upgrade 8 agents').closest('button')!).toBeEnabled();
     });
 
     it('should generate a correct kuery to select agents', async () => {

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/bulk_actions.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useMemo, useState, useEffect, useCallback } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -23,13 +23,8 @@ import {
   AgentUnenrollAgentModal,
   AgentUpgradeAgentModal,
 } from '../../components';
-import { useLicense, sendGetAgents, sendGetAgentPolicies } from '../../../../hooks';
-import {
-  LICENSE_FOR_SCHEDULE_UPGRADE,
-  AGENTS_PREFIX,
-  SO_SEARCH_LIMIT,
-  AGENT_POLICY_SAVED_OBJECT_TYPE,
-} from '../../../../../../../common/constants';
+import { useLicense } from '../../../../hooks';
+import { LICENSE_FOR_SCHEDULE_UPGRADE, AGENTS_PREFIX } from '../../../../../../../common/constants';
 import { ExperimentalFeaturesService } from '../../../../services';
 
 import { getCommonTags } from '../utils';
@@ -40,8 +35,9 @@ import type { SelectionMode } from './types';
 import { TagsAddRemove } from './tags_add_remove';
 
 export interface Props {
-  totalAgents: number;
-  totalInactiveAgents: number;
+  shownAgents: number;
+  inactiveShownAgents: number;
+  totalManagedAgentIds: string[];
   selectionMode: SelectionMode;
   currentQuery: string;
   selectedAgents: Agent[];
@@ -52,8 +48,9 @@ export interface Props {
 }
 
 export const AgentBulkActions: React.FunctionComponent<Props> = ({
-  totalAgents,
-  totalInactiveAgents,
+  shownAgents,
+  inactiveShownAgents,
+  totalManagedAgentIds,
   selectionMode,
   currentQuery,
   selectedAgents,
@@ -77,78 +74,30 @@ export const AgentBulkActions: React.FunctionComponent<Props> = ({
   const [isTagAddVisible, setIsTagAddVisible] = useState<boolean>(false);
   const [isRequestDiagnosticsModalOpen, setIsRequestDiagnosticsModalOpen] =
     useState<boolean>(false);
-  const [managedAgents, setManagedAgents] = useState<string[]>([]);
-
-  // get all the managed policies
-  const fetchManagedAgents = useCallback(async () => {
-    if (selectionMode === 'query') {
-      const managedPoliciesKuery = `${AGENT_POLICY_SAVED_OBJECT_TYPE}.is_managed:true`;
-
-      const agentPoliciesResponse = await sendGetAgentPolicies({
-        kuery: managedPoliciesKuery,
-        perPage: SO_SEARCH_LIMIT,
-        full: false,
-      });
-
-      if (agentPoliciesResponse.error) {
-        throw new Error(agentPoliciesResponse.error.message);
-      }
-
-      const managedPolicies = agentPoliciesResponse.data?.items ?? [];
-
-      if (managedPolicies.length === 0) {
-        return [];
-      }
-
-      // find all the agents that have those policies and are not unenrolled
-      const policiesKuery = managedPolicies
-        .map((policy) => `policy_id:"${policy.id}"`)
-        .join(' or ');
-      const kuery = `NOT (status:unenrolled) and ${policiesKuery}`;
-      const response = await sendGetAgents({
-        kuery,
-        perPage: SO_SEARCH_LIMIT,
-        showInactive: true,
-      });
-
-      if (response.error) {
-        throw new Error(response.error.message);
-      }
-
-      return response.data?.items ?? [];
-    }
-    return [];
-  }, [selectionMode]);
-
-  useEffect(() => {
-    async function fetchDataAsync() {
-      const allManagedAgents = await fetchManagedAgents();
-      setManagedAgents(allManagedAgents?.map((agent) => agent.id));
-    }
-    fetchDataAsync();
-  }, [fetchManagedAgents]);
 
   // update the query removing the "managed" agents
   const selectionQuery = useMemo(() => {
-    if (managedAgents.length) {
-      const excludedKuery = `${AGENTS_PREFIX}.agent.id : (${managedAgents
+    if (totalManagedAgentIds.length) {
+      const excludedKuery = `${AGENTS_PREFIX}.agent.id : (${totalManagedAgentIds
         .map((id) => `"${id}"`)
         .join(' or ')})`;
       return `${currentQuery} AND NOT (${excludedKuery})`;
     } else {
       return currentQuery;
     }
-  }, [currentQuery, managedAgents]);
+  }, [currentQuery, totalManagedAgentIds]);
 
   // Check if user is working with only inactive agents
   const atLeastOneActiveAgentSelected =
     selectionMode === 'manual'
       ? !!selectedAgents.find((agent) => agent.active)
-      : totalAgents > totalInactiveAgents;
-  const totalActiveAgents = totalAgents - totalInactiveAgents;
+      : shownAgents > inactiveShownAgents;
+  const totalActiveAgents = shownAgents - inactiveShownAgents;
 
   const agentCount =
-    selectionMode === 'manual' ? selectedAgents.length : totalActiveAgents - managedAgents?.length;
+    selectionMode === 'manual'
+      ? selectedAgents.length
+      : totalActiveAgents - totalManagedAgentIds?.length;
 
   const agents = selectionMode === 'manual' ? selectedAgents : selectionQuery;
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.test.tsx
@@ -45,8 +45,10 @@ describe('SearchAndFilterBar', () => {
   it('should show no Actions button when no agent is selected', async () => {
     const selectedAgents: Agent[] = [];
     const props: any = {
-      totalAgents: 10,
+      shownAgents: 10,
+      inactiveShownAgents: 0,
       totalInactiveAgents: 2,
+      totalManagedAgentIds: [],
       selectionMode: 'manual',
       currentQuery: '',
       selectedAgents,
@@ -77,8 +79,10 @@ describe('SearchAndFilterBar', () => {
       },
     ];
     const props: any = {
-      totalAgents: 10,
+      shownAgents: 10,
+      inactiveShownAgents: 0,
       totalInactiveAgents: 2,
+      totalManagedAgentIds: [],
       selectionMode: 'manual',
       currentQuery: '',
       selectedAgents,
@@ -97,8 +101,10 @@ describe('SearchAndFilterBar', () => {
 
   it('should show an Actions button when agents selected in query mode', async () => {
     const props: any = {
-      totalAgents: 10,
+      shownAgents: 10,
+      inactiveShownAgents: 0,
       totalInactiveAgents: 2,
+      totalManagedAgentIds: [],
       selectionMode: 'query',
       currentQuery: '',
       selectedAgents: [],

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/search_and_filter_bar.tsx
@@ -55,8 +55,10 @@ export interface SearchAndFilterBarProps {
   tags: string[];
   selectedTags: string[];
   onSelectedTagsChange: (selectedTags: string[]) => void;
-  totalAgents: number;
+  shownAgents: number;
+  inactiveShownAgents: number;
   totalInactiveAgents: number;
+  totalManagedAgentIds: string[];
   selectionMode: SelectionMode;
   currentQuery: string;
   selectedAgents: Agent[];
@@ -82,8 +84,10 @@ export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps
   tags,
   selectedTags,
   onSelectedTagsChange,
-  totalAgents,
+  shownAgents,
+  inactiveShownAgents,
   totalInactiveAgents,
+  totalManagedAgentIds,
   selectionMode,
   currentQuery,
   selectedAgents,
@@ -330,11 +334,12 @@ export const SearchAndFilterBar: React.FunctionComponent<SearchAndFilterBarProps
               </EuiFilterGroup>
             </EuiFlexItem>
             {(selectionMode === 'manual' && selectedAgents.length) ||
-            (selectionMode === 'query' && totalAgents > 0) ? (
+            (selectionMode === 'query' && shownAgents > 0) ? (
               <EuiFlexItem grow={false}>
                 <AgentBulkActions
-                  totalAgents={totalAgents}
-                  totalInactiveAgents={totalInactiveAgents}
+                  shownAgents={shownAgents}
+                  inactiveShownAgents={inactiveShownAgents}
+                  totalManagedAgentIds={totalManagedAgentIds}
                   selectionMode={selectionMode}
                   currentQuery={currentQuery}
                   selectedAgents={selectedAgents}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_header.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/table_header.tsx
@@ -22,6 +22,7 @@ export const AgentTableHeader: React.FunctionComponent<{
   showInactive: boolean;
   totalAgents: number;
   selectableAgents: number;
+  managedAgentsOnCurrentPage: number;
   selectionMode: SelectionMode;
   setSelectionMode: (mode: SelectionMode) => void;
   selectedAgents: Agent[];
@@ -32,6 +33,7 @@ export const AgentTableHeader: React.FunctionComponent<{
   agentStatus,
   totalAgents,
   selectableAgents,
+  managedAgentsOnCurrentPage,
   selectionMode,
   setSelectionMode,
   selectedAgents,
@@ -48,6 +50,7 @@ export const AgentTableHeader: React.FunctionComponent<{
             <AgentsSelectionStatus
               totalAgents={totalAgents}
               selectableAgents={selectableAgents}
+              managedAgentsOnCurrentPage={managedAgentsOnCurrentPage}
               selectionMode={selectionMode}
               setSelectionMode={setSelectionMode}
               selectedAgents={selectedAgents}

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.test.tsx
@@ -44,6 +44,7 @@ jest.mock('../../../hooks', () => ({
   },
   useFleetStatus: jest.fn().mockReturnValue({}),
   sendGetAgentStatus: jest.fn(),
+  sendGetAgentPolicies: jest.fn().mockReturnValue({ data: { items: [] } }),
   sendGetAgentTags: jest.fn().mockReturnValue({ data: { items: ['tag1', 'tag2'] } }),
   useAuthz: jest.fn().mockReturnValue({ fleet: { all: true } }),
   useStartServices: jest.fn().mockReturnValue({

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/index.tsx
@@ -24,6 +24,7 @@ import {
   useFlyoutContext,
   sendGetAgentTags,
   useFleetServerStandalone,
+  sendGetAgentPolicies,
 } from '../../../hooks';
 import { AgentEnrollmentFlyout, UninstallCommandFlyout } from '../../../components';
 import {
@@ -31,7 +32,7 @@ import {
   ExperimentalFeaturesService,
   policyHasFleetServer,
 } from '../../../services';
-import { SO_SEARCH_LIMIT } from '../../../constants';
+import { AGENT_POLICY_SAVED_OBJECT_TYPE, SO_SEARCH_LIMIT } from '../../../constants';
 import {
   AgentReassignAgentPolicyModal,
   AgentUnenrollAgentModal,
@@ -176,14 +177,17 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
     });
   }, [search, selectedAgentPolicies, selectedStatus, selectedTags]);
 
-  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agentsOnCurrentPage, setAgentsOnCurrentPage] = useState<Agent[]>([]);
   const [agentsStatus, setAgentsStatus] = useState<
     { [key in SimplifiedAgentStatus]: number } | undefined
   >();
   const [allTags, setAllTags] = useState<string[]>();
   const [isLoading, setIsLoading] = useState(false);
-  const [totalAgents, setTotalAgents] = useState(0);
+  const [shownAgents, setShownAgents] = useState(0);
+  const [inactiveShownAgents, setInactiveShownAgents] = useState(0);
   const [totalInactiveAgents, setTotalInactiveAgents] = useState(0);
+  const [totalManagedAgentIds, setTotalManagedAgentIds] = useState<string[]>([]);
+  const [managedAgentsOnCurrentPage, setManagedAgentsOnCurrentPage] = useState(0);
   const [showAgentActivityTour, setShowAgentActivityTour] = useState({ isOpen: false });
   const getSortFieldForAPI = (field: keyof Agent): string => {
     if ([VERSION_FIELD, HOSTNAME_FIELD].includes(field as string)) {
@@ -235,27 +239,36 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
 
         try {
           setIsLoading(true);
-          const [agentsResponse, totalInactiveAgentsResponse, agentTagsResponse] =
-            await Promise.all([
-              sendGetAgents({
-                page: pagination.currentPage,
-                perPage: pagination.pageSize,
-                kuery: kuery && kuery !== '' ? kuery : undefined,
-                sortField: getSortFieldForAPI(sortField),
-                sortOrder,
-                showInactive,
-                showUpgradeable,
-                getStatusSummary: true,
-                withMetrics: displayAgentMetrics,
-              }),
-              sendGetAgentStatus({
-                kuery: AgentStatusKueryHelper.buildKueryForInactiveAgents(),
-              }),
-              sendGetAgentTags({
-                kuery: kuery && kuery !== '' ? kuery : undefined,
-                showInactive,
-              }),
-            ]);
+          const [
+            agentsResponse,
+            totalInactiveAgentsResponse,
+            managedAgentPoliciesResponse,
+            agentTagsResponse,
+          ] = await Promise.all([
+            sendGetAgents({
+              page: pagination.currentPage,
+              perPage: pagination.pageSize,
+              kuery: kuery && kuery !== '' ? kuery : undefined,
+              sortField: getSortFieldForAPI(sortField),
+              sortOrder,
+              showInactive,
+              showUpgradeable,
+              getStatusSummary: true,
+              withMetrics: displayAgentMetrics,
+            }),
+            sendGetAgentStatus({
+              kuery: AgentStatusKueryHelper.buildKueryForInactiveAgents(),
+            }),
+            sendGetAgentPolicies({
+              kuery: `${AGENT_POLICY_SAVED_OBJECT_TYPE}.is_managed:true`,
+              perPage: SO_SEARCH_LIMIT,
+              full: false,
+            }),
+            sendGetAgentTags({
+              kuery: kuery && kuery !== '' ? kuery : undefined,
+              showInactive,
+            }),
+          ]);
           isLoadingVar.current = false;
           // Return if a newer request has been triggered
           if (currentRequestRef.current !== currentRequest) {
@@ -270,6 +283,9 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           if (!totalInactiveAgentsResponse.data) {
             throw new Error('Invalid GET /agents_status response');
           }
+          if (managedAgentPoliciesResponse.error) {
+            throw new Error(managedAgentPoliciesResponse.error.message);
+          }
           if (agentTagsResponse.error) {
             throw agentTagsResponse.error;
           }
@@ -278,14 +294,12 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
           }
 
           const statusSummary = agentsResponse.data.statusSummary;
-
           if (!statusSummary) {
             throw new Error('Invalid GET /agents response - no status summary');
           }
           setAgentsStatus(agentStatusesToSummary(statusSummary));
 
           const newAllTags = agentTagsResponse.data.items;
-
           // We only want to update the list of available tags if
           // - We haven't set any tags yet
           // - We've received the "refreshTags" flag which will force a refresh of the tags list when an agent is unenrolled
@@ -294,9 +308,40 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
             setAllTags(newAllTags);
           }
 
-          setAgents(agentsResponse.data.items);
-          setTotalAgents(agentsResponse.data.total);
+          setAgentsOnCurrentPage(agentsResponse.data.items);
+          setShownAgents(agentsResponse.data.total);
           setTotalInactiveAgents(totalInactiveAgentsResponse.data.results.inactive || 0);
+          setInactiveShownAgents(
+            showInactive ? totalInactiveAgentsResponse.data.results.inactive || 0 : 0
+          );
+
+          const managedAgentPolicies = managedAgentPoliciesResponse.data?.items ?? [];
+          if (managedAgentPolicies.length === 0) {
+            setTotalManagedAgentIds([]);
+            setManagedAgentsOnCurrentPage(0);
+          } else {
+            // Find all the agents that have managed policies and are not unenrolled
+            const policiesKuery = managedAgentPolicies
+              .map((policy) => `policy_id:"${policy.id}"`)
+              .join(' or ');
+            const response = await sendGetAgents({
+              kuery: `NOT (status:unenrolled) and ${policiesKuery}`,
+              perPage: SO_SEARCH_LIMIT,
+              showInactive: true,
+            });
+            if (response.error) {
+              throw new Error(response.error.message);
+            }
+            const allManagedAgents = response.data?.items ?? [];
+            const allManagedAgentIds = allManagedAgents?.map((agent) => agent.id);
+            setTotalManagedAgentIds(allManagedAgentIds);
+
+            setManagedAgentsOnCurrentPage(
+              agentsResponse.data.items
+                .map((agent) => agent.id)
+                .filter((agentId) => allManagedAgentIds.includes(agentId)).length
+            );
+          }
         } catch (error) {
           notifications.toasts.addError(error, {
             title: i18n.translate('xpack.fleet.agentList.errorFetchingDataTitle', {
@@ -366,13 +411,14 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
     if (selectionMode === 'query' && newAgents.length < selectedAgents.length) {
       // differentiating between selection changed by agents dropping from current page or user action
       const areSelectedAgentsStillVisible =
-        selectedAgents.length > 0 && differenceBy(selectedAgents, agents, 'id').length === 0;
+        selectedAgents.length > 0 &&
+        differenceBy(selectedAgents, agentsOnCurrentPage, 'id').length === 0;
       if (areSelectedAgentsStillVisible) {
         setSelectionMode('manual');
       } else {
         // force selecting all agents on current page if staying in query mode
         if (tableRef?.current) {
-          tableRef.current.setSelection(agents);
+          tableRef.current.setSelection(agentsOnCurrentPage);
         }
       }
     }
@@ -544,15 +590,17 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         tags={allTags ?? []}
         selectedTags={selectedTags}
         onSelectedTagsChange={setSelectedTags}
-        totalAgents={totalAgents}
+        shownAgents={shownAgents}
+        inactiveShownAgents={inactiveShownAgents}
         totalInactiveAgents={totalInactiveAgents}
+        totalManagedAgentIds={totalManagedAgentIds}
         selectionMode={selectionMode}
         currentQuery={kuery}
         selectedAgents={selectedAgents}
         refreshAgents={refreshAgents}
         onClickAddAgent={() => setEnrollmentFlyoutState({ isOpen: true })}
         onClickAddFleetServer={onClickAddFleetServer}
-        visibleAgents={agents}
+        visibleAgents={agentsOnCurrentPage}
         onClickAgentActivity={onClickAgentActivity}
         showAgentActivityTour={showAgentActivityTour}
       />
@@ -560,9 +608,10 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
       {/* Agent total, bulk actions and status bar */}
       <AgentTableHeader
         showInactive={showInactive}
-        totalAgents={totalAgents}
+        totalAgents={shownAgents}
         agentStatus={agentsStatus}
-        selectableAgents={agents?.filter(isAgentSelectable).length || 0}
+        selectableAgents={agentsOnCurrentPage?.filter(isAgentSelectable).length || 0}
+        managedAgentsOnCurrentPage={managedAgentsOnCurrentPage}
         selectionMode={selectionMode}
         setSelectionMode={setSelectionMode}
         selectedAgents={selectedAgents}
@@ -578,7 +627,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
       <EuiSpacer size="s" />
       {/* Agent list table */}
       <AgentListTable
-        agents={agents}
+        agents={agentsOnCurrentPage}
         sortField={sortField}
         pageSizeOptions={pageSizeOptions}
         sortOrder={sortOrder}
@@ -590,7 +639,7 @@ export const AgentListPage: React.FunctionComponent<{}> = () => {
         showUpgradeable={showUpgradeable}
         onTableChange={onTableChange}
         pagination={pagination}
-        totalAgents={Math.min(totalAgents, SO_SEARCH_LIMIT)}
+        totalAgents={Math.min(shownAgents, SO_SEARCH_LIMIT)}
         isUsingFilter={isUsingFilter}
         setEnrollmentFlyoutState={setEnrollmentFlyoutState}
         clearFilters={clearFilters}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Fleet] Fix bulk action dropdown (#166475)](https://github.com/elastic/kibana/pull/166475)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jill Guyonnet","email":"jill.guyonnet@elastic.co"},"sourceCommit":{"committedDate":"2023-09-26T13:15:08Z","message":"[Fleet] Fix bulk action dropdown (#166475)\n\nCloses https://github.com/elastic/kibana/issues/164083\r\nRelated to https://github.com/elastic/sdh-beats/issues/3759\r\nRelated to https://github.com/elastic/kibana/issues/157844\r\n\r\nThis PR addresses two current issues affecting agent selection in Fleet\r\nUI:\r\n1. When there are inactive agents that are not listed on the current\r\npage and \"Select everything on all pages\" is clicked, the count of\r\nactionable agents is incorrect (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711780591)\r\nfor details). This can have two consequences:\r\n1. Incorrect and sometimes negative agent count in the \"Actions\"\r\ndropdown.\r\n   2. Disabled menu items in the \"Actions\" dropdown.\r\n2. The \"Select everything on all pages button is incorrectly displayed\r\nwhen there are agents on managed policies on the page and there is no\r\npagination (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711781808)).","sha":"591df706da23663c898247f23faa00c015c2d26c","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v8.11.0"],"number":166475,"url":"https://github.com/elastic/kibana/pull/166475","mergeCommit":{"message":"[Fleet] Fix bulk action dropdown (#166475)\n\nCloses https://github.com/elastic/kibana/issues/164083\r\nRelated to https://github.com/elastic/sdh-beats/issues/3759\r\nRelated to https://github.com/elastic/kibana/issues/157844\r\n\r\nThis PR addresses two current issues affecting agent selection in Fleet\r\nUI:\r\n1. When there are inactive agents that are not listed on the current\r\npage and \"Select everything on all pages\" is clicked, the count of\r\nactionable agents is incorrect (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711780591)\r\nfor details). This can have two consequences:\r\n1. Incorrect and sometimes negative agent count in the \"Actions\"\r\ndropdown.\r\n   2. Disabled menu items in the \"Actions\" dropdown.\r\n2. The \"Select everything on all pages button is incorrectly displayed\r\nwhen there are agents on managed policies on the page and there is no\r\npagination (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711781808)).","sha":"591df706da23663c898247f23faa00c015c2d26c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166475","number":166475,"mergeCommit":{"message":"[Fleet] Fix bulk action dropdown (#166475)\n\nCloses https://github.com/elastic/kibana/issues/164083\r\nRelated to https://github.com/elastic/sdh-beats/issues/3759\r\nRelated to https://github.com/elastic/kibana/issues/157844\r\n\r\nThis PR addresses two current issues affecting agent selection in Fleet\r\nUI:\r\n1. When there are inactive agents that are not listed on the current\r\npage and \"Select everything on all pages\" is clicked, the count of\r\nactionable agents is incorrect (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711780591)\r\nfor details). This can have two consequences:\r\n1. Incorrect and sometimes negative agent count in the \"Actions\"\r\ndropdown.\r\n   2. Disabled menu items in the \"Actions\" dropdown.\r\n2. The \"Select everything on all pages button is incorrectly displayed\r\nwhen there are agents on managed policies on the page and there is no\r\npagination (cf. [this\r\ncomment](https://github.com/elastic/kibana/issues/164083#issuecomment-1711781808)).","sha":"591df706da23663c898247f23faa00c015c2d26c"}}]}] BACKPORT-->