### PR TITLE
[Synthetics] Remove only show retests filter

### DIFF
--- a/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
+++ b/x-pack/plugins/synthetics/common/runtime_types/ping/ping.ts
@@ -302,7 +302,6 @@ export const GetPingsParamsType = t.intersection([
     monitorId: t.string,
     sort: t.string,
     status: t.string,
-    finalAttempt: t.boolean,
   }),
 ]);
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_pings.tsx
@@ -13,7 +13,6 @@ import { useSelectedLocation } from './use_selected_location';
 import {
   getMonitorRecentPingsAction,
   selectMonitorPingsMetadata,
-  selectShowOnlyFinalAttempts,
   selectStatusFilter,
 } from '../../../state';
 
@@ -34,8 +33,6 @@ export const useMonitorPings = (props?: UseMonitorPingsProps) => {
   const monitorId = monitor?.id;
   const locationLabel = location?.label;
 
-  const showOnlyFinalAttempts = useSelector(selectShowOnlyFinalAttempts);
-
   const statusFilter = useSelector(selectStatusFilter);
 
   useEffect(() => {
@@ -48,7 +45,6 @@ export const useMonitorPings = (props?: UseMonitorPingsProps) => {
           pageIndex: props?.pageIndex,
           from: props?.from,
           to: props?.to,
-          finalAttempt: showOnlyFinalAttempts,
           statusFilter,
         })
       );
@@ -62,7 +58,6 @@ export const useMonitorPings = (props?: UseMonitorPingsProps) => {
     props?.pageIndex,
     props?.from,
     props?.to,
-    showOnlyFinalAttempts,
     statusFilter,
   ]);
 

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
@@ -8,17 +8,8 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { i18n } from '@kbn/i18n';
-import {
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiLink,
-  EuiSwitch,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiButtonEmpty, EuiFlexGroup, EuiFlexItem, EuiLink, EuiTitle } from '@elastic/eui';
 
-import { useDispatch, useSelector } from 'react-redux';
-import { selectShowOnlyFinalAttempts, showOnlyFinalAttemptsAction } from '../../../state';
 import { StatusFilter } from './status_filter';
 import { MONITOR_HISTORY_ROUTE } from '../../../../../../common/constants';
 import { ConfigKey, Ping } from '../../../../../../common/runtime_types';
