### PR TITLE
[Security Solution] Expandable flyout - fix deleted rule not showing highlighted fields

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
@@ -95,7 +95,7 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
 export const HighlightedFields: FC = () => {
   const { dataFormattedForFieldBrowser, scopeId } = useRightPanelContext();
   const { ruleId } = useBasicDataFromDetailsData(dataFormattedForFieldBrowser);
-  const { loading, error, rule: maybeRule } = useRuleWithFallback(ruleId);
+  const { loading, rule: maybeRule } = useRuleWithFallback(ruleId);
 
   const highlightedFields = useHighlightedFields({
     dataFormattedForFieldBrowser,
@@ -121,7 +121,7 @@ export const HighlightedFields: FC = () => {
       <EuiFlexItem data-test-subj={HIGHLIGHTED_FIELDS_DETAILS_TEST_ID}>
         <EuiPanel hasBorder hasShadow={false}>
           <EuiInMemoryTable
-            items={error ? [] : items}
+            items={items}
             columns={columns}
             compressed
             loading={loading}


### PR DESCRIPTION
## Summary

This PR addresses https://github.com/elastic/kibana/issues/169201 and removes the `items` override in highlighted fields table when error is returned. Highlighted fields table should show items if they are available.


After a rule is deleted
![image](https://github.com/elastic/kibana/assets/18648970/c3d4c51a-e211-466c-be72-a312ac52ba6a)

also indicated in rule preview
![image](https://github.com/elastic/kibana/assets/18648970/3c9ca1a6-0efa-4c58-a409-ccde542f02ed)



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->