### PR TITLE
[8.11.0] Promote Defend API events to Production

### DIFF
--- a/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/models/advanced_policy_schema.ts
@@ -1271,7 +1271,28 @@ export const AdvancedPolicySchema: AdvancedPolicySchemaType[] = [
       'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api',
       {
         defaultMessage:
-          'Controls whether API events are enabled. Set to false to disable API event collection. Default: true',
+          'Controls whether ETW API events are enabled. Set to false to disable ETW event collection. Default: true',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.api_disabled',
+    first_supported_version: '8.11',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api_disabled',
+      {
+        defaultMessage: 'A comma separated list of API names to selectively disable.',
+      }
+    ),
+  },
+  {
+    key: 'windows.advanced.events.api_verbose',
+    first_supported_version: '8.11',
+    documentation: i18n.translate(
+      'xpack.securitySolution.endpoint.policy.advanced.windows.advanced.events.api_verbose',
+      {
+        defaultMessage:
+          'Controls whether high volume API events are forwarded. Event filtering is recommended if enabled. Default: false',
       }
     ),
   },

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.test.tsx
@@ -70,7 +70,7 @@ describe('Policy Windows Event Collection Card', () => {
             'Operating system' +
             'Windows 8 / 8 event collections enabled' +
             'Events' +
-            'Credential Access' +
+            'API' +
             'DLL and Driver Load' +
             'DNS' +
             'File' +
@@ -98,7 +98,7 @@ describe('Policy Windows Event Collection Card', () => {
             'Windows ' +
             '6 / 8 event collections enabled' +
             'Events' +
-            'Credential Access' +
+            'API' +
             'DLL and Driver Load' +
             'Network' +
             'Process' +

--- a/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
+++ b/x-pack/plugins/security_solution/public/management/pages/policy/view/policy_settings_form/components/cards/windows_event_collection_card.tsx
@@ -17,7 +17,7 @@ const OPTIONS: ReadonlyArray<EventFormOption<OperatingSystem.WINDOWS>> = [
     name: i18n.translate(
       'xpack.securitySolution.endpoint.policyDetailsConfig.windows.events.credentialAccess',
       {
-        defaultMessage: 'Credential Access',
+        defaultMessage: 'API',
       }
     ),
     protectionField: 'credential_access',


### PR DESCRIPTION
## Summary

This PR supercedes https://github.com/elastic/kibana/pull/167107

Elastic Defend for Windows now collects ETW Threat Intelligence (ETW-TI) events.  Defend calls these API events.  API events currently include the existing Credential Access and ETW-TI.  We will add more events under the API umbrella in the future.

The Windows Events Policy `Credential Access` category has been renamed to `API` in the UI and documentation - but it remains as `credential_access` in the yaml for backwards compatibility. This new category definition is a superset of the previous category.

Two new advanced options are added -
* `windows.advanced.events.api_disabled` - comma separated list
* `windows.advanced.events.api_verbose` - boolean

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
