### PR TITLE
[Cloud Security][BugFix] Fix for missing account_type on env created via Github action

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/fleet_extensions/policy_template_form.tsx
@@ -198,7 +198,7 @@ const AwsAccountTypeSelect = ({
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [input]);
+  }, [input, updatePolicy]);
 
   return (
     <>
@@ -341,7 +341,7 @@ const GcpAccountTypeSelect = ({
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [input]);
+  }, [input, updatePolicy]);
 
   return (
     <>


### PR DESCRIPTION
## Summary

This PR is for Fix for issue where account_type is missing if that integration was made via Github Action (https://github.com/elastic/security-team/issues/7686)

