### PR TITLE
[EDR Workflows] Use internal user to fetch automated actions and results

### DIFF
--- a/x-pack/plugins/security_solution/common/search_strategy/endpoint/response_actions/types.ts
+++ b/x-pack/plugins/security_solution/common/search_strategy/endpoint/response_actions/types.ts
@@ -17,8 +17,7 @@ export enum SortOrder {
 }
 
 export interface RequestBasicOptions extends IEsSearchRequest {
-  factoryQueryType?: ResponseActionsQueries;
-  aggregations?: Record<string, estypes.AggregationsAggregationContainer>;
+  factoryQueryType: ResponseActionsQueries;
 }
 
 export type ResponseActionsSearchHit = estypes.SearchHit<

--- a/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
@@ -56,7 +56,7 @@ export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTyp
             ...('expiration' in request ? { expiration: request.expiration } : {}),
             ...('actionId' in request ? { actionId: request.actionId } : {}),
             ...('agents' in request ? { agents: request.agents } : {}),
-          };
+          } as EndpointStrategyRequestType<T>;
           const dsl = queryFactory.buildDsl(strictRequest, { authz });
 
           return es.search({ ...strictRequest, params: dsl }, options, deps).pipe(

--- a/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
@@ -8,7 +8,6 @@
 import { map, mergeMap } from 'rxjs/operators';
 import type { ISearchStrategy, PluginStart } from '@kbn/data-plugin/server';
 import { shimHitsTotal } from '@kbn/data-plugin/server';
-import { ENHANCED_ES_SEARCH_STRATEGY } from '@kbn/data-plugin/common';
 import { from } from 'rxjs';
 import type {
   EndpointStrategyParseResponseType,
@@ -37,9 +36,7 @@ export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTyp
   data: PluginStart,
   endpointContext: EndpointAppContext
 ): ISearchStrategy<EndpointStrategyRequestType<T>, EndpointStrategyResponseType<T>> => {
-  const es = data.search.getSearchStrategy(
-    ENHANCED_ES_SEARCH_STRATEGY
-  ) as unknown as ISearchStrategy<
+  const es = data.search.searchAsInternalUser as unknown as ISearchStrategy<
     EndpointStrategyRequestType<T>,
     EndpointStrategyParseResponseType<T>
   >;
@@ -51,8 +48,18 @@ export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTyp
       return from(endpointContext.service.getEndpointAuthz(deps.request)).pipe(
         mergeMap((authz) => {
           const queryFactory: EndpointFactory<T> = endpointFactory[request.factoryQueryType];
-          const dsl = queryFactory.buildDsl(request, { authz });
-          return es.search({ ...request, params: dsl }, options, deps).pipe(
+          const strictRequest = {
+            factoryQueryType: request.factoryQueryType,
+            sort: request.sort,
+            ...('alertIds' in request ? { alertIds: request.alertIds } : {}),
+            ...('agentId' in request ? { agentId: request.agentId } : {}),
+            ...('expiration' in request ? { expiration: request.expiration } : {}),
+            ...('actionId' in request ? { actionId: request.actionId } : {}),
+            ...('agents' in request ? { agents: request.agents } : {}),
+          };
+          const dsl = queryFactory.buildDsl(strictRequest, { authz });
+
+          return es.search({ ...strictRequest, params: dsl }, options, deps).pipe(
             map((response) => {
               return {
                 ...response,

--- a/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
+++ b/x-pack/plugins/security_solution/server/search_strategy/endpoint/index.ts
@@ -20,18 +20,6 @@ import type { EndpointFactory } from './factory/types';
 import type { EndpointAppContext } from '../../endpoint/types';
 import { endpointFactory } from './factory';
 
-function isObj(req: unknown): req is Record<string, unknown> {
-  return typeof req === 'object' && req !== null;
-}
-
-function assertValidRequestType<T extends EndpointFactoryQueryTypes>(
-  req: unknown
-): asserts req is EndpointStrategyRequestType<T> & { factoryQueryType: EndpointFactoryQueryTypes } {
-  if (!isObj(req) || req.factoryQueryType == null) {
-    throw new Error('factoryQueryType is required');
-  }
-}
-
 export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTypes>(
   data: PluginStart,
   endpointContext: EndpointAppContext
@@ -43,8 +31,9 @@ export const endpointSearchStrategyProvider = <T extends EndpointFactoryQueryTyp
 
   return {
     search: (request, options, deps) => {
-      assertValidRequestType<T>(request);
-
+      if (request.factoryQueryType == null) {
+        throw new Error('factoryQueryType is required');
+      }
       return from(endpointContext.service.getEndpointAuthz(deps.request)).pipe(
         mergeMap((authz) => {
           const queryFactory: EndpointFactory<T> = endpointFactory[request.factoryQueryType];


### PR DESCRIPTION
This is a quick fix to get access to .logs-osquery_manager* indices. More explained in the issue linked below.

We're aware that using internalUser is not preferred way, but this searchStrategy is only used in one place so should not affect any other functionalities than Automated response actions results. 

<!--ONMERGE {"backportTargets":["8.10","8.11"]} ONMERGE-->