### PR TITLE
fix(slo): use insert_zeros gap policy for historical summary calculation

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
@@ -279,6 +279,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
           cumulative_total: {
@@ -287,6 +288,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
         },


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/168042

## Summary

When the rollup data is too intermittent, some of the generated histogram buckets can be empty, and when calculating the moving sum, these empty buckets were skipped. 

Using `gap_policy: "insert_zeros"` fixes that issue.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->