### PR TITLE
[APM] Add telemetry from custom dashboards

### DIFF
--- a/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
+++ b/x-pack/plugins/apm/common/__snapshots__/apm_telemetry.test.ts.snap
@@ -2577,6 +2577,22 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                         }
                       }
                     },
+                    "custom_dashboards": {
+                      "properties": {
+                        "kuery_fields": {
+                          "type": "keyword",
+                          "_meta": {
+                            "description": "An array of up to 500 unique fields used to create the custom dashboards across all spaces. Example  [service.language.name, service.name] "
+                          }
+                        },
+                        "total": {
+                          "type": "long",
+                          "_meta": {
+                            "description": "Total number of custom dashboards retrived from the saved object across all spaces"
+                          }
+                        }
+                      }
+                    },
                     "per_service": {
                       "properties": {
                         "service_id": {
@@ -2961,6 +2977,20 @@ exports[`APM telemetry helpers getApmTelemetry generates a JSON object with the 
                                   "type": "long",
                                   "_meta": {
                                     "description": "Execution time in milliseconds for the \\"service_groups\\" task"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "custom_dashboards": {
+                          "properties": {
+                            "took": {
+                              "properties": {
+                                "ms": {
+                                  "type": "long",
+                                  "_meta": {
+                                    "description": "Execution time in milliseconds for the \\"custom_dashboards\\" task"
                                   }
                                 }
                               }

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -801,6 +801,58 @@ describe('data telemetry collection tasks', () => {
     });
   });
 
+  describe('custom dashboards', () => {
+    const task = tasks.find((t) => t.name === 'custom_dashboards');
+    const savedObjectsClient = savedObjectsClientMock.create();
+
+    it('returns custom dashboards stats from all spaces', async () => {
+      savedObjectsClient.find.mockResolvedValueOnce({
+        page: 1,
+        per_page: 500,
+        total: 2,
+        saved_objects: [
+          {
+            type: 'apm-custom-dashboards',
+            id: '0b6157f0-44bd-11ed-bdb7-bffab551cd4d',
+            namespaces: ['default'],
+            attributes: {
+              dashboardSavedObjectId: 'foo-id',
+              serviceEnvironmentFilterEnabled: true,
+              serviceNameFilterEnabled: true,
+              kuery: 'service.name: frontend and service.environment: prod',
+            },
+            references: [],
+            score: 1,
+          },
+          {
+            type: 'apm-custom-dashboards',
+            id: '0b6157f0-44bd-11ed-bdb7-bffab551cd4d',
+            namespaces: ['space-1'],
+            attributes: {
+              dashboardSavedObjectId: 'bar-id',
+              serviceEnvironmentFilterEnabled: true,
+              serviceNameFilterEnabled: true,
+              kuery: 'service.name: frontend',
+            },
+            references: [],
+            score: 0,
+          },
+        ],
+      });
+
+      expect(
+        await task?.executor({
+          savedObjectsClient,
+        } as any)
+      ).toEqual({
+        service_groups: {
+          kuery_fields: ['service.environment', 'service.environment'],
+          total: 2,
+        },
+      });
+    });
+  });
+
   describe('top_traces', () => {
     const task = tasks.find((t) => t.name === 'top_traces');
 

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -845,7 +845,7 @@ describe('data telemetry collection tasks', () => {
           savedObjectsClient,
         } as any)
       ).toEqual({
-        service_groups: {
+        custom_dashboards: {
           kuery_fields: ['service.environment', 'service.environment'],
           total: 2,
         },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.test.ts
@@ -846,7 +846,7 @@ describe('data telemetry collection tasks', () => {
         } as any)
       ).toEqual({
         custom_dashboards: {
-          kuery_fields: ['service.environment', 'service.environment'],
+          kuery_fields: ['service.name', 'service.environment'],
           total: 2,
         },
       });

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/collect_data_telemetry/tasks.ts
@@ -71,6 +71,10 @@ import {
 import { APM_AGENT_CONFIGURATION_INDEX } from '../../../routes/settings/apm_indices/apm_system_index_constants';
 import { IndicesStatsResponse, TelemetryClient } from '../telemetry_client';
 import { RollupInterval } from '../../../../common/rollup';
+import {
+  APM_CUSTOM_DASHBOARDS_SAVED_OBJECT_TYPE,
+  SavedApmCustomDashboard,
+} from '../../../../common/custom_dashboards';
 
 type ISavedObjectsClient = Pick<SavedObjectsClient, 'find'>;
 const TIME_RANGES = ['1d', 'all'] as const;
@@ -1485,6 +1489,32 @@ export const tasks: TelemetryTask[] = [
 
       return {
         service_groups: {
+          kuery_fields: uniq(kueryFields),
+          total: response.total ?? 0,
+        },
+      };
+    },
+  },
+  {
+    name: 'custom_dashboards',
+    executor: async ({ savedObjectsClient }) => {
+      const response = await savedObjectsClient.find<SavedApmCustomDashboard>({
+        type: APM_CUSTOM_DASHBOARDS_SAVED_OBJECT_TYPE,
+        page: 1,
+        perPage: 500,
+        sortField: 'updated_at',
+        sortOrder: 'desc',
+        namespaces: ['*'],
+      });
+
+      const kueryNodes = response.saved_objects.map(
+        ({ attributes: { kuery } }) => fromKueryExpression(kuery ?? '')
+      );
+
+      const kueryFields = getKueryFields(kueryNodes);
+
+      return {
+        custom_dashboards: {
           kuery_fields: uniq(kueryFields),
           total: response.total ?? 0,
         },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/schema.ts
@@ -1083,6 +1083,25 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
       },
     },
   },
+  custom_dashboards: {
+    kuery_fields: {
+      type: 'array',
+      items: {
+        type: 'keyword',
+        _meta: {
+          description:
+            'An array of up to 500 unique fields used to create the custom dashboards across all spaces. Example  [service.language.name, service.name] ',
+        },
+      },
+    },
+    total: {
+      type: 'long',
+      _meta: {
+        description:
+          'Total number of custom dashboards retrived from the saved object across all spaces',
+      },
+    },
+  },
   per_service: { type: 'array', items: { ...apmPerServiceSchema } },
   top_traces: {
     max: {
@@ -1259,6 +1278,17 @@ export const apmSchema: MakeSchemaFrom<APMUsage, true> = {
           _meta: {
             description:
               'Execution time in milliseconds for the "service_groups" task',
+          },
+        },
+      },
+    },
+    custom_dashboards: {
+      took: {
+        ms: {
+          type: 'long',
+          _meta: {
+            description:
+              'Execution time in milliseconds for the "custom_dashboards" task',
           },
         },
       },

--- a/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
+++ b/x-pack/plugins/apm/server/lib/apm_telemetry/types.ts
@@ -213,6 +213,10 @@ export interface APMUsage {
     kuery_fields: string[];
     total: number;
   };
+  custom_dashboards: {
+    kuery_fields: string[];
+    total: number;
+  };
   per_service: APMPerService[];
   top_traces: {
     max: number;
@@ -234,6 +238,7 @@ export interface APMUsage {
     | 'cardinality'
     | 'environments'
     | 'service_groups'
+    | 'custom_dashboards'
     | 'per_service'
     | 'top_traces',
     { took: { ms: number } }

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -5672,6 +5672,25 @@
             }
           }
         },
+        "custom_dashboards": {
+          "properties": {
+            "kuery_fields": {
+              "type": "array",
+              "items": {
+                "type": "keyword",
+                "_meta": {
+                  "description": "An array of up to 500 unique fields used to create the custom dashboards across all spaces. Example  [service.language.name, service.name] "
+                }
+              }
+            },
+            "total": {
+              "type": "long",
+              "_meta": {
+                "description": "Total number of custom dashboards retrived from the saved object across all spaces"
+              }
+            }
+          }
+        },
         "per_service": {
           "type": "array",
           "items": {
@@ -6071,6 +6090,20 @@
                       "type": "long",
                       "_meta": {
                         "description": "Execution time in milliseconds for the \"service_groups\" task"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "custom_dashboards": {
+              "properties": {
+                "took": {
+                  "properties": {
+                    "ms": {
+                      "type": "long",
+                      "_meta": {
+                        "description": "Execution time in milliseconds for the \"custom_dashboards\" task"
                       }
                     }
                   }


### PR DESCRIPTION
## Summary
closes: https://github.com/elastic/kibana/issues/167865

Adds telemetry for the total number of custom dashboards linked with services and the kuery used
 
## How to test

Navigate to `internal/apm/debug-telemetry` on any of the deployed environments

You will find the custom_dashboards field like this
<img width="370" alt="image" src="https://github.com/elastic/kibana/assets/3369346/82d24183-406a-4cb3-a75e-01c272448785">


### Update indexer
 - https://github.com/elastic/telemetry/pull/2702
