### PR TITLE
Temporary link change for ES|QL STATS-BY

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -856,7 +856,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       featureRoles: `${ELASTIC_WEBSITE_URL}guide/en/observability/${DOC_LINK_VERSION}/synthetics-feature-roles.html`,
     },
     esql: {
-      statsBy: `${ELASTICSEARCH_DOCS}esql-stats-by.html`,
+      statsBy: `${ELASTICSEARCH_DOCS}esql.html`,
     },
     telemetry: {
       settings: `${KIBANA_DOCS}telemetry-settings-kbn.html`,


### PR DESCRIPTION
Temporarily changes the deep link to the documentation for ES|QL STATS...BY to unblock https://github.com/elastic/elasticsearch/pull/100806 .

I'll change the link to the new STATS...BY link after https://github.com/elastic/elasticsearch/pull/100806 merges.