### PR TITLE
Fixing Failing test: Serverless Security API Integration Tests - Common Group 1.x-pack/test_serverless/api_integration/test_suites/common/alerting/rules·ts - Alerting APIs Alerting rules "after each" hook for "should retry when appropriate"

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
+import expect from '@kbn/expect/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import {
   createIndexConnector,
@@ -35,8 +35,7 @@ export default function ({ getService }: FtrProviderContext) {
   const esClient = getService('es');
   const esDeleteAllIndices = getService('esDeleteAllIndices');
 
-  // Failing: See https://github.com/elastic/kibana/issues/167665
-  describe.skip('Alerting rules', () => {
+  describe('Alerting rules', () => {
     const RULE_TYPE_ID = '.es-query';
     const ALERT_ACTION_INDEX = 'alert-action-es-query';
     let actionId: string;
@@ -53,6 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
         .set('x-elastic-internal-origin', 'foo');
       await esClient.deleteByQuery({
         index: '.kibana-event-log-*',
+        conflicts: 'proceed',
         query: { term: { 'kibana.alert.rule.consumer': 'alerts' } },
       });
       await esDeleteAllIndices([ALERT_ACTION_INDEX]);

--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/rules.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect/expect';
+import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 import {
   createIndexConnector,


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/167665

## Summary

The recent PR to set event log alerts to `untracked` when a rule is deleted caused this issue in the `afterEach` hook for these tests. During cleanup, the rule is deleted and then event log docs for the rule are deleted using `deleteByQuery` but since the event log docs are being updated due to the rule deletion, the `deleteByQuery` runs into conflicts. Added `conflicts: proceed` to the `deleteByQuery` to avoid this failure

Flaky test runner:
* https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3366
* https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3367
* https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3368

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->