### PR TITLE
[Security Solution] cut off rule description text if too long

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
@@ -9,6 +9,7 @@ import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eu
 import type { FC } from 'react';
 import React, { useMemo, useCallback } from 'react';
 import { isEmpty } from 'lodash';
+import { css } from '@emotion/react';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
@@ -119,7 +120,17 @@ export const Description: FC = () => {
         </EuiTitle>
       </EuiFlexItem>
       <EuiFlexItem data-test-subj={DESCRIPTION_DETAILS_TEST_ID}>
-        {isAlert ? alertRuleDescription : '-'}
+        <p
+          css={css`
+            word-break: break-word;
+            display: -webkit-box;
+            -webkit-line-clamp: 2;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+          `}
+        >
+          {isAlert ? alertRuleDescription : '-'}
+        </p>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
@@ -124,7 +124,7 @@ export const Description: FC = () => {
           css={css`
             word-break: break-word;
             display: -webkit-box;
-            -webkit-line-clamp: 2;
+            -webkit-line-clamp: 3;
             -webkit-box-orient: vertical;
             overflow: hidden;
           `}


### PR DESCRIPTION
## Summary

We're adding back a functionality that was removed in this previous [PR](https://github.com/elastic/kibana/pull/162821). The functionality consists of cutting off the rule description text if it is too long, in order to limit the height impact of that component within the expandable flyout right panel.

| Short description  | Long description |
| ------------- | ------------- |
| ![Screenshot 2023-10-16 at 4 04 15 PM](https://github.com/elastic/kibana/assets/17276605/d1316edf-00c6-4858-b2de-c7c8eb135973)  | ![Screenshot 2023-10-16 at 4 04 22 PM](https://github.com/elastic/kibana/assets/17276605/90263f8c-7236-4fce-ab12-c1d697d2c2ee)  |

The ellipsis should appear only if the description is too long: currently this is set to 2 lines. @ferenrigue how many lines do we want?

https://github.com/elastic/security-team/issues/7849