### PR TITLE
[Security Solution] Unskip prebuilt rules Cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_error_handling.cy.ts
@@ -7,7 +7,7 @@
 
 import { createRuleAssetSavedObject } from '../../../helpers/rules';
 import { createAndInstallMockedPrebuiltRules } from '../../../tasks/api_calls/prebuilt_rules';
-import { resetRulesTableState, deleteAlertsAndRules, reload } from '../../../tasks/common';
+import { resetRulesTableState, deleteAlertsAndRules } from '../../../tasks/common';
 import { login } from '../../../tasks/login';
 import {
   addElasticRulesButtonClick,
@@ -23,10 +23,9 @@ import {
 } from '../../../tasks/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../tasks/rules_management';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
 describe(
   'Detection rules, Prebuilt Rules Installation and Update - Error handling',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
+  { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
       login();
@@ -111,7 +110,7 @@ describe(
           rules: [UPDATED_RULE_1, UPDATED_RULE_2],
           installToKibana: false,
         });
-        reload();
+        cy.reload();
       });
 
       it('upgrading prebuilt rules one by one', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_install_update_workflows.cy.ts
@@ -24,7 +24,7 @@ import {
   getRuleAssets,
   createAndInstallMockedPrebuiltRules,
 } from '../../../tasks/api_calls/prebuilt_rules';
-import { resetRulesTableState, deleteAlertsAndRules, reload } from '../../../tasks/common';
+import { resetRulesTableState, deleteAlertsAndRules } from '../../../tasks/common';
 import { login } from '../../../tasks/login';
 import {
   addElasticRulesButtonClick,
@@ -40,10 +40,9 @@ import {
 } from '../../../tasks/prebuilt_rules';
 import { visitRulesManagementTable } from '../../../tasks/rules_management';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
 describe(
   'Detection rules, Prebuilt Rules Installation and Update workflow',
-  { tags: ['@ess', '@serverless', '@brokenInServerless'] },
+  { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
       login();
@@ -230,7 +229,7 @@ describe(
           rules: [UPDATED_RULE_1, UPDATED_RULE_2],
           installToKibana: false,
         });
-        reload();
+        cy.reload();
       });
 
       it('should upgrade prebuilt rules one by one', () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_management.cy.ts
@@ -51,8 +51,7 @@ const rules = Array.from(Array(5)).map((_, i) => {
   });
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-describe('Prebuilt rules', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Prebuilt rules', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/prebuilt_rules/prebuilt_rules_notifications.cy.ts
@@ -19,7 +19,6 @@ import {
 import {
   resetRulesTableState,
   deleteAlertsAndRules,
-  reload,
   deletePrebuiltRulesAssets,
 } from '../../../tasks/common';
 import { login } from '../../../tasks/login';
@@ -30,10 +29,9 @@ const RULE_1 = createRuleAssetSavedObject({
   rule_id: 'rule_1',
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161540
 describe(
   'Detection rules, Prebuilt Rules Installation and Update Notifications',
-  { tags: ['@ess', '@serverless', '@brokenInServerless'] },
+  { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
       login();
@@ -120,7 +118,7 @@ describe(
           /* Install available rules, assert that the notification is gone */
           /* then delete one rule and assert that the notification is back */
           installAllPrebuiltRulesRequest().then(() => {
-            reload();
+            cy.reload();
             deleteFirstRule();
             cy.get(ADD_ELASTIC_RULES_BTN).should('be.visible');
             cy.get(ADD_ELASTIC_RULES_BTN).should('have.text', `Add Elastic rules${1}`);
@@ -140,7 +138,7 @@ describe(
             });
             createAndInstallMockedPrebuiltRules({ rules: [UPDATED_RULE], installToKibana: false });
             visitRulesManagementTable();
-            reload();
+            cy.reload();
           });
         });
 


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/161540

## Summary

This PR unskips preuilt rules Cypress tests (besides `prebuilt_rules_install_update_authorization.cy.ts` as it uses non default role).

## Flaky test runner

[prebuilt_rules folder 150 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3384) 🟢


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->