### PR TITLE
[8.10] backport SLO fixes

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_create_slo.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_create_slo.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { encode } from '@kbn/rison';
 import type { CreateSLOInput, CreateSLOResponse, FindSLOResponse } from '@kbn/slo-schema';
@@ -13,6 +14,8 @@ import { v1 as uuidv1 } from 'uuid';
 import { paths } from '../../../common/locators/paths';
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useCreateSlo() {
   const {
@@ -24,7 +27,7 @@ export function useCreateSlo() {
 
   return useMutation<
     CreateSLOResponse,
-    string,
+    ServerError,
     { slo: CreateSLOInput },
     { previousData?: FindSLOResponse; queryKey?: QueryKey }
   >(
@@ -72,7 +75,7 @@ export function useCreateSlo() {
           queryClient.setQueryData(context.queryKey, context.previousData);
         }
 
-        toasts.addError(new Error(String(error)), {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
           title: i18n.translate('xpack.observability.slo.create.errorNotification', {
             defaultMessage: 'Something went wrong while creating {name}',
             values: { name: slo.name },

--- a/x-pack/plugins/observability/public/hooks/slo/use_delete_slo.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_delete_slo.ts
@@ -8,8 +8,11 @@
 import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
 import { i18n } from '@kbn/i18n';
 import { FindSLOResponse } from '@kbn/slo-schema';
+import { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useDeleteSlo() {
   const {
@@ -20,7 +23,7 @@ export function useDeleteSlo() {
 
   return useMutation<
     string,
-    string,
+    ServerError,
     { id: string; name: string },
     { previousData?: FindSLOResponse; queryKey?: QueryKey }
   >(
@@ -56,17 +59,17 @@ export function useDeleteSlo() {
         return { previousData, queryKey };
       },
       // If the mutation fails, use the context returned from onMutate to roll back
-      onError: (_err, { name }, context) => {
+      onError: (error, { name }, context) => {
         if (context?.previousData && context?.queryKey) {
           queryClient.setQueryData(context.queryKey, context.previousData);
         }
 
-        toasts.addDanger(
-          i18n.translate('xpack.observability.slo.slo.delete.errorNotification', {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
+          title: i18n.translate('xpack.observability.slo.slo.delete.errorNotification', {
             defaultMessage: 'Failed to delete {name}',
             values: { name },
-          })
-        );
+          }),
+        });
       },
       onSuccess: (_data, { name }) => {
         toasts.addSuccess(

--- a/x-pack/plugins/observability/public/hooks/slo/use_get_preview_data.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_get_preview_data.ts
@@ -42,7 +42,7 @@ export function useGetPreviewData(isValid: boolean, indicator: Indicator): UseGe
           }
         );
 
-        return response;
+        return Array.isArray(response) ? response : [];
       },
       retry: false,
       refetchOnWindowFocus: false,

--- a/x-pack/plugins/observability/public/hooks/slo/use_update_slo.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_update_slo.ts
@@ -5,11 +5,14 @@
  * 2.0.
  */
 
+import { IHttpFetchError, ResponseErrorBody } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import type { FindSLOResponse, UpdateSLOInput, UpdateSLOResponse } from '@kbn/slo-schema';
 import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
+
+type ServerError = IHttpFetchError<ResponseErrorBody>;
 
 export function useUpdateSlo() {
   const {
@@ -20,7 +23,7 @@ export function useUpdateSlo() {
 
   return useMutation<
     UpdateSLOResponse,
-    string,
+    ServerError,
     { sloId: string; slo: UpdateSLOInput },
     { previousData?: FindSLOResponse; queryKey?: QueryKey }
   >(
@@ -69,7 +72,7 @@ export function useUpdateSlo() {
           queryClient.setQueryData(context.queryKey, context.previousData);
         }
 
-        toasts.addError(new Error(String(error)), {
+        toasts.addError(new Error(error.body?.message ?? error.message), {
           title: i18n.translate('xpack.observability.slo.update.errorNotification', {
             defaultMessage: 'Something went wrong when updating {name}',
             values: { name },

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
@@ -21,7 +21,7 @@ export function SloList({ autoRefresh }: Props) {
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<SortField | undefined>('status');
 
-  const { isInitialLoading, isLoading, isRefetching, isError, sloList, refetch } = useFetchSloList({
+  const { isLoading, isRefetching, isError, sloList } = useFetchSloList({
     page: activePage + 1,
     kqlQuery: query,
     sortBy: sort,
@@ -38,34 +38,23 @@ export function SloList({ autoRefresh }: Props) {
 
   const handlePageClick = (pageNumber: number) => {
     setActivePage(pageNumber);
-    refetch();
   };
 
   const handleChangeQuery = (newQuery: string) => {
     setActivePage(0);
     setQuery(newQuery);
-    refetch();
   };
 
   const handleChangeSort = (newSort: SortField | undefined) => {
     setActivePage(0);
     setSort(newSort);
-    refetch();
   };
 
   return (
     <EuiFlexGroup direction="column" gutterSize="m" data-test-subj="sloList">
       <EuiFlexItem grow>
         <SloListSearchFilterSortBar
-          loading={
-            isInitialLoading ||
-            isLoading ||
-            isRefetching ||
-            isCreatingSlo ||
-            isCloningSlo ||
-            isUpdatingSlo ||
-            isDeletingSlo
-          }
+          loading={isLoading || isCreatingSlo || isCloningSlo || isUpdatingSlo || isDeletingSlo}
           onChangeQuery={handleChangeQuery}
           onChangeSort={handleChangeSort}
         />

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_search_filter_sort_bar.tsx
@@ -16,6 +16,7 @@ import {
   EuiSelectableOption,
 } from '@elastic/eui';
 import { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
+import { Query } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { QueryStringInput } from '@kbn/unified-search-plugin/public';
 import React, { useState } from 'react';
@@ -103,9 +104,13 @@ export function SloListSearchFilterSortBar({
             unifiedSearch,
           }}
           disableAutoFocus
-          onSubmit={() => onChangeQuery(query)}
+          onSubmit={(value: Query) => {
+            setQuery(String(value.query));
+            onChangeQuery(String(value.query));
+          }}
           disableLanguageSwitcher
           isDisabled={loading}
+          autoSubmit
           indexPatterns={dataView ? [dataView] : []}
           placeholder={i18n.translate('xpack.observability.slo.list.search', {
             defaultMessage: 'Search your SLOs...',

--- a/x-pack/plugins/observability/server/assets/constants.ts
+++ b/x-pack/plugins/observability/server/assets/constants.ts
@@ -6,6 +6,7 @@
  */
 
 export const SLO_RESOURCES_VERSION = 2;
+export const SLO_SUMMARY_TRANSFORMS_VERSION = 3;
 
 export const SLO_COMPONENT_TEMPLATE_MAPPINGS_NAME = '.slo-observability.sli-mappings';
 export const SLO_COMPONENT_TEMPLATE_SETTINGS_NAME = '.slo-observability.sli-settings';

--- a/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
+++ b/x-pack/plugins/observability/server/assets/transform_templates/slo_transform_template.ts
@@ -36,6 +36,7 @@ export const getSLOTransformTemplate = (
   dest: destination,
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   sync: {
     time: {

--- a/x-pack/plugins/observability/server/errors/errors.ts
+++ b/x-pack/plugins/observability/server/errors/errors.ts
@@ -25,3 +25,5 @@ export class InternalQueryError extends ObservabilityError {}
 export class NotSupportedError extends ObservabilityError {}
 export class IllegalArgumentError extends ObservabilityError {}
 export class InvalidTransformError extends ObservabilityError {}
+
+export class SecurityException extends ObservabilityError {}

--- a/x-pack/plugins/observability/server/errors/handler.ts
+++ b/x-pack/plugins/observability/server/errors/handler.ts
@@ -9,6 +9,7 @@ import {
   CompositeSLOIdConflict,
   CompositeSLONotFound,
   ObservabilityError,
+  SecurityException,
   SLOIdConflict,
   SLONotFound,
 } from './errors';
@@ -20,6 +21,10 @@ export function getHTTPResponseCode(error: ObservabilityError): number {
 
   if (error instanceof SLOIdConflict || error instanceof CompositeSLOIdConflict) {
     return 409;
+  }
+
+  if (error instanceof SecurityException) {
+    return 403;
   }
 
   return 400;

--- a/x-pack/plugins/observability/server/services/slo/create_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/create_slo.ts
@@ -36,6 +36,7 @@ export class CreateSLO {
     }
 
     try {
+      await this.transformManager.preview(sloTransformId);
       await this.transformManager.start(sloTransformId);
     } catch (err) {
       await Promise.all([

--- a/x-pack/plugins/observability/server/services/slo/get_preview_data.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_preview_data.ts
@@ -16,12 +16,13 @@ import {
   KQLCustomIndicator,
   MetricCustomIndicator,
 } from '@kbn/slo-schema';
+import { assertNever } from '@kbn/std';
 import { APMTransactionDurationIndicator } from '../../domain/models';
 import { computeSLI } from '../../domain/services';
 import { InvalidQueryError } from '../../errors';
 import {
-  GetHistogramIndicatorAggregation,
   GetCustomMetricIndicatorAggregation,
+  GetHistogramIndicatorAggregation,
 } from './aggregations';
 
 export class GetPreviewData {
@@ -299,19 +300,24 @@ export class GetPreviewData {
   }
 
   public async execute(params: GetPreviewDataParams): Promise<GetPreviewDataResponse> {
-    switch (params.indicator.type) {
-      case 'sli.apm.transactionDuration':
-        return this.getAPMTransactionDurationPreviewData(params.indicator);
-      case 'sli.apm.transactionErrorRate':
-        return this.getAPMTransactionErrorPreviewData(params.indicator);
-      case 'sli.kql.custom':
-        return this.getCustomKQLPreviewData(params.indicator);
-      case 'sli.histogram.custom':
-        return this.getHistogramPreviewData(params.indicator);
-      case 'sli.metric.custom':
-        return this.getCustomMetricPreviewData(params.indicator);
-      default:
-        return [];
+    try {
+      const type = params.indicator.type;
+      switch (type) {
+        case 'sli.apm.transactionDuration':
+          return this.getAPMTransactionDurationPreviewData(params.indicator);
+        case 'sli.apm.transactionErrorRate':
+          return this.getAPMTransactionErrorPreviewData(params.indicator);
+        case 'sli.kql.custom':
+          return this.getCustomKQLPreviewData(params.indicator);
+        case 'sli.histogram.custom':
+          return this.getHistogramPreviewData(params.indicator);
+        case 'sli.metric.custom':
+          return this.getCustomMetricPreviewData(params.indicator);
+        default:
+          assertNever(type);
+      }
+    } catch (err) {
+      return [];
     }
   }
 }

--- a/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
+++ b/x-pack/plugins/observability/server/services/slo/historical_summary_client.ts
@@ -279,6 +279,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
           cumulative_total: {
@@ -287,6 +288,7 @@ function generateSearchQuery(
               window: timeWindowDurationInDays * bucketsPerDay,
               shift: 1,
               script: 'MovingFunctions.sum(values)',
+              gap_policy: 'insert_zeros',
             },
           },
         },

--- a/x-pack/plugins/observability/server/services/slo/mocks/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/mocks/index.ts
@@ -28,6 +28,7 @@ const createSummaryTransformInstallerMock = (): jest.Mocked<SummaryTransformInst
 const createTransformManagerMock = (): jest.Mocked<TransformManager> => {
   return {
     install: jest.fn(),
+    preview: jest.fn(),
     uninstall: jest.fn(),
     start: jest.fn(),
     stop: jest.fn(),

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/__snapshots__/summary_transform_installer.test.ts.snap
@@ -7,7 +7,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 7 days rolling time window",
       "dest": Object {
@@ -173,6 +173,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -235,7 +236,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 30 days rolling time window",
       "dest": Object {
@@ -401,6 +402,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -463,7 +465,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a 90 days rolling time window",
       "dest": Object {
@@ -629,6 +631,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -691,7 +694,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a weekly calendar aligned time window",
       "dest": Object {
@@ -870,6 +873,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",
@@ -932,7 +936,7 @@ Array [
       "_meta": Object {
         "managed": true,
         "managed_by": "observability",
-        "version": 2,
+        "version": 3,
       },
       "description": "Summarize every SLO with timeslices budgeting method and a monthly calendar aligned time window",
       "dest": Object {
@@ -1126,6 +1130,7 @@ Array [
       },
       "settings": Object {
         "deduce_mappings": false,
+        "unattended": true,
       },
       "source": Object {
         "index": ".slo-observability.sli-v2*",

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/summary_transform_installer.ts
@@ -8,7 +8,7 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import {
-  SLO_RESOURCES_VERSION,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../assets/constants';
 import { retryTransientEsErrors } from '../../../utils/retry';
@@ -32,7 +32,7 @@ export class DefaultSummaryTransformInstaller implements SummaryTransformInstall
     const alreadyInstalled =
       summaryTransforms.count === allTransformIds.length &&
       summaryTransforms.transforms.every(
-        (transform) => transform._meta?.version === SLO_RESOURCES_VERSION
+        (transform) => transform._meta?.version === SLO_SUMMARY_TRANSFORMS_VERSION
       ) &&
       summaryTransforms.transforms.every((transform) => allTransformIds.includes(transform.id));
 
@@ -46,9 +46,9 @@ export class DefaultSummaryTransformInstaller implements SummaryTransformInstall
       const transform = summaryTransforms.transforms.find((t) => t.id === transformId);
 
       const transformAlreadyInstalled =
-        !!transform && transform._meta?.version === SLO_RESOURCES_VERSION;
+        !!transform && transform._meta?.version === SLO_SUMMARY_TRANSFORMS_VERSION;
       const previousTransformAlreadyInstalled =
-        !!transform && transform._meta?.version !== SLO_RESOURCES_VERSION;
+        !!transform && transform._meta?.version !== SLO_SUMMARY_TRANSFORMS_VERSION;
 
       if (transformAlreadyInstalled) {
         this.logger.info(`SLO summary transform [${transformId}] already installed - skipping`);

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_30d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,10 +143,10 @@ export const SUMMARY_OCCURRENCES_30D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
-    max_page_search_size: 8000,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_7d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_OCCURRENCES_7D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_90d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_OCCURRENCES_90D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_monthly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -141,9 +141,10 @@ export const SUMMARY_OCCURRENCES_MONTHLY_ALIGNED: TransformPutTransformRequest =
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_occurrences_weekly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -141,9 +141,10 @@ export const SUMMARY_OCCURRENCES_WEEKLY_ALIGNED: TransformPutTransformRequest = 
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_30d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_30D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_7d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_7D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_90d_rolling.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -143,9 +143,10 @@ export const SUMMARY_TIMESLICES_90D_ROLLING: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_monthly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -171,9 +171,10 @@ export const SUMMARY_TIMESLICES_MONTHLY_ALIGNED: TransformPutTransformRequest = 
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
+++ b/x-pack/plugins/observability/server/services/slo/summary_transform/templates/summary_timeslices_weekly_aligned.ts
@@ -8,9 +8,9 @@
 import { TransformPutTransformRequest } from '@elastic/elasticsearch/lib/api/types';
 import {
   SLO_DESTINATION_INDEX_PATTERN,
-  SLO_RESOURCES_VERSION,
   SLO_SUMMARY_DESTINATION_INDEX_NAME,
   SLO_SUMMARY_INGEST_PIPELINE_NAME,
+  SLO_SUMMARY_TRANSFORMS_VERSION,
   SLO_SUMMARY_TRANSFORM_NAME_PREFIX,
 } from '../../../../assets/constants';
 import { groupBy } from './common';
@@ -156,9 +156,10 @@ export const SUMMARY_TIMESLICES_WEEKLY_ALIGNED: TransformPutTransformRequest = {
   },
   settings: {
     deduce_mappings: false,
+    unattended: true,
   },
   _meta: {
-    version: SLO_RESOURCES_VERSION,
+    version: SLO_SUMMARY_TRANSFORMS_VERSION,
     managed: true,
     managed_by: 'observability',
   },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -739,6 +739,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",
@@ -1013,6 +1014,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_error_rate.test.ts.snap
@@ -708,6 +708,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",
@@ -971,6 +972,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": "metrics-apm*",

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -220,6 +220,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -476,6 +477,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/kql_custom.test.ts.snap
@@ -235,6 +235,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -465,6 +466,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/metric_custom.test.ts.snap
@@ -244,6 +244,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [
@@ -512,6 +513,7 @@ Object {
   },
   "settings": Object {
     "deduce_mappings": false,
+    "unattended": true,
   },
   "source": Object {
     "index": Array [

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.test.ts
@@ -47,7 +47,7 @@ describe('TransformManager', () => {
 
         await expect(
           service.install(createSLO({ indicator: createAPMTransactionErrorRateIndicator() }))
-        ).rejects.toThrowError('Unsupported SLI type: sli.apm.transactionErrorRate');
+        ).rejects.toThrowError('Unsupported indicator type [sli.apm.transactionErrorRate]');
       });
 
       it('throws when transform generator fails', async () => {
@@ -77,6 +77,20 @@ describe('TransformManager', () => {
 
       expect(esClientMock.transform.putTransform).toHaveBeenCalledTimes(1);
       expect(transformId).toBe(`slo-${slo.id}-${slo.revision}`);
+    });
+  });
+
+  describe('Preview', () => {
+    it('previews the transform', async () => {
+      // @ts-ignore defining only a subset of the possible SLI
+      const generators: Record<IndicatorTypes, TransformGenerator> = {
+        'sli.apm.transactionErrorRate': new ApmTransactionErrorRateTransformGenerator(),
+      };
+      const transformManager = new DefaultTransformManager(generators, esClientMock, loggerMock);
+
+      await transformManager.preview('slo-transform-id');
+
+      expect(esClientMock.transform.previewTransform).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.ts
@@ -8,6 +8,7 @@
 import { ElasticsearchClient, Logger } from '@kbn/core/server';
 
 import { SLO, IndicatorTypes } from '../../domain/models';
+import { SecurityException } from '../../errors';
 import { retryTransientEsErrors } from '../../utils/retry';
 import { TransformGenerator } from './transform_generators';
 
@@ -42,6 +43,10 @@ export class DefaultTransformManager implements TransformManager {
       });
     } catch (err) {
       this.logger.error(`Cannot create SLO transform for indicator type [${slo.indicator.type}]`);
+      if (err.meta?.body?.error?.type === 'security_exception') {
+        throw new SecurityException(err.meta.body.error.reason);
+      }
+
       throw err;
     }
 

--- a/x-pack/plugins/observability/server/services/slo/transform_manager.ts
+++ b/x-pack/plugins/observability/server/services/slo/transform_manager.ts
@@ -15,6 +15,7 @@ type TransformId = string;
 
 export interface TransformManager {
   install(slo: SLO): Promise<TransformId>;
+  preview(transformId: TransformId): Promise<void>;
   start(transformId: TransformId): Promise<void>;
   stop(transformId: TransformId): Promise<void>;
   uninstall(transformId: TransformId): Promise<void>;
@@ -30,8 +31,8 @@ export class DefaultTransformManager implements TransformManager {
   async install(slo: SLO): Promise<TransformId> {
     const generator = this.generators[slo.indicator.type];
     if (!generator) {
-      this.logger.error(`No transform generator found for ${slo.indicator.type} SLO type`);
-      throw new Error(`Unsupported SLI type: ${slo.indicator.type}`);
+      this.logger.error(`No transform generator found for indicator type [${slo.indicator.type}]`);
+      throw new Error(`Unsupported indicator type [${slo.indicator.type}]`);
     }
 
     const transformParams = generator.getTransformParams(slo);
@@ -40,11 +41,23 @@ export class DefaultTransformManager implements TransformManager {
         logger: this.logger,
       });
     } catch (err) {
-      this.logger.error(`Cannot create transform for ${slo.indicator.type} SLI type: ${err}`);
+      this.logger.error(`Cannot create SLO transform for indicator type [${slo.indicator.type}]`);
       throw err;
     }
 
     return transformParams.transform_id;
+  }
+
+  async preview(transformId: string): Promise<void> {
+    try {
+      await retryTransientEsErrors(
+        () => this.esClient.transform.previewTransform({ transform_id: transformId }),
+        { logger: this.logger }
+      );
+    } catch (err) {
+      this.logger.error(`Cannot preview SLO transform [${transformId}]`);
+      throw err;
+    }
   }
 
   async start(transformId: TransformId): Promise<void> {
@@ -55,7 +68,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot start transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot start SLO transform [${transformId}]`);
       throw err;
     }
   }
@@ -71,7 +84,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot stop transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot stop SLO transform [${transformId}]`);
       throw err;
     }
   }
@@ -87,7 +100,7 @@ export class DefaultTransformManager implements TransformManager {
         { logger: this.logger }
       );
     } catch (err) {
-      this.logger.error(`Cannot delete transform id ${transformId}: ${err}`);
+      this.logger.error(`Cannot delete SLO transform [${transformId}]`);
       throw err;
     }
   }

--- a/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
@@ -141,8 +141,9 @@ describe('UpdateSLO', () => {
   });
 
   function expectInstallationOfNewSLOTransform() {
-    expect(mockTransformManager.start).toBeCalled();
     expect(mockTransformManager.install).toBeCalled();
+    expect(mockTransformManager.preview).toBeCalled();
+    expect(mockTransformManager.start).toBeCalled();
   }
 
   function expectDeletionOfObsoleteSLOData(originalSlo: SLO) {

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -37,9 +37,12 @@ export class UpdateSLO {
     validateSLO(updatedSlo);
 
     await this.deleteObsoleteSLORevisionData(originalSlo);
+
+    const updatedSloTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
     await this.repository.save(updatedSlo);
     await this.transformManager.install(updatedSlo);
-    await this.transformManager.start(getSLOTransformId(updatedSlo.id, updatedSlo.revision));
+    await this.transformManager.preview(updatedSloTransformId);
+    await this.transformManager.start(updatedSloTransformId);
 
     await this.esClient.index({
       index: SLO_SUMMARY_TEMP_INDEX_NAME,

--- a/x-pack/plugins/observability/server/services/slo/update_slo.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.ts
@@ -36,13 +36,27 @@ export class UpdateSLO {
 
     validateSLO(updatedSlo);
 
-    await this.deleteObsoleteSLORevisionData(originalSlo);
-
     const updatedSloTransformId = getSLOTransformId(updatedSlo.id, updatedSlo.revision);
     await this.repository.save(updatedSlo);
-    await this.transformManager.install(updatedSlo);
-    await this.transformManager.preview(updatedSloTransformId);
-    await this.transformManager.start(updatedSloTransformId);
+
+    try {
+      await this.transformManager.install(updatedSlo);
+    } catch (err) {
+      await this.repository.save(originalSlo);
+      throw err;
+    }
+
+    try {
+      await this.transformManager.preview(updatedSloTransformId);
+      await this.transformManager.start(updatedSloTransformId);
+    } catch (err) {
+      await Promise.all([
+        this.transformManager.uninstall(updatedSloTransformId),
+        this.repository.save(originalSlo),
+      ]);
+
+      throw err;
+    }
 
     await this.esClient.index({
       index: SLO_SUMMARY_TEMP_INDEX_NAME,
@@ -50,13 +64,21 @@ export class UpdateSLO {
       document: createTempSummaryDocument(updatedSlo),
     });
 
+    await this.deleteOriginalSLO(originalSlo);
+
     return this.toResponse(updatedSlo);
   }
 
-  private async deleteObsoleteSLORevisionData(originalSlo: SLO) {
-    const originalSloTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
-    await this.transformManager.stop(originalSloTransformId);
-    await this.transformManager.uninstall(originalSloTransformId);
+  private async deleteOriginalSLO(originalSlo: SLO) {
+    try {
+      const originalSloTransformId = getSLOTransformId(originalSlo.id, originalSlo.revision);
+      await this.transformManager.stop(originalSloTransformId);
+      await this.transformManager.uninstall(originalSloTransformId);
+    } catch (err) {
+      // Any errors here should not prevent moving forward.
+      // Worst case we keep rolling up data for the previous revision number.
+    }
+
     await this.deleteRollupData(originalSlo.id, originalSlo.revision);
     await this.deleteSummaryData(originalSlo.id, originalSlo.revision);
   }


### PR DESCRIPTION
## 🍒 Summary

This PR backports the following commits into 8.10 for release scheduled on 8.10.4:
- https://github.com/elastic/kibana/pull/166945
- https://github.com/elastic/kibana/pull/167909
- https://github.com/elastic/kibana/pull/168044
- https://github.com/elastic/kibana/pull/167170 (only required because introduce a dependency used in the next PR)
- https://github.com/elastic/kibana/pull/168142
- https://github.com/elastic/kibana/pull/167933

## Release Notes

This PR is a mix of fixes and enhancements:
- Improve the SLO search bar, fixing the issue with focus lost when the list was refreshing
- Handle gracefully any errors when the preview data API was failing to execute for any reason.
- Fix Historical SLI and error budget calculation when data was intermittent and had gaps.
- Optimize the summary transforms by running them unattended (always retry)
- Improve resilliency of the SLO update use case, handling any errors gracefully with proper rollback.
- Improve error handling from the react hooks

## Testing notes

- For #167909 and #168142, set up a user with a role with the following:
  - Cluster Privileges: `manage_transform`
  - Index Privileges:
    - `.slo-*`: `all`
    - `high-*`: `read` and `read_cross_cluster`
  - Kibana: All spaces All privileges
  - Create an SLO with the `elastic` superuser
  - When you log in as this user, try to create a new SLO and then edit (hit save) the SLO the `elastic` user created. For the new SLO you should get an error that says you don't have the proper permissions and then end up on the create screen (not saved). When you hit save on the SLO (that the `elastic` user created) you should end up with the same error without changing the original SLO.