### PR TITLE
fix(slo): Latest SLO name used in rule name

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/slo_edit_form.tsx
@@ -258,7 +258,7 @@ export function SloEditForm({ slo }: Props) {
         <AddRuleFlyout
           canChangeTrigger={false}
           consumer={sloFeatureId}
-          initialValues={{ name: `${slo.name} burn rate rule`, params: { sloId: slo.id } }}
+          initialValues={{ name: `${watch('name')} burn rate rule`, params: { sloId: slo.id } }}
           ruleTypeId={SLO_BURN_RATE_RULE_TYPE_ID}
           onClose={handleCloseRuleFlyout}
           onSave={handleCloseRuleFlyout}


### PR DESCRIPTION
Resolves [#166086](https://github.com/elastic/kibana/issues/166086)

## Summary

This PR uses the latest SLO name from the form to populate the SLO burn rate rule name.