### PR TITLE
Add saved query title/description validation

### DIFF
--- a/src/plugins/data/server/query/route_handler_context.ts
+++ b/src/plugins/data/server/query/route_handler_context.ts
@@ -8,6 +8,7 @@
 
 import { CustomRequestHandlerContext, RequestHandlerContext, SavedObject } from '@kbn/core/server';
 import { isFilters, isOfQueryType } from '@kbn/es-query';
+import { SAVED_QUERY_NAME_MAX_LENGTH, SAVED_QUERY_DESCRIPTION_MAX_LENGTH } from './routes';
 import { isQuery, SavedQueryAttributes } from '../../common';
 import { extract, inject } from '../../common/query/filters/persistable_state';
 
@@ -62,7 +63,7 @@ function extractReferences({
   return { attributes, references };
 }
 
-function verifySavedQuery({ title, query, filters = [] }: SavedQueryAttributes) {
+function verifySavedQuery({ title, query, filters = [], description }: SavedQueryAttributes) {
   if (!isQuery(query)) {
     throw new Error(`Invalid query: ${query}`);
   }
@@ -73,6 +74,16 @@ function verifySavedQuery({ title, query, filters = [] }: SavedQueryAttributes) 
 
   if (!title.trim().length) {
     throw new Error('Cannot create saved query without a title');
+  }
+
+  if (title.trim().length > SAVED_QUERY_NAME_MAX_LENGTH) {
+    throw new Error(`Saved query name may not exceed ${SAVED_QUERY_NAME_MAX_LENGTH} characters`);
+  }
+
+  if (description?.trim()?.length > SAVED_QUERY_DESCRIPTION_MAX_LENGTH) {
+    throw new Error(
+      `Saved query description may not exceed ${SAVED_QUERY_DESCRIPTION_MAX_LENGTH} characters`
+    );
   }
 }
 

--- a/src/plugins/data/server/query/routes.ts
+++ b/src/plugins/data/server/query/routes.ts
@@ -13,12 +13,15 @@ import { SavedQueryRouteHandlerContext } from './route_handler_context';
 import { SavedQueryRestResponse } from './route_types';
 import { SAVED_QUERY_BASE_URL } from '../../common/constants';
 
+export const SAVED_QUERY_NAME_MAX_LENGTH = 50;
+export const SAVED_QUERY_DESCRIPTION_MAX_LENGTH = 200;
+
 const SAVED_QUERY_ID_CONFIG = schema.object({
   id: schema.string(),
 });
 const SAVED_QUERY_ATTRS_CONFIG = schema.object({
-  title: schema.string(),
-  description: schema.string(),
+  title: schema.string({ maxLength: SAVED_QUERY_NAME_MAX_LENGTH }),
+  description: schema.string({ maxLength: SAVED_QUERY_DESCRIPTION_MAX_LENGTH }),
   query: schema.object({
     query: schema.oneOf([schema.string(), schema.object({}, { unknowns: 'allow' })]),
     language: schema.string(),

--- a/test/api_integration/apis/saved_queries/saved_queries.js
+++ b/test/api_integration/apis/saved_queries/saved_queries.js
@@ -55,6 +55,28 @@ export default function ({ getService }) {
         .send({ description: 'my description' })
         .expect(400));
 
+    it('should return 400 for saved query with title that exceeds length', () =>
+      supertest
+        .post(`${SAVED_QUERY_BASE_URL}/_create`)
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .send({ ...mockSavedQuery, title: Array(100).fill('a').join('') })
+        .expect(400)
+        .then((res) => {
+          expect(res.body.message).to.contain('title');
+          expect(res.body.message).to.contain('maximum length');
+        }));
+
+    it('should return 400 for saved query with description that exceeds length', () =>
+      supertest
+        .post(`${SAVED_QUERY_BASE_URL}/_create`)
+        .set(ELASTIC_HTTP_VERSION_HEADER, '1')
+        .send({ ...mockSavedQuery, description: Array(1000).fill('a').join('') })
+        .expect(400)
+        .then((res) => {
+          expect(res.body.message).to.contain('description');
+          expect(res.body.message).to.contain('maximum length');
+        }));
+
     it('should return 200 for update saved query', () =>
       supertest
         .post(`${SAVED_QUERY_BASE_URL}/_create`)


### PR DESCRIPTION
## Summary

Adds validation to saved query creation (title/description).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
