### PR TITLE
[Synthetics] Fixes broken styles for headers

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/headers.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/test_now_mode/simple/ping_list/headers.tsx
@@ -38,12 +38,7 @@ export const PingHeaders = ({ headers }: Props) => {
         }
       >
         <EuiSpacer size="s" />
-        <EuiDescriptionList
-          titleProps={{ style: { width: '30%', paddingLeft: 30 } }}
-          compressed={true}
-          type="responsiveColumn"
-          listItems={headersList}
-        />
+        <EuiDescriptionList compressed={true} type="responsiveColumn" listItems={headersList} />
       </EuiAccordion>
     </>
   );


### PR DESCRIPTION
## Summary

Fixes styles most likely caused by some EUI change !!

### Before

<img width="1478" alt="image" src="https://github.com/elastic/kibana/assets/3505601/a01b52e5-b2c8-4b8d-88a4-02a6716f8e91">


### After
<img width="1459" alt="image" src="https://github.com/elastic/kibana/assets/3505601/90e78923-e3e6-4f4a-bfec-5bb979171d30">



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->