### PR TITLE
[Security solution] Stops page from crashing when there is a fields error in the stackBy component

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_count_panel/index.test.tsx
@@ -60,7 +60,7 @@ jest.mock('../../../../common/components/visualization_actions/lens_embeddable')
 jest.mock('../../../../common/components/page/use_refetch_by_session');
 jest.mock('../common/hooks', () => ({
   useInspectButton: jest.fn(),
-  useStackByFields: jest.fn(),
+  useStackByFields: jest.fn().mockReturnValue(() => []),
 }));
 const mockUseIsExperimentalFeatureEnabled = useIsExperimentalFeatureEnabled as jest.Mock;
 const getMockUseIsExperimentalFeatureEnabled =

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/components.tsx
@@ -98,7 +98,13 @@ export const StackByComboBox = React.forwardRef(
       return [{ label: selected, value: selected }];
     }, [selected]);
 
-    const stackOptions = useStackByFields(useLensCompatibleFields);
+    const getExpensiveFields = useStackByFields(useLensCompatibleFields);
+
+    const options = useMemo(
+      () => dropDownoptions ?? getExpensiveFields(),
+      [dropDownoptions, getExpensiveFields]
+    );
+
     const singleSelection = useMemo(() => {
       return { asPlainText: true };
     }, []);
@@ -115,7 +121,7 @@ export const StackByComboBox = React.forwardRef(
           singleSelection={singleSelection}
           isClearable={false}
           sortMatchesBy="startsWith"
-          options={dropDownoptions ?? stackOptions}
+          options={options}
           selectedOptions={selectedOptions}
           compressed
           onChange={onChange}

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
@@ -126,9 +126,9 @@ describe('hooks', () => {
       const { result, unmount } = renderHook(() => useStackByFields(), { wrapper });
       const aggregateableFields = result.current();
       unmount();
-      expect(aggregateableFields?.find((field) => field.label === 'agent.id')).toBeTruthy();
+      expect(aggregateableFields!.find((field) => field.label === 'agent.id')).toBeTruthy();
       expect(
-        aggregateableFields?.find((field) => field.label === 'nestedField.firstAttributes')
+        aggregateableFields!.find((field) => field.label === 'nestedField.firstAttributes')
       ).toBe(undefined);
     });
 
@@ -146,8 +146,8 @@ describe('hooks', () => {
       });
       const aggregateableFields = result.current();
       unmount();
-      expect(aggregateableFields?.find((field) => field.label === '@timestamp')).toBeUndefined();
-      expect(aggregateableFields?.find((field) => field.label === '_id')).toBeUndefined();
+      expect(aggregateableFields!.find((field) => field.label === '@timestamp')).toBeUndefined();
+      expect(aggregateableFields!.find((field) => field.label === '_id')).toBeUndefined();
     });
 
     it('returns only Lens compatible fields (check if it is a nested field)', () => {
@@ -162,7 +162,7 @@ describe('hooks', () => {
       const { result, unmount } = renderHook(() => useStackByFields(useLensCompatibleFields), {
         wrapper,
       });
-      const aggregateableFields = result.current;
+      const aggregateableFields = result.current();
       unmount();
       expect(aggregateableFields).toHaveLength(0);
     });

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.test.tsx
@@ -124,7 +124,7 @@ describe('hooks', () => {
         <TestProviders>{children}</TestProviders>
       );
       const { result, unmount } = renderHook(() => useStackByFields(), { wrapper });
-      const aggregateableFields = result.current;
+      const aggregateableFields = result.current();
       unmount();
       expect(aggregateableFields?.find((field) => field.label === 'agent.id')).toBeTruthy();
       expect(
@@ -144,7 +144,7 @@ describe('hooks', () => {
       const { result, unmount } = renderHook(() => useStackByFields(useLensCompatibleFields), {
         wrapper,
       });
-      const aggregateableFields = result.current;
+      const aggregateableFields = result.current();
       unmount();
       expect(aggregateableFields?.find((field) => field.label === '@timestamp')).toBeUndefined();
       expect(aggregateableFields?.find((field) => field.label === '_id')).toBeUndefined();

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
@@ -5,12 +5,14 @@
  * 2.0.
  */
 
-import { useEffect, useState, useMemo } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import type { EuiComboBoxOptionOption } from '@elastic/eui';
 import type { IFieldSubTypeNested } from '@kbn/es-query';
 
 import type { BrowserField } from '@kbn/timelines-plugin/common';
+import { i18n } from '@kbn/i18n';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import type { GlobalTimeArgs } from '../../../../common/containers/use_global_time';
 import { getScopeFromPath, useSourcererDataView } from '../../../../common/containers/sourcerer';
 import { getAllFieldsByName } from '../../../../common/containers/source';
@@ -95,14 +97,22 @@ export function getAggregatableFields(
 
 export const useStackByFields = (useLensCompatibleFields?: boolean) => {
   const { pathname } = useLocation();
-
+  const { addError } = useAppToasts();
   const { browserFields } = useSourcererDataView(getScopeFromPath(pathname));
-  const allFields = useMemo(() => getAllFieldsByName(browserFields), [browserFields]);
-  const [stackByFieldOptions, setStackByFieldOptions] = useState(() =>
-    getAggregatableFields(allFields, useLensCompatibleFields)
-  );
-  useEffect(() => {
-    setStackByFieldOptions(getAggregatableFields(allFields, useLensCompatibleFields));
-  }, [allFields, useLensCompatibleFields]);
-  return useMemo(() => stackByFieldOptions, [stackByFieldOptions]);
+
+  return useCallback(() => {
+    try {
+      return getAggregatableFields(getAllFieldsByName(browserFields), useLensCompatibleFields);
+    } catch (err) {
+      addError(err, {
+        title: i18n.translate('xpack.securitySolution.sourcerer.error.title', {
+          defaultMessage: 'Error fetching fields',
+        }),
+        toastMessage: i18n.translate('xpack.securitySolution.sourcerer.error.toastMessage', {
+          defaultMessage: 'This error indicates an exceedingly large number of fields in an index',
+        }),
+      });
+      return [];
+    }
+  }, [addError, browserFields, useLensCompatibleFields]);
 };

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/common/hooks.ts
@@ -105,10 +105,10 @@ export const useStackByFields = (useLensCompatibleFields?: boolean) => {
       return getAggregatableFields(getAllFieldsByName(browserFields), useLensCompatibleFields);
     } catch (err) {
       addError(err, {
-        title: i18n.translate('xpack.securitySolution.sourcerer.error.title', {
+        title: i18n.translate('xpack.securitySolution.useStackByFields.error.title', {
           defaultMessage: 'Error fetching fields',
         }),
-        toastMessage: i18n.translate('xpack.securitySolution.sourcerer.error.toastMessage', {
+        toastMessage: i18n.translate('xpack.securitySolution.useStackByFields.error.toastMessage', {
           defaultMessage: 'This error indicates an exceedingly large number of fields in an index',
         }),
       });


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/149540

We've been seeing SDHs reporting a stack overflow error that breaks the page.

The error points to a valid problem, but we wanted to improve the Alerts page UX to prevent the app to crash in these situations, making the application more resilient and showing some meaningful message to the customer when this happens.

## Testing

Start by running local es from a snapshot and local kibana. Unless you want to edit some paths in scripts the best way to do this is to run kibana with a base path and defining that base path to be `kbn` by adding this line to your `kibana.dev.yml`:
```
server.basePath: '/kbn'
```

 @e40pud created a super helpful script for generating indices with huge amounts of fields: https://github.com/elastic/kibana/tree/main/x-pack/plugins/security_solution/scripts/mappings
 
Using Huge Indices tool, cd into the directory `x-pack/plugins/security_solution/scripts/mappings` and run the following commands:

1. Creates a huge field mapping. Uses 371k fields because thats what our most recent SDH client had. Defines the index as `filebeat-` so the index will become part of our Security Data View without changes to the advanced settings
   ```
   node mappings_generator.js --fieldsCount=371675 --indexCount=1 --indexPrefix='filebeat-' --unmappedRate=.2 --buckets=10 --outputDirectory='test_unmapped'
   ```
2. Load the mappings into an index in your environment 
   ```
   node mappings_loader.js --mappings-dir='test_unmapped' --es-url=http://elastic:changeme@localhost:9200 --kibana-url=http://elastic:changeme@localhost:5601/kbn/ap
   ```

Now check the overview page. You should see our new error coming up. If you check out main, you will see the crash.

## Before
<img width="1358" alt="Screenshot 2023-10-09 at 2 50 55 PM" src="https://github.com/elastic/kibana/assets/6935300/3db3b76e-1dcf-415d-8386-b2ef0aaeecbf">

## After
<img width="1358" alt="Screenshot 2023-10-09 at 2 43 48 PM" src="https://github.com/elastic/kibana/assets/6935300/f1b66fe7-1c73-4740-9a15-f5154afda0de">
<img width="1356" alt="Screenshot 2023-10-09 at 2 42 51 PM" src="https://github.com/elastic/kibana/assets/6935300/71339722-1778-4f69-aa21-b967589b03d2">

