### PR TITLE
[Synthetics] Fix Monitor Status chart tooltip hover.

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_cell_tooltip.tsx
@@ -11,13 +11,16 @@ import { EuiProgress } from '@elastic/eui';
 
 import { TooltipTable, TooltipHeader, TooltipValue, TooltipContainer } from '@elastic/charts';
 
-import { usePingStatusesIsLoading } from '../hooks/use_ping_statuses';
 import { MonitorStatusTimeBin, SUCCESS_VIZ_COLOR, DANGER_VIZ_COLOR } from './monitor_status_data';
 import * as labels from './labels';
 
-export const MonitorStatusCellTooltip = ({ timeBin }: { timeBin?: MonitorStatusTimeBin }) => {
-  const isLoading = usePingStatusesIsLoading();
-
+export const MonitorStatusCellTooltip = ({
+  timeBin,
+  isLoading,
+}: {
+  timeBin?: MonitorStatusTimeBin;
+  isLoading: boolean;
+}) => {
   if (!timeBin) {
     return <>{''}</>;
   }

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_status/monitor_status_panel.tsx
@@ -10,6 +10,8 @@ import React, { useMemo } from 'react';
 import { EuiPanel, useEuiTheme, EuiResizeObserver, EuiSpacer } from '@elastic/eui';
 import { Chart, Settings, Heatmap, ScaleType, Tooltip } from '@elastic/charts';
 
+import { usePingStatusesIsLoading } from '../hooks/use_ping_statuses';
+
 import { MonitorStatusHeader } from './monitor_status_header';
 import { MonitorStatusCellTooltip } from './monitor_status_cell_tooltip';
 import { MonitorStatusLegend } from './monitor_status_legend';
@@ -33,6 +35,7 @@ export const MonitorStatusPanel = ({
   const { euiTheme, colorMode } = useEuiTheme();
   const { timeBins, handleResize, getTimeBinByXValue, xDomain, intervalByWidth } =
     useMonitorStatusData({ from, to });
+  const isPingStatusesLoading = usePingStatusesIsLoading();
 
   const heatmap = useMemo(() => {
     return getMonitorStatusChartTheme(euiTheme, brushable);
@@ -61,7 +64,10 @@ export const MonitorStatusPanel = ({
             >
               <Tooltip
                 customTooltip={({ values }) => (
-                  <MonitorStatusCellTooltip timeBin={getTimeBinByXValue(values?.[0]?.datum?.x)} />
+                  <MonitorStatusCellTooltip
+                    timeBin={getTimeBinByXValue(values?.[0]?.datum?.x)}
+                    isLoading={isPingStatusesLoading}
+                  />
                 )}
               />
               <Settings


### PR DESCRIPTION
Fixes #168711 

## Summary

The PR fixes the issue with Monitor Status chart tooltip. New implementation in EUI doesn't render the tooltip in parent Context's scope, which was causing the redux selector to break. This PR moves the selector call up one level, into the parent scope. 

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->