### PR TITLE
[Controls] Remove `labs:dashboard:dashboardControls` UI setting

### DIFF
--- a/packages/kbn-management/settings/setting_ids/index.ts
+++ b/packages/kbn-management/settings/setting_ids/index.ts
@@ -52,7 +52,6 @@ export const TIMEPICKER_TIME_DEFAULTS_ID = 'timepicker:timeDefaults';
 // Presentation labs settings
 export const LABS_CANVAS_BY_VALUE_EMBEDDABLE_ID = 'labs:canvas:byValueEmbeddable';
 export const LABS_CANVAS_ENABLE_UI_ID = 'labs:canvas:enable_ui';
-export const LABS_DASHBOARD_CONTROLS_ID = 'labs:dashboard:dashboardControls';
 export const LABS_DASHBOARD_DEFER_BELOW_FOLD_ID = 'labs:dashboard:deferBelowFold';
 export const LABS_DASHBOARDS_ENABLE_UI_ID = 'labs:dashboard:enable_ui';
 

--- a/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -16,7 +16,6 @@ import { ViewMode } from '@kbn/embeddable-plugin/public';
 import { ExitFullScreenButton } from '@kbn/shared-ux-button-exit-full-screen';
 
 import { DashboardGrid } from '../grid';
-import { pluginServices } from '../../../services/plugin_services';
 import { useDashboardContainer } from '../../embeddable/dashboard_container';
 import { DashboardEmptyScreen } from '../empty_screen/dashboard_empty_screen';
 

