### PR TITLE
[8.10] Fix first round of TypeScript errors (APM)

### DIFF
--- a/x-pack/plugins/apm/scripts/diagnostics_bundle/diagnostics_bundle.ts
+++ b/x-pack/plugins/apm/scripts/diagnostics_bundle/diagnostics_bundle.ts
@@ -51,7 +51,6 @@ export async function initDiagnosticsBundle({
   const kibanaClient = axios.create({
     baseURL: kbHost ?? kibanaHost,
     auth,
-    // @ts-expect-error
     headers: { 'kbn-xsrf': 'true', ...apiKeyHeader },
   });
   const apmIndices = await getApmIndices(kibanaClient);

--- a/x-pack/plugins/apm/server/routes/assistant_functions/route.ts
+++ b/x-pack/plugins/apm/server/routes/assistant_functions/route.ts
@@ -191,7 +191,7 @@ const getApmErrorDocRoute = createApmServerRoute({
   },
 });
 
-interface ApmServicesListItem {
+export interface ApmServicesListItem {
   'service.name': string;
   'agent.name'?: string;
   'transaction.type'?: string;

--- a/x-pack/plugins/apm/server/routes/traces/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/traces/queries.test.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { loggerMock } from '@kbn/logging-mocks';
 import { getTraceItems } from './get_trace_items';
 import {
   SearchParamsMock,
@@ -26,6 +27,7 @@ describe('trace queries', () => {
         apmEventClient: mockApmEventClient,
         start: 0,
         end: 50000,
+        logger: loggerMock.create(),
       })
     );
 

--- a/x-pack/plugins/apm/server/utils/test_helpers.tsx
+++ b/x-pack/plugins/apm/server/utils/test_helpers.tsx
@@ -60,7 +60,6 @@ export async function inspectSearchParams(
     span: 'myIndex',
     transaction: 'myIndex',
     metric: 'myIndex',
-    sourcemap: 'myIndex',
   };
   const mockConfig = new Proxy(
     {},

--- a/x-pack/plugins/apm/typings/es_schemas/raw/error_raw.ts
+++ b/x-pack/plugins/apm/typings/es_schemas/raw/error_raw.ts
@@ -18,7 +18,7 @@ import { TimestampUs } from './fields/timestamp_us';
 import { Url } from './fields/url';
 import { User } from './fields/user';
 
-interface Processor {
+export interface Processor {
   name: 'error';
   event: 'error';
 }


### PR DESCRIPTION
Partly fixes #167373 - This PR fixes the TypeScript errors in the following `tsconfig.json` files.

<google-sheets-html-origin style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0);">

Path | Errors
-- | --
./x-pack/plugins/fleet/cypress/tsconfig.json | 6
./x-pack/plugins/apm/tsconfig.json | 3
./x-pack/plugins/exploratory_view/e2e/tsconfig.json | 3
./x-pack/plugins/ux/e2e/tsconfig.json | 3
./x-pack/plugins/ux/tsconfig.json | 3

</google-sheets-html-origin>