### PR TITLE
Set correct ownership of older app-services code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -386,7 +386,7 @@ src/plugins/expression_reveal_image @elastic/kibana-presentation
 src/plugins/expression_shape @elastic/kibana-presentation
 src/plugins/chart_expressions/expression_tagcloud @elastic/kibana-visualizations
 src/plugins/chart_expressions/expression_xy @elastic/kibana-visualizations
-examples/expressions_explorer @elastic/kibana-app-services
+examples/expressions_explorer @elastic/kibana-visualizations
 src/plugins/expressions @elastic/kibana-visualizations
 packages/kbn-failed-test-reporter-cli @elastic/kibana-operations @elastic/appex-qa
 examples/feature_control_examples @elastic/kibana-security
@@ -454,7 +454,7 @@ packages/kbn-jest-serializers @elastic/kibana-operations
 packages/kbn-journeys @elastic/kibana-operations @elastic/appex-qa
 packages/kbn-json-ast @elastic/kibana-operations
 test/health_gateway/plugins/status @elastic/kibana-core
-test/plugin_functional/plugins/kbn_sample_panel_action @elastic/kibana-app-services
+test/plugin_functional/plugins/kbn_sample_panel_action @elastic/appex-sharedux
 test/plugin_functional/plugins/kbn_top_nav @elastic/kibana-core
 test/plugin_functional/plugins/kbn_tp_custom_visualizations @elastic/kibana-visualizations
 test/interpreter_functional/plugins/kbn_tp_run_pipeline @elastic/kibana-core
@@ -475,8 +475,8 @@ src/plugins/links @elastic/kibana-presentation
 packages/kbn-lint-packages-cli @elastic/kibana-operations
 packages/kbn-lint-ts-projects-cli @elastic/kibana-operations
 x-pack/plugins/lists @elastic/security-detection-engine
-examples/locator_examples @elastic/kibana-app-services
-examples/locator_explorer @elastic/kibana-app-services
+examples/locator_examples @elastic/appex-sharedux
+examples/locator_explorer @elastic/appex-sharedux
 x-pack/plugins/log_explorer @elastic/infra-monitoring-ui
 packages/kbn-logging @elastic/kibana-core
 packages/kbn-logging-mocks @elastic/kibana-core
@@ -497,7 +497,7 @@ packages/kbn-management/settings/section_registry @elastic/appex-sharedux @elast
 packages/kbn-management/settings/types @elastic/platform-deployment-management
 packages/kbn-management/settings/utilities @elastic/platform-deployment-management
 packages/kbn-management/storybook/config @elastic/platform-deployment-management
-test/plugin_functional/plugins/management_test_plugin @elastic/kibana-app-services
+test/plugin_functional/plugins/management_test_plugin @elastic/platform-deployment-management
 packages/kbn-mapbox-gl @elastic/kibana-gis
 x-pack/examples/third_party_maps_source_example @elastic/kibana-gis
 src/plugins/maps_ems @elastic/kibana-gis
@@ -612,7 +612,7 @@ packages/kbn-saved-objects-settings @elastic/appex-sharedux
 src/plugins/saved_objects_tagging_oss @elastic/appex-sharedux
 x-pack/plugins/saved_objects_tagging @elastic/appex-sharedux
 src/plugins/saved_search @elastic/kibana-data-discovery
-examples/screenshot_mode_example @elastic/kibana-app-services
+examples/screenshot_mode_example @elastic/appex-sharedux
 src/plugins/screenshot_mode @elastic/appex-sharedux
 x-pack/examples/screenshotting_example @elastic/appex-sharedux
 x-pack/plugins/screenshotting @elastic/kibana-reporting-services
@@ -666,7 +666,7 @@ packages/serverless/types @elastic/appex-sharedux
 test/plugin_functional/plugins/session_notifications @elastic/kibana-core
 x-pack/plugins/session_view @elastic/kibana-cloud-security-posture
 packages/kbn-set-map @elastic/kibana-operations
-examples/share_examples @elastic/kibana-app-services
+examples/share_examples @elastic/appex-sharedux
 src/plugins/share @elastic/appex-sharedux
 packages/kbn-shared-svg @elastic/apm-ui
 packages/shared-ux/avatar/solution @elastic/appex-sharedux
