### PR TITLE
[8.11] Add namespaceType to SavedObjectModelTransformationContext (#168489)

### DIFF
--- a/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/build_transform_fn.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-base-server-internal/src/model_version/build_transform_fn.test.ts
@@ -22,6 +22,7 @@ describe('buildModelVersionTransformFn', () => {
   const createContext = (): SavedObjectModelTransformationContext => ({
     log: loggerMock.create(),
     modelVersion: 42,
+    namespaceType: 'single',
   });
 
   const createDoc = <T = any>(attributes: T = {} as T): SavedObjectModelTransformationDoc<T> => ({

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.test.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.test.ts
@@ -112,6 +112,7 @@ describe('convertModelVersionTransformFn', () => {
   };
 
   it('generates a transform function calling the model transform', () => {
+    const typeDefinition = createType({});
     const upTransform = createModelTransformFn();
 
     const definition: SavedObjectsModelVersion = {
@@ -127,13 +128,14 @@ describe('convertModelVersionTransformFn', () => {
       log,
       modelVersion: 1,
       virtualVersion: '10.1.0',
-      definition,
+      modelVersionDefinition: definition,
+      typeDefinition,
     });
 
     expect(upTransform).not.toHaveBeenCalled();
 
     const doc = createDoc();
-    const context = { log, modelVersion: 1 };
+    const context = { log, modelVersion: 1, namespaceType: typeDefinition.namespaceType };
 
     transform(doc);
 
@@ -142,6 +144,7 @@ describe('convertModelVersionTransformFn', () => {
   });
 
   it('generates a transform function calling all model transforms of the version', () => {
+    const typeDefinition = createType({});
     const upTransform1 = createModelTransformFn();
     const upTransform2 = createModelTransformFn();
 
@@ -162,11 +165,12 @@ describe('convertModelVersionTransformFn', () => {
       log,
       modelVersion: 1,
       virtualVersion: '10.1.0',
-      definition,
+      typeDefinition,
+      modelVersionDefinition: definition,
     });
 
     const doc = createDoc();
-    const context = { log, modelVersion: 1 };
+    const context = { log, modelVersion: 1, namespaceType: typeDefinition.namespaceType };
 
     transform(doc);
 

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.ts
@@ -61,10 +61,11 @@ export const getModelVersionTransforms = ({
     return {
       version: virtualVersion,
       transform: convertModelVersionTransformFn({
+        typeDefinition,
         log,
         modelVersion,
         virtualVersion,
-        definition,
+        modelVersionDefinition: definition,
       }),
       transformType: TransformType.Migrate,
     };
@@ -72,21 +73,24 @@ export const getModelVersionTransforms = ({
 };
 
 export const convertModelVersionTransformFn = ({
+  typeDefinition,
   virtualVersion,
   modelVersion,
-  definition,
+  modelVersionDefinition,
   log,
 }: {
+  typeDefinition: SavedObjectsType;
   virtualVersion: string;
   modelVersion: number;
-  definition: SavedObjectsModelVersion;
+  modelVersionDefinition: SavedObjectsModelVersion;
   log: Logger;
 }): TransformFn => {
   const context: SavedObjectModelTransformationContext = {
     log,
     modelVersion,
+    namespaceType: typeDefinition.namespaceType,
   };
-  const modelTransformFn = buildModelVersionTransformFn(definition.changes);
+  const modelTransformFn = buildModelVersionTransformFn(modelVersionDefinition.changes);
 
   return function convertedTransform(doc: SavedObjectUnsanitizedDoc) {
     try {

--- a/packages/core/saved-objects/core-saved-objects-server/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/index.ts
@@ -133,7 +133,6 @@ export type {
   SavedObjectModelTransformationDoc,
   SavedObjectModelTransformationContext,
   SavedObjectModelTransformationFn,
-  SavedObjectModelBidirectionalTransformation,
   SavedObjectModelTransformationResult,
   SavedObjectModelDataBackfillFn,
   SavedObjectModelDataBackfillResult,

--- a/packages/core/saved-objects/core-saved-objects-server/src/model_version/index.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/model_version/index.ts
@@ -25,7 +25,6 @@ export type {
   SavedObjectModelTransformationDoc,
   SavedObjectModelTransformationContext,
   SavedObjectModelTransformationFn,
-  SavedObjectModelBidirectionalTransformation,
   SavedObjectModelTransformationResult,
   SavedObjectModelDataBackfillFn,
   SavedObjectModelDataBackfillResult,

--- a/packages/core/saved-objects/core-saved-objects-server/src/model_version/transformations.ts
+++ b/packages/core/saved-objects/core-saved-objects-server/src/model_version/transformations.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { SavedObjectsNamespaceType } from '@kbn/core-saved-objects-common';
 import type { SavedObjectUnsanitizedDoc } from '../serialization';
 import type { SavedObjectsMigrationLogger } from '../migration';
 
@@ -30,6 +31,10 @@ export interface SavedObjectModelTransformationContext {
    * The model version this migration is registered for
    */
   readonly modelVersion: number;
+  /**
+   * The namespace type of the savedObject type this migration is registered for
+   */
+  readonly namespaceType: SavedObjectsNamespaceType;
 }
 
 /**
@@ -56,29 +61,6 @@ export type SavedObjectModelTransformationFn<
   document: SavedObjectModelTransformationDoc<InputAttributes>,
   context: SavedObjectModelTransformationContext
 ) => SavedObjectModelTransformationResult<OutputAttributes>;
-
-/**
- * A bidirectional transformation.
- *
- * Bidirectional transformations define migration functions that can be used to
- * transform a document from the lower version to the higher one (`up`), and
- * the other way around, from the higher version to the lower one (`down`)
- *
- * @public
- */
-export interface SavedObjectModelBidirectionalTransformation<
-  PreviousAttributes = unknown,
-  NewAttributes = unknown
-> {
-  /**
-   * The upward (previous=>next) transformation.
-   */
-  up: SavedObjectModelTransformationFn<PreviousAttributes, NewAttributes>;
-  /**
-   * The downward (next=>previous) transformation.
-   */
-  down: SavedObjectModelTransformationFn<NewAttributes, PreviousAttributes>;
-}
 
 /**
  * Return type for the {@link SavedObjectModelTransformationFn | transformation functions}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [Add namespaceType to SavedObjectModelTransformationContext (#168489)](https://github.com/elastic/kibana/pull/168489)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2023-10-11T10:21:15Z","message":"Add namespaceType to SavedObjectModelTransformationContext (#168489)\n\n## Summary\r\n\r\nRequired for https://github.com/elastic/kibana/issues/161002\r\n\r\nAdd `namespaceType` to the SO migration context that is passed down to\r\nMV transformation functions\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3afef435deb1d6b2667b0b676b2e5897c0a07ec6","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Core","Feature:Saved Objects","release_note:skip","backport:skip","Feature:Migrations","v8.12.0"],"number":168489,"url":"https://github.com/elastic/kibana/pull/168489","mergeCommit":{"message":"Add namespaceType to SavedObjectModelTransformationContext (#168489)\n\n## Summary\r\n\r\nRequired for https://github.com/elastic/kibana/issues/161002\r\n\r\nAdd `namespaceType` to the SO migration context that is passed down to\r\nMV transformation functions\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3afef435deb1d6b2667b0b676b2e5897c0a07ec6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/168489","number":168489,"mergeCommit":{"message":"Add namespaceType to SavedObjectModelTransformationContext (#168489)\n\n## Summary\r\n\r\nRequired for https://github.com/elastic/kibana/issues/161002\r\n\r\nAdd `namespaceType` to the SO migration context that is passed down to\r\nMV transformation functions\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"3afef435deb1d6b2667b0b676b2e5897c0a07ec6"}}]}] BACKPORT-->