### PR TITLE
Remove mention of config SO types from SO.create API docs.

### DIFF
--- a/docs/api/saved-objects/bulk_create.asciidoc
+++ b/docs/api/saved-objects/bulk_create.asciidoc
@@ -38,7 +38,7 @@ For the most up-to-date API details, refer to the
 ==== Request body
 
 `type`::
-  (Required, string) Valid options include `visualization`, `dashboard`, `search`, `index-pattern`, `config`.
+  (Required, string) Valid options include `visualization`, `dashboard`, `search`, `index-pattern`.
 
 `id`::
   (Optional, string) Specifies an ID instead of using a randomly generated ID.

--- a/docs/api/saved-objects/create.asciidoc
+++ b/docs/api/saved-objects/create.asciidoc
@@ -32,7 +32,7 @@ For the most up-to-date API details, refer to the
   (Optional, string) An identifier for the space. If `space_id` is not provided in the URL, the default space is used.
 
 `<type>`::
-  (Required, string) Valid options include `visualization`, `dashboard`, `search`, `index-pattern`, `config`.
+  (Required, string) Valid options include `visualization`, `dashboard`, `search`, `index-pattern`.
 
 `<id>`::
   (Optional, string) Specifies an ID instead of using a randomly generated ID.


### PR DESCRIPTION
In our docs for the saved objects `create` http APIs, we mention `config` as a supported SO type. While technically possible to create a `config` SO via the API, I don't think it is advisable because Kibana generates these automatically. I think it is fine if someone wants to edit/update an existing `config` object, but I wonder if we should exclude mention of it for the `create` endpoints specifically?

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->