### PR TITLE
[ML] Data frame analytics: ensures destination index setting is persisted when cloning

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
@@ -61,7 +61,7 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
   } = form;
 
   const [destIndexSameAsId, setDestIndexSameAsId] = useState<boolean>(
-    cloneJob === undefined && hasSwitchedToEditor === false
+    hasSwitchedToEditor === false && destinationIndex !== undefined && destinationIndex === jobId
   );
   const [useResultsFieldDefault, setUseResultsFieldDefault] = useState<boolean>(
     (cloneJob === undefined && hasSwitchedToEditor === false && resultsField === undefined) ||
@@ -178,8 +178,6 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
   useEffect(() => {
     if (destIndexSameAsId === true && !jobIdEmpty && jobIdValid) {
       setFormState({ destinationIndex: jobId });
-    } else if (destIndexSameAsId === false && hasSwitchedToEditor === false) {
-      setFormState({ destinationIndex: '' });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [destIndexSameAsId, jobId]);

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
@@ -197,6 +197,9 @@ export default function ({ getService }: FtrProviderContext) {
             testData.job as DataFrameAnalyticsConfig
           );
           await ml.dataFrameAnalyticsCreation.setJobId(cloneJobId);
+          // open the dest index input
+          await ml.dataFrameAnalyticsCreation.assertDestIndexSameAsIdSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setDestIndexSameAsIdCheckState(false);
           await ml.dataFrameAnalyticsCreation.setDestIndex(cloneDestIndex);
 
           await ml.testExecution.logTestStep('should continue to the validation step');

--- a/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
@@ -716,7 +716,8 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
     async assertInitialCloneJobDetailsStep(job: DataFrameAnalyticsConfig) {
       await this.assertJobIdValue(''); // id should be empty
       await this.assertJobDescriptionValue(String(job.description));
-      await this.assertDestIndexValue(''); // destination index should be empty
+      // destination index same as id should be checked since dest index is reset to '' on clone
+      await this.assertDestIndexSameAsIdCheckState(true);
     },
 
     async assertCreationCalloutMessagesExist() {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/164696

This PR ensures that the `Destination index same as job ID` state is persisted when switching between steps for original jobs and cloned jobs.

https://github.com/elastic/kibana/assets/6446462/adb1cbcf-3387-4467-bbf9-666388e3145d

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


