### PR TITLE
Add support to provide extension definitions for cards navs rendered in management settings

### DIFF
--- a/packages/kbn-management/cards_navigation/README.mdx
+++ b/packages/kbn-management/cards_navigation/README.mdx
@@ -17,7 +17,7 @@ There are two distinctive ways of adding items to the navigation;
 
 - to add navigation items that would be visible across all consumers of this package all you have to do is;
 
-  * edit the `cards_navigation/src/types.tsx` file add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
+  * edit the `cards_navigation/src/types.tsx` file and add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
   * edit the `cards_navigation/src/const.tsx`, add a new entry to the `appDefinitions` object. In here you can specify the category where you want it to be, icon and description.
 
 - To add a localized navigation item that would only exist within the context of usage for this component, an "extend card navigation" definition can be passed in like so; 
@@ -37,7 +37,7 @@ There are two distinctive ways of adding items to the navigation;
   ```
 
   In the example above assuming the key `visualize` is a valid registered management app ID, this definition would show up as a navigation card under the predefined category `content`. It's also worth pointing out that there's also 
-  an opt out functionality that allows one to provide definitions that don't map to management app, and requires that the property `skipValidation` be passed and set to true, in this case the onus is on the 
+  an opt out functionality that allows one to provide definitions that don't map to management app, and requires that the property `skipValidation` be passed and set to true, in this case the responsibility is on the 
   user passing the defintion to also provide the `href` that the card will link to, and it's `title`.
 
 ### Removing an item from the navigation

--- a/packages/kbn-management/cards_navigation/README.mdx
+++ b/packages/kbn-management/cards_navigation/README.mdx
@@ -13,11 +13,10 @@ categories.
 
 ### Adding new items to the navigation
 
-For adding a new item to the navigation all you have to do is edit the `cards_navigation/src/consts.tsx`
-file and add two things:
+For adding a new item to the navigation all you have to do is;
 
-* Add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
-* Add a new entry to the `appDefinitions` object. In here you can specify the category where you want it to be, icon and description.
+* edit the `cards_navigation/src/types.tsx` file add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
+* edit the `cards_navigation/src/const.tsx`, add a new entry to the `appDefinitions` object. In here you can specify the category where you want it to be, icon and description.
 
 ### Removing an item from the navigation
 

--- a/packages/kbn-management/cards_navigation/README.mdx
+++ b/packages/kbn-management/cards_navigation/README.mdx
@@ -13,14 +13,36 @@ categories.
 
 ### Adding new items to the navigation
 
-For adding a new item to the navigation all you have to do is;
+There are two distinctive ways of adding items to the navigation;
 
-* edit the `cards_navigation/src/types.tsx` file add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
-* edit the `cards_navigation/src/const.tsx`, add a new entry to the `appDefinitions` object. In here you can specify the category where you want it to be, icon and description.
+- to add navigation items that would be visible across all consumers of this package all you have to do is;
+
+  * edit the `cards_navigation/src/types.tsx` file add the app id into the `appIds` enum (make sure that the app_id value matches the one from the plugin)
+  * edit the `cards_navigation/src/const.tsx`, add a new entry to the `appDefinitions` object. In here you can specify the category where you want it to be, icon and description.
+
+- To add a localized navigation item that would only exist within the context of usage for this component, an "extend card navigation" definition can be passed in like so; 
+
+  ```typescript
+  <CardsNavigation
+    sections={sections}
+    appBasePath={appBasePath}
+    extendedCardNavigationDefinitions={{
+      visualize: {
+        category: 'content',
+        description: 'create different visualizations based on your data.'
+        icon: 'visualizeApp',
+      },
+    }}
+  />
+  ```
+
+  In the example above assuming the key `visualize` is a valid registered management app ID, this definition would show up as a navigation card under the predefined category `content`. It's also worth pointing out that there's also 
+  an opt out functionality that allows one to provide definitions that don't map to management app, and requires that the property `skipValidation` be passed and set to true, in this case the onus is on the 
+  user passing the defintion to also provide the `href` that the card will link to, and it's `title`.
 
 ### Removing an item from the navigation
 
-If an item needs to be hidden from the navigation you can specify that by using the `hideLinksTo` prop:
+If an item needs to be hidden from the navigation you can specify that by using the `hideLinksTo` prop like so:
 
 ```typescript
 <CardsNavigation

--- a/packages/kbn-management/cards_navigation/index.ts
+++ b/packages/kbn-management/cards_navigation/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { AppId, CardsNavigationComponentProps, CardNavExtensionDefinition } from './src';
+export type { AppId, CardsNavigationComponentProps } from './src';
 
 export { appIds } from './src';
 export { CardsNavigation } from './src';

--- a/packages/kbn-management/cards_navigation/index.ts
+++ b/packages/kbn-management/cards_navigation/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { AppId, CardsNavigationComponentProps } from './src';
+export type { AppId, CardsNavigationComponentProps, AppDefinition } from './src';
 
 export { appIds } from './src';
 export { CardsNavigation } from './src';

--- a/packages/kbn-management/cards_navigation/index.ts
+++ b/packages/kbn-management/cards_navigation/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { AppId, CardsNavigationComponentProps, AppDefinitionExtention } from './src';
+export type { AppId, CardsNavigationComponentProps, CardNavExtensionDefinition } from './src';
 
 export { appIds } from './src';
 export { CardsNavigation } from './src';

--- a/packages/kbn-management/cards_navigation/index.ts
+++ b/packages/kbn-management/cards_navigation/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { AppId, CardsNavigationComponentProps, AppDefinition } from './src';
+export type { AppId, CardsNavigationComponentProps, AppDefinitionExtention } from './src';
 
 export { appIds } from './src';
 export { CardsNavigation } from './src';

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.test.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.test.tsx
@@ -70,4 +70,49 @@ describe('Cards Navigation', () => {
       expect(dataPipelinesApp).toBeNull();
     });
   });
