### PR TITLE
[WIP] Add query bar to Advanced Settings

### DIFF
--- a/packages/kbn-management/settings/application/__snapshots__/query_input.test.tsx.snap
+++ b/packages/kbn-management/settings/application/__snapshots__/query_input.test.tsx.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Search should render normally 1`] = `
+<Fragment>
+  <EuiSearchBar
+    box={
+      Object {
+        "aria-label": "Search advanced settings",
+        "data-test-subj": "settingsSearchBar",
+        "incremental": true,
+      }
+    }
+    filters={
+      Array [
+        Object {
+          "field": "category",
+          "multiSelect": "or",
+          "name": "Category",
+          "options": Array [
+            Object {
+              "name": "General",
+              "value": "general",
+            },
+            Object {
+              "name": "Dashboard",
+              "value": "dashboard",
+            },
+            Object {
+              "name": "Notifications",
+              "value": "notifications",
+            },
+          ],
+          "type": "field_value_selection",
+        },
+      ]
+    }
+    onChange={[Function]}
+    query={
+      Query {
+        "ast": _AST {
+          "_clauses": Array [],
+          "_indexedClauses": Object {
+            "field": Object {},
+            "group": Array [],
+            "is": Object {},
+            "term": Array [],
+          },
+        },
+        "syntax": Object {
+          "parse": [Function],
+          "print": [Function],
+          "printClause": [Function],
+        },
+        "text": "",
+      }
+    }
+  />
+</Fragment>
+`;

--- a/packages/kbn-management/settings/application/__stories__/application.stories.tsx
+++ b/packages/kbn-management/settings/application/__stories__/application.stories.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import type { ComponentMeta, Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import { Subscription } from 'rxjs';
+import { SettingsApplication as Component } from '../application';
+import { useApplicationStory } from './use_application_story';
+import { SettingsApplicationProvider } from '../services';
+
+export default {
+  title: 'Settings/Settings Application',
+  description: '',
+  parameters: {
+    backgrounds: {
+      default: 'ghost',
+    },
+  },
+} as ComponentMeta<typeof Component>;
+
+export const SettingsApplication: Story = () => {
+  const { getAllowListedSettings } = useApplicationStory();
+
+  return (
+    <SettingsApplicationProvider
+      showDanger={action('showDanger')}
+      links={{ deprecationKey: 'link/to/deprecation/docs' }}
+      getAllowlistedSettings={getAllowListedSettings}
+      isCustomSetting={() => false}
+      isOverriddenSetting={() => false}
+      saveChanges={action('saveChanges')}
+      showError={action('showError')}
+      showReloadPagePrompt={action('showReloadPagePrompt')}
+      subscribeToUpdates={() => new Subscription()}
+      addUrlToHistory={action('addUrlToHistory')}
+    >
+      <Component />
+    </SettingsApplicationProvider>
+  );
+};

--- a/packages/kbn-management/settings/application/__stories__/use_application_story.tsx
+++ b/packages/kbn-management/settings/application/__stories__/use_application_story.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getSettingsMock } from '@kbn/management-settings-utilities/mocks/settings.mock';
+
+export const useApplicationStory = () => {
+  return { getAllowListedSettings: getSettingsMock };
+};

--- a/packages/kbn-management/settings/application/query_input.test.tsx
+++ b/packages/kbn-management/settings/application/query_input.test.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { Query } from '@elastic/eui';
+import { findTestSubject } from '@elastic/eui/lib/test';
+import { act, waitFor } from '@testing-library/react';
+
+import { shallowWithI18nProvider, mountWithI18nProvider } from '@kbn/test-jest-helpers';
+import { getSettingsMock } from '@kbn/management-settings-utilities/mocks/settings.mock';
+
+import { QueryInput } from './query_input';
+import { getFieldDefinitions } from '@kbn/management-settings-field-definition';
+import { categorizeFields } from '@kbn/management-settings-utilities';
+
+const query = Query.parse('');
+const settings = getSettingsMock();
+const categories = Object.keys(
+  categorizeFields(
+    getFieldDefinitions(settings, { isCustom: () => false, isOverridden: () => false })
+  )
+);
+
+describe('Search', () => {
+  it('should render normally', async () => {
+    const onQueryChange = () => {};
+    const component = shallowWithI18nProvider(
+      <QueryInput {...{ categories, query, onQueryChange }} />
+    );
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should call parent function when query is changed', async () => {
+    // This test is brittle as it knows about implementation details
+    // (EuiFieldSearch uses onKeyup instead of onChange to handle input)
+    const onQueryChange = jest.fn();
+    const component = mountWithI18nProvider(
+      <QueryInput {...{ categories, query, onQueryChange }} />
+    );
+    findTestSubject(component, 'settingsSearchBar').simulate('keyup', {
+      target: { value: 'new filter' },
+    });
+    expect(onQueryChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle query parse error', async () => {
+    const onQueryChangeMock = jest.fn();
+    const component = mountWithI18nProvider(
+      <QueryInput {...{ categories, query }} onQueryChange={onQueryChangeMock} />
+    );
+
+    const searchBar = findTestSubject(component, 'settingsSearchBar');
+
+    // Send invalid query
+    act(() => {
+      searchBar.simulate('keyup', { target: { value: '?' } });
+    });
+
+    expect(onQueryChangeMock).toHaveBeenCalledTimes(0);
+
+    waitFor(() => {
+      expect(component.contains('Unable to parse query')).toBe(true);
+    });
+
+    onQueryChangeMock.mockReset();
+
+    // Send valid query to ensure component can recover from invalid query
+    act(() => {
+      searchBar.simulate('keyup', { target: { value: 'dateFormat' } });
+    });
+
+    expect(onQueryChangeMock).toHaveBeenCalledTimes(1);
+
+    waitFor(() => {
+      expect(component.contains('Unable to parse query')).toBe(false);
+    });
+  });
+});

--- a/packages/kbn-management/settings/application/query_input.tsx
+++ b/packages/kbn-management/settings/application/query_input.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EuiFormErrorText, EuiSearchBar, EuiSearchBarProps, Query } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { getCategoryName } from '@kbn/management-settings-utilities';
+import React, { useState } from 'react';
+
+export const CATEGORY_FIELD = 'categories';
+
+export interface QueryInputProps {
+  categories: string[];
+  query?: Query;
+  onQueryChange: (query?: Query) => void;
+}
+
+export const parseErrorMsg = i18n.translate(
+  'management.settings.searchBar.unableToParseQueryErrorMessage',
+  { defaultMessage: 'Unable to parse query' }
+);
+
+export const QueryInput = ({ categories: categoryList, onQueryChange }: QueryInputProps) => {
+  const [queryError, setQueryError] = useState<string | null>(null);
+  const [query, setQuery] = useState<Query | undefined>();
+
+  const categories = categoryList.map((category) => ({
+    value: category,
+    name: getCategoryName(category),
+  }));
+
+  const box = {
+    incremental: true,
+    'data-test-subj': 'settingsSearchBar',
+    'aria-label': i18n.translate('management.settings.searchBarAriaLabel', {
+      defaultMessage: 'Search advanced settings',
+    }),
+  };
+
+  const filters = [
+    {
+      type: 'field_value_selection' as const,
+      field: CATEGORY_FIELD,
+      name: i18n.translate('management.settings.categorySearchLabel', {
+        defaultMessage: 'Category',
+      }),
+      multiSelect: 'or' as const,
+      options: categories,
+    },
+  ];
+
+  const onChange: EuiSearchBarProps['onChange'] = ({ query: newQuery, error }) => {
+    if (error) {
+      setQueryError(error?.message || null);
+      setQuery(error ? undefined : newQuery);
+    }
+    onQueryChange(newQuery || undefined);
+  };
+
+  return (
+    <>
+      <EuiSearchBar {...{ box, filters, onChange, query }} />
+      {queryError && <EuiFormErrorText>{`${parseErrorMsg}. ${queryError}`}</EuiFormErrorText>}
+    </>
+  );
+};

--- a/packages/kbn-management/settings/application/services.tsx
+++ b/packages/kbn-management/settings/application/services.tsx
@@ -18,12 +18,14 @@ import { UiSettingMetadata } from '@kbn/management-settings-types';
 import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import { normalizeSettings } from '@kbn/management-settings-utilities';
 import { Subscription } from 'rxjs';
+import { AppMountParameters } from '@kbn/core-application-browser';
 
 export interface Services {
   getAllowlistedSettings: () => Record<string, UiSettingMetadata>;
   subscribeToUpdates: (fn: () => void) => Subscription;
   isCustomSetting: (key: string) => boolean;
   isOverriddenSetting: (key: string) => boolean;
+  addUrlToHistory: (url: string) => void;
 }
 
 export type SettingsApplicationServices = Services & FormServices;
@@ -32,6 +34,7 @@ export interface KibanaDependencies {
   settings: {
     client: Pick<IUiSettingsClient, 'getAll' | 'isCustom' | 'isOverridden' | 'getUpdate$'>;
   };
+  params: Pick<AppMountParameters, 'history'>;
 }
 
 export type SettingsApplicationKibanaDependencies = KibanaDependencies & FormKibanaDependencies;
@@ -56,11 +59,18 @@ export const SettingsApplicationProvider: FC<SettingsApplicationServices> = ({
     subscribeToUpdates,
     isCustomSetting,
     isOverriddenSetting,
+    addUrlToHistory,
   } = services;
 
   return (
     <SettingsApplicationContext.Provider
-      value={{ getAllowlistedSettings, subscribeToUpdates, isCustomSetting, isOverriddenSetting }}
+      value={{
+        getAllowlistedSettings,
+        subscribeToUpdates,
+        isCustomSetting,
+        isOverriddenSetting,
+        addUrlToHistory,
+      }}
     >
       <FormProvider {...{ saveChanges, showError, showReloadPagePrompt, links, showDanger }}>
         {children}
@@ -76,7 +86,14 @@ export const SettingsApplicationKibanaProvider: FC<SettingsApplicationKibanaDepe
   children,
   ...dependencies
 }) => {
-  const { docLinks, notifications, theme, i18n, settings } = dependencies;
+  const {
+    docLinks,
+    notifications,
+    theme,
+    i18n,
+    settings,
+    params: { history },
+  } = dependencies;
   const { client } = settings;
 
   const getAllowlistedSettings = () => {
@@ -94,6 +111,7 @@ export const SettingsApplicationKibanaProvider: FC<SettingsApplicationKibanaDepe
     isCustomSetting: (key: string) => client.isCustom(key),
     isOverriddenSetting: (key: string) => client.isOverridden(key),
     subscribeToUpdates: (fn: () => void) => client.getUpdate$().subscribe(fn),
+    addUrlToHistory: (url: string) => history.push({ pathname: '', search: url }),
   };
 
   return (

--- a/packages/kbn-management/settings/application/tsconfig.json
+++ b/packages/kbn-management/settings/application/tsconfig.json
@@ -22,5 +22,7 @@
     "@kbn/management-settings-utilities",
     "@kbn/management-settings-components-form",
     "@kbn/i18n",
+    "@kbn/test-jest-helpers",
+    "@kbn/core-application-browser",
   ]
 }


### PR DESCRIPTION
## Summary

This PR adds the query bar to the Advanced Settings application, as well as a Storybook story for the app.

While the category selector works, the query execution does not.  Unfortunately I've run out of time before my parental leave.  I'm hoping @ElenaStoeva and the @elastic/platform-deployment-management can finish it up.

See you all in a month.  Wish me luck!  🐣