### PR TITLE
fix ld client race condition

### DIFF
--- a/x-pack/plugins/cloud_integrations/cloud_experiments/kibana.jsonc
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/kibana.jsonc
@@ -14,7 +14,8 @@
     ],
     "requiredPlugins": [
       "cloud",
-      "dataViews"
+      "dataViews",
+      "kibanaUtils"
     ],
     "optionalPlugins": [
       "usageCollection"

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.test.ts
@@ -144,7 +144,7 @@ describe('LaunchDarklyClient - browser', () => {
 
       test('calls the LaunchDarkly client when the user has been defined', async () => {
         await client.updateUserMetadata(testUserMetadata);
-        await client.reportMetric('my-feature-flag', {}, 123);
+        client.reportMetric('my-feature-flag', {}, 123);
         expect(ldClientMock.track).toHaveBeenCalledTimes(1);
         expect(ldClientMock.track).toHaveBeenCalledWith('my-feature-flag', {}, 123);
       });

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.test.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.test.ts
@@ -11,6 +11,7 @@ import { LaunchDarklyClient, type LaunchDarklyClientConfig } from './launch_dark
 describe('LaunchDarklyClient - browser', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    launchDarklyLibraryMock.initialize.mockReturnValue(ldClientMock);
   });
 
   const config: LaunchDarklyClientConfig = {
@@ -29,8 +30,6 @@ describe('LaunchDarklyClient - browser', () => {
     describe('updateUserMetadata', () => {
       test("calls the client's initialize method with all the possible values", async () => {
         expect(client).toHaveProperty('launchDarklyClient', undefined);
-
-        launchDarklyLibraryMock.initialize.mockReturnValue(ldClientMock);
 
         const topFields = {
           name: 'First Last',
@@ -61,8 +60,6 @@ describe('LaunchDarklyClient - browser', () => {
             logger: undefined,
           }
         );
-
-        expect(client).toHaveProperty('launchDarklyClient', ldClientMock);
       });
 
       test('sets a minimum amount of info', async () => {
@@ -86,7 +83,6 @@ describe('LaunchDarklyClient - browser', () => {
       test('calls identify if an update comes after initializing the client', async () => {
         expect(client).toHaveProperty('launchDarklyClient', undefined);
 
-        launchDarklyLibraryMock.initialize.mockReturnValue(ldClientMock);
         await client.updateUserMetadata({ userId: 'fake-user-id', kibanaVersion: 'version' });
 
         expect(launchDarklyLibraryMock.initialize).toHaveBeenCalledWith(
@@ -102,8 +98,6 @@ describe('LaunchDarklyClient - browser', () => {
         );
         expect(ldClientMock.identify).not.toHaveBeenCalled();
 
-        expect(client).toHaveProperty('launchDarklyClient', ldClientMock);
-
         // Update user metadata a 2nd time
         await client.updateUserMetadata({ userId: 'fake-user-id', kibanaVersion: 'version' });
         expect(ldClientMock.identify).toHaveBeenCalledWith({
@@ -114,17 +108,31 @@ describe('LaunchDarklyClient - browser', () => {
     });
 
     describe('getVariation', () => {
-      test('returns the default value if the user has not been defined', async () => {
-        await expect(client.getVariation('my-feature-flag', 123)).resolves.toStrictEqual(123);
-        expect(ldClientMock.variation).toHaveBeenCalledTimes(0);
-      });
-
       test('calls the LaunchDarkly client when the user has been defined', async () => {
         ldClientMock.variation.mockResolvedValue(1234);
         await client.updateUserMetadata(testUserMetadata);
         await expect(client.getVariation('my-feature-flag', 123)).resolves.toStrictEqual(1234);
         expect(ldClientMock.variation).toHaveBeenCalledTimes(1);
         expect(ldClientMock.variation).toHaveBeenCalledWith('my-feature-flag', 123);
+      });
+
+      test('waits for initialization to complete before calling the LaunchDarkly client', async () => {
+        ldClientMock.variation.mockResolvedValue(1234);
+        client.updateUserMetadata(testUserMetadata); // don't await
+        await expect(client.getVariation('my-feature-flag', 123)).resolves.toStrictEqual(1234);
+      });
+
+      test('returns default value if ld client initialization errors', async () => {
+        const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+        launchDarklyLibraryMock.initialize.mockImplementationOnce(() => {
+          throw new Error('Something went wrong');
+        });
+        client.updateUserMetadata(testUserMetadata); // don't await
+        await expect(client.getVariation('my-feature-flag', 123)).resolves.toStrictEqual(123);
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          `Failed to initialize launchDarkly client`,
+          new Error('Something went wrong')
+        );
       });
     });
 
@@ -136,7 +144,7 @@ describe('LaunchDarklyClient - browser', () => {
 
       test('calls the LaunchDarkly client when the user has been defined', async () => {
         await client.updateUserMetadata(testUserMetadata);
-        client.reportMetric('my-feature-flag', {}, 123);
+        await client.reportMetric('my-feature-flag', {}, 123);
         expect(ldClientMock.track).toHaveBeenCalledTimes(1);
         expect(ldClientMock.track).toHaveBeenCalledWith('my-feature-flag', {}, 123);
       });
@@ -148,6 +156,7 @@ describe('LaunchDarklyClient - browser', () => {
 
         ldClientMock.flush.mockResolvedValue();
         expect(() => client.stop()).not.toThrow();
+        await new Promise((resolve) => process.nextTick(resolve)); // wait for the flush resolution
         expect(ldClientMock.flush).toHaveBeenCalledTimes(1);
         await new Promise((resolve) => process.nextTick(resolve)); // wait for the flush resolution
       });
@@ -159,6 +168,7 @@ describe('LaunchDarklyClient - browser', () => {
         const err = new Error('Something went terribly wrong');
         ldClientMock.flush.mockRejectedValue(err);
         expect(() => client.stop()).not.toThrow();
+        await new Promise((resolve) => process.nextTick(resolve)); // wait for the flush resolution
         expect(ldClientMock.flush).toHaveBeenCalledTimes(1);
         await new Promise((resolve) => process.nextTick(resolve)); // wait for the flush resolution
         expect(consoleWarnSpy).toHaveBeenCalledWith(err);

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.ts
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/public/launch_darkly_client/launch_darkly_client.ts
@@ -6,6 +6,7 @@
  */
 
 import { type LDClient, type LDUser, type LDLogLevel } from 'launchdarkly-js-client-sdk';
+import { defer, Defer } from '@kbn/kibana-utils-plugin/public';
 
 export interface LaunchDarklyClientConfig {
   client_id: string;
@@ -26,7 +27,8 @@ export interface LaunchDarklyUserMetadata
 }
 
 export class LaunchDarklyClient {
-  private launchDarklyClient?: LDClient;
+  private launchDarklyClient?: Promise<LDClient | null>;
+  private waitUntilReady: Defer<void> = defer();
 
   constructor(
     private readonly ldConfig: LaunchDarklyClientConfig,
@@ -49,31 +51,68 @@ export class LaunchDarklyClient {
       custom: custom as Record<string, string | boolean | number>,
     };
     if (this.launchDarklyClient) {
-      await this.launchDarklyClient.identify(launchDarklyUser);
+      await (await this.launchDarklyClient)?.identify(launchDarklyUser);
     } else {
-      const { initialize, basicLogger } = await import('launchdarkly-js-client-sdk');
-      this.launchDarklyClient = initialize(this.ldConfig.client_id, launchDarklyUser, {
-        application: { id: 'kibana-browser', version: this.kibanaVersion },
-        logger: basicLogger({ level: this.ldConfig.client_log_level }),
+      this.launchDarklyClient = new Promise<LDClient | null>((resolve) => {
+        const timeoutHandle = setTimeout(() => {
+          // eslint-disable-next-line no-console
+          console.warn(`Failed to initialize launchDarkly client: timeout`);
+          resolve(null);
+          this.waitUntilReady?.resolve();
+        }, 10000); // Timeout after 10 seconds
+        import('launchdarkly-js-client-sdk')
+          .then(({ initialize, basicLogger }) => {
+            const client = initialize(this.ldConfig.client_id, launchDarklyUser, {
+              application: { id: 'kibana-browser', version: this.kibanaVersion },
+              logger: basicLogger({ level: this.ldConfig.client_log_level }),
+            });
+            resolve(client);
+            this.waitUntilReady?.resolve();
+          })
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.warn(`Failed to initialize launchDarkly client`, err);
+
+            resolve(null);
+            this.waitUntilReady?.resolve();
+          })
+          .finally(() => {
+            clearTimeout(timeoutHandle);
+          });
       });
+      await this.launchDarklyClient;
     }
   }
 
   public async getVariation<Data>(configKey: string, defaultValue: Data): Promise<Data> {
+    if (this.waitUntilReady) await this.waitUntilReady.promise;
     if (!this.launchDarklyClient) return defaultValue; // Skip any action if no LD User is defined
-    await this.launchDarklyClient.waitForInitialization();
-    return await this.launchDarklyClient.variation(configKey, defaultValue);
+    const client = await this.launchDarklyClient;
+    if (!client) return defaultValue;
+    try {
+      await client.waitForInitialization();
+      return client.variation(configKey, defaultValue);
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.warn(`Failed to get variation for ${configKey}`, e);
+      return defaultValue;
+    }
   }
 
-  public reportMetric(metricName: string, meta?: unknown, value?: number): void {
+  public reportMetric(metricName: string, meta?: unknown, value?: number) {
     if (!this.launchDarklyClient) return; // Skip any action if no LD User is defined
-    this.launchDarklyClient.track(metricName, meta, value);
+    this.launchDarklyClient.then((client) => {
+      client?.track(metricName, meta, value);
+    });
   }
 
   public stop() {
-    this.launchDarklyClient
-      ?.flush()
-      // eslint-disable-next-line no-console
-      .catch((err) => console.warn(err));
+    if (!this.launchDarklyClient) return;
+    this.launchDarklyClient.then((client) => {
+      client
+        ?.flush()
+        // eslint-disable-next-line no-console
+        .catch((err) => console.warn(err));
+    });
   }
 }

--- a/x-pack/plugins/cloud_integrations/cloud_experiments/tsconfig.json
+++ b/x-pack/plugins/cloud_integrations/cloud_experiments/tsconfig.json
@@ -19,6 +19,7 @@
     "@kbn/logging",
     "@kbn/logging-mocks",
     "@kbn/utility-types",
+    "@kbn/kibana-utils-plugin",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/167240


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
