### PR TITLE
[ES|QL] Improves the parsing error message

### DIFF
--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -201,7 +201,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
               } else {
                 const { type, reason } = error.err.attributes;
                 if (type === 'parsing_exception') {
-                  error.message = `Couldn't parse Elasticsearch ES|QL query. You may need to add backticks to names containing special characters. Check your query and try again. Error: ${reason}`;
+                  error.message = `Couldn't parse Elasticsearch ES|QL query. Check your query and try again. Error: ${reason}`;
                 } else {
                   error.message = `Unexpected error from Elasticsearch: ${type} - ${reason}`;
                 }


### PR DESCRIPTION
## Summary

I decided to remove the backticks suggestion as it was a  copy paste from SQL and is not going to solve ES|QL related errors. It also creates confusion for many users.

<img width="1677" alt="image" src="https://github.com/elastic/kibana/assets/17003240/fe2a4fcb-c3e0-4d87-8568-32e7525f70d5">