### PR TITLE
[8.11] [Discover] Fixes sorting for ES|QL columns that do not exist on a dataview (#169240)

### DIFF
--- a/packages/kbn-unified-data-table/index.ts
+++ b/packages/kbn-unified-data-table/index.ts
@@ -9,6 +9,7 @@
 export { UnifiedDataTable, DataLoadingState } from './src/components/data_table';
 export type { UnifiedDataTableProps } from './src/components/data_table';
 export { getDisplayedColumns } from './src/utils/columns';
+export { getTextBasedColumnTypes } from './src/utils/get_column_types';
 export { ROWS_HEIGHT_OPTIONS } from './src/constants';
 
 export { JSONCodeEditorCommonMemoized } from './src/components/json_code_editor/json_code_editor_common';

--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -43,7 +43,7 @@ import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
 import type { ThemeServiceStart } from '@kbn/react-kibana-context-common';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
-import { UnifiedDataTableSettings, ValueToStringConverter } from '../types';
+import { UnifiedDataTableSettings, ValueToStringConverter, DataTableColumnTypes } from '../types';
 import { getDisplayedColumns } from '../utils/columns';
 import { convertValueToString } from '../utils/convert_value_to_string';
 import { getRowsPerPageOptions } from '../utils/rows_per_page';
@@ -88,6 +88,12 @@ export interface UnifiedDataTableProps {
    * Determines ids of the columns which are displayed
    */
   columns: string[];
+  /**
+   * If not provided, types will be derived by default from the dataView field types.
+   * For displaying text-based search results, pass column types (which are available separately in the fetch request) down here.
+   * Check available utils in `utils/get_column_types.ts`
+   */
+  columnTypes?: DataTableColumnTypes;
   /**
    * If set, the given document is displayed in a flyout
    */
@@ -300,6 +306,7 @@ const CONTROL_COLUMN_IDS_DEFAULT = ['openDetails', 'select'];
 export const UnifiedDataTable = ({
   ariaLabelledBy,
   columns,
+  columnTypes,
   controlColumnIds = CONTROL_COLUMN_IDS_DEFAULT,
   dataView,
   loadingState,
@@ -618,6 +625,7 @@ export const UnifiedDataTable = ({
         onFilter,
         editField,
         visibleCellActions,
+        columnTypes,
       }),
     [
       onFilter,
@@ -635,6 +643,7 @@ export const UnifiedDataTable = ({
       valueToStringConverter,
       editField,
       visibleCellActions,
+      columnTypes,
     ]
   );
 

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.test.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.test.tsx
@@ -538,4 +538,64 @@ describe('Data table columns', function () {
       expect(actual).toEqual(['timestamp', 'extension', 'message']);
     });
   });
+
+  describe('Textbased languages grid columns', () => {
+    it('returns eui grid with in memory sorting for text based languages and columns on the dataview', async () => {
+      const columnsNotInDataview = getVisibleColumns(
+        ['extension'],
+        dataViewWithTimefieldMock,
+        true
+      ) as string[];
+      const gridColumns = getEuiGridColumns({
+        columns: columnsNotInDataview,
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnTypes: {
+          var_test: 'number',
+        },
+      });
+      expect(gridColumns[1].schema).toBe('string');
+    });
+
+    it('returns eui grid with in memory sorting for text based languages and columns not on the columnTypes', async () => {
+      const columnsNotInDataview = getVisibleColumns(
+        ['var_test'],
+        dataViewWithTimefieldMock,
+        true
+      ) as string[];
+      const gridColumns = getEuiGridColumns({
+        columns: columnsNotInDataview,
+        settings: {},
+        dataView: dataViewWithTimefieldMock,
+        defaultColumns: false,
+        isSortEnabled: true,
+        isPlainRecord: true,
+        valueToStringConverter: dataTableContextMock.valueToStringConverter,
+        rowsCount: 100,
+        services: {
+          uiSettings: servicesMock.uiSettings,
+          toastNotifications: servicesMock.toastNotifications,
+        },
+        hasEditDataViewPermission: () =>
+          servicesMock.dataViewFieldEditor.userPermissions.editIndexPattern(),
+        onFilter: () => {},
+        columnTypes: {
+          var_test: 'number',
+        },
+      });
+      expect(gridColumns[1].schema).toBe('numeric');
+    });
+  });
 });

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -19,7 +19,7 @@ import type { DataView } from '@kbn/data-views-plugin/public';
 import { ToastsStart, IUiSettingsClient } from '@kbn/core/public';
 import { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import { ExpandButton } from './data_table_expand_button';
-import { UnifiedDataTableSettings } from '../types';
+import type { UnifiedDataTableSettings, DataTableColumnTypes } from '../types';
 import type { ValueToStringConverter } from '../types';
 import { buildCellActions } from './default_cell_actions';
 import { getSchemaByKbnType } from './data_table_schema';
@@ -80,6 +80,7 @@ function buildEuiGridColumn({
   editField,
   columnCellActions,
   visibleCellActions,
+  columnTypes,
 }: {
   columnName: string;
   columnWidth: number | undefined;
@@ -95,6 +96,7 @@ function buildEuiGridColumn({
   editField?: (fieldName: string) => void;
   columnCellActions?: EuiDataGridColumnCellAction[];
   visibleCellActions?: number;
+  columnTypes?: DataTableColumnTypes;
 }) {
   const dataViewField = dataView.getFieldByName(columnName);
   const editFieldButton =
@@ -118,9 +120,11 @@ function buildEuiGridColumn({
       : [];
   }
 
+  const columnType = columnTypes?.[columnName] ?? dataViewField?.type;
+
   const column: EuiDataGridColumn = {
     id: columnName,
-    schema: getSchemaByKbnType(dataViewField?.type),
+    schema: getSchemaByKbnType(columnType),
     isSortable: isSortEnabled && (isPlainRecord || dataViewField?.sortable === true),
     displayAsText: columnDisplayName,
     actions: {
@@ -203,6 +207,7 @@ export function getEuiGridColumns({
   onFilter,
   editField,
   visibleCellActions,
+  columnTypes,
 }: {
   columns: string[];
   columnsCellActions?: EuiDataGridColumnCellAction[][];
@@ -221,6 +226,7 @@ export function getEuiGridColumns({
   onFilter: DocViewFilterFn;
   editField?: (fieldName: string) => void;
   visibleCellActions?: number;
+  columnTypes?: DataTableColumnTypes;
 }) {
   const getColWidth = (column: string) => settings?.columns?.[column]?.width ?? 0;
 
@@ -240,6 +246,7 @@ export function getEuiGridColumns({
       onFilter,
       editField,
       visibleCellActions,
+      columnTypes,
     })
   );
 }

--- a/packages/kbn-unified-data-table/src/types.ts
+++ b/packages/kbn-unified-data-table/src/types.ts
@@ -22,3 +22,8 @@ export type ValueToStringConverter = (
   columnId: string,
   options?: { compatibleWithCSV?: boolean }
 ) => { formattedString: string; withFormula: boolean };
+
+/**
+ * Custom column types per column name
+ */
+export type DataTableColumnTypes = Record<string, string>;

--- a/packages/kbn-unified-data-table/src/utils/get_column_types.test.ts
+++ b/packages/kbn-unified-data-table/src/utils/get_column_types.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getTextBasedColumnTypes } from './get_column_types';
+
+describe('getColumnTypes', () => {
+  describe('getTextBasedColumnTypes', () => {
+    test('returns a correct column types map', async () => {
+      const result = getTextBasedColumnTypes([
+        {
+          id: '@timestamp',
+          name: '@timestamp',
+          meta: {
+            type: 'date',
+          },
+        },
+        {
+          id: 'agent.keyword',
+          name: 'agent.keyword',
+          meta: {
+            type: 'string',
+          },
+        },
+        {
+          id: 'bytes',
+          name: 'bytes',
+          meta: {
+            type: 'number',
+          },
+        },
+      ]);
+      expect(result).toMatchInlineSnapshot(`
+        Object {
+          "@timestamp": "date",
+          "agent.keyword": "string",
+          "bytes": "number",
+        }
+      `);
+    });
+  });
+});

--- a/packages/kbn-unified-data-table/src/utils/get_column_types.ts
+++ b/packages/kbn-unified-data-table/src/utils/get_column_types.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { DatatableColumn, DatatableColumnType } from '@kbn/expressions-plugin/common';
+
+type TextBasedColumnTypes = Record<string, DatatableColumnType>;
+
+/**
+ * Column types for text based searches
+ * @param textBasedColumns
+ */
+export const getTextBasedColumnTypes = (
+  textBasedColumns: DatatableColumn[]
+): TextBasedColumnTypes => {
+  return textBasedColumns.reduce<TextBasedColumnTypes>((map, next) => {
+    map[next.name] = next.meta.type;
+    return map;
+  }, {});
+};

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -21,7 +21,13 @@ import { SortOrder } from '@kbn/saved-search-plugin/public';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import { SearchResponseWarnings } from '@kbn/search-response-warnings';
-import { DataLoadingState, UnifiedDataTable, useColumns } from '@kbn/unified-data-table';
+import {
+  DataLoadingState,
+  UnifiedDataTable,
+  useColumns,
+  type DataTableColumnTypes,
+  getTextBasedColumnTypes,
+} from '@kbn/unified-data-table';
 import {
   DOC_HIDE_TIME_COLUMN_SETTING,
   DOC_TABLE_LEGACY,
@@ -198,6 +204,14 @@ function DiscoverDocumentsComponent({
     [isTextBasedQuery, columns, uiSettings, dataView.timeFieldName]
   );
 
+  const columnTypes: DataTableColumnTypes | undefined = useMemo(
+    () =>
+      documentState.textBasedQueryColumns
+        ? getTextBasedColumnTypes(documentState.textBasedQueryColumns)
+        : undefined,
+    [documentState.textBasedQueryColumns]
+  );
+
   const renderDocumentView = useCallback(
     (hit: DataTableRecord, displayedRows: DataTableRecord[], displayedColumns: string[]) => (
       <DiscoverGridFlyout
@@ -280,6 +294,7 @@ function DiscoverDocumentsComponent({
               <DataGridMemoized
                 ariaLabelledBy="documentsAriaLabel"
                 columns={currentColumns}
+                columnTypes={columnTypes}
                 expandedDoc={expandedDoc}
                 dataView={dataView}
                 loadingState={

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
@@ -61,7 +61,7 @@ import {
 } from '@kbn/discover-utils';
 import type { UnifiedDataTableProps } from '@kbn/unified-data-table';
 import type { UnifiedDataTableSettings } from '@kbn/unified-data-table';
-import { columnActions } from '@kbn/unified-data-table';
+import { columnActions, getTextBasedColumnTypes } from '@kbn/unified-data-table';
 import { VIEW_MODE, getDefaultRowsPerPage } from '../../common/constants';
 import type { ISearchEmbeddable, SearchInput, SearchOutput } from './types';
 import type { DiscoverServices } from '../build_services';
@@ -341,6 +341,9 @@ export class SavedSearchEmbeddable
           ...this.getOutput(),
           loading: false,
         });
+        searchProps.columnTypes = result.textBasedQueryColumns
+          ? getTextBasedColumnTypes(result.textBasedQueryColumns)
+          : undefined;
 
         searchProps.rows = result.records;
         searchProps.totalHitCount = result.records.length;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Discover] Fixes sorting for ES|QL columns that do not exist on a dataview (#169240)](https://github.com/elastic/kibana/pull/169240)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2023-10-19T07:21:58Z","message":"[Discover] Fixes sorting for ES|QL columns that do not exist on a dataview (#169240)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/168118\r\n\r\nFixes the broken sorting of columns that are created from the query and\r\nthey do not exist on the dataview. This was working correctly so I\r\nassume is a regression from a refactoring.\r\n\r\n<img width=\"1503\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/17003240/df762a28-b47f-4f3b-a902-180dd6a212c0\">\r\n\r\n\r\n### Checklist\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"662265dc50fd59eb77110c67eb2a23b94130b038","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Discover","release_note:skip","Team:DataDiscovery","backport:prev-minor","v8.11.0","Feature:ES|QL","v8.12.0"],"number":169240,"url":"https://github.com/elastic/kibana/pull/169240","mergeCommit":{"message":"[Discover] Fixes sorting for ES|QL columns that do not exist on a dataview (#169240)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/168118\r\n\r\nFixes the broken sorting of columns that are created from the query and\r\nthey do not exist on the dataview. This was working correctly so I\r\nassume is a regression from a refactoring.\r\n\r\n<img width=\"1503\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/17003240/df762a28-b47f-4f3b-a902-180dd6a212c0\">\r\n\r\n\r\n### Checklist\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"662265dc50fd59eb77110c67eb2a23b94130b038"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169240","number":169240,"mergeCommit":{"message":"[Discover] Fixes sorting for ES|QL columns that do not exist on a dataview (#169240)\n\n## Summary\r\n\r\nCloses https://github.com/elastic/kibana/issues/168118\r\n\r\nFixes the broken sorting of columns that are created from the query and\r\nthey do not exist on the dataview. This was working correctly so I\r\nassume is a regression from a refactoring.\r\n\r\n<img width=\"1503\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/17003240/df762a28-b47f-4f3b-a902-180dd6a212c0\">\r\n\r\n\r\n### Checklist\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n---------\r\n\r\nCo-authored-by: Julia Rechkunova <julia.rechkunova@gmail.com>","sha":"662265dc50fd59eb77110c67eb2a23b94130b038"}}]}] BACKPORT-->