### PR TITLE
[Visualize] fix/unskip `_area_chart.ts` interval tests

### DIFF
--- a/test/functional/apps/visualize/_area_chart.ts
+++ b/test/functional/apps/visualize/_area_chart.ts
@@ -433,9 +433,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         expect(isFieldErrorMessageExists).to.be(false);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/160913
-      describe.skip('interval errors', () => {
+      describe('interval errors', () => {
         before(async () => {
+          await PageObjects.visEditor.selectField('@timestamp');
           // to trigger displaying of error messages
           await testSubjects.clickWhenNotDisabled('visualizeEditorRenderButton');
           // this will avoid issues with the play tooltip covering the interval field
@@ -466,14 +466,17 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
         it('should show error when calendar interval invalid', async () => {
           await PageObjects.visEditor.setInterval('2w', { type: 'custom' });
-          const intervalErrorMessage = await find.byCssSelector(
+          const intervalErrorMessage1 = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );
-          let errorMessage = await intervalErrorMessage.getVisibleText();
+          let errorMessage = await intervalErrorMessage1.getVisibleText();
           expect(errorMessage).to.be('Invalid calendar interval: 2w, value must be 1');
 
+          const intervalErrorMessage2 = await find.byCssSelector(
+            '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
+          );
           await PageObjects.visEditor.setInterval('3w', { type: 'custom' });
-          errorMessage = await intervalErrorMessage.getVisibleText();
+          errorMessage = await intervalErrorMessage2.getVisibleText();
           expect(errorMessage).to.be('Invalid calendar interval: 3w, value must be 1');
         });
       });

--- a/test/functional/apps/visualize/_area_chart.ts
+++ b/test/functional/apps/visualize/_area_chart.ts
@@ -469,15 +469,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           const intervalErrorMessage1 = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );
-          let errorMessage = await intervalErrorMessage1.getVisibleText();
-          expect(errorMessage).to.be('Invalid calendar interval: 2w, value must be 1');
+          const errorMessage1 = await intervalErrorMessage1.getVisibleText();
+          expect(errorMessage1).to.be('Invalid calendar interval: 2w, value must be 1');
 
+          await PageObjects.visEditor.setInterval('3w', { type: 'custom' });
           const intervalErrorMessage2 = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );
-          await PageObjects.visEditor.setInterval('3w', { type: 'custom' });
-          errorMessage = await intervalErrorMessage2.getVisibleText();
-          expect(errorMessage).to.be('Invalid calendar interval: 3w, value must be 1');
+          const errorMessage2 = await intervalErrorMessage2.getVisibleText();
+          expect(errorMessage2).to.be('Invalid calendar interval: 3w, value must be 1');
         });
       });
     });

--- a/test/functional/apps/visualize/_area_chart.ts
+++ b/test/functional/apps/visualize/_area_chart.ts
@@ -464,20 +464,22 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
           expect(isIntervalErrorMessageExists).to.be(true);
         });
 
-        it('should show error when calendar interval invalid', async () => {
+        it('should show error when calendar interval invalid - 2w', async () => {
           await PageObjects.visEditor.setInterval('2w', { type: 'custom' });
-          const intervalErrorMessage1 = await find.byCssSelector(
+          const intervalErrorMessage = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );
-          const errorMessage1 = await intervalErrorMessage1.getVisibleText();
-          expect(errorMessage1).to.be('Invalid calendar interval: 2w, value must be 1');
+          const errorMessage = await intervalErrorMessage.getVisibleText();
+          expect(errorMessage).to.be('Invalid calendar interval: 2w, value must be 1');
+        });
 
+        it('should show error when calendar interval invalid - 3w', async () => {
           await PageObjects.visEditor.setInterval('3w', { type: 'custom' });
-          const intervalErrorMessage2 = await find.byCssSelector(
+          const intervalErrorMessage = await find.byCssSelector(
             '[data-test-subj="visEditorInterval"] + .euiFormErrorText'
           );
-          const errorMessage2 = await intervalErrorMessage2.getVisibleText();
-          expect(errorMessage2).to.be('Invalid calendar interval: 3w, value must be 1');
+          const errorMessage = await intervalErrorMessage.getVisibleText();
+          expect(errorMessage).to.be('Invalid calendar interval: 3w, value must be 1');
         });
       });
     });


### PR DESCRIPTION
## Summary

This should fix flaky test at `test/functional/apps/visualize/_area_chart.ts`.

### The Issue

I think the root of the issues is related to a bug in the ChromeDriver, see https://stackoverflow.com/a/76259537/6943587.

Splitting up the test cases appears to solve the issue just the same so leave it at that for now.

The timestamp field was also consistently missing in the `describe` block so I added this in the `before` to avoid any unexpected errors, but I don't believe this was the main cause of the failing test.

Flaky test runner job -> https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3238

Fixes #160913