### PR TITLE
[data_visualizer] Migrate deprecated `EuiPage*` component

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
+++ b/x-pack/plugins/data_visualizer/public/application/file_data_visualizer/components/import_view/import_view.js
@@ -11,7 +11,7 @@ import React, { Component } from 'react';
 import {
   EuiButton,
   EuiPageBody,
-  EuiPageContentHeader_Deprecated as EuiPageContentHeader,
+  EuiPageHeader,
   EuiPanel,
   EuiSpacer,
   EuiTitle,
@@ -481,11 +481,11 @@ export class ImportView extends Component {
 
     return (
       <EuiPageBody data-test-subj="dataVisualizerPageFileImport">
-        <EuiPageContentHeader>
+        <EuiPageHeader>
           <EuiTitle>
             <h1>{this.props.fileName}</h1>
           </EuiTitle>
-        </EuiPageContentHeader>
+        </EuiPageHeader>
         <EuiSpacer size="m" />
         <EuiPanel data-test-subj="dataVisualizerFileImportSettingsPanel">
           <EuiTitle size="s">


### PR DESCRIPTION
## Summary

EUI will shortly be removing several deprecated `EuiPage*` components, and we're updating a few remaining Kibana usages of these deprecated components ahead of time.

⚠️ PLEASE NOTE: We have **not** QA'd these changes to ensure that the UI is 1:1 from before. We do not have the domain knowledge or time to spin up local instances of all plugins with deprecations, and ask that the CODEOWNING team pull down this branch and QA the affected page(s) locally to ensure the UI looks like the same as production. ⚠️ 

See https://github.com/elastic/kibana/issues/161872 for other similar tasks with more information about this effort.