### PR TITLE
[EDR Workflows] Bring back 8.11.0 agent

### DIFF
--- a/x-pack/test/osquery_cypress/artifact_manager.ts
+++ b/x-pack/test/osquery_cypress/artifact_manager.ts
@@ -6,6 +6,5 @@
  */
 
 export async function getLatestVersion(): Promise<string> {
-  // temporary solution until newer agents work fine with Docker
-  return '8.10.4';
+  return '8.11.0-SNAPSHOT';
 }


### PR DESCRIPTION
Since these two have been reverted, we can get back to using current snapshot:
* [Revert "install fails if enroll fails and surface errors"](https://github.com/elastic/elastic-agent/pull/3629)
* [Revert "[8.11](backport #3554) install fails if enroll fails and surface errors"](https://github.com/elastic/elastic-agent/pull/3630)

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->