### PR TITLE
[Unified Field List] Add sticky header support

### DIFF
--- a/packages/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.scss
+++ b/packages/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.scss
@@ -12,9 +12,12 @@
 }
 
 .unifiedFieldList__fieldListGrouped__container {
-  padding-top: $euiSizeS;
   position: absolute;
   top: 0;
   left: $euiSize; /* 1 */
   right: $euiSizeXS; /* 1 */
+}
+
+.unifiedFieldList__fieldListGrouped__specialFields {
+  padding-top: $euiSizeS;
 }

--- a/packages/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_list_grouped/field_list_grouped.tsx
@@ -14,7 +14,7 @@ import { EuiScreenReaderOnly, EuiSpacer } from '@elastic/eui';
 import { type DataViewField } from '@kbn/data-views-plugin/common';
 import { NoFieldsCallout } from './no_fields_callout';
 import { FieldsAccordion, type FieldsAccordionProps, getFieldKey } from './fields_accordion';
-import type { FieldListGroups, FieldListItem } from '../../types';
+import type { FieldListGroups, FieldListItem, StickyHeadersOptions } from '../../types';
 import { ExistenceFetchStatus, FieldsGroup, FieldsGroupNames } from '../../types';
 import './field_list_grouped.scss';
 
@@ -40,6 +40,7 @@ export interface FieldListGroupedProps<T extends FieldListItem> {
   scrollToTopResetCounter: number;
   screenReaderDescriptionId?: string;
   localStorageKeyPrefix?: string; // Your app name: "discover", "lens", etc. If not provided, sections state would not be persisted.
+  stickyHeaders?: StickyHeadersOptions;
   'data-test-subj'?: string;
 }
 
@@ -51,6 +52,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
   scrollToTopResetCounter,
   screenReaderDescriptionId,
   localStorageKeyPrefix,
