### PR TITLE
Redact sensitive headers from KibanaRequest by default

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/cluster_client.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/cluster_client.ts
@@ -11,7 +11,7 @@ import type { Logger } from '@kbn/logging';
 import type { Headers, IAuthHeadersStorage } from '@kbn/core-http-server';
 import {
   ensureRawRequest,
-  filterHeaders,
+  pickHeaders,
   isKibanaRequest,
   isRealRequest,
 } from '@kbn/core-http-router-server-internal';
@@ -132,12 +132,12 @@ export class ClusterClient implements ICustomClusterClient {
       const authHeaders = this.authHeaders ? this.authHeaders.get(request) : {};
 
       scopedHeaders = {
-        ...filterHeaders(requestHeaders, this.config.requestHeadersWhitelist),
+        ...pickHeaders(requestHeaders, this.config.requestHeadersWhitelist),
         ...requestIdHeaders,
         ...authHeaders,
       };
     } else {
-      scopedHeaders = filterHeaders(request?.headers ?? {}, this.config.requestHeadersWhitelist);
+      scopedHeaders = pickHeaders(request?.headers ?? {}, this.config.requestHeadersWhitelist);
     }
 
     return {

--- a/packages/core/http/core-http-router-server-internal/index.ts
+++ b/packages/core/http/core-http-router-server-internal/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export { filterHeaders } from './src/headers';
+export { pickHeaders } from './src/headers';
 export { Router, type RouterOptions } from './src/router';
 export type { HandlerResolutionStrategy } from './src/versioned_router';
 export { isKibanaRequest, isRealRequest, ensureRawRequest, CoreKibanaRequest } from './src/request';

--- a/packages/core/http/core-http-router-server-internal/src/headers.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/headers.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { redactSensitiveHeaders } from './headers';
+
+describe('redactSensitiveHeaders', () => {
+  it('returns empty object when headers are undefined', () => {
+    expect(redactSensitiveHeaders()).toEqual({});
+  });
+
+  it('returns a shallow clone of headers without redacting', () => {
+    const headers = {
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'abc123',
+      'x-empty-header': '',
+    };
+    expect(redactSensitiveHeaders(headers)).toEqual(headers);
+    expect(redactSensitiveHeaders(headers)).not.toBe(headers);
+  });
+
+  it('redacts sensitive headers', () => {
+    const headers = {
+      Authorization: 'Basic dXNlcjpwYXNzd29yZA==',
+      Cookie: 'session=1234',
+      'x-custom-header': 'abc',
+      'x-empty-header': '',
+    };
+
+    const expected = {
+      Authorization: '[REDACTED]',
+      Cookie: '[REDACTED]',
+      'x-custom-header': 'abc',
+      'x-empty-header': '',
+    };
+
+    expect(redactSensitiveHeaders(headers)).toEqual(expected);
+  });
+
+  it('handles headers with array values', () => {
+    const headers = {
+      'Set-Cookie': ['cookie1=value1', 'cookie2=value2'],
+    };
+
+    const expected = {
+      'Set-Cookie': ['[REDACTED]', '[REDACTED]'],
+    };
+
+    expect(redactSensitiveHeaders(headers)).toEqual(expected);
+  });
+});

--- a/packages/core/http/core-http-router-server-internal/src/headers.ts
+++ b/packages/core/http/core-http-router-server-internal/src/headers.ts
@@ -8,19 +8,50 @@
 
 import type { Headers } from '@kbn/core-http-server';
 import { pick } from '@kbn/std';
+import { IncomingHttpHeaders } from 'http';
 
-const normalizeHeaderField = (field: string) => field.trim().toLowerCase();
+const SENSITIVE_HEADERS = [
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-elastic-app-auth',
+  'es-client-authentication',
+];
+const REDACTED_HEADER_TEXT = '[REDACTED]';
+const normalizeHeaderField = (field: string) => (field ?? '').trim().toLowerCase();
 
-export function filterHeaders(
-  headers: Headers,
-  fieldsToKeep: string[],
-  fieldsToExclude: string[] = []
-): Headers {
-  const fieldsToExcludeNormalized = fieldsToExclude.map(normalizeHeaderField);
-  // Normalize list of headers we want to allow in upstream request
-  const fieldsToKeepNormalized = fieldsToKeep
-    .map(normalizeHeaderField)
-    .filter((name) => !fieldsToExcludeNormalized.includes(name));
+/**
+ * Given a header name and value, returns the value if the header is not sensitive,
+ * otherwise returns a redacted value.
+ */
+function redactIfSensitiveHeader(
+  header: string,
+  value?: string | string[]
+): undefined | string | string[] {
+  return SENSITIVE_HEADERS.includes(normalizeHeaderField(header))
+    ? Array.isArray(value)
+      ? value.map(() => REDACTED_HEADER_TEXT)
+      : REDACTED_HEADER_TEXT
+    : value;
+}
 
-  return pick(headers, fieldsToKeepNormalized);
+/**
+ * Given an object of headers, returns a cloned object with the sensitive headers redacted.
+ */
+export function redactSensitiveHeaders(headers?: Headers): Headers {
+  // Shallow clone the headers so we don't mutate the original.
+  const result = {} as IncomingHttpHeaders;
+  if (headers) {
+    for (const key of Object.keys(headers)) {
+      result[key] = redactIfSensitiveHeader(key, headers[key]);
+    }
+  }
+  return result;
+}
+
+export function pickHeaders(headers: Headers, headersToKeep: string[]): Headers {
+  // Normalize list of headers we want to allow
+  const headersToKeepNormalized = headersToKeep.map(normalizeHeaderField);
+
+  return pick(headers, headersToKeepNormalized);
 }

--- a/packages/core/http/core-http-router-server-internal/src/request.test.ts
+++ b/packages/core/http/core-http-router-server-internal/src/request.test.ts
@@ -78,16 +78,6 @@ describe('CoreKibanaRequest', () => {
       });
     });
 
