### PR TITLE
[Search] Fix native connectors not configuring correctly

### DIFF
--- a/packages/kbn-search-connectors/lib/create_connector_document.ts
+++ b/packages/kbn-search-connectors/lib/create_connector_document.ts
@@ -116,7 +116,7 @@ export function createConnectorDocument({
       incremental: { enabled: false, interval: '0 0 0 * * ?' },
     },
     service_type: serviceType || null,
-    status: ConnectorStatus.CREATED,
+    status: isNative ? ConnectorStatus.NEEDS_CONFIGURATION : ConnectorStatus.CREATED,
     sync_now: false,
   };
 }

--- a/packages/kbn-search-connectors/lib/update_connector_configuration.ts
+++ b/packages/kbn-search-connectors/lib/update_connector_configuration.ts
@@ -26,7 +26,8 @@ export const updateConnectorConfiguration = async (
   const connector = connectorResult?.value;
   if (connector) {
     const status =
-      connector.status === ConnectorStatus.NEEDS_CONFIGURATION
+      connector.status === ConnectorStatus.NEEDS_CONFIGURATION ||
+      connector.status === ConnectorStatus.CREATED
         ? ConnectorStatus.CONFIGURED
         : connector.status;
     const updatedConfig = Object.keys(connector.configuration)


### PR DESCRIPTION
## Summary

This fixes an issue with native connectors not being set to configured after being configured.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->