### PR TITLE
[Security Solution][On-Week POC] Document navigation in flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/row_action/index.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from 'react-redux';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
 import { dataTableActions, TableId } from '@kbn/securitysolution-data-table';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 import { ENABLE_EXPANDABLE_FLYOUT_SETTING } from '../../../../../common/constants';
 import { RightPanelKey } from '../../../../flyout/right';
 import type {
@@ -43,6 +44,8 @@ type Props = EuiDataGridCellValueElementProps & {
   setEventsDeleted: SetEventsDeleted;
   pageRowIndex: number;
   refetch?: () => void;
+  docs: DataTableRecord[];
+  setExpandedDoc: (doc: DataTableRecord | undefined) => void;
 };
 
 const RowActionComponent = ({
@@ -65,6 +68,8 @@ const RowActionComponent = ({
   setEventsDeleted,
   width,
   refetch,
+  docs,
+  setExpandedDoc,
 }: Props) => {
   const { data: timelineNonEcsData, ecs: ecsData, _id: eventId, _index: indexName } = data ?? {};
 
@@ -106,9 +111,13 @@ const RowActionComponent = ({
             id: eventId,
             indexName,
             scopeId: tableId,
+            rowIndex,
+            docs,
+            setExpandedDoc,
           },
         },
       });
+      setExpandedDoc(docs[rowIndex]);
     } else {
       dispatch(
         dataTableActions.toggleDetailPanel({
@@ -118,7 +127,18 @@ const RowActionComponent = ({
         })
       );
     }
-  }, [dispatch, eventId, indexName, isSecurityFlyoutEnabled, openFlyout, tabType, tableId]);
+  }, [
+    dispatch,
+    eventId,
+    indexName,
+    isSecurityFlyoutEnabled,
+    openFlyout,
+    tabType,
+    tableId,
+    rowIndex,
+    setExpandedDoc,
+    docs,
+  ]);
 
   const Action = controlColumn.rowCellRender;
 

