### PR TITLE
[Security Solution] expandable flyout - same source alert chage

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/shared/constants/field_names.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/constants/field_names.ts
@@ -8,7 +8,6 @@
 export const ANCESTOR_ID = 'kibana.alert.ancestors.id';
 export const RULE_PARAMETERS_INDEX = 'kibana.alert.rule.parameters.index';
 export const RULE_INDICES = 'kibana.alert.rule.indices';
-export const ORIGINAL_EVENT_ID = 'kibana.alert.original_event.id';
 export const ENTRY_LEADER_ENTITY_ID = 'process.entry_leader.entity_id';
 export const ENTRY_LEADER_START = 'process.entry_leader.start';
 export const ANCESTOR_INDEX = 'kibana.alert.ancestors.index';

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_related_alerts_by_same_source_event.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_fetch_related_alerts_by_same_source_event.ts
@@ -6,7 +6,7 @@
  */
 
 import { useMemo } from 'react';
-import { ORIGINAL_EVENT_ID } from '../constants/field_names';
+import { ANCESTOR_ID } from '../constants/field_names';
 import { useAlertPrevalence } from '../../../common/containers/alerts/use_alert_prevalence';
 import { isActiveTimeline } from '../../../helpers';
 
@@ -47,7 +47,7 @@ export const useFetchRelatedAlertsBySameSourceEvent = ({
   scopeId,
 }: UseFetchRelatedAlertsBySameSourceEventParams): UseFetchRelatedAlertsBySameSourceEventResult => {
   const { loading, error, count, alertIds } = useAlertPrevalence({
-    field: ORIGINAL_EVENT_ID,
+    field: ANCESTOR_ID,
     value: originalEventId,
     isActiveTimelines: isActiveTimeline(scopeId),
     signalIndexName: null,

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_show_related_alerts_by_ancestry.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_show_related_alerts_by_ancestry.ts
@@ -14,7 +14,7 @@ import { isInvestigateInResolverActionEnabled } from '../../../detections/compon
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { useLicense } from '../../../common/hooks/use_license';
 import { getField } from '../utils';
-import { ANCESTOR_ID } from '../constants/field_names';
+import { ANCESTOR_ID, RULE_PARAMETERS_INDEX } from '../constants/field_names';
 
 export interface UseShowRelatedAlertsByAncestryParams {
   /**
@@ -63,11 +63,7 @@ export const useShowRelatedAlertsByAncestry = ({
 
   // can't use getFieldsData here as the kibana.alert.rule.parameters is different and can be nested
   const originalDocumentIndex = useMemo(
-    () =>
-      find(
-        { category: 'kibana', field: 'kibana.alert.rule.parameters.index' },
-        dataFormattedForFieldBrowser
-      ),
+    () => find({ category: 'kibana', field: RULE_PARAMETERS_INDEX }, dataFormattedForFieldBrowser),
     [dataFormattedForFieldBrowser]
   );
 

--- a/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_show_related_alerts_by_same_source_event.ts
+++ b/x-pack/plugins/security_solution/public/flyout/shared/hooks/use_show_related_alerts_by_same_source_event.ts
@@ -6,7 +6,7 @@
  */
 
 import type { GetFieldsData } from '../../../common/hooks/use_get_fields_data';
-import { ORIGINAL_EVENT_ID } from '../constants/field_names';
+import { ANCESTOR_ID } from '../constants/field_names';
 import { getField } from '../utils';
 
 export interface ShowRelatedAlertsBySameSourceEventParams {
@@ -33,7 +33,7 @@ export interface ShowRelatedAlertsBySameSourceEventResult {
 export const useShowRelatedAlertsBySameSourceEvent = ({
   getFieldsData,
 }: ShowRelatedAlertsBySameSourceEventParams): ShowRelatedAlertsBySameSourceEventResult => {
-  const originalEventId = getField(getFieldsData(ORIGINAL_EVENT_ID));
+  const originalEventId = getField(getFieldsData(ANCESTOR_ID));
   return {
     show: originalEventId != null,
     ...(originalEventId && { originalEventId }),

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
@@ -15,6 +15,9 @@ import {
   CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON,
   CORRELATIONS_SESSION_SECTION_TABLE,
   CORRELATIONS_SESSION_SECTION_TITLE,
+  CORRELATIONS_SOURCE_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON,
+  CORRELATIONS_SOURCE_SECTION_TABLE,
+  CORRELATIONS_SOURCE_SECTION_TITLE,
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON,
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_correlations_tab';
 import {
@@ -66,20 +69,33 @@ describe('Expandable flyout left panel correlations', { tags: ['@ess', '@serverl
 
     cy.log('should render all the correlations sections');
 
-    cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE).scrollIntoView();
-    cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE)
-      .should('be.visible')
-      .and('contain.text', '1 alert related by ancestry');
-    cy.get(CORRELATIONS_ANCESTRY_SECTION_TABLE).should('be.visible');
-    cy.get(CORRELATIONS_ANCESTRY_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+    cy.log('suppressed alerts');
 
-    // TODO get proper data to test this section
-    // cy.get(CORRELATIONS_SOURCE_SECTION).scrollIntoView();
-    // cy.get(CORRELATIONS_SOURCE_SECTION)
+    // TODO get proper data to test suppressed alerts
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE).scrollIntoView();
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE)
     //   .should('be.visible')
-    //   .and('contain.text', '0 alerts related by source event');
-    // cy.get(CORRELATIONS_SOURCE_SECTION_TABLE).should('be.visible');
-    // cy.get(CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+    //   .and('contain.text', '1 suppressed alert');
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+
+    cy.log('related cases');
+
+    cy.get(CORRELATIONS_CASES_SECTION_TITLE).scrollIntoView();
+    cy.get(CORRELATIONS_CASES_SECTION_TITLE)
+      .should('be.visible')
+      .and('contain.text', '1 related case');
+    cy.get(CORRELATIONS_CASES_SECTION_TABLE).should('be.visible');
+
+    cy.log('related alerts by source event');
+
+    cy.get(CORRELATIONS_SOURCE_SECTION_TITLE).scrollIntoView();
+    cy.get(CORRELATIONS_SOURCE_SECTION_TITLE)
+      .should('be.visible')
+      .and('contain.text', '1 alert related by source event');
+    cy.get(CORRELATIONS_SOURCE_SECTION_TABLE).should('be.visible');
+    cy.get(CORRELATIONS_SOURCE_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+
+    cy.log('related alerts by session');
 
     cy.get(CORRELATIONS_SESSION_SECTION_TITLE).scrollIntoView();
     cy.get(CORRELATIONS_SESSION_SECTION_TITLE)
@@ -88,17 +104,14 @@ describe('Expandable flyout left panel correlations', { tags: ['@ess', '@serverl
     cy.get(CORRELATIONS_SESSION_SECTION_TABLE).should('be.visible');
     cy.get(CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
 
-    cy.get(CORRELATIONS_CASES_SECTION_TITLE).scrollIntoView();
-    cy.get(CORRELATIONS_CASES_SECTION_TITLE)
-      .should('be.visible')
-      .and('contain.text', '1 related case');
-    cy.get(CORRELATIONS_CASES_SECTION_TABLE).should('be.visible');
+    cy.log('related alerts by ancestry');
 
-    // TODO get proper data to test suppressed alerts
-    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE).scrollIntoView();
-    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE)
-    //   .should('be.visible')
-    //   .and('contain.text', '1 suppressed alert');
-    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE).scrollIntoView();
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE)
+      .should('be.visible')
+      .and('contain.text', '1 alert related by ancestry');
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TABLE).scrollIntoView();
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TABLE).should('be.visible');
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
   });
 });


### PR DESCRIPTION
## Summary

This PR makes a small change to the way we retrieve the same source related alerts in the Security Solution expandable flyout alert details. Instead of using the value from the `kibana.alert.ancestors.id` field, we're now using the value from `kibana.alert.original_event.id` field.
No UI has been changed.

![Screenshot 2023-10-09 at 1 14 35 PM](https://github.com/elastic/kibana/assets/17276605/20ace3ec-1989-4ec1-a127-c218b40851ae)

https://github.com/elastic/security-team/issues/7778

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->