### PR TITLE
[Security solution] Fix missed gen_ai import

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/evaluate/utils.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/gen_ai/constants';
+import { OpenAiProviderType } from '@kbn/stack-connectors-plugin/common/openai/constants';
 import type { ActionResult } from '@kbn/actions-plugin/server';
 
 /**


### PR DESCRIPTION
## Summary

Looks like [Garrett](https://github.com/elastic/kibana/pull/167220) and [I](https://github.com/elastic/kibana/pull/167519) merged close together and an import was missed. Quick fix!