### PR TITLE
[8.11] [Security Solution][Entity Analytics] Mark Risk Score Calculation route as internal (#168720)

### DIFF
--- a/x-pack/plugins/security_solution/server/lib/risk_engine/routes/risk_score_calculation_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/risk_engine/routes/risk_score_calculation_route.ts
@@ -23,14 +23,14 @@ export const riskScoreCalculationRoute = (router: SecuritySolutionPluginRouter, 
   router.versioned
     .post({
       path: RISK_SCORE_CALCULATION_URL,
-      access: 'public',
+      access: 'internal',
       options: {
         tags: ['access:securitySolution', `access:${APP_ID}-entity-analytics`],
       },
     })
     .addVersion(
       {
-        version: '2023-10-31',
+        version: '1',
         validate: { request: { body: buildRouteValidation(riskScoreCalculationRequestSchema) } },
       },
       async (context, request, response) => {

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/risk_engine/risk_score_calculation.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/group10/risk_engine/risk_score_calculation.ts
@@ -38,7 +38,7 @@ export default ({ getService }: FtrProviderContext): void => {
     const { body: result } = await supertest
       .post(RISK_SCORE_CALCULATION_URL)
       .set('kbn-xsrf', 'true')
-      .set('elastic-api-version', '2023-10-31')
+      .set('elastic-api-version', '1')
       .send(body)
       .expect(200);
     return result;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution][Entity Analytics] Mark Risk Score Calculation route as internal (#168720)](https://github.com/elastic/kibana/pull/168720)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ryland Herrick","email":"ryalnd@gmail.com"},"sourceCommit":{"committedDate":"2023-10-13T14:39:39Z","message":"[Security Solution][Entity Analytics] Mark Risk Score Calculation route as internal (#168720)\n\n## Summary\r\n\r\nWe don't have a specific need to release this publicly for now, so we're\r\ngoing to keep it internal until we have need for it.\r\n\r\n\r\nThis is a followup to https://github.com/elastic/kibana/pull/167365,\r\nwhich made this route public in the first place.","sha":"07c223616c7c11d5780b284b5cfc810e3d845c42","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","chore","release_note:skip","Theme: entity_analytics","Team:Detection Engine","8.11 candidate","v8.11.0","v8.12.0"],"number":168720,"url":"https://github.com/elastic/kibana/pull/168720","mergeCommit":{"message":"[Security Solution][Entity Analytics] Mark Risk Score Calculation route as internal (#168720)\n\n## Summary\r\n\r\nWe don't have a specific need to release this publicly for now, so we're\r\ngoing to keep it internal until we have need for it.\r\n\r\n\r\nThis is a followup to https://github.com/elastic/kibana/pull/167365,\r\nwhich made this route public in the first place.","sha":"07c223616c7c11d5780b284b5cfc810e3d845c42"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/168720","number":168720,"mergeCommit":{"message":"[Security Solution][Entity Analytics] Mark Risk Score Calculation route as internal (#168720)\n\n## Summary\r\n\r\nWe don't have a specific need to release this publicly for now, so we're\r\ngoing to keep it internal until we have need for it.\r\n\r\n\r\nThis is a followup to https://github.com/elastic/kibana/pull/167365,\r\nwhich made this route public in the first place.","sha":"07c223616c7c11d5780b284b5cfc810e3d845c42"}}]}] BACKPORT-->