### PR TITLE
[Security Solution] Unskip rules table Serverless Cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_links.cy.ts
@@ -13,9 +13,7 @@ import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { RULES_MANAGEMENT_URL } from '../../../../urls/rules_management';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-// Flaky in serverless tests
-describe('Rules table: links', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Rules table: links', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
   });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_persistent_state.cy.ts
@@ -95,317 +95,306 @@ function expectDefaultRulesTableState(): void {
   expectTablePage(1);
 }
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-describe(
-  'Rules table: persistent state',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
-  () => {
-    before(() => {
-      cleanKibana();
-      createTestRules();
+describe('Rules table: persistent state', { tags: ['@ess', '@serverless'] }, () => {
+  before(() => {
+    cleanKibana();
+    createTestRules();
+  });
+
+  beforeEach(() => {
+    login();
+    resetRulesTableState();
+  });
+
+  describe('while on a happy path', { tags: ['@ess', '@serverless'] }, () => {
+    it('activates management tab by default', () => {
+      visit(RULES_MANAGEMENT_URL);
+
+      expectRulesManagementTab();
     });
 
-    beforeEach(() => {
-      login();
-      resetRulesTableState();
+    it('leads to displaying a rule according to the specified filters', () => {
+      visitRulesTableWithState({
+        searchTerm: 'rule',
+        tags: ['tag-b'],
+        source: 'custom',
+        enabled: false,
+        field: 'name',
+        order: 'asc',
+        perPage: 5,
+        page: 2,
+      });
+
+      expectManagementTableRules(['rule 6']);
     });
 
-    // Flaky on serverless
-    // FLAKY: https://github.com/elastic/kibana/issues/165740
-    describe(
-      'while on a happy path',
-      { tags: ['@ess', '@serverless', '@brokenInServerless'] },
-      () => {
-        it('activates management tab by default', () => {
-          visit(RULES_MANAGEMENT_URL);
+    it('loads from the url', () => {
+      visitRulesTableWithState({
+        searchTerm: 'rule',
+        tags: ['tag-b'],
+        source: 'custom',
+        enabled: false,
+        field: 'name',
+        order: 'asc',
+        perPage: 5,
+        page: 2,
+      });
 
-          expectRulesManagementTab();
-        });
+      expectRulesManagementTab();
+      expectFilterSearchTerm('rule');
+      expectFilterByTags(['tag-b']);
+      expectFilterByCustomRules();
+      expectFilterByDisabledRules();
+      expectTableSorting('Rule', 'asc');
+      expectRowsPerPage(5);
+      expectTablePage(2);
+    });
 
-        it('leads to displaying a rule according to the specified filters', () => {
-          visitRulesTableWithState({
-            searchTerm: 'rule',
-            tags: ['tag-b'],
-            source: 'custom',
-            enabled: false,
-            field: 'name',
-            order: 'asc',
-            perPage: 5,
-            page: 2,
-          });
+    it('loads from the session storage', () => {
+      setStorageState({
+        searchTerm: 'test',
+        tags: ['tag-a'],
+        source: 'prebuilt',
+        enabled: true,
+        field: 'severity',
+        order: 'desc',
+        perPage: 10,
+      });
 
-          expectManagementTableRules(['rule 6']);
-        });
+      visit(RULES_MANAGEMENT_URL);
 
-        it('loads from the url', () => {
-          visitRulesTableWithState({
-            searchTerm: 'rule',
-            tags: ['tag-b'],
-            source: 'custom',
-            enabled: false,
-            field: 'name',
-            order: 'asc',
-            perPage: 5,
-            page: 2,
-          });
+      expectRulesManagementTab();
+      expectFilterSearchTerm('test');
+      expectFilterByTags(['tag-a']);
+      expectFilterByPrebuiltRules();
+      expectFilterByEnabledRules();
+      expectTableSorting('Severity', 'desc');
+    });
 
-          expectRulesManagementTab();
-          expectFilterSearchTerm('rule');
-          expectFilterByTags(['tag-b']);
-          expectFilterByCustomRules();
-          expectFilterByDisabledRules();
-          expectTableSorting('Rule', 'asc');
-          expectRowsPerPage(5);
-          expectTablePage(2);
-        });
+    it('prefers url state over storage state', () => {
+      setStorageState({
+        searchTerm: 'test',
+        tags: ['tag-c'],
+        source: 'prebuilt',
+        enabled: true,
+        field: 'severity',
+        order: 'desc',
+        perPage: 10,
+      });
 
-        it('loads from the session storage', () => {
-          setStorageState({
-            searchTerm: 'test',
-            tags: ['tag-a'],
-            source: 'prebuilt',
-            enabled: true,
-            field: 'severity',
-            order: 'desc',
-            perPage: 10,
-          });
+      visitRulesTableWithState({
+        searchTerm: 'rule',
+        tags: ['tag-b'],
+        source: 'custom',
+        enabled: false,
+        field: 'name',
+        order: 'asc',
+        perPage: 5,
+        page: 2,
+      });
 
-          visit(RULES_MANAGEMENT_URL);
+      expectRulesManagementTab();
+      expectRulesTableState();
+      expectTablePage(2);
+    });
 
-          expectRulesManagementTab();
-          expectFilterSearchTerm('test');
-          expectFilterByTags(['tag-a']);
-          expectFilterByPrebuiltRules();
-          expectFilterByEnabledRules();
-          expectTableSorting('Severity', 'desc');
-        });
-
-        it('prefers url state over storage state', () => {
-          setStorageState({
-            searchTerm: 'test',
-            tags: ['tag-c'],
-            source: 'prebuilt',
-            enabled: true,
-            field: 'severity',
-            order: 'desc',
-            perPage: 10,
-          });
-
-          visitRulesTableWithState({
-            searchTerm: 'rule',
-            tags: ['tag-b'],
-            source: 'custom',
-            enabled: false,
-            field: 'name',
-            order: 'asc',
-            perPage: 5,
-            page: 2,
-          });
-
-          expectRulesManagementTab();
-          expectRulesTableState();
-          expectTablePage(2);
-        });
-
-        describe('and on the rules management tab', () => {
-          beforeEach(() => {
-            login();
-            visit(RULES_MANAGEMENT_URL);
-          });
-
-          it('persists after reloading the page', () => {
-            changeRulesTableState();
-            goToTablePage(2);
-
-            cy.reload();
-
-            expectRulesManagementTab();
-            expectRulesTableState();
-            expectTablePage(2);
-          });
-
-          it('persists after navigating back from a rule details page', () => {
-            changeRulesTableState();
-            goToTablePage(2);
-
-            goToRuleDetailsOf('rule 6');
-            cy.go('back');
-
-            expectRulesManagementTab();
-            expectRulesTableState();
-            expectTablePage(2);
-          });
-
-          it('persists after navigating to another page inside Security Solution', () => {
-            changeRulesTableState();
-            goToTablePage(2);
-
-            visit(DASHBOARDS_URL);
-            visit(RULES_MANAGEMENT_URL);
-
-            expectRulesManagementTab();
-            expectRulesTableState();
-            expectTablePage(1);
-          });
-
-          it('persists after navigating to another page outside Security Solution', () => {
-            changeRulesTableState();
-            goToTablePage(2);
-
-            visit(KIBANA_HOME);
-            visit(RULES_MANAGEMENT_URL);
-
-            expectRulesManagementTab();
-            expectRulesTableState();
-            expectTablePage(1);
-          });
-        });
-
-        describe('and on the rules monitoring tab', () => {
-          beforeEach(() => {
-            login();
-            visit(RULES_MONITORING_URL);
-          });
-
-          it('persists the selected tab', () => {
-            changeRulesTableState();
-
-            cy.reload();
-
-            expectRulesMonitoringTab();
-          });
-        });
-      }
-    );
-
-    describe('upon state format upgrade', async () => {
+    describe('and on the rules management tab', () => {
       beforeEach(() => {
         login();
+        visit(RULES_MANAGEMENT_URL);
       });
 
-      describe('and having state in the url', () => {
-        it('ignores unsupported state key', () => {
-          visitRulesTableWithState({
-            someKey: 10,
-            searchTerm: 'rule',
-            tags: ['tag-b'],
-            source: 'custom',
-            enabled: false,
-            field: 'name',
-            order: 'asc',
-            perPage: 5,
-            page: 2,
-          });
+      it('persists after reloading the page', () => {
+        changeRulesTableState();
+        goToTablePage(2);
 
-          expectRulesTableState();
-          expectTablePage(2);
-        });
+        cy.reload();
+
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(2);
       });
 
-      describe('and having state in the session storage', () => {
-        it('ignores unsupported state key', () => {
-          setStorageState({
-            someKey: 10,
-            searchTerm: 'rule',
-            tags: ['tag-b'],
-            source: 'custom',
-            enabled: false,
-            field: 'name',
-            order: 'asc',
-            perPage: 5,
-          });
+      it('persists after navigating back from a rule details page', () => {
+        changeRulesTableState();
+        goToTablePage(2);
 
-          visit(RULES_MANAGEMENT_URL);
+        goToRuleDetailsOf('rule 6');
+        cy.go('back');
 
-          expectRulesTableState();
-          expectTablePage(1);
-        });
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(2);
+      });
+
+      it('persists after navigating to another page inside Security Solution', () => {
+        changeRulesTableState();
+        goToTablePage(2);
+
+        visit(DASHBOARDS_URL);
+        visit(RULES_MANAGEMENT_URL);
+
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(1);
+      });
+
+      it('persists after navigating to another page outside Security Solution', () => {
+        changeRulesTableState();
+        goToTablePage(2);
+
+        visit(KIBANA_HOME);
+        visit(RULES_MANAGEMENT_URL);
+
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(1);
       });
     });
 
-    describe('when persisted state is partially unavailable', () => {
-      describe('and on the rules management tab', () => {
-        beforeEach(() => {
-          login();
-          visit(RULES_MANAGEMENT_URL);
+    describe('and on the rules monitoring tab', () => {
+      beforeEach(() => {
+        login();
+        visit(RULES_MONITORING_URL);
+      });
+
+      it('persists the selected tab', () => {
+        changeRulesTableState();
+
+        cy.reload();
+
+        expectRulesMonitoringTab();
+      });
+    });
+  });
+
+  describe('upon state format upgrade', async () => {
+    beforeEach(() => {
+      login();
+    });
+
+    describe('and having state in the url', () => {
+      it('ignores unsupported state key', () => {
+        visitRulesTableWithState({
+          someKey: 10,
+          searchTerm: 'rule',
+          tags: ['tag-b'],
+          source: 'custom',
+          enabled: false,
+          field: 'name',
+          order: 'asc',
+          perPage: 5,
+          page: 2,
         });
 
-        it('persists after clearing the session storage', () => {
-          changeRulesTableState();
-          goToTablePage(2);
+        expectRulesTableState();
+        expectTablePage(2);
+      });
+    });
 
-          cy.window().then((win) => {
-            win.sessionStorage.clear();
-          });
+    describe('and having state in the session storage', () => {
+      it('ignores unsupported state key', () => {
+        setStorageState({
+          someKey: 10,
+          searchTerm: 'rule',
+          tags: ['tag-b'],
+          source: 'custom',
+          enabled: false,
+          field: 'name',
+          order: 'asc',
+          perPage: 5,
+        });
+
+        visit(RULES_MANAGEMENT_URL);
+
+        expectRulesTableState();
+        expectTablePage(1);
+      });
+    });
+  });
+
+  describe('when persisted state is partially unavailable', () => {
+    describe('and on the rules management tab', () => {
+      beforeEach(() => {
+        login();
+        visit(RULES_MANAGEMENT_URL);
+      });
+
+      it('persists after clearing the session storage', () => {
+        changeRulesTableState();
+        goToTablePage(2);
+
+        cy.window().then((win) => {
+          win.sessionStorage.clear();
+        });
+        cy.reload();
+
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(2);
+      });
+
+      it('persists after clearing the url state', () => {
+        changeRulesTableState();
+        goToTablePage(2);
+
+        visit(RULES_MANAGEMENT_URL);
+
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(1);
+      });
+    });
+  });
+
+  describe('when corrupted', () => {
+    describe('and on the rules management tab', () => {
+      beforeEach(() => {
+        login();
+        visit(RULES_MANAGEMENT_URL);
+      });
+
+      it('persists after corrupting the session storage data', () => {
+        changeRulesTableState();
+        goToTablePage(2);
+
+        cy.window().then((win) => {
+          win.sessionStorage.setItem('securitySolution.rulesTable', '!invalid');
           cy.reload();
 
           expectRulesManagementTab();
           expectRulesTableState();
           expectTablePage(2);
         });
-
-        it('persists after clearing the url state', () => {
-          changeRulesTableState();
-          goToTablePage(2);
-
-          visit(RULES_MANAGEMENT_URL);
-
-          expectRulesManagementTab();
-          expectRulesTableState();
-          expectTablePage(1);
-        });
       });
-    });
 
-    describe('when corrupted', () => {
-      describe('and on the rules management tab', () => {
-        beforeEach(() => {
-          login();
-          visit(RULES_MANAGEMENT_URL);
-        });
+      it('persists after corrupting the url param data', () => {
+        changeRulesTableState();
+        goToTablePage(2);
 
-        it('persists after corrupting the session storage data', () => {
-          changeRulesTableState();
-          goToTablePage(2);
+        visit(RULES_MANAGEMENT_URL, { visitOptions: { qs: { rulesTable: '(!invalid)' } } });
 
-          cy.window().then((win) => {
-            win.sessionStorage.setItem('securitySolution.rulesTable', '!invalid');
-            cy.reload();
+        expectRulesManagementTab();
+        expectRulesTableState();
+        expectTablePage(1);
+      });
 
-            expectRulesManagementTab();
-            expectRulesTableState();
-            expectTablePage(2);
-          });
-        });
+      it('DOES NOT persist after corrupting the session storage and url param data', () => {
+        changeRulesTableState();
+        goToTablePage(2);
 
-        it('persists after corrupting the url param data', () => {
-          changeRulesTableState();
-          goToTablePage(2);
-
-          visit(RULES_MANAGEMENT_URL, { visitOptions: { qs: { rulesTable: '(!invalid)' } } });
-
-          expectRulesManagementTab();
-          expectRulesTableState();
-          expectTablePage(1);
-        });
-
-        it('DOES NOT persist after corrupting the session storage and url param data', () => {
-          changeRulesTableState();
-          goToTablePage(2);
-
-          visit(RULES_MANAGEMENT_URL, {
-            visitOptions: {
-              qs: { rulesTable: '(!invalid)' },
-              onBeforeLoad: (win) => {
-                win.sessionStorage.setItem('securitySolution.rulesTable', '!invalid');
-              },
+        visit(RULES_MANAGEMENT_URL, {
+          visitOptions: {
+            qs: { rulesTable: '(!invalid)' },
+            onBeforeLoad: (win) => {
+              win.sessionStorage.setItem('securitySolution.rulesTable', '!invalid');
             },
-          });
-
-          expectRulesManagementTab();
-          expectDefaultRulesTableState();
+          },
         });
+
+        expectRulesManagementTab();
+        expectDefaultRulesTableState();
       });
     });
-  }
-);
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_selection.cy.ts
@@ -34,74 +34,68 @@ const RULE_2 = createRuleAssetSavedObject({
   rule_id: 'rule_2',
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-// FLAKY: https://github.com/elastic/kibana/issues/165643
-describe.skip(
-  'Rules table: selection',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
-  () => {
-    before(() => {
-      cleanKibana();
+describe('Rules table: selection', { tags: ['@ess', '@serverless'] }, () => {
+  before(() => {
+    cleanKibana();
+  });
+
+  beforeEach(() => {
+    login();
+    /* Create and install two mock rules */
+    createAndInstallMockedPrebuiltRules({ rules: [RULE_1, RULE_2] });
+    visit(RULES_MANAGEMENT_URL);
+    waitForPrebuiltDetectionRulesToBeLoaded();
+  });
+
+  it('should correctly update the selection label when rules are individually selected and unselected', () => {
+    waitForPrebuiltDetectionRulesToBeLoaded();
+
+    selectRulesByName(['Test rule 1', 'Test rule 2']);
+
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
+
+    unselectRulesByName(['Test rule 1', 'Test rule 2']);
+
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+  });
+
+  it('should correctly update the selection label when rules are bulk selected and then bulk un-selected', () => {
+    waitForPrebuiltDetectionRulesToBeLoaded();
+
+    cy.get(SELECT_ALL_RULES_BTN).click();
+
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
     });
 
-    beforeEach(() => {
-      login();
-      /* Create and install two mock rules */
-      createAndInstallMockedPrebuiltRules({ rules: [RULE_1, RULE_2] });
-      visit(RULES_MANAGEMENT_URL);
-      waitForPrebuiltDetectionRulesToBeLoaded();
+    // Un-select all rules via the Bulk Selection button from the Utility bar
+    cy.get(SELECT_ALL_RULES_BTN).click();
+
+    // Current selection should be 0 rules
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    // Bulk selection button should be back to displaying all rules
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
+    });
+  });
+
+  it('should correctly update the selection label when rules are bulk selected and then unselected via the table select all checkbox', () => {
+    waitForPrebuiltDetectionRulesToBeLoaded();
+
+    cy.get(SELECT_ALL_RULES_BTN).click();
+
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
     });
 
-    it('should correctly update the selection label when rules are individually selected and unselected', () => {
-      waitForPrebuiltDetectionRulesToBeLoaded();
+    // Un-select all rules via the Un-select All checkbox from the table
+    cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
 
-      selectRulesByName(['Test rule 1', 'Test rule 2']);
-
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '2');
-
-      unselectRulesByName(['Test rule 1', 'Test rule 2']);
-
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    // Current selection should be 0 rules
+    cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
+    // Bulk selection button should be back to displaying all rules
+    getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
+      cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
     });
-
-    it('should correctly update the selection label when rules are bulk selected and then bulk un-selected', () => {
-      waitForPrebuiltDetectionRulesToBeLoaded();
-
-      cy.get(SELECT_ALL_RULES_BTN).click();
-
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-        cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
-      });
-
-      // Un-select all rules via the Bulk Selection button from the Utility bar
-      cy.get(SELECT_ALL_RULES_BTN).click();
-
-      // Current selection should be 0 rules
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
-      // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-        cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
-      });
-    });
-
-    it('should correctly update the selection label when rules are bulk selected and then unselected via the table select all checkbox', () => {
-      waitForPrebuiltDetectionRulesToBeLoaded();
-
-      cy.get(SELECT_ALL_RULES_BTN).click();
-
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-        cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', availablePrebuiltRulesCount);
-      });
-
-      // Un-select all rules via the Un-select All checkbox from the table
-      cy.get(SELECT_ALL_RULES_ON_PAGE_CHECKBOX).click();
-
-      // Current selection should be 0 rules
-      cy.get(SELECTED_RULES_NUMBER_LABEL).should('contain.text', '0');
-      // Bulk selection button should be back to displaying all rules
-      getAvailablePrebuiltRulesCount().then((availablePrebuiltRulesCount) => {
-        cy.get(SELECT_ALL_RULES_BTN).should('contain.text', availablePrebuiltRulesCount);
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rules_table/rules_table_sorting.cy.ts
@@ -37,8 +37,7 @@ import {
 } from '../../../../tasks/table_pagination';
 import { TABLE_FIRST_PAGE, TABLE_SECOND_PAGE } from '../../../../screens/table_pagination';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-describe('Rules table: sorting', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Rules table: sorting', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
     login();


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/161540

## Summary

This PR unskips rules table Serverless Cypress tests

- `rules_table_auto_refresh.cy.ts`
- `rules_table_links.cy.ts`
- `rules_table_persistent_state.cy.ts`
- `rules_table_selection.cy.ts`
- `rules_table_sorting.cy.ts`

## Flaky test runner

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3406 150 runs 🟢


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->