### PR TITLE
[Security Solution] Add Standalone Discover to Security Navigation

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -88,8 +88,6 @@ const GraphTab = tabWithSuspense(lazy(() => import('../graph_tab_content')));
 const NotesTab = tabWithSuspense(lazy(() => import('../notes_tab_content')));
 const PinnedTab = tabWithSuspense(lazy(() => import('../pinned_tab_content')));
 const SessionTab = tabWithSuspense(lazy(() => import('../session_tab_content')));
-const DiscoverTab = tabWithSuspense(lazy(() => import('../discover_tab_content')));
-
 interface BasicTimelineTab {
   renderCellValue: (props: CellValueElementProps) => React.ReactNode;
   rowRenderers: RowRenderer[];
@@ -134,7 +132,6 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
     setConversationId,
     showTimeline,
   }) => {
-    const isDiscoverInTimelineEnabled = useIsExperimentalFeatureEnabled('discoverInTimeline');
     const { hasAssistantPrivilege } = useAssistantAvailability();
     const getTab = useCallback(
       (tab: TimelineTabs) => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -231,14 +231,6 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
             )}
           </HideShowContainer>
         )}
-        {isDiscoverInTimelineEnabled && (
-          <HideShowContainer
-            $isVisible={TimelineTabs.discover === activeTimelineTab}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.discover}`}
-          >
-            <DiscoverTab timelineId={timelineId} />
-          </HideShowContainer>
-        )}
       </>
     );
   }

--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/constants.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/constants.ts
@@ -30,6 +30,8 @@ export const SecurityPagePath = {
  * The path should not be used for links displayed in the main left navigation, since highlighting won't work.
  **/
 export enum ExternalPageName {
+  // Discover
+  discover = 'discover:',
   // Osquery
   osquery = 'osquery:',
   // Analytics

--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/nav.links.test.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/nav.links.test.ts
@@ -57,6 +57,11 @@ const projectLinkDevTools: ProjectNavigationLink = {
   title: 'Dev tools',
 };
 
+const projectLinkDiscover: ProjectNavigationLink = {
+  id: ExternalPageName.discover,
+  title: 'Discover',
+};
+
 const chromeNavLink1: ChromeNavLink = {
   id: `${APP_UI_ID}:${link1.id}`,
   title: link1.title,
@@ -145,6 +150,7 @@ describe('getProjectNavLinks', () => {
       link1,
       link2,
       { ...linkMlLanding, categories: mlNavCategories, links: mlNavLinks },
+      projectLinkDiscover,
       projectLinkDevTools,
     ]);
   });
@@ -169,6 +175,7 @@ describe('getProjectNavLinks', () => {
     expect(value).toEqual([
       link1,
       { ...linkAssets, links: [...assetsNavLinks, link2] },
+      projectLinkDiscover,
       projectLinkDevTools,
     ]);
   });
@@ -193,6 +200,7 @@ describe('getProjectNavLinks', () => {
     expect(value).toEqual([
       link1,
       { ...linkInvestigations, links: [link2, ...investigationsNavLinks] },
+      projectLinkDiscover,
       projectLinkDevTools,
     ]);
   });
@@ -226,6 +234,7 @@ describe('getProjectNavLinks', () => {
         categories: projectSettingsNavCategories,
         links: [...expectedProjectSettingsNavLinks, link2],
       },
+      projectLinkDiscover,
       projectLinkDevTools,
     ]);
   });

--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/nav_links.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/nav_links.ts
@@ -18,6 +18,7 @@ import {
   projectSettingsNavLinks,
 } from './sections/project_settings_links';
 import { devToolsNavLink } from './sections/dev_tools_links';
+import { discoverNavLink } from './sections/discover_links';
 import type { ProjectNavigationLink } from './types';
 import { getCloudLinkKey, getCloudUrl, getNavLinkIdFromProjectPageName, isCloudLink } from './util';
 import { investigationsNavLinks } from './sections/investigations_links';
@@ -54,6 +55,9 @@ const processNavLinks = (
   experimentalFeatures: ExperimentalFeatures
 ): ProjectNavigationLink[] => {
   const projectNavLinks: ProjectNavigationLink[] = [...securityNavLinks];
+
+  // Discover. just pushing it
+  projectNavLinks.push(discoverNavLink);
 
   // Investigations. injecting external sub-links and categories definition to the landing
   const investigationsLinkIndex = projectNavLinks.findIndex(

--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/sections/discover_links.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/sections/discover_links.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { ExternalPageName } from '../constants';
+import type { ProjectNavigationLink } from '../types';
+import { DISCOVER_TITLE } from './discover_translations';
+
+export const discoverNavLink: ProjectNavigationLink = {
+  id: ExternalPageName.discover,
+  title: DISCOVER_TITLE,
+};

--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/sections/discover_translations.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/sections/discover_translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const DISCOVER_TITLE = i18n.translate(
+  'xpack.securitySolutionServerless.navLinks.discover.title',
+  {
+    defaultMessage: 'Discover',
+  }
+);

--- a/x-pack/plugins/security_solution_serverless/public/navigation/side_navigation/categories.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/side_navigation/categories.ts
@@ -15,7 +15,7 @@ import { ExternalPageName } from '../links/constants';
 export const CATEGORIES: SeparatorLinkCategory[] = [
   {
     type: LinkCategoryType.separator,
-    linkIds: [SecurityPageName.dashboards],
+    linkIds: [ExternalPageName.discover, SecurityPageName.dashboards],
   },
   {
     type: LinkCategoryType.separator,

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/discover_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/discover_state.cy.ts
@@ -33,7 +33,8 @@ const INITIAL_END_DATE = 'Jan 19, 2024 @ 20:33:29.186';
 const DEFAULT_ESQL_QUERY =
   'from .alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-* | limit 10';
 
-describe(
+// TODO: reuse or remove this tests when ESQL tab will be added
+describe.skip(
   'Discover State',
   {
     env: { ftrConfig: { enableExperimental: ['discoverInTimeline'] } },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/discover_timeline_state_integration.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/discover_timeline_state_integration.cy.ts
@@ -60,7 +60,8 @@ const TIMELINE_RESPONSE_SAVED_OBJECT_ID_PATH =
   'response.body.data.persistTimeline.timeline.savedObjectId';
 const esqlQuery = 'from auditbeat-* | where ecs.version == "8.0.0"';
 
-describe(
+// TODO: reuse or remove this tests when ESQL tab will be added
+describe.skip(
   'Discover Timeline State Integration',
   {
     env: { ftrConfig: { enableExperimental: ['discoverInTimeline'] } },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/search_filter.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/discover/search_filter.cy.ts
@@ -34,7 +34,8 @@ const NEW_START_DATE = 'Jan 18, 2023 @ 20:33:29.186';
 const esqlQuery = 'from auditbeat-* | where ecs.version == "8.0.0"';
 
 // Failing: See https://github.com/elastic/kibana/issues/167186
-describe(
+// TODO: reuse or remove this tests when ESQL tab will be added
+describe.skip(
   'Basic discover search and filter operations',
   {
     env: { ftrConfig: { enableExperimental: ['discoverInTimeline'] } },


### PR DESCRIPTION
Resolves https://github.com/elastic/security-team/issues/7724
Included changes:
- added discover link to security navigation
- removed discover tab from Timeline