### PR TITLE
[Synthetics] Fix monitor error duration on Monitor Errors page

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_errors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_errors.tsx
@@ -120,9 +120,13 @@ export function useMonitorErrors(monitorIdArg?: string) {
       (hits[0]?._source as Ping).monitor?.status === 'down' &&
       !!errorStates?.length;
 
+    const upStatesSortedAsc = upStates.sort(
+      (a, b) => Number(new Date(a['@timestamp'])) - Number(new Date(b['@timestamp']))
+    );
+
     return {
       errorStates,
-      upStates,
+      upStates: upStatesSortedAsc,
       loading,
       data,
       hasActiveError,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_errors.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_errors.tsx
@@ -121,7 +121,7 @@ export function useMonitorErrors(monitorIdArg?: string) {
       !!errorStates?.length;
 
     const upStatesSortedAsc = upStates.sort(
-      (a, b) => Number(new Date(a['@timestamp'])) - Number(new Date(b['@timestamp']))
+      (a, b) => Number(new Date(a.state.started_at)) - Number(new Date(b.state.started_at))
     );
 
     return {


### PR DESCRIPTION
Fixes #168724 

## Summary

The PR fixes the issue by sorting the data as needed.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->