### PR TITLE
[RAM] Fix alert summary by adding end time to untracked alerts

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -16,6 +16,10 @@ let logger: ReturnType<typeof loggingSystemMock['createLogger']>;
 
 describe('setAlertsToUntracked()', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+    const date = '2023-03-28T22:27:28.159Z';
+    jest.setSystemTime(new Date(date));
+
     logger = loggingSystemMock.createLogger();
     clusterClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
     clusterClient.search.mockResponse({
@@ -32,6 +36,11 @@ describe('setAlertsToUntracked()', () => {
       },
     });
   });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
   test('should call updateByQuery on provided ruleIds', async () => {
     await setAlertsToUntracked({
       logger,
@@ -83,12 +92,12 @@ describe('setAlertsToUntracked()', () => {
               "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
-        ctx._source.kibana.alert.end = '2023-10-04T18:40:49.459Z';
-        ctx._source.kibana.alert.time_range.lte = '2023-10-04T18:40:49.459Z';
+        ctx._source.kibana.alert.end = '2023-03-28T22:27:28.159Z';
+        ctx._source.kibana.alert.time_range.lte = '2023-03-28T22:27:28.159Z';
       } else {
         ctx._source['kibana.alert.status'] = 'untracked';
-        ctx._source['kibana.alert.end'] = '2023-10-04T18:40:49.459Z';
-        ctx._source['kibana.alert.time_range'].lte = '2023-10-04T18:40:49.459Z';
+        ctx._source['kibana.alert.end'] = '2023-03-28T22:27:28.159Z';
+        ctx._source['kibana.alert.time_range'].lte = '2023-03-28T22:27:28.159Z';
       }",
             },
           },
@@ -151,12 +160,12 @@ describe('setAlertsToUntracked()', () => {
               "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
-        ctx._source.kibana.alert.end = '2023-10-04T18:40:49.479Z';
-        ctx._source.kibana.alert.time_range.lte = '2023-10-04T18:40:49.479Z';
+        ctx._source.kibana.alert.end = '2023-03-28T22:27:28.159Z';
+        ctx._source.kibana.alert.time_range.lte = '2023-03-28T22:27:28.159Z';
       } else {
         ctx._source['kibana.alert.status'] = 'untracked';
-        ctx._source['kibana.alert.end'] = '2023-10-04T18:40:49.479Z';
-        ctx._source['kibana.alert.time_range'].lte = '2023-10-04T18:40:49.479Z';
+        ctx._source['kibana.alert.end'] = '2023-03-28T22:27:28.159Z';
+        ctx._source['kibana.alert.time_range'].lte = '2023-03-28T22:27:28.159Z';
       }",
             },
           },

--- a/x-pack/plugins/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/set_alerts_to_untracked.test.ts
@@ -83,8 +83,12 @@ describe('setAlertsToUntracked()', () => {
               "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
+        ctx._source.kibana.alert.end = '2023-10-04T18:40:49.459Z';
+        ctx._source.kibana.alert.time_range.lte = '2023-10-04T18:40:49.459Z';
       } else {
-        ctx._source['kibana.alert.status'] = 'untracked'
+        ctx._source['kibana.alert.status'] = 'untracked';
+        ctx._source['kibana.alert.end'] = '2023-10-04T18:40:49.459Z';
+        ctx._source['kibana.alert.time_range'].lte = '2023-10-04T18:40:49.459Z';
       }",
             },
           },
@@ -147,8 +151,12 @@ describe('setAlertsToUntracked()', () => {
               "source": "
       if (!ctx._source.containsKey('kibana.alert.status') || ctx._source['kibana.alert.status'].empty) {
         ctx._source.kibana.alert.status = 'untracked';
+        ctx._source.kibana.alert.end = '2023-10-04T18:40:49.479Z';
+        ctx._source.kibana.alert.time_range.lte = '2023-10-04T18:40:49.479Z';
       } else {
-        ctx._source['kibana.alert.status'] = 'untracked'
+        ctx._source['kibana.alert.status'] = 'untracked';
+        ctx._source['kibana.alert.end'] = '2023-10-04T18:40:49.479Z';
+        ctx._source['kibana.alert.time_range'].lte = '2023-10-04T18:40:49.479Z';
       }",
             },
           },


### PR DESCRIPTION
## Summary

Fixes #167832 

Untracking an alert will now add its end time to the alert document, which will correctly filter it out of the active alerts histogram.

### Before
![image](https://github.com/elastic/kibana/assets/12370520/04cda410-757c-4111-988a-c2e0ac4d2a96)
### After
<img width="912" alt="Screenshot 2023-10-04 at 12 48 13 PM" src="https://github.com/elastic/kibana/assets/1445834/91f6bbec-7eb1-480c-a39d-392cfe8973e1">



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->