### PR TITLE
[Dashboard] Fix flaky pluggable actions test

### DIFF
--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -426,7 +426,6 @@ export class DashboardPageObject extends FtrService {
     await this.header.clickVisualize();
     await this.visualize.gotoLandingPage();
     await this.navigateToAppFromAppsMenu();
-    await this.header.waitUntilLoadingHasFinished();
     await this.gotoDashboardLandingPage();
   }
 

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -425,7 +425,8 @@ export class DashboardPageObject extends FtrService {
   public async clearSavedObjectsFromAppLinks() {
     await this.header.clickVisualize();
     await this.visualize.gotoLandingPage();
-    await this.header.clickDashboard();
+    await this.navigateToAppFromAppsMenu();
+    await this.header.waitUntilLoadingHasFinished();
     await this.gotoDashboardLandingPage();
   }
 

--- a/test/functional/page_objects/header_page.ts
+++ b/test/functional/page_objects/header_page.ts
@@ -15,7 +15,6 @@ export class HeaderPageObject extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly appsMenu = this.ctx.getService('appsMenu');
   private readonly common = this.ctx.getPageObject('common');
-  private readonly screenshot = this.ctx.getService('screenshots');
 
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
 
@@ -37,15 +36,11 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async clickDashboard() {
-    await this.retry.try(async () => {
-      await this.appsMenu.clickLink('Dashboard', { category: 'kibana' });
-    });
-    await this.screenshot.take('some-test-screenshot');
+    await this.appsMenu.clickLink('Dashboard', { category: 'kibana' });
     await this.retry.waitFor('dashboard app to be loaded', async () => {
       const isNavVisible = await this.testSubjects.exists('top-nav');
-      const isBreadcrumbVisible = await this.testSubjects.exists('~dashboardListingBreadcrumb');
       const isLandingPageVisible = await this.testSubjects.exists('dashboardLandingPage');
-      return isNavVisible && (isBreadcrumbVisible || isLandingPageVisible);
+      return isNavVisible || isLandingPageVisible;
     });
     await this.awaitGlobalLoadingIndicatorHidden();
   }

--- a/test/functional/page_objects/header_page.ts
+++ b/test/functional/page_objects/header_page.ts
@@ -15,6 +15,7 @@ export class HeaderPageObject extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
   private readonly appsMenu = this.ctx.getService('appsMenu');
   private readonly common = this.ctx.getPageObject('common');
+  private readonly screenshot = this.ctx.getService('screenshots');
 
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
 
@@ -36,11 +37,15 @@ export class HeaderPageObject extends FtrService {
   }
 
   public async clickDashboard() {
-    await this.appsMenu.clickLink('Dashboard', { category: 'kibana' });
+    await this.retry.try(async () => {
+      await this.appsMenu.clickLink('Dashboard', { category: 'kibana' });
+    });
+    await this.screenshot.take('some-test-screenshot');
     await this.retry.waitFor('dashboard app to be loaded', async () => {
       const isNavVisible = await this.testSubjects.exists('top-nav');
+      const isBreadcrumbVisible = await this.testSubjects.exists('~dashboardListingBreadcrumb');
       const isLandingPageVisible = await this.testSubjects.exists('dashboardLandingPage');
-      return isNavVisible || isLandingPageVisible;
+      return isNavVisible && (isBreadcrumbVisible || isLandingPageVisible);
     });
     await this.awaitGlobalLoadingIndicatorHidden();
   }

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -47,7 +47,7 @@ export default function ({ getService, getPageObjects }) {
 
     after(async () => {
       await testSubjects.click('euiFlyoutCloseButton');
-      await testSubjects.missingOrFail('samplePanelActionFlyout');
+      await testSubjects.waitForDeleted('samplePanelActionFlyout');
     });
   });
 }

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -14,7 +14,7 @@ export default function ({ getService, getPageObjects }) {
   const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['dashboard']);
 
