### PR TITLE
[Ops] Fix hard-coded output checking 

### DIFF
--- a/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
+++ b/packages/kbn-plugin-helpers/src/integration_tests/build.test.ts
@@ -21,6 +21,9 @@ const PLUGIN_DIR = Path.resolve(REPO_ROOT, 'plugins/foo_test_plugin');
 const PLUGIN_BUILD_DIR = Path.resolve(PLUGIN_DIR, 'build');
 const PLUGIN_ARCHIVE = Path.resolve(PLUGIN_BUILD_DIR, `fooTestPlugin-7.5.0.zip`);
 const TMP_DIR = Path.resolve(__dirname, '__tmp__');
+const CURRENT_BRANCH = loadJsonFile.sync<{ branch: string }>(
+  Path.resolve(REPO_ROOT, 'package.json')
+).branch;
 
 expect.addSnapshotSerializer(createReplaceSerializer(/[\d\.]+ sec/g, '<time>'));
 expect.addSnapshotSerializer(createReplaceSerializer(/\d+(\.\d+)?[sm]/g, '<time>'));
@@ -35,6 +38,8 @@ beforeEach(async () => {
 afterEach(async () => await del([PLUGIN_DIR, TMP_DIR]));
 
 it('builds a generated plugin into a viable archive', async () => {
+  const branchSegmentInUrl = CURRENT_BRANCH === 'main' ? 'current' : CURRENT_BRANCH;
+
   const generateProc = await execa(
     process.execPath,
     ['scripts/generate_plugin', '-y', '--name', 'fooTestPlugin'],
@@ -54,7 +59,7 @@ it('builds a generated plugin into a viable archive', async () => {
   };
 
   expect(filterLogs(generateProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/${branchSegmentInUrl}/production.html#openssl-legacy-provider
      succ 🎉
 
           Your plugin has been created in plugins/foo_test_plugin
@@ -74,7 +79,7 @@ it('builds a generated plugin into a viable archive', async () => {
   );
 
   expect(filterLogs(buildProc.all)).toMatchInlineSnapshot(`
-    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/current/production.html#openssl-legacy-provider
+    "Kibana is currently running with legacy OpenSSL providers enabled! For details and instructions on how to disable see https://www.elastic.co/guide/en/kibana/${branchSegmentInUrl}/production.html#openssl-legacy-provider
      info deleting the build and target directories
      info run bazel and build required artifacts for the optimizer
      succ bazel run successfully and artifacts were created


### PR DESCRIPTION
## Summary
Fixing a bad integration test: 
- [logs](https://buildkiteartifacts.com/e0f3970e-3a75-4621-919f-e6c773e2bb12/0fda5127-f57f-42fb-8e5a-146b3d535916/018afe9a-80b7-45da-ae52-12d056fe8a41/018afe9c-648f-4226-9df5-527f3d6aa552/target/test_failures/018afe9c-648f-4226-9df5-527f3d6aa552_8ab7a3920f47ce6668b020c616adc73e.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7LSDXBUE4Z%2F20231005%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20231005T101034Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEFAaCXVzLWVhc3QtMSJIMEYCIQDK4rFrH4yeroQ%2FPokz9OksBi3D9x3XyKqaddL50EjlUAIhANmhoVyprcmRC%2FGZVGLeF96m%2Bmg84%2F8tZNWhU93oDVWkKvEDCFkQABoMMDMyMzc5NzA1MzAzIgys0AmAEF%2Fxs7O10JIqzgOUyHPnkfuZugQHWUn1lP0tp8hXKl0%2FeXga0dothenPzfk9LXZbxxp9RsjfkOB4Ah6uaIU0wg0E%2FxbOXOdUNFLpLZABxEhoaywk1ZEs%2BWNf%2B%2F3%2Bz6PGoBrTynOnR8zQnSMxK0ynj%2Bafkh3jMupKEWT9AmWLKj%2F%2F275HsJBldKK1sLy%2FkvNs2ci%2BBrFf4q7l8OkBDOuXJ3FlPgI32%2FMEmpwKbuY0q9XB5p%2BY69HQaE38vkP5lFDWSiXMNNDC9AkgcY5xme3c0%2FTSczCIFg3lPIuZKfzsozOgCgorgDTZ817mk%2FDNKgGY9WAD%2FCtKxUmW3JPqdY7Nghmf96O9%2B9cnMpRP8dy%2F3EPH5Py2FVKY%2B%2B5rY9LJ8BmcHeVYWsVdE3o9SaVIqA4LFGsiSXahs1yjsdiUKHSvGQGbljeNjhUe1urjqdWnkzeeKW24tfS0Fg6WxZQe5FfB5a4yfnTX0WU%2F1VRI%2FafUmF081EkwwoYsZSOblMvj2qCVxsdTBQQK26HSrrTxDZGYsKAwBviy9%2BsQvHCmv5oGvtnb0bPLb0OLQoa9NDF61HrpJSKxq0Zwy2UCwkjLdSGZPqRqWxCjMtvpoXoqiTF7CJBW4tEFLmsKb2IwqNL5qAY6pAGTgjoiwX5ZmQooDos6QxPMl0gfucmqNMNHLOzebFOnEkE%2FBY6whD6gZFI%2B1HiUUCdWZyewSr5T%2FG8qKXf0gRh%2FRSi8yk%2Bk7W%2FM9LvIpdTLs1QRBU8A4hbMi80xnrWiuYhjMhnXgSyhKwYWmI1QajVlL6xaWcUrvz99YZxB5msehIm5C5atGgRPbSRZ%2FN0uzpn3i7VnrJPllI%2F0CM4BhEY9QZDHow%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=0f8020273f7524d885f0066bc9fe78105890943be441755afec15da92392dbc3)
- [issue - but apparently not reported](https://github.com/elastic/kibana/issues/89079) 
- [buildkite build](https://buildkite.com/elastic/kibana-pull-request/builds/165507#018afe9c-648f-4226-9df5-527f3d6aa552)

The output snapshot checking had `current` hard-coded in it, that only works on `main`. 

fix: make output snapshot care for legacy branches, and how they might be included in the output
