### PR TITLE
[ML] Fix assertion for delete ingest pipelines api

### DIFF
--- a/x-pack/test/api_integration/apis/ml/trained_models/get_models.ts
+++ b/x-pack/test/api_integration/apis/ml/trained_models/get_models.ts
@@ -32,16 +32,16 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     after(async () => {
+      await ml.api.cleanMlIndices();
+      await esDeleteAllIndices('user-index_dfa*');
+
       // delete created ingest pipelines
       await Promise.all(
         ['dfa_regression_model_alias', ...testModelIds].map((modelId) =>
           ml.api.deleteIngestPipeline(modelId)
         )
       );
-      await ml.api.cleanMlIndices();
       await ml.testResources.cleanMLSavedObjects();
-
-      await esDeleteAllIndices('user-index_dfa*');
     });
 
     it('returns all trained models with associated pipelines including aliases', async () => {

--- a/x-pack/test/functional/services/ml/api.ts
+++ b/x-pack/test/functional/services/ml/api.ts
@@ -1504,10 +1504,10 @@ export function MachineLearningAPIProvider({ getService }: FtrProviderContext) {
 
     async deleteIngestPipeline(modelId: string, usePrefix: boolean = true) {
       log.debug(`Deleting ingest pipeline for trained model with id "${modelId}"`);
-      // const { body, status } =
-      await esSupertest.delete(`/_ingest/pipeline/${usePrefix ? 'pipeline_' : ''}${modelId}`);
-      // @todo
-      // this.assertResponseStatusCode(200, status, body);
+      const { body, status } = await esSupertest.delete(
+        `/_ingest/pipeline/${usePrefix ? 'pipeline_' : ''}${modelId}`
+      );
+      this.assertResponseStatusCode(200, status, body);
 
       log.debug('> Ingest pipeline deleted');
     },


### PR DESCRIPTION
## Summary

This PR fixes commented code in delete ingest pipelines api in ML test services.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->