### PR TITLE
[esArchiver] throw error if index is one of SOs

### DIFF
--- a/packages/kbn-es-archiver/src/lib/indices/create_index_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/create_index_stream.ts
@@ -19,7 +19,11 @@ import {
   TASK_MANAGER_SAVED_OBJECT_INDEX,
 } from '@kbn/core-saved-objects-server';
 import { Stats } from '../stats';
-import { cleanSavedObjectIndices, deleteSavedObjectIndices } from './kibana_index';
+import {
+  cleanSavedObjectIndices,
+  deleteSavedObjectIndices,
+  isSavedObjectIndex,
+} from './kibana_index';
 import { deleteIndex } from './delete_index';
 import { deleteDataStream } from './delete_data_stream';
 import { ES_CLIENT_HEADERS } from '../../client_headers';
@@ -124,6 +128,11 @@ export function createCreateIndexStream({
     const { index, settings, mappings, aliases } = record.value;
     const isKibanaTaskManager = index.startsWith(TASK_MANAGER_SAVED_OBJECT_INDEX);
     const isKibana = index.startsWith(MAIN_SAVED_OBJECT_INDEX) && !isKibanaTaskManager;
+    const isSOIndex = isSavedObjectIndex(index);
+
+    if (isSOIndex) {
+      throw new Error(`esArchiver detected saved objects index: '${index}', aborting`);
+    }
 
     if (docsOnly) {
       return;

--- a/packages/kbn-es-archiver/src/lib/indices/index.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/index.ts
@@ -14,4 +14,5 @@ export {
   deleteSavedObjectIndices,
   cleanSavedObjectIndices,
   createDefaultSpace,
+  isSavedObjectIndex,
 } from './kibana_index';

--- a/packages/kbn-es-archiver/src/lib/indices/kibana_index.ts
+++ b/packages/kbn-es-archiver/src/lib/indices/kibana_index.ts
@@ -85,7 +85,7 @@ export async function migrateSavedObjectIndices(kbnClient: KbnClient) {
 const LEGACY_INDICES_REGEXP = new RegExp(`^(${ALL_SAVED_OBJECT_INDICES.join('|')})(:?_\\d*)?$`);
 const INDICES_REGEXP = new RegExp(`^(${ALL_SAVED_OBJECT_INDICES.join('|')})_(pre)?\\d+.\\d+.\\d+`);
 
-function isSavedObjectIndex(index?: string): index is string {
+export function isSavedObjectIndex(index?: string): index is string {
   return Boolean(index && (LEGACY_INDICES_REGEXP.test(index) || INDICES_REGEXP.test(index)));
 }
 


### PR DESCRIPTION
## Summary

To be consistent and close to customer experience with Kibana, we should not load/unload SO indexes using esArchiver or any other external tool in our tests.

The first step for this is to remove its all definitions from all existing `mappings.json` files.

This PR is to check how many tests still ingest SOs.

