### PR TITLE
[SecuritySolution] Fix broken delete timeline note request

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/note_previews/index.tsx
@@ -112,6 +112,7 @@ function useDeleteNote(noteId: string | null | undefined) {
       return http.fetch('/api/note', {
         method: 'DELETE',
         body: JSON.stringify({ noteId: id }),
+        version: '2023-10-31',
       });
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/168738

The delete request for timeline notes was missing the `version` header.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->