### PR TITLE
Updates the getting started page for Ruby in serverless search

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/ruby.ts
@@ -51,8 +51,14 @@ client.bulk(body: documents)
 `,
   installClient: `# Requires Ruby version 3.0 or higher
 
-# From the project's root directory:$ gem build elasticsearch-serverless.gemspec
-$ gem install elasticsearch-serverless-x.x.x.gem`,
+# Install from RubyGems:
+gem install elasticsearch-serverless --pre
+
+# Or include the gem in your Gemfile
+gem 'elasticsearch-serverless'
+
+# And require it in your code
+require 'elasticsearch-serverless'`,
   name: i18n.translate('xpack.serverlessSearch.languages.ruby', {
     defaultMessage: 'Ruby',
   }),


### PR DESCRIPTION
Updates the "Install a client" code snippet for Ruby Elasticsearch Serverless Client. Since the library is now public and published to RubyGems, we don't need to build from source and can use `gem install` or add it to a project's Gemfile.