### PR TITLE
[Fleet] allow upgrade to snapshot

### DIFF
--- a/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
+++ b/x-pack/plugins/fleet/common/services/is_agent_upgradeable.ts
@@ -34,8 +34,7 @@ export function isAgentUpgradeable(
   }
   if (versionToUpgrade !== undefined) {
     return (
-      isNotDowngrade(agentVersion, versionToUpgrade) &&
-      isAgentVersionLessThanLatest(agentVersion, latestAgentVersion)
+      isNotDowngrade(agentVersion, versionToUpgrade)
     );
   }
   return isAgentVersionLessThanLatest(agentVersion, latestAgentVersion);


### PR DESCRIPTION
## Summary

The recent [change](https://github.com/elastic/kibana/pull/167410) broke an integration test in agent where the test upgrades to a newer snapshot version.

This change is removing the version check against the latest agent version if `versionToUpgrade` is given.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
