### PR TITLE
Add platform docs as codeowners for OpenAPI files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1421,6 +1421,12 @@ x-pack/plugins/observability_shared/public/components/profiling @elastic/profili
 # Shared UX
 packages/react @elastic/appex-sharedux
 
+# OpenAPI spec files
+/x-pack/plugins/fleet/common/openapi          @elastic/platform-docs-team
+/x-pack/plugins/ml/common/openapi             @elastic/platform-docs-team
+/packages/core/saved-objects/docs/openapi     @elastic/platform-docs-team
+/plugins/data_views/docs/openapi              @elastic/platform-docs-team
+
 ####
 ## These rules are always last so they take ultimate priority over everything else
 ####

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1422,10 +1422,10 @@ x-pack/plugins/observability_shared/public/components/profiling @elastic/profili
 packages/react @elastic/appex-sharedux
 
 # OpenAPI spec files
-/x-pack/plugins/fleet/common/openapi          @elastic/platform-docs-team
-/x-pack/plugins/ml/common/openapi             @elastic/platform-docs-team
-/packages/core/saved-objects/docs/openapi     @elastic/platform-docs-team
-/plugins/data_views/docs/openapi              @elastic/platform-docs-team
+/x-pack/plugins/fleet/common/openapi          @elastic/platform-docs
+/x-pack/plugins/ml/common/openapi             @elastic/platform-docs
+/packages/core/saved-objects/docs/openapi     @elastic/platform-docs
+/plugins/data_views/docs/openapi              @elastic/platform-docs
 
 ####
 ## These rules are always last so they take ultimate priority over everything else


### PR DESCRIPTION
## Summary

**Problem:**
For now, the docs team has to manually sync changes to this repo's OpenAPI spec files to the docs repo used to generate API reference docs.

**Solution:**
Add the Platform docs team as CODEOWNERS to ensure we're notified of any changes (and can then sync them).

**About the error...**
GitHub is complaining that the file contains errors. It doesn't — the Platform docs team exists ([proof](https://github.com/orgs/elastic/teams/platform-docs)), and the members have write access (the _team_ may not).
