### PR TITLE
[8.11] [Cases] Delete Comment - Fix Flaky Test (#167971)

### DIFF
--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/comments/delete_comment.ts
@@ -54,8 +54,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const log = getService('log');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/157589
-  describe.skip('delete_comment', () => {
+  describe('delete_comment', () => {
     afterEach(async () => {
       await deleteCasesByESQuery(es);
       await deleteComments(es);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Cases] Delete Comment - Fix Flaky Test (#167971)](https://github.com/elastic/kibana/pull/167971)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Julian Gernun","email":"17549662+jcger@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-10-05T14:50:22Z","message":"[Cases] Delete Comment - Fix Flaky Test (#167971)\n\nJust unskipping because flaky test runner passed this test 99/100 times,\r\nit failed once because of something else\r\n\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3355#018aff58-5c88-4dd7-962f-1b0c8fb252ac","sha":"34a73cc909ed9c69532049f49b158ebf978ba801","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","backport:prev-minor","v8.12.0"],"number":167971,"url":"https://github.com/elastic/kibana/pull/167971","mergeCommit":{"message":"[Cases] Delete Comment - Fix Flaky Test (#167971)\n\nJust unskipping because flaky test runner passed this test 99/100 times,\r\nit failed once because of something else\r\n\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3355#018aff58-5c88-4dd7-962f-1b0c8fb252ac","sha":"34a73cc909ed9c69532049f49b158ebf978ba801"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/167971","number":167971,"mergeCommit":{"message":"[Cases] Delete Comment - Fix Flaky Test (#167971)\n\nJust unskipping because flaky test runner passed this test 99/100 times,\r\nit failed once because of something else\r\n\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3355#018aff58-5c88-4dd7-962f-1b0c8fb252ac","sha":"34a73cc909ed9c69532049f49b158ebf978ba801"}}]}] BACKPORT-->