### PR TITLE
Relocate security solution QG soft fail to the correct place.

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -15,10 +15,10 @@ steps:
 
   - group: ":female-detective: Security Solution Tests"
     key: "security"
-    soft_fail: true # Remove this when tests are fixed
     steps:
       - label: ":pipeline::female-detective::seedling: Trigger Security Solution quality gate script"
         command: .buildkite/scripts/pipelines/security_solution_quality_gate/pipeline.sh
+        soft_fail: true # Remove this when tests are fixed
 
   - label: ":pipeline::ship::seedling: Trigger Fleet serverless smoke tests for ${ENVIRONMENT}"
     trigger: fleet-smoke-tests # https://buildkite.com/elastic/fleet-smoke-tests


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/168898, the `soft_fail` for the security solution quality gate was accidentally added to the wrong spot in the pipeline config. This fixes it per the [buildkite docs](https://buildkite.com/docs/pipelines/command-step#soft-fail-attributes).