### PR TITLE
Allow security solution QA QGs to soft fail.

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -15,6 +15,7 @@ steps:
 
   - group: ":female-detective: Security Solution Tests"
     key: "security"
+    soft_fail: true # Remove this when tests are fixed
     steps:
       - label: ":pipeline::female-detective::seedling: Trigger Security Solution quality gate script"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/pipeline.sh


### PR DESCRIPTION
Security solution's serverless QA quality gates which were added in https://github.com/elastic/kibana/pull/167494 are failing when trying to run cypress tests. I've marked them to soft fail here so we can unblock the serverless release pipeline.

cc @watson @elastic/kibana-operations @MadameSheema @charlie-pichette @YulNaumenko 