### PR TITLE
[ci] Temporarily move osquery tests back to on_merge_unsupported pipeline

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -187,18 +187,6 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    label: 'Osquery Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    parallelism: 6
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
   - command: '.buildkite/scripts/steps/functional/on_merge_unsupported_ftrs.sh'
     label: Trigger unsupported ftr tests
     timeout_in_minutes: 10

--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -63,3 +63,15 @@ steps:
           limit: 3
         - exit_status: '*'
           limit: 1
+
+  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
+    label: 'Osquery Cypress Tests'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 50
+    parallelism: 6
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -198,32 +198,6 @@ steps:
       automatic: false
     soft_fail: true
 
-  - command: .buildkite/scripts/steps/functional/osquery_cypress_burn.sh
-    label: 'Osquery Cypress Tests, burning changed specs'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    soft_fail: true
-    retry:
-      automatic: false
-    artifact_paths:
-      - 'target/kibana-osquery/**/*'
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    parallelism: 6
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-    artifact_paths:
-      - 'target/kibana-osquery/**/*'
-
   # status_exception: Native role management is not enabled in this Elasticsearch instance
   # - command: .buildkite/scripts/steps/functional/security_serverless_defend_workflows.sh
   #   label: 'Serverless Security Defend Workflows Cypress Tests'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -187,20 +187,6 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
-    label: 'Osquery Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    parallelism: 6
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-    artifact_paths:
-      - 'target/kibana-osquery/**/*'
-
   - command: .buildkite/scripts/steps/functional/security_solution_burn.sh
     label: 'Security Solution Cypress tests, burning changed specs'
     agents:

--- a/.buildkite/pipelines/pull_request/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/osquery_cypress.yml
@@ -1,0 +1,14 @@
+steps:
+  - command: .buildkite/scripts/steps/functional/osquery_cypress.sh
+    label: 'Osquery Cypress Tests'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 50
+    parallelism: 6
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+    artifact_paths:
+      - "target/kibana-osquery/**/*"

--- a/.buildkite/pipelines/pull_request/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/osquery_cypress.yml
@@ -12,3 +12,29 @@ steps:
           limit: 1
     artifact_paths:
       - "target/kibana-osquery/**/*"
+
+  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
+    label: 'Serverless Osquery Cypress Tests'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 50
+    parallelism: 6
+    retry:
+      automatic:
+        - exit_status: '*'
+          limit: 1
+    artifact_paths:
+      - 'target/kibana-osquery/**/*'
+
+  - command: .buildkite/scripts/steps/functional/osquery_cypress_burn.sh
+    label: 'Osquery Cypress Tests, burning changed specs'
+    agents:
+      queue: n2-4-spot
+    depends_on: build
+    timeout_in_minutes: 50
+    soft_fail: true
+    retry:
+      automatic: false
+    artifact_paths:
+      - 'target/kibana-osquery/**/*'

--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -152,6 +152,14 @@ const uploadPipeline = (pipelineContent: string | object) => {
     }
 
     if (
+      ((await doAnyChangesMatch([/^x-pack\/plugins\/osquery/, /^x-pack\/test\/osquery_cypress/])) ||
+        GITHUB_PR_LABELS.includes('ci:all-cypress-suites')) &&
+      !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
+    ) {
+      pipeline.push(getPipeline('.buildkite/pipelines/pull_request/osquery_cypress.yml'));
+    }
+
+    if (
       (await doAnyChangesMatch([
         /\.docnav\.json$/,
         /\.apidocs\.json$/,


### PR DESCRIPTION
These tests are currently failing - 
https://buildkite.com/elastic/kibana-on-merge/builds/36968
https://buildkite.com/elastic/kibana-on-merge/builds/36969

We can move these back to the main pipeline after tests are working and [junit reports are available](https://github.com/elastic/kibana/issues/169018).

