### PR TITLE
[Enterprise Search] Update search page title

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_title.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/generate_title.ts
@@ -6,13 +6,14 @@
  */
 
 import {
+  AI_SEARCH_PLUGIN,
   ANALYTICS_PLUGIN,
   APP_SEARCH_PLUGIN,
-  WORKPLACE_SEARCH_PLUGIN,
+  ENTERPRISE_SEARCH_CONTENT_PLUGIN,
   SEARCH_EXPERIENCES_PLUGIN,
   SEARCH_PRODUCT_NAME,
-  AI_SEARCH_PLUGIN,
   VECTOR_SEARCH_PLUGIN,
+  WORKPLACE_SEARCH_PLUGIN,
 } from '../../../../common/constants';
 
 /**
@@ -53,3 +54,6 @@ export const aiSearchTitle = (page: Title = []) => generateTitle([...page, AI_SE
 
 export const vectorSearchTitle = (page: Title = []) =>
   generateTitle([...page, VECTOR_SEARCH_PLUGIN.NAME]);
+
+export const enterpriseSearchContentTitle = (page: Title = []) =>
+  generateTitle([...page, ENTERPRISE_SEARCH_CONTENT_PLUGIN.NAME]);

--- a/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/kibana_chrome/set_chrome.tsx
@@ -28,14 +28,15 @@ import {
   useVectorSearchBreadcrumbs,
 } from './generate_breadcrumbs';
 import {
-  searchTitle,
-  analyticsTitle,
-  elasticsearchTitle,
-  appSearchTitle,
-  workplaceSearchTitle,
-  searchExperiencesTitle,
   aiSearchTitle,
+  analyticsTitle,
+  appSearchTitle,
+  elasticsearchTitle,
+  enterpriseSearchContentTitle,
+  searchExperiencesTitle,
+  searchTitle,
   vectorSearchTitle,
+  workplaceSearchTitle,
 } from './generate_title';
 
 /**
@@ -163,7 +164,7 @@ export const SetEnterpriseSearchContentChrome: React.FC<SetChromeProps> = ({ tra
   const { setBreadcrumbs, setDocTitle } = useValues(KibanaLogic);
 
   const title = reverseArray(trail);
-  const docTitle = appSearchTitle(title);
+  const docTitle = enterpriseSearchContentTitle(title);
 
   const crumbs = useGenerateBreadcrumbs(trail);
   const breadcrumbs = useEnterpriseSearchContentBreadcrumbs(crumbs);


### PR DESCRIPTION
## Summary

Update Page title for Search plugin.

<img width="280" alt="Screenshot 2023-10-23 at 14 51 18" src="https://github.com/elastic/kibana/assets/1410658/70053a93-62a9-4340-aa4e-e28a1bb559dd">



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->