### PR TITLE
[Search][Search Experience] Gated form is shown only when user is admin and kibana_uis_enabled is false

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -112,7 +112,7 @@ describe('WorkplaceSearchConfigured', () => {
 
   it('initializes app data with passed props', () => {
     const { workplaceSearch } = DEFAULT_INITIAL_APP_DATA;
-    setMockValues({ organization: { kibanaUIsEnabled: false }, account: { isAdmin: true } });
+    setMockValues({ account: { isAdmin: true }, organization: { kibanaUIsEnabled: false } });
     shallow(<WorkplaceSearchConfigured workplaceSearch={workplaceSearch} />);
 
     expect(initializeAppData).toHaveBeenCalledWith({ workplaceSearch });
@@ -120,9 +120,9 @@ describe('WorkplaceSearchConfigured', () => {
 
   it('does not re-initialize app data or re-render header actions', () => {
     setMockValues({
+      account: { isAdmin: true },
       hasInitialized: true,
       organization: { kibanaUIsEnabled: false },
-      account: { isAdmin: true },
     });
 
     shallow(<WorkplaceSearchConfigured />);
@@ -139,7 +139,7 @@ describe('WorkplaceSearchConfigured', () => {
     expect(wrapper.find(SourceAdded)).toHaveLength(1);
   });
   describe('when admin user is logged in', () => {
-    it('All routes accessible when kibanaUIsEnabled is true', () => {
+    it('all routes accessible when kibanaUIsEnabled is true', () => {
       setMockValues({
         account: { isAdmin: true },
         organization: { kibanaUIsEnabled: true },
@@ -150,7 +150,7 @@ describe('WorkplaceSearchConfigured', () => {
       expect(wrapper.find(RoleMappings)).toHaveLength(1);
     });
 
-    it('Only Overview and Notfound routes are available when kibanaUIsEnabled is false', () => {
+    it('only Overview and Notfound routes are available when kibanaUIsEnabled is false', () => {
       setMockValues({
         account: { isAdmin: true },
         organization: { kibanaUIsEnabled: false },
@@ -177,9 +177,9 @@ describe('WorkplaceSearchConfigured', () => {
     it('when kibanaUIsEnabled is false ', () => {
       setMockValues({
         account: { isAdmin: false },
-        organization: { kibanaUIsEnabled: true },
+        organization: { kibanaUIsEnabled: false },
       });
-      const props = { isAdmin: true, kibanaUIsEnabled: true };
+      const props = { isAdmin: false, kibanaUIsEnabled: false };
 
       const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
       expect(wrapper.find(SourcesRouter)).toHaveLength(2);

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.test.tsx
@@ -18,12 +18,20 @@ import { shallow } from 'enzyme';
 import { VersionMismatchPage } from '../shared/version_mismatch';
 
 import { WorkplaceSearchHeaderActions } from './components/layout';
+import { SourcesRouter } from './views/content_sources';
 import { SourceAdded } from './views/content_sources/components/source_added';
 import { ErrorState } from './views/error_state';
+import { NotFound } from './views/not_found';
 import { Overview } from './views/overview';
+import { RoleMappings } from './views/role_mappings';
 import { SetupGuide } from './views/setup_guide';
 
-import { WorkplaceSearch, WorkplaceSearchUnconfigured, WorkplaceSearchConfigured } from '.';
+import {
+  WorkplaceSearch,
+  WorkplaceSearchUnconfigured,
+  WorkplaceSearchConfigured,
+  WorkplaceSearchConfiguredRoutes,
+} from '.';
 
 describe('WorkplaceSearch', () => {
   it('renders VersionMismatchPage when there are mismatching versions', () => {
@@ -89,24 +97,33 @@ describe('WorkplaceSearchConfigured', () => {
   });
 
   it('renders chrome and header actions', () => {
-    setMockValues({ organization: { kibanaUIsEnabled: false } });
-    const wrapper = shallow(<WorkplaceSearchConfigured />);
-    expect(wrapper.find(Overview)).toHaveLength(1);
+    setMockValues({
+      account: { isAdmin: true },
+      organization: { kibanaUIsEnabled: true },
+    });
+    const props = { isAdmin: true, kibanaUIsEnabled: true };
+    const wrapperConfiguredRoutes = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
+    expect(wrapperConfiguredRoutes.find(Overview)).toHaveLength(1);
 
+    shallow(<WorkplaceSearchConfigured />);
     expect(mockKibanaValues.setChromeIsVisible).toHaveBeenCalledWith(true);
     expect(mockKibanaValues.renderHeaderActions).toHaveBeenCalledWith(WorkplaceSearchHeaderActions);
   });
 
   it('initializes app data with passed props', () => {
     const { workplaceSearch } = DEFAULT_INITIAL_APP_DATA;
-    setMockValues({ organization: { kibanaUIsEnabled: false } });
+    setMockValues({ organization: { kibanaUIsEnabled: false }, account: { isAdmin: true } });
     shallow(<WorkplaceSearchConfigured workplaceSearch={workplaceSearch} />);
 
     expect(initializeAppData).toHaveBeenCalledWith({ workplaceSearch });
   });
 
   it('does not re-initialize app data or re-render header actions', () => {
-    setMockValues({ hasInitialized: true, organization: { kibanaUIsEnabled: false } });
+    setMockValues({
+      hasInitialized: true,
+      organization: { kibanaUIsEnabled: false },
+      account: { isAdmin: true },
+    });
 
     shallow(<WorkplaceSearchConfigured />);
 
@@ -115,14 +132,57 @@ describe('WorkplaceSearchConfigured', () => {
   });
 
   it('renders SourceAdded', () => {
-    setMockValues({ organization: { kibanaUIsEnabled: true } });
-    const wrapper = shallow(<WorkplaceSearchConfigured />);
+    setMockValues({ organization: { kibanaUIsEnabled: true }, account: { isAdmin: true } });
+    const props = { isAdmin: true, kibanaUIsEnabled: true };
+    const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
 
     expect(wrapper.find(SourceAdded)).toHaveLength(1);
   });
-  it('renders Overview when kibanaUIsEnabled is true', () => {
-    setMockValues({ organization: { kibanaUIsEnabled: false } });
-    const wrapper = shallow(<WorkplaceSearchConfigured />);
-    expect(wrapper.find(Overview)).toHaveLength(1);
+  describe('when admin user is logged in', () => {
+    it('All routes accessible when kibanaUIsEnabled is true', () => {
+      setMockValues({
+        account: { isAdmin: true },
+        organization: { kibanaUIsEnabled: true },
+      });
+      const props = { isAdmin: true, kibanaUIsEnabled: true };
+
+      const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
+      expect(wrapper.find(RoleMappings)).toHaveLength(1);
+    });
+
+    it('Only Overview and Notfound routes are available when kibanaUIsEnabled is false', () => {
+      setMockValues({
+        account: { isAdmin: true },
+        organization: { kibanaUIsEnabled: false },
+      });
+      const props = { isAdmin: true, kibanaUIsEnabled: false };
+
+      const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
+      expect(wrapper.find(RoleMappings)).toHaveLength(0);
+      expect(wrapper.find(Overview)).toHaveLength(1);
+      expect(wrapper.find(NotFound)).toHaveLength(1);
+    });
+  });
+  describe('when non admin user is logged in, all routes are accessible', () => {
+    it('when kibanaUIsEnabled is true ', () => {
+      setMockValues({
+        account: { isAdmin: false },
+        organization: { kibanaUIsEnabled: true },
+      });
+      const props = { isAdmin: true, kibanaUIsEnabled: true };
+
+      const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
+      expect(wrapper.find(RoleMappings)).toHaveLength(1);
+    });
+    it('when kibanaUIsEnabled is false ', () => {
+      setMockValues({
+        account: { isAdmin: false },
+        organization: { kibanaUIsEnabled: true },
+      });
+      const props = { isAdmin: true, kibanaUIsEnabled: true };
+
+      const wrapper = shallow(<WorkplaceSearchConfiguredRoutes {...props} />);
+      expect(wrapper.find(SourcesRouter)).toHaveLength(2);
+    });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -73,10 +73,80 @@ export const WorkplaceSearch: React.FC<InitialAppData> = (props) => {
   return <WorkplaceSearchConfigured {...props} />;
 };
 
+export const WorkplaceSearchConfiguredRoutes: React.FC<{
+  isAdmin: boolean;
+  kibanaUIsEnabled: boolean;
+}> = ({ isAdmin, kibanaUIsEnabled }) => {
+  const isblockingRoutes = isAdmin && !kibanaUIsEnabled;
+  return !isblockingRoutes ? (
+    <Routes>
+      <Route exact path="/">
+        <Overview />
+      </Route>
+      <Route path={SETUP_GUIDE_PATH}>
+        <SetupGuide />
+      </Route>
+      <Route path={SOURCE_ADDED_PATH}>
+        <SourceAdded />
+      </Route>
+      <Route path={PERSONAL_PATH}>
+        <Routes>
+          <Redirect exact from={PERSONAL_PATH} to={PRIVATE_SOURCES_PATH} />
+          <Route path={PRIVATE_SOURCES_PATH}>
+            <SourcesRouter />
+          </Route>
+          <Route path={PERSONAL_SETTINGS_PATH}>
+            <AccountSettings />
+          </Route>
+          <Route path={OAUTH_AUTHORIZE_PATH}>
+            <OAuthAuthorize />
+          </Route>
+          <Route path={SEARCH_AUTHORIZE_PATH}>
+            <SearchAuthorize />
+          </Route>
+          <Route>
+            <NotFound isOrganization={false} />
+          </Route>
+        </Routes>
+      </Route>
+      <Route path={SOURCES_PATH}>
+        <SourcesRouter />
+      </Route>
+      <Route path={GROUPS_PATH}>
+        <GroupsRouter />
+      </Route>
+      <Route path={USERS_AND_ROLES_PATH}>
+        <RoleMappings />
+      </Route>
+      <Route path={API_KEYS_PATH}>
+        <ApiKeys />
+      </Route>
+      <Route path={SECURITY_PATH}>
+        <Security />
+      </Route>
+      <Route path={ORG_SETTINGS_PATH}>
+        <SettingsRouter />
+      </Route>
+      <Route>
+        <NotFound />
+      </Route>
+    </Routes>
+  ) : (
+    <Routes>
+      <Route exact path="/">
+        <Overview />
+      </Route>
+      <Route>
+        <NotFound />
+      </Route>
+    </Routes>
+  );
+};
 export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
   const {
     hasInitialized,
     organization: { kibanaUIsEnabled },
+    account: { isAdmin },
   } = useValues(AppLogic);
   const { initializeAppData, setContext } = useActions(AppLogic);
   const { renderHeaderActions, setChromeIsVisible } = useValues(KibanaLogic);
@@ -100,65 +170,13 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
     }
   }, [hasInitialized]);
 
-  return (
-    <Routes>
-      <Route exact path="/">
-        <Overview />
-      </Route>
-      {kibanaUIsEnabled && (
-        <>
-          <Route path={SETUP_GUIDE_PATH}>
-            <SetupGuide />
-          </Route>
-          <Route path={SOURCE_ADDED_PATH}>
-            <SourceAdded />
-          </Route>
-          <Route path={PERSONAL_PATH}>
-            <Routes>
-              <Redirect exact from={PERSONAL_PATH} to={PRIVATE_SOURCES_PATH} />
-              <Route path={PRIVATE_SOURCES_PATH}>
-                <SourcesRouter />
-              </Route>
-              <Route path={PERSONAL_SETTINGS_PATH}>
-                <AccountSettings />
-              </Route>
-              <Route path={OAUTH_AUTHORIZE_PATH}>
-                <OAuthAuthorize />
-              </Route>
-              <Route path={SEARCH_AUTHORIZE_PATH}>
-                <SearchAuthorize />
-              </Route>
-              <Route>
-                <NotFound isOrganization={false} />
-              </Route>
-            </Routes>
-          </Route>
-          <Route path={SOURCES_PATH}>
-            <SourcesRouter />
-          </Route>
-          <Route path={GROUPS_PATH}>
-            <GroupsRouter />
-          </Route>
-          <Route path={USERS_AND_ROLES_PATH}>
-            <RoleMappings />
-          </Route>
-          <Route path={API_KEYS_PATH}>
-            <ApiKeys />
-          </Route>
-          <Route path={SECURITY_PATH}>
-            <Security />
-          </Route>
-          <Route path={ORG_SETTINGS_PATH}>
-            <SettingsRouter />
-          </Route>
-        </>
-      )}
+  // return isAdmin && !kibanaUIsEnabled ? (
+  //   <WorkplaceSearchConfiguredRoutes isblockingRoutes />
+  // ) : (
+  //   <WorkplaceSearchConfiguredRoutes isblockingRoutes={false} />
+  // );
 
-      <Route>
-        <NotFound />
-      </Route>
-    </Routes>
-  );
+  return <WorkplaceSearchConfiguredRoutes isAdmin={isAdmin} kibanaUIsEnabled={kibanaUIsEnabled} />;
 };
 
 export const WorkplaceSearchUnconfigured: React.FC = () => (

--- a/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/workplace_search/index.tsx
@@ -170,12 +170,6 @@ export const WorkplaceSearchConfigured: React.FC<InitialAppData> = (props) => {
     }
   }, [hasInitialized]);
 
-  // return isAdmin && !kibanaUIsEnabled ? (
-  //   <WorkplaceSearchConfiguredRoutes isblockingRoutes />
-  // ) : (
-  //   <WorkplaceSearchConfiguredRoutes isblockingRoutes={false} />
-  // );
-
   return <WorkplaceSearchConfiguredRoutes isAdmin={isAdmin} kibanaUIsEnabled={kibanaUIsEnabled} />;
 };
 


### PR DESCRIPTION
## Summary

This PR fixes issue with non-admin user not able access WS personal path routes(`/p/`) routes when `kibana_uis_enabled` is `false`. 

The gated form will only be accessible when  `kibana_uis_enabled =  false`  and `isAdmin == true`

In other cases all routes are accessible by all users. 
### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


