### PR TITLE
Fix watcher simulation crash

### DIFF
--- a/x-pack/plugins/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/simulate_watch_results_flyout.tsx
+++ b/x-pack/plugins/watcher/public/application/sections/watch_edit_page/components/json_watch_edit/simulate_watch_results_flyout.tsx
@@ -81,6 +81,7 @@ export const SimulateWatchResultsFlyout = ({
       return Object.keys(actions).map((actionKey) => {
         const actionStatus = actionStatuses.find((status) => status.id === actionKey);
         const isConditionMet = executeResults.details?.result?.condition.met;
+
         return {
           actionId: actionKey,
           actionType: getTypeFromAction(actions[actionKey]),
@@ -90,7 +91,7 @@ export const SimulateWatchResultsFlyout = ({
           actionStatus:
             (isConditionMet &&
               executeResults.details.result.actions.find((action: any) => action.id === actionKey)
-                .status) ||
+                ?.status) ||
             conditionNotMetActionStatus(actionModes[actionKey]),
         };
       });


### PR DESCRIPTION
## Summary
Closes #163881 

See issue for reproducing. This would have been caught by TS, but the type is `any`:

https://github.com/elastic/kibana/blob/d0e99258c68d57bc83788724814783ece176aa78/x-pack/plugins/watcher/common/types/watch_types.ts#L11

The better fix would be to update the type as well, but I'm not familiar with the shape of the data returned, so I opted not to.

## Release note
Fixes crash when simulating a watch that contains a Painless script with a Debug.explain().

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->