### PR TITLE
[Logs Onboarding] Fix casing on Elastic Agent text

### DIFF
--- a/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/home/index.tsx
@@ -258,7 +258,7 @@ export function Home() {
                         'xpack.observability_onboarding.card.k8s.description',
                         {
                           defaultMessage:
-                            'Collect logs and metrics from Kubernetes clusters with Elastic agent.',
+                            'Collect logs and metrics from Kubernetes clusters with Elastic Agent.',
                         }
                       )}
                     </p>
@@ -392,5 +392,5 @@ const getStartedLabel = i18n.translate(
 
 const elasticAgentLabel = i18n.translate(
   'xpack.observability_onboarding.card.elasticAgent',
-  { defaultMessage: 'Elastic agent' }
+  { defaultMessage: 'Elastic Agent' }
 );

--- a/x-pack/plugins/observability_onboarding/public/components/shared/install_elastic_agent_steps.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/shared/install_elastic_agent_steps.tsx
@@ -144,7 +144,7 @@ export function InstallElasticAgentSteps<PlatformId extends string>({
                 'xpack.observability_onboarding.installElasticAgent.configStep.manual.description',
                 {
                   defaultMessage:
-                    'Add the following configuration to {configPath} on the host where you installed the Elastic agent.',
+                    'Add the following configuration to {configPath} on the host where you installed the Elastic Agent.',
                   values: {
                     configPath,
                   },
@@ -157,7 +157,7 @@ export function InstallElasticAgentSteps<PlatformId extends string>({
         isLoading={false}
         contentAriaLabel={i18n.translate(
           'xpack.observability_onboarding.installElasticAgent.configStep.yamlCodeBlockdescription',
-          { defaultMessage: 'Elastic agent yaml configuration' }
+          { defaultMessage: 'Elastic Agent yaml configuration' }
         )}
         width="100%"
         height={300}
@@ -326,7 +326,7 @@ export function InstallElasticAgentSteps<PlatformId extends string>({
           'data-test-subj': 'obltOnboardingConfigureElasticAgentStep',
           title: i18n.translate(
             'xpack.observability_onboarding.installElasticAgent.configureStep.title',
-            { defaultMessage: 'Configure the Elastic agent' }
+            { defaultMessage: 'Configure the Elastic Agent' }
           ),
           status: disableSteps ? 'disabled' : configureAgentStatus,
           children: disableSteps ? <></> : configureStep,


### PR DESCRIPTION
In several places, "Elastic agent" instead of "Elastic Agent" was used.

Before: 
<img width="438" alt="Screenshot 2023-10-06 at 12 18 54" src="https://github.com/elastic/kibana/assets/244900/77be6308-e97c-419e-9959-cd75b6403d71">

After:

<img width="410" alt="Screenshot 2023-10-06 at 12 25 32" src="https://github.com/elastic/kibana/assets/244900/d5315f42-9b7c-4b12-aa65-b2964660de6d">

