### PR TITLE
[ES|QL] Do not refresh the query when a user clicks the warning/error popover

### DIFF
--- a/packages/kbn-text-based-editor/src/editor_footer.tsx
+++ b/packages/kbn-text-based-editor/src/editor_footer.tsx
@@ -58,14 +58,12 @@ export function ErrorsWarningsPopover({
   isPopoverOpen,
   items,
   type,
-  refreshErrors,
   setIsPopoverOpen,
   onErrorClick,
 }: {
   isPopoverOpen: boolean;
   items: MonacoError[];
   type: 'error' | 'warning';
-  refreshErrors: () => void;
   setIsPopoverOpen: (flag: boolean) => void;
   onErrorClick: (error: MonacoError) => void;
 }) {
@@ -89,7 +87,6 @@ export function ErrorsWarningsPopover({
                   }
                 `}
                 onClick={() => {
-                  refreshErrors();
                   setIsPopoverOpen(!isPopoverOpen);
                 }}
               >
@@ -184,7 +181,6 @@ export const EditorFooter = memo(function EditorFooter({
               isPopoverOpen={isPopoverOpen}
               items={errors}
               type="error"
-              refreshErrors={refreshErrors}
               setIsPopoverOpen={setIsPopoverOpen}
               onErrorClick={onErrorClick}
             />
@@ -194,7 +190,6 @@ export const EditorFooter = memo(function EditorFooter({
               isPopoverOpen={isPopoverOpen}
               items={warning}
               type="warning"
-              refreshErrors={refreshErrors}
               setIsPopoverOpen={setIsPopoverOpen}
               onErrorClick={onErrorClick}
             />


### PR DESCRIPTION
## Summary

Leftover from my ES|QL implementation. We don't need to rerun the query when a user clicks the warning popover. I am removing this here.

Note: I still keep it on the footer component because I will need this here https://github.com/elastic/kibana/pull/167754

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->