-    describe('get all headers', () => {
-      it('returns all headers', () => {
-        const request = hapiMocks.createRequest({
-          headers: { custom: 'one', authorization: 'token' },
-        });
-        const kibanaRequest = CoreKibanaRequest.from(request);
-        expect(kibanaRequest.headers).toEqual({ custom: 'one', authorization: 'token' });
-      });
-    });
-
     describe('headers property', () => {
       it('provides a frozen copy of request headers', () => {
         const rawRequestHeaders = { custom: 'one' };
@@ -101,12 +91,13 @@ describe('CoreKibanaRequest', () => {
         expect(Object.isFrozen(kibanaRequest.headers)).toBe(true);
       });
 
-      it.skip("doesn't expose authorization header by default", () => {
+      it("doesn't expose authorization header by default", () => {
         const request = hapiMocks.createRequest({
           headers: { custom: 'one', authorization: 'token' },
         });
         const kibanaRequest = CoreKibanaRequest.from(request);
         expect(kibanaRequest.headers).toEqual({
+          authorization: '[REDACTED]',
           custom: 'one',
         });
       });

--- a/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
+++ b/packages/core/http/core-http-router-server-mocks/src/router.mock.ts
@@ -113,7 +113,8 @@ function createKibanaRequestMock<P = any, Q = any, B = any>({
       params: validation.params || schema.any(),
       body: validation.body || schema.any(),
       query: validation.query || schema.any(),
-    }
+    },
+    false
   );
 }
 

--- a/packages/core/http/core-http-server/src/router/request.ts
+++ b/packages/core/http/core-http-server/src/router/request.ts
@@ -119,7 +119,7 @@ export interface KibanaRequest<
   /**
    * Readonly copy of incoming request headers.
    * @remarks
-   * This property will contain a `filtered` copy of request headers.
+   * This property will contain a `redacted` copy of request headers.
    */
   readonly headers: Headers;
 

--- a/x-pack/plugins/actions/server/lib/task_runner_factory.ts
+++ b/x-pack/plugins/actions/server/lib/task_runner_factory.ts
@@ -272,7 +272,7 @@ function getFakeRequest(apiKey?: string) {
 
   // Since we're using API keys and accessing elasticsearch can only be done
   // via a request, we're faking one with the proper authorization headers.
-  return CoreKibanaRequest.from(fakeRawRequest);
+  return CoreKibanaRequest.from(fakeRawRequest, undefined, false);
 }
 
 async function getActionTaskParams(

--- a/x-pack/plugins/alerting/server/task_runner/rule_loader.ts
+++ b/x-pack/plugins/alerting/server/task_runner/rule_loader.ts
@@ -157,7 +157,7 @@ export function getFakeKibanaRequest(
     path: '/',
   };
 
-  const fakeRequest = CoreKibanaRequest.from(fakeRawRequest);
+  const fakeRequest = CoreKibanaRequest.from(fakeRawRequest, undefined, false);
   context.basePathService.set(fakeRequest, path);
 
   return fakeRequest;

--- a/x-pack/plugins/fleet/server/services/api_keys/transform_api_keys.ts
+++ b/x-pack/plugins/fleet/server/services/api_keys/transform_api_keys.ts
@@ -43,7 +43,7 @@ function createKibanaRequestFromAuth(authorizationHeader: HTTPAuthorizationHeade
 
   // Since we're using API keys and accessing elasticsearch can only be done
   // via a request, we're faking one with the proper authorization headers.
-  const fakeRequest = CoreKibanaRequest.from(fakeRawRequest);
+  const fakeRequest = CoreKibanaRequest.from(fakeRawRequest, undefined, false);
 
   return fakeRequest;
 }

--- a/x-pack/plugins/reporting/server/export_types/common/export_type.ts
+++ b/x-pack/plugins/reporting/server/export_types/common/export_type.ts
@@ -111,7 +111,7 @@ export abstract class ExportType<
       headers,
       path: '/',
     };
-    const fakeRequest = CoreKibanaRequest.from(rawRequest);
+    const fakeRequest = CoreKibanaRequest.from(rawRequest, undefined, false);
 
     const spacesService = this.setupDeps.spaces?.spacesService;
     if (spacesService) {

--- a/x-pack/plugins/security/server/anonymous_access/anonymous_access_service.ts
+++ b/x-pack/plugins/security/server/anonymous_access/anonymous_access_service.ts
@@ -175,6 +175,6 @@ export class AnonymousAccessService {
       auth: { isAuthenticated: authenticateRequest },
       path: '/',
     };
-    return CoreKibanaRequest.from(fakeRawRequest);
+    return CoreKibanaRequest.from(fakeRawRequest, undefined, false);
   }
 }

--- a/x-pack/plugins/security/server/authentication/api_keys/fake_kibana_request.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/fake_kibana_request.ts
@@ -20,5 +20,5 @@ export function getFakeKibanaRequest(apiKey: { id: string; api_key: string }) {
     path: '/',
   };
 
-  return CoreKibanaRequest.from(fakeRawRequest);
+  return CoreKibanaRequest.from(fakeRawRequest, undefined, false);
 }

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.ts
@@ -44,7 +44,7 @@ const buildFakeScopedRequest = ({
     path: '/',
   };
 
-  const request = CoreKibanaRequest.from(rawRequest);
+  const request = CoreKibanaRequest.from(rawRequest, undefined, false);
   const scopedPath = addSpaceIdToPath('/', namespace);
 
   coreStart.http.basePath.set(request, scopedPath);

--- a/x-pack/plugins/synthetics/server/synthetics_service/utils/fake_kibana_request.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/utils/fake_kibana_request.ts
@@ -20,5 +20,5 @@ export function getFakeKibanaRequest(apiKey: { id: string; api_key: string }) {
     path: '/',
   };
 
-  return CoreKibanaRequest.from(fakeRawRequest);
+  return CoreKibanaRequest.from(fakeRawRequest, undefined, false);
 }


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/166844


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
