### PR TITLE
[Serverless Search] Update G/S "Elasticsearch clients" link

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -824,6 +824,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       elasticsearch: `${SEARCH_UI_DOCS}tutorials/elasticsearch`,
     },
     serverlessClients: {
+      clientLib: `${SERVERLESS_ELASTICSEARCH_DOCS}clients`,
       goApiReference: `${SERVERLESS_ELASTICSEARCH_DOCS}go-client-getting-started`,
       goGettingStarted: `${SERVERLESS_ELASTICSEARCH_DOCS}go-client-getting-started`,
       httpApis: `${SERVERLESS_ELASTICSEARCH_DOCS}http-apis`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -581,6 +581,7 @@ export interface DocLinks {
     readonly elasticsearch: string;
   };
   readonly serverlessClients: {
+    readonly clientLib: string;
     readonly goApiReference: string;
     readonly goGettingStarted: string;
     readonly httpApis: string;

--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -61,7 +61,7 @@ class ESDocLinks {
     this.securityApis = newDocLinks.apis.securityApis;
 
     // Client links
-    this.elasticsearchClients = newDocLinks.serverlessClients.httpApis;
+    this.elasticsearchClients = newDocLinks.serverlessClients.clientLib;
     // Go
     this.goApiReference = newDocLinks.serverlessClients.goApiReference;
     this.goBasicConfig = newDocLinks.serverlessClients.goGettingStarted;


### PR DESCRIPTION
## Summary

**Problem:** The "Elasticsearch Clients" link under **Select your client** points to the HTTP API docs rather than the ES clients docs.

**Solution:** Update the link to the point to the **ES Client Libraries** page instead.