### PR TITLE
[Fleet] Make experimental config robust

### DIFF
--- a/x-pack/plugins/fleet/server/config.test.ts
+++ b/x-pack/plugins/fleet/server/config.test.ts
@@ -5,9 +5,18 @@
  * 2.0.
  */
 
+import { loggingSystemMock } from '@kbn/core/server/mocks';
+
 import { config } from './config';
+import { appContextService } from './services';
+
+jest.mock('./services/app_context');
 
 describe('Config schema', () => {
+  beforeEach(() => {
+    const mockedLogger = loggingSystemMock.createLogger();
+    jest.mocked(appContextService.getLogger).mockReturnValue(mockedLogger);
+  });
   it('should not allow to specify both default output in xpack.fleet.ouputs and xpack.fleet.agents.elasticsearch.hosts ', () => {
     expect(() => {
       config.schema.validate({
@@ -69,5 +78,27 @@ describe('Config schema', () => {
         agents: { elasticsearch: { hosts: ['https://elasticsearch:9200'] } },
       });
     }).not.toThrow();
+  });
+
+  it('should log a warning when trying to enable a non existing experimental feature', () => {
+    expect(() => {
+      config.schema.validate({
+        enableExperimental: ['notvalid'],
+      });
+    }).not.toThrow();
+
+    expect(appContextService.getLogger().warn).toBeCalledWith(
+      '[notvalid] is not a valid fleet experimental feature.'
+    );
+  });
+
+  it('should not log a warning when enabling an existing experimental feature', () => {
+    expect(() => {
+      config.schema.validate({
+        enableExperimental: ['displayAgentMetrics'],
+      });
+    }).not.toThrow();
+
+    expect(appContextService.getLogger().warn).not.toBeCalled();
   });
 });

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -11,11 +11,7 @@ import { schema } from '@kbn/config-schema';
 import type { TypeOf } from '@kbn/config-schema';
 import type { PluginConfigDescriptor } from '@kbn/core/server';
 
-import {
-  getExperimentalAllowedValues,
-  isValidExperimentalValue,
-} from '../common/experimental_features';
-const allowedExperimentalValues = getExperimentalAllowedValues();
+import { isValidExperimentalValue } from '../common/experimental_features';
 
 import {
   PreconfiguredPackagesSchema,

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -25,6 +25,7 @@ import {
   PreconfiguredFleetProxiesSchema,
 } from './types';
 import { BULK_CREATE_MAX_ARTIFACTS_BYTES } from './services/artifacts/artifacts';
+import { appContextService } from './services';
 
 const DEFAULT_BUNDLED_PACKAGE_LOCATION = path.join(__dirname, '../target/bundled_packages');
 const DEFAULT_GPG_KEY_PATH = path.join(__dirname, '../target/keys/GPG-KEY-elasticsearch');
@@ -162,9 +163,9 @@ export const config: PluginConfigDescriptor = {
         validate(list) {
           for (const key of list) {
             if (!isValidExperimentalValue(key)) {
-              return `[${key}] is not allowed. Allowed values are: ${allowedExperimentalValues.join(
-                ', '
-              )}`;
+              appContextService
+                .getLogger()
+                .warn(`[${key}] is not a valid fleet experimental feature.`);
             }
           }
         },


### PR DESCRIPTION
## Summary

Make experimental config more robust to not crash when an experimental feature is removed.

## Test

Try to add a non existing experimental feature to your config it should log a warning but not crash
```
xpack.fleet.enableExperimental: ['aaaa']
```