### PR TITLE
[8.9] [ResponseOps] Allow bulk snoozing of Security Rules (#169180)

### DIFF
--- a/x-pack/plugins/alerting/server/rules_client/methods/bulk_edit.ts
+++ b/x-pack/plugins/alerting/server/rules_client/methods/bulk_edit.ts
@@ -642,15 +642,6 @@ async function getUpdatedAttributesFromOperations(
         break;
       }
       case 'snoozeSchedule': {
-        // Silently skip adding snooze or snooze schedules on security
-        // rules until we implement snoozing of their rules
-        if (rule.attributes.consumer === AlertConsumers.SIEM) {
-          // While the rule is technically not updated, we are still marking
-          // the rule as updated in case of snoozing, until support
-          // for snoozing is added.
-          isAttributesUpdateSkipped = false;
-          break;
-        }
         if (operation.operation === 'set') {
           const snoozeAttributes = getBulkSnoozeAttributes(rule.attributes, operation.value);
           try {

--- a/x-pack/plugins/alerting/server/rules_client/tests/bulk_edit.test.ts
+++ b/x-pack/plugins/alerting/server/rules_client/tests/bulk_edit.test.ts
@@ -1381,40 +1381,6 @@ describe('bulkEdit()', () => {
         'Error updating rule: could not add snooze - Rule cannot have more than 5 snooze schedules'
       );
     });
-
-    test('should ignore siem rules when bulk editing snooze', async () => {
-      mockCreatePointInTimeFinderAsInternalUser({
-        saved_objects: [
-          {
-            ...existingDecryptedRule,
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            attributes: { ...existingDecryptedRule.attributes, consumer: 'siem' } as any,
-          },
-        ],
-      });
-
-      unsecuredSavedObjectsClient.bulkCreate.mockResolvedValue(getMockAttribute());
-
-      const snoozePayload = getSnoozeSchedule();
-
-      await rulesClient.bulkEdit({
-        filter: '',
-        operations: [
-          {
-            operation: 'set',
-            field: 'snoozeSchedule',
-            value: snoozePayload,
-          },
-        ],
-      });
-
-      expect(unsecuredSavedObjectsClient.bulkCreate).toHaveBeenCalledTimes(1);
-      expect(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (unsecuredSavedObjectsClient.bulkCreate.mock.calls[0][0][0].attributes as any)
-          .snoozeSchedule
-      ).toBeUndefined();
-    });
   });
 
   describe('apiKey operations', () => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list_table.tsx
@@ -8,7 +8,6 @@ import React, { useCallback, useMemo, useState } from 'react';
 import moment from 'moment';
 import numeral from '@elastic/numeral';
 import { i18n } from '@kbn/i18n';
-import { AlertConsumers } from '@kbn/rule-data-utils';
 import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
 import {
   EuiBasicTable,
@@ -478,7 +477,7 @@ export const RulesListTable = (props: RulesListTableProps) => {
         width: '14%',
         'data-test-subj': 'rulesTableCell-rulesListNotify',
         render: (rule: RuleTableItem) => {
-          if (rule.consumer === AlertConsumers.SIEM || !rule.enabled) {
+          if (!rule.enabled) {
             return null;
           }
           return (

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_edit.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group4/bulk_edit.ts
@@ -424,46 +424,7 @@ export default function createUpdateTests({ getService }: FtrProviderContext) {
       });
     });
 
-    it('should ignore bulk snooze and snooze schedule rule for SIEM rules', async () => {
-      const { body: createdRule } = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
-        .set('kbn-xsrf', 'foo')
-        .send(getTestRuleData({ enabled: false, consumer: 'siem' }));
-
-      objectRemover.add(Spaces.space1.id, createdRule.id, 'rule', 'alerting');
-
-      const payload = {
-        ids: [createdRule.id],
-        operations: [
-          {
-            operation: 'set',
-            field: 'snoozeSchedule',
-            value: getSnoozeSchedule(),
-          },
-        ],
-      };
-
-      const bulkSnoozeResponse = await supertest
-        .post(`${getUrlPrefix(Spaces.space1.id)}/internal/alerting/rules/_bulk_edit`)
-        .set('kbn-xsrf', 'foo')
-        .send(payload);
-
-      expect(bulkSnoozeResponse.body.errors).to.have.length(0);
-      expect(bulkSnoozeResponse.body.rules).to.have.length(1);
-      expect(bulkSnoozeResponse.body.rules[0].snooze_schedule).empty();
-      // Ensure revision is NOT updated
-      expect(bulkSnoozeResponse.body.rules[0].revision).to.eql(0);
-
-      // Ensure AAD isn't broken
-      await checkAAD({
-        supertest,
-        spaceId: Spaces.space1.id,
-        type: 'alert',
-        id: createdRule.id,
-      });
-    });
-
-    it('should bulk update API key with apiKey operation', async () => {
+    it('should not bulk update API key with apiKey operation', async () => {
       const { body: createdRule } = await supertest
         .post(`${getUrlPrefix(Spaces.space1.id)}/api/alerting/rule`)
         .set('kbn-xsrf', 'foo')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[ResponseOps] Allow bulk snoozing of Security Rules (#169180)](https://github.com/elastic/kibana/pull/169180)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Juan Pablo Djeredjian","email":"jpdjeredjian@gmail.com"},"sourceCommit":{"committedDate":"2023-10-18T15:54:45Z","message":"[ResponseOps] Allow bulk snoozing of Security Rules (#169180)\n\nFixes: https://github.com/elastic/kibana/issues/169131\r\n\r\n## Summary\r\n\r\nBulk snoozing of SIEM (Security Rules) was previously silently skipped\r\nin the Rules Client when bulk editing rules to snooze scheduling a rule.\r\n\r\nSince then, the snoozing functionality was introduced in the Security\r\nSolution, but the check that silently skipped this update was never\r\nremoved in the Rules Client side.\r\n\r\nThe issue was only noticeable when bulk editing Rules to add snoozing in\r\nthe **Alerts and Insights > Rules** page, since Security Solution\r\ndoesn't allow bulk snoozing (as of yet) and all other areas of the UI do\r\nnot use bulk but single snoozing.\r\n\r\nRemoving the check to skip SIEM rules sufficed to fix the issue.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Team: SecuritySolution","v8.8.3","v8.11.0","v8.9.3","v8.12.0","v8.10.5"],"number":169180,"url":"https://github.com/elastic/kibana/pull/169180","mergeCommit":{"message":"[ResponseOps] Allow bulk snoozing of Security Rules (#169180)\n\nFixes: https://github.com/elastic/kibana/issues/169131\r\n\r\n## Summary\r\n\r\nBulk snoozing of SIEM (Security Rules) was previously silently skipped\r\nin the Rules Client when bulk editing rules to snooze scheduling a rule.\r\n\r\nSince then, the snoozing functionality was introduced in the Security\r\nSolution, but the check that silently skipped this update was never\r\nremoved in the Rules Client side.\r\n\r\nThe issue was only noticeable when bulk editing Rules to add snoozing in\r\nthe **Alerts and Insights > Rules** page, since Security Solution\r\ndoesn't allow bulk snoozing (as of yet) and all other areas of the UI do\r\nnot use bulk but single snoozing.\r\n\r\nRemoving the check to skip SIEM rules sufficed to fix the issue.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2"}},"sourceBranch":"main","suggestedTargetBranches":["8.9"],"targetPullRequestStates":[{"branch":"8.8","label":"v8.8.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/169289","number":169289,"state":"OPEN"},{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/169266","number":169266,"state":"MERGED","mergeCommit":{"sha":"8355fed9ba896e18fcd1faae44a1a1ec0a0223dc","message":"[8.11] [ResponseOps] Allow bulk snoozing of Security Rules (#169180) (#169266)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.11`:\n- [[ResponseOps] Allow bulk snoozing of Security Rules\n(#169180)](https://github.com/elastic/kibana/pull/169180)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Juan Pablo\nDjeredjian\",\"email\":\"jpdjeredjian@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2023-10-18T15:54:45Z\",\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\",\"branchLabelMapping\":{\"^v8.12.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:ResponseOps\",\"Team:\nSecuritySolution\",\"v8.8.3\",\"v8.11.0\",\"v8.9.3\",\"v8.12.0\",\"v8.10.5\"],\"number\":169180,\"url\":\"https://github.com/elastic/kibana/pull/169180\",\"mergeCommit\":{\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.8\",\"8.11\",\"8.9\",\"8.10\"],\"targetPullRequestStates\":[{\"branch\":\"8.8\",\"label\":\"v8.8.3\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.11\",\"label\":\"v8.11.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.9\",\"label\":\"v8.9.3\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.12.0\",\"labelRegex\":\"^v8.12.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/169180\",\"number\":169180,\"mergeCommit\":{\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\"}},{\"branch\":\"8.10\",\"label\":\"v8.10.5\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Juan Pablo Djeredjian <jpdjeredjian@gmail.com>"}},{"branch":"8.9","label":"v8.9.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169180","number":169180,"mergeCommit":{"message":"[ResponseOps] Allow bulk snoozing of Security Rules (#169180)\n\nFixes: https://github.com/elastic/kibana/issues/169131\r\n\r\n## Summary\r\n\r\nBulk snoozing of SIEM (Security Rules) was previously silently skipped\r\nin the Rules Client when bulk editing rules to snooze scheduling a rule.\r\n\r\nSince then, the snoozing functionality was introduced in the Security\r\nSolution, but the check that silently skipped this update was never\r\nremoved in the Rules Client side.\r\n\r\nThe issue was only noticeable when bulk editing Rules to add snoozing in\r\nthe **Alerts and Insights > Rules** page, since Security Solution\r\ndoesn't allow bulk snoozing (as of yet) and all other areas of the UI do\r\nnot use bulk but single snoozing.\r\n\r\nRemoving the check to skip SIEM rules sufficed to fix the issue.\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)","sha":"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2"}},{"branch":"8.10","label":"v8.10.5","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/169264","number":169264,"state":"MERGED","mergeCommit":{"sha":"0d2d023bbcfc969dc08050b87198008330fe3596","message":"[8.10] [ResponseOps] Allow bulk snoozing of Security Rules (#169180) (#169264)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.10`:\n- [[ResponseOps] Allow bulk snoozing of Security Rules\n(#169180)](https://github.com/elastic/kibana/pull/169180)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Juan Pablo\nDjeredjian\",\"email\":\"jpdjeredjian@gmail.com\"},\"sourceCommit\":{\"committedDate\":\"2023-10-18T15:54:45Z\",\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\",\"branchLabelMapping\":{\"^v8.12.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:fix\",\"Team:ResponseOps\",\"Team:\nSecuritySolution\",\"v8.8.3\",\"v8.11.0\",\"v8.9.3\",\"v8.12.0\",\"v8.10.5\"],\"number\":169180,\"url\":\"https://github.com/elastic/kibana/pull/169180\",\"mergeCommit\":{\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.8\",\"8.11\",\"8.9\",\"8.10\"],\"targetPullRequestStates\":[{\"branch\":\"8.8\",\"label\":\"v8.8.3\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.11\",\"label\":\"v8.11.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.9\",\"label\":\"v8.9.3\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.12.0\",\"labelRegex\":\"^v8.12.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/169180\",\"number\":169180,\"mergeCommit\":{\"message\":\"[ResponseOps]\nAllow bulk snoozing of Security Rules (#169180)\\n\\nFixes:\nhttps://github.com/elastic/kibana/issues/169131\\r\\n\\r\\n##\nSummary\\r\\n\\r\\nBulk snoozing of SIEM (Security Rules) was previously\nsilently skipped\\r\\nin the Rules Client when bulk editing rules to\nsnooze scheduling a rule.\\r\\n\\r\\nSince then, the snoozing functionality\nwas introduced in the Security\\r\\nSolution, but the check that silently\nskipped this update was never\\r\\nremoved in the Rules Client\nside.\\r\\n\\r\\nThe issue was only noticeable when bulk editing Rules to\nadd snoozing in\\r\\nthe **Alerts and Insights > Rules** page, since\nSecurity Solution\\r\\ndoesn't allow bulk snoozing (as of yet) and all\nother areas of the UI do\\r\\nnot use bulk but single\nsnoozing.\\r\\n\\r\\nRemoving the check to skip SIEM rules sufficed to fix\nthe issue.\\r\\n\\r\\n### For maintainers\\r\\n\\r\\n- [ ] This was checked for\nbreaking API changes and was\n[labeled\\r\\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\",\"sha\":\"2f80ca2ef89c7858fa2e7a544acc0402e460bbf2\"}},{\"branch\":\"8.10\",\"label\":\"v8.10.5\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"}]}]\nBACKPORT-->\n\nCo-authored-by: Juan Pablo Djeredjian <jpdjeredjian@gmail.com>"}}]}] BACKPORT-->