### PR TITLE
[Ops] Trigger Security Solution quality gate job instead of running it

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-qa.yaml
@@ -13,12 +13,13 @@ steps:
         EC_REGION: aws-eu-west-1
       message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-qa.yaml)"
 
-  - group: ":female-detective: Security Solution Tests"
-    key: "security"
-    steps:
-      - label: ":pipeline::female-detective::seedling: Trigger Security Solution quality gate script"
-        command: .buildkite/scripts/pipelines/security_solution_quality_gate/pipeline.sh
-        soft_fail: true # Remove this when tests are fixed
+  - label: ":pipeline::female-detective::seedling: Trigger Security Solution quality gate script"
+    trigger: security-serverless-quality-gate # https://buildkite.com/elastic/security-serverless-quality-gate
+    soft_fail: true # Remove this when tests are fixed
+    build:
+      env:
+        ENVIRONMENT: ${ENVIRONMENT}
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-qa.yaml)"
 
   - label: ":pipeline::ship::seedling: Trigger Fleet serverless smoke tests for ${ENVIRONMENT}"
     trigger: fleet-smoke-tests # https://buildkite.com/elastic/fleet-smoke-tests


### PR DESCRIPTION
## Summary
Now that the security solution tests are moved to their own pipeline, we can trigger it. It's also required because the job relies on the Kibana-buildkite environment. 

See: https://elastic.slack.com/archives/C05NJL80DB8/p1697233389455979