### PR TITLE
Validate EQL search strategy requests without `ignore` client option

### DIFF
--- a/src/plugins/data/common/search/strategies/eql_search/types.ts
+++ b/src/plugins/data/common/search/strategies/eql_search/types.ts
@@ -7,19 +7,16 @@
  */
 
 import type { EqlSearchRequest } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import type { TransportResult, TransportRequestOptions } from '@elastic/elasticsearch';
+import type { TransportResult } from '@elastic/elasticsearch';
 
 import { IKibanaSearchRequest, IKibanaSearchResponse } from '../../types';
 
 export const EQL_SEARCH_STRATEGY = 'eql';
 
-export type EqlRequestParams = EqlSearchRequest;
-
-export interface EqlSearchStrategyRequest extends IKibanaSearchRequest<EqlRequestParams> {
-  /**
-   * @deprecated: use IAsyncSearchOptions.transport instead.
-   */
-  options?: TransportRequestOptions;
+export interface EqlRequestParams extends EqlSearchRequest {
+  validate?: boolean;
 }
+
+export type EqlSearchStrategyRequest = IKibanaSearchRequest<EqlRequestParams>;
 
 export type EqlSearchStrategyResponse<T = unknown> = IKibanaSearchResponse<TransportResult<T>>;

--- a/src/plugins/data/server/search/strategies/eql_search/response_utils.ts
+++ b/src/plugins/data/server/search/strategies/eql_search/response_utils.ts
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { TransportResult } from '@elastic/elasticsearch';
+import { get } from 'lodash';
+import { errors, TransportResult } from '@elastic/elasticsearch';
 import { EqlSearchResponse } from './types';
 import { EqlSearchStrategyResponse } from '../../../../common';
 
@@ -24,3 +25,40 @@ export function toEqlKibanaSearchResponse(
     isRunning: response.body.is_running,
   };
 }
+
+export function errorToEqlKibanaSearchResponse(
+  response: EqlResponseError
+): EqlSearchStrategyResponse {
+  return {
+    id: undefined,
+    rawResponse: response.meta,
+    isPartial: false,
+    isRunning: false,
+  };
+}
+
+const PARSING_ERROR_TYPE = 'parsing_exception';
+const VERIFICATION_ERROR_TYPE = 'verification_exception';
+const MAPPING_ERROR_TYPE = 'mapping_exception';
+
+interface ErrorCause {
+  type: string;
+  reason: string;
+}
+
+interface EqlErrorBody {
+  error: ErrorCause & { root_cause: ErrorCause[] };
+}
+
+export interface EqlResponseError extends errors.ResponseError {
+  meta: TransportResult<EqlErrorBody>;
+}
+
+const isValidationErrorType = (type: unknown): boolean =>
+  type === PARSING_ERROR_TYPE || type === VERIFICATION_ERROR_TYPE || type === MAPPING_ERROR_TYPE;
+
+export const isEqlResponseError = (response: unknown): response is EqlResponseError =>
+  response instanceof errors.ResponseError;
+
+export const isEqlValidationResponseError = (response: unknown): response is EqlResponseError =>
+  isEqlResponseError(response) && isValidationErrorType(get(response, 'meta.body.error.type'));

--- a/x-pack/plugins/security_solution/public/common/hooks/eql/api.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/eql/api.ts
@@ -38,8 +38,8 @@ export const validateEql = async ({
         params: {
           index: dataViewTitle,
           body: { query, runtime_mappings: runtimeMappings, size: 0 },
+          validate: true,
         },
-        options: { ignore: [400] },
       },
       {
         strategy: EQL_SEARCH_STRATEGY,


### PR DESCRIPTION
Previously (since https://github.com/elastic/kibana/pull/77493), we had been leveraging the following facts:

* EQL search endpoint returns syntax errors as a 400 response
* ES client can specify an `ignore` option to opt out of the "throw unsuccessful responses" behavior

in order to perform EQL "validation" in a normal, non-exception control flow.

This effectively replaces that with a try/catch, where we no longer pass (nor _can_ pass) `ignore` to the search strategy, and instead indicate we'd like the "validation" behavior via a new `validate` param. When set to true, we will capture the 400 response and, if valid, return it as before; in all other situations that syntax error will result in an error response from the search strategy.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios