### PR TITLE
[Fleet] Fix missing item in output openapi specs

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -4573,7 +4573,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/output_create_request"
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "$ref": "#/components/schemas/output_create_request"
+                    }
+                  }
                 }
               }
             }
@@ -4650,7 +4655,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/output_update_request"
+                  "type": "object",
+                  "properties": {
+                    "item": {
+                      "$ref": "#/components/schemas/output_update_request"
+                    }
+                  }
                 }
               }
             }

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -2853,7 +2853,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/output_create_request'
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/output_create_request'
         '400':
           $ref: '#/components/responses/error'
       operationId: get-output
@@ -2900,7 +2903,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/output_update_request'
+                type: object
+                properties:
+                  item:
+                    $ref: '#/components/schemas/output_update_request'
         '400':
           $ref: '#/components/responses/error'
       parameters:

--- a/x-pack/plugins/fleet/common/openapi/paths/outputs@{output_id}.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/outputs@{output_id}.yaml
@@ -8,7 +8,10 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/output_create_request.yaml
+            type: object
+            properties:
+              item:
+                $ref: ../components/schemas/output_create_request.yaml
     '400':
       $ref: ../components/responses/error.yaml
   operationId: get-output
@@ -55,7 +58,10 @@ put:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/output_update_request.yaml
+            type: object
+            properties:
+              item:
+                $ref: ../components/schemas/output_update_request.yaml
     '400':
       $ref: ../components/responses/error.yaml
   parameters:


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/167181

## Summary
Fix of Fleet openapi specs: `item` was mistakenly removed in the responses of these two endpoints:
- GET /outputs/{outputId}
- PUT /outputs/{outputId}

Adding back the missing fields to align the actual behavior with the docs.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
