### PR TITLE
[Security Solution] Add ESLint rules used at Observability

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1059,6 +1059,9 @@ module.exports = {
             patterns: ['**/server/*'],
           },
         ],
+        '@kbn/telemetry/event_generating_elements_should_be_instrumented': 'error',
+        '@kbn/i18n/strings_should_be_translated_with_i18n': 'warn',
+        '@kbn/i18n/strings_should_be_translated_with_formatted_message': 'warn',
       },
     },
     {


### PR DESCRIPTION
## Summary

Over the past couple months, Observability folks have developed some ESLint rules that help them with writing JSX:

- `@kbn/telemetry/event_generating_elements_should_be_instrumented`. An ESLint rule which can auto-add a `data-test-subj` value to event-generating Eui elements (buttons, inputs, etc). The suggested value is based on the location of the file, component name, and Eui component name. https://github.com/elastic/kibana/pull/153108

- `@kbn/i18n/strings_should_be_translated_with_i18n`, `@kbn/i18n/strings_should_be_translated_with_formatted_message` An ESLint rule which can auto-replace a text string in a component with either a `i18n.translate` or `<FormattedMessage />` with a suggested `id` based on the location of the file, component name and parent wrapping element name. https://github.com/elastic/kibana/pull/168001

They're currently enabled for all Observability and ML apps, they haven't been enabled for Security yet. Perhaps they can be of use to us too.


https://github.com/elastic/kibana/assets/7359339/ee97aa4d-18ef-4bea-a0fa-9a364fe5bcf1

https://github.com/elastic/kibana/assets/7359339/f09ce62a-b103-4f11-af7b-e0fba809b783
