### PR TITLE
[Defend Workflows][Fleet] Hide uninstall token for Cloud Agent Policy

### DIFF
--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -241,6 +241,7 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
             field: `${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.attributes.policy_id`,
             size: bucketSize,
             include,
+            exclude: 'policy-elastic-agent-on-cloud', // todo: find a better way to not return or even generate token for managed policies
           },
           aggs: {
             latest: {


### PR DESCRIPTION
## Summary

fixes #164013

The API does not return uninstall token for the policy id `policy-elastic-agent-on-cloud`


### questions
- should it omit uninstall tokens for other `managed` policies, too?
- or should we not generate uninstall tokens for `managed` policies at all?