### PR TITLE
[Security Solution] Increasing parallelism for Serverless Security specific executions

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -63,7 +63,7 @@ steps:
           queue: n2-4-spot
         depends_on: build
         timeout_in_minutes: 60
-        parallelism: 2
+        parallelism: 4
         retry:
           automatic:
             - exit_status: '*'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -85,7 +85,7 @@ steps:
       queue: n2-4-spot
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 2
+    parallelism: 4
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary

Looks like we increased the `parallelism` number for Serverless Security specific executions on the `base.yml` but we forgot to do it in the `on_merge.yml`.

In this PR we are aligning those numbers to avoid failures.
