### PR TITLE
[Enterprise Search] fix: use full path for search apps nav url

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -63,7 +63,7 @@ describe('useEnterpriseSearchContentNav', () => {
         id: 'applications',
         items: [
           {
-            href: '/app/enterprise_search/applications',
+            href: '/app/enterprise_search/applications/search_applications',
             id: 'searchApplications',
             name: 'Search Applications',
           },
@@ -226,7 +226,7 @@ describe('useEnterpriseSearchApplicationNav', () => {
         id: 'applications',
         items: [
           {
-            href: '/app/enterprise_search/applications',
+            href: '/app/enterprise_search/applications/search_applications',
             id: 'searchApplications',
             name: 'Search Applications',
           },
@@ -413,7 +413,7 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
       id: 'applications',
       items: [
         {
-          href: '/app/enterprise_search/applications',
+          href: '/app/enterprise_search/applications/search_applications',
           id: 'searchApplications',
           name: 'Search Applications',
         },

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -78,7 +78,7 @@ export const useEnterpriseSearchNav = () => {
           }),
           ...generateNavLink({
             shouldNotCreateHref: true,
-            to: APPLICATIONS_PLUGIN.URL,
+            to: APPLICATIONS_PLUGIN.URL + SEARCH_APPLICATIONS_PATH,
           }),
         },
         {


### PR DESCRIPTION
## Summary

Updated the left nav `to` path for search applications to match the full path so the isActive check can pass instead of used the base path to redirect.

![image](https://github.com/elastic/kibana/assets/1972968/9b8ac4fa-8896-43d5-825c-39f5b38d48ee)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->