### PR TITLE
[8.11] [DOCS] Fix cases link for notifications domain allowlist (#168656)

### DIFF
--- a/docs/management/cases/manage-cases.asciidoc
+++ b/docs/management/cases/manage-cases.asciidoc
@@ -90,8 +90,7 @@ cases.
 
 For hosted {kib} on {ess}:
 
-. Add the email addresses to the monitoring email allowlist. Follow the steps in
-{cloud}/ec-watcher.html#ec-watcher-allowlist[Send alerts by email].
+. Add the email domains to the {cloud}/ec-organizations-notifications-domain-allowlist.html[notifications domain allowlist].
 +
 --
 You do not need to take any more steps to configure an email connector or update


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Fix cases link for notifications domain allowlist (#168656)](https://github.com/elastic/kibana/pull/168656)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2023-10-12T18:16:43Z","message":"[DOCS] Fix cases link for notifications domain allowlist (#168656)","sha":"bc8f45f529264534c2a98b9209cb95cea166a5d8","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","docs","Feature:Cases","v8.11.0","v8.12.0"],"number":168656,"url":"https://github.com/elastic/kibana/pull/168656","mergeCommit":{"message":"[DOCS] Fix cases link for notifications domain allowlist (#168656)","sha":"bc8f45f529264534c2a98b9209cb95cea166a5d8"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/168656","number":168656,"mergeCommit":{"message":"[DOCS] Fix cases link for notifications domain allowlist (#168656)","sha":"bc8f45f529264534c2a98b9209cb95cea166a5d8"}}]}] BACKPORT-->