-  describe.only('Panel Actions', () => {
+  describe('Panel Actions', () => {
     before(async () => {
       await PageObjects.dashboard.loadSavedDashboard('few panels');
     });

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -13,7 +13,7 @@ export default function ({ getService, getPageObjects }) {
   const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['dashboard']);
 
-  describe('Panel Actions', () => {
+  describe.only('Panel Actions', () => {
     before(async () => {
       await PageObjects.dashboard.loadSavedDashboard('few panels');
     });
@@ -44,5 +44,10 @@ export default function ({ getService, getPageObjects }) {
       await testSubjects.existOrFail('samplePanelActionTitle');
       await testSubjects.existOrFail('samplePanelActionBody');
     });
+
+    // after(async () => {
+    //   await testSubjects.click('euiFlyoutCloseButton');
+    //   await testSubjects.missingOrFail('samplePanelActionFlyout');
+    // });
   });
 }

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -10,6 +10,7 @@ import expect from '@kbn/expect';
 
 export default function ({ getService, getPageObjects }) {
   const dashboardPanelActions = getService('dashboardPanelActions');
+  const retry = getService('retry');
   const testSubjects = getService('testSubjects');
   const PageObjects = getPageObjects(['dashboard']);
 
@@ -46,8 +47,10 @@ export default function ({ getService, getPageObjects }) {
     });
 
     after(async () => {
-      await testSubjects.click('euiFlyoutCloseButton');
-      await testSubjects.waitForDeleted('samplePanelActionFlyout');
+      await retry.try(async () => {
+        await testSubjects.click('euiFlyoutCloseButton');
+        await testSubjects.missingOrFail('samplePanelActionFlyout');
+      });
     });
   });
 }

--- a/test/plugin_functional/test_suites/panel_actions/panel_actions.js
+++ b/test/plugin_functional/test_suites/panel_actions/panel_actions.js
@@ -45,9 +45,9 @@ export default function ({ getService, getPageObjects }) {
       await testSubjects.existOrFail('samplePanelActionBody');
     });
 
-    // after(async () => {
-    //   await testSubjects.click('euiFlyoutCloseButton');
-    //   await testSubjects.missingOrFail('samplePanelActionFlyout');
-    // });
+    after(async () => {
+      await testSubjects.click('euiFlyoutCloseButton');
+      await testSubjects.missingOrFail('samplePanelActionFlyout');
+    });
   });
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/136460

## Summary

Similar to https://github.com/elastic/kibana/pull/167836, navigation through `header.clickDashboard()` was flaky in the attached test because the same `data-test-subj` was re-used for both the application-specific top navigation **and** the reusable application listing page component:

https://github.com/elastic/kibana/blob/8b6ba3d15ff18de07d32ab2302bf9e18844ce25c/src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx#L120-L124

https://github.com/elastic/kibana/blob/8b6ba3d15ff18de07d32ab2302bf9e18844ce25c/packages/content-management/table_list_view/src/table_list_view.tsx#L91-L96

This meant that, when the referenced flaky test tried to navigate from the Visualization listing page to the dashboard app in `clearSavedObjectsFromAppLinks` via the header page object's `clickDashboard` method, it wasn't actually waiting to navigate to the dashboard app because it detected the `top-nav` data test subject from the **visualization** listing page **and not** from the dashboard app.

Therefore, instead of navigating through the `header` method, I switched to the new `navigateToAppFromAppsMenu`, which relies on the URL to update to ensure navigation has occured rather than the `top-nav` data test subject. I also added logic to close the flyout as part of the test cleanup, since it was remaining open even after navigating to the Visualizations listing page, which was getting in the way of the failure screenshot.


### Flaky Test Runner

- Without closing of flyout: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3323 

   ![image](https://github.com/elastic/kibana/assets/8698078/628f0da9-1e2a-45a9-b58b-dab92e345118)

- With closing of flyout: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3336
    
    ![image](https://github.com/elastic/kibana/assets/8698078/3456db1a-9cee-4db9-a28d-4c0d1520a5ec)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->