### PR TITLE
[RAM] Remove restriction on setting a start time in the past on Snooze Scheduler UI

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rule_snooze/scheduler.tsx
@@ -121,7 +121,15 @@ const RuleSnoozeSchedulerPanel: React.FunctionComponent<PanelOpts> = ({
   const minDate = useMemo(
     // If the initial schedule is earlier than now, set minDate to it
     // Set minDate to now if the initial schedule is in the future
-    () => moment.min(moment(), moment(initialSchedule?.rRule.dtstart ?? undefined)),
+    () =>
+      moment
+        .min(moment(), moment(initialSchedule?.rRule.dtstart ?? undefined))
+        // Allow the time on minDate to be earlier than the current time
+        // This is useful especially when the user is trying to create a recurring schedule
+        // that starts today, and should start at a time earlier than the current time on future
+        // occurrences
+        .hour(0)
+        .minute(0),
     [initialSchedule]
   );
 


### PR DESCRIPTION
## Summary

Closes #167176

Sets the minimum date in the snooze scheduler datepicker to the current date at `00:00`. This is useful especially when the user is trying to create a recurring schedule that starts today, and should start at a time earlier than the current time on future occurrences.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->