### PR TITLE
[8.10] [Reporting] Add protocolTimeout to screenshotting plugin (#167335)

### DIFF
--- a/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
+++ b/x-pack/plugins/screenshotting/server/browsers/chromium/driver_factory/index.ts
@@ -167,6 +167,7 @@ export class HeadlessChromiumDriverFactory {
               TZ: browserTimezone,
             },
             headless: 'new',
+            protocolTimeout: 0,
           });
         } catch (err) {
           observer.error(


### PR DESCRIPTION
I missed the backport label for https://github.com/elastic/kibana/pull/167335