### PR TITLE
[ci] Run precommit_hook against all commits on pull requests

### DIFF
--- a/.buildkite/scripts/steps/checks/precommit_hook.sh
+++ b/.buildkite/scripts/steps/checks/precommit_hook.sh
@@ -32,3 +32,6 @@ node scripts/precommit_hook.js \
   --no-stage # we have to disable staging or check_for_changed_files won't see the changes
 
 check_for_changed_files 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix' true
+
+
+# test

--- a/.buildkite/scripts/steps/checks/precommit_hook.sh
+++ b/.buildkite/scripts/steps/checks/precommit_hook.sh
@@ -16,8 +16,16 @@ That check is intended to provide earlier CI feedback after we remove the automa
 If you want, you can still manually install the pre-commit hook locally by running 'node scripts/register_git_hook locally'
 !!!!!!!!!!!!!!!!!!!!!!!!!!!"
 
+# Run on all commits in a pull request
+# Run on the most recent commmit otherwise, assuming squash and merge
+if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
+  START_REF="HEAD~1"
+else
+  START_REF="$BUILDKITE_BRANCH"
+fi
+
 node scripts/precommit_hook.js \
-  --ref HEAD~1..HEAD \
+  --ref "$START_REF..HEAD" \
   --max-files 200 \
   --verbose \
   --fix \

--- a/.buildkite/scripts/steps/checks/precommit_hook.sh
+++ b/.buildkite/scripts/steps/checks/precommit_hook.sh
@@ -21,7 +21,7 @@ If you want, you can still manually install the pre-commit hook locally by runni
 if [[ "${BUILDKITE_PULL_REQUEST}" == "false" ]]; then
   START_REF="HEAD~1"
 else
-  START_REF="$BUILDKITE_BRANCH"
+  START_REF="$BUILDKITE_PULL_REQUEST_BASE_BRANCH"
 fi
 
 node scripts/precommit_hook.js \
@@ -32,6 +32,3 @@ node scripts/precommit_hook.js \
   --no-stage # we have to disable staging or check_for_changed_files won't see the changes
 
 check_for_changed_files 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix' true
-
-
-# test

--- a/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.test.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/slo_edit.test.tsx
@@ -110,7 +110,6 @@ const mockKibana = () => {
       triggersActionsUi: {
         getAddRuleFlyout: jest
           .fn()
-          // eslint-disable-next-line @kbn/i18n/strings_should_be_translated_with_i18n, @kbn/i18n/strings_should_be_translated_with_formatted_message
           .mockReturnValue(<div data-test-subj="add-rule-flyout">Add Rule Flyout</div>),
       },
       uiSettings: {


### PR DESCRIPTION
Currently the precommit hook only runs on the most recent commit in CI.

In situations where more than one commit is pushed up at once, earlier
commits will not be checked for errors.  This can inadvertently causes
autofixable warnings that won't fail other checks to make it to main
branches and other pull requests - causing the appearance of unrelated
changes.