### PR TITLE
[Profiling] Fix frame group ID when source filename is empty

### DIFF
--- a/packages/kbn-profiling-utils/common/frame_group.test.ts
+++ b/packages/kbn-profiling-utils/common/frame_group.test.ts
@@ -40,7 +40,7 @@ const elfSymbolizedTests = [
       sourceFilename: '',
       functionName: 'strlen()',
     },
-    expected: 'elf;libc;strlen()',
+    expected: 'elf;0x0123456789ABCDEF;strlen()',
   },
   {
     params: {
@@ -50,7 +50,7 @@ const elfSymbolizedTests = [
       sourceFilename: '',
       functionName: 'strtok()',
     },
-    expected: 'elf;libc;strtok()',
+    expected: 'elf;0xFEDCBA9876543210;strtok()',
   },
 ];
 

--- a/packages/kbn-profiling-utils/common/frame_group.ts
+++ b/packages/kbn-profiling-utils/common/frame_group.ts
@@ -41,7 +41,7 @@ export function createFrameGroupID(
   }
 
   if (sourceFilename === '') {
-    return `elf;${exeFilename};${functionName}`;
+    return `elf;${fileID};${functionName}`;
   }
 
   return `full;${exeFilename};${functionName};${stripLeadingSubdirs(sourceFilename || '')}`;


### PR DESCRIPTION
This PR addresses an issue identified after the port from Kibana in https://github.com/elastic/elasticsearch/pull/99091:

- update `createFrameGroupID` to use `fileID`+`functionName` in ID instead of `exeFilename`+`functionName` if the source filename is empty