### PR TITLE
[Lens] Fixes clickable timepicker in dashboards when inline editing is on

### DIFF
--- a/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
+++ b/x-pack/plugins/lens/public/trigger_actions/open_lens_config/helpers.scss
@@ -5,7 +5,7 @@
     padding-left: $euiFormMaxWidth;
     margin-left: -$euiFormMaxWidth;
     pointer-events: none;
-    > * {
+    .euiFlyoutFooter {
       pointer-events: auto;
     }
   }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/168014

![inline_editing](https://github.com/elastic/kibana/assets/17003240/86b9c3d5-d592-4027-920f-2f1f71f6b10e)



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->