### PR TITLE
[ML] AIOps: Reenable `kibana_sample_data_logs` dataset for functional tests

### DIFF
--- a/x-pack/test/functional/apps/aiops/test_data.ts
+++ b/x-pack/test/functional/apps/aiops/test_data.ts
@@ -21,7 +21,7 @@ export const kibanaLogsDataViewTestData: TestData = {
   fieldSelectorApplyAvailable: true,
   action: {
     type: 'LogPatternAnalysis',
-    tableRowId: '157690148',
+    tableRowId: '1064853178',
     expected: {
       queryBar:
         'clientip:30.156.16.164 AND host.keyword:elastic-elastic-elastic.org AND ip:30.156.16.163 AND response.keyword:404 AND machine.os.keyword:win xp AND geo.dest:IN AND geo.srcdest:US\\:IN',
@@ -233,9 +233,7 @@ const getArtificialLogDataViewTestData = (analysisType: LogRateAnalysisType): Te
 });
 
 export const logRateAnalysisTestData: TestData[] = [
-  // Temporarily disabling since the data seems out of sync on local dev installs and CI
-  // so it's not possible to compare and update assertions accordingly.
-  // kibanaLogsDataViewTestData,
+  kibanaLogsDataViewTestData,
   farequoteDataViewTestData,
   farequoteDataViewTestDataWithQuery,
   getArtificialLogDataViewTestData(LOG_RATE_ANALYSIS_TYPE.SPIKE),


### PR DESCRIPTION
## Summary

Follow up to #165124.
Part of #167467.

Reenables the `kibana_sample_data_logs` dataset for functional tests for log rate analysis. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->