### PR TITLE
[Type Check] Add newly included AlertStatus item to the infra tests

### DIFF
--- a/x-pack/test/functional/page_objects/infra_hosts_view.ts
+++ b/x-pack/test/functional/page_objects/infra_hosts_view.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { AlertStatus, ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+import { AlertStatus } from '@kbn/rule-data-utils';
 import { WebElementWrapper } from '../../../../test/functional/services/lib/web_element_wrapper';
 import { FtrProviderContext } from '../ftr_provider_context';
 
@@ -201,9 +201,10 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
     },
 
     setAlertStatusFilter(alertStatus?: AlertStatus) {
-      const buttons = {
-        [ALERT_STATUS_ACTIVE]: 'hostsView-alert-status-filter-active-button',
-        [ALERT_STATUS_RECOVERED]: 'hostsView-alert-status-filter-recovered-button',
+      const buttons: Record<AlertStatus | 'all', string> = {
+        active: 'hostsView-alert-status-filter-active-button',
+        recovered: 'hostsView-alert-status-filter-recovered-button',
+        untracked: 'hostsView-alert-status-filter-untracked-button',
         all: 'hostsView-alert-status-filter-show-all-button',
       };
 


### PR DESCRIPTION
## Summary

This PR fix type check problems caused by the inclusion of a new item in the AlertStatus union type

