### PR TITLE
do not add fleet server to settings in serverless in start_fleet_server script

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
@@ -290,7 +290,7 @@ const startFleetServerWithDocker = async ({
       if (!isServerless) {
         await addFleetServerHostToFleetSettings(kbnClient, log, fleetServerUrl);
       }
-      
+
       await updateFleetElasticsearchOutputHostNames(kbnClient, log);
 
       if (isServerless) {

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
@@ -287,7 +287,10 @@ const startFleetServerWithDocker = async ({
 
       log.info(`Fleet server started`);
 
-      await addFleetServerHostToFleetSettings(kbnClient, log, fleetServerUrl);
+      if (!isServerless) {
+        await addFleetServerHostToFleetSettings(kbnClient, log, fleetServerUrl);
+      }
+      
       await updateFleetElasticsearchOutputHostNames(kbnClient, log);
 
       if (isServerless) {


### PR DESCRIPTION
## Summary

Starting fleet server fails when Kibana is running in serverless mode with `Fleet server host write APIs are disabled`. Not adding the fleet server to fleet settings fixes it. Kudos to @patrykkopycinski for the fix!
