### PR TITLE
[EDR Workflows] Fix osquery tests failing due to discover change

### DIFF
--- a/x-pack/plugins/osquery/cypress/e2e/all/alerts_automated_action_results.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/alerts_automated_action_results.cy.ts
@@ -48,7 +48,7 @@ describe(
           // @ts-expect-error-next-line href string - check types
           cy.visit($href);
           cy.getBySel('discoverDocTable', { timeout: 60000 }).within(() => {
-            cy.contains(`action_data.query`);
+            cy.contains('action_data{ "query":');
           });
           cy.contains(discoverRegex);
         });

--- a/x-pack/plugins/osquery/cypress/e2e/all/custom_space.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/all/custom_space.cy.ts
@@ -90,7 +90,7 @@ describe('ALL - Custom space', () => {
             // @ts-expect-error-next-line href string - check types
             cy.visit($href);
             cy.getBySel('discoverDocTable', { timeout: 60000 }).within(() => {
-              cy.contains('action_data.queryselect * from uptime');
+              cy.contains('action_data{ "query": "select * from uptime;"');
             });
           });
       });


### PR DESCRIPTION
Apparently the way the data is shown in discover has changed. 
I am backporting this to 8.11.0 too, just in case the change applies there, if it doesn't the test will fail there and I'll close the packport PR.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->