### PR TITLE
[ML] Fixes anomaly charts when partition field contains an empty string

### DIFF
--- a/x-pack/plugins/ml/server/models/results_service/anomaly_charts.ts
+++ b/x-pack/plugins/ml/server/models/results_service/anomaly_charts.ts
@@ -526,9 +526,9 @@ export function anomalyChartsDataProvider(mlClient: MlClient, client: IScopedClu
 
       // TODO - work out how best to display results from detectors with just an over field.
       const firstFieldName =
-        record.partition_field_name || record.by_field_name || record.over_field_name;
+        record.partition_field_name ?? record.by_field_name ?? record.over_field_name;
       const firstFieldValue =
-        record.partition_field_value || record.by_field_value || record.over_field_value;
+        record.partition_field_value ?? record.by_field_value ?? record.over_field_value;
       if (firstFieldName !== undefined && firstFieldValue !== undefined) {
         const groupsForDetector = detectorsForJob[detectorIndex];
 
@@ -544,7 +544,7 @@ export function anomalyChartsDataProvider(mlClient: MlClient, client: IScopedClu
 
         let isSecondSplit = false;
         if (record.partition_field_name !== undefined) {
-          const splitFieldName = record.over_field_name || record.by_field_name;
+          const splitFieldName = record.over_field_name ?? record.by_field_name;
           if (splitFieldName !== undefined) {
             isSecondSplit = true;
           }
@@ -562,8 +562,8 @@ export function anomalyChartsDataProvider(mlClient: MlClient, client: IScopedClu
           }
         } else {
           // Aggregate another level for the over or by field.
-          const secondFieldName = record.over_field_name || record.by_field_name;
-          const secondFieldValue = record.over_field_value || record.by_field_value;
+          const secondFieldName = record.over_field_name ?? record.by_field_name;
+          const secondFieldValue = record.over_field_value ?? record.by_field_value;
 
           if (secondFieldName !== undefined && secondFieldValue !== undefined) {
             if (dataForGroupValue[secondFieldName] === undefined) {
@@ -1044,7 +1044,7 @@ export function anomalyChartsDataProvider(mlClient: MlClient, client: IScopedClu
       let chartData: ChartPoint[] = [];
       if (metricData !== undefined) {
         if (records.length > 0) {
-          const filterField = records[0].by_field_value || records[0].over_field_value;
+          const filterField = records[0].by_field_value ?? records[0].over_field_value;
           if (eventDistribution && eventDistribution.length > 0) {
             chartData = eventDistribution.filter((d: { entity: any }) => d.entity !== filterField);
           }
@@ -1143,7 +1143,7 @@ export function anomalyChartsDataProvider(mlClient: MlClient, client: IScopedClu
         chartType === CHART_TYPE.POPULATION_DISTRIBUTION
       ) {
         return chartData.filter((d) => {
-          return d.entity === (record && (record.by_field_value || record.over_field_value));
+          return d.entity === (record && (record.by_field_value ?? record.over_field_value));
         });
       }
 


### PR DESCRIPTION
## Summary

Fixes #168067.

Fixes anomaly charts fetching by replacing logical OR operator with nullish coalescing.

![image](https://github.com/elastic/kibana/assets/5236598/e8e43c49-507c-4725-9e1a-f412e3bdbe98)


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->