### PR TITLE
[8.11] [Security Solution][Entity Analytics] Risk scoring cancellation telemetry (#167932)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.test.ts
@@ -6,7 +6,7 @@
  */
 
 import moment from 'moment';
-import { convertDateToISOString, isExecutionDurationExceededInterval } from './helpers';
+import { convertDateToISOString } from './helpers';
 
 moment.suppressDeprecationWarnings = true;
 
@@ -47,19 +47,5 @@ describe('convertDateToISOString', () => {
     expect(() => {
       convertDateToISOString(date);
     }).toThrowErrorMatchingInlineSnapshot(`"Could not convert string \\"hi mom\\" to ISO string"`);
-  });
-});
-
-describe('isExecutionDurationExceededInterval', () => {
-  it('return false if the execution duration interval not defiend', () => {
-    expect(isExecutionDurationExceededInterval(undefined, 1000)).toEqual(false);
-  });
-
-  it('return false if the execution duration is less than the interval', () => {
-    expect(isExecutionDurationExceededInterval('1m', 59)).toEqual(false);
-  });
-
-  it('return true if the execution duration is greater than the interval', () => {
-    expect(isExecutionDurationExceededInterval('1m', 61)).toEqual(true);
   });
 });

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/helpers.ts
@@ -13,7 +13,6 @@ import {
   type CoreStart,
 } from '@kbn/core/server';
 import { addSpaceIdToPath } from '@kbn/spaces-plugin/server';
-import { parseIntervalAsSecond } from '@kbn/task-manager-plugin/server/lib/intervals';
 
 import type { Range } from '../../../../common/risk_engine';
 
@@ -72,16 +71,4 @@ export const buildScopedInternalSavedObjectsClientUnsafe = ({
   return coreStart.savedObjects.getScopedClient(fakeScopedRequest, {
     excludedExtensions: [SECURITY_EXTENSION_ID],
   });
-};
-
-export const isExecutionDurationExceededInterval = (
-  interval: string | undefined,
-  taskDurationInSeconds: number
-): boolean => {
-  let executionDurationExceededInterval = false;
-  if (interval) {
-    executionDurationExceededInterval = taskDurationInSeconds > parseIntervalAsSecond(interval);
-  }
-
-  return executionDurationExceededInterval;
 };

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.mock.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.mock.ts
@@ -7,7 +7,7 @@
 
 import { type ConcreteTaskInstance, TaskStatus } from '@kbn/task-manager-plugin/server';
 import { taskManagerMock } from '@kbn/task-manager-plugin/server/mocks';
-import { TYPE, VERSION } from './constants';
+import { INTERVAL, TYPE, VERSION } from './constants';
 import { defaultState } from './state';
 
 const createRiskScoringTaskInstanceMock = (
@@ -21,6 +21,7 @@ const createRiskScoringTaskInstanceMock = (
     status: TaskStatus.Running,
     startedAt: new Date(),
     scheduledAt: new Date(),
+    schedule: { interval: INTERVAL },
     retryAt: new Date(),
     params: {},
     state: defaultState,

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.test.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.test.ts
@@ -461,9 +461,8 @@ describe('Risk Scoring Task', () => {
             telemetry: mockTelemetry,
           });
 
-          expect(mockTelemetry.reportEvent).toHaveBeenCalledTimes(1);
           expect(mockTelemetry.reportEvent).toHaveBeenCalledWith('risk_score_execution_success', {
-            executionDurationExceededInterval: false,
+            interval: '1h',
             scoresWritten: 10,
             taskDurationInSeconds: 0,
           });
@@ -490,6 +489,27 @@ describe('Risk Scoring Task', () => {
               {}
             );
           }
+        });
+
+        it('sends a cancellation telemetry event if the task was cancelled', async () => {
+          mockIsCancelled.mockReturnValue(true);
+
+          await runTask({
+            getRiskScoreService,
+            isCancelled: mockIsCancelled,
+            logger: mockLogger,
+            taskInstance: riskScoringTaskInstanceMock,
+            telemetry: mockTelemetry,
+          });
+
+          expect(mockTelemetry.reportEvent).toHaveBeenCalledWith(
+            'risk_score_execution_cancellation',
+            {
+              interval: '1h',
+              scoresWritten: 0,
+              taskDurationInSeconds: 0,
+            }
+          );
         });
       });
     });

