### PR TITLE
Fix type error re: missing AlertStatus option

### DIFF
--- a/x-pack/test/functional/page_objects/infra_hosts_view.ts
+++ b/x-pack/test/functional/page_objects/infra_hosts_view.ts
@@ -4,7 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { AlertStatus, ALERT_STATUS_ACTIVE, ALERT_STATUS_RECOVERED } from '@kbn/rule-data-utils';
+import {
+  AlertStatus,
+  ALERT_STATUS_ACTIVE,
+  ALERT_STATUS_RECOVERED,
+  ALERT_STATUS_UNTRACKED,
+} from '@kbn/rule-data-utils';
 import { WebElementWrapper } from '../../../../test/functional/services/lib/web_element_wrapper';
 import { FtrProviderContext } from '../ftr_provider_context';
 
@@ -204,6 +209,7 @@ export function InfraHostsViewProvider({ getService }: FtrProviderContext) {
       const buttons = {
         [ALERT_STATUS_ACTIVE]: 'hostsView-alert-status-filter-active-button',
         [ALERT_STATUS_RECOVERED]: 'hostsView-alert-status-filter-recovered-button',
+        [ALERT_STATUS_UNTRACKED]: 'hostsView-alert-status-filter-untracked-button',
         all: 'hostsView-alert-status-filter-show-all-button',
       };
 


### PR DESCRIPTION
## Summary
This PR snuck in a type error under the guise of the night: https://github.com/elastic/kibana/pull/164788

The attempt is to fix that missing mapping. cc: @Zacqary (or @elastic/response-ops-ram) please check if it's right, suggest otherwise.