### PR TITLE
[Data Discovery] Unskip and fix flaky Serverless examples tests

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/index.ts
@@ -23,8 +23,7 @@ export default function ({ getService, getPageObjects, loadTestFile }: FtrProvid
   const retry = getService('retry');
   const kibanaServer = getService('kibanaServer');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/167939
-  describe.skip('data view field editor example', function () {
+  describe('data view field editor example', function () {
     before(async () => {
       // TODO: Serverless tests require login first
       await PageObjects.svlCommonPage.login();

--- a/x-pack/test_serverless/functional/test_suites/common/examples/search/warnings.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/search/warnings.ts
@@ -13,7 +13,7 @@ import type { WebElementWrapper } from '../../../../../../../test/functional/ser
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['common', 'timePicker']);
+  const PageObjects = getPageObjects(['common', 'timePicker', 'svlCommonPage']);
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const retry = getService('retry');
@@ -23,14 +23,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const comboBox = getService('comboBox');
   const kibanaServer = getService('kibanaServer');
   const esArchiver = getService('esArchiver');
+  const browser = getService('browser');
 
-  // Failing: See https://github.com/elastic/kibana/issues/165623
-  // FLAKY: https://github.com/elastic/kibana/issues/165379
-  // FLAKY: https://github.com/elastic/kibana/issues/165502
-  // FLAKY: https://github.com/elastic/kibana/issues/165503
-  // FLAKY: https://github.com/elastic/kibana/issues/165624
-  // FLAKY: https://github.com/elastic/kibana/issues/165635
-  describe.skip('handling warnings with search source fetch', function () {
+  describe('handling warnings with search source fetch', function () {
     const dataViewTitle = 'sample-01,sample-01-rollup';
     const fromTime = 'Jun 17, 2022 @ 00:00:00.000';
     const toTime = 'Jun 23, 2022 @ 00:00:00.000';
@@ -51,6 +46,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     };
 
     before(async () => {
+      // TODO: Serverless tests require login first
+      await PageObjects.svlCommonPage.login();
       // create rollup data
       log.info(`loading ${testIndex} index...`);
       await esArchiver.loadIfNeeded(testArchive);
@@ -104,7 +101,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.common.clearAllToasts();
     });
 
-    it('shows shard failure warning notifications by default', async () => {
+    it('should show search warnings as toasts', async () => {
       await testSubjects.click('searchSourceWithOther');
 
       // wait for response - toasts appear before the response is rendered
@@ -117,30 +114,25 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       // toasts
       const toasts = await find.allByCssSelector(toastsSelector);
       expect(toasts.length).to.be(2);
-      const expects = ['2 of 4 shards failed', 'Query result'];
+      const expects = ['The data might be incomplete or wrong.', 'Query result'];
       await asyncForEach(toasts, async (t, index) => {
         expect(await t.getVisibleText()).to.eql(expects[index]);
       });
 
       // click "see full error" button in the toast
-      const [openShardModalButton] = await testSubjects.findAll('openShardFailureModalBtn');
+      const [openShardModalButton] = await testSubjects.findAll('viewWarningBtn');
       await openShardModalButton.click();
 
-      await retry.waitFor('modal title visible', async () => {
-        const modalHeader = await testSubjects.find('shardFailureModalTitle');
-        return (await modalHeader.getVisibleText()) === '2 of 4 shards failed';
-      });
-
       // request
-      await testSubjects.click('shardFailuresModalRequestButton');
-      const requestBlock = await testSubjects.find('shardsFailedModalRequestBlock');
-      expect(await requestBlock.getVisibleText()).to.contain(testRollupField);
+      await testSubjects.click('inspectorRequestDetailRequest');
+      await testSubjects.click('inspectorRequestCopyClipboardButton');
+      expect(await browser.getClipboardValue()).to.contain(testRollupField);
       // response
-      await testSubjects.click('shardFailuresModalResponseButton');
-      const responseBlock = await testSubjects.find('shardsFailedModalResponseBlock');
-      expect(await responseBlock.getVisibleText()).to.contain(shardFailureReason);
+      await testSubjects.click('inspectorRequestDetailResponse');
+      await testSubjects.click('inspectorRequestCopyClipboardButton');
+      expect(await browser.getClipboardValue()).to.contain(shardFailureReason);
 
-      await testSubjects.click('closeShardFailureModal');
+      await testSubjects.click('euiFlyoutCloseButton');
 
       // response tab
       assert(response && response._shards.failures);
@@ -158,7 +150,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       expect(warnings).to.eql([]);
     });
 
-    it('able to handle shard failure warnings and prevent default notifications', async () => {
+    it('should show search warnings in results tab', async () => {
       await testSubjects.click('searchSourceWithoutOther');
 
       // wait for toasts - toasts appear after the response is rendered
@@ -167,52 +159,15 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         toasts = await find.allByCssSelector(toastsSelector);
         expect(toasts.length).to.be(2);
       });
-      const expects = ['Query result', '2 of 4 shards failed'];
+      const expects = ['The data might be incomplete or wrong.', 'Query result'];
       await asyncForEach(toasts, async (t, index) => {
         expect(await t.getVisibleText()).to.eql(expects[index]);
       });
 
-      // click "see full error" button in the toast
-      const [openShardModalButton] = await testSubjects.findAll('openShardFailureModalBtn');
-      await openShardModalButton.click();
-
-      await retry.waitFor('modal title visible', async () => {
-        const modalHeader = await testSubjects.find('shardFailureModalTitle');
-        return (await modalHeader.getVisibleText()) === '2 of 4 shards failed';
-      });
-
-      // request
-      await testSubjects.click('shardFailuresModalRequestButton');
-      const requestBlock = await testSubjects.find('shardsFailedModalRequestBlock');
-      expect(await requestBlock.getVisibleText()).to.contain(testRollupField);
-      // response
-      await testSubjects.click('shardFailuresModalResponseButton');
-      const responseBlock = await testSubjects.find('shardsFailedModalResponseBlock');
-      expect(await responseBlock.getVisibleText()).to.contain(shardFailureReason);
-
-      await testSubjects.click('closeShardFailureModal');
-
-      // response tab
-      const response = await getTestJson('responseTab', 'responseCodeBlock');
-      expect(response._shards.total).to.be(4);
-      expect(response._shards.successful).to.be(2);
-      expect(response._shards.skipped).to.be(0);
-      expect(response._shards.failed).to.be(2);
-      expect(response._shards.failures.length).to.equal(1);
-      expect(response._shards.failures[0].index).to.equal(testRollupIndex);
-      expect(response._shards.failures[0].reason.type).to.equal(shardFailureType);
-      expect(response._shards.failures[0].reason.reason).to.equal(shardFailureReason);
-
       // warnings tab
       const warnings = await getTestJson('warningsTab', 'warningsCodeBlock');
-      expect(warnings).to.eql([
-        {
-          type: 'shard_failure',
-          message: '2 of 4 shards failed',
-          reason: { reason: shardFailureReason, type: shardFailureType },
-          text: 'The data might be incomplete or wrong.',
-        },
-      ]);
+      expect(warnings.length).to.be(1);
+      expect(warnings[0].type).to.be('incomplete');
     });
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/common/examples/search_examples/search_example.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/search_examples/search_example.ts
@@ -10,14 +10,17 @@ import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
-  const PageObjects = getPageObjects(['common', 'timePicker']);
+  const PageObjects = getPageObjects(['common', 'timePicker', 'svlCommonPage']);
   const retry = getService('retry');
   const comboBox = getService('comboBox');
   const toasts = getService('toasts');
 
-  // Failing: See https://github.com/elastic/kibana/issues/165730
-  // FLAKY: https://github.com/elastic/kibana/issues/165735
   describe('Search example', () => {
+    before(async () => {
+      // TODO: Serverless tests require login first
+      await PageObjects.svlCommonPage.login();
+    });
+
     describe('with bfetch', () => {
       testSearchExample();
     });
@@ -83,7 +86,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
       });
 
-      // failing because no toasts are displayed
+      // TODO: This test fails in Serverless because it relies on
+      // `error_query` which doesn't seem to be supported in Serverless
       it.skip('should handle warnings', async () => {
         await testSubjects.click('searchWithWarning');
         await retry.waitFor('', async () => {

--- a/x-pack/test_serverless/functional/test_suites/common/examples/unified_field_list_examples/field_stats.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/unified_field_list_examples/field_stats.ts
@@ -12,7 +12,13 @@ const TEST_START_TIME = 'Sep 19, 2015 @ 06:31:44.000';
 const TEST_END_TIME = 'Sep 23, 2015 @ 18:31:44.000';
 
 export default ({ getService, getPageObjects }: FtrProviderContext) => {
-  const PageObjects = getPageObjects(['common', 'timePicker', 'header', 'unifiedFieldList']);
+  const PageObjects = getPageObjects([
+    'common',
+    'timePicker',
+    'header',
+    'unifiedFieldList',
+    'svlCommonPage',
+  ]);
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
   const comboBox = getService('comboBox');
@@ -21,9 +27,10 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const filterBar = getService('filterBar');
   const dataViewTitle = 'logstash-2015.09.22';
 
-  // FLAKY: https://github.com/elastic/kibana/issues/165882
-  describe.skip('Field stats', () => {
+  describe('Field stats', () => {
     before(async () => {
+      // TODO: Serverless tests require login first
+      await PageObjects.svlCommonPage.login();
       await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(
@@ -59,8 +66,7 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
       await PageObjects.unifiedFieldList.cleanSidebarLocalStorage();
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/165797
-    describe.skip('field distribution', () => {
+    describe('field distribution', () => {
       before(async () => {
         await PageObjects.unifiedFieldList.toggleSidebarSection('empty'); // it will allow to render more fields in Available fields section
       });


### PR DESCRIPTION
## Summary

This PR unskips and fixes the remaining flaky Serverless examples tests.

Resolves #165730.
Resolves #165735.
Resolves #165624.
Resolves #165623.
Resolves #165635.
Resolves #165938.
Resolves #165927.
Resolves #165882.
Resolves #165797.
Resolves #167939.
Resolves #165503.
Resolves #165502.
Resolves #165379.

Flaky test runs:
- x300: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3430 🟢
- x300: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3455 🔴
- x100: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3478 🟢

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->