### PR TITLE
Fix KibanaPageTemplate.BottomBar in serverless

### DIFF
--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -26,8 +26,8 @@
   margin-left: 320px; // Hard-coded for now -- @cchaos
 }
 
-// Add support for serverless nabbar
-.euiBody--hasFlyout .euiBottomBar {
+// Add support for serverless navbar
+.euiBody--hasFlyout .euiBottomBar--fixed {
   margin-left: var(--euiCollapsibleNavOffset, 0);
 }
 


### PR DESCRIPTION
## Summary

The latest changes applied [here ](https://github.com/elastic/kibana/pull/166840) caused the `KibanaPageTemplate.BottomBar` to not work properly:

![KibanaPageTemplate.BottomBar](https://github.com/elastic/kibana/assets/17747913/5720fb62-1352-4140-b0f6-93c818689660)

The `margin-left` should be applied only to `.euiBottomBar--fixed` instead of all `.euiBottomBar`, `--sticky` and `--static` are already positioned correctly to the relative parent, so no margin needs to be applied.