### PR TITLE
[DOCS] Clean up APM UI docs

### DIFF
--- a/docs/apm/infrastructure.asciidoc
+++ b/docs/apm/infrastructure.asciidoc
@@ -2,6 +2,8 @@
 [[infrastructure]]
 === Infrastructure
 
+beta::[]
+
 The *Infrastructure* tab provides information about the containers, pods, and hosts,
 that the selected service is linked to.
 

--- a/docs/apm/spans.asciidoc
+++ b/docs/apm/spans.asciidoc
@@ -43,8 +43,9 @@ For example, quickly view:
 [[distributed-tracing]]
 ==== Distributed tracing
 
-If your trace sample timeline is colorful, it's indicative of a distributed trace.
-Services in a distributed trace are separated by color and listed in the order they occur.
+When a trace travels through multiple services it is known as a _distributed trace_.
+In APM, the colors in a distributed trace represent different services and
+are listed in the order they occur.
 
 [role="screenshot"]
 image::apm/images/apm-services-trace.png[Example of distributed trace colors in the APM app in Kibana]

--- a/docs/apm/traces.asciidoc
+++ b/docs/apm/traces.asciidoc
@@ -17,6 +17,10 @@ it's the collective amount of pain a specific endpoint is causing your users.
 If there's a particular endpoint you're worried about, select it to view its
 <<transaction-details,transaction details>>.
 
+You can also use queries to filter and search the transactions shown on this page.
+Note that only properties available on root transactions are searchable.
+For example, you can't search for `label.tier: 'high'`, as that field is only available on non-root transactions.
+
 [role="screenshot"]
 image::apm/images/apm-traces.png[Example view of the Traces overview in APM app in Kibana]
 


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/3292

## Summary

Updates documentation related to the APM UI based on issues found during the Observability docs bug bash last week.

### Checklist

Delete any items that are not applicable to this PR.

- [x] @colleenmcginnis [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials:
  - [x] Clarify that distributed traces aren't the only colorful traces in [Trace sample timeline](https://www.elastic.co/guide/en/kibana/current/spans.html#distributed-tracing) (https://github.com/elastic/kibana/commit/b707c3936bbf6fd3dcf2651653d5fa527a085171)
  - [x] Clarify the implications of the traces table only showing root transactions in [Traces](https://www.elastic.co/guide/en/kibana/current/traces.html) (https://github.com/elastic/kibana/commit/c1de678f912c03159926119aead13912a6d9239b)
  - [x] Add beta admonition to APM [Infrastucture](https://www.elastic.co/guide/en/kibana/current/infrastructure.html) page (https://github.com/elastic/kibana/commit/d3bc4a972d3066485f9c6feb747af64298758f59)
- [x] @bmorelli25 review

<!--ONMERGE {"backportTargets":["8.10","8.11"]} ONMERGE-->