### PR TITLE
[Enterprise Search]Render native connector docs conditionally

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/research_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/research_configuration.tsx
@@ -44,17 +44,19 @@ export const ResearchConfiguration: React.FC<ResearchConfigurationProps> = ({
             )}
           </EuiLink>
         </EuiFlexItem>
-        <EuiFlexItem grow={false}>
-          <EuiLink target="_blank" href={externalDocsUrl}>
-            {i18n.translate(
-              'xpack.enterpriseSearch.content.indices.configurationConnector.researchConfiguration.serviceDocumentationLinkLabel',
-              {
-                defaultMessage: '{name} documentation',
-                values: { name },
-              }
-            )}
-          </EuiLink>
-        </EuiFlexItem>
+        {externalDocsUrl && (
+          <EuiFlexItem grow={false}>
+            <EuiLink target="_blank" href={externalDocsUrl}>
+              {i18n.translate(
+                'xpack.enterpriseSearch.content.indices.configurationConnector.researchConfiguration.serviceDocumentationLinkLabel',
+                {
+                  defaultMessage: '{name} documentation',
+                  values: { name },
+                }
+              )}
+            </EuiLink>
+          </EuiFlexItem>
+        )}
       </EuiFlexGroup>
     </>
   );


### PR DESCRIPTION
## Summary

<img width="772" alt="Screenshot 2023-10-17 at 16 36 45" src="https://github.com/elastic/kibana/assets/1410658/f668ab82-485d-46a6-8598-c1c9973b6255">

## Release Note
External documentation links are rendered conditionally now to avoid empty links.

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->