### PR TITLE
[kbn-journey] temporary disable APM for ES

### DIFF
--- a/src/dev/performance/run_performance_cli.ts
+++ b/src/dev/performance/run_performance_cli.ts
@@ -11,7 +11,6 @@ import { run } from '@kbn/dev-cli-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
 import fs from 'fs';
 import path from 'path';
-import { JOURNEY_APM_CONFIG } from '@kbn/journeys';
 
 const JOURNEY_BASE_PATH = 'x-pack/performance/journeys';
 
@@ -108,20 +107,21 @@ run(
           'scripts/es',
           'snapshot',
           '--license=trial',
-          ...(JOURNEY_APM_CONFIG.active
-            ? [
-                '-E',
-                'tracing.apm.enabled=true',
-                '-E',
-                'tracing.apm.agent.transaction_sample_rate=1.0',
-                '-E',
-                `tracing.apm.agent.server_url=${JOURNEY_APM_CONFIG.serverUrl}`,
-                '-E',
-                `tracing.apm.agent.secret_token=${JOURNEY_APM_CONFIG.secretToken}`,
-                '-E',
-                `tracing.apm.agent.environment=${JOURNEY_APM_CONFIG.environment}`,
-              ]
-            : []),
+          // Disabling APM until https://github.com/elastic/elasticsearch/issues/100072 is fixed
+          // ...(JOURNEY_APM_CONFIG.active
+          //   ? [
+          //       '-E',
+          //       'tracing.apm.enabled=true',
+          //       '-E',
+          //       'tracing.apm.agent.transaction_sample_rate=1.0',
+          //       '-E',
+          //       `tracing.apm.agent.server_url=${JOURNEY_APM_CONFIG.serverUrl}`,
+          //       '-E',
+          //       `tracing.apm.agent.secret_token=${JOURNEY_APM_CONFIG.secretToken}`,
+          //       '-E',
+          //       `tracing.apm.agent.environment=${JOURNEY_APM_CONFIG.environment}`,
+          //     ]
+          //   : []),
         ],
         cwd: REPO_ROOT,
         wait: /kbn\/es setup complete/,

--- a/src/dev/tsconfig.json
+++ b/src/dev/tsconfig.json
@@ -38,7 +38,6 @@
     "@kbn/repo-file-maps",
     "@kbn/get-repo-files",
     "@kbn/import-locator",
-    "@kbn/journeys",
     "@kbn/config-schema",
   ]
 }


### PR DESCRIPTION
## Summary

Disable APM for ES until elastic/elasticsearch/issues/100072 is fixed

It will unblock our performance pipelines that were failing since ES snapshot was promoted on Sept 30th.

The last working with APM one can be tested with:
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.11.0/archives/20230929-142326_e08153e2/manifest.json"