### PR TITLE
unskip Failing test: Chrome X-Pack UI Functional Tests.x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value·ts

### DIFF
--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -21,7 +21,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const dashboardPanelActions = getService('dashboardPanelActions');
   const testSubjects = getService('testSubjects');
-  const appsMenu = getService('appsMenu');
   const dashboardAddPanel = getService('dashboardAddPanel');
   const kibanaServer = getService('kibanaServer');
 

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -60,7 +60,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       if (!saveToDashboard) {
-        await dashboard.navigateToAppFromAppsMenu();
+        await PageObjects.dashboard.navigateToAppFromAppsMenu();
       }
     } else {
       await PageObjects.maps.clickSaveAndReturnButton();

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -60,10 +60,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       });
 
       if (!saveToDashboard) {
-        await appsMenu.clickLink('Dashboard', {
-          category: 'kibana',
-          closeCollapsibleNav: true,
-        });
+        await dashboard.navigateToAppFromAppsMenu();
       }
     } else {
       await PageObjects.maps.clickSaveAndReturnButton();

--- a/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/dashboard_maps_by_value.ts
@@ -78,8 +78,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     await PageObjects.dashboard.clickNewDashboard();
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/152476
-  describe.skip('dashboard maps by value', function () {
+  describe('dashboard maps by value', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/152476

flaky test runner https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3343

Similar to https://github.com/elastic/kibana/pull/167836, test is failing because appsMenu.clickLink is not loading dashboard (see captured log messages from failure). Switching to navigateToAppFromAppsMenu to include retry logic.

<img width="500" alt="Screenshot 2023-10-04 at 9 45 46 AM" src="https://github.com/elastic/kibana/assets/373691/194c4f87-d6dd-4b59-b645-31e01776c7be">




<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->