### PR TITLE
Reenable type check in api docs build

### DIFF
--- a/.buildkite/scripts/steps/build_api_docs.sh
+++ b/.buildkite/scripts/steps/build_api_docs.sh
@@ -4,9 +4,8 @@ set -euo pipefail
 
 .buildkite/scripts/bootstrap.sh
 
-# TODO: Enable in #166813 after fixing types
-# echo "--- Run scripts/type_check to ensure that all build available"
-# node scripts/type_check
+echo "--- Run scripts/type_check to ensure that all build available"
+node scripts/type_check
 
 echo "--- Build API Docs"
 node --max-old-space-size=12000 scripts/build_api_docs


### PR DESCRIPTION
## Summary

This was missed as part of #167392



<!--ONMERGE {"backportTargets":["8.10"]} ONMERGE-->