### PR TITLE
[Security Solution] Increassing parallelism for Serverless Investigations execution

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -87,7 +87,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 40
-    parallelism: 6
+    parallelism: 4
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -87,7 +87,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 40
-    parallelism: 2
+    parallelism: 6
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary

Lately we have been added more tests to the `Serverless Investigations Cypress execution`:

* https://github.com/elastic/kibana/pull/167513
* https://github.com/elastic/kibana/pull/167512 

Looks like the current number of parallelism is not enough since we are starting to see timeouts on the executions:

![image](https://github.com/elastic/kibana/assets/17427073/61c4c048-0400-4cdb-9672-3a6f071f92cd)

In this PR we are increasing that number to try to solve the timeout issues.