### PR TITLE
[Serverless Search] add api integration tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/search/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/index.ts
@@ -15,5 +15,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./telemetry/telemetry_config'));
     loadTestFile(require.resolve('./cases/find_cases'));
     loadTestFile(require.resolve('./cases/post_case'));
+    loadTestFile(require.resolve('./serverless_search'));
   });
 }

--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/api_key.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/api_key.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { kibanaTestUser } from '@kbn/test';
+import { SecurityApiKey } from '@elastic/elasticsearch/lib/api/types';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/internal/serverless_search';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const supertest = getService('supertest');
+  const es = getService('es');
+  const log = getService('log');
+
+  describe('API Key routes', function () {
+    describe('GET api_keys', function () {
+      it('return apiKeys', async () => {
+        const { body } = await supertest
+          .get(`${API_BASE_PATH}/api_keys`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .expect(200);
+
+        expect(body).toBeDefined();
+        expect(body.apiKeys).toBeDefined();
+        expect(Array.isArray(body.apiKeys)).toBe(true);
+      });
+    });
+
+    describe('POST api_key', function () {
+      const deleteAllApiKeys = async () => {
+        let apiKeys: SecurityApiKey[];
+        // Delete existing API keys
+        try {
+          const apiKeysResult = await es.security.getApiKey({ username: kibanaTestUser.username });
+          apiKeys = apiKeysResult.api_keys;
+        } catch (err) {
+          log.debug('[Setup error] error listing API keys');
+          throw err;
+        }
+
+        expect(Array.isArray(apiKeys)).toBe(true);
+        if (apiKeys.length === 0) {
+          return;
+        }
+
+        const apiKeysToDelete = apiKeys.map(({ id }) => id);
+        await es.security.invalidateApiKey({ ids: apiKeysToDelete });
+      };
+      before(async () => {
+        await deleteAllApiKeys();
+      });
+      after(async () => {
+        await deleteAllApiKeys();
+      });
+      it('can create a key that expires', async () => {
+        const createBody = {
+          name: 'test-api-key-001',
+          expiration: '60d',
+        };
+        const { body } = await supertest
+          .post(`${API_BASE_PATH}/api_key`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .send(createBody)
+          .expect(200);
+
+        expect(body).toMatchObject({ name: 'test-api-key-001', expiration: expect.anything() });
+      });
+      it('can create a key that never expires', async () => {
+        const createBody = {
+          name: 'test-api-key-002',
+        };
+        const { body } = await supertest
+          .post(`${API_BASE_PATH}/api_key`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .send(createBody)
+          .expect(200);
+
+        expect(body).toMatchObject({ name: 'test-api-key-002' });
+      });
+      it('has beats_logstash_format in result', async () => {
+        const createBody = {
+          name: 'test-api-key-003',
+        };
+        const { body } = await supertest
+          .post(`${API_BASE_PATH}/api_key`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .send(createBody)
+          .expect(200);
+
+        expect(body).toMatchObject({
+          name: 'test-api-key-003',
+          beats_logstash_format: expect.stringContaining(':'),
+        });
+      });
+    });
+  });
+}

--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/connectors.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/internal/serverless_search';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const supertest = getService('supertest');
+
+  describe('Connectors routes', function () {
+    describe('GET connectors', function () {
+      it('returns list of connectors', async () => {
+        const { body } = await supertest
+          .get(`${API_BASE_PATH}/connectors`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .expect(200);
+
+        expect(body.connectors).toBeDefined();
+        expect(Array.isArray(body.connectors)).toBe(true);
+      });
+    });
+    describe('GET connectors', function () {
+      it('returns list of connector_types', async () => {
+        const { body } = await supertest
+          .get(`${API_BASE_PATH}/connector_types`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .expect(200);
+
+        expect(body.connectors).toBeDefined();
+        expect(Array.isArray(body.connectors)).toBe(true);
+        expect(body.connectors.length).toBeGreaterThan(0);
+      });
+    });
+  });
+}

--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
+  describe('Serverless Search - Server', function () {
+    loadTestFile(require.resolve('./api_key'));
+    loadTestFile(require.resolve('./connectors'));
+    loadTestFile(require.resolve('./indices'));
+  });
+}

--- a/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/indices.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/search/serverless_search/indices.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from 'expect';
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const API_BASE_PATH = '/internal/serverless_search';
+
+export default function ({ getService }: FtrProviderContext) {
+  const svlCommonApi = getService('svlCommonApi');
+  const supertest = getService('supertest');
+
+  describe('Indices routes', function () {
+    describe('GET indices', function () {
+      it('has route', async () => {
+        const { body } = await supertest
+          .get(`${API_BASE_PATH}/indices`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .expect(200);
+
+        expect(body).toBeDefined();
+      });
+      it('accepts search_query', async () => {
+        await supertest
+          .get(`${API_BASE_PATH}/indices`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .query({ search_query: 'foo' })
+          .expect(200);
+      });
+      it('accepts from & size', async () => {
+        await supertest
+          .get(`${API_BASE_PATH}/indices`)
+          .set(svlCommonApi.getInternalRequestHeader())
+          .query({ from: 0, size: 10 })
+          .expect(200);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adding API integration tests for exists routes (most of them). This is missing some of the connector routes for now.