### PR TITLE
[Synthetics] Add test id attributes to synthetics retest elements

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table.tsx
@@ -182,7 +182,11 @@ export const TestRunsTable = ({
               <StatusBadge status={parseBadgeStatus(status ?? 'skipped')} />
             </EuiFlexItem>
             <EuiFlexItem>
-              <EuiIconTip type="refresh" content={FINAL_ATTEMPT_LABEL} />
+              <EuiIconTip
+                data-test-subj="isRetestIcon"
+                type="refresh"
+                content={FINAL_ATTEMPT_LABEL}
+              />
             </EuiFlexItem>
           </EuiFlexGroup>
         );

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
@@ -61,6 +61,7 @@ export const TestRunsTableHeader = ({
       <EuiFlexItem grow={false}>
         <EuiSwitch
           compressed
+          data-test-subj="toggleRetestSwitch"
           label={ONLY_SHOW_RETEST}
           checked={showOnlyFinalAttempts}
           onChange={(e) => dispatch(showOnlyFinalAttemptsAction(e.target.checked))}


### PR DESCRIPTION
## Summary

Adds test IDs to some newly-added elements. This is useful to us for E2E testing purposes. We can select other attributes/text for these features, but it is beneficial to have the added assurance and simplicity of using a test ID to find these elements.



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->