### PR TITLE
[Discover] Fixes sorting for ES|QL columns that do not exist on a dataview

### DIFF
--- a/packages/kbn-unified-data-table/src/components/__snapshots__/data_table_columns.test.tsx.snap
+++ b/packages/kbn-unified-data-table/src/components/__snapshots__/data_table_columns.test.tsx.snap
@@ -956,7 +956,7 @@ Array [
     "displayAsText": "extension",
     "id": "extension",
     "isSortable": false,
-    "schema": "string",
+    "schema": "numeric",
     "visibleCellActions": undefined,
   },
   Object {
@@ -1272,7 +1272,7 @@ Array [
     "displayAsText": "message",
     "id": "message",
     "isSortable": false,
-    "schema": "string",
+    "schema": "kibana-json",
     "visibleCellActions": undefined,
   },
 ]

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.test.tsx
@@ -159,4 +159,64 @@ describe('Data table columns', function () {
       expect(actual).toMatchSnapshot();
     });
   });
+
+  describe('Textbased languages grid columns', () => {
+    it('returns eui grid with in memory sorting for text based languages and columns on the dataview', async () => {
+      const columnsNotInDataview = getVisibleColumns(
+        ['extension'],
+        dataViewWithTimefieldMock,
+        true
+      ) as string[];
+      const gridColumns = getEuiGridColumns({
+        columns: columnsNotInDataview,
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnTypes: {
+          var_test: 'number',
+        },
+      });
+      expect(gridColumns[1].schema).toBe('string');
+    });
+
+    it('returns eui grid with in memory sorting for text based languages and columns not on the columnTypes', async () => {
+      const columnsNotInDataview = getVisibleColumns(
+        ['var_test'],
+        dataViewWithTimefieldMock,
+        true
+      ) as string[];
+      const gridColumns = getEuiGridColumns({
+        columns: columnsNotInDataview,
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnTypes: {
+          var_test: 'number',
+        },
+      });
+      expect(gridColumns[1].schema).toBe('numeric');
+    });
+  });
 });

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -125,7 +125,7 @@ function buildEuiGridColumn({
       : [];
   }
 
-  const columnType = columnTypes?.[columnName] ?? dataViewField?.type;
+  const columnType = dataViewField?.type ?? columnTypes?.[columnName];
 
   const column: EuiDataGridColumn = {
     id: columnName,

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -125,7 +125,7 @@ function buildEuiGridColumn({
       : [];
   }
 
-  const columnType = dataViewField?.type ?? columnTypes?.[columnName];
+  const columnType = columnTypes?.[columnName] ?? dataViewField?.type;
 
   const column: EuiDataGridColumn = {
     id: columnName,

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -125,9 +125,11 @@ function buildEuiGridColumn({
       : [];
   }
 
+  const columnType = dataViewField?.type ?? columnTypes?.[columnName];
+
   const column: EuiDataGridColumn = {
     id: columnName,
-    schema: getSchemaByKbnType(dataViewField?.type),
+    schema: getSchemaByKbnType(columnType),
     isSortable: isSortEnabled && (isPlainRecord || dataViewField?.sortable === true),
     display: showColumnTokens ? (
       <DataTableColumnHeaderMemoized


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/168118

Fixes the broken sorting of columns that are created from the query and they do not exist on the dataview. This was working correctly so I assume is a regression from a refactoring.

<img width="1503" alt="image" src="https://github.com/elastic/kibana/assets/17003240/df762a28-b47f-4f3b-a902-180dd6a212c0">


### Checklist
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->