--- a/x-pack/plugins/security_solution/public/common/components/control_columns/transform_control_columns.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/control_columns/transform_control_columns.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
 import { addBuildingBlockStyle, getPageRowIndex } from '@kbn/securitysolution-data-table';
 import type { SortColumnTable } from '@kbn/securitysolution-data-table';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type {
   BrowserFields,
   TimelineItem,
@@ -49,6 +50,8 @@ export interface TransformColumnsProps {
   theme: EuiTheme;
   setEventsLoading: SetEventsLoading;
   setEventsDeleted: SetEventsDeleted;
+  docs: DataTableRecord[];
+  setExpandedDoc: (doc: DataTableRecord | undefined) => void;
 }
 
 export const transformControlColumns = ({
@@ -71,6 +74,8 @@ export const transformControlColumns = ({
   theme,
   setEventsLoading,
   setEventsDeleted,
+  docs,
+  setExpandedDoc,
 }: TransformColumnsProps): EuiDataGridControlColumn[] => {
   return controlColumns.map(
     ({ id: columnId, headerCellRender = EmptyHeaderCellRender, rowCellRender, width }, i) => ({
@@ -142,6 +147,8 @@ export const transformControlColumns = ({
             width={width}
             setEventsLoading={setEventsLoading}
             setEventsDeleted={setEventsDeleted}
+            setExpandedDoc={setExpandedDoc}
+            docs={docs}
           />
         );
       },

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -7,10 +7,11 @@
 
 import {
   dataTableActions,
-  DataTableComponent,
   defaultHeaders,
   getEventIdToDataMapping,
 } from '@kbn/securitysolution-data-table';
+import { DataView } from '@kbn/data-views-plugin/public';
+
 import type {
   SubsetDataTableModel,
   TableId,
@@ -23,16 +24,13 @@ import type { ConnectedProps } from 'react-redux';
 import { connect, useDispatch, useSelector } from 'react-redux';
 import { ThemeContext } from 'styled-components';
 import type { Filter } from '@kbn/es-query';
-import type {
-  DeprecatedCellValueElementProps,
-  DeprecatedRowRenderer,
-  Direction,
-  EntityType,
-} from '@kbn/timelines-plugin/common';
+import type { Direction, EntityType, TimelineItem } from '@kbn/timelines-plugin/common';
 import { isEmpty } from 'lodash';
 import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import type { EuiTheme } from '@kbn/kibana-react-plugin/common';
-import type { EuiDataGridRowHeightsOptions } from '@elastic/eui';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
+import { DataLoadingState } from '@kbn/unified-data-table';
+import { UnifiedDataTable } from '../unified_data_table';
 import { ALERTS_TABLE_VIEW_SELECTION_KEY } from '../../../../common/constants';
 import type { Sort } from '../../../timelines/components/timeline/body/sort';
 import type {
@@ -68,7 +66,7 @@ import {
   StyledEuiPanel,
 } from './styles';
 import { getDefaultViewSelection, getCombinedFilterQuery } from './helpers';
-import { useTimelineEvents } from './use_timelines_events';
+import { useDataTableRows } from './use_data_table_rows';
 import { TableContext, EmptyTable, TableLoading } from './shared';
 import type { AlertWorkflowStatus } from '../../types';
 import { useQueryInspector } from '../page/manage_query';
@@ -77,12 +75,11 @@ import { checkBoxControlColumn, transformControlColumns } from '../control_colum
 import { RightTopMenu } from './right_top_menu';
 import { useAlertBulkActions } from './use_alert_bulk_actions';
 import type { BulkActionsProp } from '../toolbar/bulk_actions/types';
-import { StatefulEventContext } from './stateful_event_context';
 import { defaultUnit } from '../toolbar/unit';
-import { useGetFieldSpec } from '../../hooks/use_get_field_spec';
 
 const storage = new Storage(localStorage);
-
+const REQUEST_SIZE = 50;
+const SAMPLE_SIZE = 1000;
 const SECURITY_ALERTS_CONSUMERS = [AlertConsumers.SIEM];
 
 export interface EventsViewerProps {
@@ -151,7 +148,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
       itemsPerPage,
       itemsPerPageOptions,
       sessionViewConfig,
-      showCheckboxes,
+      // showCheckboxes,
       sort,
       queryFields,
       selectAll,
@@ -162,10 +159,15 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     } = defaultModel,
   } = useSelector((state: State) => eventsViewerSelector(state, tableId));
 
+  const showCheckboxes = false; // checkboxes are handled inside the unified data table
+
   const {
     uiSettings,
     data,
-    triggersActionsUi: { getFieldBrowser },
+    fieldFormats,
+    theme: themeService,
+    dataViewFieldEditor,
+    notifications: { toasts: toastNotifications },
   } = useKibana().services;
 
   const [tableView, setTableView] = useState<ViewSelection>(
@@ -181,28 +183,22 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     indexPattern,
     runtimeMappings,
     selectedPatterns,
-    dataViewId: selectedDataViewId,
     loading: isLoadingIndexPattern,
+    sourcererDataView,
   } = useSourcererDataView(sourcererScope);
 
-  const getFieldSpec = useGetFieldSpec(sourcererScope);
+  const dataView = useMemo(() => {
+    if (sourcererDataView != null) {
+      return new DataView({ spec: sourcererDataView, fieldFormats });
+    } else {
+      return null;
+    }
+  }, [sourcererDataView, fieldFormats]);
 
   const { globalFullScreen } = useGlobalFullScreen();
 
   const editorActionsRef = useRef<FieldEditorActions>(null);
   useEffect(() => {
-    dispatch(
-      dataTableActions.createDataTable({
-        columns,
-        dataViewId: selectedDataViewId,
-        defaultColumns,
-        id: tableId,
-        indexNames: indexNames ?? selectedPatterns,
-        itemsPerPage,
-        showCheckboxes,
-        sort,
-      })
-    );
     return () => {
       dispatch(inputsActions.deleteOneQuery({ id: tableId, inputId: InputsModelId.global }));
       if (editorActionsRef.current) {
@@ -303,8 +299,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     [sort]
   );
 
-  const [loading, { events, loadPage, pageInfo, refetch, totalCount = 0, inspect }] =
-    useTimelineEvents({
+  const [loading, { rows, loadMore, pageInfo, refetch, totalCount = 0, inspect }] =
+    useDataTableRows({
       // We rely on entityType to determine Events vs Alerts
       alertConsumers: SECURITY_ALERTS_CONSUMERS,
       data,
@@ -315,7 +311,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
       filterQuery,
       id: tableId,
       indexNames: indexNames ?? selectedPatterns,
-      limit: itemsPerPage,
+      limit: REQUEST_SIZE,
       runtimeMappings,
       skip: !canQueryTimeline,
       sort: sortField,
@@ -356,38 +352,20 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
   const showFullLoading = loading && !hasAlerts;
 
   const nonDeletedEvents = useMemo(
-    () => events.filter((e) => !deletedEventIds.includes(e._id)),
-    [deletedEventIds, events]
+    () => rows.filter((e) => !deletedEventIds.includes(e._id)),
+    [deletedEventIds, rows]
   );
   useEffect(() => {
     setQuery({ id: tableId, inspect, loading, refetch });
   }, [inspect, loading, refetch, setQuery, tableId]);
 
-  // Clear checkbox selection when new events are fetched
-  useEffect(() => {
-    dispatch(dataTableActions.clearSelected({ id: tableId }));
-    dispatch(
-      dataTableActions.setDataTableSelectAll({
-        id: tableId,
-        selectAll: false,
-      })
-    );
-  }, [nonDeletedEvents, dispatch, tableId]);
-
   const onChangeItemsPerPage = useCallback(
-    (itemsChangedPerPage) => {
+    (itemsChangedPerPage: number) => {
       dispatch(
         dataTableActions.updateItemsPerPage({ id: tableId, itemsPerPage: itemsChangedPerPage })
       );
     },
     [tableId, dispatch]
-  );
-
-  const onChangePage = useCallback(
-    (page) => {
-      loadPage(page);
-    },
-    [loadPage]
   );
 
   const setEventsLoading = useCallback<SetEventsLoading>(
@@ -507,39 +485,6 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     selectedCount,
   });
 
-  // Store context in state rather than creating object in provider value={} to prevent re-renders caused by a new object being created
-  const [activeStatefulEventContext] = useState({
-    timelineID: tableId,
-    tabType: 'query',
-    enableHostDetailsFlyout: true,
-    enableIpDetailsFlyout: true,
-  });
-
-  const unitCountText = useMemo(
-    () => `${totalCountMinusDeleted.toLocaleString()} ${unit(totalCountMinusDeleted)}`,
-    [totalCountMinusDeleted, unit]
-  );
-
-  const rowHeightsOptions: EuiDataGridRowHeightsOptions | undefined = useMemo(() => {
-    if (tableView === 'eventRenderedView') {
-      return {
-        defaultHeight: 'auto' as const,
-      };
-    }
-    return undefined;
-  }, [tableView]);
-
-  const pagination = useMemo(
-    () => ({
-      pageIndex: pageInfo.activePage,
-      pageSize: itemsPerPage,
-      pageSizeOptions: itemsPerPageOptions,
-      onChangeItemsPerPage,
-      onChangePage,
-    }),
-    [itemsPerPage, itemsPerPageOptions, onChangeItemsPerPage, onChangePage, pageInfo.activePage]
-  );
-
   return (
     <>
       <FullScreenContainer $isFullScreen={globalFullScreen}>
@@ -573,41 +518,53 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
                   />
 
                   {!hasAlerts && !loading && !graphOverlay && <EmptyTable />}
-                  {hasAlerts && (
+                  {hasAlerts && dataView && (
                     <FullWidthFlexGroupTable
                       $visible={!graphEventId && graphOverlay == null}
                       gutterSize="none"
                     >
                       <ScrollableFlexItem grow={1}>
-                        <StatefulEventContext.Provider value={activeStatefulEventContext}>
-                          <DataTableComponent
-                            cellActionsTriggerId={cellActionsTriggerId}
-                            additionalControls={alertBulkActions}
-                            unitCountText={unitCountText}
-                            browserFields={browserFields}
-                            data={nonDeletedEvents}
-                            id={tableId}
-                            loadPage={loadPage}
-                            // TODO: migrate away from deprecated type
-                            renderCellValue={
-                              renderCellValue as (
-                                props: DeprecatedCellValueElementProps
-                              ) => React.ReactNode
-                            }
-                            // TODO: migrate away from deprecated type
-                            rowRenderers={rowRenderers as unknown as DeprecatedRowRenderer[]}
-                            totalItems={totalCountMinusDeleted}
-                            bulkActions={bulkActions}
-                            fieldBrowserOptions={fieldBrowserOptions}
-                            hasCrudPermissions={hasCrudPermissions}
-                            leadingControlColumns={transformedLeadingControlColumns}
-                            pagination={pagination}
-                            isEventRenderedView={tableView === 'eventRenderedView'}
-                            rowHeightsOptions={rowHeightsOptions}
-                            getFieldBrowser={getFieldBrowser}
-                            getFieldSpec={getFieldSpec}
-                          />
-                        </StatefulEventContext.Provider>
+                        <UnifiedDataTable
+                          ariaLabelledBy="events-viewer"
+                          loadingState={
+                            loading ? DataLoadingState.loadingMore : DataLoadingState.loaded
+                          }
+                          cellActionsTriggerId={cellActionsTriggerId}
+                          externalAdditionalControls={alertBulkActions}
+                          dataView={dataView}
+                          columns={columns.map(({ id }) => id)}
+                          rows={timelineItemsToTableRecords(nonDeletedEvents)}
+                          onFilter={() => {}}
+                          onSetColumns={() => {}}
+                          onFetchMoreRecords={loadMore}
+                          sampleSize={SAMPLE_SIZE}
+                          showTimeCol={false}
+                          sort={[]}
+                          useNewFieldsApi={false}
+                          onUpdateRowsPerPage={onChangeItemsPerPage}
+                          rowsPerPageState={itemsPerPage}
+                          rowsPerPageOptions={itemsPerPageOptions}
+                          // TODO: migrate away from deprecated type
+                          // renderCellValue={
+                          //   renderCellValue as (
+                          //     props: DeprecatedCellValueElementProps
+                          //   ) => React.ReactNode
+                          // }
+                          // TODO: migrate away from deprecated type
+                          // rowRenderers={rowRenderers as unknown as DeprecatedRowRenderer[]}
+                          totalHits={totalCountMinusDeleted}
+                          externalControlColumns={transformedLeadingControlColumns}
+                          rowHeightState={2}
+                          services={{
+                            theme: themeService,
+                            fieldFormats,
+                            uiSettings,
+                            dataViewFieldEditor,
+                            toastNotifications,
+                            storage,
+                            data,
+                          }}
+                        />
                       </ScrollableFlexItem>
                     </FullWidthFlexGroupTable>
                   )}
@@ -634,3 +591,22 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 export const StatefulEventsViewer: React.FunctionComponent<EventsViewerProps> = connector(
   StatefulEventsViewerComponent
 );
+
+function timelineItemsToTableRecords(events: TimelineItem[]): DataTableRecord[] {
+  return events.map((event) => {
+    const dataRecord = event.data.reduce<Record<string, unknown>>((acc, { field, value }) => {
+      acc[field] = value;
+      return acc;
+    }, {});
+
+    return {
+      id: event._id,
+      raw: {
+        _id: event._id,
+        _index: event._index ?? '',
+        _source: dataRecord,
+      },
+      flattened: dataRecord,
+    };
+  });
+}

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/index.tsx
@@ -426,6 +426,13 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     }
   }, [isSelectAllChecked, onSelectPage, selectAll]);
 
+  const docs: DataTableRecord[] = useMemo(
+    () => timelineItemsToTableRecords(nonDeletedEvents),
+    [nonDeletedEvents]
+  );
+  const [expandedDoc, setExpanded] = useState<DataTableRecord | undefined>();
+  const setExpandedDoc = useCallback((doc?: DataTableRecord) => setExpanded(doc), [setExpanded]);
+
   const [transformedLeadingControlColumns] = useMemo(() => {
     return [
       showCheckboxes ? [checkBoxControlColumn, ...leadingControlColumns] : leadingControlColumns,
@@ -450,6 +457,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
         setEventsLoading,
         setEventsDeleted,
         pageSize: itemsPerPage,
+        docs,
+        setExpandedDoc,
       })
     );
   }, [
@@ -471,6 +480,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
     setEventsLoading,
     setEventsDeleted,
     itemsPerPage,
+    docs,
+    setExpandedDoc,
   ]);
 
   const alertBulkActions = useAlertBulkActions({
@@ -533,7 +544,7 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
                           externalAdditionalControls={alertBulkActions}
                           dataView={dataView}
                           columns={columns.map(({ id }) => id)}
-                          rows={timelineItemsToTableRecords(nonDeletedEvents)}
+                          rows={docs}
                           onFilter={() => {}}
                           onSetColumns={() => {}}
                           onFetchMoreRecords={loadMore}
@@ -564,6 +575,8 @@ const StatefulEventsViewerComponent: React.FC<EventsViewerProps & PropsFromRedux
                             storage,
                             data,
                           }}
+                          setExpandedDoc={setExpandedDoc}
+                          expandedDoc={expandedDoc}
                         />
                       </ScrollableFlexItem>
                     </FullWidthFlexGroupTable>

--- a/x-pack/plugins/security_solution/public/common/components/events_viewer/use_data_table_rows.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/events_viewer/use_data_table_rows.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect, useMemo } from 'react';
+import type { TimelineItem } from '@kbn/timelines-plugin/common';
+import {
+  useTimelineEvents,
+  type TimelineArgs,
+  type UseTimelineEventsProps,
+} from './use_timelines_events';
+
+type UseDataTable = [
+  boolean,
+  Omit<TimelineArgs, 'loadPage' | 'events'> & { rows: TimelineItem[]; loadMore: () => void }
+];
+
+export const useDataTableRows = (props: UseTimelineEventsProps): UseDataTable => {
+  const [loading, result] = useTimelineEvents(props);
+  const { events, loadPage, pageInfo, ...rest } = result;
+
+  const [pageRows, setPageRows] = useState<TimelineItem[][]>([]);
+
+  const loadMore = () => {
+    loadPage(pageInfo.activePage + 1);
+  };
+
+  useEffect(() => {
+    setPageRows((currentPageRows) => {
+      if (currentPageRows[pageInfo.activePage]?.length) {
+        return currentPageRows;
+      }
+      const newPageRows = [...currentPageRows];
+      newPageRows[pageInfo.activePage] = events;
+      return newPageRows;
+    });
+  }, [events, pageInfo.activePage]);
+
+  const rows = useMemo(() => pageRows.flat(), [pageRows]);
+
+  return [loading, { ...rest, rows, loadMore, pageInfo }];
+};

--- a/x-pack/plugins/security_solution/public/common/components/unified_data_table/index.ts
+++ b/x-pack/plugins/security_solution/public/common/components/unified_data_table/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+export { UnifiedDataTable, type UnifiedDataTableProps } from './unified_data_table';

--- a/x-pack/plugins/security_solution/public/common/components/unified_data_table/unified_data_table.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/unified_data_table/unified_data_table.tsx
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiLoadingSpinner } from '@elastic/eui';
+import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
+import React from 'react';
+
+export type { UnifiedDataTableProps };
+
+const UnifiedDataTableLazy = React.lazy(() =>
+  import('@kbn/unified-data-table').then(({ UnifiedDataTable }) => ({
+    default: UnifiedDataTable,
+  }))
+);
+
+const UnifiedDataTableLazyWithSuspense = (props: UnifiedDataTableProps) => (
+  <React.Suspense fallback={<EuiLoadingSpinner size="m" />}>
+    <UnifiedDataTableLazy {...props} />
+  </React.Suspense>
+);
+
+export const UnifiedDataTable = React.memo(UnifiedDataTableLazyWithSuspense);

--- a/x-pack/plugins/security_solution/public/flyout/right/components/header_title.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/header_title.tsx
@@ -6,9 +6,9 @@
  */
 
 import type { VFC } from 'react';
-import React, { memo } from 'react';
+import React, { memo, useCallback } from 'react';
 import { NewChatById } from '@kbn/elastic-assistant';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer, EuiTitle, EuiPagination } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { css } from '@emotion/react';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -38,7 +38,15 @@ export interface HeaderTitleProps {
  * Document details flyout right section header
  */
 export const HeaderTitle: VFC<HeaderTitleProps> = memo(({ flyoutIsExpandable }) => {
-  const { dataFormattedForFieldBrowser, eventId, indexName } = useRightPanelContext();
+  const {
+    dataFormattedForFieldBrowser,
+    eventId,
+    indexName,
+    rowIndex,
+    setRowIndex,
+    setExpandedDoc,
+    docs,
+  } = useRightPanelContext();
   const { isAlert, ruleName, timestamp } = useBasicDataFromDetailsData(
     dataFormattedForFieldBrowser
   );
@@ -47,6 +55,14 @@ export const HeaderTitle: VFC<HeaderTitleProps> = memo(({ flyoutIsExpandable }) 
     _index: indexName,
     timestamp,
   });
+
+  const setPage = useCallback(
+    (pageIndex: number) => {
+      setRowIndex(pageIndex);
+      setExpandedDoc(docs[pageIndex]);
+    },
+    [setRowIndex, setExpandedDoc, docs]
+  );
 
   const showShareAlertButton = isAlert && alertDetailsLink;
 
@@ -115,6 +131,14 @@ export const HeaderTitle: VFC<HeaderTitleProps> = memo(({ flyoutIsExpandable }) 
           <RiskScore />
         </EuiFlexItem>
       </EuiFlexGroup>
+      {rowIndex !== -1 && (
+        <EuiPagination
+          pageCount={docs.length}
+          activePage={rowIndex}
+          onPageClick={setPage}
+          compressed
+        />
+      )}
     </>
   );
 });

--- a/x-pack/plugins/security_solution/public/flyout/right/index.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/index.tsx
@@ -9,6 +9,7 @@ import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
 import type { FlyoutPanelProps, PanelPath } from '@kbn/expandable-flyout';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
+import type { DataTableRecord } from '@kbn/discover-utils/types';
 import { EventKind } from '../shared/constants/event_kinds';
 import { getField } from '../shared/utils';
 import { useRightPanelContext } from './context';
@@ -28,6 +29,9 @@ export interface RightPanelProps extends FlyoutPanelProps {
     id: string;
     indexName: string;
     scopeId: string;
+    rowIndex: number;
+    docs: DataTableRecord[];
+    setExpandedDoc: (doc: DataTableRecord | undefined) => void;
   };
 }
 
@@ -36,7 +40,8 @@ export interface RightPanelProps extends FlyoutPanelProps {
  */
 export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
   const { openRightPanel } = useExpandableFlyoutContext();
-  const { eventId, getFieldsData, indexName, scopeId } = useRightPanelContext();
+  const { eventId, getFieldsData, indexName, scopeId, rowIndex, setExpandedDoc, docs } =
+    useRightPanelContext();
 
   // for 8.10, we only render the flyout in its expandable mode if the document viewed is of type signal
   const documentIsSignal = getField(getFieldsData('event.kind')) === EventKind.signal;
@@ -58,6 +63,9 @@ export const RightPanel: FC<Partial<RightPanelProps>> = memo(({ path }) => {
         id: eventId,
         indexName,
         scopeId,
+        rowIndex,
+        docs,
+        setExpandedDoc,
       },
     });
   };

--- a/x-pack/plugins/security_solution/tsconfig.json
+++ b/x-pack/plugins/security_solution/tsconfig.json
@@ -177,6 +177,7 @@
     "@kbn/core-application-common",
     "@kbn/openapi-generator",
     "@kbn/es",
-    "@kbn/react-kibana-mount"
+    "@kbn/react-kibana-mount",
+    "@kbn/unified-data-table"
   ]
 }


### PR DESCRIPTION
## Summary

This PR builds on [this POC](https://github.com/elastic/kibana/pull/166104) and adds event navigation within the new expandable flyout framework in _**explore pages**_. This mimics the current discover experience, when an user open the flyout, the row is highlighted. When user navigate to the next/prev document, the row highlight is also updated.

https://github.com/elastic/kibana/assets/18648970/198777de-b1cd-491b-a3ba-1ead553cc3fe

Not included in this PR
- Handle paging when the table row index changes (i.e. user sort table). In current discover table, the navigation is hidden when index changes
- Revisit the loading stage, currently loading spinner causes flyout to flash
- Handle resetting highlighting when closing the flyout. `setExpandedDoc` is passed in as context for this POC, but for it to be accessible when flyout closes, may need to bring this up higher level...

Considerations for future (actual) implementation
- This POC passes the entire data array (`docs`) to flyout context due to discover table requires the document for `expandedDoc` and `setExpandedDoc`. Obviously this is not good on performance, since alert table currently capped at 100,000 records
   - Should investigate if it is possible to change the prop to be an array of docs without data, i.e. array of object that has `id` and `index`.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
