### PR TITLE
Limit download concurrency for files within Kibana

### DIFF
--- a/packages/kbn-logging-mocks/src/logger.mock.ts
+++ b/packages/kbn-logging-mocks/src/logger.mock.ts
@@ -24,9 +24,10 @@ const createLoggerMock = (context: string[] = []) => {
     isLevelEnabled: jest.fn(),
   };
   mockLog.get.mockImplementation((...ctx) => ({
-    ctx,
     ...mockLog,
+    context: Array.isArray(context) ? context.concat(ctx) : [context, ...ctx].filter(Boolean),
   }));
+
   mockLog.isLevelEnabled.mockReturnValue(true);
 
   return mockLog;

--- a/src/plugins/files/server/blob_storage_service/adapters/es/es.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/es.ts
@@ -188,8 +188,8 @@ export class ElasticsearchBlobStorageClient implements BlobStorageClient {
     return lastValueFrom(defer(processUpload).pipe(this.uploadSemaphore.acquire()));
   }
 
-  private getReadableContentStream(id: string, size?: number): ReadableContentStream {
-    return getReadableContentStream({
+  private getReadableContentStream(id: string, size?: number): () => ReadableContentStream {
+    return getReadableContentStream.bind(this, {
       id,
       client: this.esClient,
       index: this.index,
@@ -207,9 +207,7 @@ export class ElasticsearchBlobStorageClient implements BlobStorageClient {
     await this.esClient.indices.refresh({ index: this.index });
 
     return lastValueFrom(
-      defer(this.getReadableContentStream.bind(this, id, size)).pipe(
-        this.downloadSemaphore.acquire()
-      )
+      defer(this.getReadableContentStream(id, size)).pipe(this.downloadSemaphore.acquire())
     );
   }
 

--- a/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
+++ b/src/plugins/files/server/blob_storage_service/adapters/es/integration_tests/es.test.ts
@@ -25,7 +25,7 @@ describe('Elasticsearch blob storage', () => {
   let esRefreshIndexSpy: jest.SpyInstance;
 
   beforeAll(async () => {
-    ElasticsearchBlobStorageClient.configureConcurrentUpload(Infinity);
+    ElasticsearchBlobStorageClient.configureConcurrentTransfers(Infinity);
     const { startES, startKibana } = createTestServers({ adjustTimeout: jest.setTimeout });
     manageES = await startES();
     manageKbn = await startKibana();

--- a/src/plugins/files/server/blob_storage_service/blob_storage_service.ts
+++ b/src/plugins/files/server/blob_storage_service/blob_storage_service.ts
@@ -22,8 +22,16 @@ export class BlobStorageService {
    */
   private readonly concurrentUploadsToES = 20;
 
+  /**
+   * The number of downloads per Kibana instance that can be running simultaneously
+   */
+  private readonly concurrentDownloadsFromES = 5;
+
   constructor(private readonly esClient: ElasticsearchClient, private readonly logger: Logger) {
-    ElasticsearchBlobStorageClient.configureConcurrentUpload(this.concurrentUploadsToES);
+    ElasticsearchBlobStorageClient.configureConcurrentTransfers([
+      this.concurrentUploadsToES,
+      this.concurrentDownloadsFromES,
+    ]);
   }
 
   private createESBlobStorage({

--- a/src/plugins/files/server/file_client/create_es_file_client.test.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.test.ts
@@ -23,7 +23,7 @@ describe('When initializing file client via createESFileClient()', () => {
   let logger: MockedLogger;
 
   beforeEach(() => {
-    ElasticsearchBlobStorageClient.configureConcurrentUpload(Infinity);
+    ElasticsearchBlobStorageClient.configureConcurrentTransfers(Infinity);
     esClient = elasticsearchServiceMock.createElasticsearchClient();
     logger = loggingSystemMock.createLogger();
   });

--- a/src/plugins/files/server/file_client/create_es_file_client.ts
+++ b/src/plugins/files/server/file_client/create_es_file_client.ts
@@ -78,6 +78,7 @@ export function createEsFileClient(arg: CreateEsFileClientArgs): FileClient {
       undefined,
       logger,
       undefined,
+      undefined,
       indexIsAlias
     ),
     undefined,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/151986

This PR adds a limit to the number of concurrent downloads a user can initiate from kibana. 

P.S.

This PR renames the previous static method `configureConcurrentUpload` exposed by the `ElasticsearchBlobStorageClient` to `configureConcurrentTransfers` so that one might use a single static method to configure the limits for concurrent transfers possible for upload and download transfers in one go.

The new static method `configureConcurrentTransfers` accepts either a number or a tuple, when a number is passed it's value is set as the concurrent limit for both uploads and transfers, when a tuple is passed the value of the first index sets the concurrent limit for uploads, whilst the value of the second index sets the concurrent limit for downloads.


<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->
