### PR TITLE
[ci] Synchronize serverless tests between pipelines

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -50,7 +50,7 @@ steps:
         agents:
           queue: n2-4-spot
         depends_on: build
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         parallelism: 2
         retry:
           automatic:
@@ -74,8 +74,8 @@ steps:
         agents:
           queue: n2-4-spot
         depends_on: build
-        timeout_in_minutes: 120
-        parallelism: 2
+        timeout_in_minutes: 60
+        parallelism: 4
         retry:
           automatic:
             - exit_status: '*'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -84,7 +84,7 @@ steps:
     agents:
       queue: n2-4-spot
     depends_on: build
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     parallelism: 2
     retry:
       automatic:
@@ -108,8 +108,8 @@ steps:
     agents:
       queue: n2-4-spot
     depends_on: build
-    timeout_in_minutes: 120
-    parallelism: 2
+    timeout_in_minutes: 60
+    parallelism: 4
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -99,7 +99,7 @@ steps:
   #   agents:
   #     queue: n2-4-spot
   #   depends_on: build
-  #   timeout_in_minutes: 40
+  #   timeout_in_minutes: 60
   #   retry:
   #     automatic:
   #       - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -62,8 +62,32 @@ steps:
     agents:
       queue: n2-4-spot
     depends_on: build
-    timeout_in_minutes: 40
+    timeout_in_minutes: 60
     parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
+    label: 'Serverless Explore - Security Solution Cypress Tests'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 60
+    parallelism: 2
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
+    label: 'Serverless Investigations - Security Solution Cypress Tests'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 60
+    parallelism: 4
     retry:
       automatic:
         - exit_status: '*'
@@ -80,30 +104,6 @@ steps:
   #     automatic:
   #       - exit_status: '*'
   #         limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_investigations.sh
-    label: 'Serverless Security Investigations Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 40
-    parallelism: 4
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_explore.sh
-    label: 'Serverless Security Explore Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 40
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
 
   - command: .buildkite/scripts/steps/lint.sh
     label: 'Linting'


### PR DESCRIPTION
We're running serverless cypress tests in three locations

1) on-merge
2) pull requests
3) verifying the latest elasticsearch snapshot

These have diverged slightly, causing a small issue where we missed timeouts in pull requests due to a longer timeout in on-merge (which triggers our notifications).

Timeouts are all set to 60 minutes.  Target time is 40 minutes, with a 20 minute buffer that we can use to increase the parallelism as needed.