+
+  describe('extending card navigation definition', () => {
+    test('does not render a card for a definition that specifies an invalid app id', () => {
+      const invalidAppId = 'some-invalid-app-id';
+
+      renderCardsNavigationComponent({
+        sections: sectionsMock,
+        appBasePath: APP_BASE_PATH,
+        extendedCardNavigationDefinitions: {
+          [invalidAppId]: {
+            icon: 'launch',
+            description: 'Invalid app not part of any registered management section',
+            category: 'other',
+          },
+        },
+      });
+
+      const invalidAppCard = screen.queryByTestId(`app-card-${invalidAppId}`);
+
+      expect(invalidAppCard).toBeNull();
+    });
+
+    test("renders a card for a definition that specifies any key, given the skipValidation property has a value of 'true'", () => {
+      const notManagementAppId = 'some-external-app';
+
+      renderCardsNavigationComponent({
+        sections: sectionsMock,
+        appBasePath: APP_BASE_PATH,
+        extendedCardNavigationDefinitions: {
+          [notManagementAppId]: {
+            icon: 'launch',
+            description: 'Invalid app not part of any registered management section',
+            category: 'other',
+            skipValidation: true,
+            title: 'Some external app',
+            href: '/path-to-said-external-app',
+          },
+        },
+      });
+
+      const externalAppCard = screen.queryByTestId(`app-card-${notManagementAppId}`);
+
+      expect(externalAppCard).not.toBeNull();
+    });
+  });
 });

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -27,12 +27,12 @@ import {
   AppProps,
   AppId,
   AppDefinition,
-  AppDefinitionExtention,
+  CardNavExtensionDefinition,
 } from './types';
 import { appCategories, appDefinitions as defaultCardNavigationDefinitions } from './consts';
 
 type AggregatedCardNavDefinitions =
-  | NonNullable<CardsNavigationComponentProps['extendCardNavigationDefinitions']>
+  | NonNullable<CardsNavigationComponentProps['cardNavExtensionDefinitions']>
   | Record<AppId, AppDefinition>;
 
 // Retrieve the data we need from a given app from the management app registry
