### PR TITLE
[Synthetics] Use agent policy namespace for monitors if custom not defined

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_private_locations.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/monitor_management/synthetics_private_locations.ts
@@ -22,6 +22,7 @@ export const PrivateLocationCodec = t.intersection([
       lat: t.number,
       lon: t.number,
     }),
+    namespace: t.string,
   }),
 ]);
 

--- a/x-pack/plugins/synthetics/common/types/synthetics_monitor.ts
+++ b/x-pack/plugins/synthetics/common/types/synthetics_monitor.ts
@@ -27,4 +27,5 @@ export interface AgentPolicyInfo {
   agents: number;
   status: string;
   description?: string;
+  namespace?: string;
 }

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_agent_policies.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/get_agent_policies.ts
@@ -39,5 +39,24 @@ export const getAgentPoliciesAsInternalUser = async (server: SyntheticsServerSet
     agents: agentPolicy.agents ?? 0,
     status: agentPolicy.status,
     description: agentPolicy.description,
+    namespace: agentPolicy.namespace,
   }));
+};
+
+export const getAgentPolicyAsInternalUser = async (server: SyntheticsServerSetup, id: string) => {
+  const soClient = server.coreStart.savedObjects.createInternalRepository();
+
+  const agentPolicy = await server.fleet?.agentPolicyService.get(soClient, id);
+  if (!agentPolicy) {
+    return null;
+  }
+
+  return {
+    id: agentPolicy.id,
+    name: agentPolicy.name,
+    agents: agentPolicy.agents ?? 0,
+    status: agentPolicy.status,
+    description: agentPolicy.description,
+    namespace: agentPolicy.namespace,
+  };
 };

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/helpers.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/helpers.ts
@@ -17,16 +17,20 @@ export const toClientContract = (
   agentPolicies?: AgentPolicyInfo[]
 ): SyntheticsPrivateLocations => {
   return {
-    locations: attributes.locations.map((location) => ({
-      label: location.label,
-      id: location.id,
-      agentPolicyId: location.agentPolicyId,
-      concurrentMonitors: location.concurrentMonitors,
-      isServiceManaged: false,
-      isInvalid: !Boolean(agentPolicies?.find((policy) => policy.id === location.agentPolicyId)),
-      tags: location.tags,
-      geo: location.geo,
-    })),
+    locations: attributes.locations.map((location) => {
+      const agPolicy = agentPolicies?.find((policy) => policy.id === location.agentPolicyId);
+      return {
+        label: location.label,
+        id: location.id,
+        agentPolicyId: location.agentPolicyId,
+        concurrentMonitors: location.concurrentMonitors,
+        isServiceManaged: false,
+        isInvalid: !Boolean(agPolicy),
+        tags: location.tags,
+        geo: location.geo,
+        namespace: agPolicy?.namespace,
+      };
+    }),
   };
 };
 
@@ -39,5 +43,6 @@ export const toSavedObjectContract = (location: PrivateLocation): PrivateLocatio
     tags: location.tags,
     isServiceManaged: false,
     geo: location.geo,
+    namespace: location.namespace,
   };
 };

--- a/x-pack/plugins/synthetics/server/runtime_types/private_locations.ts
+++ b/x-pack/plugins/synthetics/server/runtime_types/private_locations.ts
@@ -21,6 +21,7 @@ export const PrivateLocationAttributesCodec = t.intersection([
       lat: t.number,
       lon: t.number,
     }),
+    namespace: t.string,
   }),
 ]);
 

--- a/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/private_location/synthetics_private_location.ts
@@ -8,12 +8,16 @@ import { NewPackagePolicy } from '@kbn/fleet-plugin/common';
 import { NewPackagePolicyWithId } from '@kbn/fleet-plugin/server/services/package_policy';
 import { cloneDeep } from 'lodash';
 import { SavedObjectError } from '@kbn/core-saved-objects-common';
+import { DEFAULT_NAMESPACE_STRING } from '../../../common/constants/monitor_defaults';
 import {
   BROWSER_TEST_NOW_RUN,
   LIGHTWEIGHT_TEST_NOW_RUN,
 } from '../synthetics_monitor/synthetics_monitor_client';
 import { scheduleCleanUpTask } from './clean_up_task';
