### PR TITLE
[cypress] Trim long cypress configs

### DIFF
--- a/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
+++ b/x-pack/plugins/security_solution/scripts/run_cypress/parallel.ts
@@ -263,7 +263,17 @@ ${JSON.stringify(cypressConfigFile, null, 2)}
 Cypress FTR setup for file: ${filePath}:
 ----------------------------------------------
 
-${JSON.stringify(config.getAll(), null, 2)}
+${JSON.stringify(
+  config.getAll(),
+  (key, v) => {
+    if (Array.isArray(v) && v.length > 32) {
+      return v.slice(0, 32).concat('... trimmed after 32 items.');
+    } else {
+      return v;
+    }
+  },
+  2
+)}
 
 ----------------------------------------------
 `);


### PR DESCRIPTION
## Summary 
In cypress tests, when the logs are output in the beginning, some binary buffers are also stringified, so when looking at logs, we have to scroll through thousands of lines of logs, that's annoying and doesn't help debugging.

I'd like that to be somewhat more readable, there are a few options: 
 - the replacer should interpret buffers as strings, try to output it like that
   - not every binary buffer is printable
 - the replacer should redact the exact fields (certificateAuthority?)
   - too specific, might need fixing later
 - trim long arrays after 32 items
   -  I chose this as a solution

Other suggestions are welcome.

<img width="666" alt="Screenshot 2023-09-27 at 12 49 54" src="https://github.com/elastic/kibana/assets/4738868/7d35e59d-fb14-4d2a-9225-277cc2e1519b">