@@ -61,7 +61,7 @@ const getAppsForCategoryFactory =
   (category: string, filteredApps: { [key: string]: Application }) => {
     return getAppIdsByCategory(category, appDefinitions)
       .map((appId: AppId) => {
-        if ((appDefinitions[appId] as AppDefinitionExtention<boolean>).noVerify) {
+        if ((appDefinitions[appId] as CardNavExtensionDefinition<boolean>).noVerify) {
           return appDefinitions[appId];
         }
 
@@ -136,7 +136,7 @@ export const CardsNavigation = ({
   appBasePath,
   onCardClick,
   hideLinksTo = [],
-  extendCardNavigationDefinitions = {},
+  cardNavExtensionDefinitions: extendCardNavigationDefinitions = {},
 }: CardsNavigationComponentProps) => {
   const cardNavigationDefintions = useMemo<AggregatedCardNavDefinitions>(
     () => ({
@@ -185,7 +185,11 @@ export const CardsNavigation = ({
                   titleSize="xs"
                   title={app.title}
                   description={app.description}
-                  href={appBasePath + app.href}
+                  href={
+                    (app as CardNavExtensionDefinition<boolean>).noVerify
+                      ? app.href
+                      : appBasePath + app.href
+                  }
                   onClick={onCardClick}
                 />
               </EuiFlexItem>

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -18,6 +18,7 @@ import {
   EuiCard,
   EuiText,
   EuiHorizontalRule,
+  EuiIcon,
 } from '@elastic/eui';
 import {
   CardsNavigationComponentProps,
@@ -167,7 +168,7 @@ export const CardsNavigation = ({
                 <EuiCard
                   data-test-subj={`app-card-${app.id}`}
                   layout="horizontal"
-                  icon={app.icon}
+                  icon={<EuiIcon type={app.icon} size={'l'} />}
                   titleSize="xs"
                   title={app.title}
                   description={app.description}

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -62,7 +62,10 @@ const getAppsForCategoryFactory =
     return getAppIdsByCategory(category, appDefinitions)
       .map((appId: AppId) => {
         if ((appDefinitions[appId] as CardNavExtensionDefinition<boolean>).noVerify) {
-          return appDefinitions[appId];
+          return {
+            id: appId,
+            ...appDefinitions[appId],
+          };
         }
 
         if (!filteredApps[appId]) {

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -19,9 +19,14 @@ import {
   EuiText,
   EuiHorizontalRule,
 } from '@elastic/eui';
-import { CardsNavigationComponentProps, AppRegistrySections, Application, AppProps } from './types';
+import {
+  CardsNavigationComponentProps,
+  AppRegistrySections,
+  Application,
+  AppProps,
+  AppId,
+} from './types';
 import { appCategories, appDefinitions, getAppIdsByCategory } from './consts';
-import type { AppId } from './consts';
 
 // Retrieve the data we need from a given app from the management app registry
 const getDataFromManagementApp = (app: Application) => {

--- a/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
+++ b/packages/kbn-management/cards_navigation/src/cards_navigation.tsx
@@ -32,7 +32,7 @@ import {
 import { appCategories, appDefinitions as defaultCardNavigationDefinitions } from './consts';
 
 type AggregatedCardNavDefinitions =
-  | NonNullable<CardsNavigationComponentProps['cardNavExtensionDefinitions']>
+  | NonNullable<CardsNavigationComponentProps['extendedCardNavigationDefinitions']>
   | Record<AppId, AppDefinition>;
 
 // Retrieve the data we need from a given app from the management app registry
@@ -61,7 +61,7 @@ const getAppsForCategoryFactory =
   (category: string, filteredApps: { [key: string]: Application }) => {
     return getAppIdsByCategory(category, appDefinitions)
       .map((appId: AppId) => {
-        if ((appDefinitions[appId] as CardNavExtensionDefinition<boolean>).noVerify) {
+        if ((appDefinitions[appId] as CardNavExtensionDefinition).skipValidation) {
           return {
             id: appId,
             ...appDefinitions[appId],
@@ -139,14 +139,14 @@ export const CardsNavigation = ({
   appBasePath,
   onCardClick,
   hideLinksTo = [],
-  cardNavExtensionDefinitions: extendCardNavigationDefinitions = {},
+  extendedCardNavigationDefinitions = {},
 }: CardsNavigationComponentProps) => {
   const cardNavigationDefintions = useMemo<AggregatedCardNavDefinitions>(
     () => ({
       ...defaultCardNavigationDefinitions,
-      ...extendCardNavigationDefinitions,
+      ...extendedCardNavigationDefinitions,
     }),
-    [extendCardNavigationDefinitions]
+    [extendedCardNavigationDefinitions]
   );
 
   const appsByCategory = getEnabledAppsByCategory(sections, cardNavigationDefintions, hideLinksTo);
@@ -189,7 +189,7 @@ export const CardsNavigation = ({
                   title={app.title}
                   description={app.description}
                   href={
-                    (app as CardNavExtensionDefinition<boolean>).noVerify
+                    (app as CardNavExtensionDefinition).skipValidation
                       ? app.href
                       : appBasePath + app.href
                   }

--- a/packages/kbn-management/cards_navigation/src/consts.tsx
+++ b/packages/kbn-management/cards_navigation/src/consts.tsx
@@ -6,10 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
 import { i18n } from '@kbn/i18n';
-import { EuiIcon } from '@elastic/eui';
-
 import { AppIds, AppId, AppDefinition, appCategories } from './types';
 
 export { AppIds, appCategories } from './types';
@@ -24,14 +21,14 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
           'Configure and maintain your Elasticsearch indices for data storage and retrieval.',
       }
     ),
-    icon: <EuiIcon size="l" type="indexSettings" />,
+    icon: 'indexSettings',
   },
   [AppIds.TRANSFORM]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.transformDescription', {
       defaultMessage: 'Pivot your data or copy the latest documents into an entity-centric index.',
     }),
-    icon: <EuiIcon size="l" type="indexFlush" />,
+    icon: 'indexFlush',
   },
   [AppIds.INGEST_PIPELINES]: {
     category: appCategories.DATA,
@@ -41,14 +38,14 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
         defaultMessage: 'Remove fields, extract values, and perform transformations on your data.',
       }
     ),
-    icon: <EuiIcon size="l" type="logstashInput" />,
+    icon: 'logstashInput',
   },
   [AppIds.DATA_VIEWS]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.dataViewsDescription', {
       defaultMessage: 'Create and manage the Elasticsearch data you selected for exploration.',
     }),
-    icon: <EuiIcon size="l" type="indexEdit" />,
+    icon: 'indexEdit',
   },
   [AppIds.ML]: {
     category: appCategories.DATA,
@@ -56,7 +53,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
       defaultMessage:
         'Identify, analyze, and process your data using advanced analysis techniques.',
     }),
-    icon: <EuiIcon size="l" type="indexMapping" />,
+    icon: 'indexMapping',
   },
   [AppIds.PIPELINES]: {
     category: appCategories.DATA,
@@ -64,7 +61,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
       defaultMessage:
         'Manage and view the Logstash event processing pipeline from inputs to outputs.',
     }),
-    icon: <EuiIcon size="l" type="logstashQueue" />,
+    icon: 'logstashQueue',
   },
 
   [AppIds.RULES]: {
@@ -72,14 +69,14 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     description: i18n.translate('management.landing.withCardNavigation.rulesDescription', {
       defaultMessage: 'Define when to generate alerts and notifications.',
     }),
-    icon: <EuiIcon size="l" type="editorChecklist" />,
+    icon: 'editorChecklist',
   },
   [AppIds.CONNECTORS]: {
     category: appCategories.ALERTS,
     description: i18n.translate('management.landing.withCardNavigation.connectorsDescription', {
       defaultMessage: 'Configure connections to third party systems for use in cases and rules.',
     }),
-    icon: <EuiIcon size="l" type="desktop" />,
+    icon: 'desktop',
   },
   [AppIds.MAINTENANCE_WINDOWS]: {
     category: appCategories.ALERTS,
@@ -90,7 +87,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
           'Suppress rule notifications during scheduled times for maintenance, updates, and other system tasks.',
       }
     ),
-    icon: <EuiIcon size="l" type="wrench" />,
+    icon: 'wrench',
   },
 
   [AppIds.SAVED_OBJECTS]: {
@@ -98,28 +95,28 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     description: i18n.translate('management.landing.withCardNavigation.objectsDescription', {
       defaultMessage: 'Manage your saved dashboards, maps, data views, and Canvas workpads.',
     }),
-    icon: <EuiIcon size="l" type="save" />,
+    icon: 'save',
   },
   [AppIds.FILES_MANAGEMENT]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.fileManagementDescription', {
       defaultMessage: 'Access all files that you uploaded.',
     }),
-    icon: <EuiIcon size="l" type="documents" />,
+    icon: 'documents',
   },
   [AppIds.REPORTING]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.reportingDescription', {
       defaultMessage: 'Manage generated PDF, PNG and CSV reports.',
     }),
-    icon: <EuiIcon size="l" type="visPie" />,
+    icon: 'visPie',
   },
   [AppIds.TAGS]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.tagsDescription', {
       defaultMessage: 'Organize, search, and filter your saved objects by specific criteria.',
     }),
-    icon: <EuiIcon size="l" type="tag" />,
+    icon: 'tag',
   },
 
   [AppIds.API_KEYS]: {
@@ -127,7 +124,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     description: i18n.translate('management.landing.withCardNavigation.apiKeysDescription', {
       defaultMessage: 'Allow programmatic access to your project data and capabilities.',
     }),
-    icon: <EuiIcon size="l" type="lockOpen" />,
+    icon: 'lockOpen',
   },
 
   [AppIds.SERVERLESS_SETTINGS]: {
@@ -135,6 +132,6 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     description: i18n.translate('management.landing.withCardNavigation.settingsDescription', {
       defaultMessage: 'Control project behavior, such as date display and default sorting.',
     }),
-    icon: <EuiIcon size="l" type="gear" />,
+    icon: 'gear',
   },
 };

--- a/packages/kbn-management/cards_navigation/src/consts.tsx
+++ b/packages/kbn-management/cards_navigation/src/consts.tsx
@@ -10,35 +10,9 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiIcon } from '@elastic/eui';
 
-import { AppDefinition } from './types';
+import { appIds, AppId, AppDefinition, appCategories } from './types';
 
