### PR TITLE
Risk score error message

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
@@ -69,7 +69,7 @@ const RiskScoreErrorPanel = ({ errors }: { errors: string[] }) => (
     >
       <p>{i18n.ERROR_PANEL_MESSAGE}</p>
 
-      <EuiAccordion id={'risk-engine-erros'} buttonContent={i18n.ERROR_PANEL_ERRORS}>
+      <EuiAccordion id="risk-engine-erros" buttonContent={i18n.ERROR_PANEL_ERRORS}>
         <>
           {errors.map((error) => (
             <div key={error}>
@@ -80,7 +80,7 @@ const RiskScoreErrorPanel = ({ errors }: { errors: string[] }) => (
         </>
       </EuiAccordion>
 
-      <EuiAccordion id={'risk-engine-erros'} buttonContent={i18n.CHECK_PRIVILEGES}>
+      <EuiAccordion id="risk-engine-privileges" buttonContent={i18n.CHECK_PRIVILEGES}>
         <p>
           {i18n.NEED_TO_HAVE}
           <ul>

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
@@ -78,6 +78,27 @@ const RiskScoreErrorPanel = ({ errors }: { errors: string[] }) => (
           ))}
         </>
       </EuiAccordion>
+
+      <EuiAccordion id={'risk-engine-erros'} buttonContent={i18n.CHECK_PRIVILEGES}>
+        <>
+          <p>
+            {i18n.NEED_TO_HAVE}
+            <ul>
+              <li>
+                <b>{'all'}</b> {i18n.PRIVILEGES_FOR} <b>{'risk-score.risk-score-*'}</b> {i18n.INDEX}
+              </li>
+              <li>
+                <b>{'manage_index_templates'}</b>
+                {','} <b>{'manage_transform'}</b>
+                {i18n.SECURITY_PRIVILEGES}
+              </li>
+              <li>
+                <b>{'Saved Objects Management'}</b> {i18n.KIBANA_PRIVILEGES}
+              </li>
+            </ul>
+          </p>
+        </>
+      </EuiAccordion>
     </EuiCallOut>
   </>
 );

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_enable_section.tsx
@@ -28,6 +28,7 @@ import {
   EuiCallOut,
   EuiAccordion,
 } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
 import {
   DETECTION_ENTITY_DASHBOARD,
   RISKY_HOSTS_DOC_LINK,
@@ -80,24 +81,44 @@ const RiskScoreErrorPanel = ({ errors }: { errors: string[] }) => (
       </EuiAccordion>
 
       <EuiAccordion id={'risk-engine-erros'} buttonContent={i18n.CHECK_PRIVILEGES}>
-        <>
-          <p>
-            {i18n.NEED_TO_HAVE}
-            <ul>
-              <li>
-                <b>{'all'}</b> {i18n.PRIVILEGES_FOR} <b>{'risk-score.risk-score-*'}</b> {i18n.INDEX}
-              </li>
-              <li>
-                <b>{'manage_index_templates'}</b>
-                {','} <b>{'manage_transform'}</b>
-                {i18n.SECURITY_PRIVILEGES}
-              </li>
-              <li>
-                <b>{'Saved Objects Management'}</b> {i18n.KIBANA_PRIVILEGES}
-              </li>
-            </ul>
-          </p>
-        </>
+        <p>
+          {i18n.NEED_TO_HAVE}
+          <ul>
+            <li>
+              <FormattedMessage
+                id="xpack.securitySolution.riskScore.errors.privileges.requiredPrivilege"
+                defaultMessage="{required_privilege} privileges for {index} index"
+                values={{
+                  required_privilege: <b>{'all'}</b>,
+                  index: <b>{'risk-score.risk-score-*'}</b>,
+                }}
+              />
+            </li>
+            <li>
+              <FormattedMessage
+                id="xpack.securitySolution.riskScore.errors.privileges.securityPrivilege"
+                defaultMessage="{security_privileges} security privileges"
+                values={{
+                  security_privileges: (
+                    <span>
+                      <b>{'manage_index_templates'}</b>
+                      {','} <b>{'manage_transform'}</b>
+                    </span>
+                  ),
+                }}
+              />
+            </li>
+            <li>
+              <FormattedMessage
+                id="xpack.securitySolution.riskScore.errors.privileges.kibanaPrivilege"
+                defaultMessage="{kibana_privilege} Kibana privilege"
+                values={{
+                  kibana_privilege: <b>{'Saved Objects Management'}</b>,
+                }}
+              />
+            </li>
+          </ul>
+        </p>
       </EuiAccordion>
     </EuiCallOut>
   </>

--- a/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/pages/entity_analytics_management_page.tsx
@@ -10,14 +10,12 @@ import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiPageHeader, EuiSpacer } fro
 
 import { RiskScorePreviewSection } from '../components/risk_score_preview_section';
 import { RiskScoreEnableSection } from '../components/risk_score_enable_section';
-import { MissingPrivilegesCallOut } from '../../detections/components/callouts/missing_privileges_callout';
 import { ENTITY_ANALYTICS_RISK_SCORE } from '../../app/translations';
 import { BETA } from '../../common/translations';
 
 export const EntityAnalyticsManagementPage = () => {
   return (
     <>
-      <MissingPrivilegesCallOut />
       <EuiFlexGroup gutterSize="s" alignItems="baseline">
         <EuiFlexItem grow={false}>
           <EuiPageHeader

--- a/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
@@ -260,7 +260,6 @@ export const MAX_SPACE_PANEL_MESSAGE = i18n.translate(
   }
 );
 
-
 export const CHECK_PRIVILEGES = i18n.translate(
   'xpack.securitySolution.riskScore.errors.privileges.check',
   {

--- a/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
@@ -259,3 +259,45 @@ export const MAX_SPACE_PANEL_MESSAGE = i18n.translate(
     defaultMessage: 'Please disable a currently running engine before enabling it here.',
   }
 );
+
+
+export const CHECK_PRIVILEGES = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.check',
+  {
+    defaultMessage: 'Check privileges',
+  }
+);
+
+export const NEED_TO_HAVE = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.needToHave',
+  {
+    defaultMessage: 'You need to have:',
+  }
+);
+
+export const PRIVILEGES_FOR = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.priviligesFor',
+  {
+    defaultMessage: 'privileges for',
+  }
+);
+export const INDEX = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.priviligesFor',
+  {
+    defaultMessage: 'index',
+  }
+);
+
+export const SECURITY_PRIVILEGES = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.securityPrivileges',
+  {
+    defaultMessage: ' security privileges',
+  }
+);
+
+export const KIBANA_PRIVILEGES = i18n.translate(
+  'xpack.securitySolution.riskScore.errors.privileges.kibanaPrivilege',
+  {
+    defaultMessage: 'Kibana privilege',
+  }
+);

