### PR TITLE
[8.11] [Security Solution] [Elastic AI Assistant] Throw error if Knowledge Base is enabled but ELSER is unavailable (#169330)

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
@@ -95,7 +95,7 @@ export const fetchConnectorExecuteAction = async ({
     };
   } catch (error) {
     return {
-      response: API_ERROR,
+      response: `${API_ERROR}\n\n${error?.body?.message ?? error?.message}`,
       isError: true,
     };
   }

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/context_pills/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/context_pills/index.tsx
@@ -66,21 +66,30 @@ const ContextPillsComponent: React.FC<Props> = ({
 
   return (
     <EuiFlexGroup gutterSize="none" wrap>
-      {sortedPromptContexts.map(({ description, id, getPromptContext, tooltip }) => (
-        <EuiFlexItem grow={false} key={id}>
-          <EuiToolTip content={tooltip}>
-            <PillButton
-              data-test-subj={`pillButton-${id}`}
-              disabled={selectedPromptContexts[id] != null}
-              iconSide="left"
-              iconType="plus"
-              onClick={() => selectPromptContext(id)}
-            >
-              {description}
-            </PillButton>
-          </EuiToolTip>
-        </EuiFlexItem>
-      ))}
+      {sortedPromptContexts.map(({ description, id, getPromptContext, tooltip }) => {
+        // Workaround for known issue where tooltip won't dismiss after button state is changed once clicked
+        // See: https://github.com/elastic/eui/issues/6488#issuecomment-1379656704
+        const button = (
+          <PillButton
+            data-test-subj={`pillButton-${id}`}
+            disabled={selectedPromptContexts[id] != null}
+            iconSide="left"
+            iconType="plus"
+            onClick={() => selectPromptContext(id)}
+          >
+            {description}
+          </PillButton>
+        );
+        return (
+          <EuiFlexItem grow={false} key={id}>
+            {selectedPromptContexts[id] != null ? (
+              button
+            ) : (
+              <EuiToolTip content={tooltip}>{button}</EuiToolTip>
+            )}
+          </EuiFlexItem>
+        );
+      })}
     </EuiFlexGroup>
   );
 };

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings/knowledge_base_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings/knowledge_base_settings.tsx
@@ -27,12 +27,12 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { css } from '@emotion/react';
 import * as i18n from './translations';
-import { useAssistantContext } from '../assistant_context';
-import { useDeleteKnowledgeBase } from './use_delete_knowledge_base';
-import { useKnowledgeBaseStatus } from './use_knowledge_base_status';
-import { useSetupKnowledgeBase } from './use_setup_knowledge_base';
+import { useAssistantContext } from '../../assistant_context';
+import { useDeleteKnowledgeBase } from '../use_delete_knowledge_base/use_delete_knowledge_base';
+import { useKnowledgeBaseStatus } from '../use_knowledge_base_status/use_knowledge_base_status';
+import { useSetupKnowledgeBase } from '../use_setup_knowledge_base/use_setup_knowledge_base';
 
-import type { KnowledgeBaseConfig } from '../assistant/types';
+import type { KnowledgeBaseConfig } from '../../assistant/types';
 
 const ESQL_RESOURCE = 'esql';
 const KNOWLEDGE_BASE_INDEX_PATTERN = '.kibana-elastic-ai-assistant-kb';

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings/translations.ts
@@ -36,6 +36,13 @@ export const KNOWLEDGE_BASE_LABEL = i18n.translate(
   }
 );
 
+export const KNOWLEDGE_BASE_TOOLTIP = i18n.translate(
+  'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.knowledgeBaseTooltip',
+  {
+    defaultMessage: 'ELSER must be configured to enable the Knowledge Base',
+  }
+);
+
 export const KNOWLEDGE_BASE_DESCRIPTION = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.knowledgeBaseDescription',
   {

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/elasticsearch_store/elasticsearch_store.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/elasticsearch_store/elasticsearch_store.ts
@@ -37,7 +37,7 @@ interface CreateIndexParams {
 }
 
 /**
- * A fallback for the the query `size` that determines how many documents to
+ * A fallback for the query `size` that determines how many documents to
  * return from Elasticsearch when performing a similarity search.
  *
  * The size is typically determined by the implementation of LangChain's
@@ -360,14 +360,17 @@ export class ElasticsearchStore extends VectorStore {
    * @param modelId ID of the model to check
    * @returns Promise<boolean> indicating whether the model is installed
    */
-  async isModelInstalled(modelId: string): Promise<boolean> {
+  async isModelInstalled(modelId?: string): Promise<boolean> {
     try {
-      const getResponse = await this.esClient.ml.getTrainedModels({
-        model_id: modelId,
-        include: 'definition_status',
+      const getResponse = await this.esClient.ml.getTrainedModelsStats({
+        model_id: modelId ?? this.model,
       });
 
-      return Boolean(getResponse.trained_model_configs[0]?.fully_defined);
+      return getResponse.trained_model_stats.some(
+        (stats) =>
+          stats.deployment_stats?.state === 'started' &&
+          stats.deployment_stats?.allocation_status.state === 'fully_allocated'
+      );
     } catch (e) {
       // Returns 404 if it doesn't exist
       return false;

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/execute_custom_llm_chain/index.ts
@@ -47,6 +47,14 @@ export const callAgentExecutor = async ({
     elserId,
     kbResource
   );
+
+  const modelExists = await esStore.isModelInstalled();
+  if (!modelExists) {
+    throw new Error(
+      'Please ensure ELSER is configured to use the Knowledge Base, otherwise disable the Knowledge Base in Advanced Settings to continue.'
+    );
+  }
+
   const chain = RetrievalQAChain.fromLLM(llm, esStore.asRetriever());
 
   const tools: Tool[] = [

--- a/x-pack/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
+++ b/x-pack/plugins/elastic_assistant/server/routes/post_actions_connector_execute.ts
@@ -44,11 +44,15 @@ export const postActionsConnectorExecuteRoute = (
 
         // if not langchain, call execute action directly and return the response:
         if (!request.body.assistantLangChain) {
+          logger.debug('Executing via actions framework directly, assistantLangChain: false');
           const result = await executeAction({ actions, request, connectorId });
           return response.ok({
             body: result,
           });
         }
+
+        // TODO: Add `traceId` to actions request when calling via langchain
+        logger.debug('Executing via langchain, assistantLangChain: true');
 
         // get a scoped esClient for assistant memory
         const esClient = (await context.core).elasticsearch.client.asCurrentUser;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution] [Elastic AI Assistant] Throw error if Knowledge Base is enabled but ELSER is unavailable (#169330)](https://github.com/elastic/kibana/pull/169330)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Garrett Spong","email":"spong@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-10-19T20:34:39Z","message":"[Security Solution] [Elastic AI Assistant] Throw error if Knowledge Base is enabled but ELSER is unavailable (#169330)\n\n## Summary\r\n\r\nThis fixes the Knowledge Base UX a bit by throwing an error if somehow\r\nELSER has been disabled in the background, and instructs the user on how\r\nto resolve or to disable the Knowledge Base to continue.\r\n\r\nAdditionally, if ELSER is not available, we prevent the enabling of the\r\nKnowledge Base as to not provide a degraded experience when ELSER and\r\nthe ES|QL documentation is not available.\r\n\r\n\r\n<p align=\"center\">\r\n<img width=\"500\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2946766/e4d326fa-c996-43ad-9d1c-d76f7d16f916\"\r\n/>\r\n</p> \r\n\r\n> [!NOTE]\r\n> `isModelInstalled` logic has been updated to not just check the model\r\n`definition_status`, but to actually ensure that it's deployed by\r\nchecking to see that it is `started` and `fully_allocated`. This better\r\nguards ELSER availability as the previous check would return true if the\r\nmodel was just downloaded and not actually deployed.\r\n\r\n\r\n\r\nAlso resolves: https://github.com/elastic/kibana/issues/169403\r\n\r\n\r\n## Test Instructions\r\n\r\nAfter enabling the KB, disable the ELSER deployment in the `Trained\r\nModels` ML UI and then try using the assistant.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"60bb1f8da1f50e0cca42d4c73fc9c730e5c76a0a","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team: SecuritySolution","Feature:Elastic AI Assistant","v8.11.0","v8.12.0"],"number":169330,"url":"https://github.com/elastic/kibana/pull/169330","mergeCommit":{"message":"[Security Solution] [Elastic AI Assistant] Throw error if Knowledge Base is enabled but ELSER is unavailable (#169330)\n\n## Summary\r\n\r\nThis fixes the Knowledge Base UX a bit by throwing an error if somehow\r\nELSER has been disabled in the background, and instructs the user on how\r\nto resolve or to disable the Knowledge Base to continue.\r\n\r\nAdditionally, if ELSER is not available, we prevent the enabling of the\r\nKnowledge Base as to not provide a degraded experience when ELSER and\r\nthe ES|QL documentation is not available.\r\n\r\n\r\n<p align=\"center\">\r\n<img width=\"500\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2946766/e4d326fa-c996-43ad-9d1c-d76f7d16f916\"\r\n/>\r\n</p> \r\n\r\n> [!NOTE]\r\n> `isModelInstalled` logic has been updated to not just check the model\r\n`definition_status`, but to actually ensure that it's deployed by\r\nchecking to see that it is `started` and `fully_allocated`. This better\r\nguards ELSER availability as the previous check would return true if the\r\nmodel was just downloaded and not actually deployed.\r\n\r\n\r\n\r\nAlso resolves: https://github.com/elastic/kibana/issues/169403\r\n\r\n\r\n## Test Instructions\r\n\r\nAfter enabling the KB, disable the ELSER deployment in the `Trained\r\nModels` ML UI and then try using the assistant.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"60bb1f8da1f50e0cca42d4c73fc9c730e5c76a0a"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169330","number":169330,"mergeCommit":{"message":"[Security Solution] [Elastic AI Assistant] Throw error if Knowledge Base is enabled but ELSER is unavailable (#169330)\n\n## Summary\r\n\r\nThis fixes the Knowledge Base UX a bit by throwing an error if somehow\r\nELSER has been disabled in the background, and instructs the user on how\r\nto resolve or to disable the Knowledge Base to continue.\r\n\r\nAdditionally, if ELSER is not available, we prevent the enabling of the\r\nKnowledge Base as to not provide a degraded experience when ELSER and\r\nthe ES|QL documentation is not available.\r\n\r\n\r\n<p align=\"center\">\r\n<img width=\"500\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2946766/e4d326fa-c996-43ad-9d1c-d76f7d16f916\"\r\n/>\r\n</p> \r\n\r\n> [!NOTE]\r\n> `isModelInstalled` logic has been updated to not just check the model\r\n`definition_status`, but to actually ensure that it's deployed by\r\nchecking to see that it is `started` and `fully_allocated`. This better\r\nguards ELSER availability as the previous check would return true if the\r\nmodel was just downloaded and not actually deployed.\r\n\r\n\r\n\r\nAlso resolves: https://github.com/elastic/kibana/issues/169403\r\n\r\n\r\n## Test Instructions\r\n\r\nAfter enabling the KB, disable the ELSER deployment in the `Trained\r\nModels` ML UI and then try using the assistant.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"60bb1f8da1f50e0cca42d4c73fc9c730e5c76a0a"}}]}] BACKPORT-->