### PR TITLE
[DOCS] Remove a-data-source shared attribute

### DIFF
--- a/docs/api/saved-objects/bulk_create.asciidoc
+++ b/docs/api/saved-objects/bulk_create.asciidoc
@@ -80,7 +80,7 @@ Saved objects that are unable to persist are replaced with an error object.
 [[saved-objects-api-bulk-create-example]]
 ==== Example
 
-Create {a-data-source} with the `my-pattern` ID, and a dashboard with the `my-dashboard` ID:
+Create a {data-source} with the `my-pattern` ID, and a dashboard with the `my-dashboard` ID:
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/saved-objects/delete.asciidoc
+++ b/docs/api/saved-objects/delete.asciidoc
@@ -51,7 +51,7 @@ TIP: Use this if you attempted to delete an object and received an HTTP 400 erro
 
 ==== Example
 
-Delete {a-data-source} object with the `my-pattern` ID:
+Delete a {data-source} object with the `my-pattern` ID:
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/saved-objects/import.asciidoc
+++ b/docs/api/saved-objects/import.asciidoc
@@ -107,7 +107,7 @@ to resolve errors, refer to the <<saved-objects-api-import-example,examples>>.
 [[saved-objects-api-import-example-1]]
 ===== Successful import with `createNewCopies` enabled
 
-Import {a-data-source} and dashboard:
+Import a {data-source} and dashboard:
 
 [source,sh]
 --------------------------------------------------
@@ -159,7 +159,7 @@ The result indicates a successful import, and both objects are created. Since th
 [[saved-objects-api-import-example-2]]
 ===== Successful import with `createNewCopies` disabled
 
-Import {a-data-source} and dashboard:
+Import a {data-source} and dashboard:
 
 [source,sh]
 --------------------------------------------------
@@ -208,7 +208,7 @@ The result indicates a successful import, and both objects are created.
 [[saved-objects-api-import-example-3]]
 ===== Failed import with conflict errors
 
-Import {a-data-source}, visualization, *Canvas* workpad, and dashboard that include saved objects:
+Import a {data-source}, visualization, *Canvas* workpad, and dashboard that include saved objects:
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/saved-objects/resolve_import_errors.asciidoc
+++ b/docs/api/saved-objects/resolve_import_errors.asciidoc
@@ -111,7 +111,7 @@ to the <<saved-objects-api-resolve-import-errors-example, examples>>.
 
 This example builds upon the <<saved-objects-api-import-example-3,Import objects API example with conflict errors>>.
 
-Resolve conflict errors for {a-data-source}, visualization, and *Canvas* workpad by overwriting the existing saved objects:
+Resolve conflict errors for a {data-source}, visualization, and *Canvas* workpad by overwriting the existing saved objects:
 
 [source,sh]
 --------------------------------------------------

--- a/docs/api/spaces-management/copy_saved_objects.asciidoc
+++ b/docs/api/spaces-management/copy_saved_objects.asciidoc
@@ -140,7 +140,7 @@ refer to the <<spaces-api-copy-saved-objects-example,examples>>.
 ===== Successful copy (with `createNewCopies` enabled)
 
 Copy a dashboard with the `my-dashboard` ID, including all references from the `default` space to the `marketing` space. In this example,
-the dashboard has a reference to a visualization, and that has a reference to {a-data-source}:
+the dashboard has a reference to a visualization, and that has a reference to a {data-source}:
 
 [source,sh]
 ----
@@ -204,7 +204,7 @@ The result indicates a successful copy, and all three objects are created. Since
 ===== Successful copy (with `createNewCopies` disabled)
 
 Copy a dashboard with the `my-dashboard` ID, including all references from the `default` space to the `marketing` space. In this example,
-the dashboard has a reference to a visualization, and that has a reference to {a-data-source}:
+the dashboard has a reference to a visualization, and that has a reference to a {data-source}:
 
 [source,sh]
 ----
@@ -418,7 +418,7 @@ API>>.
 ===== Failed copy (with missing reference errors)
 
 Copy a dashboard with the `my-dashboard` ID, including all references from the `default` space to the `marketing` space. In this example,
-the dashboard has a reference to a visualization and a *Canvas* workpad, and the visualization has a reference to {a-data-source}:
+the dashboard has a reference to a visualization and a *Canvas* workpad, and the visualization has a reference to a {data-source}:
 
 [source,sh]
 ----

--- a/docs/api/spaces-management/resolve_copy_saved_objects_conflicts.asciidoc
+++ b/docs/api/spaces-management/resolve_copy_saved_objects_conflicts.asciidoc
@@ -141,7 +141,7 @@ refer to the <<spaces-api-resolve-copy-saved-objects-conflicts-example,examples>
 
 This example builds upon the <<spaces-api-copy-saved-objects-example-3,Copy objects API example with conflict errors>>.
 
-Resolve conflict errors for {a-data-source}, visualization, and *Canvas* workpad by overwriting the existing saved objects:
+Resolve conflict errors for a {data-source}, visualization, and *Canvas* workpad by overwriting the existing saved objects:
 
 [source,sh]
 ----

--- a/docs/user/dashboard/timelion.asciidoc
+++ b/docs/user/dashboard/timelion.asciidoc
@@ -32,7 +32,7 @@ The fist parameter of the .es function is the parameter q (for query), which is 
 .es(*)
 .es(q=*)
 
-Multiple parameters are separated by a comma. The .es function has another parameter called index, that can be used to specify {a-data-source} for this series, so the query won't be executed against all indexes (or whatever you changed the setting to).
+Multiple parameters are separated by a comma. The .es function has another parameter called index, that can be used to specify a {data-source} for this series, so the query won't be executed against all indexes (or whatever you changed the setting to).
 
 .es(q=*, index=logstash-*)
 

--- a/docs/user/dashboard/vega.asciidoc
+++ b/docs/user/dashboard/vega.asciidoc
@@ -10,7 +10,7 @@ URL, or static data, and support <<reference-for-kibana-extensions,{kib} extensi
 Use *Vega* or *Vega-Lite* when you want to create visualizations with:
 
 * Aggregations that use `nested` or `parent/child` mapping
-* Aggregations without {a-data-source}
+* Aggregations without a {data-source}
 * Queries that use custom time filters
 * Complex calculations
 * Extracted data from _source instead of aggregations


### PR DESCRIPTION
## Summary

This PR removes the use of the "a-data-source" shared attribute as part of simplifying the variables that we carry forward into serverless docs.