### PR TITLE
[data views] REST API - get scripted field, fix response schema

### DIFF
--- a/src/plugins/data_views/server/rest_api_routes/public/scripted_fields/get_scripted_field.ts
+++ b/src/plugins/data_views/server/rest_api_routes/public/scripted_fields/get_scripted_field.ts
@@ -15,7 +15,7 @@ import type {
   DataViewsServerPluginStartDependencies,
 } from '../../../types';
 import { INITIAL_REST_VERSION } from '../../../constants';
-import { serializedFieldFormatSchema } from '../../../../common/schemas';
+import { fieldSpecSchemaFields } from '../../../../common/schemas';
 import { FieldSpecRestResponse } from '../../route_types';
 
 export const registerGetScriptedFieldRoute = (
@@ -49,7 +49,7 @@ export const registerGetScriptedFieldRoute = (
           response: {
             200: {
               body: schema.object({
-                field: serializedFieldFormatSchema,
+                field: schema.object(fieldSpecSchemaFields),
               }),
             },
           },


### PR DESCRIPTION
## Summary

Response schema fixed. from field formatter response to scripted field. I suspect this slipped through since its not enforced aside from dev environment.

Discovered and broken out from https://github.com/elastic/kibana/pull/161611

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->