### PR TITLE
[8.10] fix(slo): use insert_zeros gap policy for historical summary calculation (#168044)

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
@@ -279,6 +279,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
           cumulative_total: {
@@ -287,6 +288,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
         },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [fix(slo): use insert_zeros gap policy for historical summary calculation (#168044)](https://github.com/elastic/kibana/pull/168044)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Delemme","email":"kevin.delemme@elastic.co"},"sourceCommit":{"committedDate":"2023-10-05T17:01:26Z","message":"fix(slo): use insert_zeros gap policy for historical summary calculation (#168044)","sha":"cee55e3b50fffa9e1237c389d030a5c25bdb3f6a","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: Actionable Observability","backport:prev-minor","v8.12.0"],"number":168044,"url":"https://github.com/elastic/kibana/pull/168044","mergeCommit":{"message":"fix(slo): use insert_zeros gap policy for historical summary calculation (#168044)","sha":"cee55e3b50fffa9e1237c389d030a5c25bdb3f6a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/168044","number":168044,"mergeCommit":{"message":"fix(slo): use insert_zeros gap policy for historical summary calculation (#168044)","sha":"cee55e3b50fffa9e1237c389d030a5c25bdb3f6a"}}]}] BACKPORT-->