### PR TITLE
[Index Management] Add tech preview badge for DSL

### DIFF
--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -131,7 +131,7 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
       <EuiToolTip
         content={i18n.translate('xpack.idxMgmt.dataStreamList.table.dataRetentionColumnTooltip', {
           defaultMessage:
-            'Data will be be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
+            '[Tech preview] Data will be be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
         })}
       >
         <span>

--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -131,7 +131,7 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
       <EuiToolTip
         content={i18n.translate('xpack.idxMgmt.dataStreamList.table.dataRetentionColumnTooltip', {
           defaultMessage:
-            '[Technical preview] Data will be be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
+            '[Technical preview] Data will be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
         })}
       >
         <span>

--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/data_stream_table/data_stream_table.tsx
@@ -131,7 +131,7 @@ export const DataStreamTable: React.FunctionComponent<Props> = ({
       <EuiToolTip
         content={i18n.translate('xpack.idxMgmt.dataStreamList.table.dataRetentionColumnTooltip', {
           defaultMessage:
-            '[Tech preview] Data will be be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
+            '[Technical preview] Data will be be kept at least this long before it is automatically deleted. Only applies to data streams managed by a data stream lifecycle. This value might not apply to all data if the data stream also has an index lifecycle policy.',
         })}
       >
         <span>

--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
@@ -239,7 +239,7 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
                 {i18n.translate(
                   'xpack.idxMgmt.dataStreamsDetailsPanel.editDataRetentionModal.techPreviewLabel',
                   {
-                    defaultMessage: 'Tech preview',
+                    defaultMessage: 'Technical preview',
                   }
                 )}
               </EuiText>

--- a/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/data_stream_list/edit_data_retention_modal/edit_data_retention_modal.tsx
@@ -17,6 +17,7 @@ import {
   EuiSpacer,
   EuiLink,
   EuiText,
+  EuiBadge,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -232,7 +233,17 @@ export const EditDataRetentionModal: React.FunctionComponent<Props> = ({
             <FormattedMessage
               id="xpack.idxMgmt.dataStreamsDetailsPanel.editDataRetentionModal.modalTitleText"
               defaultMessage="Edit data retention"
-            />
+            />{' '}
+            <EuiBadge color="hollow">
+              <EuiText size="xs">
+                {i18n.translate(
+                  'xpack.idxMgmt.dataStreamsDetailsPanel.editDataRetentionModal.techPreviewLabel',
+                  {
+                    defaultMessage: 'Tech preview',
+                  }
+                )}
+              </EuiText>
+            </EuiBadge>
           </EuiModalHeaderTitle>
         </EuiModalHeader>
 


### PR DESCRIPTION
Data stream lifecycle (DSL) will be considered tech preview for 8.11, and not GA. This PR updates the tooltip copy on the table and adds a tech preview badge to the edit retention modal.

Opened https://github.com/elastic/kibana/issues/167805 to follow up to remove badge post-8.11; it is also not applicable on serverless.

<img width="671" alt="Screenshot 2023-10-02 at 12 12 41 PM" src="https://github.com/elastic/kibana/assets/5226211/4f444355-7f71-469d-b4b9-7fdf150b2230">

<img width="387" alt="Screenshot 2023-10-02 at 1 14 02 PM" src="https://github.com/elastic/kibana/assets/5226211/7d328134-61b4-4a4d-8301-1192db2332ed">

