### PR TITLE
fix(slo): rollback when errors happen during the update use case

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -49,15 +49,21 @@ export class UpdateSLO {
       refresh: true,
     });
 
-    await this.deleteObsoleteSLORevisionData(originalSlo);
+    await this.deleteOriginalSLO(originalSlo);
 
     return this.toResponse(updatedSlo);
   }
 
-  private async deleteObsoleteSLORevisionData(originalSlo: SLO) {
-    const originalSloTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
-    await this.transformManager.stop(originalSloTransformId);
-    await this.transformManager.uninstall(originalSloTransformId);
+  private async deleteOriginalSLO(originalSlo: SLO) {
+    try {
+      const originalSloTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
+      await this.transformManager.stop(originalSloTransformId);
+      await this.transformManager.uninstall(originalSloTransformId);
+    } catch (err) {
+      // Any errors here should not prevent moving forward.
+      // Worst case we keep rolling up data for the previous revision number.
+    }
+
     await this.deleteRollupData(originalSlo.id, originalSlo.revision);
     await this.deleteSummaryData(originalSlo.id, originalSlo.revision);
   }

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -36,8 +36,6 @@ export class UpdateSLO {
 
     validateSLO(updatedSlo);
 
-    await this.deleteObsoleteSLORevisionData(originalSlo);
-
     const updatedSloTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
     await this.repository.save(updatedSlo);
     await this.transformManager.install(updatedSlo);
@@ -50,6 +48,8 @@ export class UpdateSLO {
       document: createTempSummaryDocument(updatedSlo),
       refresh: true,
     });
+
+    await this.deleteObsoleteSLORevisionData(originalSlo);
 
     return this.toResponse(updatedSlo);
   }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/167938
Resolves https://github.com/elastic/kibana/issues/168051

## Summary

This PR changes the update SLO use case to make it more resilient to errors happening at any step of the flow.
We moved the deletion of the original SLO data (rollup and summary) at the very end of the flow, and we handle errors at every step, and always restore the original SLO.

Step | Rollback steps in case of error during the step
-- | --
Saving the updated SLO in the repository | Nothing
Transform installation | Store (restore) the original SLO in the repository
Transform preview or start | Uninstall the new transform, store the original SLO in the repository
Original transform stop or uninstallation | Nothing

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->