### PR TITLE
chore(typecheck): clean up unused parameter

### DIFF
--- a/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/step_define_form.tsx
+++ b/x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/step_define_form.tsx
@@ -35,7 +35,6 @@ import {
 import { useStorage } from '@kbn/ml-local-storage';
 import { useUrlState } from '@kbn/ml-url-state';
 
-import { useEnabledFeatures } from '../../../../serverless_context';
 import { PivotAggDict } from '../../../../../../common/types/pivot_aggs';
 import { PivotGroupByDict } from '../../../../../../common/types/pivot_group_by';
 import { TRANSFORM_FUNCTION } from '../../../../../../common/constants';
@@ -113,7 +112,6 @@ export const StepDefineForm: FC<StepDefineFormProps> = React.memo((props) => {
   );
   const toastNotifications = useToastNotifications();
   const stepDefineForm = useStepDefineForm(props);
-  const { showNodeInfo } = useEnabledFeatures();
 
   const { advancedEditorConfig } = stepDefineForm.advancedPivotEditor.state;
   const {
@@ -355,7 +353,6 @@ export const StepDefineForm: FC<StepDefineFormProps> = React.memo((props) => {
                   query={undefined}
                   disabled={false}
                   timefilter={timefilter}
-                  hideFrozenDataTierChoice={!showNodeInfo}
                 />
               </EuiFlexItem>
             </EuiFlexGroup>


### PR DESCRIPTION
## Summary
This unused parameter is causing typescript error in many builds:
https://buildkite.com/elastic/kibana-pull-request/builds/162839#018ad64e-f2db-4572-a2df-2a9257777077
```
proc [tsc] x-pack/plugins/transform/public/app/sections/create_transform/components/step_define/step_define_form.tsx:358:19 - error TS2322: Type '{ frozenDataPreference: FrozenTierPreference; setFrozenDataPreference: (value: FrozenTierPreference \| undefined) => void; dataView: DataView; query: undefined; disabled: false; timefilter: TimefilterContract; hideFrozenDataTierChoice: boolean; }' is not assignable to type 'IntrinsicAttributes & FullTimeRangeSelectorProps & { children?: ReactNode; }'.
--
  | proc [tsc]   Property 'hideFrozenDataTierChoice' does not exist on type 'IntrinsicAttributes & FullTimeRangeSelectorProps & { children?: ReactNode; }'.
  | proc [tsc]
  | proc [tsc] 358                   hideFrozenDataTierChoice={!showNodeInfo}
```
