### PR TITLE
chore(NA): use a n2-8-spot instance to build storybooks on prs as well

### DIFF
--- a/.buildkite/pipelines/pull_request/storybooks.yml
+++ b/.buildkite/pipelines/pull_request/storybooks.yml
@@ -2,6 +2,6 @@ steps:
   - command: .buildkite/scripts/steps/storybooks/build_and_upload.sh
     label: 'Build Storybooks'
     agents:
-      queue: n2-4-spot
+      queue: n2-8-spot
     key: storybooks
     timeout_in_minutes: 60


### PR DESCRIPTION
This PR makes sure we use the more capable machine to build storybooks on PRs as well.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->