+  stickyHeaders,
   'data-test-subj': dataTestSubject = 'fieldListGrouped',
 }: FieldListGroupedProps<T>) {
   const hasSyncedExistingFields =
@@ -221,7 +223,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
         )}
         {hasSpecialFields && (
           <>
-            <ul>
+            <ul className="unifiedFieldList__fieldListGrouped__specialFields">
               {fieldGroupsToCollapse.flatMap(([key, { fields, fieldSearchHighlight }]) =>
                 fields.map((field, index) => (
                   <Fragment key={getFieldKey(field)}>
@@ -237,7 +239,6 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
                 ))
               )}
             </ul>
-            <EuiSpacer size="s" />
           </>
         )}
         {fieldGroupsToShow.map(([key, fieldGroup], index) => {
@@ -260,6 +261,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
                 paginatedFields={paginatedFields[key]}
                 groupIndex={index + 1}
                 groupName={key as FieldsGroupNames}
+                stickyHeaders={stickyHeaders}
                 onToggle={(open) => {
                   setAccordionState((s) => ({
                     ...s,
@@ -296,7 +298,7 @@ function InnerFieldListGrouped<T extends FieldListItem = DataViewField>({
                 )}
                 renderFieldItem={renderFieldItem}
               />
-              <EuiSpacer size="m" />
+              <EuiSpacer size="s" />
             </Fragment>
           );
         })}

--- a/packages/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
+++ b/packages/kbn-unified-field-list/src/containers/unified_field_list_sidebar/field_list_sidebar.tsx
@@ -28,7 +28,11 @@ import { FIELDS_LIMIT_SETTING, SEARCH_FIELDS_FROM_SOURCE } from '@kbn/discover-u
 import { FieldList } from '../../components/field_list';
 import { FieldListFilters } from '../../components/field_list_filters';
 import { FieldListGrouped, type FieldListGroupedProps } from '../../components/field_list_grouped';
-import { FieldsGroupNames, type ButtonAddFieldVariant } from '../../types';
+import {
+  FieldsGroupNames,
+  type StickyHeadersOptions,
+  type ButtonAddFieldVariant,
+} from '../../types';
 import { GroupedFieldsParams, useGroupedFields } from '../../hooks/use_grouped_fields';
 import { UnifiedFieldListItem, type UnifiedFieldListItemProps } from '../unified_field_list_item';
 import { SidebarToggleButton, type SidebarToggleButtonProps } from './sidebar_toggle_button';
@@ -68,6 +72,11 @@ export type UnifiedFieldListSidebarCustomizableProps = Pick<
    * Compressed view
    */
   compressed?: boolean;
+
+  /**
+   * Custom sticky headers options
+   */
+  stickyHeaders?: StickyHeadersOptions;
 
   /**
    * Custom logic for determining which field is selected
@@ -151,6 +160,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
   showFieldList = true,
   compressed = true,
   fullWidth,
+  stickyHeaders,
   isAffectedByGlobalFilter,
   prepend,
   onAddFieldToWorkspace,
@@ -390,6 +400,7 @@ export const UnifiedFieldListSidebarComponent: React.FC<UnifiedFieldListSidebarP
                 {...fieldListGroupedProps}
                 renderFieldItem={renderFieldItem}
                 localStorageKeyPrefix={stateService.creationOptions.localStorageKeyPrefix}
+                stickyHeaders={stickyHeaders}
               />
             ) : (
               <EuiFlexItem grow />

--- a/packages/kbn-unified-field-list/src/types.ts
+++ b/packages/kbn-unified-field-list/src/types.ts
@@ -199,3 +199,11 @@ export interface UnifiedFieldListSidebarContainerCreationOptions {
 export interface UnifiedFieldListSidebarContainerStateService {
   creationOptions: UnifiedFieldListSidebarContainerCreationOptions;
 }
+
+/**
+ * Options used for field list sticky headers
+ */
+export interface StickyHeadersOptions {
+  enabled: boolean;
+  backgroundColor: string;
+}

--- a/packages/kbn-unified-field-list/tsconfig.json
+++ b/packages/kbn-unified-field-list/tsconfig.json
@@ -31,6 +31,7 @@
     "@kbn/ebt-tools",
     "@kbn/shared-ux-button-toolbar",
     "@kbn/field-utils",
+    "@kbn/ui-theme",
   ],
   "exclude": ["target/**/*"]
 }

--- a/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_sidebar_responsive.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 import { UiCounterMetricType } from '@kbn/analytics';
 import { i18n } from '@kbn/i18n';
 import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
@@ -17,6 +17,7 @@ import {
   type UnifiedFieldListSidebarContainerApi,
   FieldsGroupNames,
 } from '@kbn/unified-field-list';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { PLUGIN_ID } from '../../../../../common';
 import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import {
@@ -373,6 +374,11 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
     [onRemoveField]
   );
 
+  const [stickyHeaders] = useState(() => ({
+    enabled: true,
+    backgroundColor: euiThemeVars.euiColorEmptyShade,
+  }));
+
   if (!selectedDataView) {
     return null;
   }
@@ -389,6 +395,7 @@ export function DiscoverSidebarResponsive(props: DiscoverSidebarResponsiveProps)
       showFieldList={showFieldList}
       workspaceSelectedFieldNames={columns}
       fullWidth
+      stickyHeaders={stickyHeaders}
       onAddFieldToWorkspace={onAddFieldToWorkspace}
       onRemoveFieldFromWorkspace={onRemoveFieldFromWorkspace}
       onAddFilter={onAddFilter}

--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.tsx
@@ -7,7 +7,7 @@
 
 import './datapanel.scss';
 import { uniq } from 'lodash';
-import React, { memo, useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { EuiCallOut, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -28,6 +28,7 @@ import {
   useGroupedFields,
 } from '@kbn/unified-field-list';
 import { ChartsPluginSetup } from '@kbn/charts-plugin/public';
+import { euiThemeVars } from '@kbn/ui-theme';
 import type {
   DatasourceDataPanelProps,
   FramePublicAPI,
@@ -392,6 +393,11 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
     ]
   );
 
+  const [stickyHeaders] = useState(() => ({
+    enabled: true,
+    backgroundColor: euiThemeVars.euiColorLightestShade,
+  }));
+
   return (
     <FieldList
       className="lnsInnerIndexPatternDataPanel"
@@ -403,6 +409,7 @@ export const InnerFormBasedDataPanel = function InnerFormBasedDataPanel({
         renderFieldItem={renderFieldItem}
         data-test-subj="lnsIndexPattern"
         localStorageKeyPrefix="lens"
+        stickyHeaders={stickyHeaders}
       />
     </FieldList>
   );

--- a/x-pack/plugins/lens/public/datasources/text_based/datapanel.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/datapanel.tsx
@@ -24,6 +24,7 @@ import {
   GetCustomFieldType,
   useGroupedFields,
 } from '@kbn/unified-field-list';
+import { euiThemeVars } from '@kbn/ui-theme';
 import type { DatasourceDataPanelProps } from '../../types';
 import type { TextBasedPrivateState } from './types';
 import { getStateFromAggregateQuery } from './utils';
@@ -130,6 +131,11 @@ export function TextBasedDataPanel({
     [hasSuggestionForField, dropOntoWorkspace]
   );
 
+  const [stickyHeaders] = useState(() => ({
+    enabled: true,
+    backgroundColor: euiThemeVars.euiColorLightestShade,
+  }));
+
   return (
     <KibanaContextProvider
       services={{
@@ -148,6 +154,7 @@ export function TextBasedDataPanel({
           renderFieldItem={renderFieldItem}
           data-test-subj="lnsTextBasedLanguages"
           localStorageKeyPrefix="lens"
+          stickyHeaders={stickyHeaders}
         />
       </FieldList>
     </KibanaContextProvider>


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)