### PR TITLE
[Serverless Tests] Use public headers for the public telemetry config endpoint

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/search/telemetry/telemetry_config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/telemetry/telemetry_config.ts
@@ -25,7 +25,7 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
     it('GET should get the default config', async () => {
       await supertest
         .get('/api/telemetry/v2/config')
-        .set(svlCommonApi.getInternalRequestHeader())
+        .set(svlCommonApi.getCommonRequestHeader())
         .expect(200, baseConfig);
     });
 
@@ -39,7 +39,7 @@ export default function telemetryConfigTest({ getService }: FtrProviderContext) 
 
       await supertest
         .get('/api/telemetry/v2/config')
-        .set(svlCommonApi.getInternalRequestHeader())
+        .set(svlCommonApi.getCommonRequestHeader())
         .expect(200, {
           ...baseConfig,
           labels: {


### PR DESCRIPTION
## Summary

Intentionally test the endpoint with the public headers, since we had to keep it public because we know external consumers use it.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
