### PR TITLE
[Serverless Search] Fix Python client "basic configuration" link

### DIFF
--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -76,7 +76,7 @@ class ESDocLinks {
     this.phpClient = newDocLinks.serverlessClients.phpGettingStarted;
     // Python
     this.pythonApiReference = newDocLinks.serverlessClients.pythonGettingStarted;
-    this.pythonBasicConfig = newDocLinks.clients.pythonConnecting;
+    this.pythonBasicConfig = newDocLinks.clients.pythonGettingStarted;
     this.pythonClient = newDocLinks.serverlessClients.pythonGettingStarted;
     // Python
     this.rubyBasicConfig = newDocLinks.serverlessClients.rubyGettingStarted;

--- a/x-pack/plugins/serverless_search/common/doc_links.ts
+++ b/x-pack/plugins/serverless_search/common/doc_links.ts
@@ -76,7 +76,7 @@ class ESDocLinks {
     this.phpClient = newDocLinks.serverlessClients.phpGettingStarted;
     // Python
     this.pythonApiReference = newDocLinks.serverlessClients.pythonGettingStarted;
-    this.pythonBasicConfig = newDocLinks.clients.pythonGettingStarted;
+    this.pythonBasicConfig = newDocLinks.serverlessClients.pythonGettingStarted;
     this.pythonClient = newDocLinks.serverlessClients.pythonGettingStarted;
     // Python
     this.rubyBasicConfig = newDocLinks.serverlessClients.rubyGettingStarted;


### PR DESCRIPTION
## Summary

When the Python client is selected, this link sends the user to a doc that isn't relevant to serverless. Replace with a relevant link.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)