-export enum appIds {
-  INGEST_PIPELINES = 'ingest_pipelines',
-  PIPELINES = 'pipelines',
-  INDEX_MANAGEMENT = 'index_management',
-  TRANSFORM = 'transform',
-  ML = 'jobsListLink',
-  SAVED_OBJECTS = 'objects',
-  TAGS = 'tags',
-  FILES_MANAGEMENT = 'filesManagement',
-  API_KEYS = 'api_keys',
-  DATA_VIEWS = 'dataViews',
-  REPORTING = 'reporting',
-  CONNECTORS = 'triggersActionsConnectors',
-  RULES = 'triggersActions',
-  MAINTENANCE_WINDOWS = 'maintenanceWindows',
-  SERVERLESS_SETTINGS = 'settings',
-}
-
-// Create new type that is a union of all the appId values
-export type AppId = `${appIds}`;
-
-export const appCategories = {
-  DATA: 'data',
-  ALERTS: 'alerts',
-  CONTENT: 'content',
-  OTHER: 'other',
-};
+export { appIds, appCategories } from './types';
 
 export const appDefinitions: Record<AppId, AppDefinition> = {
   [appIds.INDEX_MANAGEMENT]: {

--- a/packages/kbn-management/cards_navigation/src/consts.tsx
+++ b/packages/kbn-management/cards_navigation/src/consts.tsx
@@ -10,12 +10,12 @@ import React from 'react';
 import { i18n } from '@kbn/i18n';
 import { EuiIcon } from '@elastic/eui';
 
-import { appIds, AppId, AppDefinition, appCategories } from './types';
+import { AppIds, AppId, AppDefinition, appCategories } from './types';
 
-export { appIds, appCategories } from './types';
+export { AppIds, appCategories } from './types';
 
 export const appDefinitions: Record<AppId, AppDefinition> = {
-  [appIds.INDEX_MANAGEMENT]: {
+  [AppIds.INDEX_MANAGEMENT]: {
     category: appCategories.DATA,
     description: i18n.translate(
       'management.landing.withCardNavigation.indexmanagementDescription',
@@ -26,14 +26,14 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     ),
     icon: <EuiIcon size="l" type="indexSettings" />,
   },
-  [appIds.TRANSFORM]: {
+  [AppIds.TRANSFORM]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.transformDescription', {
       defaultMessage: 'Pivot your data or copy the latest documents into an entity-centric index.',
     }),
     icon: <EuiIcon size="l" type="indexFlush" />,
   },
-  [appIds.INGEST_PIPELINES]: {
+  [AppIds.INGEST_PIPELINES]: {
     category: appCategories.DATA,
     description: i18n.translate(
       'management.landing.withCardNavigation.ingestPipelinesDescription',
@@ -43,14 +43,14 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     ),
     icon: <EuiIcon size="l" type="logstashInput" />,
   },
-  [appIds.DATA_VIEWS]: {
+  [AppIds.DATA_VIEWS]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.dataViewsDescription', {
       defaultMessage: 'Create and manage the Elasticsearch data you selected for exploration.',
     }),
     icon: <EuiIcon size="l" type="indexEdit" />,
   },
-  [appIds.ML]: {
+  [AppIds.ML]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.mlDescription', {
       defaultMessage:
@@ -58,7 +58,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     }),
     icon: <EuiIcon size="l" type="indexMapping" />,
   },
