### PR TITLE
[Serverless Search] Getting started - Add Java & .Net

### DIFF
--- a/packages/kbn-search-api-panels/components/code_box.scss
+++ b/packages/kbn-search-api-panels/components/code_box.scss
@@ -1,3 +1,7 @@
 .codeBoxPanel {
   border-top: $euiBorderThin $euiColorLightShade;
 }
+
+.codeBoxCodeBlock {
+  word-break: break-all;
+}

--- a/packages/kbn-search-api-panels/components/code_box.tsx
+++ b/packages/kbn-search-api-panels/components/code_box.tsx
@@ -128,6 +128,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
           fontSize="m"
           language={languageType || selectedLanguage.languageStyling || selectedLanguage.id}
           overflowHeight={500}
+          className="codeBoxCodeBlock"
         >
           {codeSnippet}
         </EuiCodeBlock>

--- a/x-pack/plugins/serverless_search/public/application/components/languages/dotnet.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/dotnet.ts
@@ -20,9 +20,9 @@ export const dotnetDefinition: LanguageDefinition = {
     link: 'https://github.com/elastic/elasticsearch-serverless-net',
   },
   // Code Snippets,
-  installClient: `dotnet add package Elastic.Clients.Elasticsearch`,
+  installClient: 'dotnet add package Elastic.Clients.Elasticsearch.Serverless',
   configureClient: ({ apiKey, cloudId }) => `using System;
-using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Serverless;
 using Elastic.Clients.Elasticsearch.QueryDsl;
 
 var client = new ElasticsearchClient("${cloudId}", new ApiKey("${apiKey}"));`,

