### PR TITLE
[Enterprise Search] Escape Lucene reserved characters when calling document search.

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/fetch_search_results.ts
@@ -9,6 +9,7 @@ import { SearchResponseBody } from '@elastic/elasticsearch/lib/api/types';
 import { IScopedClusterClient } from '@kbn/core/server';
 
 import { ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT } from '../../common/constants';
+import { escapeLuceneChars } from '../utils/escape_lucene_chars';
 
 export const fetchSearchResults = async (
   client: IScopedClusterClient,
@@ -21,7 +22,7 @@ export const fetchSearchResults = async (
     from,
     index: indexName,
     size,
-    ...(!!query ? { q: query.replace(/"/g, '\\"') } : {}),
+    ...(!!query ? { q: escapeLuceneChars(query) } : {}),
   });
   return results;
 };

--- a/x-pack/plugins/enterprise_search/server/utils/escape_lucene_chars.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/escape_lucene_chars.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const escapeLuceneChars = (query: string) =>
+  query
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\?/g, '\\?')
+    .replace(/\+/g, '\\+')
+    .replace(/\*/g, '\\*')
+    .replace(/\|/g, '\\|')
+    .replace(/{/g, '\\{')
+    .replace(/}/g, '\\}')
+    .replace(/\[/g, '\\[')
+    .replace(/\]/g, '\\]')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)')
+    .replace(/\./g, '\\.')
+    .replace(/\^/g, '\\^')
+    .replace(/\!/g, '\\!')
+    .replace(/\~/g, '\\~')
+    .replace(/\-/g, '\\-')
+    .replace(/\</g, '\\<')
+    .replace(/\//g, '\\/');


### PR DESCRIPTION
## Summary

Escape Lucene reserved characters when Document box is used. It was returning 502 before when certain characters like `&<>!` etc is entered to the search box.


https://github.com/elastic/kibana/assets/1410658/a672f71a-e40f-4111-b942-2f3ba9434b7a


## Release note

Filter box in Search Index documents tab is no more throwing errors when certain characters entered.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->