### PR TITLE
[Data View Field Editor] Fix `getErrorCodeFromErrorReason` check to work in both stateful and Serverless

### DIFF
--- a/src/plugins/data_view_field_editor/public/lib/runtime_field_validation.ts
+++ b/src/plugins/data_view_field_editor/public/lib/runtime_field_validation.ts
@@ -10,7 +10,7 @@ import { ScriptError } from '../components/preview/types';
 import { RuntimeFieldPainlessError, PainlessErrorCode } from '../types';
 
 export const getErrorCodeFromErrorReason = (reason: string = ''): PainlessErrorCode => {
-  if (reason.startsWith('Cannot cast from')) {
+  if (reason.includes('Cannot cast from')) {
     return 'CAST_ERROR';
   }
   return 'UNKNOWN';

--- a/x-pack/test_serverless/api_integration/test_suites/common/data_view_field_editor/field_preview.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/data_view_field_editor/field_preview.ts
@@ -48,8 +48,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
   };
 
-  // Failing: See https://github.com/elastic/kibana/issues/165868
-  describe.skip('Field preview', function () {
+  describe('Field preview', function () {
     before(async () => await createIndex());
     after(async () => await deleteIndex());
 
@@ -149,10 +148,7 @@ export default function ({ getService }: FtrProviderContext) {
       // As ES does not return error codes we will add a test to make sure its error message string
       // does not change overtime as we rely on it to extract our own error code.
       // If this test fail we'll need to update the "getErrorCodeFromErrorReason()" handler
-      // TODO: `response.error?.caused_by?.reason` returns
-      // `class_cast_exception: Cannot cast from [int] to [java.lang.String].`
-      // in Serverless, which causes `getErrorCodeFromErrorReason` to fail
-      it.skip('should detect a script casting error', async () => {
+      it('should detect a script casting error', async () => {
         const { body: response } = await supertest
           .post(FIELD_PREVIEW_PATH)
           .set(ELASTIC_HTTP_VERSION_HEADER, INITIAL_REST_VERSION)


### PR DESCRIPTION
## Summary

This PR fixes the `getErrorCodeFromErrorReason ` check to work in both stateful and Serverless. Oddly the `class_cast_exception: Cannot cast` issue mentioned in #165100 is intermittent. Sometimes the error reason is the same as stateful and only sometimes it incudes `class_cast_exception`, even though the failure is identical, but regardless this change fixes the issue.

Flaky test runs:
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3365

Fixes #165100.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->