### PR TITLE
[Cases] Add migration test for the cases table

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/attachment_framework.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/attachment_framework.ts
@@ -333,6 +333,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
     describe('Lens visualization as persistable attachment', () => {
       const myDashboardName = `My-dashboard-${uuidv4()}`;
+
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
         await kibanaServer.importExport.load(
@@ -362,6 +363,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await kibanaServer.importExport.unload(
           'x-pack/test/functional/fixtures/kbn_archiver/lens/lens_basic.json'
         );
+
+        await cases.api.deleteAllCases();
       });
 
       it('adds lens visualization to a new case from dashboard', async () => {

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/upgrade.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/upgrade.ts
@@ -62,8 +62,6 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         },
         secrets: { email: 'elastic@elastic.co', apiToken: '123' },
       });
-
-      await cases.navigation.navigateToSingleCase('cases', CASE_ID);
     });
 
     after(async () => {
@@ -75,6 +73,10 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
 
     describe('Case view page', function () {
+      before(async () => {
+        await cases.navigation.navigateToSingleCase('cases', CASE_ID);
+      });
+
       it('does not show any error toasters', async () => {
         expect(await toasts.getToastCount()).to.be(0);
       });
@@ -283,6 +285,73 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
       it('shows the assignees section', async () => {
         await testSubjects.exists('case-view-assignees');
+      });
+    });
+
+    describe('Cases table', function () {
+      before(async () => {
+        await cases.navigation.navigateToApp();
+      });
+
+      it('does not show any error toasters', async () => {
+        expect(await toasts.getToastCount()).to.be(0);
+      });
+
+      it('shows the title correctly', async () => {
+        const title = await testSubjects.find('case-details-link');
+        expect(await title.getVisibleText()).equal('Upgrade test in Kibana');
+      });
+
+      it('shows the tags correctly', async () => {
+        const tags = ['upgrade', 'test', 'kibana'];
+
+        for (const tag of tags) {
+          const tagElement = await testSubjects.find(`case-table-column-tags-${tag}`);
+          expect(await tagElement.getVisibleText()).equal(tag);
+        }
+      });
+
+      it('shows the status correctly', async () => {
+        const status = await testSubjects.find('case-status-badge-open');
+        expect(await status.getVisibleText()).equal('Open');
+      });
+
+      it('shows the severity correctly', async () => {
+        const severity = await testSubjects.find('case-table-column-severity-low');
+        expect(await severity.getVisibleText()).equal('Low');
+      });
+
+      it('shows the count of comments correctly', async () => {
+        const comments = await testSubjects.find('case-table-column-commentCount');
+        expect(await comments.getVisibleText()).equal('4');
+      });
+
+      it('shows the creation date correctly', async () => {
+        const comments = await testSubjects.find('case-table-column-createdAt');
+        expect(await comments.getVisibleText()).equal('Jul 22, 2022 @ 13:40:43');
+      });
+
+      it('shows the update date correctly', async () => {
+        const comments = await testSubjects.find('case-table-column-updatedAt');
+        expect(await comments.getVisibleText()).equal('Jul 22, 2022 @ 13:46:32');
+      });
+
+      it('shows the external service column correctly', async () => {
+        const link = await testSubjects.find('case-table-column-external');
+        const upToDate = await testSubjects.find('case-table-column-external-upToDate');
+
+        expect(await link.getVisibleText()).equal('ROC-526\n(opens in a new tab or window)');
+        expect(await upToDate.getVisibleText()).equal('is up to date');
+      });
+
+      it('shows the counts correctly', async () => {
+        const openCases = await testSubjects.find('openStatsHeader');
+        const inProgressCases = await testSubjects.find('inProgressStatsHeader');
+        const closedCases = await testSubjects.find('closedStatsHeader');
+
+        expect(await openCases.getVisibleText()).equal('Open cases\n1');
+        expect(await inProgressCases.getVisibleText()).equal('In progress cases\n0');
+        expect(await closedCases.getVisibleText()).equal('Closed cases\n0');
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR adds a test to see if everything works as expected in the cases table when upgrading a case from 7.15 to the latest Kibana version.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3416

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->