### PR TITLE
[Security Solution] Flaky test runner for `sourcerer` and `overview` Cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/sourcerer/sourcerer_timeline.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/sourcerer/sourcerer_timeline.cy.ts
@@ -40,7 +40,7 @@ const siemDataViewTitle = 'Security Default Data View';
 const dataViews = ['auditbeat-*,fakebeat-*', 'auditbeat-*,*beat*,siem-read*,.kibana*,fakebeat-*'];
 
 // TODO: https://github.com/elastic/kibana/issues/161539
-describe.skip('Timeline scope', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Timeline scope', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     cy.clearLocalStorage();
     login();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/overview/cti_link_panel.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/overview/cti_link_panel.cy.ts
@@ -18,7 +18,7 @@ import { OVERVIEW_URL } from '../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 // FLAKY: https://github.com/elastic/kibana/issues/165709
-describe.skip('CTI Link Panel', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('CTI Link Panel', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     login();
   });
@@ -34,39 +34,35 @@ describe.skip('CTI Link Panel', { tags: ['@ess', '@serverless', '@skipInServerle
   });
 
   // TODO: https://github.com/elastic/kibana/issues/161539
-  describe(
-    'enabled threat intel module',
-    { tags: ['@ess', '@serverless', '@brokenInServerless'] },
-    () => {
-      before(() => {
-        // illegal_argument_exception: unknown setting [index.lifecycle.name]
-        cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });
-      });
+  describe('enabled threat intel module', { tags: ['@ess', '@serverless'] }, () => {
+    before(() => {
+      // illegal_argument_exception: unknown setting [index.lifecycle.name]
+      cy.task('esArchiverLoad', { archiveName: 'threat_indicator' });
+    });
 
-      beforeEach(() => {
-        login();
-      });
+    beforeEach(() => {
+      login();
+    });
 
-      after(() => {
-        cy.task('esArchiverUnload', 'threat_indicator');
-      });
+    after(() => {
+      cy.task('esArchiverUnload', 'threat_indicator');
+    });
 
-      it('renders disabled dashboard module as expected when there are no events in the selected time period', () => {
-        visit(
-          `${OVERVIEW_URL}?sourcerer=(timerange:(from:%272021-07-08T04:00:00.000Z%27,kind:absolute,to:%272021-07-09T03:59:59.999Z%27))`
-        );
-        cy.get(`${OVERVIEW_CTI_LINKS}`).should('exist');
-        cy.get(`${OVERVIEW_CTI_TOTAL_EVENT_COUNT}`).should('have.text', 'Showing: 0 indicators');
-      });
+    it('renders disabled dashboard module as expected when there are no events in the selected time period', () => {
+      visit(
+        `${OVERVIEW_URL}?sourcerer=(timerange:(from:%272021-07-08T04:00:00.000Z%27,kind:absolute,to:%272021-07-09T03:59:59.999Z%27))`
+      );
+      cy.get(`${OVERVIEW_CTI_LINKS}`).should('exist');
+      cy.get(`${OVERVIEW_CTI_TOTAL_EVENT_COUNT}`).should('have.text', 'Showing: 0 indicators');
+    });
 
-      it('renders dashboard module as expected when there are events in the selected time period', () => {
-        visit(OVERVIEW_URL);
+    it('renders dashboard module as expected when there are events in the selected time period', () => {
+      visit(OVERVIEW_URL);
 
-        cy.get(`${OVERVIEW_CTI_LINKS}`).should('exist');
-        cy.get(OVERVIEW_CTI_LINKS).should('not.contain.text', 'Anomali');
-        cy.get(OVERVIEW_CTI_LINKS).should('contain.text', 'AbuseCH malware');
-        cy.get(`${OVERVIEW_CTI_TOTAL_EVENT_COUNT}`).should('have.text', 'Showing: 1 indicator');
-      });
-    }
-  );
+      cy.get(`${OVERVIEW_CTI_LINKS}`).should('exist');
+      cy.get(OVERVIEW_CTI_LINKS).should('not.contain.text', 'Anomali');
+      cy.get(OVERVIEW_CTI_LINKS).should('contain.text', 'AbuseCH malware');
+      cy.get(`${OVERVIEW_CTI_TOTAL_EVENT_COUNT}`).should('have.text', 'Showing: 1 indicator');
+    });
+  });
 });

--- a/x-pack/test/security_solution_cypress/package.json
+++ b/x-pack/test/security_solution_cypress/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cypress": "NODE_OPTIONS=--openssl-legacy-provider ../../../node_modules/.bin/cypress",
     "cypress:open:ess": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ../../test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ../../test/security_solution_cypress/cli_config",
-    "cypress:run:ess": "yarn cypress:ess --spec './cypress/e2e/!(investigations|explore)/**/*.cy.ts'",
+    "cypress:run:ess": "yarn cypress:ess --spec './cypress/e2e/{detection_response/sourcerer,overview}/**/*.cy.ts'",
     "cypress:run:cases:ess": "yarn cypress:ess --spec './cypress/e2e/explore/cases/*.cy.ts'",
     "cypress:ess": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider node ../../plugins/security_solution/scripts/start_cypress_parallel run --config-file ../../test/security_solution_cypress/cypress/cypress_ci.config.ts --ftr-config-file ../../test/security_solution_cypress/cli_config",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/(detection_alerts|detection_rules|exceptions)/*.cy.ts'",
@@ -21,7 +21,7 @@
     "cypress:cloud:serverless": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider NODE_TLS_REJECT_UNAUTHORIZED=0 ../../../node_modules/.bin/cypress",
     "cypress:open:cloud:serverless": "yarn cypress:cloud:serverless open --config-file ./cypress/cypress_serverless.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:open:serverless": "yarn cypress:serverless open --config-file ../../test/security_solution_cypress/cypress/cypress_serverless.config.ts --spec './cypress/e2e/**/*.cy.ts'",
-    "cypress:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/!(investigations|explore)/**/*.cy.ts'",
+    "cypress:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/{detection_response/sourcerer,overview}/**/*.cy.ts'",
     "cypress:run:cloud:serverless": "yarn cypress:cloud:serverless run --config-file ./cypress/cypress_ci_serverless.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:run:qa:serverless": "yarn cypress:cloud:serverless run --config-file ./cypress/cypress_ci_serverless_qa.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/**/*.cy.ts'",


### PR DESCRIPTION
## Summary

Flaky test runner for Cypress tests in:
- `x-pack/test/security_solution_cypress/cypress/e2e/detection_response/sourcerer` 
- `x-pack/test/security_solution_cypress/cypress/e2e/overview` 

## Related failing-test issues

### `e2e/detection_response/sourcerer`

1. https://github.com/elastic/kibana/issues/165766
2. https://github.com/elastic/kibana/issues/169402
**Test reported as failing while running flaky-test-runner. Marked as `legit-flake` and assigned to @elastic/security-detection-engine** 

### `e2e/overview`

4. https://github.com/elastic/kibana/issues/165765
**Marked as `legit-flake`**
5. https://github.com/elastic/kibana/issues/165709
**Marked as `legit-flake`**

### Flaky test runner link

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3591