--- a/x-pack/plugins/serverless_search/public/application/components/languages/dotnet.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/dotnet.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+// import { docLinks } from '../../../../common/doc_links';
+
+export const dotnetDefinition: LanguageDefinition = {
+  id: Languages.DOTNET,
+  name: i18n.translate('xpack.serverlessSearch.languages.dotnet', { defaultMessage: '.NET' }),
+  iconType: 'dotnet.svg',
+  github: {
+    label: i18n.translate('xpack.serverlessSearch.languages.dotnet.githubLabel', {
+      defaultMessage: 'elasticsearch-serverless-net',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-serverless-net',
+  },
+  // Code Snippets,
+  installClient: `dotnet add package Elastic.Clients.Elasticsearch`,
+  configureClient: ({ apiKey, cloudId }) => `using System;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.QueryDsl;
+
+var client = new ElasticsearchClient("${cloudId}", new ApiKey("${apiKey}"));`,
+  testConnection: `var info = await client.InfoAsync();`,
+  ingestData: `var doc = new Book
+{
+  Id = "9780553351927",
+  Name = "Snow Crash",
+  Author = "Neal Stephenson",
+  ReleaseDate = new DateTime(1992, 06, 01),
+  PageCount = 470
+};
+
+var response = await client.IndexAsync(doc, "books");`,
+  buildSearchQuery: `var response = await client.SearchAsync<Book>(s => s
+  .Index("books")
+  .From(0)
+  .Size(10)
+  .Query("snow")
+);
+
+if (response.IsValidResponse)
+{
+    var books = response.Documents.FirstOrDefault();
+}`,
+};

--- a/x-pack/plugins/serverless_search/public/application/components/languages/java.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/java.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
+
+export const javaDefinition: LanguageDefinition = {
+  id: Languages.JAVA,
+  name: i18n.translate('xpack.serverlessSearch.languages.java', { defaultMessage: 'Java' }),
+  iconType: 'java.svg',
+  github: {
+    label: i18n.translate('xpack.serverlessSearch.languages.java.githubLabel', {
+      defaultMessage: 'elasticsearch-java-serverless',
+    }),
+    link: 'https://github.com/elastic/elasticsearch-java/tree/main/java-client-serverless',
+  },
+  // Code Snippets,
+  installClient: `dependencies {
+    implementation 'co.elastic.clients:elasticsearch-java-serverless:1.0.0-20231031'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.3'
+}`,
+  configureClient: ({ apiKey, url }) => `// URL and API key
+String serverUrl = "${url}";
+String apiKey = "${apiKey}";
+
+// Create the low-level client
+RestClient restClient = RestClient
+  .builder(HttpHost.create(serverUrl))
+  .setDefaultHeaders(new Header[]{
+      new BasicHeader("Authorization", "ApiKey " + apiKey)
+  })
+  .build();
+
+// Create the transport with a Jackson mapper
+ElasticsearchTransport transport = new RestClientTransport(
+  restClient, new JacksonJsonpMapper());
+
+// And create the API client
+ElasticsearchClient esClient = new ElasticsearchClient(transport);`,
+  testConnection: `InfoResponse info = esClient.info();
+
+logger.info(info.toString());`,
+  ingestData: `List<Book> books = new ArrayList<>();
+books.add(new Book("9780553351927", "Snow Crash", "Neal Stephenson", "1992-06-01", 470));
+books.add(new Book("9780441017225", "Revelation Space", "Alastair Reynolds", "2000-03-15", 585));
+books.add(new Book("9780451524935", "1984", "George Orwell", "1985-06-01", 328));
+books.add(new Book("9781451673319", "Fahrenheit 451", "Ray Bradbury", "1953-10-15", 227));
+books.add(new Book("9780060850524", "Brave New World", "Aldous Huxley", "1932-06-01", 268));
+books.add(new Book("9780385490818", "The Handmaid's Tale", "Margaret Atwood", "1985-06-01", 311));
+
+BulkRequest.Builder br = new BulkRequest.Builder();
+
+for (Book book : books) {
+    br.operations(op -> op
+        .index(idx -> idx
+            .index("books")
+            .id(product.getId())
+            .document(book)
+        )
+    );
+}
+
+BulkResponse result = esClient.bulk(br.build());
+
+// Log errors, if any
+if (result.errors()) {
+    logger.error("Bulk had errors");
+    for (BulkResponseItem item: result.items()) {
+        if (item.error() != null) {
+            logger.error(item.error().reason());
+        }
+    }
+}`,
+  buildSearchQuery: `String searchText = "snow";
+
+SearchResponse<Book> response = esClient.search(s -> s
+  .index("books")
+  .query(q -> q
+      .match(t -> t
+          .field("name")
+          .query(searchText)
+      )
+  ),
+  Book.class
+);
+
+TotalHits total = response.hits().total();`,
+};

--- a/x-pack/plugins/serverless_search/public/application/components/languages/language_grid.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/language_grid.tsx
@@ -5,9 +5,8 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 import {
-  EuiButton,
   EuiFlexGroup,
   EuiFlexGrid,
   EuiFlexItem,
@@ -15,9 +14,9 @@ import {
   EuiImage,
   EuiText,
   useEuiTheme,
+  useIsWithinBreakpoints,
 } from '@elastic/eui';
 
-import { i18n } from '@kbn/i18n';
 import { LanguageDefinition, Languages } from '@kbn/search-api-panels';
 
 export interface LanguageGridProps {
@@ -25,7 +24,6 @@ export interface LanguageGridProps {
   languages: LanguageDefinition[];
   selectedLanguage: Languages;
   setSelectedLanguage: (language: LanguageDefinition) => void;
-  defaultVisibleCount?: number;
 }
 
 export const LanguageGrid: React.FC<LanguageGridProps> = ({
@@ -33,80 +31,48 @@ export const LanguageGrid: React.FC<LanguageGridProps> = ({
   languages,
   selectedLanguage,
   setSelectedLanguage,
-  defaultVisibleCount = 4,
 }: LanguageGridProps) => {
   const { euiTheme } = useEuiTheme();
-  const [allLanguagesVisible, setAllLanguagesVisible] = useState<boolean>(false);
-  const visibleLanguages = allLanguagesVisible
-    ? languages
-    : languages.slice(0, defaultVisibleCount);
+  const isLarge = useIsWithinBreakpoints(['l']);
+  const isXLarge = useIsWithinBreakpoints(['xl']);
+  const columns = isXLarge ? 3 : isLarge ? 2 : 1;
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="m">
-      <EuiFlexItem>
-        <EuiFlexGrid columns={2} gutterSize="s">
-          {visibleLanguages.map((language) => (
-            <EuiFlexItem>
-              <EuiPanel
-                hasBorder
-                borderRadius="m"
-                className={
-                  language.id === selectedLanguage
-                    ? 'serverlessSearchSelectClientPanelSelectedBorder'
-                    : 'serverlessSearchSelectClientPanelBorder'
-                }
-                onClick={() => setSelectedLanguage(language)}
-                color={language.id === selectedLanguage ? 'primary' : 'plain'}
-              >
-                <EuiFlexGroup justifyContent="flexStart">
-                  <EuiFlexItem grow={false}>
-                    <EuiImage
-                      alt=""
-                      src={`${assetBasePath}/${language.iconType}`}
-                      height={euiTheme.size.l}
-                      width={euiTheme.size.l}
-                    />
-                  </EuiFlexItem>
-                  <EuiFlexItem>
-                    <EuiText
-                      textAlign="left"
-                      color={language.id === selectedLanguage ? 'default' : 'subdued'}
-                    >
-                      <h5>{language.name}</h5>
-                    </EuiText>
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiPanel>
-            </EuiFlexItem>
-          ))}
-        </EuiFlexGrid>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        {allLanguagesVisible ? (
-          <EuiButton
-            iconSide="right"
-            iconType="arrowUp"
-            onClick={() => setAllLanguagesVisible(false)}
+    <EuiFlexGrid columns={columns} gutterSize="s">
+      {languages.map((language) => (
+        <EuiFlexItem key={language.id}>
+          <EuiPanel
+            hasBorder
+            borderRadius="m"
+            className={
+              language.id === selectedLanguage
+                ? 'serverlessSearchSelectClientPanelSelectedBorder'
+                : 'serverlessSearchSelectClientPanelBorder'
+            }
+            onClick={() => setSelectedLanguage(language)}
+            color={language.id === selectedLanguage ? 'primary' : 'plain'}
           >
-            {i18n.translate('xpack.serverlessSearch.selectClient.languagesGrid.showLessLabel', {
-              defaultMessage: 'See less',
-            })}
-          </EuiButton>
-        ) : (
-          <EuiButton
-            iconSide="right"
-            iconType="arrowDown"
-            onClick={() => setAllLanguagesVisible(true)}
-          >
-            {i18n.translate('xpack.serverlessSearch.selectClient.languagesGrid.showMoreLabel', {
-              defaultMessage: 'See {additionalCount} more',
-              values: {
-                additionalCount: languages.length - defaultVisibleCount,
-              },
-            })}
-          </EuiButton>
-        )}
-      </EuiFlexItem>
-    </EuiFlexGroup>
+            <EuiFlexGroup justifyContent="flexStart" responsive={false}>
+              <EuiFlexItem grow={false}>
+                <EuiImage
+                  alt=""
+                  src={`${assetBasePath}/${language.iconType}`}
+                  height={euiTheme.size.l}
+                  width={euiTheme.size.l}
+                />
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiText
+                  textAlign="left"
+                  color={language.id === selectedLanguage ? 'default' : 'subdued'}
+                >
+                  <h5>{language.name}</h5>
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPanel>
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGrid>
   );
 };

--- a/x-pack/plugins/serverless_search/public/application/components/languages/language_grid.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/language_grid.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import {
+  EuiButton,
+  EuiFlexGroup,
+  EuiFlexGrid,
+  EuiFlexItem,
+  EuiPanel,
+  EuiImage,
+  EuiText,
+  useEuiTheme,
+} from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+import { LanguageDefinition, Languages } from '@kbn/search-api-panels';
+
+export interface LanguageGridProps {
+  assetBasePath: string;
+  languages: LanguageDefinition[];
+  selectedLanguage: Languages;
+  setSelectedLanguage: (language: LanguageDefinition) => void;
+  defaultVisibleCount?: number;
+}
+
+export const LanguageGrid: React.FC<LanguageGridProps> = ({
+  assetBasePath,
+  languages,
+  selectedLanguage,
+  setSelectedLanguage,
+  defaultVisibleCount = 4,
+}: LanguageGridProps) => {
+  const { euiTheme } = useEuiTheme();
+  const [allLanguagesVisible, setAllLanguagesVisible] = useState<boolean>(false);
+  const visibleLanguages = allLanguagesVisible
+    ? languages
+    : languages.slice(0, defaultVisibleCount);
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="m">
+      <EuiFlexItem>
+        <EuiFlexGrid columns={2} gutterSize="s">
+          {visibleLanguages.map((language) => (
+            <EuiFlexItem>
+              <EuiPanel
+                hasBorder
+                borderRadius="m"
+                className={
+                  language.id === selectedLanguage
+                    ? 'serverlessSearchSelectClientPanelSelectedBorder'
+                    : 'serverlessSearchSelectClientPanelBorder'
+                }
+                onClick={() => setSelectedLanguage(language)}
+                color={language.id === selectedLanguage ? 'primary' : 'plain'}
+              >
+                <EuiFlexGroup justifyContent="flexStart">
+                  <EuiFlexItem grow={false}>
+                    <EuiImage
+                      alt=""
+                      src={`${assetBasePath}/${language.iconType}`}
+                      height={euiTheme.size.l}
+                      width={euiTheme.size.l}
+                    />
+                  </EuiFlexItem>
+                  <EuiFlexItem>
+                    <EuiText
+                      textAlign="left"
+                      color={language.id === selectedLanguage ? 'default' : 'subdued'}
+                    >
+                      <h5>{language.name}</h5>
+                    </EuiText>
+                  </EuiFlexItem>
+                </EuiFlexGroup>
+              </EuiPanel>
+            </EuiFlexItem>
+          ))}
+        </EuiFlexGrid>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        {allLanguagesVisible ? (
+          <EuiButton
+            iconSide="right"
+            iconType="arrowUp"
+            onClick={() => setAllLanguagesVisible(false)}
+          >
+            {i18n.translate('xpack.serverlessSearch.selectClient.languagesGrid.showLessLabel', {
+              defaultMessage: 'See less',
+            })}
+          </EuiButton>
+        ) : (
+          <EuiButton
+            iconSide="right"
+            iconType="arrowDown"
+            onClick={() => setAllLanguagesVisible(true)}
+          >
+            {i18n.translate('xpack.serverlessSearch.selectClient.languagesGrid.showMoreLabel', {
+              defaultMessage: 'See {additionalCount} more',
+              values: {
+                additionalCount: languages.length - defaultVisibleCount,
+              },
+            })}
+          </EuiButton>
+        )}
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/languages/languages.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/languages.ts
@@ -8,7 +8,9 @@
 import { Languages, LanguageDefinition } from '@kbn/search-api-panels';
 
 import { curlDefinition } from './curl';
+import { dotnetDefinition } from './dotnet';
 import { goDefinition } from './go';
+import { javaDefinition } from './java';
 import { javascriptDefinition } from './javascript';
 import { phpDefinition } from './php';
 import { pythonDefinition } from './python';
@@ -17,8 +19,10 @@ import { rubyDefinition } from './ruby';
 const languageDefinitionRecords: Partial<Record<Languages, LanguageDefinition>> = {
   [Languages.CURL]: curlDefinition,
   [Languages.PYTHON]: pythonDefinition,
+  [Languages.DOTNET]: dotnetDefinition,
   [Languages.JAVASCRIPT]: javascriptDefinition,
   [Languages.PHP]: phpDefinition,
+  [Languages.JAVA]: javaDefinition,
   [Languages.GO]: goDefinition,
   [Languages.RUBY]: rubyDefinition,
 };

--- a/x-pack/plugins/serverless_search/public/application/components/languages/languages.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/languages.ts
@@ -18,11 +18,11 @@ import { rubyDefinition } from './ruby';
 
 const languageDefinitionRecords: Partial<Record<Languages, LanguageDefinition>> = {
   [Languages.CURL]: curlDefinition,
-  [Languages.PYTHON]: pythonDefinition,
+  [Languages.JAVA]: javaDefinition,
   [Languages.DOTNET]: dotnetDefinition,
+  [Languages.PYTHON]: pythonDefinition,
   [Languages.JAVASCRIPT]: javascriptDefinition,
   [Languages.PHP]: phpDefinition,
-  [Languages.JAVA]: javaDefinition,
   [Languages.GO]: goDefinition,
   [Languages.RUBY]: rubyDefinition,
 };

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -26,7 +26,6 @@ import {
   SelectClientPanel,
   OverviewPanel,
   CodeBox,
-  LanguageClientPanel,
   InstallClientPanel,
   getLanguageDefinitionCodeSnippet,
   getConsoleRequest,
@@ -42,9 +41,14 @@ import { Connector } from '@kbn/search-connectors';
 import { docLinks } from '../../../common/doc_links';
 import { PLUGIN_ID } from '../../../common';
 import { useKibanaServices } from '../hooks/use_kibana';
-import { API_KEY_PLACEHOLDER, ELASTICSEARCH_URL_PLACEHOLDER } from '../constants';
+import {
+  API_KEY_PLACEHOLDER,
+  CLOUD_ID_PLACEHOLDER,
+  ELASTICSEARCH_URL_PLACEHOLDER,
+} from '../constants';
 import { javascriptDefinition } from './languages/javascript';
 import { languageDefinitions } from './languages/languages';
+import { LanguageGrid } from './languages/language_grid';
 import './overview.scss';
 import { ApiKeyPanel } from './api_key/api_key';
 
@@ -57,10 +61,14 @@ export const ElasticsearchOverview = () => {
   const elasticsearchURL = useMemo(() => {
     return cloud?.elasticsearchUrl ?? ELASTICSEARCH_URL_PLACEHOLDER;
   }, [cloud]);
+  const cloudId = useMemo(() => {
+    return cloud?.cloudId ?? CLOUD_ID_PLACEHOLDER;
+  }, [cloud]);
   const assetBasePath = http.basePath.prepend(`/plugins/${PLUGIN_ID}/assets`);
   const codeSnippetArguments: LanguageDefinitionSnippetArguments = {
     url: elasticsearchURL,
     apiKey: clientApiKey,
+    cloudId,
   };
 
   const { data: _data } = useQuery({
@@ -78,16 +86,14 @@ export const ElasticsearchOverview = () => {
       </EuiPageTemplate.Section>
       <EuiPageTemplate.Section color="subdued" bottomBorder="extended">
         <SelectClientPanel docLinks={docLinks} http={http}>
-          {languageDefinitions.map((language, index) => (
-            <EuiFlexItem key={`panelItem.${index}`}>
-              <LanguageClientPanel
-                language={language}
-                setSelectedLanguage={setSelectedLanguage}
-                isSelectedLanguage={selectedLanguage === language}
-                assetBasePath={assetBasePath}
-              />
-            </EuiFlexItem>
-          ))}
+          <EuiFlexItem>
+            <LanguageGrid
+              assetBasePath={assetBasePath}
+              setSelectedLanguage={setSelectedLanguage}
+              languages={languageDefinitions}
+              selectedLanguage={selectedLanguage.id}
+            />
+          </EuiFlexItem>
         </SelectClientPanel>
       </EuiPageTemplate.Section>
 

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -57,11 +57,11 @@ export const ElasticsearchOverview = () => {
   const [clientApiKey, setClientApiKey] = useState<string>(API_KEY_PLACEHOLDER);
   const { application, cloud, http, user, share } = useKibanaServices();
 
-  const elasticsearchURL = useMemo(() => {
-    return cloud?.elasticsearchUrl ?? ELASTICSEARCH_URL_PLACEHOLDER;
-  }, [cloud]);
-  const cloudId = useMemo(() => {
-    return cloud?.cloudId ?? CLOUD_ID_PLACEHOLDER;
+  const { elasticsearchURL, cloudId } = useMemo(() => {
+    return {
+      elasticsearchURL: cloud?.elasticsearchUrl ?? ELASTICSEARCH_URL_PLACEHOLDER,
+      cloudId: cloud?.cloudId ?? CLOUD_ID_PLACEHOLDER,
+    };
   }, [cloud]);
   const assetBasePath = http.basePath.prepend(`/plugins/${PLUGIN_ID}/assets`);
   const codeSnippetArguments: LanguageDefinitionSnippetArguments = {

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -46,15 +46,14 @@ import {
   CLOUD_ID_PLACEHOLDER,
   ELASTICSEARCH_URL_PLACEHOLDER,
 } from '../constants';
-import { javascriptDefinition } from './languages/javascript';
+import { javaDefinition } from './languages/java';
 import { languageDefinitions } from './languages/languages';
 import { LanguageGrid } from './languages/language_grid';
 import './overview.scss';
 import { ApiKeyPanel } from './api_key/api_key';
 
 export const ElasticsearchOverview = () => {
-  const [selectedLanguage, setSelectedLanguage] =
-    useState<LanguageDefinition>(javascriptDefinition);
+  const [selectedLanguage, setSelectedLanguage] = useState<LanguageDefinition>(javaDefinition);
   const [clientApiKey, setClientApiKey] = useState<string>(API_KEY_PLACEHOLDER);
   const { application, cloud, http, user, share } = useKibanaServices();
 

--- a/x-pack/plugins/serverless_search/public/application/constants.ts
+++ b/x-pack/plugins/serverless_search/public/application/constants.ts
@@ -7,4 +7,5 @@
 
 export const API_KEY_PLACEHOLDER = 'your_api_key';
 export const ELASTICSEARCH_URL_PLACEHOLDER = 'https://your_deployment_url';
+export const CLOUD_ID_PLACEHOLDER = '<CLOUD_ID>';
 export const INDEX_NAME_PLACEHOLDER = 'index_name';


### PR DESCRIPTION
## Summary

- Added Java language to the getting started page
- Added .Net language to the getting started page
- Updated the serverless search getting started page client select to use a grid with overflow "see more"
- fixed a bug where CodeBox was not wrapping when it had long strings.

### Screenshots
Default 3 columns (XL breakpoint)
<img width="1479" alt="image" src="https://github.com/elastic/kibana/assets/1972968/0f33935d-01b0-44d3-913f-4eead46599f7">
L breakpoint - 2 columns
<img width="1161" alt="image" src="https://github.com/elastic/kibana/assets/1972968/70a14213-a266-4ba1-a82e-49fc43c058b5">
< L breakpoint - 1 column
<img width="960" alt="image" src="https://github.com/elastic/kibana/assets/1972968/e8d9a43f-14b2-4e6e-92b7-ca99cbb9fe3b">

.Net example snippets
<img width="1899" alt="image" src="https://github.com/elastic/kibana/assets/1972968/30c9d21b-f63b-413c-abdf-5c83df9d5b96">
Java
<img width="1899" alt="image" src="https://github.com/elastic/kibana/assets/1972968/72c7e999-28a8-41eb-b493-4adff445f236">
