### PR TITLE
[FTR] Skip failing serverless tests for MKI runs

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/reporting/management.ts
@@ -23,6 +23,9 @@ export default ({ getService }: FtrProviderContext) => {
   const supertest = getService('supertestWithoutAuth');
 
   describe('Reporting Management', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.reporting-2020.04.19], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     const dataArchive = 'x-pack/test/functional/es_archives/reporting/archived_reports';
 
     beforeEach(async () => {

--- a/x-pack/test_serverless/api_integration/test_suites/observability/infra/index.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/infra/index.ts
@@ -9,6 +9,10 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Infra UI', function () {
+    // all these tests are failing on MKI:
+    // Error: expected 200 "OK", got 404 "Not Found"
+    this.tags(['failsOnMKI']);
+
     loadTestFile(require.resolve('./metadata'));
     loadTestFile(require.resolve('./snapshot'));
     loadTestFile(require.resolve('./processes'));

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/benchmark.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/benchmark.ts
@@ -18,7 +18,10 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('GET /internal/cloud_security_posture/benchmark', () => {
+  describe('GET /internal/cloud_security_posture/benchmark', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
     let agentPolicyId2: string;
     let agentPolicyId3: string;

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/get_csp_rule_template.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/get_csp_rule_template.ts
@@ -19,7 +19,10 @@ export default function ({ getService }: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('GET internal/cloud_security_posture/rules/_find', () => {
+  describe('GET internal/cloud_security_posture/rules/_find', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
 
     beforeEach(async () => {

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_indexed.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_indexed.ts
@@ -41,7 +41,10 @@ export default function (providerContext: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('GET /internal/cloud_security_posture/status', () => {
+  describe('GET /internal/cloud_security_posture/status', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
 
     describe('STATUS = INDEXED TEST', () => {

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_indexing.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_indexing.ts
@@ -41,7 +41,10 @@ export default function (providerContext: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('GET /internal/cloud_security_posture/status', () => {
+  describe('GET /internal/cloud_security_posture/status', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
 
     describe('STATUS = INDEXING TEST', () => {

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_not_deployed_not_installed.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/status/status_not_deployed_not_installed.ts
@@ -19,7 +19,10 @@ export default function (providerContext: FtrProviderContext) {
   const esArchiver = getService('esArchiver');
   const kibanaServer = getService('kibanaServer');
 
-  describe('GET /internal/cloud_security_posture/status', () => {
+  describe('GET /internal/cloud_security_posture/status', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
 
     describe('STATUS = NOT-DEPLOYED and STATUS = NOT-INSTALLED TEST', () => {

--- a/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/telemetry.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/cloud_security_posture/telemetry.ts
@@ -61,7 +61,10 @@ export default function ({ getService }: FtrProviderContext) {
     },
   };
 
-  describe('Verify cloud_security_posture telemetry payloads', async () => {
+  describe('Verify cloud_security_posture telemetry payloads', function () {
+    // security_exception: action [indices:admin/create] is unauthorized for user [elastic] with effective roles [superuser] on restricted indices [.fleet-actions-7], this action is granted by the index privileges [create_index,manage,all]
+    this.tags(['failsOnMKI']);
+
     let agentPolicyId: string;
 
     before(async () => {


### PR DESCRIPTION
## Summary

This PR adds another round of `failsOnMKI` tags to serverless test suites together with comments about the failure.