### PR TITLE
[8.11] [ES|QL] Hides fields with nulls from document view (#168321)

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -517,7 +517,8 @@ export const UnifiedDataTable = ({
         () => dataGridRef.current?.closeCellPopover(),
         services.fieldFormats,
         maxDocFieldsDisplayed,
-        externalCustomRenderers
+        externalCustomRenderers,
+        isPlainRecord
       ),
     [
       dataView,
@@ -527,6 +528,7 @@ export const UnifiedDataTable = ({
       maxDocFieldsDisplayed,
       services.fieldFormats,
       externalCustomRenderers,
+      isPlainRecord,
     ]
   );
 

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
@@ -380,7 +380,6 @@ describe('Unified data table cell rendering', function () {
       />
     );
     expect(component).toMatchInlineSnapshot(
-      '',
       `
       <EuiDescriptionList
         className="unifiedDataTable__descriptionList unifiedDataTable__cellValue"

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.test.tsx
@@ -75,6 +75,18 @@ const rowsSource: EsHitRecord[] = [
   },
 ];
 
+const rowsSourceWithEmptyValues: EsHitRecord[] = [
+  {
+    _id: '1',
+    _index: 'test',
+    _score: 1,
+    _source: { bytes: 100, extension: null },
+    highlight: {
+      extension: ['@kibana-highlighted-field.gz@/kibana-highlighted-field'],
+    },
+  },
+];
+
 const rowsFields: EsHitRecord[] = [
   {
     _id: '1',
@@ -342,6 +354,68 @@ describe('Unified data table cell rendering', function () {
         </EuiFlexItem>
       </EuiFlexGroup>
     `);
+  });
+
+  it('renders _source column correctly if on text based mode and have nulls', () => {
+    const DataTableCellValue = getRenderCellValueFn(
+      dataViewMock,
+      rowsSourceWithEmptyValues.map(build),
+      false,
+      () => false,
+      jest.fn(),
+      mockServices.fieldFormats as unknown as FieldFormatsStart,
+      100,
+      undefined,
+      true
+    );
+    const component = shallow(
+      <DataTableCellValue
+        rowIndex={0}
+        colIndex={0}
+        columnId="_source"
+        isDetails={false}
+        isExpanded={false}
+        isExpandable={true}
+        setCellProps={jest.fn()}
+      />
+    );
+    expect(component).toMatchInlineSnapshot(
+      '',
+      `
+      <EuiDescriptionList
+        className="unifiedDataTable__descriptionList unifiedDataTable__cellValue"
+        compressed={true}
+        type="inline"
+      >
+        <EuiDescriptionListTitle
+          className="unifiedDataTable__descriptionListTitle"
+        >
+          _index
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription
+          className="unifiedDataTable__descriptionListDescription"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "test",
+            }
+          }
+        />
+        <EuiDescriptionListTitle
+          className="unifiedDataTable__descriptionListTitle"
+        >
+          _score
+        </EuiDescriptionListTitle>
+        <EuiDescriptionListDescription
+          className="unifiedDataTable__descriptionListDescription"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": 1,
+            }
+          }
+        />
+      </EuiDescriptionList>
+    `
+    );
   });
 
   it('renders fields-based column correctly', () => {

--- a/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
+++ b/packages/kbn-unified-data-table/src/utils/get_render_cell_value.tsx
@@ -45,7 +45,8 @@ export const getRenderCellValueFn =
     externalCustomRenderers?: Record<
       string,
       (props: EuiDataGridCellValueElementProps) => React.ReactNode
-    >
+    >,
+    isPlainRecord?: boolean
   ) =>
   ({
     rowIndex,
@@ -135,17 +136,22 @@ export const getRenderCellValueFn =
           compressed
           className={classnames('unifiedDataTable__descriptionList', CELL_CLASS)}
         >
-          {pairs.map(([key, value]) => (
-            <Fragment key={key}>
-              <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
-                {key}
-              </EuiDescriptionListTitle>
-              <EuiDescriptionListDescription
-                className="unifiedDataTable__descriptionListDescription"
-                dangerouslySetInnerHTML={{ __html: value }}
-              />
-            </Fragment>
-          ))}
+          {pairs.map(([key, value]) => {
+            // temporary solution for text based mode. As there are a lot of unsupported fields we want to
+            // hide the empty one from the Document view
+            if (isPlainRecord && row.flattened[key] === null) return null;
+            return (
+              <Fragment key={key}>
+                <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">
+                  {key}
+                </EuiDescriptionListTitle>
+                <EuiDescriptionListDescription
+                  className="unifiedDataTable__descriptionListDescription"
+                  dangerouslySetInnerHTML={{ __html: value }}
+                />
+              </Fragment>
+            );
+          })}
         </EuiDescriptionList>
       );
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ES|QL] Hides fields with nulls from document view (#168321)](https://github.com/elastic/kibana/pull/168321)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2023-10-10T11:37:42Z","message":"[ES|QL] Hides fields with nulls from document view (#168321)\n\n## Summary\r\n\r\nES|QL atm can be quite noisy at the Document view with many fields with\r\nnull values. To improve a bit the experience we decided to not display\r\nthese values in the Document view. The columns still exist in the\r\navailable fields list and the expanded row. It is only for the document\r\nview that we don't want them to be rendered.\r\n\r\nIn the example below you can see the `meta.char` field which is hidden\r\non the document view but still available in the sidebar and the expanded\r\nrow.\r\n\r\n![image\r\n(11)](https://github.com/elastic/kibana/assets/17003240/35f975be-ff96-4eee-8420-571386329cfb)\r\n![image\r\n(12)](https://github.com/elastic/kibana/assets/17003240/f5db6303-c583-4114-b18d-fa6088cb618f)\r\n![image\r\n(13)](https://github.com/elastic/kibana/assets/17003240/82c5fbb1-5dc7-41c2-8978-c7d248821eee)\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b0dbc706038c77a53c8757d9b8f7149dac71426b","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","Team:DataDiscovery","backport:prev-minor","v8.11.0","Feature:ES|QL","v8.12.0"],"number":168321,"url":"https://github.com/elastic/kibana/pull/168321","mergeCommit":{"message":"[ES|QL] Hides fields with nulls from document view (#168321)\n\n## Summary\r\n\r\nES|QL atm can be quite noisy at the Document view with many fields with\r\nnull values. To improve a bit the experience we decided to not display\r\nthese values in the Document view. The columns still exist in the\r\navailable fields list and the expanded row. It is only for the document\r\nview that we don't want them to be rendered.\r\n\r\nIn the example below you can see the `meta.char` field which is hidden\r\non the document view but still available in the sidebar and the expanded\r\nrow.\r\n\r\n![image\r\n(11)](https://github.com/elastic/kibana/assets/17003240/35f975be-ff96-4eee-8420-571386329cfb)\r\n![image\r\n(12)](https://github.com/elastic/kibana/assets/17003240/f5db6303-c583-4114-b18d-fa6088cb618f)\r\n![image\r\n(13)](https://github.com/elastic/kibana/assets/17003240/82c5fbb1-5dc7-41c2-8978-c7d248821eee)\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b0dbc706038c77a53c8757d9b8f7149dac71426b"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/168321","number":168321,"mergeCommit":{"message":"[ES|QL] Hides fields with nulls from document view (#168321)\n\n## Summary\r\n\r\nES|QL atm can be quite noisy at the Document view with many fields with\r\nnull values. To improve a bit the experience we decided to not display\r\nthese values in the Document view. The columns still exist in the\r\navailable fields list and the expanded row. It is only for the document\r\nview that we don't want them to be rendered.\r\n\r\nIn the example below you can see the `meta.char` field which is hidden\r\non the document view but still available in the sidebar and the expanded\r\nrow.\r\n\r\n![image\r\n(11)](https://github.com/elastic/kibana/assets/17003240/35f975be-ff96-4eee-8420-571386329cfb)\r\n![image\r\n(12)](https://github.com/elastic/kibana/assets/17003240/f5db6303-c583-4114-b18d-fa6088cb618f)\r\n![image\r\n(13)](https://github.com/elastic/kibana/assets/17003240/82c5fbb1-5dc7-41c2-8978-c7d248821eee)\r\n\r\n### Checklist\r\n\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"b0dbc706038c77a53c8757d9b8f7149dac71426b"}}]}] BACKPORT-->