### PR TITLE
[OAS] Bundle security OAS files

### DIFF
--- a/x-pack/plugins/security_solution/common/api/README.md
+++ b/x-pack/plugins/security_solution/common/api/README.md
@@ -1,0 +1,48 @@
+To generate the files in the bundles directory, which have the shared components added to each file, 
+[install redocly CLI](https://redocly.com/docs/cli/installation/) and run this bundle command:
+
+npx @redocly/cli bundle --output bundles --ext json \
+endpoint/actions/actions.schema.yaml \
+endpoint/actions/actions_status.schema.yaml \
+endpoint/actions/audit_log.schema.yaml \
+endpoint/actions/details.schema.yaml \
+endpoint/actions/execute.schema.yaml \
+endpoint/actions/file_download.schema.yaml \
+endpoint/actions/file_info.schema.yaml \
+endpoint/actions/file_upload.schema.yaml \
+endpoint/actions/get_file.schema.yaml \
+endpoint/actions/list.schema.yaml \
+endpoint/metadata/metadata.schema.yaml \
+endpoint/policy/policy.schema.yaml \
+endpoint/suggestions/get_suggestions.schema.yaml \
+detection_engine/prebuilt_rules/get_prebuilt_rules_and_timelines_status/get_prebuilt_rules_and_timelines_status_route.schema.yaml \
+detection_engine/prebuilt_rules/install_prebuilt_rules_and_timelines/install_prebuilt_rules_and_timelines_route.schema.yaml \
+detection_engine/rule_management/bulk_actions/bulk_actions_route.schema.yaml \
+detection_engine/rule_management/bulk_crud/bulk_create_rules/bulk_create_rules_route.schema.yaml \
+detection_engine/rule_management/bulk_crud/bulk_delete_rules/bulk_delete_rules_route.schema.yaml \
+detection_engine/rule_management/bulk_crud/bulk_patch_rules/bulk_patch_rules_route.schema.yaml \
+detection_engine/rule_management/bulk_crud/bulk_update_rules/bulk_update_rules_route.schema.yaml \
+detection_engine/rule_management/crud/create_rule/create_rule_route.schema.yaml \
+detection_engine/rule_management/crud/delete_rule/delete_rule_route.schema.yaml \
+detection_engine/rule_management/crud/patch_rule/patch_rule_route.schema.yaml \
+detection_engine/rule_management/crud/read_rule/read_rule_route.schema.yaml \
+detection_engine/rule_management/crud/update_rule/update_rule_route.schema.yaml \
+detection_engine/rule_management/export_rules/export_rules_route.schema.yaml \
+detection_engine/rule_management/import_rules/import_rules_route.schema.yaml \
+detection_engine/rule_management/read_tags/read_tags_route.schema.yaml \
+detection_engine/rule_monitoring/rule_execution_logs/get_rule_execution_events/get_rule_execution_events_route.schema.yaml \
+detection_engine/rule_monitoring/rule_execution_logs/get_rule_execution_results/get_rule_execution_results_route.schema.yaml \
+timeline/clean_draft_timelines/clean_draft_timelines_route_schema.yaml \
+timeline/create_timelines/create_timelines_route_schema.yaml \
+timeline/delete_note/delete_note_route_schema.yaml \
+timeline/delete_timelines/delete_timelines_route_schema.yaml \
+timeline/export_timelines/export_timelines_route_schema.yaml \
+timeline/get_draft_timelines/get_draft_timelines_route_schema.yaml \
+timeline/get_timeline/get_timeline_route_schema.yaml \
+timeline/get_timelines/get_timelines_route_schema.yaml \
+timeline/import_timelines/import_timelines_route_schema.yaml \
+timeline/install_prepackaged_timelines/install_prepackaged_timelines_route_schema.yaml \
+timeline/patch_timelines/patch_timeline_route_schema.yaml \
+timeline/persist_favorite/persist_favorite_route_schema.yaml \
+timeline/persist_note/persist_note_route_schema.yaml \
+timeline/pinned_events/pinned_events_route_schema.yaml

--- a/x-pack/plugins/security_solution/common/api/bundles/actions.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/actions.schema.json
@@ -1,0 +1,273 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Endpoint Actions Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/state": {
+      "get": {
+        "summary": "Get Action State schema",
+        "operationId": "EndpointGetActionsState",
+        "x-codegen-enabled": false,
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/action/running_procs": {
+      "post": {
+        "summary": "Get Running Processes Action",
+        "operationId": "EndpointGetRunningProcessesAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BaseActionSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/action/isolate": {
+      "post": {
+        "summary": "Isolate host Action",
+        "operationId": "EndpointIsolateHostAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BaseActionSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/action/unisolate": {
+      "post": {
+        "summary": "Unisolate host Action",
+        "operationId": "EndpointUnisolateHostAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BaseActionSchema"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/action/kill_process": {
+      "post": {
+        "summary": "Kill process Action",
+        "operationId": "EndpointKillProcessAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessActionSchemas"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/action/suspend_process": {
+      "post": {
+        "summary": "Suspend process Action",
+        "operationId": "EndpointSuspendProcessAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProcessActionSchemas"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "EndpointIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "List of endpoint IDs (cannot contain empty strings)"
+      },
+      "AlertIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "If defined, any case associated with the given IDs will be updated (cannot contain empty strings)"
+      },
+      "CaseIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "Case IDs to be updated (cannot contain empty strings)"
+      },
+      "Comment": {
+        "type": "string",
+        "description": "Optional comment"
+      },
+      "Parameters": {
+        "type": "object",
+        "description": "Optional parameters object"
+      },
+      "BaseActionSchema": {
+        "type": "object",
+        "properties": {
+          "endpoint_ids": {
+            "$ref": "#/components/schemas/EndpointIds"
+          },
+          "alert_ids": {
+            "$ref": "#/components/schemas/AlertIds"
+          },
+          "case_ids": {
+            "$ref": "#/components/schemas/CaseIds"
+          },
+          "comment": {
+            "$ref": "#/components/schemas/Comment"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/Parameters"
+          }
+        }
+      },
+      "ProcessActionSchemas": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseActionSchema"
+          },
+          {
+            "type": "object",
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "pid": {
+                        "type": "integer",
+                        "minimum": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "entity_id": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/actions_status.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/actions_status.schema.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Get Action status schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action_status": {
+      "get": {
+        "summary": "Get Actions status schema",
+        "operationId": "EndpointGetActionsStatus",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "agent_ids": {
+                  "$ref": "#/components/schemas/AgentIds"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AgentIds": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "minLength": 1
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/audit_log.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/audit_log.schema.json
@@ -1,0 +1,104 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Audit Log Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action_log/{agent_id}": {
+      "get": {
+        "summary": "Get action audit log schema",
+        "operationId": "EndpointGetActionAuditLog",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AuditLogRequestQuery"
+            }
+          },
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AuditLogRequestParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AuditLogRequestQuery": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "$ref": "#/components/schemas/Page"
+          },
+          "page_size": {
+            "$ref": "#/components/schemas/PageSize"
+          },
+          "start_date": {
+            "$ref": "#/components/schemas/StartDate"
+          },
+          "end_date": {
+            "$ref": "#/components/schemas/EndDate"
+          }
+        }
+      },
+      "AuditLogRequestParams": {
+        "type": "object",
+        "properties": {
+          "agent_id": {
+            "$ref": "#/components/schemas/AgentId"
+          }
+        }
+      },
+      "Page": {
+        "type": "integer",
+        "default": 1,
+        "minimum": 1,
+        "description": "Page number"
+      },
+      "PageSize": {
+        "type": "integer",
+        "default": 10,
+        "minimum": 1,
+        "maximum": 100,
+        "description": "Number of items per page"
+      },
+      "StartDate": {
+        "type": "string",
+        "description": "Start date"
+      },
+      "EndDate": {
+        "type": "string",
+        "description": "End date"
+      },
+      "AgentId": {
+        "type": "string",
+        "description": "Agent ID"
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/bulk_actions_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/bulk_actions_route.schema.json
@@ -1,0 +1,718 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bulk Actions API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_bulk_action": {
+      "post": {
+        "operationId": "PerformBulkAction",
+        "x-codegen-enabled": false,
+        "summary": "Applies a bulk action to multiple rules",
+        "description": "The bulk action is applied to all rules that match the filter or to the list of rules by their IDs.",
+        "tags": [
+          "Bulk API"
+        ],
+        "parameters": [
+          {
+            "name": "dry_run",
+            "in": "query",
+            "description": "Enables dry run mode for the request call.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PerformBulkActionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BulkEditActionResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "x-codegen-enabled": false,
+    "schemas": {
+      "BulkEditSkipReason": {
+        "type": "string",
+        "enum": [
+          "RULE_NOT_MODIFIED"
+        ]
+      },
+      "BulkActionSkipResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "skip_reason": {
+            "$ref": "#/components/schemas/BulkEditSkipReason"
+          }
+        },
+        "required": [
+          "id",
+          "skip_reason"
+        ]
+      },
+      "RuleDetailsInError": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id"
+        ]
+      },
+      "BulkActionsDryRunErrCode": {
+        "type": "string"
+      },
+      "NormalizedRuleError": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "status_code": {
+            "type": "integer"
+          },
+          "err_code": {
+            "$ref": "#/components/schemas/BulkActionsDryRunErrCode"
+          },
+          "rules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleDetailsInError"
+            }
+          }
+        },
+        "required": [
+          "message",
+          "status_code",
+          "rules"
+        ]
+      },
+      "BulkEditActionResults": {
+        "type": "object",
+        "properties": {
+          "updated": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleResponse"
+            }
+          },
+          "created": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleResponse"
+            }
+          },
+          "deleted": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RuleResponse"
+            }
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkActionSkipResult"
+            }
+          }
+        },
+        "required": [
+          "updated",
+          "created",
+          "deleted",
+          "skipped"
+        ]
+      },
+      "BulkEditActionSummary": {
+        "type": "object",
+        "properties": {
+          "failed": {
+            "type": "integer"
+          },
+          "skipped": {
+            "type": "integer"
+          },
+          "succeeded": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "failed",
+          "skipped",
+          "succeeded",
+          "total"
+        ]
+      },
+      "BulkEditActionSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "rules_count": {
+            "type": "integer"
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "results": {
+                "$ref": "#/components/schemas/BulkEditActionResults"
+              },
+              "summary": {
+                "$ref": "#/components/schemas/BulkEditActionSummary"
+              }
+            },
+            "required": [
+              "results",
+              "summary"
+            ]
+          }
+        },
+        "required": [
+          "success",
+          "rules_count",
+          "attributes"
+        ]
+      },
+      "BulkEditActionErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status_code": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "results": {
+                "$ref": "#/components/schemas/BulkEditActionResults"
+              },
+              "summary": {
+                "$ref": "#/components/schemas/BulkEditActionSummary"
+              },
+              "errors": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NormalizedRuleError"
+                }
+              }
+            },
+            "required": [
+              "results",
+              "summary"
+            ]
+          }
+        },
+        "required": [
+          "status_code",
+          "message",
+          "attributes"
+        ]
+      },
+      "BulkEditActionResponse": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BulkEditActionSuccessResponse"
+          },
+          {
+            "$ref": "#/components/schemas/BulkEditActionErrorResponse"
+          }
+        ]
+      },
+      "BulkActionBase": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "query": {
+                "type": "string",
+                "description": "Query to filter rules"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "ids": {
+                "type": "array",
+                "description": "Array of rule IDs",
+                "minItems": 1,
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      },
+      "BulkDeleteRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "delete"
+                ]
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        ]
+      },
+      "BulkDisableRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "disable"
+                ]
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        ]
+      },
+      "BulkEnableRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "enable"
+                ]
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        ]
+      },
+      "BulkExportRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "export"
+                ]
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        ]
+      },
+      "BulkDuplicateRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "enum": [
+                  "duplicate"
+                ]
+              },
+              "duplicate": {
+                "type": "object",
+                "properties": {
+                  "include_exceptions": {
+                    "type": "boolean",
+                    "description": "Whether to copy exceptions from the original rule"
+                  },
+                  "include_expired_exceptions": {
+                    "type": "boolean",
+                    "description": "Whether to copy expired exceptions from the original rule"
+                  }
+                }
+              }
+            },
+            "required": [
+              "action"
+            ]
+          }
+        ]
+      },
+      "RuleActionSummary": {
+        "type": "boolean",
+        "description": "Action summary indicates whether we will send a summary notification about all the generate alerts or notification per individual alert"
+      },
+      "RuleActionNotifyWhen": {
+        "type": "string",
+        "description": "The condition for throttling the notification: 'onActionGroupChange', 'onActiveAlert',  or 'onThrottleInterval'",
+        "enum": [
+          "onActionGroupChange",
+          "onActiveAlert",
+          "onThrottleInterval"
+        ]
+      },
+      "RuleActionThrottle": {
+        "type": "string",
+        "description": "The condition for throttling the notification: 'rule', 'no_actions', or time duration"
+      },
+      "RuleActionFrequency": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/RuleActionSummary"
+          },
+          "notifyWhen": {
+            "$ref": "#/components/schemas/RuleActionNotifyWhen"
+          },
+          "throttle": {
+            "$ref": "#/components/schemas/RuleActionThrottle",
+            "nullable": true
+          }
+        }
+      },
+      "BulkActionType": {
+        "type": "string",
+        "enum": [
+          "enable",
+          "disable",
+          "export",
+          "delete",
+          "duplicate",
+          "edit"
+        ]
+      },
+      "BulkActionEditType": {
+        "type": "string",
+        "enum": [
+          "add_tags",
+          "delete_tags",
+          "set_tags",
+          "add_index_patterns",
+          "delete_index_patterns",
+          "set_index_patterns",
+          "set_timeline",
+          "add_rule_actions",
+          "set_rule_actions",
+          "set_schedule"
+        ]
+      },
+      "BulkActionEditPayloadRuleActions": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "add_rule_actions",
+              "set_rule_actions"
+            ]
+          },
+          "value": {
+            "type": "object",
+            "properties": {
+              "throttle": {
+                "$ref": "#/components/schemas/RuleActionThrottle"
+              },
+              "actions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "description": "Action group"
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Action ID"
+                    },
+                    "params": {
+                      "type": "object",
+                      "description": "Action parameters"
+                    },
+                    "frequency": {
+                      "$ref": "#/components/schemas/RuleActionFrequency",
+                      "description": "Action frequency"
+                    }
+                  },
+                  "required": [
+                    "group",
+                    "id",
+                    "params"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "actions"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      },
+      "BulkActionEditPayloadSchedule": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "set_schedule"
+            ]
+          },
+          "value": {
+            "type": "object",
+            "properties": {
+              "interval": {
+                "type": "string",
+                "description": "Interval in which the rule is executed"
+              },
+              "lookback": {
+                "type": "string",
+                "description": "Lookback time for the rule"
+              }
+            },
+            "required": [
+              "interval",
+              "lookback"
+            ]
+          }
+        }
+      },
+      "BulkActionEditPayloadIndexPatterns": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "add_index_patterns",
+              "delete_index_patterns",
+              "set_index_patterns"
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/IndexPatternArray"
+          },
+          "overwrite_data_views": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      },
+      "BulkActionEditPayloadTags": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "add_tags",
+              "delete_tags",
+              "set_tags"
+            ]
+          },
+          "value": {
+            "$ref": "#/components/schemas/RuleTagArray"
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      },
+      "BulkActionEditPayloadTimeline": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "set_timeline"
+            ]
+          },
+          "value": {
+            "type": "object",
+            "properties": {
+              "timeline_id": {
+                "$ref": "#/components/schemas/TimelineTemplateId"
+              },
+              "timeline_title": {
+                "$ref": "#/components/schemas/TimelineTemplateTitle"
+              }
+            },
+            "required": [
+              "timeline_id",
+              "timeline_title"
+            ]
+          }
+        },
+        "required": [
+          "type",
+          "value"
+        ]
+      },
+      "BulkActionEditPayload": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionEditPayloadTags"
+          },
+          {
+            "$ref": "#/components/schemas/BulkActionEditPayloadIndexPatterns"
+          },
+          {
+            "$ref": "#/components/schemas/BulkActionEditPayloadTimeline"
+          },
+          {
+            "$ref": "#/components/schemas/BulkActionEditPayloadRuleActions"
+          },
+          {
+            "$ref": "#/components/schemas/BulkActionEditPayloadSchedule"
+          }
+        ]
+      },
+      "BulkEditRules": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BulkActionBase"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "action": {
+                "type": "string",
+                "x-type": "literal",
+                "enum": [
+                  "edit"
+                ]
+              },
+              "edit": {
+                "type": "array",
+                "description": "Array of objects containing the edit operations",
+                "items": {
+                  "$ref": "#/components/schemas/BulkActionEditPayload"
+                }
+              }
+            },
+            "required": [
+              "action",
+              "rule"
+            ]
+          }
+        ]
+      },
+      "PerformBulkActionRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BulkDeleteRules"
+          },
+          {
+            "$ref": "#/components/schemas/BulkDisableRules"
+          },
+          {
+            "$ref": "#/components/schemas/BulkEnableRules"
+          },
+          {
+            "$ref": "#/components/schemas/BulkExportRules"
+          },
+          {
+            "$ref": "#/components/schemas/BulkDuplicateRules"
+          },
+          {
+            "$ref": "#/components/schemas/BulkEditRules"
+          }
+        ]
+      },
+      "RuleTagArray": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "IndexPatternArray": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "TimelineTemplateId": {
+        "type": "string"
+      },
+      "TimelineTemplateTitle": {
+        "type": "string"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/bulk_create_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/bulk_create_rules_route.schema.json
@@ -1,0 +1,112 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bulk Create API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_bulk_create": {
+      "post": {
+        "operationId": "CreateRulesBulk",
+        "x-codegen-enabled": false,
+        "deprecated": true,
+        "description": "Creates new detection rules in bulk.",
+        "tags": [
+          "Bulk API"
+        ],
+        "requestBody": {
+          "description": "A JSON array of rules, where each rule contains the required fields.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RuleCreateProps"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCrudRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleCreateProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      },
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "ErrorSchema": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/RuleSignatureId"
+          },
+          "list_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "item_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "status_code",
+              "message"
+            ],
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "minimum": 400
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BulkCrudRulesResponse": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/RuleResponse"
+            },
+            {
+              "$ref": "#/components/schemas/ErrorSchema"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/bulk_delete_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/bulk_delete_rules_route.schema.json
@@ -1,0 +1,120 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bulk Delete API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_bulk_delete": {
+      "delete": {
+        "operationId": "DeleteRulesBulk",
+        "x-codegen-enabled": false,
+        "deprecated": true,
+        "description": "Deletes multiple rules.",
+        "tags": [
+          "Bulk API"
+        ],
+        "requestBody": {
+          "description": "A JSON array of `id` or `rule_id` fields of the rules you want to delete.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "$ref": "#/components/schemas/RuleObjectId"
+                    },
+                    "rule_id": {
+                      "$ref": "#/components/schemas/RuleSignatureId"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCrudRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleObjectId": {
+        "type": "string"
+      },
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "RuleResponse": {
+        "type": "object"
+      },
+      "ErrorSchema": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/RuleSignatureId"
+          },
+          "list_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "item_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "status_code",
+              "message"
+            ],
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "minimum": 400
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BulkCrudRulesResponse": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/RuleResponse"
+            },
+            {
+              "$ref": "#/components/schemas/ErrorSchema"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/bulk_patch_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/bulk_patch_rules_route.schema.json
@@ -1,0 +1,112 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bulk Patch API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_bulk_update": {
+      "patch": {
+        "operationId": "PatchRulesBulk",
+        "x-codegen-enabled": false,
+        "deprecated": true,
+        "description": "Updates multiple rules using the `PATCH` method.",
+        "tags": [
+          "Bulk API"
+        ],
+        "requestBody": {
+          "description": "A JSON array of rules, where each rule contains the required fields.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RulePatchProps"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCrudRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RulePatchProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      },
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "ErrorSchema": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/RuleSignatureId"
+          },
+          "list_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "item_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "status_code",
+              "message"
+            ],
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "minimum": 400
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BulkCrudRulesResponse": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/RuleResponse"
+            },
+            {
+              "$ref": "#/components/schemas/ErrorSchema"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/bulk_update_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/bulk_update_rules_route.schema.json
@@ -1,0 +1,112 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Bulk Update API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_bulk_update": {
+      "put": {
+        "operationId": "UpdateRulesBulk",
+        "x-codegen-enabled": false,
+        "deprecated": true,
+        "description": "Updates multiple rules using the `PUT` method.",
+        "tags": [
+          "Bulk API"
+        ],
+        "requestBody": {
+          "description": "A JSON array where each element includes the `id` or `rule_id` field of the rule you want to update and the fields you want to modify.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RuleUpdateProps"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkCrudRulesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleUpdateProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      },
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "ErrorSchema": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/RuleSignatureId"
+          },
+          "list_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "item_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "status_code",
+              "message"
+            ],
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "minimum": 400
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BulkCrudRulesResponse": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/RuleResponse"
+            },
+            {
+              "$ref": "#/components/schemas/ErrorSchema"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/clean_draft_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/clean_draft_timelines_route_schema.json
@@ -1,0 +1,631 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Draft Timeline API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/timeline/_draft": {
+      "post": {
+        "operationId": "cleanDraftTimelines",
+        "summary": "Retrieves a draft timeline or timeline template.",
+        "description": "Retrieves a clean draft timeline. If a draft timeline does not exist, it is created and returned.\n",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The type of timeline to create. Valid values are `default` and `template`.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "timelineType": {
+                    "$ref": "#/components/schemas/TimelineType"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates that the draft timeline was successfully created. In the event the user already has a draft timeline, the existing draft timeline is cleared and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistTimeline": {
+                          "type": "object",
+                          "properties": {
+                            "timeline": {
+                              "$ref": "#/components/schemas/TimelineResponse"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates that the user does not have the required permissions to create a draft timeline.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates that there is already a draft timeline with the given timelineId.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/create_rule_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/create_rule_route.schema.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Create Rule API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules": {
+      "post": {
+        "operationId": "CreateRule",
+        "x-codegen-enabled": false,
+        "description": "Create a single detection rule",
+        "tags": [
+          "Rules API"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuleCreateProps"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleCreateProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/create_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/create_timelines_route_schema.json
@@ -1,0 +1,665 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Create Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-create.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline": {
+      "post": {
+        "operationId": "createTimelines",
+        "description": "Creates a new timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The required timeline fields used to create a new timeline along with optional fields that will be created if not provided.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "timeline"
+                ],
+                "properties": {
+                  "status": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/TimelineStatus"
+                      },
+                      {
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "timelineId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "templateTimelineId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "templateTimelineVersion": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "timelineType": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/TimelineType"
+                      },
+                      {
+                        "nullable": true
+                      }
+                    ]
+                  },
+                  "version": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "timeline": {
+                    "$ref": "#/components/schemas/SavedTimeline"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the timeline was successfully created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistTimeline": {
+                          "type": "object",
+                          "properties": {
+                            "timeline": {
+                              "$ref": "#/components/schemas/TimelineResponse"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Indicates that there was an error in the timeline creation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TimelineStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "draft",
+          "immutable"
+        ],
+        "default": "draft",
+        "description": "The status of the timeline. Valid values are `active`, `draft`, and `immutable`."
+      },
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/delete_note_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/delete_note_route_schema.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Notes API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/note": {
+      "delete": {
+        "operationId": "deleteNote",
+        "description": "Deletes a note from a timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The id of the note to delete.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "noteId": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the note was successfully deleted."
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/delete_rule_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/delete_rule_route.schema.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Delete Rule API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules": {
+      "delete": {
+        "operationId": "DeleteRule",
+        "x-codegen-enabled": false,
+        "description": "Deletes a single rule using the `rule_id` or `id` field.",
+        "tags": [
+          "Rules API"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "description": "The rule's `id` value.",
+            "schema": {
+              "$ref": "#/components/schemas/RuleSignatureId"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "query",
+            "required": false,
+            "description": "The rule's `rule_id` value.",
+            "schema": {
+              "$ref": "#/components/schemas/RuleObjectId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "RuleObjectId": {
+        "type": "string"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/delete_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/delete_timelines_route_schema.json
@@ -1,0 +1,83 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Delete Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-delete.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline": {
+      "delete": {
+        "operationId": "deleteTimelines",
+        "description": "Deletes one or more timelines or timeline templates.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The ids of the timelines or timeline templates to delete.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "savedObjectIds"
+                ],
+                "properties": {
+                  "savedObjectIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the timeline was successfully deleted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "deleteTimeline": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/details.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/details.schema.json
@@ -1,0 +1,54 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Details Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/{action_id}": {
+      "get": {
+        "summary": "Get Action details schema",
+        "operationId": "EndpointGetActionsDetails",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DetailsRequestParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DetailsRequestParams": {
+        "type": "object",
+        "properties": {
+          "action_id": {
+            "type": "string"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/execute.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/execute.schema.json
@@ -1,0 +1,150 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Execute Action Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/execute": {
+      "post": {
+        "summary": "Execute Action",
+        "operationId": "EndpointExecuteAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecuteActionRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ExecuteActionRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseActionSchema"
+          },
+          {
+            "type": "object",
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "required": [
+                  "command"
+                ],
+                "type": "object",
+                "properties": {
+                  "command": {
+                    "$ref": "#/components/schemas/Command"
+                  },
+                  "timeout": {
+                    "$ref": "#/components/schemas/Timeout"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "EndpointIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "List of endpoint IDs (cannot contain empty strings)"
+      },
+      "AlertIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "If defined, any case associated with the given IDs will be updated (cannot contain empty strings)"
+      },
+      "CaseIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "Case IDs to be updated (cannot contain empty strings)"
+      },
+      "Comment": {
+        "type": "string",
+        "description": "Optional comment"
+      },
+      "Parameters": {
+        "type": "object",
+        "description": "Optional parameters object"
+      },
+      "BaseActionSchema": {
+        "type": "object",
+        "properties": {
+          "endpoint_ids": {
+            "$ref": "#/components/schemas/EndpointIds"
+          },
+          "alert_ids": {
+            "$ref": "#/components/schemas/AlertIds"
+          },
+          "case_ids": {
+            "$ref": "#/components/schemas/CaseIds"
+          },
+          "comment": {
+            "$ref": "#/components/schemas/Comment"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/Parameters"
+          }
+        }
+      },
+      "Command": {
+        "type": "string",
+        "enum": [
+          "isolate",
+          "unisolate",
+          "kill-process",
+          "suspend-process",
+          "running-processes",
+          "get-file",
+          "execute",
+          "upload"
+        ],
+        "minLength": 1,
+        "description": "The command to be executed (cannot be an empty string)"
+      },
+      "Timeout": {
+        "type": "integer",
+        "minimum": 1,
+        "description": "The maximum timeout value in milliseconds (optional)"
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/export_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/export_rules_route.schema.json
@@ -1,0 +1,96 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Export Rules API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_export": {
+      "summary": "Exports rules to an `.ndjson` file",
+      "post": {
+        "operationId": "ExportRules",
+        "x-codegen-enabled": true,
+        "summary": "Export rules",
+        "description": "Exports rules to an `.ndjson` file. The following configuration items are also included in the `.ndjson` file - Actions, Exception lists. Prebuilt rules cannot be exported.",
+        "tags": [
+          "Import/Export API"
+        ],
+        "parameters": [
+          {
+            "name": "exclude_export_details",
+            "in": "query",
+            "required": false,
+            "description": "Determines whether a summary of the exported rules is returned.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "file_name",
+            "in": "query",
+            "required": false,
+            "description": "File name for saving the exported rules.",
+            "schema": {
+              "type": "string",
+              "default": "export.ndjson"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "objects"
+                ],
+                "nullable": true,
+                "properties": {
+                  "objects": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "rule_id"
+                      ],
+                      "properties": {
+                        "rule_id": {
+                          "$ref": "#/components/schemas/RuleSignatureId"
+                        }
+                      }
+                    },
+                    "description": "Array of `rule_id` fields. Exports all rules when unspecified."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/ndjson": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary",
+                  "description": "An `.ndjson` file containing the returned rules."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/export_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/export_timelines_route_schema.json
@@ -1,0 +1,97 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Import Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-import.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline/_export": {
+      "post": {
+        "operationId": "exportTimelines",
+        "description": "Exports timelines as an NDJSON file",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "file_name",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the file to export"
+          }
+        ],
+        "requestBody": {
+          "description": "The id of the timelines to export",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "nullable": true,
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the timelines were successfully exported",
+            "content": {
+              "application/ndjson": {
+                "schema": {
+                  "type": "string",
+                  "description": "NDJSON of the exported timelines"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Indicates that the export size limit was exceeded",
+            "content": {
+              "application/ndjson": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/file_download.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/file_download.schema.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "File Download Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/{action_id}/file/{file_id}/download`": {
+      "get": {
+        "summary": "File Download schema",
+        "operationId": "EndpointFileDownload",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FileDownloadRequestParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FileDownloadRequestParams": {
+        "type": "object",
+        "required": [
+          "action_id",
+          "file_id"
+        ],
+        "properties": {
+          "action_id": {
+            "type": "string"
+          },
+          "file_id": {
+            "type": "string"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/file_info.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/file_info.schema.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "File Info Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/{action_id}/file/{file_id}`": {
+      "get": {
+        "summary": "File Info schema",
+        "operationId": "EndpointFileInfo",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/FileInfoRequestParams"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FileInfoRequestParams": {
+        "type": "object",
+        "required": [
+          "action_id",
+          "file_id"
+        ],
+        "properties": {
+          "action_id": {
+            "type": "string"
+          },
+          "file_id": {
+            "type": "string"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/file_upload.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/file_upload.schema.json
@@ -1,0 +1,130 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "File Upload Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/upload": {
+      "post": {
+        "summary": "Upload Action",
+        "operationId": "EndpointUploadAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileUploadActionRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FileUploadActionRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseActionSchema"
+          },
+          {
+            "type": "object",
+            "required": [
+              "parameters",
+              "file"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "overwrite": {
+                    "type": "boolean",
+                    "default": false
+                  }
+                }
+              },
+              "file": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        ]
+      },
+      "EndpointIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "List of endpoint IDs (cannot contain empty strings)"
+      },
+      "AlertIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "If defined, any case associated with the given IDs will be updated (cannot contain empty strings)"
+      },
+      "CaseIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "Case IDs to be updated (cannot contain empty strings)"
+      },
+      "Comment": {
+        "type": "string",
+        "description": "Optional comment"
+      },
+      "Parameters": {
+        "type": "object",
+        "description": "Optional parameters object"
+      },
+      "BaseActionSchema": {
+        "type": "object",
+        "properties": {
+          "endpoint_ids": {
+            "$ref": "#/components/schemas/EndpointIds"
+          },
+          "alert_ids": {
+            "$ref": "#/components/schemas/AlertIds"
+          },
+          "case_ids": {
+            "$ref": "#/components/schemas/CaseIds"
+          },
+          "comment": {
+            "$ref": "#/components/schemas/Comment"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/Parameters"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_draft_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_draft_timelines_route_schema.json
@@ -1,0 +1,624 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Get Draft Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/_get_timeline_timeline_template_by_savedobjectid.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline/_draft": {
+      "get": {
+        "operationId": "getDraftTimelines",
+        "description": "Retrieves the draft timeline for the current user. If the user does not have a draft timeline, an empty timeline is returned.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "timelineType",
+            "schema": {
+              "$ref": "#/components/schemas/TimelineType"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates that the draft timeline was successfully retrieved.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistTimeline": {
+                          "type": "object",
+                          "properties": {
+                            "timeline": {
+                              "$ref": "#/components/schemas/TimelineResponse"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "If a draft timeline was not found and we attempted to create one, it indicates that the user does not have the required permissions to create a draft timeline.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "This should never happen, but if a draft timeline was not found and we attempted to create one, it indicates that there is already a draft timeline with the given timelineId.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_file.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_file.schema.json
@@ -1,0 +1,128 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Get File Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action/get_file": {
+      "post": {
+        "summary": "Get File Action",
+        "operationId": "EndpointGetFileAction",
+        "x-codegen-enabled": false,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GetFileActionRequestBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GetFileActionRequestBody": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BaseActionSchema"
+          },
+          {
+            "type": "object",
+            "required": [
+              "parameters",
+              "file"
+            ],
+            "properties": {
+              "parameters": {
+                "required": [
+                  "path"
+                ],
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      },
+      "EndpointIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "List of endpoint IDs (cannot contain empty strings)"
+      },
+      "AlertIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "If defined, any case associated with the given IDs will be updated (cannot contain empty strings)"
+      },
+      "CaseIds": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "minItems": 1,
+        "description": "Case IDs to be updated (cannot contain empty strings)"
+      },
+      "Comment": {
+        "type": "string",
+        "description": "Optional comment"
+      },
+      "Parameters": {
+        "type": "object",
+        "description": "Optional parameters object"
+      },
+      "BaseActionSchema": {
+        "type": "object",
+        "properties": {
+          "endpoint_ids": {
+            "$ref": "#/components/schemas/EndpointIds"
+          },
+          "alert_ids": {
+            "$ref": "#/components/schemas/AlertIds"
+          },
+          "case_ids": {
+            "$ref": "#/components/schemas/CaseIds"
+          },
+          "comment": {
+            "$ref": "#/components/schemas/Comment"
+          },
+          "parameters": {
+            "$ref": "#/components/schemas/Parameters"
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_prebuilt_rules_and_timelines_status_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_prebuilt_rules_and_timelines_status_route.schema.json
@@ -1,0 +1,79 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Prebuilt Rules Status API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/prepackaged/_status": {
+      "get": {
+        "operationId": "GetPrebuiltRulesAndTimelinesStatus",
+        "x-codegen-enabled": true,
+        "summary": "Get the status of Elastic prebuilt rules",
+        "tags": [
+          "Prebuilt Rules API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "rules_custom_installed": {
+                      "type": "integer",
+                      "description": "The total number of custom rules",
+                      "minimum": 0
+                    },
+                    "rules_installed": {
+                      "type": "integer",
+                      "description": "The total number of installed prebuilt rules",
+                      "minimum": 0
+                    },
+                    "rules_not_installed": {
+                      "type": "integer",
+                      "description": "The total number of available prebuilt rules that are not installed",
+                      "minimum": 0
+                    },
+                    "rules_not_updated": {
+                      "type": "integer",
+                      "description": "The total number of outdated prebuilt rules",
+                      "minimum": 0
+                    },
+                    "timelines_installed": {
+                      "type": "integer",
+                      "description": "The total number of installed prebuilt timelines",
+                      "minimum": 0
+                    },
+                    "timelines_not_installed": {
+                      "type": "integer",
+                      "description": "The total number of available prebuilt timelines that are not installed",
+                      "minimum": 0
+                    },
+                    "timelines_not_updated": {
+                      "type": "integer",
+                      "description": "The total number of outdated prebuilt timelines",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "rules_custom_installed",
+                    "rules_installed",
+                    "rules_not_installed",
+                    "rules_not_updated",
+                    "timelines_installed",
+                    "timelines_not_installed",
+                    "timelines_not_updated"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_rule_execution_events_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_rule_execution_events_route.schema.json
@@ -1,0 +1,260 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Get Rule Execution Events API endpoint",
+    "version": "1"
+  },
+  "paths": {
+    "/internal/detection_engine/rules/{ruleId}/execution/events": {
+      "put": {
+        "operationId": "GetRuleExecutionEvents",
+        "x-codegen-enabled": true,
+        "summary": "Returns execution events of a given rule (aggregated by execution UUID) from Event Log.",
+        "tags": [
+          "Rule Execution Log API"
+        ],
+        "parameters": [
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "description": "Saved object ID of the rule to get execution results for",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Start date of the time range to query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "description": "End date of the time range to query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "query_text",
+            "in": "query",
+            "required": false,
+            "description": "Query text to filter results by",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "status_filters",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of rule execution statuses to filter results by",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RuleExecutionStatus"
+              },
+              "default": []
+            }
+          },
+          {
+            "name": "sort_field",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by",
+            "schema": {
+              "$ref": "#/components/schemas/SortFieldOfRuleExecutionResult",
+              "default": "timestamp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order to sort results by",
+            "schema": {
+              "$ref": "#/components/schemas/SortOrder",
+              "default": "desc"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number to return",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RuleExecutionResult"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleExecutionStatus": {
+        "type": "string",
+        "description": "Custom execution status of Security rules that is different from the status used in the Alerting Framework. We merge our custom status with the Framework's status to determine the resulting status of a rule.\n- going to run - @deprecated Replaced by the 'running' status but left for backwards compatibility with rule execution events already written to Event Log in the prior versions of Kibana. Don't use when writing rule status changes.\n- running - Rule execution started but not reached any intermediate or final status.\n- partial failure - Rule can partially fail for various reasons either in the middle of an execution (in this case we update its status right away) or in the end of it. So currently this status can be both intermediate and final at the same time. A typical reason for a partial failure: not all the indices that the rule searches over actually exist.\n- failed - Rule failed to execute due to unhandled exception or a reason defined in the business logic of its executor function.\n- succeeded - Rule executed successfully without any issues. Note: this status is just an indication of a rule's \"health\". The rule might or might not generate any alerts despite of it.",
+        "enum": [
+          "going to run",
+          "running",
+          "partial failure",
+          "failed",
+          "succeeded"
+        ]
+      },
+      "SortFieldOfRuleExecutionResult": {
+        "type": "string",
+        "description": "We support sorting rule execution results by these fields.",
+        "enum": [
+          "timestamp",
+          "duration_ms",
+          "gap_duration_s",
+          "indexing_duration_ms",
+          "search_duration_ms",
+          "schedule_delay_ms"
+        ]
+      },
+      "SortOrder": {
+        "type": "string",
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "RuleExecutionResult": {
+        "type": "object",
+        "description": "Rule execution result is an aggregate that groups plain rule execution events by execution UUID. It contains such information as execution UUID, date, status and metrics.",
+        "properties": {
+          "execution_uuid": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "duration_ms": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "num_active_alerts": {
+            "type": "integer"
+          },
+          "num_new_alerts": {
+            "type": "integer"
+          },
+          "num_recovered_alerts": {
+            "type": "integer"
+          },
+          "num_triggered_actions": {
+            "type": "integer"
+          },
+          "num_succeeded_actions": {
+            "type": "integer"
+          },
+          "num_errored_actions": {
+            "type": "integer"
+          },
+          "total_search_duration_ms": {
+            "type": "integer"
+          },
+          "es_search_duration_ms": {
+            "type": "integer"
+          },
+          "schedule_delay_ms": {
+            "type": "integer"
+          },
+          "timed_out": {
+            "type": "boolean"
+          },
+          "indexing_duration_ms": {
+            "type": "integer"
+          },
+          "search_duration_ms": {
+            "type": "integer"
+          },
+          "gap_duration_s": {
+            "type": "integer"
+          },
+          "security_status": {
+            "type": "string"
+          },
+          "security_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "execution_uuid",
+          "timestamp",
+          "duration_ms",
+          "status",
+          "message",
+          "num_active_alerts",
+          "num_new_alerts",
+          "num_recovered_alerts",
+          "num_triggered_actions",
+          "num_succeeded_actions",
+          "num_errored_actions",
+          "total_search_duration_ms",
+          "es_search_duration_ms",
+          "schedule_delay_ms",
+          "timed_out",
+          "indexing_duration_ms",
+          "search_duration_ms",
+          "gap_duration_s",
+          "security_status",
+          "security_message"
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_rule_execution_results_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_rule_execution_results_route.schema.json
@@ -1,0 +1,260 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Get Rule Execution Results API endpoint",
+    "version": "1"
+  },
+  "paths": {
+    "/internal/detection_engine/rules/{ruleId}/execution/results": {
+      "put": {
+        "operationId": "GetRuleExecutionResults",
+        "x-codegen-enabled": true,
+        "summary": "Returns execution results of a given rule (aggregated by execution UUID) from Event Log.",
+        "tags": [
+          "Rule Execution Log API"
+        ],
+        "parameters": [
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "description": "Saved object ID of the rule to get execution results for",
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Start date of the time range to query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "description": "End date of the time range to query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "query_text",
+            "in": "query",
+            "required": false,
+            "description": "Query text to filter results by",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "status_filters",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of rule execution statuses to filter results by",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/RuleExecutionStatus"
+              },
+              "default": []
+            }
+          },
+          {
+            "name": "sort_field",
+            "in": "query",
+            "required": false,
+            "description": "Field to sort results by",
+            "schema": {
+              "$ref": "#/components/schemas/SortFieldOfRuleExecutionResult",
+              "default": "timestamp"
+            }
+          },
+          {
+            "name": "sort_order",
+            "in": "query",
+            "required": false,
+            "description": "Sort order to sort results by",
+            "schema": {
+              "$ref": "#/components/schemas/SortOrder",
+              "default": "desc"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number to return",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/RuleExecutionResult"
+                      }
+                    },
+                    "total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleExecutionStatus": {
+        "type": "string",
+        "description": "Custom execution status of Security rules that is different from the status used in the Alerting Framework. We merge our custom status with the Framework's status to determine the resulting status of a rule.\n- going to run - @deprecated Replaced by the 'running' status but left for backwards compatibility with rule execution events already written to Event Log in the prior versions of Kibana. Don't use when writing rule status changes.\n- running - Rule execution started but not reached any intermediate or final status.\n- partial failure - Rule can partially fail for various reasons either in the middle of an execution (in this case we update its status right away) or in the end of it. So currently this status can be both intermediate and final at the same time. A typical reason for a partial failure: not all the indices that the rule searches over actually exist.\n- failed - Rule failed to execute due to unhandled exception or a reason defined in the business logic of its executor function.\n- succeeded - Rule executed successfully without any issues. Note: this status is just an indication of a rule's \"health\". The rule might or might not generate any alerts despite of it.",
+        "enum": [
+          "going to run",
+          "running",
+          "partial failure",
+          "failed",
+          "succeeded"
+        ]
+      },
+      "SortFieldOfRuleExecutionResult": {
+        "type": "string",
+        "description": "We support sorting rule execution results by these fields.",
+        "enum": [
+          "timestamp",
+          "duration_ms",
+          "gap_duration_s",
+          "indexing_duration_ms",
+          "search_duration_ms",
+          "schedule_delay_ms"
+        ]
+      },
+      "SortOrder": {
+        "type": "string",
+        "enum": [
+          "asc",
+          "desc"
+        ]
+      },
+      "RuleExecutionResult": {
+        "type": "object",
+        "description": "Rule execution result is an aggregate that groups plain rule execution events by execution UUID. It contains such information as execution UUID, date, status and metrics.",
+        "properties": {
+          "execution_uuid": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "duration_ms": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "num_active_alerts": {
+            "type": "integer"
+          },
+          "num_new_alerts": {
+            "type": "integer"
+          },
+          "num_recovered_alerts": {
+            "type": "integer"
+          },
+          "num_triggered_actions": {
+            "type": "integer"
+          },
+          "num_succeeded_actions": {
+            "type": "integer"
+          },
+          "num_errored_actions": {
+            "type": "integer"
+          },
+          "total_search_duration_ms": {
+            "type": "integer"
+          },
+          "es_search_duration_ms": {
+            "type": "integer"
+          },
+          "schedule_delay_ms": {
+            "type": "integer"
+          },
+          "timed_out": {
+            "type": "boolean"
+          },
+          "indexing_duration_ms": {
+            "type": "integer"
+          },
+          "search_duration_ms": {
+            "type": "integer"
+          },
+          "gap_duration_s": {
+            "type": "integer"
+          },
+          "security_status": {
+            "type": "string"
+          },
+          "security_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "execution_uuid",
+          "timestamp",
+          "duration_ms",
+          "status",
+          "message",
+          "num_active_alerts",
+          "num_new_alerts",
+          "num_recovered_alerts",
+          "num_triggered_actions",
+          "num_succeeded_actions",
+          "num_errored_actions",
+          "total_search_duration_ms",
+          "es_search_duration_ms",
+          "schedule_delay_ms",
+          "timed_out",
+          "indexing_duration_ms",
+          "search_duration_ms",
+          "gap_duration_s",
+          "security_status",
+          "security_message"
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_suggestions.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_suggestions.schema.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Get Suggestions Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/suggestions/{suggestion_type}": {
+      "post": {
+        "summary": "Get suggestions",
+        "operationId": "GetEndpointSuggestions",
+        "x-codegen-enabled": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "parameters"
+                ],
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "query": {
+                    "type": "string"
+                  },
+                  "filters": {},
+                  "fieldMeta": {}
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "suggestion_type": {
+                  "type": "string",
+                  "enum": [
+                    "eventFilters"
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_timeline_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_timeline_route_schema.json
@@ -1,0 +1,602 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Get Timeline API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/_get_timeline_timeline_template_by_savedobjectid.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline": {
+      "get": {
+        "operationId": "getTimeline",
+        "description": "Get an existing saved timeline or timeline template. This API is used to retrieve an existing saved timeline or timeline template.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "template_timeline_id",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the template timeline to retrieve"
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The ID of the timeline to retrieve"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates that the draft timeline was successfully created. In the event the user already has a draft timeline, the existing draft timeline is cleared and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "getOneTimeline": {
+                          "oneOf": [
+                            {
+                              "$ref": "#/components/schemas/TimelineResponse"
+                            },
+                            {
+                              "nullable": true
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/get_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/get_timelines_route_schema.json
@@ -1,0 +1,729 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Get Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-get.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timelines": {
+      "get": {
+        "operationId": "getTimelines",
+        "description": "This API is used to retrieve a list of existing saved timelines or timeline templates.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "only_user_favorite",
+            "schema": {
+              "nullable": true,
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            },
+            "description": "If true, only timelines that are marked as favorites by the user are returned."
+          },
+          {
+            "in": "query",
+            "name": "timeline_type",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/TimelineType"
+                },
+                {
+                  "nullable": true
+                }
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_field",
+            "schema": {
+              "$ref": "#/components/schemas/SortFieldTimeline"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort_order",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_index",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "nullable": true,
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/TimelineStatus"
+                },
+                {
+                  "nullable": true
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates that the draft timeline was successfully created. In the event the user already has a draft timeline, the existing draft timeline is cleared and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "timelines": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/TimelineResponse"
+                          }
+                        },
+                        "totalCount": {
+                          "type": "number"
+                        },
+                        "defaultTimelineCount": {
+                          "type": "number"
+                        },
+                        "templateTimelineCount": {
+                          "type": "number"
+                        },
+                        "favoriteCount": {
+                          "type": "number"
+                        },
+                        "elasticTemplateTimelineCount": {
+                          "type": "number"
+                        },
+                        "customTemplateTimelineCount": {
+                          "type": "number"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. The user supplied invalid data.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "SortFieldTimeline": {
+        "type": "object",
+        "description": "The field to sort the timelines by.",
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "draft",
+          "immutable"
+        ],
+        "default": "draft",
+        "description": "The status of the timeline. Valid values are `active`, `draft`, and `immutable`."
+      },
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/import_rules_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/import_rules_route.schema.json
@@ -1,0 +1,226 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Import Rules API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/_import": {
+      "summary": "Imports rules from an `.ndjson` file",
+      "post": {
+        "operationId": "ImportRules",
+        "x-codegen-enabled": true,
+        "summary": "Import rules",
+        "description": "Imports rules from an `.ndjson` file, including actions and exception lists.",
+        "tags": [
+          "Import/Export API"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "The `.ndjson` file containing the rules."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "overwrite",
+            "in": "query",
+            "required": false,
+            "description": "Determines whether existing rules with the same `rule_id` are overwritten.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "overwrite_exceptions",
+            "in": "query",
+            "required": false,
+            "description": "Determines whether existing exception lists with the same `list_id` are overwritten.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "overwrite_action_connectors",
+            "in": "query",
+            "required": false,
+            "description": "Determines whether existing actions with the same `kibana.alert.rule.actions.id` are overwritten.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "as_new_list",
+            "in": "query",
+            "required": false,
+            "description": "Generates a new list ID for each imported exception list.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "exceptions_success",
+                    "exceptions_success_count",
+                    "exceptions_errors",
+                    "rules_count",
+                    "success",
+                    "success_count",
+                    "errors",
+                    "action_connectors_errors",
+                    "action_connectors_warnings",
+                    "action_connectors_success",
+                    "action_connectors_success_count"
+                  ],
+                  "properties": {
+                    "exceptions_success": {
+                      "type": "boolean"
+                    },
+                    "exceptions_success_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "exceptions_errors": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ErrorSchema"
+                      }
+                    },
+                    "rules_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "success_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ErrorSchema"
+                      }
+                    },
+                    "action_connectors_errors": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/ErrorSchema"
+                      }
+                    },
+                    "action_connectors_warnings": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/WarningSchema"
+                      }
+                    },
+                    "action_connectors_success": {
+                      "type": "boolean"
+                    },
+                    "action_connectors_success_count": {
+                      "type": "integer",
+                      "minimum": 0
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "ErrorSchema": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "rule_id": {
+            "$ref": "#/components/schemas/RuleSignatureId"
+          },
+          "list_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "item_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "error": {
+            "type": "object",
+            "required": [
+              "status_code",
+              "message"
+            ],
+            "properties": {
+              "status_code": {
+                "type": "integer",
+                "minimum": 400
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "WarningSchema": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "actionPath": {
+            "type": "string"
+          },
+          "buttonLabel": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "message",
+          "actionPath"
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/import_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/import_timelines_route_schema.json
@@ -1,0 +1,226 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Import Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-import.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/timeline/_import": {
+      "post": {
+        "operationId": "importTimelines",
+        "description": "Imports timelines.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The timelines to import as a readable stream.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "object",
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/Readable"
+                      },
+                      {
+                        "properties": {
+                          "hapi": {
+                            "type": "object",
+                            "properties": {
+                              "filename": {
+                                "type": "string"
+                              },
+                              "headers": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the import of timelines was successful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ImportTimelineResult"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Indicates the import of timelines was unsuccessful because of an invalid file extension.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Indicates that we were unable to locate the saved object client necessary to handle the import.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Indicates the import of timelines was unsuccessful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Readable": {
+        "type": "object",
+        "properties": {
+          "_maxListeners": {
+            "type": {}
+          },
+          "_readableState": {
+            "type": {}
+          },
+          "_read": {
+            "type": {}
+          },
+          "readable": {
+            "type": "boolean"
+          },
+          "_events": {
+            "type": {}
+          },
+          "_eventsCount": {
+            "type": "number"
+          },
+          "_data": {
+            "type": {}
+          },
+          "_position": {
+            "type": "number"
+          },
+          "_encoding": {
+            "type": "string"
+          }
+        }
+      },
+      "ImportTimelineResult": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "success_count": {
+            "type": "number"
+          },
+          "timelines_installed": {
+            "type": "number"
+          },
+          "timelines_updated": {
+            "type": "number"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/install_prebuilt_rules_and_timelines_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/install_prebuilt_rules_and_timelines_route.schema.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Install Prebuilt Rules API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules/prepackaged": {
+      "put": {
+        "operationId": "InstallPrebuiltRulesAndTimelines",
+        "x-codegen-enabled": true,
+        "summary": "Installs all Elastic prebuilt rules and timelines",
+        "tags": [
+          "Prebuilt Rules API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "rules_installed": {
+                      "type": "integer",
+                      "description": "The number of rules installed",
+                      "minimum": 0
+                    },
+                    "rules_updated": {
+                      "type": "integer",
+                      "description": "The number of rules updated",
+                      "minimum": 0
+                    },
+                    "timelines_installed": {
+                      "type": "integer",
+                      "description": "The number of timelines installed",
+                      "minimum": 0
+                    },
+                    "timelines_updated": {
+                      "type": "integer",
+                      "description": "The number of timelines updated",
+                      "minimum": 0
+                    }
+                  },
+                  "required": [
+                    "rules_installed",
+                    "rules_updated",
+                    "timelines_installed",
+                    "timelines_updated"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/install_prepackaged_timelines_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/install_prepackaged_timelines_route_schema.json
@@ -1,0 +1,605 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Install Prepackaged Timelines API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/timeline/_prepackaged": {
+      "post": {
+        "operationId": "installPrepackedTimelines",
+        "description": "Installs prepackaged timelines.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The timelines to install or update.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "timelinesToInstall": {
+                    "type": "array",
+                    "items": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ImportTimelines"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    }
+                  },
+                  "timelinesToUpdate": {
+                    "type": "array",
+                    "items": {
+                      "allOf": [
+                        {
+                          "$ref": "#/components/schemas/ImportTimelines"
+                        },
+                        {
+                          "nullable": true
+                        }
+                      ]
+                    }
+                  },
+                  "prepackagedTimelines": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/SavedTimeline"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the installation of prepackaged timelines was successful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/ImportTimelineResult"
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Indicates the installation of prepackaged timelines was unsuccessful.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "ImportTimelines": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "savedObjectId": {
+                "type": "string",
+                "nullable": true
+              },
+              "version": {
+                "type": "string",
+                "nullable": true
+              },
+              "globalNotes": {
+                "nullable": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BareNote"
+                }
+              },
+              "eventNotes": {
+                "nullable": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/BareNote"
+                }
+              },
+              "pinnedEventIds": {
+                "nullable": true,
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "ImportTimelineResult": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "success_count": {
+            "type": "number"
+          },
+          "timelines_installed": {
+            "type": "number"
+          },
+          "timelines_updated": {
+            "type": "number"
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/list.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/list.schema.json
@@ -1,0 +1,184 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Actions List Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/action": {
+      "get": {
+        "summary": "Get Actions List schema",
+        "operationId": "EndpointGetActionsList",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ListRequestQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ListRequestQuery": {
+        "type": "object",
+        "properties": {
+          "agentIds": {
+            "$ref": "#/components/schemas/AgentIds"
+          },
+          "commands": {
+            "$ref": "#/components/schemas/Commands"
+          },
+          "page": {
+            "$ref": "#/components/schemas/Page"
+          },
+          "pageSize": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 10000,
+            "description": "Number of items per page"
+          },
+          "startDate": {
+            "$ref": "#/components/schemas/StartDate"
+          },
+          "endDate": {
+            "$ref": "#/components/schemas/EndDate"
+          },
+          "userIds": {
+            "$ref": "#/components/schemas/UserIds"
+          },
+          "types": {
+            "$ref": "#/components/schemas/Types"
+          },
+          "withOutputs": {
+            "$ref": "#/components/schemas/WithOutputs"
+          }
+        }
+      },
+      "AgentIds": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1,
+            "maxItems": 50
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "minLength": 1
+      },
+      "Command": {
+        "type": "string",
+        "enum": [
+          "isolate",
+          "unisolate",
+          "kill-process",
+          "suspend-process",
+          "running-processes",
+          "get-file",
+          "execute",
+          "upload"
+        ],
+        "minLength": 1,
+        "description": "The command to be executed (cannot be an empty string)"
+      },
+      "Commands": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Command"
+        }
+      },
+      "Page": {
+        "type": "integer",
+        "default": 1,
+        "minimum": 1,
+        "description": "Page number"
+      },
+      "StartDate": {
+        "type": "string",
+        "description": "Start date"
+      },
+      "EndDate": {
+        "type": "string",
+        "description": "End date"
+      },
+      "UserIds": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "description": "User IDs"
+      },
+      "Type": {
+        "type": "string",
+        "enum": [
+          "automated",
+          "manual"
+        ]
+      },
+      "Types": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Type"
+        },
+        "minLength": 1,
+        "maxLength": 2
+      },
+      "WithOutputs": {
+        "oneOf": [
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          {
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "description": "With Outputs"
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/metadata.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/metadata.schema.json
@@ -1,0 +1,159 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Endpoint Metadata Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/metadata": {
+      "get": {
+        "summary": "Get Metadata List schema",
+        "operationId": "GetEndpointMetadataList",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ListRequestQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/metadata/transforms": {
+      "get": {
+        "summary": "Get Metadata Transform schema",
+        "operationId": "GetEndpointMetadataTransform",
+        "x-codegen-enabled": false,
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/metadata/{id}": {
+      "get": {
+        "summary": "Get Metadata schema",
+        "operationId": "GetEndpointMetadata",
+        "x-codegen-enabled": false,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ListRequestQuery": {
+        "type": "object",
+        "required": [
+          "hostStatuses"
+        ],
+        "properties": {
+          "page": {
+            "type": "integer",
+            "default": 0,
+            "minimum": 0,
+            "description": "Page number"
+          },
+          "pageSize": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 10000,
+            "description": "Number of items per page"
+          },
+          "kuery": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortField": {
+            "type": "string",
+            "enum": [
+              "enrolled_at",
+              "metadata.host.hostname",
+              "host_status",
+              "metadata.Endpoint.policy.applied.name",
+              "metadata.Endpoint.policy.applied.status",
+              "metadata.host.os.name",
+              "metadata.host.ip",
+              "metadata.agent.version",
+              "last_checkin"
+            ]
+          },
+          "sortDirection": {
+            "type": "string",
+            "enum": [
+              "asc",
+              "desc"
+            ],
+            "nullable": true
+          },
+          "hostStatuses": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "healthy",
+                "offline",
+                "updating",
+                "inactive",
+                "unenrolled"
+              ]
+            }
+          }
+        }
+      },
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/patch_rule_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/patch_rule_route.schema.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Patch Rule API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules": {
+      "patch": {
+        "operationId": "PatchRule",
+        "x-codegen-enabled": false,
+        "description": "Patch a single rule",
+        "tags": [
+          "Rules API"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RulePatchProps"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RulePatchProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/patch_timeline_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/patch_timeline_route_schema.json
@@ -1,0 +1,619 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Patch Timeline API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/timeline": {
+      "patch": {
+        "operationId": "patchTimeline",
+        "summary": "Updates an existing timeline.",
+        "description": "Updates an existing timeline. This API is used to update the title, description, date range, pinned events, pinned queries, and/or pinned saved queries of an existing timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The timeline updates along with the timeline ID and version.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "timelineId": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "timeline": {
+                    "$ref": "#/components/schemas/SavedTimeline"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates that the draft timeline was successfully created. In the event the user already has a draft timeline, the existing draft timeline is cleared and returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistTimeline": {
+                          "type": "object",
+                          "properties": {
+                            "timeline": {
+                              "$ref": "#/components/schemas/TimelineResponse"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Indicates that the user does not have the required access to create a draft timeline.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColumnHeaderResult": {
+        "type": "object",
+        "properties": {
+          "aggregatable": {
+            "type": "boolean"
+          },
+          "category": {
+            "type": "string"
+          },
+          "columnHeaderType": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "example": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              }
+            ]
+          },
+          "indexes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "placeholder": {
+            "type": "string"
+          },
+          "searchable": {
+            "type": "boolean"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "QueryMatchResult": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "displayField": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "displayValue": {
+            "type": "string"
+          },
+          "operator": {
+            "type": "string"
+          }
+        }
+      },
+      "DataProviderResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "excluded": {
+            "type": "boolean"
+          },
+          "kqlQuery": {
+            "type": "string"
+          },
+          "queryMatch": {
+            "$ref": "#/components/schemas/QueryMatchResult"
+          },
+          "and": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "type": {
+            "$ref": "#/components/schemas/DataProviderType"
+          }
+        }
+      },
+      "DataProviderType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of data provider to create. Valid values are `default` and `template`."
+      },
+      "RowRendererId": {
+        "type": "string",
+        "enum": [
+          "alert",
+          "alerts",
+          "auditd",
+          "auditd_file",
+          "library",
+          "netflow",
+          "plain",
+          "registry",
+          "suricata",
+          "system",
+          "system_dns",
+          "system_endgame_process",
+          "system_file",
+          "system_fim",
+          "system_security_event",
+          "system_socket",
+          "threat_match",
+          "zeek"
+        ]
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FilterTimelineResult": {
+        "type": "object",
+        "properties": {
+          "exists": {
+            "type": "boolean"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "type": "string"
+              },
+              "controlledBy": {
+                "type": "string"
+              },
+              "disabled": {
+                "type": "boolean"
+              },
+              "field": {
+                "type": "string"
+              },
+              "formattedValue": {
+                "type": "string"
+              },
+              "index": {
+                "type": "string"
+              },
+              "key": {
+                "type": "string"
+              },
+              "negate": {
+                "type": "boolean"
+              },
+              "params": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "match_all": {
+            "type": "string"
+          },
+          "missing": {
+            "type": "string"
+          },
+          "query": {
+            "type": "string"
+          },
+          "range": {
+            "type": "string"
+          },
+          "script": {
+            "type": "string"
+          }
+        }
+      },
+      "SerializedFilterQueryResult": {
+        "type": "object",
+        "properties": {
+          "filterQuery": {
+            "type": "object",
+            "properties": {
+              "kuery": {
+                "type": "object",
+                "properties": {
+                  "kind": {
+                    "type": "string"
+                  },
+                  "expression": {
+                    "type": "string"
+                  }
+                }
+              },
+              "serializedQuery": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sort": {
+        "type": "object",
+        "properties": {
+          "columnId": {
+            "type": "string"
+          },
+          "sortDirection": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "SavedTimeline": {
+        "type": "object",
+        "properties": {
+          "columns": {
+            "$ref": "#/components/schemas/ColumnHeaderResult"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "dataProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataProviderResult"
+            }
+          },
+          "dataViewId": {
+            "type": "string"
+          },
+          "dateRange": {
+            "type": "object",
+            "properties": {
+              "end": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              },
+              "start": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  }
+                ]
+              }
+            }
+          },
+          "description": {
+            "type": "string"
+          },
+          "eqlOptions": {
+            "type": "object",
+            "properties": {
+              "eventCategoryField": {
+                "type": "string"
+              },
+              "tiebreakerField": {
+                "type": "string"
+              },
+              "timestampField": {
+                "type": "string"
+              }
+            }
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "excludedRowRendererIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RowRendererId"
+            }
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterTimelineResult"
+            }
+          },
+          "kqlMode": {
+            "type": "string"
+          },
+          "kqlQuery": {
+            "$ref": "#/components/schemas/SerializedFilterQueryResult"
+          },
+          "indexNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "savedQueryId": {
+            "type": "string"
+          },
+          "sort": {
+            "$ref": "#/components/schemas/Sort"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "draft",
+              "immutable"
+            ]
+          },
+          "title": {
+            "type": "string"
+          },
+          "templateTimelineId": {
+            "type": "string"
+          },
+          "templateTimelineVersion": {
+            "type": "number"
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      },
+      "TimelineResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/SavedTimeline"
+          },
+          {
+            "type": "object",
+            "required": [
+              "savedObjectId",
+              "version"
+            ],
+            "properties": {
+              "eventIdToNoteIds": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "notes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Note"
+                }
+              },
+              "noteIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "pinnedEventsSaveObject": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PinnedEvent"
+                }
+              },
+              "savedObjectId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/persist_favorite_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/persist_favorite_route_schema.json
@@ -1,0 +1,176 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Favorite API (https://www.elastic.co/guide/en/security/current/timeline-api-delete.html)",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/timeline/_favorite": {
+      "patch": {
+        "operationId": "persistFavoriteRoute",
+        "description": "Persists a given users favorite status of a timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The required timeline fields used to create a new timeline along with optional fields that will be created if not provided.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "timelineId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "templateTimelineId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "templateTimelineVersion": {
+                    "type": "number",
+                    "nullable": true
+                  },
+                  "timelineType": {
+                    "allOf": [
+                      {
+                        "$ref": "#/components/schemas/TimelineType"
+                      },
+                      {
+                        "nullable": true
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the favorite status was successfully updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistFavorite": {
+                          "$ref": "#/components/schemas/FavoriteTimelineResponse"
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Indicates the user does not have the required permissions to persist the favorite status.",
+            "content": {
+              "application:json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "body": {
+                      "type": "string"
+                    },
+                    "statusCode": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TimelineType": {
+        "type": "string",
+        "enum": [
+          "default",
+          "template"
+        ],
+        "default": "default",
+        "description": "The type of timeline to create. Valid values are `default` and `template`."
+      },
+      "FavoriteTimelineResult": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string"
+          },
+          "userName": {
+            "type": "string"
+          },
+          "favoriteDate": {
+            "type": "number"
+          }
+        }
+      },
+      "FavoriteTimelineResponse": {
+        "type": "object",
+        "required": [
+          "savedObjectId",
+          "version"
+        ],
+        "properties": {
+          "savedObjectId": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "code": {
+            "type": "number",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "templateTimelineId": {
+            "type": "string",
+            "nullable": true
+          },
+          "templateTimelineVersion": {
+            "type": "number",
+            "nullable": true
+          },
+          "timelineType": {
+            "$ref": "#/components/schemas/TimelineType"
+          },
+          "favorite": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FavoriteTimelineResult"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/persist_note_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/persist_note_route_schema.json
@@ -1,0 +1,154 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Notes API",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "externalDocs": {
+    "url": "https://www.elastic.co/guide/en/security/current/timeline-api-update.html",
+    "description": "Documentation"
+  },
+  "paths": {
+    "/api/note": {
+      "patch": {
+        "operationId": "persistNoteroute",
+        "description": "Persists a note to a timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The note to persist or update along with additional metadata.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "note"
+                ],
+                "properties": {
+                  "note": {
+                    "$ref": "#/components/schemas/BareNote"
+                  },
+                  "overrideOwner": {
+                    "type": "boolean",
+                    "nullable": true
+                  },
+                  "noteId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "version": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates the favorite status was successfully updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistNote": {
+                          "type": "object",
+                          "properties": {
+                            "code": {
+                              "type": "number"
+                            },
+                            "message": {
+                              "type": "string"
+                            },
+                            "note": {
+                              "$ref": "#/components/schemas/Note"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BareNote": {
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          }
+        }
+      },
+      "Note": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/BareNote"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "noteId": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              },
+              "timelineVersion": {
+                "nullable": true,
+                "type": "string"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/pinned_events_route_schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/pinned_events_route_schema.json
@@ -1,0 +1,134 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Elastic Security - Timeline - Pinned Event API (https://www.elastic.co/guide/en/security/current/_pin_an_event_to_an_existing_timeline.html)",
+    "version": "8.9.0"
+  },
+  "servers": [
+    {
+      "url": "http://{kibana_host}:{port}",
+      "variables": {
+        "kibana_host": {
+          "default": "localhost"
+        },
+        "port": {
+          "default": "5601"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/pinned_event": {
+      "patch": {
+        "operationId": "persistPinnedEventRoute",
+        "description": "Persists a pinned event to a timeline.",
+        "tags": [
+          "access:securitySolution"
+        ],
+        "requestBody": {
+          "description": "The pinned event to persist or update along with additional metadata.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "eventId"
+                ],
+                "properties": {
+                  "eventId": {
+                    "type": "string"
+                  },
+                  "pinnedEventId": {
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "timelineId": {
+                    "type": "string",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicate the event was successfully pinned in the timeline.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "persistPinnedEventOnTimeline": {
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/PinnedEvent"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "code": {
+                                  "type": "number"
+                                },
+                                "message": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PinnedEvent": {
+        "type": "object",
+        "properties": {
+          "pinnedEventId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "timelineId": {
+            "type": "string"
+          },
+          "created": {
+            "type": "number"
+          },
+          "createdBy": {
+            "type": "string"
+          },
+          "updated": {
+            "type": "number"
+          },
+          "updatedBy": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "timelineVersion": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/policy.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/policy.schema.json
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Endpoint Policy Schema",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/endpoint/policy/summaries": {
+      "get": {
+        "summary": "Get Agent Policy Summary schema",
+        "operationId": "GetAgentPolicySummary",
+        "x-codegen-enabled": true,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "package_name": {
+                  "type": "string"
+                },
+                "policy_id": {
+                  "type": "string",
+                  "nullable": true
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/endpoint/policy_response": {
+      "get": {
+        "summary": "Get Policy Response schema",
+        "operationId": "GetPolicyResponse",
+        "x-codegen-enabled": true,
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "agentId": {
+                  "$ref": "#/components/schemas/AgentId"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SuccessResponse": {
+        "type": "object",
+        "properties": {}
+      },
+      "AgentId": {
+        "type": "string",
+        "description": "Agent ID"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/read_rule_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/read_rule_route.schema.json
@@ -1,0 +1,65 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Read Rule API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules": {
+      "get": {
+        "operationId": "ReadRule",
+        "x-codegen-enabled": false,
+        "description": "Read a single rule",
+        "tags": [
+          "Rules API"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "description": "The rule's `id` value.",
+            "schema": {
+              "$ref": "#/components/schemas/RuleSignatureId"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "query",
+            "required": false,
+            "description": "The rule's `rule_id` value.",
+            "schema": {
+              "$ref": "#/components/schemas/RuleObjectId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleSignatureId": {
+        "type": "string",
+        "description": "Could be any string, not necessarily a UUID"
+      },
+      "RuleObjectId": {
+        "type": "string"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/read_tags_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/read_tags_route.schema.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Tags API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/tags": {
+      "summary": "Aggregates and returns rule tags",
+      "get": {
+        "operationId": "ReadTags",
+        "x-codegen-enabled": true,
+        "summary": "Aggregates and returns all unique tags from all rules",
+        "tags": [
+          "Tags API"
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleTagArray"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleTagArray": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/x-pack/plugins/security_solution/common/api/bundles/update_rule_route.schema.json
+++ b/x-pack/plugins/security_solution/common/api/bundles/update_rule_route.schema.json
@@ -1,0 +1,51 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Update Rule API endpoint",
+    "version": "2023-10-31"
+  },
+  "paths": {
+    "/api/detection_engine/rules": {
+      "put": {
+        "operationId": "UpdateRule",
+        "x-codegen-enabled": false,
+        "description": "Update a single rule",
+        "tags": [
+          "Rules API"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuleUpdateProps"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates a successful call.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RuleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RuleUpdateProps": {
+        "type": "object"
+      },
+      "RuleResponse": {
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Since some OpenAPI tools don't support the multi-file approach that is currently used to pull shared components into the security OpenAPI specifications, this PR adds a readme file and a `bundles` directory to https://github.com/elastic/kibana/tree/main/x-pack/plugins/security_solution/common/api.

NOTE: If there's a better folder name (e.g. `oas`), that's fine by me.

The readme includes the `bundle` command that is used to generate the contents of the `bundles` directory. It pulls the relevant parts of each API description and its shared components into individual file outputs.

For example, the `components` are added directly to the file:
```
       "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/SuccessResponse"
                }
              }
```

Instead of:
```
   responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                $ref: '../model/schema/common.schema.yaml#/components/schemas/SuccessResponse'
```

If it's preferable to have a single output file that contains all the endpoints, that's also an option with a modified `bundle` command.