### PR TITLE
WIP [Cloud Security][D4C] fix: avoid showing error when adding new condition to selector

### DIFF
--- a/x-pack/plugins/cloud_defend/common/v1.ts
+++ b/x-pack/plugins/cloud_defend/common/v1.ts
@@ -60,7 +60,8 @@ export interface CloudDefendPolicy {
 // Currently we support file and process selectors (which match on their respective set of hook points)
 export type SelectorType = 'file' | 'process';
 
-export type SelectorCondition =
+export type SelectorCondition = keyof Pick<
+  Selector,
   | 'containerImageFullName'
   | 'containerImageName'
   | 'containerImageTag'
@@ -75,7 +76,8 @@ export type SelectorCondition =
   | 'operation'
   | 'processExecutable'
   | 'processName'
-  | 'sessionLeaderInteractive';
+  | 'sessionLeaderInteractive'
+>;
 
 export type ResponseAction = 'log' | 'alert' | 'block';
 

--- a/x-pack/plugins/cloud_defend/public/components/control_general_view/index.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view/index.tsx
@@ -254,27 +254,22 @@ export const ControlGeneralView = ({ policy, onChange, show }: ViewDeps) => {
   );
 
   const onSelectorChange = useCallback(
-    (updatedSelector: Selector, index: number) => {
-      const old = selectors[index];
+    (updatedSelector: Selector, updatedSelectorIndex: number) => {
+      const oldSelector = selectors[updatedSelectorIndex];
 
-      if (updatedSelector.hasErrors === false) {
-        delete updatedSelector.hasErrors;
-      }
+      let updatedResponses = structuredClone(responses);
 
-      const updatedSelectors: Selector[] = JSON.parse(JSON.stringify(selectors));
-      let updatedResponses: Response[] = JSON.parse(JSON.stringify(responses));
-
-      if (old.name !== updatedSelector.name) {
+      if (oldSelector.name !== updatedSelector.name) {
         // update all references to this selector in responses
         updatedResponses = responses.map((response) => {
-          let oldNameIndex = response.match.indexOf(old.name);
+          let oldNameIndex = response.match.indexOf(oldSelector.name);
 
           if (oldNameIndex !== -1) {
             response.match[oldNameIndex] = updatedSelector.name;
           }
 
           if (response.exclude) {
-            oldNameIndex = response.exclude.indexOf(old.name);
+            oldNameIndex = response.exclude.indexOf(oldSelector.name);
 
             if (oldNameIndex !== -1) {
               response.exclude[oldNameIndex] = updatedSelector.name;
@@ -285,7 +280,9 @@ export const ControlGeneralView = ({ policy, onChange, show }: ViewDeps) => {
         });
       }
 
-      updatedSelectors[index] = JSON.parse(JSON.stringify(updatedSelector));
+      const updatedSelectors = structuredClone(selectors);
+      updatedSelectors[updatedSelectorIndex] = structuredClone(updatedSelector);
+
       onUpdateYaml(updatedSelectors, updatedResponses);
     },
     [onUpdateYaml, responses, selectors]

--- a/x-pack/plugins/cloud_defend/public/components/control_general_view_selector/index.test.tsx
+++ b/x-pack/plugins/cloud_defend/public/components/control_general_view_selector/index.test.tsx
@@ -215,8 +215,8 @@ describe('<ControlGeneralViewSelector />', () => {
     expect(onChange.mock.calls[0][0]).toHaveProperty('hasErrors');
   });
 
-  it('shows an error if no values provided for condition', async () => {
-    const { getByText, getByTestId } = render(<WrappedComponent />);
+  it('shoud not show any errors after adding a new combobox condition', async () => {
+    const { getByText, getByTestId, queryByText } = render(<WrappedComponent />);
     const addConditionBtn = getByTestId('cloud-defend-btnaddselectorcondition');
 
     getByTestId('cloud-defend-btnremovecondition-operation').click();
@@ -226,8 +226,8 @@ describe('<ControlGeneralViewSelector />', () => {
 
     expect(onChange.mock.calls).toHaveLength(2);
     expect(onChange.mock.calls[1][0]).toHaveProperty('containerImageName');
-    expect(onChange.mock.calls[1][0]).toHaveProperty('hasErrors');
-    expect(getByText(i18n.errorValueRequired)).toBeTruthy();
+    expect(onChange.mock.calls[1][0]).not.toHaveProperty('hasErrors');
+    expect(queryByText(/Please address the highlighted errors/)).toBeNull();
   });
 
   it('prevents conditions from having values that exceed MAX_CONDITION_VALUE_LENGTH_BYTES', async () => {


### PR DESCRIPTION
## Summary

This PR improves the UX when it comes to adding a new condition powered by combobox. 

Before:
Adding a new condition triggers an error "At least one value is required", even though the user didn't touch the field.

After:
Adding a new condition doesn't trigger the error.

Closes #163215


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] `pending` Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] `pending` Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