--- a/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
@@ -280,12 +280,9 @@ export const PRIVILEGES_FOR = i18n.translate(
     defaultMessage: 'privileges for',
   }
 );
-export const INDEX = i18n.translate(
-  'xpack.securitySolution.riskScore.errors.privileges.priviligesFor',
-  {
-    defaultMessage: 'index',
-  }
-);
+export const INDEX = i18n.translate('xpack.securitySolution.riskScore.errors.privileges.index', {
+  defaultMessage: 'index',
+});
 
 export const SECURITY_PRIVILEGES = i18n.translate(
   'xpack.securitySolution.riskScore.errors.privileges.securityPrivileges',

--- a/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
@@ -199,14 +199,14 @@ export const UPDATE_RISK_ENGINE_MODAL_BUTTON_YES = i18n.translate(
 export const ERROR_PANEL_TITLE = i18n.translate(
   'xpack.securitySolution.riskScore.errorPanel.title',
   {
-    defaultMessage: 'Sorry, there was an error',
+    defaultMessage: 'There was an error',
   }
 );
 
 export const ERROR_PANEL_MESSAGE = i18n.translate(
   'xpack.securitySolution.riskScore.errorPanel.message',
   {
-    defaultMessage: 'Something went wrong. Try again later.',
+    defaultMessage: 'The risk engine status could not be changed. Fix the following and try again:',
   }
 );
 
@@ -271,29 +271,5 @@ export const NEED_TO_HAVE = i18n.translate(
   'xpack.securitySolution.riskScore.errors.privileges.needToHave',
   {
     defaultMessage: 'You need to have:',
-  }
-);
-
-export const PRIVILEGES_FOR = i18n.translate(
-  'xpack.securitySolution.riskScore.errors.privileges.priviligesFor',
-  {
-    defaultMessage: 'privileges for',
-  }
-);
-export const INDEX = i18n.translate('xpack.securitySolution.riskScore.errors.privileges.index', {
-  defaultMessage: 'index',
-});
-
-export const SECURITY_PRIVILEGES = i18n.translate(
-  'xpack.securitySolution.riskScore.errors.privileges.securityPrivileges',
-  {
-    defaultMessage: ' security privileges',
-  }
-);
-
-export const KIBANA_PRIVILEGES = i18n.translate(
-  'xpack.securitySolution.riskScore.errors.privileges.kibanaPrivilege',
-  {
-    defaultMessage: 'Kibana privilege',
   }
 );

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
@@ -134,7 +134,7 @@ describe(
         // init
         riskEngineStatusChange();
 
-        cy.get(RISK_SCORE_ERROR_PANEL).contains('Sorry, there was an error');
+        cy.get(RISK_SCORE_ERROR_PANEL).contains('There was an error');
       });
 
       it('should update if there legacy risk score installed', () => {


### PR DESCRIPTION
## Risk score error message includes info about needed privileges

Error panel for risk engine API requests always will include a section, `Check privileges` with information about all privileges they need to have. 

We are not checking for missing one here, we just list all of that needed, as a quick fix.



### Default view:
<img width="469" alt="Screenshot 2023-10-18 at 11 55 09" src="https://github.com/elastic/kibana/assets/7609147/c653e29f-8b9b-4fe9-983d-dca256c4fc9a">


### Expanded view:
<img width="493" alt="Screenshot 2023-10-18 at 11 55 01" src="https://github.com/elastic/kibana/assets/7609147/d808883a-b66b-4f58-9acc-6d977c644741">


### This callout was removed because it's not related to the risk engine:
<img width="1616" alt="Screenshot 2023-10-16 at 20 02 01" src="https://github.com/elastic/kibana/assets/7609147/685f24f8-13ed-4b76-bbe5-c6fecbd38d27">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->