### PR TITLE
[DOCS] Fix cases link for notifications domain allowlist

### DIFF
--- a/docs/management/cases/manage-cases.asciidoc
+++ b/docs/management/cases/manage-cases.asciidoc
@@ -90,7 +90,7 @@ cases.
 
 For hosted {kib} on {ess}:
 
-. Add the email addresses to the {cloud}/ec-organizations-notifications-domain-allowlist.html[notifications domain allowlist].
+. Add the email domains to the {cloud}/ec-organizations-notifications-domain-allowlist.html[notifications domain allowlist].
 +
 --
 You do not need to take any more steps to configure an email connector or update

--- a/docs/management/cases/manage-cases.asciidoc
+++ b/docs/management/cases/manage-cases.asciidoc
@@ -90,8 +90,7 @@ cases.
 
 For hosted {kib} on {ess}:
 
-. Add the email addresses to the monitoring email allowlist. Follow the steps in
-{cloud}/ec-watcher.html#ec-watcher-allowlist[Send alerts by email].
+. Add the email addresses to the {cloud}/ec-organizations-notifications-domain-allowlist.html[notifications domain allowlist].
 +
 --
 You do not need to take any more steps to configure an email connector or update


### PR DESCRIPTION
## Summary

This PR fixes a link in the [Cases documentation](https://www.elastic.co/guide/en/kibana/current/manage-cases.html#add-case-notifications), since it was linking to a Cloud page about Watcher that wasn't very helpful. It now uses the following target instead: https://www.elastic.co/guide/en/cloud/current/ec-organizations-notifications-domain-allowlist.html 

