### PR TITLE
Isolate the serverless avatar test for flaky runner

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/platform_security/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/platform_security/index.ts
@@ -9,7 +9,7 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Serverless Common UI - Platform Security', function () {
-    loadTestFile(require.resolve('./api_keys'));
+    // loadTestFile(require.resolve('./api_keys'));
     loadTestFile(require.resolve('./navigation/avatar_menu'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group1.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/common_configs/config.group1.ts
@@ -13,8 +13,8 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...baseTestConfig.getAll(),
     testFiles: [
-      require.resolve('../../common/home_page'),
-      require.resolve('../../common/management'),
+      // require.resolve('../../common/home_page'),
+      // require.resolve('../../common/management'),
       require.resolve('../../common/platform_security'),
     ],
     junit: {


### PR DESCRIPTION
## Summary

DO NOT MERGE

Isolates the serverless avatar test when running `/test_serverless/functional/test_suites/observability/common_configs/config.group1.ts`. This is to facilitate running a flaky runner on the avatar test, investigating if [recent changes](https://github.com/elastic/elasticsearch/pull/100056) have resolved the issues we believe to be causing flakiness.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3289