### PR TITLE
[Ops] create-deploy-tag workflow: Add link to deployed commits overview

### DIFF
--- a/.github/workflows/create-deploy-tag.yml
+++ b/.github/workflows/create-deploy-tag.yml
@@ -48,6 +48,10 @@ jobs:
             echo "This workflow can only be run on the main branch"
             exit 1
           fi
+      - name: Find previous tag
+        run: |
+          prev_tag_name=`git tag -l 'deploy@[0-9]*' | tail -1`
+          echo "PREV_TAG_NAME=${prev_tag_name}" >> "${GITHUB_ENV}"
       - name: Prepare tag
         run: |
           tag_name="deploy@$(date +%s)"
@@ -103,7 +107,7 @@ jobs:
           JSON_USEFUL_LINKS_ARRAY: |
             [
               "*Useful links:*\\n",
-              "<https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>",
+              "<https://github.com/elastic/kibana/compare/${{ env.PREV_TAG_NAME }}...${{ env.TAG_NAME }}|Commits contained in deploy>",
               "<https://buildkite.com/elastic/kibana-serverless-release/builds?branch=${{ env.TAG_NAME }}|Kibana Serverless Release pipeline>",
               "<https://argo-workflows.us-central1.gcp.qa.cld.elstc.co/workflows?label=hash%3D${{ env.COMMIT }}|Argo Workflow> (use Elastic Cloud Staging VPN)",
               "<https://overview.qa.cld.elstc.co/app/dashboards#/view/serverless-tooling-gpctl-deployment-status?_g=(refreshInterval:(pause:!t,value:0),time:(from:now-1d,to:now))&service-name=kibana&_a=(controlGroupInput:(chainingSystem:HIERARCHICAL,controlStyle:oneLine,ignoreParentSettings:(ignoreFilters:!f,ignoreQuery:!f,ignoreTimerange:!f,ignoreValidations:!f),panels:('18201b8e-3aae-4459-947d-21e007b6a3a5':(explicitInput:(dataViewId:'serverless.logs-*',enhancements:(),fieldName:commit-hash,id:'18201b8e-3aae-4459-947d-21e007b6a3a5',selectedOptions:!('${{ env.COMMIT }}'),title:commit-hash),grow:!t,order:1,type:optionsListControl,width:medium),'41060e65-ce4c-414e-b8cf-492ccb19245f':(explicitInput:(dataViewId:'serverless.logs-*',enhancements:(),fieldName:service-name,id:'41060e65-ce4c-414e-b8cf-492ccb19245f',selectedOptions:!(kibana),title:service-name),grow:!t,order:0,type:optionsListControl,width:medium),ed96828e-efe9-43ad-be3f-0e04218f79af:(explicitInput:(dataViewId:'serverless.logs-*',enhancements:(),fieldName:to-env,id:ed96828e-efe9-43ad-be3f-0e04218f79af,selectedOptions:!(qa),title:to-env),grow:!t,order:2,type:optionsListControl,width:medium))))|GPCTL Deployment Status dashboard for nonprod>",
@@ -152,6 +156,5 @@ jobs:
           JSON_USEFUL_LINKS_ARRAY: |
             [
               "*Useful links:*\\n",
-              "<https://docs.google.com/document/d/1c2LzojDh1wawjeMsKh4D_L2jpVJALhxukkmmL-TUbrs/edit#heading=h.50173f90utwr|Release process playbook>",
               "<https://github.com/elastic/kibana/actions/runs/${{ github.run_id }}|GitHub Workflow run>"
             ]


### PR DESCRIPTION
Besides adding the link to the overview over the deployed commits, this PR also removes the link to the release process playbook as that link is not dynamic and is already linked to from within the Slack channel.