### PR TITLE
[ES|QL] Improve the histogram query

### DIFF
--- a/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
+++ b/src/plugins/unified_histogram/public/layout/hooks/use_lens_suggestions.ts
@@ -85,8 +85,8 @@ export const useLensSuggestions = ({
 
       const interval = computeInterval(timeRange, data);
       const language = getAggregateQueryMode(query);
-      const histogramQuery = `${query[language]} | eval uniqueName = 1
-        | EVAL timestamp=DATE_TRUNC(${interval}, ${dataView.timeFieldName}) | stats rows = count(uniqueName) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${interval}\``;
+      const histogramQuery = `${query[language]}
+        | EVAL timestamp=DATE_TRUNC(${interval}, ${dataView.timeFieldName}) | stats rows = count(*) by timestamp | rename timestamp as \`${dataView.timeFieldName} every ${interval}\``;
       const context = {
         dataViewSpec: dataView?.toSpec(),
         fieldName: '',


### PR DESCRIPTION
## Summary

Now that ES supports count(*) we can simplify the query which generates the histogram in ES|QL mode and remove our hacky solution!

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->