### PR TITLE
[Serverless Search] Fix API key privileges link

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -847,6 +847,9 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       gettingStartedIngest: `${SERVERLESS_ELASTICSEARCH_DOCS}get-started#ingest`,
       gettingStartedSearch: `${SERVERLESS_ELASTICSEARCH_DOCS}get-started#search`,
     },
+    serverlessSecurity: {
+      apiKeyPrivileges: `${SERVERLESS_DOCS}api-keys#restrict-privileges`,
+    },
     synthetics: {
       featureRoles: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-feature-roles.html`,
     },

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -604,6 +604,9 @@ export interface DocLinks {
     readonly integrationsConnectorClient: string;
     readonly integrationsLogstash: string;
   };
+  readonly serverlessSecurity: {
+    readonly apiKeyPrivileges: string;
+  };
   readonly synthetics: {
     readonly featureRoles: string;
   };

--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -57,7 +57,7 @@ class ESDocLinks {
     this.kibanaFeedback = newDocLinks.kibana.feedback;
     this.kibanaRunApiInConsole = newDocLinks.console.serverlessGuide;
     this.metadata = newDocLinks.security.mappingRoles;
-    this.roleDescriptors = newDocLinks.security.mappingRoles;
+    this.roleDescriptors = newDocLinks.serverlessSecurity.apiKeyPrivileges;
     this.securityApis = newDocLinks.apis.securityApis;
 
     // Client links


### PR DESCRIPTION
## Summary

**Problem:** When creating an API key from the **Getting Started** page, the "Learn how to structure role descriptors" link under **Security Privileges** links to https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping-roles.html. This page talks about Security realms and isn't relevant for Serverless.

**Solution:** Update the link to the point to a related page in the Serverless docs instead.

**Note:** We can't apply this to the **API Keys** page under **Project settings > Management > API keys** as its shared.