### PR TITLE
[fleet] Fix key path

### DIFF
--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -27,7 +27,7 @@ import {
 import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts';
 
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
-const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
+const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch.sha1');
 
 const REGISTRY_SPEC_MAX_VERSION = '3.0';
 


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/167148 the filename was updated.  This updates the file read path in the fleet plugin.


Fixes `proc [kibana] [2023-09-27T18:12:07.561+00:00][WARN ][plugins.fleet] Unable to retrieve GPG key from '/var/lib/buildkite-agent/builds/kb-n2-4-spot-e622c074d3147d71/elastic/kibana-on-merge/kibana-build-xpack/node_modules/@kbn/fleet-plugin/target/keys/GPG-KEY-elasticsearch': ENOENT`



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->