### PR TITLE
[inspector] rename clusters tab to 'Clustesrs and shards'

### DIFF
--- a/src/plugins/inspector/public/views/requests/components/request_details.tsx
+++ b/src/plugins/inspector/public/views/requests/components/request_details.tsx
@@ -36,7 +36,7 @@ const DETAILS: DetailViewData[] = [
   {
     name: 'Clusters',
     label: i18n.translate('inspector.requests.clustersTabLabel', {
-      defaultMessage: 'Clusters',
+      defaultMessage: 'Clusters and shards',
     }),
     component: ClustersView,
   },


### PR DESCRIPTION
Updated figma designs have change label to 'Clustesrs and shards'
<img width="744" alt="Screenshot 2023-10-02 at 11 24 42 AM" src="https://github.com/elastic/kibana/assets/373691/456cf747-7793-406b-b304-9ba896d4f2ac">
