### PR TITLE
[ML] Remove the Tech Preview label from ELSER v2

### DIFF
--- a/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
+++ b/x-pack/packages/ml/trained_models_utils/src/constants/trained_models.ts
@@ -72,7 +72,7 @@ export const ELASTIC_MODEL_DEFINITIONS: Record<string, ModelDefinition> = Object
       },
     },
     description: i18n.translate('xpack.ml.trainedModels.modelsList.elserV2Description', {
-      defaultMessage: 'Elastic Learned Sparse EncodeR v2 (Tech Preview)',
+      defaultMessage: 'Elastic Learned Sparse EncodeR v2',
     }),
   },
   '.elser_model_2_linux-x86_64': {
@@ -86,8 +86,7 @@ export const ELASTIC_MODEL_DEFINITIONS: Record<string, ModelDefinition> = Object
       },
     },
     description: i18n.translate('xpack.ml.trainedModels.modelsList.elserV2x86Description', {
-      defaultMessage:
-        'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64 (Tech Preview)',
+      defaultMessage: 'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64',
     }),
   },
 } as const);

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -43,7 +43,6 @@ import {
   type ModelState,
 } from '@kbn/ml-trained-models-utils';
 import { isDefined } from '@kbn/ml-is-defined';
-import { css } from '@emotion/react';
 import { useStorage } from '@kbn/ml-local-storage';
 import { getModelStateColor } from './get_model_state_color';
 import { ML_ELSER_CALLOUT_DISMISSED } from '../../../common/types/storage';
@@ -485,32 +484,28 @@ export const ModelsList: FC<Props> = ({
       'data-test-subj': 'mlModelsTableColumnDescription',
       render: ({ description, recommended }: ModelItem) => {
         if (!description) return null;
-        return (
-          <>
-            {description.replace('(Tech Preview)', '')}
-            {recommended ? (
-              <EuiToolTip
-                content={
-                  <FormattedMessage
-                    id="xpack.ml.trainedModels.modelsList.recommendedDownloadContent"
-                    defaultMessage="Recommended ELSER model version for your cluster's hardware configuration"
-                  />
-                }
-              >
-                <b
-                  css={css`
-                    text-wrap: nowrap;
-                  `}
-                >
-                  &nbsp;
-                  <FormattedMessage
-                    id="xpack.ml.trainedModels.modelsList.recommendedDownloadLabel"
-                    defaultMessage="(Recommended)"
-                  />
-                </b>
-              </EuiToolTip>
-            ) : null}
-          </>
+        const descriptionText = description.replace('(Tech Preview)', '');
+        return recommended ? (
+          <EuiToolTip
+            content={
+              <FormattedMessage
+                id="xpack.ml.trainedModels.modelsList.recommendedDownloadContent"
+                defaultMessage="Recommended ELSER model version for your cluster's hardware configuration"
+              />
+            }
+          >
+            <>
+              {descriptionText}&nbsp;
+              <b>
+                <FormattedMessage
+                  id="xpack.ml.trainedModels.modelsList.recommendedDownloadLabel"
+                  defaultMessage="(Recommended)"
+                />
+              </b>
+            </>
+          </EuiToolTip>
+        ) : (
+          descriptionText
         );
       },
     },

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -455,7 +455,7 @@ export const ModelsList: FC<Props> = ({
     },
     {
       name: modelIdColumnName,
-      width: '15%',
+      width: '215px',
       sortable: ({ model_id: modelId }: ModelItem) => modelId,
       truncateText: false,
       textOnly: false,
@@ -476,7 +476,7 @@ export const ModelsList: FC<Props> = ({
       },
     },
     {
-      width: '35%',
+      width: '300px',
       name: i18n.translate('xpack.ml.trainedModels.modelsList.modelDescriptionHeader', {
         defaultMessage: 'Description',
       }),
@@ -529,6 +529,7 @@ export const ModelsList: FC<Props> = ({
         </EuiFlexGroup>
       ),
       'data-test-subj': 'mlModelsTableColumnType',
+      width: '130px',
     },
     {
       field: 'state',
@@ -546,6 +547,7 @@ export const ModelsList: FC<Props> = ({
         ) : null;
       },
       'data-test-subj': 'mlModelsTableColumnDeploymentState',
+      width: '130px',
     },
     {
       field: ModelsTableToConfigMapping.createdAt,
@@ -556,6 +558,7 @@ export const ModelsList: FC<Props> = ({
       render: (v: number) => dateFormatter(v),
       sortable: true,
       'data-test-subj': 'mlModelsTableColumnCreatedAt',
+      width: '210px',
     },
     {
       width: '150px',
@@ -692,12 +695,13 @@ export const ModelsList: FC<Props> = ({
       <EuiSpacer size="m" />
       <div data-test-subj="mlModelsTableContainer">
         <EuiInMemoryTable<ModelItem>
+          css={{ overflowX: 'auto' }}
+          isSelectable={true}
+          isExpandable={true}
+          hasActions={true}
           allowNeutralSort={false}
           columns={columns}
-          hasActions={true}
-          isExpandable={true}
           itemIdToExpandedRowMap={itemIdToExpandedRowMap}
-          isSelectable={false}
           items={items}
           itemId={ModelsTableToConfigMapping.id}
           loading={isLoading}

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -558,6 +558,7 @@ export const ModelsList: FC<Props> = ({
       'data-test-subj': 'mlModelsTableColumnCreatedAt',
     },
     {
+      width: '150px',
       name: i18n.translate('xpack.ml.trainedModels.modelsList.actionsHeader', {
         defaultMessage: 'Actions',
       }),

--- a/x-pack/plugins/ml/server/models/model_management/model_provider.test.ts
+++ b/x-pack/plugins/ml/server/models/model_management/model_provider.test.ts
@@ -57,15 +57,14 @@ describe('modelsProvider', () => {
         {
           config: { input: { field_names: ['text_field'] } },
           default: true,
-          description: 'Elastic Learned Sparse EncodeR v2 (Tech Preview)',
+          description: 'Elastic Learned Sparse EncodeR v2',
           name: '.elser_model_2',
           version: 2,
         },
         {
           arch: 'amd64',
           config: { input: { field_names: ['text_field'] } },
-          description:
-            'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64 (Tech Preview)',
+          description: 'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64',
           name: '.elser_model_2_linux-x86_64',
           os: 'Linux',
           recommended: true,
@@ -109,15 +108,14 @@ describe('modelsProvider', () => {
         {
           config: { input: { field_names: ['text_field'] } },
           recommended: true,
-          description: 'Elastic Learned Sparse EncodeR v2 (Tech Preview)',
+          description: 'Elastic Learned Sparse EncodeR v2',
           name: '.elser_model_2',
           version: 2,
         },
         {
           arch: 'amd64',
           config: { input: { field_names: ['text_field'] } },
-          description:
-            'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64 (Tech Preview)',
+          description: 'Elastic Learned Sparse EncodeR v2, optimized for linux-x86_64',
           name: '.elser_model_2_linux-x86_64',
           os: 'Linux',
           version: 2,


### PR DESCRIPTION
## Summary

- Removes the Tech Preview label from ELSER v2 models. 
- Fixes issues with responsive layout 

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->