-  [appIds.PIPELINES]: {
+  [AppIds.PIPELINES]: {
     category: appCategories.DATA,
     description: i18n.translate('management.landing.withCardNavigation.ingestDescription', {
       defaultMessage:
@@ -67,21 +67,21 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     icon: <EuiIcon size="l" type="logstashQueue" />,
   },
 
-  [appIds.RULES]: {
+  [AppIds.RULES]: {
     category: appCategories.ALERTS,
     description: i18n.translate('management.landing.withCardNavigation.rulesDescription', {
       defaultMessage: 'Define when to generate alerts and notifications.',
     }),
     icon: <EuiIcon size="l" type="editorChecklist" />,
   },
-  [appIds.CONNECTORS]: {
+  [AppIds.CONNECTORS]: {
     category: appCategories.ALERTS,
     description: i18n.translate('management.landing.withCardNavigation.connectorsDescription', {
       defaultMessage: 'Configure connections to third party systems for use in cases and rules.',
     }),
     icon: <EuiIcon size="l" type="desktop" />,
   },
-  [appIds.MAINTENANCE_WINDOWS]: {
+  [AppIds.MAINTENANCE_WINDOWS]: {
     category: appCategories.ALERTS,
     description: i18n.translate(
       'management.landing.withCardNavigation.maintenanceWindowsDescription',
@@ -93,28 +93,28 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     icon: <EuiIcon size="l" type="wrench" />,
   },
 
-  [appIds.SAVED_OBJECTS]: {
+  [AppIds.SAVED_OBJECTS]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.objectsDescription', {
       defaultMessage: 'Manage your saved dashboards, maps, data views, and Canvas workpads.',
     }),
     icon: <EuiIcon size="l" type="save" />,
   },
-  [appIds.FILES_MANAGEMENT]: {
+  [AppIds.FILES_MANAGEMENT]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.fileManagementDescription', {
       defaultMessage: 'Access all files that you uploaded.',
     }),
     icon: <EuiIcon size="l" type="documents" />,
   },
-  [appIds.REPORTING]: {
+  [AppIds.REPORTING]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.reportingDescription', {
       defaultMessage: 'Manage generated PDF, PNG and CSV reports.',
     }),
     icon: <EuiIcon size="l" type="visPie" />,
   },
-  [appIds.TAGS]: {
+  [AppIds.TAGS]: {
     category: appCategories.CONTENT,
     description: i18n.translate('management.landing.withCardNavigation.tagsDescription', {
       defaultMessage: 'Organize, search, and filter your saved objects by specific criteria.',
@@ -122,7 +122,7 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     icon: <EuiIcon size="l" type="tag" />,
   },
 
-  [appIds.API_KEYS]: {
+  [AppIds.API_KEYS]: {
     category: appCategories.OTHER,
     description: i18n.translate('management.landing.withCardNavigation.apiKeysDescription', {
       defaultMessage: 'Allow programmatic access to your project data and capabilities.',
@@ -130,19 +130,11 @@ export const appDefinitions: Record<AppId, AppDefinition> = {
     icon: <EuiIcon size="l" type="lockOpen" />,
   },
 
-  [appIds.SERVERLESS_SETTINGS]: {
+  [AppIds.SERVERLESS_SETTINGS]: {
     category: appCategories.OTHER,
     description: i18n.translate('management.landing.withCardNavigation.settingsDescription', {
       defaultMessage: 'Control project behavior, such as date display and default sorting.',
     }),
     icon: <EuiIcon size="l" type="gear" />,
   },
-};
-
-// Compose a list of app ids that belong to a given category
-export const getAppIdsByCategory = (category: string) => {
-  const appKeys = Object.keys(appDefinitions) as AppId[];
-  return appKeys.filter((appId: AppId) => {
-    return appDefinitions[appId].category === category;
-  });
 };

--- a/packages/kbn-management/cards_navigation/src/index.ts
+++ b/packages/kbn-management/cards_navigation/src/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { CardsNavigationComponentProps, AppId, CardNavExtensionDefinition } from './types';
+export type { CardsNavigationComponentProps, AppId } from './types';
 
 export { AppIds as appIds } from './consts';
 export { CardsNavigation } from './cards_navigation';

--- a/packages/kbn-management/cards_navigation/src/index.ts
+++ b/packages/kbn-management/cards_navigation/src/index.ts
@@ -8,5 +8,5 @@
 
 export type { CardsNavigationComponentProps, AppId, AppDefinition } from './types';
 
-export { appIds } from './consts';
+export { AppIds as appIds } from './consts';
 export { CardsNavigation } from './cards_navigation';

--- a/packages/kbn-management/cards_navigation/src/index.ts
+++ b/packages/kbn-management/cards_navigation/src/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { CardsNavigationComponentProps, AppId, AppDefinitionExtention } from './types';
+export type { CardsNavigationComponentProps, AppId, CardNavExtensionDefinition } from './types';
 
 export { AppIds as appIds } from './consts';
 export { CardsNavigation } from './cards_navigation';

--- a/packages/kbn-management/cards_navigation/src/index.ts
+++ b/packages/kbn-management/cards_navigation/src/index.ts
@@ -6,8 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { CardsNavigationComponentProps } from './types';
-export type { AppId } from './consts';
+export type { CardsNavigationComponentProps, AppId, AppDefinition } from './types';
 
 export { appIds } from './consts';
 export { CardsNavigation } from './cards_navigation';

--- a/packages/kbn-management/cards_navigation/src/index.ts
+++ b/packages/kbn-management/cards_navigation/src/index.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-export type { CardsNavigationComponentProps, AppId, AppDefinition } from './types';
+export type { CardsNavigationComponentProps, AppId, AppDefinitionExtention } from './types';
 
 export { AppIds as appIds } from './consts';
 export { CardsNavigation } from './cards_navigation';

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -9,7 +9,7 @@
 /**
  * app ids shared by all solutions
  */
-export enum appIds {
+export enum AppIds {
   INGEST_PIPELINES = 'ingest_pipelines',
   PIPELINES = 'pipelines',
   INDEX_MANAGEMENT = 'index_management',
@@ -28,7 +28,7 @@ export enum appIds {
 }
 
 // Create new type that is a union of all the appId values
-export type AppId = `${appIds}`;
+export type AppId = `${AppIds}`;
 
 export const appCategories = {
   DATA: 'data',

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -57,7 +57,7 @@ export interface CardsNavigationComponentProps {
   appBasePath: string;
   onCardClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   hideLinksTo?: AppId[];
-  extendCardNavigationDefinitions?: Record<string, AppDefinition>;
+  extendCardNavigationDefinitions?: Record<string, AppDefinitionExtention<boolean>>;
 }
 
 export interface ManagementAppProps {
@@ -70,6 +70,12 @@ export interface AppDefinition {
   category: typeof appCategories[keyof typeof appCategories];
   description: string;
   icon: EuiIconProps['type'];
+}
+
+export interface AppDefinitionExtention<N extends boolean> extends AppDefinition {
+  noVerify: N;
+  href: [N] extends [true] ? string : never;
+  title: [N] extends [true] ? string : never;
 }
 
 export type AppProps = ManagementAppProps & AppDefinition;

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -57,7 +57,7 @@ export interface CardsNavigationComponentProps {
   appBasePath: string;
   onCardClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   hideLinksTo?: AppId[];
-  cardNavExtensionDefinitions?: Record<string, CardNavExtensionDefinition<boolean>>;
+  extendedCardNavigationDefinitions?: Record<string, CardNavExtensionDefinition>;
 }
 
 export interface ManagementAppProps {
@@ -72,10 +72,28 @@ export interface AppDefinition {
   icon: EuiIconProps['type'];
 }
 
-export interface CardNavExtensionDefinition<N extends boolean> extends AppDefinition {
-  noVerify: N;
-  href: [N] extends [true] ? string : never;
-  title: [N] extends [true] ? string : never;
-}
+export type CardNavExtensionDefinition = AppDefinition &
+  (
+    | {
+        /**
+         * Optional prop that indicates if the card nav definition being declared,
+         * skips validation to ascertain it's key is a valid id for a mangement app.
+         */
+        skipValidation?: false;
+      }
+    | {
+        skipValidation: true;
+        /**
+         * Specify the url that the card nav being defined should route to,
+         * and is only expected when the value of {@link skipValidation} prop is passed true.
+         */
+        href: string;
+        /**
+         * Defines the title of the card nav being defined,
+         * and is only expected when the {@link skipValidation} prop value is true.
+         */
+        title: string;
+      }
+  );
 
-export type AppProps = ManagementAppProps & (AppDefinition | CardNavExtensionDefinition<boolean>);
+export type AppProps = ManagementAppProps & (AppDefinition | CardNavExtensionDefinition);

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -5,7 +5,37 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { AppId } from './consts';
+
+/**
+ * app ids shared by all solutions
+ */
+export enum appIds {
+  INGEST_PIPELINES = 'ingest_pipelines',
+  PIPELINES = 'pipelines',
+  INDEX_MANAGEMENT = 'index_management',
+  TRANSFORM = 'transform',
+  ML = 'jobsListLink',
+  SAVED_OBJECTS = 'objects',
+  TAGS = 'tags',
+  FILES_MANAGEMENT = 'filesManagement',
+  API_KEYS = 'api_keys',
+  DATA_VIEWS = 'dataViews',
+  REPORTING = 'reporting',
+  CONNECTORS = 'triggersActionsConnectors',
+  RULES = 'triggersActions',
+  MAINTENANCE_WINDOWS = 'maintenanceWindows',
+  SERVERLESS_SETTINGS = 'settings',
+}
+
+// Create new type that is a union of all the appId values
+export type AppId = `${appIds}`;
+
+export const appCategories = {
+  DATA: 'data',
+  ALERTS: 'alerts',
+  CONTENT: 'content',
+  OTHER: 'other',
+} as const;
 
 export interface Application {
   id: string;
@@ -34,7 +64,7 @@ export interface ManagementAppProps {
 }
 
 export interface AppDefinition {
-  category: string;
+  category: typeof appCategories[keyof typeof appCategories];
   description: string;
   icon: React.ReactElement;
 }

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -57,7 +57,7 @@ export interface CardsNavigationComponentProps {
   appBasePath: string;
   onCardClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   hideLinksTo?: AppId[];
-  extendCardNavigationDefinitions?: Record<string, AppDefinitionExtention<boolean>>;
+  cardNavExtensionDefinitions?: Record<string, CardNavExtensionDefinition<boolean>>;
 }
 
 export interface ManagementAppProps {
@@ -72,10 +72,10 @@ export interface AppDefinition {
   icon: EuiIconProps['type'];
 }
 
-export interface AppDefinitionExtention<N extends boolean> extends AppDefinition {
+export interface CardNavExtensionDefinition<N extends boolean> extends AppDefinition {
   noVerify: N;
   href: [N] extends [true] ? string : never;
   title: [N] extends [true] ? string : never;
 }
 
-export type AppProps = ManagementAppProps & AppDefinition;
+export type AppProps = ManagementAppProps & (AppDefinition | CardNavExtensionDefinition<boolean>);

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import type { EuiIconProps } from '@elastic/eui';
+
 /**
  * app ids shared by all solutions
  */
@@ -67,7 +69,7 @@ export interface ManagementAppProps {
 export interface AppDefinition {
   category: typeof appCategories[keyof typeof appCategories];
   description: string;
-  icon: React.ReactElement;
+  icon: EuiIconProps['type'];
 }
 
 export type AppProps = ManagementAppProps & AppDefinition;

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -77,7 +77,7 @@ export type CardNavExtensionDefinition = AppDefinition &
     | {
         /**
          * Optional prop that indicates if the card nav definition being declared,
-         * skips validation to ascertain it's key is a valid id for a mangement app.
+         * skips validation to ascertain it's key is a valid id for a management app.
          */
         skipValidation?: false;
       }

--- a/packages/kbn-management/cards_navigation/src/types.ts
+++ b/packages/kbn-management/cards_navigation/src/types.ts
@@ -55,6 +55,7 @@ export interface CardsNavigationComponentProps {
   appBasePath: string;
   onCardClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   hideLinksTo?: AppId[];
+  extendCardNavigationDefinitions?: Record<string, AppDefinition>;
 }
 
 export interface ManagementAppProps {

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -38,7 +38,7 @@ export const ManagementLandingPage = ({
           sections={sections}
           appBasePath={appBasePath}
           hideLinksTo={cardsNavigationConfig?.hideLinksTo}
-          extendCardNavigationDefinitions={cardsNavigationConfig?.extendAppDefinitons}
+          extendCardNavigationDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
         />
       </EuiPageBody>
     );

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -38,7 +38,7 @@ export const ManagementLandingPage = ({
           sections={sections}
           appBasePath={appBasePath}
           hideLinksTo={cardsNavigationConfig?.hideLinksTo}
-          cardNavExtensionDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
+          extendedCardNavigationDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
         />
       </EuiPageBody>
     );

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -38,7 +38,7 @@ export const ManagementLandingPage = ({
           sections={sections}
           appBasePath={appBasePath}
           hideLinksTo={cardsNavigationConfig?.hideLinksTo}
-          extendedCardNavigationDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
+          extendedCardNavigationDefinitions={cardsNavigationConfig?.extendCardNavDefinitions}
         />
       </EuiPageBody>
     );

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -38,7 +38,7 @@ export const ManagementLandingPage = ({
           sections={sections}
           appBasePath={appBasePath}
           hideLinksTo={cardsNavigationConfig?.hideLinksTo}
-          extendCardNavigationDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
+          cardNavExtensionDefinitions={cardsNavigationConfig?.extendCardNavDefinitons}
         />
       </EuiPageBody>
     );

--- a/src/plugins/management/public/components/landing/landing.tsx
+++ b/src/plugins/management/public/components/landing/landing.tsx
@@ -38,6 +38,7 @@ export const ManagementLandingPage = ({
           sections={sections}
           appBasePath={appBasePath}
           hideLinksTo={cardsNavigationConfig?.hideLinksTo}
+          extendCardNavigationDefinitions={cardsNavigationConfig?.extendAppDefinitons}
         />
       </EuiPageBody>
     );

--- a/src/plugins/management/public/components/management_app/management_app.tsx
+++ b/src/plugins/management/public/components/management_app/management_app.tsx
@@ -42,7 +42,7 @@ export interface ManagementAppDependencies {
   coreStart: CoreStart;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;
   isSidebarEnabled$: BehaviorSubject<boolean>;
-  cardsNavigationConfig$: BehaviorSubject<NavigationCardsSubject>;
+  cardsNavigationConfig$: BehaviorSubject<NavigationCardsSubject<boolean>>;
 }
 
 export const ManagementApp = ({

--- a/src/plugins/management/public/components/management_app/management_app.tsx
+++ b/src/plugins/management/public/components/management_app/management_app.tsx
@@ -42,7 +42,7 @@ export interface ManagementAppDependencies {
   coreStart: CoreStart;
   setBreadcrumbs: (newBreadcrumbs: ChromeBreadcrumb[]) => void;
   isSidebarEnabled$: BehaviorSubject<boolean>;
-  cardsNavigationConfig$: BehaviorSubject<NavigationCardsSubject<boolean>>;
+  cardsNavigationConfig$: BehaviorSubject<NavigationCardsSubject>;
 }
 
 export const ManagementApp = ({

--- a/src/plugins/management/public/plugin.tsx
+++ b/src/plugins/management/public/plugin.tsx
@@ -93,6 +93,7 @@ export class ManagementPlugin
   private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject>({
     enabled: false,
     hideLinksTo: [],
+    extendAppDefinitons: {},
   });
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
@@ -205,8 +206,8 @@ export class ManagementPlugin
     return {
       setIsSidebarEnabled: (isSidebarEnabled: boolean) =>
         this.isSidebarEnabled$.next(isSidebarEnabled),
-      setupCardsNavigation: ({ enabled, hideLinksTo }) =>
-        this.cardsNavigationConfig$.next({ enabled, hideLinksTo }),
+      setupCardsNavigation: ({ enabled, hideLinksTo, extendAppDefinitons }) =>
+        this.cardsNavigationConfig$.next({ enabled, hideLinksTo, extendAppDefinitons }),
     };
   }
 }

--- a/src/plugins/management/public/plugin.tsx
+++ b/src/plugins/management/public/plugin.tsx
@@ -90,10 +90,10 @@ export class ManagementPlugin
   private hasAnyEnabledApps = true;
 
   private isSidebarEnabled$ = new BehaviorSubject<boolean>(true);
-  private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject>({
+  private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject<boolean>>({
     enabled: false,
     hideLinksTo: [],
-    extendAppDefinitons: {},
+    extendCardNavDefinitons: {},
   });
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
@@ -206,8 +206,8 @@ export class ManagementPlugin
     return {
       setIsSidebarEnabled: (isSidebarEnabled: boolean) =>
         this.isSidebarEnabled$.next(isSidebarEnabled),
-      setupCardsNavigation: ({ enabled, hideLinksTo, extendAppDefinitons }) =>
-        this.cardsNavigationConfig$.next({ enabled, hideLinksTo, extendAppDefinitons }),
+      setupCardsNavigation: ({ enabled, hideLinksTo, extendCardNavDefinitons }) =>
+        this.cardsNavigationConfig$.next({ enabled, hideLinksTo, extendCardNavDefinitons }),
     };
   }
 }

--- a/src/plugins/management/public/plugin.tsx
+++ b/src/plugins/management/public/plugin.tsx
@@ -90,7 +90,7 @@ export class ManagementPlugin
   private hasAnyEnabledApps = true;
 
   private isSidebarEnabled$ = new BehaviorSubject<boolean>(true);
-  private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject<boolean>>({
+  private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject>({
     enabled: false,
     hideLinksTo: [],
     extendCardNavDefinitons: {},

--- a/src/plugins/management/public/plugin.tsx
+++ b/src/plugins/management/public/plugin.tsx
@@ -93,7 +93,7 @@ export class ManagementPlugin
   private cardsNavigationConfig$ = new BehaviorSubject<NavigationCardsSubject>({
     enabled: false,
     hideLinksTo: [],
-    extendCardNavDefinitons: {},
+    extendCardNavDefinitions: {},
   });
 
   constructor(private initializerContext: PluginInitializerContext<ConfigSchema>) {}
@@ -206,8 +206,8 @@ export class ManagementPlugin
     return {
       setIsSidebarEnabled: (isSidebarEnabled: boolean) =>
         this.isSidebarEnabled$.next(isSidebarEnabled),
-      setupCardsNavigation: ({ enabled, hideLinksTo, extendCardNavDefinitons }) =>
-        this.cardsNavigationConfig$.next({ enabled, hideLinksTo, extendCardNavDefinitons }),
+      setupCardsNavigation: ({ enabled, hideLinksTo, extendCardNavDefinitions }) =>
+        this.cardsNavigationConfig$.next({ enabled, hideLinksTo, extendCardNavDefinitions }),
     };
   }
 }

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -11,7 +11,7 @@ import { ScopedHistory, Capabilities } from '@kbn/core/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ChromeBreadcrumb, CoreTheme } from '@kbn/core/public';
 import type {
-  AppDefinitionExtention,
+  CardNavExtensionDefinition,
   CardsNavigationComponentProps,
 } from '@kbn/management-cards-navigation';
 import { AppNavLinkStatus } from '@kbn/core/public';
@@ -92,7 +92,7 @@ export interface CreateManagementItemArgs {
 export interface NavigationCardsSubject<N extends boolean>
   extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
   enabled: boolean;
-  extendCardNavDefinitons?: Record<string, AppDefinitionExtention<N>>;
+  extendCardNavDefinitons?: Record<string, CardNavExtensionDefinition<N>>;
 }
 
 export interface AppDependencies {

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -10,10 +10,7 @@ import { Observable } from 'rxjs';
 import { ScopedHistory, Capabilities } from '@kbn/core/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ChromeBreadcrumb, CoreTheme } from '@kbn/core/public';
-import type {
-  CardNavExtensionDefinition,
-  CardsNavigationComponentProps,
-} from '@kbn/management-cards-navigation';
+import type { CardsNavigationComponentProps } from '@kbn/management-cards-navigation';
 import { AppNavLinkStatus } from '@kbn/core/public';
 import { ManagementSection, RegisterManagementSectionArgs } from './utils';
 import type { ManagementAppLocatorParams } from '../common/locator';
@@ -34,11 +31,11 @@ export interface DefinedSections {
 
 export interface ManagementStart {
   setIsSidebarEnabled: (enabled: boolean) => void;
-  setupCardsNavigation: <N extends boolean>({
+  setupCardsNavigation: ({
     enabled,
     hideLinksTo,
     extendCardNavDefinitons,
-  }: NavigationCardsSubject<N>) => void;
+  }: NavigationCardsSubject) => void;
 }
 
 export interface ManagementSectionsStartPrivate {
@@ -89,17 +86,16 @@ export interface CreateManagementItemArgs {
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
 
-export interface NavigationCardsSubject<N extends boolean>
-  extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
+export interface NavigationCardsSubject extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
   enabled: boolean;
-  extendCardNavDefinitons?: Record<string, CardNavExtensionDefinition<N>>;
+  extendCardNavDefinitons?: CardsNavigationComponentProps['extendedCardNavigationDefinitions'];
 }
 
 export interface AppDependencies {
   appBasePath: string;
   kibanaVersion: string;
   sections: ManagementSection[];
-  cardsNavigationConfig?: NavigationCardsSubject<boolean>;
+  cardsNavigationConfig?: NavigationCardsSubject;
 }
 
 export interface ConfigSchema {

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -34,7 +34,7 @@ export interface ManagementStart {
   setupCardsNavigation: ({
     enabled,
     hideLinksTo,
-    extendCardNavDefinitons,
+    extendCardNavDefinitions,
   }: NavigationCardsSubject) => void;
 }
 
@@ -88,7 +88,7 @@ export interface CreateManagementItemArgs {
 
 export interface NavigationCardsSubject extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
   enabled: boolean;
-  extendCardNavDefinitons?: CardsNavigationComponentProps['extendedCardNavigationDefinitions'];
+  extendCardNavDefinitions?: CardsNavigationComponentProps['extendedCardNavigationDefinitions'];
 }
 
 export interface AppDependencies {

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -10,7 +10,10 @@ import { Observable } from 'rxjs';
 import { ScopedHistory, Capabilities } from '@kbn/core/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ChromeBreadcrumb, CoreTheme } from '@kbn/core/public';
-import type { CardsNavigationComponentProps } from '@kbn/management-cards-navigation';
+import type {
+  AppDefinition,
+  CardsNavigationComponentProps,
+} from '@kbn/management-cards-navigation';
 import { AppNavLinkStatus } from '@kbn/core/public';
 import { ManagementSection, RegisterManagementSectionArgs } from './utils';
 import type { ManagementAppLocatorParams } from '../common/locator';
@@ -82,9 +85,9 @@ export interface CreateManagementItemArgs {
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
 
-export interface NavigationCardsSubject
-  extends Pick<CardsNavigationComponentProps, 'hideLinksTo' | 'extendAppDefinitons'> {
+export interface NavigationCardsSubject extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
   enabled: boolean;
+  extendAppDefinitons?: Record<string, AppDefinition>;
 }
 
 export interface AppDependencies {

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -11,7 +11,7 @@ import { ScopedHistory, Capabilities } from '@kbn/core/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ChromeBreadcrumb, CoreTheme } from '@kbn/core/public';
 import type {
-  AppDefinition,
+  AppDefinitionExtention,
   CardsNavigationComponentProps,
 } from '@kbn/management-cards-navigation';
 import { AppNavLinkStatus } from '@kbn/core/public';
@@ -34,7 +34,11 @@ export interface DefinedSections {
 
 export interface ManagementStart {
   setIsSidebarEnabled: (enabled: boolean) => void;
-  setupCardsNavigation: ({ enabled, hideLinksTo }: NavigationCardsSubject) => void;
+  setupCardsNavigation: <N extends boolean>({
+    enabled,
+    hideLinksTo,
+    extendCardNavDefinitons,
+  }: NavigationCardsSubject<N>) => void;
 }
 
 export interface ManagementSectionsStartPrivate {
@@ -85,16 +89,17 @@ export interface CreateManagementItemArgs {
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
 
-export interface NavigationCardsSubject extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
+export interface NavigationCardsSubject<N extends boolean>
+  extends Pick<CardsNavigationComponentProps, 'hideLinksTo'> {
   enabled: boolean;
-  extendAppDefinitons?: Record<string, AppDefinition>;
+  extendCardNavDefinitons?: Record<string, AppDefinitionExtention<N>>;
 }
 
 export interface AppDependencies {
   appBasePath: string;
   kibanaVersion: string;
   sections: ManagementSection[];
-  cardsNavigationConfig?: NavigationCardsSubject;
+  cardsNavigationConfig?: NavigationCardsSubject<boolean>;
 }
 
 export interface ConfigSchema {

--- a/src/plugins/management/public/types.ts
+++ b/src/plugins/management/public/types.ts
@@ -10,7 +10,7 @@ import { Observable } from 'rxjs';
 import { ScopedHistory, Capabilities } from '@kbn/core/public';
 import type { LocatorPublic } from '@kbn/share-plugin/common';
 import { ChromeBreadcrumb, CoreTheme } from '@kbn/core/public';
-import type { AppId } from '@kbn/management-cards-navigation';
+import type { CardsNavigationComponentProps } from '@kbn/management-cards-navigation';
 import { AppNavLinkStatus } from '@kbn/core/public';
 import { ManagementSection, RegisterManagementSectionArgs } from './utils';
 import type { ManagementAppLocatorParams } from '../common/locator';
@@ -82,9 +82,9 @@ export interface CreateManagementItemArgs {
   redirectFrom?: string; // redirects from an old app id to the current app id
 }
 
-export interface NavigationCardsSubject {
+export interface NavigationCardsSubject
+  extends Pick<CardsNavigationComponentProps, 'hideLinksTo' | 'extendAppDefinitons'> {
   enabled: boolean;
-  hideLinksTo?: AppId[];
 }
 
 export interface AppDependencies {


### PR DESCRIPTION
## Summary

This PR modifies the implementation for displaying management settings as card navs, to provide support to any consumer of the `kbn-manangement` package in including custom card navs that remain localized to the experience of said consumer.

Doing this resolves the issue with diverging needs of items to display in management settings across serverless solutions, with this implementation there's no need to add all possible nav card definitions and then further hide them in other solutions. This solution also preserves the business logic that requires that the definition being included is enabled for the particular solutions, with a caveat that allows the card nav to also support customization that doesn't link to a management app whenever a definition including the property `skipValidation` is specified, a use case for this is https://github.com/elastic/kibana/issues/167453. 

That being said the proposed API for extending the card navs displayed in management settings, are along the following lines;

```js
    management.setupCardsNavigation({
      enabled: true,
      extendCardNavDefinitons: {
        // This definition will be included to the management nav cards to be rendered under it's specified category because it specifies
       //  the property 'skipValidation' as true, it's href will be used as is
        visualize: {
          category: 'content',
          description: i18n.translate(
            'xpack.serverlessSearch.app.management.extendAppDefinitions.visualise.title',
            {
              defaultMessage:
                'Configure and maintain your Elasticsearch indices for data storage and retrieval.',
            }
          ),
          skipValidation: true,
          href: '/visualize',
          title: 'Visualize',
          icon: 'visualizeApp',
        },
      },
    });
```

The config referenced above would yield the following changes in the UI;

### Visuals
![Image 18 10 23 at 16 51](https://github.com/elastic/kibana/assets/7893459/5ab1c881-c2e5-4977-b7ed-b2b1f1da35f5)

In summary; 
- for the defined card nav extensions to show up the extension property key has to map to the link of an app that is registered as a management section and is enabled if the `skipValidation` property is omitted.
- This implementation also makes modifications to how icons for the card nav are declared, simply passing in a valid EUI icon type string value would suffice for most cases as EuiIcon component also [accepts custom SVGs](https://eui.elastic.co/#/display/icons#custom-svgs)
- Valid categories are only the ones defined within the management package, type support is also provided for enhanced DX
- When a definition that specifies `skipValidation` has either the value `false` or `undefined`, in that case the property `title` and `href` are not expected to be passed and will fail typescript type checks if they are passed.


### Checklist

Delete any items that are not applicable to this PR.

~- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~
- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
~- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
~- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~


<!-- ### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
