### PR TITLE
[8.10] [Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values (#166891)

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.test.tsx
@@ -69,7 +69,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -77,7 +77,7 @@ describe('PrevalenceDetails', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,
@@ -119,7 +119,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: 'field1',
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1000,
           docCount: 2000000,
           hostPrevalence: 0.05,
@@ -149,6 +149,35 @@ describe('PrevalenceDetails', () => {
     );
   });
 
+  it('should render multiple values in value column', () => {
+    (usePrevalence as jest.Mock).mockReturnValue({
+      loading: false,
+      error: false,
+      data: [
+        {
+          field: 'field1',
+          values: ['value1', 'value2'],
+          alertCount: 1000,
+          docCount: 2000000,
+          hostPrevalence: 0.05,
+          userPrevalence: 0.1,
+        },
+      ],
+    });
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <LeftPanelContext.Provider value={panelContextValue}>
+          <PrevalenceDetails />
+        </LeftPanelContext.Provider>
+      </TestProviders>
+    );
+
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value1');
+    expect(getByTestId(PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID)).toHaveTextContent('value2');
+  });
+
   it('should render the table with only basic columns if license is not platinum', () => {
     const field1 = 'field1';
     const field2 = 'field2';
@@ -158,7 +187,7 @@ describe('PrevalenceDetails', () => {
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -166,7 +195,7 @@ describe('PrevalenceDetails', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,

--- a/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/left/components/prevalence_details.tsx
@@ -90,10 +90,18 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     width: '20%',
   },
   {
-    field: 'value',
+    field: 'values',
     name: PREVALENCE_TABLE_VALUE_COLUMN_TITLE,
     'data-test-subj': PREVALENCE_DETAILS_TABLE_VALUE_CELL_TEST_ID,
-    render: (value: string) => <EuiText size="xs">{value}</EuiText>,
+    render: (values: string[]) => (
+      <EuiFlexGroup direction="column" gutterSize="none">
+        {values.map((value) => (
+          <EuiFlexItem key={value}>
+            <EuiText size="xs">{value}</EuiText>
+          </EuiFlexItem>
+        ))}
+      </EuiFlexGroup>
+    ),
     width: '20%',
   },
   {
@@ -107,9 +115,9 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     ),
     'data-test-subj': PREVALENCE_DETAILS_TABLE_ALERT_COUNT_CELL_TEST_ID,
     render: (data: PrevalenceDetailsRow) => {
-      const dataProviders = [
-        getDataProvider(data.field, `timeline-indicator-${data.field}-${data.value}`, data.value),
-      ];
+      const dataProviders = data.values.map((value) =>
+        getDataProvider(data.field, `timeline-indicator-${data.field}-${value}`, value)
+      );
       return data.alertCount > 0 ? (
         <InvestigateInTimelineButton
           asEmptyButton={true}
@@ -136,24 +144,18 @@ const columns: Array<EuiBasicTableColumn<PrevalenceDetailsRow>> = [
     ),
     'data-test-subj': PREVALENCE_DETAILS_TABLE_DOC_COUNT_CELL_TEST_ID,
     render: (data: PrevalenceDetailsRow) => {
-      const dataProviders = [
-        {
-          ...getDataProvider(
-            data.field,
-            `timeline-indicator-${data.field}-${data.value}`,
-            data.value
+      const dataProviders = data.values.map((value) => ({
+        ...getDataProvider(data.field, `timeline-indicator-${data.field}-${value}`, value),
+        and: [
+          getDataProviderAnd(
+            'event.kind',
+            `timeline-indicator-event.kind-not-signal`,
+            'signal',
+            IS_OPERATOR,
+            true
           ),
-          and: [
-            getDataProviderAnd(
-              'event.kind',
-              `timeline-indicator-event.kind-not-signal`,
-              'signal',
-              IS_OPERATOR,
-              true
-            ),
-          ],
-        },
-      ];
+        ],
+      }));
       return data.docCount > 0 ? (
         <InvestigateInTimelineButton
           asEmptyButton={true}

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.test.tsx
@@ -90,13 +90,14 @@ describe('<PrevalenceOverview />', () => {
   it('should render only data with prevalence less than 10%', () => {
     const field1 = 'field1';
     const field2 = 'field2';
+    const field3 = 'field3';
     (usePrevalence as jest.Mock).mockReturnValue({
       loading: false,
       error: false,
       data: [
         {
           field: field1,
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,
@@ -104,7 +105,15 @@ describe('<PrevalenceOverview />', () => {
         },
         {
           field: field2,
-          value: 'value2',
+          values: ['value2', 'value22'],
+          alertCount: 1,
+          docCount: 1,
+          hostPrevalence: 0.06,
+          userPrevalence: 0.2,
+        },
+        {
+          field: field3,
+          values: ['value3'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.5,
@@ -125,8 +134,14 @@ describe('<PrevalenceOverview />', () => {
 
     const iconDataTestSubj2 = `${INSIGHTS_PREVALENCE_TEST_ID}${field2}Icon`;
     const valueDataTestSubj2 = `${INSIGHTS_PREVALENCE_TEST_ID}${field2}Value`;
-    expect(queryByTestId(iconDataTestSubj2)).not.toBeInTheDocument();
-    expect(queryByTestId(valueDataTestSubj2)).not.toBeInTheDocument();
+    expect(getByTestId(iconDataTestSubj2)).toBeInTheDocument();
+    expect(getByTestId(valueDataTestSubj2)).toBeInTheDocument();
+    expect(getByTestId(valueDataTestSubj2)).toHaveTextContent('field2, value2,value22 is uncommon');
+
+    const iconDataTestSubj3 = `${INSIGHTS_PREVALENCE_TEST_ID}${field3}Icon`;
+    const valueDataTestSubj3 = `${INSIGHTS_PREVALENCE_TEST_ID}${field3}Value`;
+    expect(queryByTestId(iconDataTestSubj3)).not.toBeInTheDocument();
+    expect(queryByTestId(valueDataTestSubj3)).not.toBeInTheDocument();
   });
 
   it('should render null if eventId is null', () => {
@@ -184,7 +199,7 @@ describe('<PrevalenceOverview />', () => {
       data: [
         {
           field: 'field1',
-          value: 'value1',
+          values: ['value1'],
           alertCount: 1,
           docCount: 1,
           hostPrevalence: 0.05,

--- a/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/prevalence_overview.tsx
@@ -92,7 +92,7 @@ export const PrevalenceOverview: FC = () => {
           uncommonData.map((d) => (
             <InsightsSummaryRow
               icon={'warning'}
-              text={`${d.field}, ${d.value} ${PREVALENCE_ROW_UNCOMMON}`}
+              text={`${d.field}, ${d.values} ${PREVALENCE_ROW_UNCOMMON}`}
               data-test-subj={`${INSIGHTS_PREVALENCE_TEST_ID}${d.field}`}
             />
           ))

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.test.tsx
@@ -124,7 +124,7 @@ describe('usePrevalence', () => {
     expect(hookResult.result.current.data).toEqual([
       {
         field: 'host.name',
-        value: 'host-1',
+        values: ['host-1'],
         alertCount: 1,
         docCount: 1,
         hostPrevalence: 0.1,

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_prevalence.ts
@@ -6,7 +6,6 @@
  */
 
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
-import { isArray } from 'lodash/fp';
 import { useMemo } from 'react';
 import { useHighlightedFields } from './use_highlighted_fields';
 import { convertHighlightedFieldsToPrevalenceFilters } from '../utils/highlighted_fields_helpers';
@@ -24,7 +23,7 @@ import { EventKind } from '../constants/event_kinds';
 
 export interface PrevalenceData {
   field: string;
-  value: string;
+  values: string[];
   alertCount: number;
   docCount: number;
   hostPrevalence: number;
@@ -91,7 +90,7 @@ export const usePrevalence = ({
     const fieldNames = Object.keys(data.aggregations[FIELD_NAMES_AGG_KEY].buckets);
 
     fieldNames.forEach((fieldName: string) => {
-      const fieldValue = highlightedFields[fieldName].values;
+      const fieldValues = highlightedFields[fieldName].values;
 
       // retrieves the number of signals for the current field/value pair
       const alertCount =
@@ -131,7 +130,7 @@ export const usePrevalence = ({
 
       items.push({
         field: fieldName,
-        value: isArray(fieldValue) ? fieldValue[0] : fieldValue,
+        values: fieldValues,
         alertCount,
         docCount,
         hostPrevalence,

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.test.ts
@@ -58,12 +58,12 @@ describe('convertHighlightedFieldsToPrevalenceFilters', () => {
         values: ['host-1'],
       },
       'user.name': {
-        values: ['user-1'],
+        values: ['user-1', 'user-2'],
       },
     };
     expect(convertHighlightedFieldsToPrevalenceFilters(highlightedFields)).toEqual({
-      'host.name': { match: { 'host.name': 'host-1' } },
-      'user.name': { match: { 'user.name': 'user-1' } },
+      'host.name': { terms: { 'host.name': ['host-1'] } },
+      'user.name': { terms: { 'user.name': ['user-1', 'user-2'] } },
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/utils/highlighted_fields_helpers.ts
@@ -48,7 +48,7 @@ export const convertHighlightedFieldsToPrevalenceFilters = (
 
     return {
       ...acc,
-      [curr]: { match: { [curr]: Array.isArray(values) ? values[0] : values } },
+      [curr]: { terms: { [curr]: values } },
     };
   }, []) as unknown as Record<string, QueryDslQueryContainer>;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values (#166891)](https://github.com/elastic/kibana/pull/166891)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Philippe Oberti","email":"philippe.oberti@elastic.co"},"sourceCommit":{"committedDate":"2023-09-27T20:26:36Z","message":"[Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values (#166891)","sha":"af51e263339664f66331d9c00d388c084b69abed","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","v8.11.0","v8.10.3"],"number":166891,"url":"https://github.com/elastic/kibana/pull/166891","mergeCommit":{"message":"[Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values (#166891)","sha":"af51e263339664f66331d9c00d388c084b69abed"}},"sourceBranch":"main","suggestedTargetBranches":["8.10"],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/166891","number":166891,"mergeCommit":{"message":"[Security Solution] expandable flyout - fix prevalence query not taking into account fields with multiple values (#166891)","sha":"af51e263339664f66331d9c00d388c084b69abed"}},{"branch":"8.10","label":"v8.10.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->