### PR TITLE
[Synthetics] Fix duration metric label

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item.tsx
@@ -148,7 +148,7 @@ export const MetricItem = ({
                       <EuiFlexItem grow={false} component="span">
                         <EuiIconTip
                           title={i18n.translate('xpack.synthetics.overview.duration.description', {
-                            defaultMessage: 'Median duration of last 24 checks',
+                            defaultMessage: 'Median duration of last 50 checks',
                           })}
                           content={i18n.translate(
                             'xpack.synthetics.overview.duration.description.values',


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/166806
Fix duration metric label !!


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->