### PR TITLE
Risk score for 1 space change message

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/translations.ts
@@ -249,14 +249,15 @@ export const UPDATE_PANEL_GO_TO_DISMISS = i18n.translate(
 export const getMaxSpaceTitle = (maxSpaces: number) =>
   i18n.translate('xpack.securitySolution.riskScore.maxSpacePanel.title', {
     defaultMessage:
-      'Entity Risk Scoring in the current version can run in {maxSpaces, plural, =1 {# Kibana space} other {# Kibana spaces}}',
+      'You cannot enable entity risk scoring in more than {maxSpaces, plural, =1 {# Kibana space} other {# Kibana spaces}}.',
     values: { maxSpaces },
   });
 
 export const MAX_SPACE_PANEL_MESSAGE = i18n.translate(
   'xpack.securitySolution.riskScore.maxSpacePanel.message',
   {
-    defaultMessage: 'Please disable a currently running engine before enabling it here.',
+    defaultMessage:
+      'You can disable entity risk scoring in the space it is currently enabled before enabling it in this space',
   }
 );
 


### PR DESCRIPTION
Change the message according to this [comment](https://github.com/elastic/security-team/issues/7319#issuecomment-1735960127).


<img width="530" alt="Screenshot 2023-10-23 at 14 27 55" src="https://github.com/elastic/kibana/assets/7609147/7dc88b16-40f3-42e6-81ab-438626acf1b9">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->