### PR TITLE
[PoC] Add resize support to Discover doc viewer

### DIFF
--- a/packages/kbn-resizable-layout/index.ts
+++ b/packages/kbn-resizable-layout/index.ts
@@ -9,6 +9,6 @@
 import { withSuspense } from '@kbn/shared-ux-utility';
 import { lazy } from 'react';
 
-export { ResizableLayoutMode, ResizableLayoutDirection } from './types';
+export { ResizableLayoutMode, ResizableLayoutDirection, FixedPanelPosition } from './types';
 export type { ResizableLayoutProps } from './src/resizable_layout';
 export const ResizableLayout = withSuspense(lazy(() => import('./src/resizable_layout')));

--- a/packages/kbn-resizable-layout/src/panels_resizable.tsx
+++ b/packages/kbn-resizable-layout/src/panels_resizable.tsx
@@ -12,13 +12,14 @@ import { css } from '@emotion/react';
 import { isEqual, round } from 'lodash';
 import type { ReactElement } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
-import { ResizableLayoutDirection } from '../types';
+import { FixedPanelPosition, ResizableLayoutDirection } from '../types';
 import { getContainerSize, percentToPixels, pixelsToPercent } from './utils';
 
 export const PanelsResizable = ({
   className,
   direction,
   container,
+  fixedPanelPosition,
   fixedPanelSize,
   minFixedPanelSize,
   minFlexPanelSize,
@@ -33,6 +34,7 @@ export const PanelsResizable = ({
   className?: string;
   direction: ResizableLayoutDirection;
   container: HTMLElement | null;
+  fixedPanelPosition: FixedPanelPosition;
   fixedPanelSize: number;
   minFixedPanelSize: number;
   minFlexPanelSize: number;
@@ -194,8 +196,8 @@ export const PanelsResizable = ({
         height: 100%;
       `}
     >
-      {(EuiResizablePanel, EuiResizableButton) => (
-        <>
+      {(EuiResizablePanel, EuiResizableButton) => {
+        const fixedResizablePanel = (
           <EuiResizablePanel
             id={fixedPanelId}
             minSize={`${minFixedPanelSize}px`}
@@ -205,13 +207,8 @@ export const PanelsResizable = ({
           >
             {fixedPanel}
           </EuiResizablePanel>
-          <EuiResizableButton
-            className={resizeButtonClassName}
-            css={
-              resizeWithPortalsHackIsResizing ? resizeWithPortalsHackButtonCss : defaultButtonCss
-            }
-            data-test-subj={`${dataTestSubj}ResizableButton`}
-          />
+        );
+        const flexResizablePanel = (
           <EuiResizablePanel
             minSize={`${minFlexPanelSize}px`}
             size={panelSizes.flexPanelSizePct}
@@ -220,9 +217,31 @@ export const PanelsResizable = ({
           >
             {flexPanel}
           </EuiResizablePanel>
-          {resizeWithPortalsHackIsResizing ? <div css={resizeWithPortalsHackOverlayCss} /> : <></>}
-        </>
-      )}
+        );
+
+        return (
+          <>
+            {fixedPanelPosition === FixedPanelPosition.Start
+              ? fixedResizablePanel
+              : flexResizablePanel}
+            <EuiResizableButton
+              className={resizeButtonClassName}
+              css={
+                resizeWithPortalsHackIsResizing ? resizeWithPortalsHackButtonCss : defaultButtonCss
+              }
+              data-test-subj={`${dataTestSubj}ResizableButton`}
+            />
+            {fixedPanelPosition === FixedPanelPosition.End
+              ? fixedResizablePanel
+              : flexResizablePanel}
+            {resizeWithPortalsHackIsResizing ? (
+              <div css={resizeWithPortalsHackOverlayCss} />
+            ) : (
+              <></>
+            )}
+          </>
+        );
+      }}
     </EuiResizableContainer>
   );
 };

--- a/packages/kbn-resizable-layout/src/panels_static.tsx
+++ b/packages/kbn-resizable-layout/src/panels_static.tsx
@@ -10,18 +10,20 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { ReactElement } from 'react';
 import React from 'react';
-import { ResizableLayoutDirection } from '../types';
+import { FixedPanelPosition, ResizableLayoutDirection } from '../types';
 
 export const PanelsStatic = ({
   className,
   direction,
   hideFixedPanel,
   fixedPanel,
+  fixedPanelPosition,
   flexPanel,
 }: {
   className?: string;
   direction: ResizableLayoutDirection;
   hideFixedPanel?: boolean;
+  fixedPanelPosition: FixedPanelPosition;
   fixedPanel: ReactElement;
   flexPanel: ReactElement;
 }) => {
@@ -33,6 +35,8 @@ export const PanelsStatic = ({
   const flexPanelCss = css`
     overflow: auto;
   `;
+  const fixedPanelItem = !hideFixedPanel && <EuiFlexItem grow={false}>{fixedPanel}</EuiFlexItem>;
+  const flexPanelItem = <EuiFlexItem css={flexPanelCss}>{flexPanel}</EuiFlexItem>;
 
   return (
     <EuiFlexGroup
@@ -45,8 +49,8 @@ export const PanelsStatic = ({
         height: 100%;
       `}
     >
-      {!hideFixedPanel && <EuiFlexItem grow={false}>{fixedPanel}</EuiFlexItem>}
-      <EuiFlexItem css={flexPanelCss}>{flexPanel}</EuiFlexItem>
+      {fixedPanelPosition === FixedPanelPosition.Start ? fixedPanelItem : flexPanelItem}
+      {fixedPanelPosition === FixedPanelPosition.End ? fixedPanelItem : flexPanelItem}
     </EuiFlexGroup>
   );
 };

--- a/packages/kbn-resizable-layout/src/resizable_layout.tsx
+++ b/packages/kbn-resizable-layout/src/resizable_layout.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import { round } from 'lodash';
 import { PanelsResizable } from './panels_resizable';
 import { PanelsStatic } from './panels_static';
-import { ResizableLayoutDirection, ResizableLayoutMode } from '../types';
+import { FixedPanelPosition, ResizableLayoutDirection, ResizableLayoutMode } from '../types';
 import { getContainerSize, pixelsToPercent } from './utils';
 
 export interface ResizableLayoutProps {
@@ -31,6 +31,10 @@ export interface ResizableLayoutProps {
    * The parent container element, used to calculate the layout size
    */
   container: HTMLElement | null;
+  /**
+   * The position of the fixed panel, defaults to FixedPanelPosition.Start
+   */
+  fixedPanelPosition?: FixedPanelPosition;
   /**
    * Current size of the fixed panel in pixels
    */
@@ -72,6 +76,7 @@ const ResizableLayout = ({
   mode,
   direction,
   container,
+  fixedPanelPosition = FixedPanelPosition.Start,
   fixedPanelSize,
   minFixedPanelSize,
   minFlexPanelSize,
@@ -81,7 +86,7 @@ const ResizableLayout = ({
   ['data-test-subj']: dataTestSubj,
   onFixedPanelSizeChange,
 }: ResizableLayoutProps) => {
-  const panelsProps = { className, fixedPanel, flexPanel };
+  const panelsProps = { className, fixedPanelPosition, fixedPanel, flexPanel };
   const [panelSizes, setPanelSizes] = useState(() => {
     if (!container) {
       return { fixedPanelSizePct: 0, flexPanelSizePct: 0 };

--- a/packages/kbn-resizable-layout/types.ts
+++ b/packages/kbn-resizable-layout/types.ts
@@ -31,3 +31,14 @@ export enum ResizableLayoutDirection {
    */
   Vertical = 'vertical',
 }
+
+export enum FixedPanelPosition {
+  /**
+   * Fixed panel is on the left or top
+   */
+  Start = 'start',
+  /**
+   * Fixed panel is on the right or bottom
+   */
+  End = 'end',
+}

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -684,7 +684,7 @@ export const UnifiedDataTable = ({
     return { columns: sortingColumns, onSort: () => {} };
   }, [isSortEnabled, sortingColumns, isPlainRecord, inmemorySortingColumns, onTableSort]);
 
-  const canSetExpandedDoc = Boolean(setExpandedDoc && !!renderDocumentView);
+  const canSetExpandedDoc = Boolean(setExpandedDoc);
 
   const leadingControlColumns = useMemo(() => {
     const internalControlColumns = getLeadControlColumns(canSetExpandedDoc).filter(({ id }) =>
@@ -865,7 +865,7 @@ export const UnifiedDataTable = ({
         )}
         {canSetExpandedDoc &&
           expandedDoc &&
-          renderDocumentView!(expandedDoc, displayedRows, displayedColumns, columnTypes)}
+          renderDocumentView?.(expandedDoc, displayedRows, displayedColumns, columnTypes)}
       </span>
     </UnifiedDataTableContext.Provider>
   );

--- a/src/plugins/discover/public/application/context/context_app.scss
+++ b/src/plugins/discover/public/application/context/context_app.scss
@@ -1,7 +1,7 @@
 @import '../../../../../core/public/mixins';
 
 .dscDocsPage {
-  @include kibanaFullBodyHeight(54px); // action bar height
+  @include kibanaFullBodyHeight(48px); // action bar height
 }
 
 .dscDocsContent {
@@ -17,4 +17,14 @@
   &__cell--highlight {
     background-color: tintOrShade($euiColorPrimary, 90%, 70%);
   }
+}
+
+.dscDocViewer {
+  @include kibanaFullBodyHeight();
+}
+
+.dscDocViewer__body {
+  @include euiOverflowShadow;
+  @include euiScrollBar;
+  overflow-y: auto;
 }

--- a/src/plugins/discover/public/application/context/context_app.tsx
+++ b/src/plugins/discover/public/application/context/context_app.tsx
@@ -6,11 +6,23 @@
  * Side Public License, v 1.
  */
 
-import React, { Fragment, memo, useEffect, useRef, useMemo, useCallback } from 'react';
+import React, { Fragment, memo, useEffect, useRef, useMemo, useCallback, useState } from 'react';
 import './context_app.scss';
 import classNames from 'classnames';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { EuiText, EuiPage, EuiPageBody, EuiSpacer, useEuiPaddingSize } from '@elastic/eui';
+import {
+  EuiText,
+  EuiPage,
+  EuiPageBody,
+  EuiSpacer,
+  useEuiPaddingSize,
+  useEuiTheme,
+  EuiPanel,
+  useIsWithinMaxBreakpoint,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonIcon,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { cloneDeep } from 'lodash';
 import { DataView, DataViewField } from '@kbn/data-views-plugin/public';
@@ -25,6 +37,13 @@ import {
 } from '@kbn/discover-utils';
 import { popularizeField, useColumns } from '@kbn/unified-data-table';
 import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
+import { ResizableLayout, FixedPanelPosition } from '@kbn/resizable-layout';
+import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { ResizableLayoutDirection, ResizableLayoutMode } from '@kbn/resizable-layout';
+import { DataTableRecord } from '@kbn/discover-utils/types';
+import { euiThemeVars } from '@kbn/ui-theme';
+import useEvent from 'react-use/lib/useEvent';
 import { ContextErrorMessage } from './components/context_error_message';
 import { LoadingStatus } from './services/context_query_state';
 import { AppState, GlobalState, isEqualFilters } from './services/context_state';
@@ -34,6 +53,9 @@ import { ContextAppContent } from './context_app_content';
 import { SurrDocType } from './services/context';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
 import { setBreadcrumbs } from '../../utils/breadcrumbs';
+import { DiscoverGridFlyout } from '../../components/discover_grid_flyout';
+import { useDiscoverGridFlyoutPagination } from '../../components/discover_grid_flyout/use_discover_grid_flyout_pagination';
+import { useDiscoverGridFlyoutBody } from '../../components/discover_grid_flyout/use_discover_grid_flyout_body';
 
 const ContextAppContentMemoized = memo(ContextAppContent);
 
@@ -214,7 +236,76 @@ export const ContextApp = ({ dataView, anchorId, referrer }: ContextAppProps) =>
     };
   };
 
+  const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
+  const discoverGridFlyoutPagination = useDiscoverGridFlyoutPagination({
+    hits: rows,
+    hit: expandedDoc!,
+    setExpandedDoc,
+  });
+  const renderDocumentView = useCallback(
+    (hit: DataTableRecord, displayedRows: DataTableRecord[], displayedColumns: string[]) => (
+      <DiscoverGridFlyout
+        dataView={dataView}
+        hit={hit}
+        hits={displayedRows}
+        // if default columns are used, dont make them part of the URL - the context state handling will take care to restore them
+        columns={displayedColumns}
+        onFilter={addFilter as DocViewFilterFn}
+        onRemoveColumn={onRemoveColumn}
+        onAddColumn={onAddColumn}
+        onClose={() => setExpandedDoc(undefined)}
+        {...discoverGridFlyoutPagination}
+      />
+    ),
+    [addFilter, dataView, discoverGridFlyoutPagination, onAddColumn, onRemoveColumn]
+  );
+
   const titlePadding = useEuiPaddingSize('m');
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [docViewerPanelNode] = useState(() =>
+    createHtmlPortalNode({ attributes: { class: 'eui-fullHeight' } })
+  );
+  const [mainPanelNode] = useState(() =>
+    createHtmlPortalNode({ attributes: { class: 'eui-fullHeight' } })
+  );
+  const { euiTheme } = useEuiTheme();
+  const minDocViewerWidth = euiTheme.base * 38;
+  const defaultDocViewerWidth = euiTheme.base * 56;
+  const minMainPanelWidth = euiTheme.base * 30;
+  const [docViewerWidth, setDocViewerWidth] = useLocalStorage(
+    'discover:docViewerWidth',
+    defaultDocViewerWidth
+  );
+
+  const isMobile = useIsWithinMaxBreakpoint('l');
+  const showDocViewer = expandedDoc && !isMobile;
+  const layoutMode = showDocViewer ? ResizableLayoutMode.Resizable : ResizableLayoutMode.Single;
+  const layoutDirection = ResizableLayoutDirection.Horizontal;
+  const { header, body } = useDiscoverGridFlyoutBody({
+    dataView,
+    hit: expandedDoc!,
+    hits: rows,
+    columns,
+    onFilter: addFilter as DocViewFilterFn,
+    onRemoveColumn,
+    onAddColumn,
+    ...discoverGridFlyoutPagination,
+  });
+
+  useEvent('keydown', (ev: KeyboardEvent) => {
+    if (ev.key === 'Escape' && expandedDoc) {
+      setExpandedDoc(undefined);
+    }
+  });
+
+  const closeButton = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (showDocViewer) {
+      closeButton.current?.focus();
+      // closeButton.current?.blur();
+    }
+  }, [showDocViewer]);
 
   return (
     <Fragment>
@@ -232,51 +323,141 @@ export const ContextApp = ({ dataView, anchorId, referrer }: ContextAppProps) =>
               values: { anchorId },
             })}
           </h1>
-          <TopNavMenu {...getNavBarProps()} />
-          <EuiPage className={classNames({ dscDocsPage: !isLegacy })}>
-            <EuiPageBody
-              panelled
-              paddingSize="none"
-              className="dscDocsContent"
-              panelProps={{ role: 'main' }}
-            >
-              <EuiText
-                data-test-subj="contextDocumentSurroundingHeader"
-                css={css`
-                  padding: ${titlePadding} ${titlePadding} 0;
-                `}
-              >
-                <strong>
-                  <FormattedMessage
-                    id="discover.context.contextOfTitle"
-                    defaultMessage="Documents surrounding #{anchorId}"
-                    values={{ anchorId }}
+          <div
+            ref={setContainer}
+            className="eui-fullHeight"
+            css={css`
+              .resizeButton {
+                height: auto;
+                background-color: transparent !important;
+
+                &:not(:hover):not(:focus) {
+                  &:before,
+                  &:after {
+                    width: 0;
+                  }
+                }
+              }
+            `}
+          >
+            <InPortal node={mainPanelNode}>
+              <TopNavMenu {...getNavBarProps()} />
+              <EuiPage className={classNames({ dscDocsPage: !isLegacy })}>
+                <EuiPageBody
+                  panelled
+                  paddingSize="none"
+                  className="dscDocsContent"
+                  panelProps={{ role: 'main' }}
+                >
+                  <EuiText
+                    data-test-subj="contextDocumentSurroundingHeader"
+                    css={css`
+                      padding: ${titlePadding} ${titlePadding} 0;
+                    `}
+                  >
+                    <strong>
+                      <FormattedMessage
+                        id="discover.context.contextOfTitle"
+                        defaultMessage="Documents surrounding #{anchorId}"
+                        values={{ anchorId }}
+                      />
+                    </strong>
+                  </EuiText>
+                  <EuiSpacer size="s" />
+                  <ContextAppContentMemoized
+                    dataView={dataView}
+                    useNewFieldsApi={useNewFieldsApi}
+                    isLegacy={isLegacy}
+                    columns={columns}
+                    onAddColumn={onAddColumn}
+                    onRemoveColumn={onRemoveColumn}
+                    onSetColumns={onSetColumns}
+                    predecessorCount={appState.predecessorCount}
+                    successorCount={appState.successorCount}
+                    setAppState={stateContainer.setAppState}
+                    addFilter={addFilter as DocViewFilterFn}
+                    rows={rows}
+                    predecessors={fetchedState.predecessors}
+                    successors={fetchedState.successors}
+                    anchorStatus={fetchedState.anchorStatus.value}
+                    predecessorsStatus={fetchedState.predecessorsStatus.value}
+                    successorsStatus={fetchedState.successorsStatus.value}
+                    interceptedWarnings={interceptedWarnings}
+                    expandedDoc={expandedDoc}
+                    setExpandedDoc={setExpandedDoc}
+                    renderDocumentView={showDocViewer ? undefined : renderDocumentView}
                   />
-                </strong>
-              </EuiText>
-              <EuiSpacer size="s" />
-              <ContextAppContentMemoized
-                dataView={dataView}
-                useNewFieldsApi={useNewFieldsApi}
-                isLegacy={isLegacy}
-                columns={columns}
-                onAddColumn={onAddColumn}
-                onRemoveColumn={onRemoveColumn}
-                onSetColumns={onSetColumns}
-                predecessorCount={appState.predecessorCount}
-                successorCount={appState.successorCount}
-                setAppState={stateContainer.setAppState}
-                addFilter={addFilter as DocViewFilterFn}
-                rows={rows}
-                predecessors={fetchedState.predecessors}
-                successors={fetchedState.successors}
-                anchorStatus={fetchedState.anchorStatus.value}
-                predecessorsStatus={fetchedState.predecessorsStatus.value}
-                successorsStatus={fetchedState.successorsStatus.value}
-                interceptedWarnings={interceptedWarnings}
-              />
-            </EuiPageBody>
-          </EuiPage>
+                </EuiPageBody>
+              </EuiPage>
+            </InPortal>
+            <InPortal node={docViewerPanelNode}>
+              {showDocViewer && (
+                <EuiPanel
+                  panelRef={closeButton}
+                  className="dscDocViewer"
+                  borderRadius="none"
+                  paddingSize="none"
+                  hasBorder
+                  tabIndex={-1}
+                  onKeyDown={discoverGridFlyoutPagination.onKeyDown}
+                  css={css`
+                    border-top: none;
+                    border-right: none;
+                    border-bottom: none;
+                  `}
+                >
+                  <EuiFlexGroup
+                    direction="column"
+                    gutterSize="none"
+                    css={css`
+                      height: 100%;
+                    `}
+                  >
+                    <EuiFlexItem
+                      grow={false}
+                      css={css`
+                        padding: ${euiThemeVars.euiSize};
+                        border-bottom: ${euiThemeVars.euiBorderThin};
+                      `}
+                    >
+                      <EuiButtonIcon
+                        iconType="cross"
+                        onClick={() => setExpandedDoc(undefined)}
+                        css={css`
+                          position: absolute;
+                          top: ${euiThemeVars.euiSizeM};
+                          right: ${euiThemeVars.euiSizeM};
+                        `}
+                      />
+                      {header}
+                    </EuiFlexItem>
+                    <EuiFlexItem className="dscDocViewer__body">
+                      <div
+                        css={css`
+                          padding: ${euiThemeVars.euiSize};
+                        `}
+                      >
+                        {body}
+                      </div>
+                    </EuiFlexItem>
+                  </EuiFlexGroup>
+                </EuiPanel>
+              )}
+            </InPortal>
+            <ResizableLayout
+              mode={layoutMode}
+              direction={layoutDirection}
+              container={container}
+              fixedPanelPosition={FixedPanelPosition.End}
+              fixedPanelSize={docViewerWidth ?? defaultDocViewerWidth}
+              minFixedPanelSize={minDocViewerWidth}
+              minFlexPanelSize={minMainPanelWidth}
+              fixedPanel={<OutPortal node={docViewerPanelNode} />}
+              flexPanel={<OutPortal node={mainPanelNode} />}
+              resizeButtonClassName="resizeButton"
+              onFixedPanelSizeChange={setDocViewerWidth}
+            />
+          </div>
         </Fragment>
       )}
     </Fragment>

--- a/src/plugins/discover/public/application/context/context_app_content.tsx
+++ b/src/plugins/discover/public/application/context/context_app_content.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { Fragment, useCallback, useMemo, useState } from 'react';
+import React, { Fragment, useCallback, useMemo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiSpacer, EuiText, useEuiPaddingSize } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -26,7 +26,7 @@ import {
   ROW_HEIGHT_OPTION,
   SHOW_MULTIFIELDS,
 } from '@kbn/discover-utils';
-import { DataLoadingState, UnifiedDataTable } from '@kbn/unified-data-table';
+import { DataLoadingState, UnifiedDataTable, UnifiedDataTableProps } from '@kbn/unified-data-table';
 import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { getDefaultRowsPerPage } from '../../../common/constants';
 import { LoadingStatus } from './services/context_query_state';
@@ -36,7 +36,6 @@ import { SurrDocType } from './services/context';
 import { MAX_CONTEXT_SIZE, MIN_CONTEXT_SIZE } from './services/constants';
 import { DocTableContext } from '../../components/doc_table/doc_table_context';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
-import { DiscoverGridFlyout } from '../../components/discover_grid_flyout';
 import { DISCOVER_TOUR_STEP_ANCHOR_IDS } from '../../components/discover_tour';
 
 export interface ContextAppContentProps {
@@ -56,8 +55,11 @@ export interface ContextAppContentProps {
   interceptedWarnings: SearchResponseInterceptedWarning[] | undefined;
   useNewFieldsApi: boolean;
   isLegacy: boolean;
+  expandedDoc: UnifiedDataTableProps['expandedDoc'];
+  setExpandedDoc: UnifiedDataTableProps['setExpandedDoc'];
   setAppState: (newState: Partial<AppState>) => void;
   addFilter: DocViewFilterFn;
+  renderDocumentView: UnifiedDataTableProps['renderDocumentView'];
 }
 
 const controlColumnIds = ['openDetails'];
@@ -87,13 +89,15 @@ export function ContextAppContent({
   interceptedWarnings,
   useNewFieldsApi,
   isLegacy,
+  expandedDoc,
+  setExpandedDoc,
   setAppState,
   addFilter,
+  renderDocumentView,
 }: ContextAppContentProps) {
   const { uiSettings: config, uiActions } = useDiscoverServices();
   const services = useDiscoverServices();
 
-  const [expandedDoc, setExpandedDoc] = useState<DataTableRecord | undefined>();
   const isAnchorLoading =
     anchorStatus === LoadingStatus.LOADING || anchorStatus === LoadingStatus.UNINITIALIZED;
   const arePredecessorsLoading =
@@ -129,24 +133,6 @@ export function ContextAppContent({
   const sort = useMemo(() => {
     return [[dataView.timeFieldName!, SortDirection.desc]];
   }, [dataView]);
-
-  const renderDocumentView = useCallback(
-    (hit: DataTableRecord, displayedRows: DataTableRecord[], displayedColumns: string[]) => (
-      <DiscoverGridFlyout
-        dataView={dataView}
-        hit={hit}
-        hits={displayedRows}
-        // if default columns are used, dont make them part of the URL - the context state handling will take care to restore them
-        columns={displayedColumns}
-        onFilter={addFilter}
-        onRemoveColumn={onRemoveColumn}
-        onAddColumn={onAddColumn}
-        onClose={() => setExpandedDoc(undefined)}
-        setExpandedDoc={setExpandedDoc}
-      />
-    ),
-    [addFilter, dataView, onAddColumn, onRemoveColumn]
-  );
 
   return (
     <Fragment>

--- a/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -6,28 +6,13 @@
  * Side Public License, v 1.
  */
 
-import React, { useMemo, useCallback } from 'react';
-import { i18n } from '@kbn/i18n';
+import React, { KeyboardEventHandler } from 'react';
 import type { DataView } from '@kbn/data-views-plugin/public';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiFlyout,
-  EuiFlyoutBody,
-  EuiFlyoutHeader,
-  EuiTitle,
-  EuiSpacer,
-  EuiPortal,
-  EuiPagination,
-  keys,
-} from '@elastic/eui';
+import { EuiFlyout, EuiFlyoutBody, EuiFlyoutHeader, EuiPortal } from '@elastic/eui';
 import type { Filter, Query, AggregateQuery } from '@kbn/es-query';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
-import { UnifiedDocViewer } from '@kbn/unified-doc-viewer-plugin/public';
-import { useDiscoverServices } from '../../hooks/use_discover_services';
-import { isTextBasedQuery } from '../../application/main/utils/is_text_based_query';
-import { useFlyoutActions } from './use_flyout_actions';
+import { useDiscoverGridFlyoutBody } from './use_discover_grid_flyout_body';
 
 export interface DiscoverGridFlyoutProps {
   savedSearchId?: string;
@@ -38,18 +23,15 @@ export interface DiscoverGridFlyoutProps {
   hit: DataTableRecord;
   hits?: DataTableRecord[];
   dataView: DataView;
+  activePage: number;
   onAddColumn: (column: string) => void;
   onClose: () => void;
   onFilter?: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
+  setPage: (page: number) => void;
+  onKeyDown: KeyboardEventHandler<HTMLDivElement>;
 }
 
-function getIndexByDocId(hits: DataTableRecord[], id: string) {
-  return hits.findIndex((h) => {
-    return h.id === id;
-  });
-}
 /**
  * Flyout displaying an expanded Elasticsearch document
  */
@@ -62,53 +44,28 @@ export function DiscoverGridFlyout({
   savedSearchId,
   filters,
   query,
+  activePage,
   onFilter,
   onClose,
   onRemoveColumn,
   onAddColumn,
-  setExpandedDoc,
+  setPage,
+  onKeyDown,
 }: DiscoverGridFlyoutProps) {
-  const services = useDiscoverServices();
-  const isPlainRecord = isTextBasedQuery(query);
-  // Get actual hit with updated highlighted searches
-  const actualHit = useMemo(() => hits?.find(({ id }) => id === hit?.id) || hit, [hit, hits]);
-  const pageCount = useMemo<number>(() => (hits ? hits.length : 0), [hits]);
-  const activePage = useMemo<number>(() => {
-    const id = hit.id;
-    if (!hits || pageCount <= 1) {
-      return -1;
-    }
-
-    return getIndexByDocId(hits, id);
-  }, [hits, hit, pageCount]);
-
-  const setPage = useCallback(
-    (index: number) => {
-      if (hits && hits[index]) {
-        setExpandedDoc(hits[index]);
-      }
-    },
-    [hits, setExpandedDoc]
-  );
-
-  const onKeyDown = useCallback(
-    (ev: React.KeyboardEvent) => {
-      if (ev.key === keys.ARROW_LEFT || ev.key === keys.ARROW_RIGHT) {
-        ev.preventDefault();
-        ev.stopPropagation();
-        setPage(activePage + (ev.key === keys.ARROW_RIGHT ? 1 : -1));
-      }
-    },
-    [activePage, setPage]
-  );
-
-  const { flyoutActions } = useFlyoutActions({
+  const { header, body } = useDiscoverGridFlyoutBody({
+    hit,
+    hits,
     dataView,
-    rowIndex: hit.raw._index,
-    rowId: hit.raw._id,
     columns,
-    filters,
+    columnTypes,
     savedSearchId,
+    filters,
+    query,
+    activePage,
+    onFilter,
+    onRemoveColumn,
+    onAddColumn,
+    setPage,
   });
 
   return (
@@ -120,72 +77,8 @@ export function DiscoverGridFlyout({
         onKeyDown={onKeyDown}
         ownFocus={false}
       >
-        <EuiFlyoutHeader hasBorder>
-          <EuiTitle
-            size="s"
-            className="unifiedDataTable__flyoutHeader"
-            data-test-subj="docTableRowDetailsTitle"
-          >
-            <h2>
-              {isPlainRecord
-                ? i18n.translate('discover.grid.tableRow.textBasedDetailHeading', {
-                    defaultMessage: 'Expanded row',
-                  })
-                : i18n.translate('discover.grid.tableRow.detailHeading', {
-                    defaultMessage: 'Expanded document',
-                  })}
-            </h2>
-          </EuiTitle>
-
-          <EuiSpacer size="s" />
-          <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center">
-            {!isPlainRecord &&
-              flyoutActions.map((action) => action.enabled && <action.Content key={action.id} />)}
-            {activePage !== -1 && (
-              <EuiFlexItem data-test-subj={`dscDocNavigationPage-${activePage}`}>
-                <EuiPagination
-                  aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
-                    defaultMessage: 'Document navigation',
-                  })}
-                  pageCount={pageCount}
-                  activePage={activePage}
-                  onPageClick={setPage}
-                  className="unifiedDataTable__flyoutDocumentNavigation"
-                  compressed
-                  data-test-subj="dscDocNavigation"
-                />
-              </EuiFlexItem>
-            )}
-          </EuiFlexGroup>
-        </EuiFlyoutHeader>
-        <EuiFlyoutBody>
-          <UnifiedDocViewer
-            hit={actualHit}
-            columns={columns}
-            columnTypes={columnTypes}
-            dataView={dataView}
-            filter={onFilter}
-            onRemoveColumn={(columnName: string) => {
-              onRemoveColumn(columnName);
-              services.toastNotifications.addSuccess(
-                i18n.translate('discover.grid.flyout.toastColumnRemoved', {
-                  defaultMessage: `Column '{columnName}' was removed`,
-                  values: { columnName },
-                })
-              );
-            }}
-            onAddColumn={(columnName: string) => {
-              onAddColumn(columnName);
-              services.toastNotifications.addSuccess(
-                i18n.translate('discover.grid.flyout.toastColumnAdded', {
-                  defaultMessage: `Column '{columnName}' was added`,
-                  values: { columnName },
-                })
-              );
-            }}
-            textBasedHits={isPlainRecord ? hits : undefined}
-          />
-        </EuiFlyoutBody>
+        <EuiFlyoutHeader hasBorder>{header}</EuiFlyoutHeader>
+        <EuiFlyoutBody>{body}</EuiFlyoutBody>
       </EuiFlyout>
     </EuiPortal>
   );

--- a/src/plugins/discover/public/components/discover_grid_flyout/use_discover_grid_flyout_body.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/use_discover_grid_flyout_body.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EuiFlexGroup, EuiFlexItem, EuiPagination, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { DataView } from '@kbn/data-views-plugin/common';
+import { DataTableRecord } from '@kbn/discover-utils/types';
+import { AggregateQuery, Filter, Query } from '@kbn/es-query';
+import { i18n } from '@kbn/i18n';
+import { UnifiedDocViewer } from '@kbn/unified-doc-viewer-plugin/public';
+import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
+import React, { useMemo } from 'react';
+import { isTextBasedQuery } from '../../application/main/utils/is_text_based_query';
+import { useDiscoverServices } from '../../hooks/use_discover_services';
+import { useFlyoutActions } from './use_flyout_actions';
+
+export interface DiscoverGridFlyoutBodyProps {
+  savedSearchId?: string;
+  filters?: Filter[];
+  query?: Query | AggregateQuery;
+  columns: string[];
+  columnTypes?: Record<string, string>;
+  hit?: DataTableRecord;
+  hits?: DataTableRecord[];
+  dataView: DataView;
+  activePage: number;
+  onAddColumn: (column: string) => void;
+  onFilter?: DocViewFilterFn;
+  onRemoveColumn: (column: string) => void;
+  setPage: (page: number) => void;
+}
+
+export const useDiscoverGridFlyoutBody = ({
+  hit,
+  hits,
+  dataView,
+  columns,
+  columnTypes,
+  savedSearchId,
+  filters,
+  query,
+  activePage,
+  onFilter,
+  onRemoveColumn,
+  onAddColumn,
+  setPage,
+}: DiscoverGridFlyoutBodyProps) => {
+  const services = useDiscoverServices();
+  const isPlainRecord = isTextBasedQuery(query);
+  // Get actual hit with updated highlighted searches
+  const actualHit = useMemo(() => hits?.find(({ id }) => id === hit?.id) || hit, [hit, hits]);
+  const pageCount = useMemo<number>(() => (hits ? hits.length : 0), [hits]);
+
+  const { flyoutActions } = useFlyoutActions({
+    dataView,
+    rowIndex: hit?.raw._index ?? '',
+    rowId: hit?.raw._id ?? '',
+    columns,
+    filters,
+    savedSearchId,
+  });
+
+  const header = actualHit && (
+    <>
+      <EuiTitle
+        size="s"
+        className="unifiedDataTable__flyoutHeader"
+        data-test-subj="docTableRowDetailsTitle"
+      >
+        <h2>
+          {isPlainRecord
+            ? i18n.translate('discover.grid.tableRow.textBasedDetailHeading', {
+                defaultMessage: 'Expanded row',
+              })
+            : i18n.translate('discover.grid.tableRow.detailHeading', {
+                defaultMessage: 'Expanded document',
+              })}
+        </h2>
+      </EuiTitle>
+
+      <EuiSpacer size="s" />
+      <EuiFlexGroup responsive={false} gutterSize="s" alignItems="center" wrap={true}>
+        {!isPlainRecord &&
+          flyoutActions.map((action) => action.enabled && <action.Content key={action.id} />)}
+        {activePage !== -1 && (
+          <EuiFlexItem data-test-subj={`dscDocNavigationPage-${activePage}`}>
+            <EuiPagination
+              aria-label={i18n.translate('discover.grid.flyout.documentNavigation', {
+                defaultMessage: 'Document navigation',
+              })}
+              pageCount={pageCount}
+              activePage={activePage}
+              onPageClick={setPage}
+              className="unifiedDataTable__flyoutDocumentNavigation"
+              compressed
+              data-test-subj="dscDocNavigation"
+            />
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </>
+  );
+
+  const body = actualHit && (
+    <UnifiedDocViewer
+      hit={actualHit}
+      columns={columns}
+      columnTypes={columnTypes}
+      dataView={dataView}
+      filter={onFilter}
+      onRemoveColumn={(columnName: string) => {
+        onRemoveColumn(columnName);
+        services.toastNotifications.addSuccess(
+          i18n.translate('discover.grid.flyout.toastColumnRemoved', {
+            defaultMessage: `Column '{columnName}' was removed`,
+            values: { columnName },
+          })
+        );
+      }}
+      onAddColumn={(columnName: string) => {
+        onAddColumn(columnName);
+        services.toastNotifications.addSuccess(
+          i18n.translate('discover.grid.flyout.toastColumnAdded', {
+            defaultMessage: `Column '{columnName}' was added`,
+            values: { columnName },
+          })
+        );
+      }}
+      textBasedHits={isPlainRecord ? hits : undefined}
+    />
+  );
+
+  return { header, body };
+};

--- a/src/plugins/discover/public/components/discover_grid_flyout/use_discover_grid_flyout_pagination.tsx
+++ b/src/plugins/discover/public/components/discover_grid_flyout/use_discover_grid_flyout_pagination.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { keys } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { useCallback, useMemo } from 'react';
+
+function getIndexByDocId(hits: DataTableRecord[], id: string) {
+  return hits.findIndex((h) => {
+    return h.id === id;
+  });
+}
+
+export const useDiscoverGridFlyoutPagination = ({
+  hits,
+  hit,
+  setExpandedDoc,
+}: {
+  hits?: DataTableRecord[];
+  hit?: DataTableRecord;
+  setExpandedDoc: (doc?: DataTableRecord) => void;
+}) => {
+  const pageCount = useMemo<number>(() => (hits ? hits.length : 0), [hits]);
+
+  const activePage = useMemo<number>(() => {
+    if (!hit || !hits || pageCount <= 1) {
+      return -1;
+    }
+    const id = hit.id;
+    return getIndexByDocId(hits, id);
+  }, [hits, hit, pageCount]);
+
+  const setPage = useCallback(
+    (index: number) => {
+      if (hits && hits[index]) {
+        setExpandedDoc(hits[index]);
+      }
+    },
+    [hits, setExpandedDoc]
+  );
+
+  const onKeyDown = useCallback(
+    (ev: React.KeyboardEvent) => {
+      if (ev.key === keys.ARROW_LEFT || ev.key === keys.ARROW_RIGHT) {
+        ev.preventDefault();
+        ev.stopPropagation();
+        setPage(activePage + (ev.key === keys.ARROW_RIGHT ? 1 : -1));
+      }
+    },
+    [activePage, setPage]
+  );
+
+  return {
+    activePage,
+    setPage,
+    onKeyDown,
+  };
+};


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)