### PR TITLE
[ML] Transform: Reenable/Fix cloning tests

### DIFF
--- a/x-pack/test/functional/apps/transform/edit_clone/cloning.ts
+++ b/x-pack/test/functional/apps/transform/edit_clone/cloning.ts
@@ -190,7 +190,7 @@ export default function ({ getService }: FtrProviderContext) {
   const transform = getService('transform');
 
   // Failing: See https://github.com/elastic/kibana/issues/165883
-  describe.skip('cloning', function () {
+  describe('cloning', function () {
     const transformConfigWithPivot = getTransformConfig();
     const transformConfigWithRuntimeMapping = getTransformConfigWithRuntimeMappings();
     const transformConfigWithBoolFilterAgg = getTransformConfigWithBoolFilterAgg();

--- a/x-pack/test/functional/services/transform/transform_table.ts
+++ b/x-pack/test/functional/services/transform/transform_table.ts
@@ -7,6 +7,8 @@
 
 import expect from '@kbn/expect';
 
+import { WebElementWrapper } from '../../../../../test/functional/services/lib/web_element_wrapper';
+
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 type TransformRowActionName =
@@ -19,10 +21,11 @@ type TransformRowActionName =
   | 'Stop'
   | 'Reauthorize';
 
-export function TransformTableProvider({ getService }: FtrProviderContext) {
+export function TransformTableProvider({ getPageObject, getService }: FtrProviderContext) {
   const find = getService('find');
   const retry = getService('retry');
   const testSubjects = getService('testSubjects');
+  const commonPage = getPageObject('common');
   const browser = getService('browser');
   const ml = getService('ml');
 
@@ -89,20 +92,47 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
       await this.waitForRefreshButtonLoaded();
       await testSubjects.click('~transformRefreshTransformListButton');
       await this.waitForRefreshButtonLoaded();
-      await this.waitForTransformsToLoad();
+      await this.waitForTransformsTableToLoad();
     }
 
-    public async waitForTransformsToLoad() {
+    public async waitForTransformsTableToStartLoading() {
+      await testSubjects.existOrFail(`~transformListTable`, { timeout: 60 * 1000 });
+
+      // After invoking an action that caused the table to start loading, the loading
+      // should start quickly after the table exists. Sometimes it is even so quick that
+      // the loading is already done when we try to check for it, so we're not failing
+      // in that case and just move on.
+      await testSubjects.exists(`transformListTable loading`, { timeout: 3 * 1000 });
+    }
+
+    public async waitForTransformsTableToLoad() {
       await testSubjects.existOrFail('~transformListTable', { timeout: 60 * 1000 });
       await testSubjects.existOrFail('transformListTable loaded', { timeout: 30 * 1000 });
     }
 
-    public async filterWithSearchString(filter: string, expectedRowCount: number = 1) {
-      await this.waitForTransformsToLoad();
+    async getSearchInput(): Promise<WebElementWrapper> {
       const tableListContainer = await testSubjects.find('transformListTableContainer');
-      const searchBarInput = await tableListContainer.findByClassName('euiFieldSearch');
+      return await tableListContainer.findByClassName('euiFieldSearch');
+    }
+
+    public async assertSearchInputValue(expectedSearchValue: string) {
+      const searchBarInput = await this.getSearchInput();
+      const actualSearchValue = await searchBarInput.getAttribute('value');
+      expect(actualSearchValue).to.eql(
+        expectedSearchValue,
+        `Search input value should be '${expectedSearchValue}' (got '${actualSearchValue}')`
+      );
+    }
+
+    public async filterWithSearchString(filter: string, expectedRowCount: number = 1) {
+      await this.waitForTransformsTableToLoad();
+      const searchBarInput = await this.getSearchInput();
       await searchBarInput.clearValueWithKeyboard();
       await searchBarInput.type(filter);
+      await commonPage.pressEnterKey();
+      await this.assertSearchInputValue(filter);
+      await this.waitForTransformsTableToStartLoading();
+      await this.waitForTransformsTableToLoad();
 
       const rows = await this.parseTransformTable();
       const filteredRows = rows.filter((row) => row.id === filter);
@@ -113,7 +143,7 @@ export function TransformTableProvider({ getService }: FtrProviderContext) {
     }
 
     public async clearSearchString(expectedRowCount: number = 1) {
-      await this.waitForTransformsToLoad();
+      await this.waitForTransformsTableToLoad();
       const tableListContainer = await testSubjects.find('transformListTableContainer');
       const searchBarInput = await tableListContainer.findByClassName('euiFieldSearch');
       await searchBarInput.clearValueWithKeyboard();


### PR DESCRIPTION
## Summary

Fixes #165883.

Reenables/fixes the cloning tests. Stabilises table assertions by bringing the code in line with the assertions done in the `ml` plugin (taken from here #141775).

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->