### PR TITLE
[APM] Ensure APM data view is available across all spaces

### DIFF
--- a/x-pack/plugins/apm/server/plugin.ts
+++ b/x-pack/plugins/apm/server/plugin.ts
@@ -11,6 +11,7 @@ import {
   Logger,
   Plugin,
   PluginInitializerContext,
+  SavedObjectsClient,
 } from '@kbn/core/server';
 import { isEmpty, mapValues } from 'lodash';
 import { Dataset } from '@kbn/rule-registry-plugin/server';
@@ -48,6 +49,7 @@ import { scheduleSourceMapMigration } from './routes/source_maps/schedule_source
 import { createApmSourceMapIndexTemplate } from './routes/source_maps/create_apm_source_map_index_template';
 import { addApiKeysToEveryPackagePolicyIfMissing } from './routes/fleet/api_keys/add_api_keys_to_policies_if_missing';
 import { apmTutorialCustomIntegration } from '../common/tutorial/tutorials';
+import { APM_STATIC_DATA_VIEW_ID } from '../common/data_view_constants';
 
 export class APMPlugin
   implements
@@ -118,6 +120,26 @@ export class APMPlugin
         },
       ],
     });
+
+    // ensure that the APM data view is globally available
+    getCoreStart()
+      .then(async (coreStart) => {
+        const soClient = new SavedObjectsClient(
+          coreStart.savedObjects.createInternalRepository()
+        );
+
+        await soClient.updateObjectsSpaces(
+          [{ id: APM_STATIC_DATA_VIEW_ID, type: 'index-pattern' }],
+          ['*'],
+          []
+        );
+      })
+      .catch((e) => {
+        this.logger?.error(
+          'Failed to make APM data view available globally',
+          e
+        );
+      });
 
     const resourcePlugins = mapValues(plugins, (value, key) => {
       return {


### PR DESCRIPTION
This PR partially solves https://github.com/elastic/kibana/issues/167613 by ensuring that the APM data view is available across all spaces. This is needed since data views created before 8.6 were scoped to a single space.



## Testing instructions

_Note: this cannot be tested on a cloud deployment because to test this you need to restart Kibana_

- Delete the APM data view if it already exists. 
  - _Make sure NOT to navigate to APM UI since this will re-create the data view which you do not want at this point_
- Manually create a data view with the custom id `apm_static_index_pattern_id`
- Verify that the data view is limited to the current space (eg default)
- Create a new space
- Open APM UI in the new space and verify that links to discover do not work
- Restart Kibana
- Open APM UI and verify that links to Discover work in both the default space and the new space