### PR TITLE
[EDR Workflows] Degrade agent version

### DIFF
--- a/x-pack/test/osquery_cypress/artifact_manager.ts
+++ b/x-pack/test/osquery_cypress/artifact_manager.ts
@@ -6,5 +6,6 @@
  */
 
 export async function getLatestVersion(): Promise<string> {
-  return '8.11.0-SNAPSHOT';
+  // temporary solution until newer agents work fine with Docker
+  return '8.10.4';
 }


### PR DESCRIPTION
We identified an issue where osquery tests are failing because new agent release doesn't start properly in docker. 

Hopefully this PR doesn't get merged, but in case where agent issue is not fixable soon, we should merge this to unblock other PRs.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->