### PR TITLE
[Cases] Make Cases in the Stack Management GA

### DIFF
--- a/x-pack/plugins/cases/public/components/app/index.tsx
+++ b/x-pack/plugins/cases/public/components/app/index.tsx
@@ -44,7 +44,7 @@ const CasesAppComponent: React.FC<CasesAppProps> = ({
         permissions: userCapabilities.generalCases,
         basePath: '/',
         features: { alerts: { enabled: false } },
-        releasePhase: 'experimental',
+        releasePhase: 'ga',
       })}
     </Wrapper>
   );

--- a/x-pack/plugins/cases/public/components/app/index.tsx
+++ b/x-pack/plugins/cases/public/components/app/index.tsx
@@ -44,7 +44,6 @@ const CasesAppComponent: React.FC<CasesAppProps> = ({
         permissions: userCapabilities.generalCases,
         basePath: '/',
         features: { alerts: { enabled: false } },
-        releasePhase: 'ga',
       })}
     </Wrapper>
   );


### PR DESCRIPTION
## Summary

This PR makes Cases in the Stack Management GA. All headers in Cases should not have the experimental badge.

<img width="1639" alt="Screenshot 2023-10-02 at 7 39 56 PM" src="https://github.com/elastic/kibana/assets/7871006/31739f7c-b666-4f48-8d3a-019410e33ad9">
<img width="369" alt="Screenshot 2023-10-02 at 7 39 36 PM" src="https://github.com/elastic/kibana/assets/7871006/8b750864-a163-43a1-8ee8-12ff3fa83f33">
<img width="584" alt="Screenshot 2023-10-02 at 7 39 30 PM" src="https://github.com/elastic/kibana/assets/7871006/e8d06fbe-ff88-449e-86a0-b0febbb955ea">
<img width="1655" alt="Screenshot 2023-10-02 at 7 39 24 PM" src="https://github.com/elastic/kibana/assets/7871006/c8326d8b-9c73-44df-bd0b-1ecb72405bab">


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release notes
Cases in the Stack Management is now GA
