### PR TITLE
[EDR Workflows] Unskip no_license.cy.ts

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
@@ -38,7 +38,7 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
     beforeEach(() => {
       login(ROLE.endpoint_response_actions_access);
     });
-    after(() => {
+    afterEach(() => {
       cleanupRule(ruleId);
     });
 
@@ -87,16 +87,14 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
     const testedCommand = 'isolate';
     const newDescription = 'Example isolate host description';
 
-    before(() => {
+    beforeEach(() => {
+      login(ROLE.endpoint_response_actions_access);
       loadRule().then((res) => {
         ruleId = res.id;
         ruleName = res.name;
       });
     });
-    beforeEach(() => {
-      login(ROLE.endpoint_response_actions_access);
-    });
-    after(() => {
+    afterEach(() => {
       cleanupRule(ruleId);
     });
 
@@ -162,16 +160,14 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
   describe('User without access can not edit, add nor delete an endpoint response action', () => {
     let ruleId: string;
 
-    before(() => {
+    beforeEach(() => {
+      login(ROLE.endpoint_response_actions_no_access);
       loadRule().then((res) => {
         ruleId = res.id;
       });
     });
-    beforeEach(() => {
-      login(ROLE.endpoint_response_actions_no_access);
-    });
 
-    after(() => {
+    afterEach(() => {
       cleanupRule(ruleId);
     });
 

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/form.cy.ts
@@ -20,7 +20,7 @@ import { login, ROLE } from '../../tasks/login';
 
 describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
   describe('User with no access can not create an endpoint response action', () => {
-    before(() => {
+    beforeEach(() => {
       login(ROLE.endpoint_response_actions_no_access);
     });
 
@@ -35,7 +35,7 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
     let ruleId: string;
     const [ruleName, ruleDescription] = generateRandomStringName(2);
 
-    before(() => {
+    beforeEach(() => {
       login(ROLE.endpoint_response_actions_access);
     });
     after(() => {
@@ -145,7 +145,7 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
   describe('User should not see endpoint action when no rbac', () => {
     const [ruleName, ruleDescription] = generateRandomStringName(2);
 
-    before(() => {
+    beforeEach(() => {
       login(ROLE.endpoint_response_actions_no_access);
     });
 
@@ -166,8 +166,11 @@ describe('Form', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () =>
       loadRule().then((res) => {
         ruleId = res.id;
       });
+    });
+    beforeEach(() => {
       login(ROLE.endpoint_response_actions_no_access);
     });
+
     after(() => {
       cleanupRule(ruleId);
     });

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/no_license.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/automated_response_actions/no_license.cy.ts
@@ -15,12 +15,11 @@ import type { ReturnTypeFromChainable } from '../../types';
 import { indexEndpointHosts } from '../../tasks/index_endpoint_hosts';
 import { indexEndpointRuleAlerts } from '../../tasks/index_endpoint_rule_alerts';
 
-// Failing: See https://github.com/elastic/kibana/issues/169320
-describe.skip('No License', { tags: '@ess', env: { ftrConfig: { license: 'basic' } } }, () => {
+describe('No License', { tags: '@ess', env: { ftrConfig: { license: 'basic' } } }, () => {
   describe('User cannot use endpoint action in form', () => {
     const [ruleName, ruleDescription] = generateRandomStringName(2);
 
-    before(() => {
+    beforeEach(() => {
       login(ROLE.endpoint_response_actions_access);
     });
 


### PR DESCRIPTION
With introduction of global `before` that logs us in with role `soc_manager` we should explicitly login with `beforeEach` to prevent cookies mixup when using user that is not `soc_manager` - https://github.com/elastic/kibana/blame/54d4e181c38b63bffea7b4d8a216fa12fbb35984/x-pack/plugins/security_solution/public/management/cypress/support/e2e.ts#L107
Closes https://github.com/elastic/kibana/issues/169320
Closes https://github.com/elastic/kibana/issues/169334

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->