### PR TITLE
[journeys] re-enable APM instrumentation for Elasticsearch

### DIFF
--- a/src/dev/performance/run_performance_cli.ts
+++ b/src/dev/performance/run_performance_cli.ts
@@ -11,6 +11,7 @@ import { run } from '@kbn/dev-cli-runner';
 import { REPO_ROOT } from '@kbn/repo-info';
 import fs from 'fs';
 import path from 'path';
+import { JOURNEY_APM_CONFIG } from '@kbn/journeys';
 
 const JOURNEY_BASE_PATH = 'x-pack/performance/journeys';
 
@@ -107,21 +108,20 @@ run(
           'scripts/es',
           'snapshot',
           '--license=trial',
-          // Disabling APM until https://github.com/elastic/elasticsearch/issues/100072 is fixed
-          // ...(JOURNEY_APM_CONFIG.active
-          //   ? [
-          //       '-E',
-          //       'tracing.apm.enabled=true',
-          //       '-E',
-          //       'tracing.apm.agent.transaction_sample_rate=1.0',
-          //       '-E',
-          //       `tracing.apm.agent.server_url=${JOURNEY_APM_CONFIG.serverUrl}`,
-          //       '-E',
-          //       `tracing.apm.agent.secret_token=${JOURNEY_APM_CONFIG.secretToken}`,
-          //       '-E',
-          //       `tracing.apm.agent.environment=${JOURNEY_APM_CONFIG.environment}`,
-          //     ]
-          //   : []),
+          ...(JOURNEY_APM_CONFIG.active
+            ? [
+                '-E',
+                'tracing.apm.enabled=true',
+                '-E',
+                'tracing.apm.agent.transaction_sample_rate=1.0',
+                '-E',
+                `tracing.apm.agent.server_url=${JOURNEY_APM_CONFIG.serverUrl}`,
+                '-E',
+                `tracing.apm.agent.secret_token=${JOURNEY_APM_CONFIG.secretToken}`,
+                '-E',
+                `tracing.apm.agent.environment=${JOURNEY_APM_CONFIG.environment}`,
+              ]
+            : []),
         ],
         cwd: REPO_ROOT,
         wait: /kbn\/es setup complete/,

--- a/src/dev/tsconfig.json
+++ b/src/dev/tsconfig.json
@@ -39,5 +39,6 @@
     "@kbn/get-repo-files",
     "@kbn/import-locator",
     "@kbn/config-schema",
+    "@kbn/journeys",
   ]
 }


### PR DESCRIPTION
## Summary

In #167810 I disabled APM for ES due to ES crash. The issue was fixed and it is working for me locally.

perf journeys pipeline check https://buildkite.com/elastic/kibana-single-user-performance/builds/11578

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->