@@ -43,10 +34,6 @@ export const TestRunsTableHeader = ({
 
   const { monitor } = useSelectedMonitor();
 
-  const showOnlyFinalAttempts = useSelector(selectShowOnlyFinalAttempts);
-
-  const dispatch = useDispatch();
-
   return (
     <EuiFlexGroup alignItems="center" gutterSize="l">
       <EuiFlexItem grow={false}>
@@ -57,15 +44,6 @@ export const TestRunsTableHeader = ({
       <EuiFlexItem grow={true} />
       <EuiFlexItem grow={false}>
         <StatusFilter />
-      </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <EuiSwitch
-          compressed
-          data-test-subj="toggleRetestSwitch"
-          label={ONLY_SHOW_RETEST}
-          checked={showOnlyFinalAttempts}
-          onChange={(e) => dispatch(showOnlyFinalAttemptsAction(e.target.checked))}
-        />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         {showViewHistoryButton ? (
@@ -104,10 +82,6 @@ export const TestRunsTableHeader = ({
 
 const TEST_RUNS = i18n.translate('xpack.synthetics.monitorDetails.summary.testRuns', {
   defaultMessage: 'Test Runs',
-});
-
-const ONLY_SHOW_RETEST = i18n.translate('xpack.synthetics.monitorDetails.summary.onlyRetests', {
-  defaultMessage: 'Only show retests',
 });
 
 export const LAST_10_TEST_RUNS = i18n.translate(

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/actions.ts
@@ -38,5 +38,4 @@ export const getMonitorRecentPingsAction = createAsyncAction<MostRecentPingsRequ
   '[MONITOR DETAILS] GET RECENT PINGS'
 );
 
-export const showOnlyFinalAttemptsAction = createAction<boolean>('SHOW ONLY FINAL ATTEMPTS');
 export const setStatusFilter = createAction<'up' | 'down' | undefined>('SET STATUS FILTER');

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/api.ts
@@ -32,7 +32,6 @@ export interface MostRecentPingsRequest {
   to?: string;
   size?: number;
   pageIndex?: number;
-  finalAttempt?: boolean;
   statusFilter?: 'up' | 'down';
 }
 
@@ -43,7 +42,6 @@ export const fetchMonitorRecentPings = async ({
   to,
   size = 10,
   pageIndex = 0,
-  finalAttempt,
   statusFilter,
 }: MostRecentPingsRequest): Promise<PingsResponse> => {
   const locations = JSON.stringify([locationId]);
@@ -59,7 +57,6 @@ export const fetchMonitorRecentPings = async ({
       sort,
       size,
       pageIndex,
-      finalAttempt,
       status: statusFilter,
     },
     PingsResponseType

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/index.ts
@@ -19,7 +19,6 @@ import {
   getMonitorRecentPingsAction,
   setMonitorDetailsLocationAction,
   getMonitorAction,
-  showOnlyFinalAttemptsAction,
   setStatusFilter,
 } from './actions';
 
@@ -39,7 +38,6 @@ export interface MonitorDetailsState {
   syntheticsMonitorDispatchedAt: number;
   error: IHttpSerializedFetchError | null;
   selectedLocationId: string | null;
-  showOnlyFinalAttempts?: boolean;
   statusFilter?: 'up' | 'down' | undefined;
 }
 
@@ -51,7 +49,6 @@ const initialState: MonitorDetailsState = {
   syntheticsMonitorDispatchedAt: 0,
   error: null,
   selectedLocationId: null,
-  showOnlyFinalAttempts: false,
 };
 
 export const monitorDetailsReducer = createReducer(initialState, (builder) => {
@@ -115,9 +112,6 @@ export const monitorDetailsReducer = createReducer(initialState, (builder) => {
       if ('updated_at' in action.payload && state.syntheticsMonitor) {
         state.syntheticsMonitor = action.payload;
       }
-    })
-    .addCase(showOnlyFinalAttemptsAction, (state, action) => {
-      state.showOnlyFinalAttempts = action.payload;
     })
     .addCase(setStatusFilter, (state, action) => {
       state.statusFilter = action.payload;

--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/selectors.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/monitor_details/selectors.ts
@@ -25,9 +25,5 @@ export const selectPingsLoading = createSelector(getState, (state) => state.ping
 export const selectMonitorPingsMetadata = createSelector(getState, (state) => state.pings);
 
 export const selectPingsError = createSelector(getState, (state) => state.error);
-export const selectShowOnlyFinalAttempts = createSelector(
-  getState,
-  (state) => state.showOnlyFinalAttempts ?? false
-);
 
 export const selectStatusFilter = createSelector(getState, (state) => state.statusFilter);

--- a/x-pack/plugins/synthetics/server/common/pings/query_pings.ts
+++ b/x-pack/plugins/synthetics/server/common/pings/query_pings.ts
@@ -50,7 +50,6 @@ export async function queryPings<F>(
     pageIndex,
     locations,
     excludedLocations,
-    finalAttempt,
   } = params;
   const size = sizeParam ?? DEFAULT_PAGE_SIZE;
 
@@ -65,7 +64,6 @@ export async function queryPings<F>(
           { range: { '@timestamp': { gte: from, lte: to } } },
           ...(monitorId ? [{ term: { 'monitor.id': monitorId } }] : []),
           ...(status ? [{ term: { 'monitor.status': status } }] : []),
-          ...(finalAttempt ? [{ term: { 'summary.final_attempt': finalAttempt } }] : []),
         ] as QueryDslQueryContainer[],
       },
     },

--- a/x-pack/plugins/synthetics/server/routes/pings/get_pings.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/get_pings.ts
@@ -21,7 +21,6 @@ export const getPingsRouteQuerySchema = schema.object({
   pageIndex: schema.maybe(schema.number()),
   sort: schema.maybe(schema.string()),
   status: schema.maybe(schema.string()),
-  finalAttempt: schema.maybe(schema.boolean()),
 });
 
 type GetPingsRouteRequest = TypeOf<typeof getPingsRouteQuerySchema>;
@@ -44,7 +43,6 @@ export const syntheticsGetPingsRoute: SyntheticsRestApiRouteFactory = () => ({
       pageIndex,
       locations,
       excludedLocations,
-      finalAttempt,
     } = request.query as GetPingsRouteRequest;
 
     return await queryPings({
@@ -58,7 +56,6 @@ export const syntheticsGetPingsRoute: SyntheticsRestApiRouteFactory = () => ({
       pageIndex,
       locations: locations ? JSON.parse(locations) : [],
       excludedLocations,
-      finalAttempt,
     });
   },
 });


### PR DESCRIPTION
## Summary

Filter was added to check for tests where retests happened but same can be achieved using down filter. Earlier there was no down filter. 

 <img width="1476" alt="image" src="https://github.com/elastic/kibana/assets/3505601/42ef1a1c-1b8c-4a73-8876-872ac88f78d4">

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->