--- a/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/tasks/risk_scoring_task.ts
@@ -30,15 +30,12 @@ import {
   type LatestTaskStateSchema as RiskScoringTaskState,
 } from './state';
 import { INTERVAL, SCOPE, TIMEOUT, TYPE, VERSION } from './constants';
-import {
-  buildScopedInternalSavedObjectsClientUnsafe,
-  convertRangeToISO,
-  isExecutionDurationExceededInterval,
-} from './helpers';
+import { buildScopedInternalSavedObjectsClientUnsafe, convertRangeToISO } from './helpers';
 import { RiskScoreEntity } from '../../../../common/risk_engine/types';
 import {
   RISK_SCORE_EXECUTION_SUCCESS_EVENT,
   RISK_SCORE_EXECUTION_ERROR_EVENT,
+  RISK_SCORE_EXECUTION_CANCELLATION_EVENT,
 } from '../../telemetry/event_based/events';
 
 const logFactory =
@@ -253,23 +250,20 @@ export const runTask = async ({
     updatedState.scoresWritten = scoresWritten;
 
     const taskCompletionTime = moment().utc().toISOString();
-
     const taskDurationInSeconds = moment(taskCompletionTime).diff(moment(taskStartTime), 'seconds');
-
     const telemetryEvent = {
       scoresWritten,
       taskDurationInSeconds,
-      executionDurationExceededInterval: isExecutionDurationExceededInterval(
-        taskInstance?.schedule?.interval,
-        taskDurationInSeconds
-      ),
+      interval: taskInstance?.schedule?.interval,
     };
 
     telemetry.reportEvent(RISK_SCORE_EXECUTION_SUCCESS_EVENT.eventType, telemetryEvent);
 
     if (isCancelled()) {
       log('task was cancelled');
+      telemetry.reportEvent(RISK_SCORE_EXECUTION_CANCELLATION_EVENT.eventType, telemetryEvent);
     }
+
     log('task run completed');
     log(JSON.stringify(telemetryEvent));
     return {

--- a/x-pack/plugins/security_solution/server/lib/telemetry/event_based/events.ts
+++ b/x-pack/plugins/security_solution/server/lib/telemetry/event_based/events.ts
@@ -9,7 +9,7 @@ import type { EventTypeOpts } from '@kbn/analytics-client';
 export const RISK_SCORE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
   scoresWritten: number;
   taskDurationInSeconds: number;
-  executionDurationExceededInterval: boolean;
+  interval: string;
 }> = {
   eventType: 'risk_score_execution_success',
   schema: {
@@ -25,10 +25,10 @@ export const RISK_SCORE_EXECUTION_SUCCESS_EVENT: EventTypeOpts<{
         description: 'Duration (in seconds) of the current risk scoring task execution',
       },
     },
-    executionDurationExceededInterval: {
-      type: 'boolean',
+    interval: {
+      type: 'keyword',
       _meta: {
-        description: `Whether the risk scoring task's duration exceeded its allocated interval`,
+        description: `Configured interval for the current risk scoring task`,
       },
     },
   },
@@ -39,4 +39,36 @@ export const RISK_SCORE_EXECUTION_ERROR_EVENT: EventTypeOpts<{}> = {
   schema: {},
 };
 
-export const events = [RISK_SCORE_EXECUTION_SUCCESS_EVENT, RISK_SCORE_EXECUTION_ERROR_EVENT];
+export const RISK_SCORE_EXECUTION_CANCELLATION_EVENT: EventTypeOpts<{
+  scoresWritten: number;
+  taskDurationInSeconds: number;
+  interval: string;
+}> = {
+  eventType: 'risk_score_execution_cancellation',
+  schema: {
+    scoresWritten: {
+      type: 'long',
+      _meta: {
+        description: 'Number of risk scores written during this scoring task execution',
+      },
+    },
+    taskDurationInSeconds: {
+      type: 'long',
+      _meta: {
+        description: 'Duration (in seconds) of the current risk scoring task execution',
+      },
+    },
+    interval: {
+      type: 'keyword',
+      _meta: {
+        description: `Configured interval for the current risk scoring task`,
+      },
+    },
+  },
+};
+
+export const events = [
+  RISK_SCORE_EXECUTION_SUCCESS_EVENT,
+  RISK_SCORE_EXECUTION_ERROR_EVENT,
+  RISK_SCORE_EXECUTION_CANCELLATION_EVENT,
+];


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution][Entity Analytics] Risk scoring cancellation telemetry (#167932)](https://github.com/elastic/kibana/pull/167932)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ryland Herrick","email":"ryalnd@gmail.com"},"sourceCommit":{"committedDate":"2023-10-05T14:44:41Z","message":"[Security Solution][Entity Analytics] Risk scoring cancellation telemetry (#167932)\n\n## Summary\r\n\r\nAdds a new cancellation telemetry event, for cases where the risk\r\nscoring task was cancelled. In order to provide more context about the\r\ntask execution (and potential cancellation) in general, we now ship the\r\ntask `interval` instead of the boolean\r\n`isExecutionDurationExceededInterval`, which we can derive from\r\n`interval` and `duration` (although I do not expect `duration` to ever\r\nexceed `interval` based on the way the cancellation works).\r\n\r\n\r\n### For data-analytics folks\r\nThe following changes are made here:\r\n* New \"cancelled execution\" telemetry event\r\n* Removing field from existing telemetry event schema\r\n* Adding field to existing telemetry event schema\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f1faebf633fd20bab67dec87170b601bed3ce238","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Telemetry","release_note:skip","Theme: entity_analytics","Feature:Entity Analytics","8.11 candidate","v8.11.0","v8.12.0"],"number":167932,"url":"https://github.com/elastic/kibana/pull/167932","mergeCommit":{"message":"[Security Solution][Entity Analytics] Risk scoring cancellation telemetry (#167932)\n\n## Summary\r\n\r\nAdds a new cancellation telemetry event, for cases where the risk\r\nscoring task was cancelled. In order to provide more context about the\r\ntask execution (and potential cancellation) in general, we now ship the\r\ntask `interval` instead of the boolean\r\n`isExecutionDurationExceededInterval`, which we can derive from\r\n`interval` and `duration` (although I do not expect `duration` to ever\r\nexceed `interval` based on the way the cancellation works).\r\n\r\n\r\n### For data-analytics folks\r\nThe following changes are made here:\r\n* New \"cancelled execution\" telemetry event\r\n* Removing field from existing telemetry event schema\r\n* Adding field to existing telemetry event schema\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f1faebf633fd20bab67dec87170b601bed3ce238"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/167932","number":167932,"mergeCommit":{"message":"[Security Solution][Entity Analytics] Risk scoring cancellation telemetry (#167932)\n\n## Summary\r\n\r\nAdds a new cancellation telemetry event, for cases where the risk\r\nscoring task was cancelled. In order to provide more context about the\r\ntask execution (and potential cancellation) in general, we now ship the\r\ntask `interval` instead of the boolean\r\n`isExecutionDurationExceededInterval`, which we can derive from\r\n`interval` and `duration` (although I do not expect `duration` to ever\r\nexceed `interval` based on the way the cancellation works).\r\n\r\n\r\n### For data-analytics folks\r\nThe following changes are made here:\r\n* New \"cancelled execution\" telemetry event\r\n* Removing field from existing telemetry event schema\r\n* Adding field to existing telemetry event schema\r\n\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"f1faebf633fd20bab67dec87170b601bed3ce238"}}]}] BACKPORT-->