### PR TITLE
[kbn-es] Increase ready timeout to two minutes

### DIFF
--- a/packages/kbn-es/src/utils/wait_until_cluster_ready.ts
+++ b/packages/kbn-es/src/utils/wait_until_cluster_ready.ts
@@ -9,7 +9,7 @@
 import { Client } from '@elastic/elasticsearch';
 import { HealthStatus } from '@elastic/elasticsearch/lib/api/types';
 import { ToolingLog } from '@kbn/tooling-log';
-const DEFAULT_READY_TIMEOUT = 60 * 1000; // 1 minute
+const DEFAULT_READY_TIMEOUT = 120 * 1000; // 2 minutes
 
 export type ClusterReadyStatus = 'green' | 'yellow';
 export interface WaitOptions {


### PR DESCRIPTION
Average start times of serverless ES are near one minute, and in [some cases exceeding the limit](https://buildkite.com/elastic/kibana-on-merge/builds/37049#018b44ec-832c-48be-a5b9-93e9c42e1db7/243-1554).  

This increases the limit to two minutes