### PR TITLE
profiling: include new config key in package schema

### DIFF
--- a/x-pack/plugins/profiling/server/index.ts
+++ b/x-pack/plugins/profiling/server/index.ts
@@ -12,11 +12,15 @@ import { ProfilingPlugin } from './plugin';
 /**
  * These properties are used to create both the Collector and the Symbolizer integrations
  * when Universal Profiling is initialized.
- * As of now Universal Profiling is only availble on Elastic Cloud, so
- * Elastic Cloud will be responsable of filling these properties up and pass it to Kibana.
+ * As of now Universal Profiling is only available on Elastic Cloud, so
+ * Elastic Cloud will fill these properties up and pass it to Kibana.
+ * Note that the list of config options does not encompass all the avaiable entries
+ * offered by the integrations pacakges, but are limited to the ones that
+ * Cloud will make use of.
  */
 const packageInputSchema = schema.object({
   host: schema.maybe(schema.string()),
+  telemetry: schema.maybe(schema.boolean()),
   tls_enabled: schema.maybe(schema.boolean()),
   tls_supported_protocols: schema.maybe(schema.arrayOf(schema.string())),
   tls_certificate_path: schema.maybe(schema.string()),

--- a/x-pack/plugins/profiling/server/lib/setup/fleet_policies.test.ts
+++ b/x-pack/plugins/profiling/server/lib/setup/fleet_policies.test.ts
@@ -72,4 +72,29 @@ describe('getVarsFor', () => {
       tls_key_path: { type: 'text', value: '456' },
     });
   });
+
+  it('returns vars with the telemetry key', () => {
+    const config: PackageInputType = {
+      host: 'example.com',
+      telemetry: true,
+      tls_enabled: true,
+      tls_supported_protocols: ['foo', 'bar'],
+      tls_certificate_path: '123',
+      tls_key_path: '456',
+    };
+
+    const { secret_token: secretToken, ...result } = getVarsFor({
+      config,
+      includeSecretToken: false,
+    });
+    expect(secretToken).toBeUndefined();
+    expect(result).toEqual({
+      host: { type: 'text', value: 'example.com' },
+      telemetry: { type: 'bool', value: true },
+      tls_enabled: { type: 'bool', value: true },
+      tls_supported_protocols: { type: 'text', value: ['foo', 'bar'] },
+      tls_certificate_path: { type: 'text', value: '123' },
+      tls_key_path: { type: 'text', value: '456' },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Include the `telemetry` config key as part of the Fleet policy configuring the Universal Profiling backend services.

### Checklist

Delete any items that are not applicable to this PR.

- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

**Note** Creating this will require also updating the assets that are deploying the backend in Cloud
