### PR TITLE
Hosts inventory table example

### DIFF
--- a/x-pack/plugins/asset_manager/common/types_api.ts
+++ b/x-pack/plugins/asset_manager/common/types_api.ts
@@ -214,6 +214,7 @@ export const getHostAssetsQueryOptionsRT = rt.intersection([
     filters: assetFiltersSingleKindRT,
   }),
 ]);
+
 export type GetHostAssetsQueryOptions = rt.TypeOf<typeof getHostAssetsQueryOptionsRT>;
 export const getHostAssetsResponseRT = rt.type({
   hosts: rt.array(assetRT),

--- a/x-pack/plugins/asset_manager/public/index.ts
+++ b/x-pack/plugins/asset_manager/public/index.ts
@@ -18,3 +18,4 @@ export const plugin: PluginInitializer<
 
 export type { AssetManagerPublicPluginSetup, AssetManagerPublicPluginStart };
 export type AssetManagerAppId = 'assetManager';
+export { isAssetFilters } from '../common/types_api';

--- a/x-pack/plugins/asset_manager/public/index.ts
+++ b/x-pack/plugins/asset_manager/public/index.ts
@@ -18,4 +18,4 @@ export const plugin: PluginInitializer<
 
 export type { AssetManagerPublicPluginSetup, AssetManagerPublicPluginStart };
 export type AssetManagerAppId = 'assetManager';
-export { isAssetFilters } from '../common/types_api';
+export { assetFiltersRT } from '../common/types_api';

--- a/x-pack/plugins/asset_manager/server/lib/collectors/hosts.ts
+++ b/x-pack/plugins/asset_manager/server/lib/collectors/hosts.ts
@@ -65,7 +65,11 @@ export async function collectHosts({
     dsl.search_after = afterKey;
   }
 
+  console.log('hi 22', JSON.stringify(dsl));
+
   const esResponse = await client.search(dsl);
+
+  console.log('hi 33', JSON.stringify(esResponse));
 
   const assets = esResponse.hits.hits.reduce<Asset[]>((acc: Asset[], hit: any) => {
     const { fields = {} } = hit;
@@ -111,6 +115,8 @@ export async function collectHosts({
 
     return acc;
   }, []);
+
+  console.log('hi 44');
 
   const hitsLen = esResponse.hits.hits.length;
   const next = hitsLen === QUERY_MAX_SIZE ? esResponse.hits.hits[hitsLen - 1].sort : undefined;

--- a/x-pack/plugins/observability/common/locators/paths.ts
+++ b/x-pack/plugins/observability/common/locators/paths.ts
@@ -21,6 +21,7 @@ export const SLO_DETAIL_PATH = '/slos/:sloId' as const;
 export const SLO_CREATE_PATH = '/slos/create' as const;
 export const SLO_EDIT_PATH = '/slos/edit/:sloId' as const;
 export const CASES_PATH = '/cases' as const;
+export const ASSETS_INVENTORY_PATH = '/assets-inventory' as const;
 
 export const paths = {
   observability: {

--- a/x-pack/plugins/observability/kibana.jsonc
+++ b/x-pack/plugins/observability/kibana.jsonc
@@ -13,6 +13,7 @@
     "requiredPlugins": [
       "aiops",
       "alerting",
+      "assetManager",
       "cases",
       "charts",
       "contentManagement",

--- a/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
@@ -13,12 +13,14 @@ import {
   EuiProgress,
   EuiSpacer,
 } from '@elastic/eui';
-import { Asset } from '@kbn/assetManager-plugin/common/types_api';
+import { Asset, AssetFilters } from '@kbn/assetManager-plugin/common/types_api';
+
 import { i18n } from '@kbn/i18n';
 import { useKibana } from '@kbn/kibana-react-plugin/public';
 import React, { useEffect, useState } from 'react';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { ObservabilityPublicPluginsStart } from '../../plugin';
+import { SearchBar } from './components/search_bar';
 
 const TestBox: React.FC = ({ children }) => (
   <div style={{ padding: 20, border: '1px solid magenta' }}>{children}</div>
@@ -29,16 +31,20 @@ export function AssetsInventoryPage() {
   const { services } = useKibana<ObservabilityPublicPluginsStart>();
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [hosts, setHosts] = useState<Asset[]>([]);
+  const [filters, setFilters] = useState<AssetFilters>({});
 
   useEffect(() => {
     async function retrieve() {
       setIsLoading(true);
-      const { hosts } = await services.assetManager.publicAssetsClient.getHosts({ from: 'now-1d' });
+      const { hosts } = await services.assetManager.publicAssetsClient.getHosts({
+        from: 'now-1d',
+        filters,
+      });
       setHosts(hosts);
       setIsLoading(false);
     }
     retrieve();
-  }, [services]);
+  }, [services, filters]);
 
   return (
     <ObservabilityPageTemplate
@@ -55,7 +61,23 @@ export function AssetsInventoryPage() {
     >
       <EuiFlexGroup>
         <EuiFlexItem>
-          <TestBox>Unified search box</TestBox>
+          <SearchBar
+            onSubmit={(filters) => {
+              console.log('incoming filters', filters);
+              setFilters(filters);
+            }}
+          />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          Show filters:{' '}
+          <pre>
+            <code>{JSON.stringify(filters, null, 2)}</code>
+          </pre>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <TestBox>
+            <div style={{ width: '200px' }}>Date picker xyz</div>
+          </TestBox>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer />

--- a/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
@@ -40,24 +40,21 @@ export function AssetsInventoryPage() {
   useEffect(() => {
     async function retrieve() {
       setIsLoading(true);
-      const { hosts } = await services.assetManager.publicAssetsClient.getHosts({
+      const result = await services.assetManager.publicAssetsClient.getHosts({
         from: start,
         to: end,
         filters,
       });
-      setHosts(hosts);
+      setHosts(result.hosts);
       setIsLoading(false);
     }
     retrieve();
   }, [services, filters, start, end]);
 
-  const onTimeChange = useCallback(
-    ({ start, end }: OnTimeChangeProps) => {
-      setStart(start);
-      setEnd(end);
-    },
-    [start, end]
-  );
+  const onTimeChange = useCallback((update: OnTimeChangeProps) => {
+    setStart(update.start);
+    setEnd(update.end);
+  }, []);
 
   return (
     <ObservabilityPageTemplate
@@ -75,9 +72,8 @@ export function AssetsInventoryPage() {
       <EuiFlexGroup>
         <EuiFlexItem>
           <SearchBar
-            onSubmit={(filters) => {
-              console.log('incoming filters', filters);
-              setFilters(filters);
+            onSubmit={(submittedFilters) => {
+              setFilters(submittedFilters);
             }}
           />
         </EuiFlexItem>

--- a/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/assets_inventory.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React from 'react';
+import { usePluginContext } from '../../hooks/use_plugin_context';
+
+const TestBox: React.FC = ({ children }) => (
+  <div style={{ padding: 20, border: '1px solid magenta' }}>{children}</div>
+);
+
+export function AssetsInventoryPage() {
+  const { ObservabilityPageTemplate } = usePluginContext();
+  return (
+    <ObservabilityPageTemplate
+      data-test-subj="assetsInventoryPageWithData"
+      pageHeader={{
+        pageTitle: (
+          <>
+            {i18n.translate('xpack.observability.assetsInventoryTitle', {
+              defaultMessage: 'Assets Inventory',
+            })}{' '}
+          </>
+        ),
+      }}
+    >
+      <EuiFlexGroup direction="column" gutterSize="m">
+        <EuiFlexItem>
+          <TestBox>Area 1</TestBox>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <TestBox>Area 2</TestBox>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <TestBox>Area 3, Table</TestBox>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </ObservabilityPageTemplate>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/assets_inventory/components/search_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/components/search_bar.tsx
@@ -7,7 +7,7 @@
 
 import { EuiFieldSearch } from '@elastic/eui';
 import type { AssetFilters } from '@kbn/assetManager-plugin/common/types_api';
-import { isAssetFilters } from '@kbn/assetManager-plugin/public';
+import { assetFiltersRT } from '@kbn/assetManager-plugin/public';
 import React, { ChangeEventHandler, KeyboardEventHandler, useCallback, useState } from 'react';
 
 export interface SearchBarOptions {
@@ -75,7 +75,7 @@ export class InvalidSearchError extends Error {
 
 export function parseQueryString(queryString: string) {
   console.log('parsing query string', queryString);
-  const noSpacesRegex = new RegExp(/([^\s]*)\s*:\s*([^\s]*)/g);
+  const noSpacesRegex = new RegExp(/([^\:\s]*)\s*:\s*([^\s]*)/g);
   const matches = [...queryString.matchAll(noSpacesRegex)];
 
   console.log('Inspect matches', matches);
@@ -96,7 +96,7 @@ export function parseQueryString(queryString: string) {
   // }
 
   console.log('Validating filter hash', filters);
-  const validated = isAssetFilters(filters);
+  const validated = assetFiltersRT.is(filters);
   console.log('Validation result:', validated);
 
   if (!validated) {

--- a/x-pack/plugins/observability/public/pages/assets_inventory/components/search_bar.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/components/search_bar.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiFieldSearch } from '@elastic/eui';
+import type { AssetFilters } from '@kbn/assetManager-plugin/common/types_api';
+import { isAssetFilters } from '@kbn/assetManager-plugin/public';
+import React, { ChangeEventHandler, KeyboardEventHandler, useCallback, useState } from 'react';
+
+export interface SearchBarOptions {
+  onChange?: (queryString: string) => void;
+  onSubmit?: (parsed: AssetFilters) => void;
+  onInvalidSearch?: (error: InvalidSearchError) => void;
+}
+
+export function SearchBar({ onChange, onSubmit, onInvalidSearch }: SearchBarOptions) {
+  const [queryString, setQueryString] = useState<string>('');
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+
+  const internalOnChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      console.log('setting queryString', e.target.value);
+      setQueryString(e.target.value);
+      if (onChange) onChange(e.target.value);
+    },
+    [setQueryString]
+  );
+
+  const internalOnKeyDown: KeyboardEventHandler = useCallback(
+    (e) => {
+      setIsInvalid(false);
+      if (e.key === 'Enter') {
+        try {
+          console.log('About to parse query string', queryString);
+          const parsed = parseQueryString(queryString);
+          console.log('we parsed em!', parsed);
+          if (onSubmit) onSubmit(parsed);
+        } catch (error: any) {
+          console.log('Error found while parsing query string', `${error}`);
+          if (error instanceof InvalidSearchError) {
+            console.log('annnnnd its an invalid search error too', error.queryString);
+            if (onInvalidSearch) onInvalidSearch(error);
+            setIsInvalid(true);
+          }
+        }
+      }
+    },
+    [queryString, onSubmit, onInvalidSearch]
+  );
+
+  return (
+    <EuiFieldSearch
+      data-test-subj="AssetsSearchBarQuery"
+      value={queryString}
+      onChange={internalOnChange}
+      onKeyDown={internalOnKeyDown}
+      isInvalid={isInvalid}
+      fullWidth
+    />
+  );
+}
+
+export class InvalidSearchError extends Error {
+  public queryString: string;
+
+  constructor(message: string, queryString: string) {
+    super(message);
+    this.name = 'InvalidSearchError';
+    this.queryString = queryString;
+  }
+}
+
+export function parseQueryString(queryString: string) {
+  console.log('parsing query string', queryString);
+  const noSpacesRegex = new RegExp(/([^\s]*)\s*:\s*([^\s]*)/g);
+  const matches = [...queryString.matchAll(noSpacesRegex)];
+
+  console.log('Inspect matches', matches);
+
+  const filters = matches.reduce<any>((f, match) => {
+    f[match[1]] = match[2];
+    return f;
+  }, {});
+
+  // const eanMatch = matches.find((match) => match[1] === 'ean');
+  // if (eanMatch) {
+  //   filters.ean = eanMatch[2];
+  // }
+
+  // const typeMatch = matches.find((match) => match[1] === 'type');
+  // if (typeMatch) {
+  //   filters.type = typeMatch[2];
+  // }
+
+  console.log('Validating filter hash', filters);
+  const validated = isAssetFilters(filters);
+  console.log('Validation result:', validated);
+
+  if (!validated) {
+    throw new InvalidSearchError(`Query string is not currently valid`, queryString);
+  }
+
+  return filters;
+}

--- a/x-pack/plugins/observability/public/pages/assets_inventory/components/search_error.tsx
+++ b/x-pack/plugins/observability/public/pages/assets_inventory/components/search_error.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiCallOut, EuiSpacer } from '@elastic/eui';
+import React from 'react';
+
+export function SearchError({ error }: { error: string | null }) {
+  if (error === null) {
+    return null;
+  }
+
+  return (
+    <div>
+      <EuiCallOut title="Search error" color="danger" iconType="error">
+        <p>{error}</p>
+      </EuiCallOut>
+      <EuiSpacer />
+    </div>
+  );
+}

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -20,6 +20,10 @@ import {
   Plugin as PluginClass,
   PluginInitializerContext,
 } from '@kbn/core/public';
+import type {
+  AssetManagerPublicPluginSetup,
+  AssetManagerPublicPluginStart,
+} from '@kbn/assetManager-plugin/public';
 import type { DataPublicPluginSetup, DataPublicPluginStart } from '@kbn/data-plugin/public';
 import { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
@@ -107,6 +111,7 @@ export interface ConfigSchema {
 export type ObservabilityPublicSetup = ReturnType<Plugin['setup']>;
 
 export interface ObservabilityPublicPluginsSetup {
+  assetManager: AssetManagerPublicPluginSetup;
   data: DataPublicPluginSetup;
   observabilityShared: ObservabilitySharedPluginSetup;
   observabilityAIAssistant: ObservabilityAIAssistantPluginSetup;
@@ -119,6 +124,7 @@ export interface ObservabilityPublicPluginsSetup {
 
 export interface ObservabilityPublicPluginsStart {
   actionTypeRegistry: ActionTypeRegistryContract;
+  assetManager: AssetManagerPublicPluginStart;
   cases: CasesUiStart;
   charts: ChartsPluginStart;
   contentManagement: ContentManagementPublicStart;

--- a/x-pack/plugins/observability/public/plugin.ts
+++ b/x-pack/plugins/observability/public/plugin.ts
@@ -62,6 +62,7 @@ import { ServerlessPluginStart } from '@kbn/serverless/public';
 import { observabilityAppId, observabilityFeatureId } from '../common';
 import {
   ALERTS_PATH,
+  ASSETS_INVENTORY_PATH,
   CASES_PATH,
   OBSERVABILITY_BASE_PATH,
   OVERVIEW_PATH,
@@ -208,6 +209,13 @@ export class Plugin
         },
       },
     }),
+    {
+      id: 'assets-inventory',
+      title: 'Assets Inventory',
+      navLinkStatus: AppNavLinkStatus.visible,
+      order: 8004,
+      path: ASSETS_INVENTORY_PATH,
+    },
   ];
 
   constructor(private readonly initContext: PluginInitializerContext<ConfigSchema>) {}

--- a/x-pack/plugins/observability/public/routes/routes.tsx
+++ b/x-pack/plugins/observability/public/routes/routes.tsx
@@ -23,6 +23,7 @@ import { SloEditPage } from '../pages/slo_edit/slo_edit';
 import {
   ALERTS_PATH,
   ALERT_DETAIL_PATH,
+  ASSETS_INVENTORY_PATH,
   CASES_PATH,
   EXPLORATORY_VIEW_PATH,
   LANDING_PATH,
@@ -37,6 +38,7 @@ import {
   SLO_DETAIL_PATH,
   SLO_EDIT_PATH,
 } from '../../common/locators/paths';
+import { AssetsInventoryPage } from '../pages/assets_inventory/assets_inventory';
 
 // Note: React Router DOM <Redirect> component was not working here
 // so I've recreated this simple version for this purpose.
@@ -161,6 +163,13 @@ export const routes = {
   [SLO_DETAIL_PATH]: {
     handler: () => {
       return <SloDetailsPage />;
+    },
+    params: {},
+    exact: true,
+  },
+  [ASSETS_INVENTORY_PATH]: {
+    handler: () => {
+      return <AssetsInventoryPage />;
     },
     params: {},
     exact: true,


### PR DESCRIPTION
## Summary

This is an example of how we could build a hosts-only inventory using the Assets API in Kibana. The page is found at {kibana_url}/app/observability/assets-inventory

You can try loading it if you have:
- metrics that reference `host.hostname` and/or `host.name`
- logs that reference `host.hostname` and/or `host.name`

<img width="1620" alt="Screenshot 2023-10-11 at 11 12 08 AM" src="https://github.com/elastic/kibana/assets/159370/f7e8375e-6629-43a7-8ad8-f034f0624413">

To Do:
- [ ] Demo what this looks like with logs only
- [ ] Add host flyout on row click
- [ ] Add unified search box, if simple to do
- [ ] Time range selector? 
- [ ] Add supplemental query inside asset client, to query for assetbeat assets, and test with assetbeat running