### PR TITLE
[ci/pull_requests] Disable kibana-kme-test

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -55,7 +55,7 @@
       "repoName": "kibana",
       "pipelineSlug": "kibana-kme-test",
 
-      "enabled": true,
+      "enabled": false,
       "allow_org_users": true,
       "allowed_repo_permissions": ["admin", "write"],
       "allowed_list": ["barlowm", "renovate[bot]"],


### PR DESCRIPTION
Introduced in https://github.com/elastic/kibana/pull/157334

This pipeline was/(is?) used for testing the new buildkite system.  We're running into an issue where `trigger_comment_regex` matches on both the legacy and new systems, triggering builds in both.  GitHub checks can end up conflicting making it difficult to find the correct build link.

This disables the pr integration for kibana-kme-test.  If we're done with the testing pipeline we can remove it, if not we can change the trigger word.  I'm not sure what the current status is, ping @elastic/ci-systems .  

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->