### PR TITLE
[inspector] do not show clusters health bar when there are no remotes

### DIFF
--- a/src/plugins/inspector/public/views/requests/components/details/clusters_view/__snapshots__/clusters_view.test.tsx.snap
+++ b/src/plugins/inspector/public/views/requests/components/details/clusters_view/__snapshots__/clusters_view.test.tsx.snap
@@ -73,25 +73,6 @@ exports[`render should render local cluster details from _shards 1`] = `
   <EuiSpacer
     size="m"
   />
-  <ClustersHealth
-    clusters={
-      Object {
-        "(local)": Object {
-          "_shards": Object {
-            "failed": 0,
-            "skipped": 0,
-            "successful": 2,
-            "total": 2,
-          },
-          "failures": undefined,
-          "indices": "",
-          "status": "successful",
-          "timed_out": undefined,
-          "took": undefined,
-        },
-      }
-    }
-  />
   <ClustersTable
     clusters={
       Object {

--- a/src/plugins/inspector/public/views/requests/components/details/clusters_view/clusters_view.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/clusters_view/clusters_view.tsx
@@ -44,7 +44,10 @@ export class ClustersView extends Component<RequestDetailsProps> {
     return this.props.request.response?.json ? (
       <>
         <EuiSpacer size="m" />
-        <ClustersHealth clusters={clusters} />
+        { Object.keys(clusters).length > 1
+            ? <ClustersHealth clusters={clusters} />
+            : null
+        }
         <ClustersTable clusters={clusters} />
       </>
     ) : null;

--- a/src/plugins/inspector/public/views/requests/components/details/clusters_view/clusters_view.tsx
+++ b/src/plugins/inspector/public/views/requests/components/details/clusters_view/clusters_view.tsx
@@ -44,10 +44,7 @@ export class ClustersView extends Component<RequestDetailsProps> {
     return this.props.request.response?.json ? (
       <>
         <EuiSpacer size="m" />
-        { Object.keys(clusters).length > 1
-            ? <ClustersHealth clusters={clusters} />
-            : null
-        }
+        {Object.keys(clusters).length > 1 ? <ClustersHealth clusters={clusters} /> : null}
         <ClustersTable clusters={clusters} />
       </>
     ) : null;


### PR DESCRIPTION
<img width="400" alt="Screenshot 2023-09-29 at 8 42 00 AM" src="https://github.com/elastic/kibana/assets/373691/a8d575d7-776b-425b-a6fa-de91301f0512">
