### PR TITLE
[Security Solution] Unskip rules export import serverless cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/export_rule.cy.ts
@@ -33,7 +33,6 @@ import {
   cleanKibana,
   resetRulesTableState,
   deleteAlertsAndRules,
-  reload,
 } from '../../../../../tasks/common';
 import { login } from '../../../../../tasks/login';
 import { visit } from '../../../../../tasks/navigation';
@@ -56,8 +55,7 @@ const prebuiltRules = Array.from(Array(7)).map((_, i) => {
   });
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-describe('Export rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Export rules', { tags: ['@ess', '@serverless'] }, () => {
   const downloadsFolder = Cypress.config('downloadsFolder');
 
   before(() => {
@@ -171,7 +169,7 @@ describe('Export rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] 
       const expectedNumberCustomRulesToBeExported = 2;
 
       createAndInstallMockedPrebuiltRules(prebuiltRules);
-      reload();
+      cy.reload();
       selectAllRules();
       bulkExportRules();
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/rule_actions/import_export/import_rules.cy.ts
@@ -11,15 +11,16 @@ import {
   importRules,
   importRulesWithOverwriteAll,
 } from '../../../../../tasks/alerts_detection_rules';
-import { cleanKibana, deleteAlertsAndRules, reload } from '../../../../../tasks/common';
+import { cleanKibana, deleteAlertsAndRules } from '../../../../../tasks/common';
+import { deleteExceptionList } from '../../../../../tasks/api_calls/exceptions';
 import { login } from '../../../../../tasks/login';
 import { visit } from '../../../../../tasks/navigation';
 
 import { RULES_MANAGEMENT_URL } from '../../../../../urls/rules_management';
 const RULES_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_rules.ndjson';
+const IMPORTED_EXCEPTION_ID = 'b8dfd17f-1e11-41b0-ae7e-9e7f8237de49';
 
-// TODO: https://github.com/elastic/kibana/issues/161540
-describe('Import rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Import rules', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
   });
@@ -27,6 +28,7 @@ describe('Import rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] 
   beforeEach(() => {
     login();
     deleteAlertsAndRules();
+    deleteExceptionList(IMPORTED_EXCEPTION_ID, 'single');
     cy.intercept('POST', '/api/detection_engine/rules/_import*').as('import');
     visit(RULES_MANAGEMENT_URL);
   });
@@ -52,7 +54,7 @@ describe('Import rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] 
       cy.wrap(response?.statusCode).should('eql', 200);
     });
 
-    reload();
+    cy.reload();
     importRules(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {
@@ -68,7 +70,7 @@ describe('Import rules', { tags: ['@ess', '@serverless', '@brokenInServerless'] 
       cy.wrap(response?.statusCode).should('eql', 200);
     });
 
-    reload();
+    cy.reload();
     importRulesWithOverwriteAll(RULES_TO_IMPORT_FILENAME);
 
     cy.wait('@import').then(({ response }) => {

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts_detection_rules.ts
@@ -285,11 +285,11 @@ export const waitForRuleToUpdate = () => {
 
 export const importRules = (rulesFile: string) => {
   cy.get(RULE_IMPORT_MODAL).click();
-  cy.get(INPUT_FILE).click({ force: true });
+  cy.get(INPUT_FILE).click();
   cy.get(INPUT_FILE).selectFile(rulesFile);
   cy.get(INPUT_FILE).trigger('change');
-  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click({ force: true });
-  cy.get(INPUT_FILE).should('not.exist');
+  cy.get(RULE_IMPORT_MODAL_BUTTON).last().click();
+  cy.get(INPUT_FILE, { timeout: 300000 }).should('not.exist');
 };
 
 export const expectRulesManagementTab = () => {


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/161540

## Summary

This PR unskips import and export security rules Serverless Cypress tests.

## Flaky test runner

`import_export` folder [150 runs](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3588)