### PR TITLE
[Uptime] Revert migration to remove synthetics-* pattern

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -153,7 +153,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "ui-metric": "d227284528fd19904e9d972aea0a13716fc5fe24",
         "upgrade-assistant-ml-upgrade-operation": "421f52731cb24e242d70672ba4725e169277efb3",
         "upgrade-assistant-reindex-operation": "01f3c3e051659ace56492a73928987e717537a93",
-        "uptime-dynamic-settings": "b6756ff71d6b5258971b1c8fd433d167affbde52",
+        "uptime-dynamic-settings": "a9e9c42d8c1b6643946f32558478b274de0f89e0",
         "uptime-synthetics-api-key": "7ae976a461248f9dbd8442af14a179bdbc229eca",
         "url": "c923a4a5002a09c0080c9095e958f07d518e6704",
         "usage-counters": "48782b3bcb6b5a23ba6f2bfe3a380d835e68890a",

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/migrations.test.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/migrations.test.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { add820Indices, remove890Indices } from './migrations';
+import { add820Indices } from './migrations';
 import { SavedObject, SavedObjectMigrationContext } from '@kbn/core/server';
 import { DynamicSettingsAttributes } from '../../../runtime_types/settings';
 
@@ -87,80 +87,6 @@ describe('add820Indices migration', () => {
       attributes: {
         ...doc.attributes,
         heartbeatIndices: 'synthetics-*,heartbeat-8*',
-      },
-    });
-  });
-});
-
-describe('remove890Indices migration', () => {
-  const context = { log: { warning: () => {} } } as unknown as SavedObjectMigrationContext;
-
-  const makeSettings = (heartbeatIndices: string): SavedObject<DynamicSettingsAttributes> => {
-    return {
-      id: '1',
-      type: 't',
-      references: [],
-      attributes: {
-        heartbeatIndices,
-        certAgeThreshold: 1,
-        certExpirationThreshold: 2,
-        defaultConnectors: ['example'],
-      },
-    };
-  };
-
-  it("removes the synthetics-* index if it's in the indices settings", () => {
-    const doc = makeSettings('heartbeat-8*,synthetics-*,something_else');
-    const result = remove890Indices(doc, context);
-    expect(result).toEqual({
-      ...doc,
-      attributes: {
-        ...doc.attributes,
-        heartbeatIndices: 'heartbeat-8*,something_else',
-        syntheticsIndexRemoved: true,
-      },
-    });
-  });
-
-  it("adds the heartbeat-8* index if it's not in the indices settings", () => {
-    const doc = makeSettings('synthetics-*,something_else');
-    const result = remove890Indices(doc, context);
-    expect(result).toEqual({
-      ...doc,
-      attributes: {
-        ...doc.attributes,
-        heartbeatIndices: 'something_else,heartbeat-8*',
-        syntheticsIndexRemoved: true,
-      },
-    });
-  });
-
-  it('works for empty heartbeat indices fields', () => {
-    const doc = makeSettings('');
-    const result = remove890Indices(doc, context);
-    expect(result).toEqual({
-      ...doc,
-      attributes: {
-        ...doc.attributes,
-        heartbeatIndices: 'heartbeat-8*',
-      },
-    });
-  });
-
-  it('works for undefined heartbeat indices fields', () => {
-    const doc = makeSettings('');
-
-    // We must TS ignore this so that we can delete this
-    // non-optional field and test that the migration still works
-    // when the field does not exist in the document
-    // @ts-expect-error
-    delete doc.attributes.heartbeatIndices;
-    const result = remove890Indices(doc, context);
-    expect(result).toEqual({
-      ...doc,
-      attributes: {
-        ...doc.attributes,
-        heartbeatIndices: 'heartbeat-8*',
       },
     });
   });

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/migrations.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/migrations.ts
@@ -34,33 +34,3 @@ export const add820Indices: SavedObjectMigrationFn<
 
   return migratedObj;
 };
-
-export const remove890Indices: SavedObjectMigrationFn<
-  DynamicSettingsAttributes,
-  DynamicSettingsAttributes
-> = (doc) => {
-  const heartbeatIndices = doc.attributes?.heartbeatIndices;
-
-  const indicesArr = !heartbeatIndices ? [] : heartbeatIndices.split(',');
-
-  // remove synthetics-* from the array
-  const indexToRemove = indicesArr.indexOf('synthetics-*');
-  if (indexToRemove > -1) {
-    indicesArr.splice(indexToRemove, 1);
-  }
-
-  if (!indicesArr.includes('heartbeat-8*')) {
-    indicesArr.push('heartbeat-8*');
-  }
-
-  const syntheticsIndexRemoved = indexToRemove > -1;
-
-  return {
-    ...doc,
-    attributes: {
-      ...doc.attributes,
-      heartbeatIndices: indicesArr.join(','),
-      ...(syntheticsIndexRemoved && { syntheticsIndexRemoved }),
-    },
-  };
-};

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/uptime_settings.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/saved_objects/uptime_settings.ts
@@ -7,7 +7,7 @@
 
 import { SavedObjectsType } from '@kbn/core/server';
 import { i18n } from '@kbn/i18n';
-import { add820Indices, remove890Indices } from './migrations';
+import { add820Indices } from './migrations';
 
 export const settingsObjectType = 'uptime-dynamic-settings';
 export const settingsObjectId = 'uptime-dynamic-settings-singleton';
@@ -48,6 +48,5 @@ export const umDynamicSettings: SavedObjectsType = {
   migrations: {
     // Takes a pre 8.2.0 doc, and converts it to 8.2.0
     '8.2.0': add820Indices,
-    '8.9.0': remove890Indices,
   },
 };


### PR DESCRIPTION
## Summary

Revert migration to remove synthetics-* pattern !!

We have been facing lot of sdhs and confusion because of this change. 


