### PR TITLE
[DataViewField] Fix removal of a custom label from a runtime field

### DIFF
--- a/src/plugins/data_views/common/data_views/data_view.test.ts
+++ b/src/plugins/data_views/common/data_views/data_view.test.ts
@@ -368,6 +368,20 @@ describe('IndexPattern', () => {
       expect(indexPattern.toSpec()!.fields!.new_field).toBeUndefined();
     });
 
+    test('add and remove a custom label from a runtime field', () => {
+      const newField = 'new_field_test';
+      indexPattern.addRuntimeField(newField, {
+        ...runtimeWithAttrs,
+        customLabel: 'test1',
+      });
+      expect(indexPattern.getFieldByName(newField)?.customLabel).toEqual('test1');
+      indexPattern.setFieldCustomLabel(newField, 'test2');
+      expect(indexPattern.getFieldByName(newField)?.customLabel).toEqual('test2');
+      indexPattern.setFieldCustomLabel(newField, undefined);
+      expect(indexPattern.getFieldByName(newField)?.customLabel).toBeUndefined();
+      indexPattern.removeRuntimeField(newField);
+    });
+
     test('add and remove composite runtime field as new fields', () => {
       const fieldCount = indexPattern.fields.length;
       indexPattern.addRuntimeField('new_field', runtimeCompositeWithAttrs);

--- a/src/plugins/data_views/common/data_views/data_view.ts
+++ b/src/plugins/data_views/common/data_views/data_view.ts
@@ -812,9 +812,7 @@ export class DataView implements DataViewBase {
     }
 
     // Apply configuration to the field
-    if (config.customLabel || config.customLabel === null) {
-      this.setFieldCustomLabel(fieldName, config.customLabel);
-    }
+    this.setFieldCustomLabel(fieldName, config.customLabel);
 
     if (config.popularity || config.popularity === null) {
       this.setFieldCount(fieldName, config.popularity);


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/168585

## Summary

This PR fixes an issue with removing a custom label from a runtime field.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->