### PR TITLE
[8.10] [Security Solution] expandable flyout - add tooltip to correlations table cells (#166913)

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/correlations_details_alerts_table.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/correlations_details_alerts_table.tsx
@@ -20,6 +20,7 @@ import { ExpandablePanel } from '../../shared/components/expandable_panel';
 import { InvestigateInTimelineButton } from '../../../common/components/event_details/table/investigate_in_timeline_button';
 import { ACTION_INVESTIGATE_IN_TIMELINE } from '../../../detections/components/alerts_table/translations';
 import { getDataProvider } from '../../../common/components/event_details/table/use_action_cell_data_provider';
+import { CellTooltipWrapper } from '../../shared/components/cell_tooltip_wrapper';
 
 export const TIMESTAMP_DATE_FORMAT = 'MMM D, YYYY @ HH:mm:ss.SSS';
 const dataProviderLimit = 5;
@@ -30,17 +31,34 @@ export const columns = [
     name: i18n.CORRELATIONS_TIMESTAMP_COLUMN_TITLE,
     truncateText: true,
     dataType: 'date' as const,
-    render: (value: string) => formatDate(value, TIMESTAMP_DATE_FORMAT),
+    render: (value: string) => {
+      const date = formatDate(value, TIMESTAMP_DATE_FORMAT);
+      return (
+        <CellTooltipWrapper tooltip={date}>
+          <span>{date}</span>
+        </CellTooltipWrapper>
+      );
+    },
   },
   {
     field: ALERT_RULE_NAME,
     name: i18n.CORRELATIONS_RULE_COLUMN_TITLE,
     truncateText: true,
+    render: (value: string) => (
+      <CellTooltipWrapper tooltip={value}>
+        <span>{value}</span>
+      </CellTooltipWrapper>
+    ),
   },
   {
     field: ALERT_REASON,
     name: i18n.CORRELATIONS_REASON_COLUMN_TITLE,
     truncateText: true,
+    render: (value: string) => (
+      <CellTooltipWrapper tooltip={value} anchorPosition="left">
+        <span>{value}</span>
+      </CellTooltipWrapper>
+    ),
   },
   {
     field: 'kibana.alert.severity',
@@ -48,7 +66,12 @@ export const columns = [
     truncateText: true,
     render: (value: string) => {
       const decodedSeverity = Severity.decode(value);
-      return isRight(decodedSeverity) ? <SeverityBadge value={decodedSeverity.right} /> : value;
+      const renderValue = isRight(decodedSeverity) ? (
+        <SeverityBadge value={decodedSeverity.right} />
+      ) : (
+        <p>{value}</p>
+      );
+      return <CellTooltipWrapper tooltip={value}>{renderValue}</CellTooltipWrapper>;
     },
   },
 ];

--- a/x-pack/plugins/security_solution/public/flyout/left/components/related_cases.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/related_cases.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 import type { EuiBasicTableColumn } from '@elastic/eui';
 import { EuiInMemoryTable, EuiSkeletonText } from '@elastic/eui';
 import type { RelatedCase } from '@kbn/cases-plugin/common';
+import { CellTooltipWrapper } from '../../shared/components/cell_tooltip_wrapper';
 import { CaseDetailsLink } from '../../../common/components/links';
 import { CORRELATIONS_RELATED_CASES } from '../../shared/translations';
 import {
@@ -31,15 +32,18 @@ const columns: Array<EuiBasicTableColumn<RelatedCase>> = [
     name: CORRELATIONS_CASE_NAME_COLUMN_TITLE,
     truncateText: true,
     render: (value: string, caseData: RelatedCase) => (
-      <CaseDetailsLink detailName={caseData.id} title={caseData.title}>
-        {caseData.title}
-      </CaseDetailsLink>
+      <CellTooltipWrapper tooltip={caseData.title}>
+        <CaseDetailsLink detailName={caseData.id} title={caseData.title}>
+          {caseData.title}
+        </CaseDetailsLink>
+      </CellTooltipWrapper>
     ),
   },
   {
     field: 'status',
     name: CORRELATIONS_CASE_STATUS_COLUMN_TITLE,
     truncateText: true,
+    width: '25%',
   },
 ];
 

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.test.tsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { CellTooltipWrapper } from './cell_tooltip_wrapper';
+
+const TEST_ID = 'test-id';
+const children = <p data-test-subj={TEST_ID}>{'test content'}</p>;
+
+describe('<CellTooltipWrapper />', () => {
+  it('should render non-expandable panel by default', () => {
+    const { getByTestId } = render(
+      <CellTooltipWrapper tooltip="test tooltip">{children}</CellTooltipWrapper>
+    );
+    expect(getByTestId(TEST_ID)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/cell_tooltip_wrapper.tsx
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { VFC, ReactElement } from 'react';
+import React from 'react';
+import { EuiToolTip } from '@elastic/eui';
+
+export interface CellTooltipWrapperProps {
+  /**
+   * Value displayed in the tooltip and in the cell itself
+   */
+  tooltip: string | ReactElement;
+  /**
+   * Tooltip anchor position
+   */
+  anchorPosition?: 'left' | 'right' | 'top' | 'bottom';
+  /**
+   * React components to render
+   */
+  children: React.ReactElement;
+}
+
+export const CellTooltipWrapper: VFC<CellTooltipWrapperProps> = ({
+  tooltip,
+  anchorPosition = 'top',
+  children,
+}) => (
+  <EuiToolTip content={tooltip} position={anchorPosition}>
+    {children}
+  </EuiToolTip>
+);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Security Solution] expandable flyout - add tooltip to correlations table cells (#166913)](https://github.com/elastic/kibana/pull/166913)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2023-09-22T06:46:50Z","message":"[Security Solution] expandable flyout - add tooltip to correlations table cells (#166913)","sha":"b4d8f6ef51967f05e026224674e8177d864a1fef","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","v8.11.0","v8.10.3"],"number":166913,"url":"https://github.com/elastic/kibana/pull/166913","mergeCommit":{"message":"[Security Solution] expandable flyout - add tooltip to correlations table cells (#166913)","sha":"b4d8f6ef51967f05e026224674e8177d864a1fef"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166913","number":166913,"mergeCommit":{"message":"[Security Solution] expandable flyout - add tooltip to correlations table cells (#166913)","sha":"b4d8f6ef51967f05e026224674e8177d864a1fef"}},{"branch":"8.10","label":"v8.10.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->