### PR TITLE
[APM] re-enable links to Infra in serverless

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -40,7 +40,7 @@ xpack.fleet.packages:
 xpack.apm.featureFlags.agentConfigurationAvailable: false
 xpack.apm.featureFlags.configurableIndicesAvailable: false
 xpack.apm.featureFlags.infrastructureTabAvailable: false
-xpack.apm.featureFlags.infraUiAvailable: false
+xpack.apm.featureFlags.infraUiAvailable: true
 xpack.apm.featureFlags.migrationToFleetAvailable: false
 xpack.apm.featureFlags.sourcemapApiAvailable: false
 xpack.apm.featureFlags.storageExplorerAvailable: false


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/167849\

Blocked by: https://github.com/elastic/obs-infraobs-team/issues/1102

This re-enables the links to Infra UI from APM UI in serverless