### PR TITLE
[Security Solution] Skipping just the problematic tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
@@ -110,7 +110,7 @@ const assertFilterControlsWithFilterObject = (
 
 // Failing: See https://github.com/elastic/kibana/issues/167914
 // Failing: See https://github.com/elastic/kibana/issues/167915
-describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@serverless'] }, () => {
+describe(`Detections : Page Filters`, { tags: ['@ess', '@brokenInServerless'] }, () => {
   before(() => {
     cleanKibana();
     createRule(getNewRule({ rule_id: 'custom_rule_filters' }));


### PR DESCRIPTION
## Summary

In this PR we enabled several tests for serverless first-quality gate execution: https://github.com/elastic/kibana/pull/167513

One of those tests was `detection_page_filters.cy.ts` what was creating several timeouts during the serverless execution.

* https://github.com/elastic/kibana/issues/167915
* https://github.com/elastic/kibana/issues/167914

In order to unblock people, kibana operations skipped the whole spec by using `.skip` instead of our tags what skips the tests for the both executions. 

In this PR we are enabling the tests back on ESS but keep it skipped in serverless after the root cause of the issue is investigated.


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->