### PR TITLE
[LaunchDarkly] Add renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -119,6 +119,27 @@
       "enabled": true
     },
     {
+      "groupName": "LaunchDarkly",
+      "matchPackageNames": [
+        "launchdarkly-js-client-sdk",
+        "launchdarkly-node-server-sdk"
+      ],
+      "reviewers": [
+        "team:kibana-security",
+        "team:kibana-core"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "labels": [
+        "release_note:skip",
+        "Team:Security",
+        "Team:Core",
+        "backport:prev-minor"
+      ],
+      "enabled": true
+    },
+    {
       "groupName": "APM",
       "matchPackageNames": [
         "elastic-apm-node",


### PR DESCRIPTION
## Summary

Let's use renovate to ping us whenever LaunchDarkly releases a new version of their clients. 

[LaunchDarkly's EOL's policy](https://launchdarkly.com/policies/end-of-life-policy/) forces us to always be on the late-ish version (putting together our support matrix + theirs, we've got between 6-12 months reaction time to upgrade).

Pinging the Security team as well in these PRs because an Infosec validation is required.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