@@ -787,7 +787,7 @@ src/plugins/unified_histogram @elastic/kibana-data-discovery
 src/plugins/unified_search @elastic/kibana-visualizations
 x-pack/plugins/upgrade_assistant @elastic/platform-deployment-management
 x-pack/plugins/uptime @elastic/uptime
-x-pack/plugins/drilldowns/url_drilldown @elastic/kibana-app-services
+x-pack/plugins/drilldowns/url_drilldown @elastic/appex-sharedux
 src/plugins/url_forwarding @elastic/kibana-visualizations
 packages/kbn-url-state @elastic/security-threat-hunting-investigations
 src/plugins/usage_collection @elastic/kibana-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -463,7 +463,7 @@ packages/kbn-kibana-manifest-schema @elastic/kibana-operations
 src/plugins/kibana_overview @elastic/appex-sharedux
 src/plugins/kibana_react @elastic/appex-sharedux
 src/plugins/kibana_usage_collection @elastic/kibana-core
-src/plugins/kibana_utils @elastic/kibana-app-services
+src/plugins/kibana_utils @elastic/appex-sharedux
 x-pack/plugins/kubernetes_security @elastic/kibana-cloud-security-posture
 packages/kbn-language-documentation-popover @elastic/kibana-visualizations
 packages/kbn-lens-embeddable-utils @elastic/infra-monitoring-ui

--- a/dev_docs/key_concepts/anatomy_of_a_plugin.mdx
+++ b/dev_docs/key_concepts/anatomy_of_a_plugin.mdx
@@ -49,8 +49,8 @@ plugins/
   "configPath": "path/to/config",
   "type": "standard",
   "owner": {
-    "name": "App Services",
-    "githubTeam": "kibana-app-services"
+    "name": "Shared UX",
+    "githubTeam": "appex-sharedux"
   },
   "description": "A description about this plugin!",
   "requiredPlugins": ["data"],

--- a/examples/expressions_explorer/kibana.jsonc
+++ b/examples/expressions_explorer/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/expressions-explorer-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/kibana-visualizations",
   "plugin": {
     "id": "expressionsExplorer",
     "server": false,

--- a/examples/locator_examples/kibana.jsonc
+++ b/examples/locator_examples/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/locator-examples-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "description": "Example app that registers custom URL locators",
   "plugin": {
     "id": "locatorExamples",

--- a/examples/locator_explorer/kibana.jsonc
+++ b/examples/locator_explorer/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/locator-explorer-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "description": "Example app that shows how to use custom URL locators",
   "plugin": {
     "id": "locatorExplorer",

--- a/examples/screenshot_mode_example/kibana.jsonc
+++ b/examples/screenshot_mode_example/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/screenshot-mode-example-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "description": "Example plugin of how to use screenshotMode plugin services",
   "plugin": {
     "id": "screenshotModeExample",

--- a/examples/share_examples/kibana.jsonc
+++ b/examples/share_examples/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/share-examples-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "description": "Small demos of share plugin usage",
   "plugin": {
     "id": "shareExamples",

--- a/src/plugins/kibana_utils/kibana.jsonc
+++ b/src/plugins/kibana_utils/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/kibana-utils-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "plugin": {
     "id": "kibanaUtils",
     "server": false,

--- a/test/plugin_functional/plugins/kbn_sample_panel_action/kibana.jsonc
+++ b/test/plugin_functional/plugins/kbn_sample_panel_action/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/kbn-sample-panel-action-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "plugin": {
     "id": "kbnSamplePanelAction",
     "server": false,

--- a/test/plugin_functional/plugins/management_test_plugin/kibana.jsonc
+++ b/test/plugin_functional/plugins/management_test_plugin/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/management-test-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/platform-deployment-management",
   "plugin": {
     "id": "managementTestPlugin",
     "server": false,

--- a/x-pack/plugins/drilldowns/url_drilldown/kibana.jsonc
+++ b/x-pack/plugins/drilldowns/url_drilldown/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/url-drilldown-plugin",
-  "owner": "@elastic/kibana-app-services",
+  "owner": "@elastic/appex-sharedux",
   "description": "Adds drilldown implementations to Kibana",
   "plugin": {
     "id": "urlDrilldown",


### PR DESCRIPTION
## Summary

Removes `@elastic/kibana-app-services` from `CODEOWNERS` file.