### PR TITLE
[SOM] use aggregation for type counts

### DIFF
--- a/src/plugins/saved_objects_management/server/lib/get_saved_objects_counts.ts
+++ b/src/plugins/saved_objects_management/server/lib/get_saved_objects_counts.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { estypes } from '@elastic/elasticsearch';
+import type { SavedObjectsFindOptions } from '@kbn/core-saved-objects-api-server';
+import type { SavedObjectsClientContract } from '@kbn/core/server';
+
+export const getSavedObjectCounts = async ({
+  types,
+  options,
+  client,
+}: {
+  types: string[];
+  options: SavedObjectsFindOptions;
+  client: SavedObjectsClientContract;
+}): Promise<Record<string, number>> => {
+  const body = await client.find<void, { types: estypes.AggregationsStringTermsAggregate }>({
+    ...options,
+    type: types,
+    perPage: 0,
+    aggs: {
+      types: {
+        terms: {
+          field: 'type',
+          size: types.length,
+        },
+      },
+    },
+  });
+
+  const buckets =
+    (body.aggregations?.types?.buckets as estypes.AggregationsStringTermsBucketKeys[]) || [];
+
+  const counts = buckets.reduce((memo, bucket) => {
+    memo[bucket.key] = bucket.doc_count;
+    return memo;
+  }, {} as Record<string, number>);
+
+  return counts;
+};

--- a/src/plugins/saved_objects_management/server/lib/index.ts
+++ b/src/plugins/saved_objects_management/server/lib/index.ts
@@ -9,3 +9,4 @@
 export { toSavedObjectWithMeta } from './to_saved_object_with_meta';
 export { injectMetaAttributes } from './inject_meta_attributes';
 export { findRelationships } from './find_relationships';
+export { getSavedObjectCounts } from './get_saved_objects_counts';

--- a/src/plugins/saved_objects_management/tsconfig.json
+++ b/src/plugins/saved_objects_management/tsconfig.json
@@ -28,6 +28,7 @@
     "@kbn/shared-ux-router",
     "@kbn/core-ui-settings-browser-mocks",
     "@kbn/core-ui-settings-browser",
+    "@kbn/core-saved-objects-api-server",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Use an aggregation for type counts in SO management instead of scrolling through all the documents.