### PR TITLE
Improve Type Check Commit Diff script

### DIFF
--- a/.buildkite/scripts/steps/check_types_commits.sh
+++ b/.buildkite/scripts/steps/check_types_commits.sh
@@ -106,10 +106,12 @@ done
 
 echo "Looking for related tsconfig.json files..."
 
-for dir in "${uniq_dirs[@]}"
-do
-  find_tsconfig $dir
-done
+if [ ${#uniq_dirs[@]} -gt 0 ]; then
+  for dir in "${uniq_dirs[@]}"
+  do
+    find_tsconfig $dir
+  done
+fi
 
 if [ ${#uniq_tsconfigs[@]} -eq 0 ]; then
   if [[ "$sha1" == "--cached" ]]; then

--- a/.buildkite/scripts/steps/check_types_commits.sh
+++ b/.buildkite/scripts/steps/check_types_commits.sh
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-
 if [[ "${CI-}" == "true" ]]; then
   .buildkite/scripts/bootstrap.sh
 

--- a/.buildkite/scripts/steps/check_types_commits.sh
+++ b/.buildkite/scripts/steps/check_types_commits.sh
@@ -124,7 +124,17 @@ fi
 
 echo "Running scripts/type_check for each found tsconfig.json file..."
 
+finalExitCode=0
+
 for tsconfig in "${uniq_tsconfigs[@]}"
 do
+  set +e
   node scripts/type_check --project $tsconfig
+  exitCode=$?
+  set -e
+  if [ "$exitCode" -gt "$finalExitCode" ]; then
+    finalExitCode=$exitCode
+  fi
 done
+
+exit $finalExitCode


### PR DESCRIPTION
Fix a bug and allow for all errors to be shown if more than one `tsconfig.json` file is being checked