### PR TITLE
[Serverless Search] Fix getting started footer to align with design

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -12,6 +12,7 @@ import {
   EuiCodeBlock,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiIcon,
   EuiPageTemplate,
   EuiPanel,
   EuiSpacer,
@@ -342,41 +343,22 @@ const OverviewFooter = () => {
             title={i18n.translate('xpack.serverlessSearch.overview.footer.discover.title', {
               defaultMessage: 'Discover',
             })}
-            description={i18n.translate(
-              'xpack.serverlessSearch.overview.footer.discover.description',
-              {
-                defaultMessage:
-                  'Search and filter your data, learn how your fields are structured, and create visualizations.',
-              }
-            )}
-            onClick={() => navigateToApp('discover')}
-          />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiCard
-            layout="horizontal"
-            icon={
-              <EuiAvatar
-                size="xl"
-                color="subdued"
-                type="space"
-                iconType="pipelineApp"
-                iconSize="original"
-                name="pipelines"
-              />
+            description={
+              <EuiFlexGroup justifyContent="spaceAround">
+                <EuiFlexItem>
+                  <p>
+                    {i18n.translate('xpack.serverlessSearch.overview.footer.discover.description', {
+                      defaultMessage:
+                        'Search and filter your data, learn how your fields are structured, and create visualizations.',
+                    })}
+                  </p>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon type="arrowRight" color="subdued" />
+                </EuiFlexItem>
+              </EuiFlexGroup>
             }
-            titleSize="xs"
-            title={i18n.translate('xpack.serverlessSearch.overview.footer.pipelines.title', {
-              defaultMessage: 'Pipelines',
-            })}
-            description={i18n.translate(
-              'xpack.serverlessSearch.overview.footer.pipelines.description',
-              {
-                defaultMessage:
-                  'Transform your data before indexing. Remove or rename fields, run custom scripts, and much more.',
-              }
-            )}
-            onClick={() => navigateToApp('management', { path: '/ingest/ingest_pipelines' })}
+            onClick={() => navigateToApp('discover')}
           />
         </EuiFlexItem>
         <EuiFlexItem>
@@ -396,12 +378,24 @@ const OverviewFooter = () => {
             title={i18n.translate('xpack.serverlessSearch.overview.footer.documentation.title', {
               defaultMessage: 'Documentation',
             })}
-            description={i18n.translate(
-              'xpack.serverlessSearch.overview.footer.documentation.description',
-              {
-                defaultMessage: 'Learn more with our references, how-to guides, and tutorials.',
-              }
-            )}
+            description={
+              <EuiFlexGroup justifyContent="spaceAround">
+                <EuiFlexItem>
+                  <p>
+                    {i18n.translate(
+                      'xpack.serverlessSearch.overview.footer.documentation.description',
+                      {
+                        defaultMessage:
+                          'Learn more with our references, how-to guides, and tutorials.',
+                      }
+                    )}
+                  </p>
+                </EuiFlexItem>
+                <EuiFlexItem grow={false}>
+                  <EuiIcon type="arrowRight" color="subdued" />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            }
             href={docLinks.gettingStartedSearch}
           />
         </EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR:  
* Removes pipeline card from Getting started page Footer
* Adds right-chevron icon next to Discover and Documentation cards to align with design


## Screen shot
<img width="1678" alt="Fix footer to align with design" src="https://github.com/elastic/kibana/assets/55930906/bacb0bd1-df17-4927-b221-ae8ba463ee5a">



### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


