### PR TITLE
[Enterprise Search] Remove view additional integration link

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -20,7 +20,6 @@ import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { HttpLogic } from '../../../shared/http';
 import { KibanaLogic } from '../../../shared/kibana/kibana_logic';
 
-import { EuiLinkTo } from '../../../shared/react_router_helpers';
 import { NEW_INDEX_METHOD_PATH, NEW_INDEX_SELECT_CONNECTOR_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 import { CannotConnect } from '../search_index/components/cannot_connect';
@@ -37,7 +36,7 @@ const getAvailableMethodOptions = (productFeatures: ProductFeatures): INGESTION_
 };
 
 export const NewIndex: React.FC = () => {
-  const { capabilities, config, productFeatures } = useValues(KibanaLogic);
+  const { config, productFeatures } = useValues(KibanaLogic);
   const availableIngestionMethodOptions = getAvailableMethodOptions(productFeatures);
   const { errorConnectingMessage } = useValues(HttpLogic);
 
@@ -91,15 +90,6 @@ export const NewIndex: React.FC = () => {
               ))}
             </EuiFlexGroup>
           </EuiFlexItem>
-          {capabilities.navLinks.integrations && (
-            <EuiFlexItem>
-              <EuiLinkTo to="/app/integrations" shouldNotCreateHref>
-                {i18n.translate('xpack.enterpriseSearch.content.newIndex.viewIntegrationsLink', {
-                  defaultMessage: 'View additional integrations',
-                })}
-              </EuiLinkTo>
-            </EuiFlexItem>
-          )}
         </>
       </EuiFlexGroup>
     </EnterpriseSearchContentPageTemplate>

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -13670,7 +13670,6 @@
     "xpack.enterpriseSearch.content.newIndex.types.crawler": "网络爬虫",
     "xpack.enterpriseSearch.content.newIndex.types.elasticsearch": "Elasticsearch 索引",
     "xpack.enterpriseSearch.content.newIndex.types.json": "JSON",
-    "xpack.enterpriseSearch.content.newIndex.viewIntegrationsLink": "查看其他集成",
     "xpack.enterpriseSearch.content.overview.documementExample.generateApiKeyButton.createNew": "创建新 API 密钥",
     "xpack.enterpriseSearch.content.overview.documementExample.generateApiKeyButton.viewAll": "查看所有 API 密钥",
     "xpack.enterpriseSearch.content.overview.documentExample.clientLibraries.dotnet": ".NET",


### PR DESCRIPTION
## Summary

Removes link to View additional integrations on Connector Creation page.



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->