### PR TITLE
[Synthetics] Fix project monitor private location editing

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.test.ts
@@ -19,6 +19,7 @@ import { formatSyntheticsPolicy } from '../formatters/private_formatters/format_
 import { savedObjectsServiceMock } from '@kbn/core-saved-objects-server-mocks';
 import { SyntheticsServerSetup } from '../../types';
 import { PrivateLocationAttributes } from '../../runtime_types/private_locations';
+import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 
 describe('SyntheticsPrivateLocation', () => {
   const mockPrivateLocation: PrivateLocationAttributes = {
@@ -77,6 +78,7 @@ describe('SyntheticsPrivateLocation', () => {
     },
     coreStart: {
       savedObjects: savedObjectsServiceMock.createStartContract(),
+      elasticsearch: elasticsearchServiceMock.createStart(),
     },
   } as unknown as SyntheticsServerSetup;
 

--- a/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -356,7 +356,7 @@ export class SyntheticsPrivateLocation {
 
   async createPolicyBulk(newPolicies: NewPackagePolicyWithId[]) {
     const soClient = this.server.coreStart.savedObjects.createInternalRepository();
-    const esClient = this.server.uptimeEsClient.baseESClient;
+    const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
     if (esClient && newPolicies.length > 0) {
       return await this.server.fleet.packagePolicyService.bulkCreate(
         soClient,
@@ -368,8 +368,8 @@ export class SyntheticsPrivateLocation {
 
   async updatePolicyBulk(policiesToUpdate: NewPackagePolicyWithId[]) {
     const soClient = this.server.coreStart.savedObjects.createInternalRepository();
-    const esClient = this.server.uptimeEsClient.baseESClient;
-    if (soClient && esClient && policiesToUpdate.length > 0) {
+    const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
+    if (policiesToUpdate.length > 0) {
       const { failedPolicies } = await this.server.fleet.packagePolicyService.bulkUpdate(
         soClient,
         esClient,
@@ -384,8 +384,8 @@ export class SyntheticsPrivateLocation {
 
   async deletePolicyBulk(policyIdsToDelete: string[]) {
     const soClient = this.server.coreStart.savedObjects.createInternalRepository();
-    const esClient = this.server.uptimeEsClient.baseESClient;
-    if (soClient && esClient && policyIdsToDelete.length > 0) {
+    const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
+    if (policyIdsToDelete.length > 0) {
       try {
         return await this.server.fleet.packagePolicyService.delete(
           soClient,
@@ -403,7 +403,7 @@ export class SyntheticsPrivateLocation {
 
   async deleteMonitors(configs: HeartbeatConfig[], spaceId: string) {
     const soClient = this.server.coreStart.savedObjects.createInternalRepository();
-    const esClient = this.server.uptimeEsClient.baseESClient;
+    const esClient = this.server.coreStart.elasticsearch.client.asInternalUser;
 
     const policyIdsToDelete = [];
     for (const config of configs) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/synthetics/issues/843

Fix project monitor private location editing !!

We aren't granting any ES cluster permissions to the API key. Fleet added a feature which is querying some indices, since for saved object client we are using internal client it makes sense to do the same for ES client. 

<!--ONMERGE {"backportTargets":["8.10","8.11"]} ONMERGE-->