### PR TITLE
[8.10][Sec-solutions] Fix a few 8.10 type errors

### DIFF
--- a/x-pack/plugins/security_solution_ess/public/common/__mocks__/services.mock.ts
+++ b/x-pack/plugins/security_solution_ess/public/common/__mocks__/services.mock.ts
@@ -7,9 +7,11 @@
 
 import { coreMock } from '@kbn/core/public/mocks';
 import { securitySolutionMock } from '@kbn/security-solution-plugin/public/mocks';
+import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
 import type { Services } from '../services';
 
 export const mockServices: Services = {
   ...coreMock.createStart(),
   securitySolution: securitySolutionMock.createStart(),
+  licensing: licensingMock.createStart(),
 };

--- a/x-pack/plugins/security_solution_serverless/public/get_started/get_started.tsx
+++ b/x-pack/plugins/security_solution_serverless/public/get_started/get_started.tsx
@@ -19,7 +19,6 @@ import {
 import type { SecurityProductTypes } from '../../common/config';
 import { ProductSwitch } from './product_switch';
 import { useTogglePanel } from './use_toggle_panel';
-import { useKibana } from '../common/services';
 
 const CONTENT_WIDTH = 1150;
 
@@ -44,7 +43,6 @@ export const GetStartedComponent: React.FC<GetStartedProps> = ({ productTypes })
       expandedCardSteps,
     },
   } = useTogglePanel({ productTypes });
-  const services = useKibana().services;
   return (
     <KibanaPageTemplate
       restrictWidth={false}


### PR DESCRIPTION
## Summary
Fix a few issues that occurred around `x-pack/plugins/security_solution_ess/tsconfig.json` in 8.10. 

- chore(typecheck): fix type errors re: unused variables and missing mock fields

Required for: #167609 

Part of: https://github.com/elastic/kibana/issues/167373
