### PR TITLE
[Enterprise Search] Remove unused doclink

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -167,7 +167,6 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       connectorsSharepointOnline: `${ENTERPRISE_SEARCH_DOCS}connectors-sharepoint-online.html`,
       connectorsSlack: `${ENTERPRISE_SEARCH_DOCS}connectors-slack.html`,
       connectorsTeams: `${ENTERPRISE_SEARCH_DOCS}connectors-teams.html`,
-      connectorsWorkplaceSearch: `${ENTERPRISE_SEARCH_DOCS}workplace-search-connectors.html`,
       connectorsZoom: `${ENTERPRISE_SEARCH_DOCS}connectors-zoom.html`,
       crawlerExtractionRules: `${ENTERPRISE_SEARCH_DOCS}crawler-extraction-rules.html`,
       crawlerManaging: `${ENTERPRISE_SEARCH_DOCS}crawler-managing.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -148,7 +148,6 @@ export interface DocLinks {
     readonly connectorsSharepointOnline: string;
     readonly connectorsTeams: string;
     readonly connectorsSlack: string;
-    readonly connectorsWorkplaceSearch: string;
     readonly connectorsZoom: string;
     readonly crawlerExtractionRules: string;
     readonly crawlerManaging: string;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/doc_links/doc_links.ts
@@ -92,7 +92,6 @@ class DocLinks {
   public connectorsSlack: string;
   public connectorsTeams: string;
   public connectorsZoom: string;
-  public connectorsWorkplaceSearch: string;
   public consoleGuide: string;
   public crawlerExtractionRules: string;
   public crawlerManaging: string;
@@ -260,7 +259,6 @@ class DocLinks {
     this.connectorsSlack = '';
     this.connectorsTeams = '';
     this.connectorsZoom = '';
-    this.connectorsWorkplaceSearch = '';
     this.consoleGuide = '';
     this.crawlerExtractionRules = '';
     this.crawlerManaging = '';
@@ -430,7 +428,6 @@ class DocLinks {
     this.connectorsSlack = docLinks.links.enterpriseSearch.connectorsSlack;
     this.connectorsTeams = docLinks.links.enterpriseSearch.connectorsTeams;
     this.connectorsZoom = docLinks.links.enterpriseSearch.connectorsZoom;
-    this.connectorsWorkplaceSearch = docLinks.links.enterpriseSearch.connectorsWorkplaceSearch;
     this.consoleGuide = docLinks.links.console.guide;
     this.crawlerExtractionRules = docLinks.links.enterpriseSearch.crawlerExtractionRules;
     this.crawlerManaging = docLinks.links.enterpriseSearch.crawlerManaging;


### PR DESCRIPTION
I don't this link is used, so we can safely remove it?

The only other file that contains a reference is `api_docs/kbn_doc_links.devdocs.json`, but I assume that's a generated file?

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->