### PR TITLE
Fix issue with long left nav title

### DIFF
--- a/packages/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
+++ b/packages/shared-ux/page/solution_nav/src/__snapshots__/solution_nav.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`SolutionNav accepts EuiSideNavProps 1`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="SolutionNav_generated-id_heading"
         size="xs"
       >
@@ -101,6 +102,7 @@ exports[`SolutionNav accepts EuiSideNavProps 1`] = `
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="SolutionNav_generated-id_heading"
       size="xs"
     >
@@ -199,6 +201,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="SolutionNav_generated-id_heading"
         size="xs"
       >
@@ -289,6 +292,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 1`] = `
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="SolutionNav_generated-id_heading"
       size="xs"
     >
@@ -386,6 +390,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="SolutionNav_generated-id_heading"
         size="xs"
       >
@@ -476,6 +481,7 @@ exports[`SolutionNav accepts canBeCollapsed prop 2`] = `
     className="kbnSolutionNav"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="SolutionNav_generated-id_heading"
       size="xs"
     >
@@ -570,6 +576,7 @@ exports[`SolutionNav heading accepts more headingProps 1`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="testID"
         size="xs"
       >
@@ -600,6 +607,7 @@ exports[`SolutionNav heading accepts more headingProps 1`] = `
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="testID"
       size="xs"
     >
@@ -638,6 +646,7 @@ exports[`SolutionNav renders 1`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="SolutionNav_generated-id_heading"
         size="xs"
       >
@@ -728,6 +737,7 @@ exports[`SolutionNav renders 1`] = `
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="SolutionNav_generated-id_heading"
       size="xs"
     >
@@ -825,12 +835,13 @@ exports[`SolutionNav renders with icon 1`] = `
     paddingSize="none"
     title={
       <EuiTitle
+        className="kbnSolutionNav__title"
         id="SolutionNav_generated-id_heading"
         size="xs"
       >
         <h2>
           <KibanaSolutionAvatar
-            className="kbnSolutionNav__avatar"
+            className="kbnSolutionNav__titleAvatar"
             iconType="logoElastic"
             name="Solution"
           />
@@ -920,12 +931,13 @@ exports[`SolutionNav renders with icon 1`] = `
     className="kbnSolutionNav kbnSolutionNav--hidden"
   >
     <EuiTitle
+      className="kbnSolutionNav__title"
       id="SolutionNav_generated-id_heading"
       size="xs"
     >
       <h2>
         <KibanaSolutionAvatar
-          className="kbnSolutionNav__avatar"
+          className="kbnSolutionNav__titleAvatar"
           iconType="logoElastic"
           name="Solution"
         />

--- a/packages/shared-ux/page/solution_nav/src/solution_nav.scss
+++ b/packages/shared-ux/page/solution_nav/src/solution_nav.scss
@@ -24,7 +24,7 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
   }
 
   &__titleAvatar {
-    margin-right: $euiSize;
+    margin-right: $euiSizeM;
     align-self: flex-start;
   }
 }

--- a/packages/shared-ux/page/solution_nav/src/solution_nav.scss
+++ b/packages/shared-ux/page/solution_nav/src/solution_nav.scss
@@ -18,8 +18,14 @@ $euiSideNavEmphasizedBackgroundColor: transparentize($euiColorLightShade, .7);
     padding: $euiSizeL;
   }
 
-  .kbnSolutionNav__avatar {
+  &__title {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  &__titleAvatar {
     margin-right: $euiSize;
+    align-self: flex-start;
   }
 }
 

--- a/packages/shared-ux/page/solution_nav/src/solution_nav.tsx
+++ b/packages/shared-ux/page/solution_nav/src/solution_nav.tsx
@@ -121,10 +121,19 @@ export const SolutionNav: FC<SolutionNavProps> = ({
   const HeadingElement = headingProps?.element || 'h2';
 
   const titleText = (
-    <EuiTitle size="xs" id={headingID} data-test-subj={headingProps?.['data-test-subj']}>
+    <EuiTitle
+      size="xs"
+      id={headingID}
+      data-test-subj={headingProps?.['data-test-subj']}
+      className="kbnSolutionNav__title"
+    >
       <HeadingElement>
         {icon && (
-          <KibanaSolutionAvatar className="kbnSolutionNav__avatar" iconType={icon} name={name} />
+          <KibanaSolutionAvatar
+            className="kbnSolutionNav__titleAvatar"
+            iconType={icon}
+            name={name}
+          />
         )}
         <strong>
           <FormattedMessage


### PR DESCRIPTION
## Summary

Closes #167586 

This PR applies global changes to how side nav titles that are unusually lengthy are handled. 

#### Nav title with appropriately regular length
<img width="297" alt="Screenshot 2023-10-05 at 17 41 12" src="https://github.com/elastic/kibana/assets/7893459/d65c72d5-44a2-4e91-8068-47476072ad1c">

#### Nav title with really long title
<img width="334" alt="Screenshot 2023-10-05 at 17 41 39" src="https://github.com/elastic/kibana/assets/7893459/cac7915d-3245-485a-8771-2b50f8ceccf0">

This approach makes it so that the fix provided for the issue above also applies to any occurrence of the same issue else where within the product.


### Checklist
<!--
Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers) -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!-- 
### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) 

-->



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->