### PR TITLE
[Synthetics] Fix doc links for alerts and documentation

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -543,6 +543,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       monitorUptimeSynthetics: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/monitor-uptime-synthetics.html`,
       userExperience: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/user-experience.html`,
       createAlerts: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/create-alerts.html`,
+      syntheticsAlerting: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-settings.html#synthetics-settings-alerting`,
       syntheticsCommandReference: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-configuration.html#synthetics-configuration-playwright-options`,
       syntheticsProjectMonitors: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetic-run-tests.html#synthetic-monitor-choose-project`,
       syntheticsMigrateFromIntegration: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-migrate-from-integration.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -415,6 +415,7 @@ export interface DocLinks {
     monitorUptimeSynthetics: string;
     userExperience: string;
     createAlerts: string;
+    syntheticsAlerting: string;
     syntheticsCommandReference: string;
     syntheticsProjectMonitors: string;
     syntheticsMigrateFromIntegration: string;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/monitor_status.tsx
@@ -30,7 +30,7 @@ export const initMonitorStatusAlertType: AlertTypeInitializer = ({
   description,
   iconClass: 'uptimeApp',
   documentationUrl(docLinks) {
-    return `${docLinks.links.observability.monitorStatus}`;
+    return `${docLinks.links.observability.syntheticsAlerting}`;
   },
   ruleParamsExpression: (paramProps: RuleTypeParamsExpressionProps<StatusRuleParams>) => (
     <MonitorStatusAlert core={core} plugins={plugins} params={paramProps} />

--- a/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/tls.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/tls.tsx
@@ -27,7 +27,7 @@ export const initTlsAlertType: AlertTypeInitializer = ({
   id: SYNTHETICS_ALERT_RULE_TYPES.TLS,
   iconClass: 'uptimeApp',
   documentationUrl(docLinks) {
-    return `${docLinks.links.observability.tlsCertificate}`;
+    return `${docLinks.links.observability.syntheticsAlerting}`;
   },
   ruleParamsExpression: (params: RuleTypeParamsExpressionProps<TLSParams>) => (
     <TLSAlert

--- a/x-pack/plugins/synthetics/public/apps/synthetics/render_app.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/render_app.tsx
@@ -66,7 +66,7 @@ export function renderApp(
           },
           {
             linkType: 'discuss',
-            href: 'https://discuss.elastic.co/c/uptime', // Redirects to https://discuss.elastic.co/c/uptime
+            href: 'https://discuss.elastic.co/c/uptime', // Redirects to https://discuss.elastic.co/c/observability/synthetics/75
           },
         ],
       }),

--- a/x-pack/plugins/synthetics/public/apps/synthetics/render_app.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/render_app.tsx
@@ -62,11 +62,11 @@ export function renderApp(
         links: [
           {
             linkType: 'documentation',
-            href: `${docLinks.links.observability.monitorUptime}`, // TODO: Include synthetics link
+            href: `${docLinks.links.observability.monitorUptimeSynthetics}`,
           },
           {
             linkType: 'discuss',
-            href: 'https://discuss.elastic.co/c/uptime', // TODO: Include synthetics link
+            href: 'https://discuss.elastic.co/c/uptime', // Redirects to https://discuss.elastic.co/c/uptime
           },
         ],
       }),


### PR DESCRIPTION
Fixes #167688  

## Summary

Updates the links to Synthetics from Uptime on the following:
1. "learn more" link on Monitor Status alert flyout
2. "learn more" link on TLS alert flyout
3. Synthetics app "Documentation" link (under _help_  top header button)

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->