### PR TITLE
[APM] Handle cleanup errors in API tests

### DIFF
--- a/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
@@ -17,10 +17,10 @@ import { waitForRuleStatus } from './helpers/wait_for_rule_status';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
-
   const supertest = getService('supertest');
   const ml = getService('ml');
   const es = getService('es');
+  const logger = getService('log');
 
   const synthtraceEsClient = getService('synthtraceEsClient');
   // FLAKY https://github.com/elastic/kibana/issues/160298
@@ -68,8 +68,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await synthtraceEsClient.clean();
-        await deleteRuleById({ supertest, ruleId });
+        try {
+          await synthtraceEsClient.clean();
+          await deleteRuleById({ supertest, ruleId });
+        } catch (e) {
+          logger.info('Could not delete rule by id', e);
+        }
       });
 
       describe('with ml jobs', () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
@@ -289,8 +289,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await deleteRuleById({ supertest, ruleId });
-        await deleteAlertsByRuleId({ es, ruleId });
+        try {
+          await deleteRuleById({ supertest, ruleId });
+          await deleteAlertsByRuleId({ es, ruleId });
+        } catch (e) {
+          logger.info('Could not delete rule', e);
+        }
       });
 
       it('produces one alert for the opbeans-php service', async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
@@ -77,8 +77,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await synthtraceEsClient.clean();
-      await clearKibanaApmEventLog(es);
+      try {
+        await synthtraceEsClient.clean();
+        await clearKibanaApmEventLog(es);
+      } catch (e) {
+        logger.info('Could not clear apm event log', e);
+      }
     });
 
     describe('create rule for opbeans-java without kql filter', () => {
@@ -229,8 +233,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await deleteAlertsByRuleId({ es, ruleId });
-        await deleteRuleById({ supertest, ruleId });
+        try {
+          await deleteAlertsByRuleId({ es, ruleId });
+          await deleteRuleById({ supertest, ruleId });
+        } catch (e) {
+          logger.info('Could not delete rule or action connector', e);
+        }
       });
 
       it('checks if rule is active', async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -76,8 +76,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await synthtraceEsClient.clean();
-      await clearKibanaApmEventLog(es);
+      try {
+        await synthtraceEsClient.clean();
+        await clearKibanaApmEventLog(es);
+      } catch (e) {
+        logger.info('Could not clean up apm event log', e);
+      }
     });
 
     describe('create rule without kql query', () => {
@@ -250,8 +254,12 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await deleteRuleById({ supertest, ruleId });
-        await deleteAlertsByRuleId({ es, ruleId });
+        try {
+          await deleteRuleById({ supertest, ruleId });
+          await deleteAlertsByRuleId({ es, ruleId });
+        } catch (e) {
+          logger.info('Could not delete rule', e);
+        }
       });
 
       it('indexes alert document with all group-by fields', async () => {


### PR DESCRIPTION
Follow up to #168080 

This adds additional guards around cleanup logic in api tests to reduce flakiness.


Flaky test runner:

- ✅ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3382

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->