--- a/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -60,7 +60,6 @@ export const DashboardViewportComponent = () => {
   const description = dashboard.select((state) => state.explicitInput.description);
   const focusedPanelId = dashboard.select((state) => state.componentState.focusedPanelId);
   const expandedPanelId = dashboard.select((state) => state.componentState.expandedPanelId);
-  const controlsEnabled = isProjectEnabledInLabs('labs:dashboard:dashboardControls');
 
   const { ref: resizeRef, width: viewportWidth } = useDebouncedWidthObserver(!!focusedPanelId);
 
@@ -71,7 +70,7 @@ export const DashboardViewportComponent = () => {
 
   return (
     <div className={'dshDashboardViewportWrapper'}>
-      {controlsEnabled && controlGroup && viewMode !== ViewMode.PRINT ? (
+      {controlGroup && viewMode !== ViewMode.PRINT ? (
         <div
           className={controlCount > 0 ? 'dshDashboardViewport-controls' : ''}
           ref={controlsRoot}

--- a/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
+++ b/src/plugins/dashboard/public/dashboard_container/component/viewport/dashboard_viewport.tsx
@@ -35,9 +35,6 @@ export const useDebouncedWidthObserver = (skipDebounce = false, wait = 100) => {
 };
 
 export const DashboardViewportComponent = () => {
-  const {
-    settings: { isProjectEnabledInLabs },
-  } = pluginServices.getServices();
   const controlsRoot = useRef(null);
 
   const dashboard = useDashboardContainer();

--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -489,10 +489,6 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },
   },
-  'labs:dashboard:dashboardControls': {
-    type: 'boolean',
-    _meta: { description: 'Non-default value of setting.' },
-  },
   'labs:dashboard:linksPanel': {
     type: 'boolean',
     _meta: { description: 'Non-default value of setting.' },

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -137,7 +137,6 @@ export interface UsageStats {
   'labs:dashboard:enable_ui': boolean;
   'labs:dashboard:linksPanel': boolean;
   'labs:dashboard:deferBelowFold': boolean;
-  'labs:dashboard:dashboardControls': boolean;
   'discover:rowHeightOption': number;
   hideAnnouncements: boolean;
   isDefaultIndexMigrated: boolean;

--- a/src/plugins/presentation_util/common/labs.ts
+++ b/src/plugins/presentation_util/common/labs.ts
@@ -11,15 +11,9 @@ import { i18n } from '@kbn/i18n';
 export const LABS_PROJECT_PREFIX = 'labs:';
 export const DEFER_BELOW_FOLD = `${LABS_PROJECT_PREFIX}dashboard:deferBelowFold` as const;
 export const DASHBOARD_LINKS_PANEL = `${LABS_PROJECT_PREFIX}dashboard:linksPanel` as const;
-export const DASHBOARD_CONTROLS = `${LABS_PROJECT_PREFIX}dashboard:dashboardControls` as const;
 export const BY_VALUE_EMBEDDABLE = `${LABS_PROJECT_PREFIX}canvas:byValueEmbeddable` as const;
 
-export const projectIDs = [
-  DEFER_BELOW_FOLD,
-  DASHBOARD_CONTROLS,
-  BY_VALUE_EMBEDDABLE,
-  DASHBOARD_LINKS_PANEL,
-] as const;
+export const projectIDs = [DEFER_BELOW_FOLD, BY_VALUE_EMBEDDABLE, DASHBOARD_LINKS_PANEL] as const;
 export const environmentNames = ['kibana', 'browser', 'session'] as const;
 export const solutionNames = ['canvas', 'dashboard', 'presentation'] as const;
 
@@ -46,20 +40,6 @@ export const projects: { [ID in ProjectID]: ProjectConfig & { id: ID } } = {
     description: i18n.translate('presentationUtil.labs.enableDeferBelowFoldProjectDescription', {
       defaultMessage:
         'Any panels below "the fold"-- the area hidden beyond the bottom of the window, accessed by scrolling-- will not be loaded immediately, but only when they enter the viewport',
-    }),
-    solutions: ['dashboard'],
-  },
-  [DASHBOARD_CONTROLS]: {
-    id: DASHBOARD_CONTROLS,
-    isActive: true,
-    isDisplayed: true,
-    environments: ['kibana', 'browser', 'session'],
-    name: i18n.translate('presentationUtil.labs.enableDashboardControlsProjectName', {
-      defaultMessage: 'Enable dashboard controls',
-    }),
-    description: i18n.translate('presentationUtil.labs.enableDashboardControlsProjectDescription', {
-      defaultMessage:
-        'Enables the controls system for dashboard, which allows dashboard authors to more easily build interactive elements for their users.',
     }),
     solutions: ['dashboard'],
   },

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -9923,12 +9923,6 @@
             "description": "Non-default value of setting."
           }
         },
-        "labs:dashboard:dashboardControls": {
-          "type": "boolean",
-          "_meta": {
-            "description": "Non-default value of setting."
-          }
-        },
         "labs:dashboard:linksPanel": {
           "type": "boolean",
           "_meta": {

--- a/test/functional/apps/dashboard_elements/controls/common/index.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/index.ts
@@ -28,8 +28,6 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
 
     // enable the controls lab and navigate to the dashboard listing page to start
     await dashboard.navigateToApp();
-    await dashboardControls.enableControlsLab();
-    await dashboard.navigateToApp();
     await dashboard.preserveCrossAppState();
   }
 

--- a/test/functional/apps/dashboard_elements/controls/common/index.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/index.ts
@@ -13,7 +13,7 @@ export default function ({ loadTestFile, getService, getPageObjects }: FtrProvid
   const kibanaServer = getService('kibanaServer');
   const security = getService('security');
 
-  const { dashboardControls, dashboard } = getPageObjects(['dashboardControls', 'dashboard']);
+  const { dashboard } = getPageObjects(['dashboard']);
 
   async function setup() {
     await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/dashboard/current/data');

--- a/test/functional/apps/dashboard_elements/controls/common/range_slider.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/range_slider.ts
@@ -50,8 +50,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         to: 'Dec 3, 2018 @ 00:00:00.000',
       });
       await dashboard.navigateToApp();
-      await dashboardControls.enableControlsLab();
-      await dashboard.navigateToApp();
       await dashboard.preserveCrossAppState();
       await dashboard.gotoDashboardLandingPage();
       await dashboard.clickNewDashboard();

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -61,19 +61,6 @@ export class DashboardPageControls extends FtrService {
      General controls functions
      ----------------------------------------------------------- */
 
-  public async enableControlsLab() {
-    await this.header.clickStackManagement();
-    await this.settings.clickKibanaSettings();
-
-    const currentValue = await this.settings.getAdvancedSettingAriaCheckbox(
-      'labs:dashboard:dashboardControls'
-    );
-
-    if (currentValue !== 'true') {
-      await this.settings.toggleAdvancedSettingCheckbox('labs:dashboard:dashboardControls');
-    }
-  }
-
   public async expectControlsEmpty() {
     await this.testSubjects.existOrFail('controls-empty');
   }

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -54,8 +54,6 @@ export class DashboardPageControls extends FtrService {
   private readonly testSubjects = this.ctx.getService('testSubjects');
 
   private readonly common = this.ctx.getPageObject('common');
-  private readonly header = this.ctx.getPageObject('header');
-  private readonly settings = this.ctx.getPageObject('settings');
 
   /* -----------------------------------------------------------
      General controls functions

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -4807,8 +4807,6 @@
     "presentationUtil.labs.components.titleLabel": "实验",
     "presentationUtil.labs.enableByValueEmbeddableDescription": "在 Canvas 中启用按值嵌入的支持",
     "presentationUtil.labs.enableByValueEmbeddableName": "按值嵌入",
-    "presentationUtil.labs.enableDashboardControlsProjectDescription": "为仪表板启用控件系统，这允许仪表板作者更轻松地为其用户构建交互式元素。",
-    "presentationUtil.labs.enableDashboardControlsProjectName": "启用仪表板控件",
     "presentationUtil.labs.enableDeferBelowFoldProjectDescription": "“折叠”下的任何面板即可通过滚动访问的窗口底部隐藏的区域，将不会立即加载，而仅在进入视区时加载",
     "presentationUtil.labs.enableDeferBelowFoldProjectName": "推迟加载“折叠”下的面板",
     "presentationUtil.saveModalDashboard.addToDashboardLabel": "添加到仪表板",

--- a/x-pack/test/functional/apps/dashboard/group2/migration_smoke_tests/controls_migration_smoke_test.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/migration_smoke_tests/controls_migration_smoke_test.ts
@@ -55,7 +55,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     });
 
     it('should render all panels on the dashboard', async () => {
-      await dashboardControls.enableControlsLab();
       await dashboard.navigateToApp();
       await dashboard.loadSavedDashboard('[8.0.0] Controls Dashboard');
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/162978

## Summary

This PR removes the `labs:dashboard:dashboardControls` advanced UI setting. The removal of this setting is **not** a breaking change, as it hasn't functioned properly for quite some time; it is completely safe to remove this setting **regardless** of the previous value. Telemetry tracking for this setting is also no longer required.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
