### PR TITLE
Ignore Version Mismatch in serverless run cases

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -133,3 +133,7 @@ xpack.task_manager.allow_reading_invalid_state: false
 
 ## TaskManager requeue invalid tasks, supports ZDT
 xpack.task_manager.requeue_invalid_tasks.enabled: true
+
+# Disables ElasticSearch version compatibility check in serverless cases
+elasticsearch.ignoreVersionMismatch: true
+


### PR DESCRIPTION
## Summary
Band-aid fix to allow serverless startup: Ignore es<->kibana version mismatch in serverless run cases, in the `serverless.yml` config, through the `elasticsearch.ignoreVersionMismatch`

## Context
Since Kibana graduated to v8.12, it halts start-up with an error:
```
 proc [kibana] [2023-10-05T09:22:18.754+02:00][ERROR][elasticsearch-service] This version of Kibana (v8.12.0) is incompatible with the following Elasticsearch nodes in your cluster: v8.11.0 @ 172.18.0.2:9200 (172.18.0.2), v8.11.0 @ 172.18.0.3:9237 (172.18.0.3), v8.11.0 @ 172.18.0.4:9200 (172.18.0.4)
```

Probably because ES / ES Serverless reports v8.11 still, and there's a compatibility check in Kibana for keeping versions tight.

However, in the serverless world, this tight version coupling shouldn't be present as releases are continuous.

As a quick fix, I found we can toggle this escape hatch in a central place for serverless, so it would allow serverless cases to start up happily once again.

## Links
https://elastic.slack.com/archives/C5UDAFZQU/p1696491308228019
https://elastic.slack.com/archives/C5TQ33ND8/p1696496482394589
