### PR TITLE
[Serverless] ES should ignore the version mismatch

### DIFF
--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -86,6 +86,9 @@ xpack.spaces.allowFeatureVisibility: false
 # Only display console autocomplete suggestions for ES endpoints that are available in serverless
 console.autocompleteDefinitions.endpointsAvailability: serverless
 
+# Do not check the ES version when running on Serverless
+elasticsearch.ignoreVersionMismatch: true
+
 # Allow authentication via the Elasticsearch JWT realm with the `shared_secret` client authentication type.
 elasticsearch.requestHeadersWhitelist: ['authorization', 'es-client-authentication']
 

--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { schema, TypeOf } from '@kbn/config-schema';
+import { schema, TypeOf, offeringBasedSchema } from '@kbn/config-schema';
 import { readPkcs12Keystore, readPkcs12Truststore } from '@kbn/crypto';
 import { i18n } from '@kbn/i18n';
 import { Duration } from 'moment';
@@ -145,20 +145,22 @@ export const configSchema = schema.object({
   ),
   apiVersion: schema.string({ defaultValue: DEFAULT_API_VERSION }),
   healthCheck: schema.object({ delay: schema.duration({ defaultValue: 2500 }) }),
-  ignoreVersionMismatch: schema.conditional(
-    schema.contextRef('dev'),
-    false,
-    schema.boolean({
-      validate: (rawValue) => {
-        if (rawValue === true) {
-          return '"ignoreVersionMismatch" can only be set to true in development mode';
-        }
-      },
-      // When running in serverless mode, default to `true`
-      defaultValue: schema.contextRef('serverless'),
-    }),
-    schema.boolean({ defaultValue: false })
-  ),
+  ignoreVersionMismatch: offeringBasedSchema({
+    serverless: schema.boolean({ defaultValue: true }),
+    traditional: schema.conditional(
+      schema.contextRef('dev'),
+      false,
+      schema.boolean({
+        validate: (rawValue) => {
+          if (rawValue === true) {
+            return '"ignoreVersionMismatch" can only be set to true in development mode';
+          }
+        },
+        defaultValue: false,
+      }),
+      schema.boolean({ defaultValue: false })
+    ),
+  }),
   skipStartupConnectionCheck: schema.conditional(
     // Using dist over dev because integration_tests run with dev: false,
     // and this config is solely introduced to allow some of the integration tests to run without an ES server.


### PR DESCRIPTION
## Summary

On Serverless, Kibana and ES will release at a different pace, so Kibana shouldn't validate the version mismatch with ES.

This currently works in production, but our CI and dev environments might fail because the current schema sets it to `false` when running in dev mode.

This PR adds the setting to `config/serverless.yml` to be explicit about this behavior in any environment, and adapts the schema to allow this explicit configuration on Serverless (for both, dev and prod).

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
