### PR TITLE
[ES|QL] Hides fields with nulls from document view

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -538,6 +538,7 @@ export const UnifiedDataTable = ({
         fieldFormats: services.fieldFormats,
         maxEntries: maxDocFieldsDisplayed,
         externalCustomRenderers,
+        isPlainRecord,
       }),
     [
       dataView,
@@ -547,6 +548,7 @@ export const UnifiedDataTable = ({
       maxDocFieldsDisplayed,
       services.fieldFormats,
       externalCustomRenderers,
+      isPlainRecord,
     ]
   );
 

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
@@ -75,6 +75,18 @@ const rowsSource: EsHitRecord[] = [
   },
 ];
 
+const rowsSourceWithEmptyValues: EsHitRecord[] = [
+  {
+    _id: '1',
+    _index: 'test',
+    _score: 1,
+    _source: { bytes: 100, extension: ' - ' },
+    highlight: {
+      extension: ['@kibana-highlighted-field.gz@/kibana-highlighted-field'],
+    },
+  },
+];
+
 const rowsFields: EsHitRecord[] = [
   {
     _id: '1',
@@ -341,6 +353,77 @@ describe('Unified data table cell rendering', function () {
           />
         </EuiFlexItem>
       </EuiFlexGroup>
+    `);
+  });
+
+  it('renders _source column correctly if on text based mode and have nulls', () => {
+    const DataTableCellValue = getRenderCellValueFn({
+      dataView: dataViewMock,
+      rows: rowsSourceWithEmptyValues.map(build),
+      useNewFieldsApi: false,
+      shouldShowFieldHandler: (fieldName) => ['extension', 'bytes'].includes(fieldName),
+      closePopover: jest.fn(),
+      fieldFormats: mockServices.fieldFormats as unknown as FieldFormatsStart,
+      maxEntries: 100,
+      isPlainRecord: true,
+    });
+    const component = shallow(
+      <DataTableCellValue
+        rowIndex={0}
+        colIndex={0}
+        columnId="_source"
+        isDetails={false}
+        isExpanded={false}
+        isExpandable={true}
+        setCellProps={jest.fn()}
+      />
+    );
+    expect(component).toMatchInlineSnapshot(`
+      <EuiDescriptionList
+        className="unifiedDataTable__descriptionList unifiedDataTable__cellValue"
+        compressed={true}
+        type="inline"
+      >
+        <EuiDescriptionListTitle
+          className="unifiedDataTable__descriptionListTitle"
+        >
+          bytesDisplayName
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription
+          className="unifiedDataTable__descriptionListDescription"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": 100,
+            }
+          }
+        />
+        <EuiDescriptionListTitle
+          className="unifiedDataTable__descriptionListTitle"
+        >
+          _index
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription
+          className="unifiedDataTable__descriptionListDescription"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "test",
+            }
+          }
+        />
+        <EuiDescriptionListTitle
+          className="unifiedDataTable__descriptionListTitle"
+        >
+          _score
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription
+          className="unifiedDataTable__descriptionListDescription"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": 1,
+            }
+          }
+        />
+      </EuiDescriptionList>
     `);
   });
 

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
@@ -80,7 +80,7 @@ const rowsSourceWithEmptyValues: EsHitRecord[] = [
     _id: '1',
     _index: 'test',
     _score: 1,
-    _source: { bytes: 100, extension: ' - ' },
+    _source: { bytes: 100, extension: null },
     highlight: {
       extension: ['@kibana-highlighted-field.gz@/kibana-highlighted-field'],
     },

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
@@ -33,7 +33,6 @@ import { defaultMonacoEditorWidth } from '../constants';
 import JsonCodeEditor from '../components/json_code_editor/json_code_editor';
 
 const CELL_CLASS = 'unifiedDataTable__cellValue';
-const EMPTY_VALUE = ' - ';
 
 export const getRenderCellValueFn = ({
   dataView,
@@ -147,10 +146,10 @@ export const getRenderCellValueFn = ({
           compressed
           className={classnames('unifiedDataTable__descriptionList', CELL_CLASS)}
         >
-          {pairs.map(([fieldDisplayName, value]) => {
+          {pairs.map(([fieldDisplayName, value, fieldName]) => {
             // temporary solution for text based mode. As there are a lot of unsupported fields we want to
             // hide the empty one from the Document view
-            if (isPlainRecord && value === EMPTY_VALUE) return null;
+            if (isPlainRecord && fieldName && row.flattened[fieldName] === null) return null;
             return (
               <Fragment key={fieldDisplayName}>
                 <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
@@ -33,6 +33,7 @@ import { defaultMonacoEditorWidth } from '../constants';
 import JsonCodeEditor from '../components/json_code_editor/json_code_editor';
 
 const CELL_CLASS = 'unifiedDataTable__cellValue';
+const EMPTY_VALUE = ' - ';
 
 export const getRenderCellValueFn = ({
   dataView,
@@ -43,6 +44,7 @@ export const getRenderCellValueFn = ({
   fieldFormats,
   maxEntries,
   externalCustomRenderers,
+  isPlainRecord,
 }: {
   dataView: DataView;
   rows: DataTableRecord[] | undefined;
@@ -55,6 +57,7 @@ export const getRenderCellValueFn = ({
     string,
     (props: EuiDataGridCellValueElementProps) => React.ReactNode
   >;
+  isPlainRecord?: boolean;
 }) => {
   return ({
     rowIndex,
@@ -144,17 +147,22 @@ export const getRenderCellValueFn = ({
           compressed
           className={classnames('unifiedDataTable__descriptionList', CELL_CLASS)}
         >
-          {pairs.map(([fieldDisplayName, value]) => (
-            <Fragment key={fieldDisplayName}>
-              <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
-                {fieldDisplayName}
-              </EuiDescriptionListTitle>
-              <EuiDescriptionListDescription
-                className="unifiedDataTable__descriptionListDescription"
-                dangerouslySetInnerHTML={{ __html: value }}
-              />
-            </Fragment>
-          ))}
+          {pairs.map(([fieldDisplayName, value]) => {
+            // temporary solution for text based mode. As there are a lot of unsupported fields we want to
+            // hide the empty one from the Document view
+            if (isPlainRecord && value === EMPTY_VALUE) return null;
+            return (
+              <Fragment key={fieldDisplayName}>
+                <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
+                  {fieldDisplayName}
+                </EuiDescriptionListTitle>
+                <EuiDescriptionListDescription
+                  className="unifiedDataTable__descriptionListDescription"
+                  dangerouslySetInnerHTML={{ __html: value }}
+                />
+              </Fragment>
+            );
+          })}
         </EuiDescriptionList>
       );
     }


### PR DESCRIPTION
## Summary

ES|QL atm can be quite noisy at the Document view with many fields with null values. To improve a bit the experience we decided to not display these values in the Document view. The columns still exist in the available fields list and the expanded row. It is only for the document view that we don't want them to be rendered.

In the example below you can see the `meta.char` field which is hidden on the document view but still available in the sidebar and the expanded row.

![image (11)](https://github.com/elastic/kibana/assets/17003240/35f975be-ff96-4eee-8420-571386329cfb)
![image (12)](https://github.com/elastic/kibana/assets/17003240/f5db6303-c583-4114-b18d-fa6088cb618f)
![image (13)](https://github.com/elastic/kibana/assets/17003240/82c5fbb1-5dc7-41c2-8978-c7d248821eee)

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->