-import { getAgentPoliciesAsInternalUser } from '../../routes/settings/private_locations/get_agent_policies';
+import {
+  getAgentPoliciesAsInternalUser,
+  getAgentPolicyAsInternalUser,
+} from '../../routes/settings/private_locations/get_agent_policies';
 import { SyntheticsServerSetup } from '../../types';
 import { formatSyntheticsPolicy } from '../formatters/private_formatters/format_synthetics_policy';
 import {
@@ -66,7 +70,7 @@ export class SyntheticsPrivateLocation {
     return `${config.id}-${locId}-${spaceId}`;
   }
 
-  generateNewPolicy(
+  async generateNewPolicy(
     config: HeartbeatConfig,
     privateLocation: PrivateLocationAttributes,
     newPolicyTemplate: NewPackagePolicy,
@@ -74,7 +78,7 @@ export class SyntheticsPrivateLocation {
     globalParams: Record<string, string>,
     testRunId?: string,
     runOnce?: boolean
-  ): (NewPackagePolicy & { policy_id: string }) | null {
+  ): Promise<(NewPackagePolicy & { policy_id: string }) | null> {
     const { label: locName } = privateLocation;
 
     const newPolicy = cloneDeep(newPolicyTemplate);
@@ -92,7 +96,9 @@ export class SyntheticsPrivateLocation {
           newPolicy.name = `${config[ConfigKey.NAME]}-${locName}-${spaceId}`;
         }
       }
-      newPolicy.namespace = config[ConfigKey.NAMESPACE];
+      const configNameSpace = config[ConfigKey.NAMESPACE];
+
+      newPolicy.namespace = await this.getPolicyNameSpace(configNameSpace, privateLocation);
 
       const { formattedPolicy } = formatSyntheticsPolicy(
         newPolicy,
@@ -152,7 +158,7 @@ export class SyntheticsPrivateLocation {
             );
           }
 
-          const newPolicy = this.generateNewPolicy(
+          const newPolicy = await this.generateNewPolicy(
             config,
             location,
             newPolicyTemplate,
@@ -226,7 +232,7 @@ export class SyntheticsPrivateLocation {
 
       const location = allPrivateLocations?.find((loc) => loc.id === privateLocation?.id)!;
 
-      const newPolicy = this.generateNewPolicy(
+      const newPolicy = await this.generateNewPolicy(
         config,
         location,
         newPolicyTemplate,
@@ -278,7 +284,7 @@ export class SyntheticsPrivateLocation {
         const hasPolicy = existingPolicies?.some((policy) => policy.id === currId);
         try {
           if (hasLocation) {
-            const newPolicy = this.generateNewPolicy(
+            const newPolicy = await this.generateNewPolicy(
               config,
               privateLocation,
               newPolicyTemplate,
@@ -436,6 +442,17 @@ export class SyntheticsPrivateLocation {
 
   async getAgentPolicies() {
     return await getAgentPoliciesAsInternalUser(this.server);
+  }
+
+  async getPolicyNameSpace(configNameSpace: string, privateLocation: PrivateLocationAttributes) {
+    if (configNameSpace && configNameSpace !== DEFAULT_NAMESPACE_STRING) {
+      return configNameSpace;
+    }
+    if (privateLocation.namespace) {
+      return privateLocation.namespace;
+    }
+    const agentPolicy = await getAgentPolicyAsInternalUser(this.server, privateLocation.id);
+    return agentPolicy?.namespace ?? DEFAULT_NAMESPACE_STRING;
   }
 }
 

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor_private_location.ts
@@ -81,6 +81,7 @@ export default function ({ getService }: FtrProviderContext) {
             lon: 0,
           },
           agentPolicyId: testFleetPolicyID,
+          namespace: 'default',
         },
       ]);
     });

--- a/x-pack/test/api_integration/apis/synthetics/sync_global_params.ts
+++ b/x-pack/test/api_integration/apis/synthetics/sync_global_params.ts
@@ -89,6 +89,7 @@ export default function ({ getService }: FtrProviderContext) {
             lon: '',
           },
           agentPolicyId: testFleetPolicyID,
+          namespace: 'default',
         },
       ]);
     });


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/165066

Use agent policy namespace for monitors if custom not defined !!


### Testing

- Create a fleet agent policy and set namespace value to non default 
- Create a private location and add a monitor
- Notice that in fleet the package policy which got created has namespace of the agent policy


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->