### PR TITLE
[ftr] fix url check by excluding port

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -33,6 +33,12 @@ export class CommonPageObject extends FtrService {
   private readonly defaultTryTimeout = this.config.get('timeouts.try');
   private readonly defaultFindTimeout = this.config.get('timeouts.find');
 
+  private getUrlWithoutPort(urlStr: string) {
+    const url = new URL(urlStr);
+    url.port = '';
+    return url.toString();
+  }
+
   /**
    * Logins to Kibana as default user and navigates to provided app
    * @param appUrl Kibana URL
@@ -121,8 +127,13 @@ export class CommonPageObject extends FtrService {
         throw new Error(msg);
       }
 
-      if (ensureCurrentUrl && !currentUrl.includes(appUrl)) {
-        throw new Error(`expected ${currentUrl}.includes(${appUrl})`);
+      if (ensureCurrentUrl) {
+        const actualUrl = this.getUrlWithoutPort(currentUrl);
+        const expectedUrl = this.getUrlWithoutPort(appUrl);
+
+        if (!actualUrl.includes(expectedUrl)) {
+          throw new Error(`expected ${actualUrl}.includes(${expectedUrl})`);
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

Addressing MKI `commonPage.navigateToUrl()` failures when `actualUrl` contains port value.

```
✖ fail: Serverless Common UI - Management Data View Management disables scripted fields Scripted fields tab is missing
--
  | │      Error: retry.try timeout: Error: expected https://bk-serverless-ftr-185-elasticsearch-e79c7a.kb.eu-west-1.aws.qa.elastic.cloud/app/management/kibana/dataViews.includes(https://bk-serverless-ftr-185-elasticsearch-e79c7a.kb.eu-west-1.aws.qa.elastic.cloud:443/app/management/kibana/dataViews)
```

Works both on MKI and local serverless run.

<!--ONMERGE {"backportTargets":["8.10","8.11","8.9"]} ONMERGE-->