### PR TITLE
[Security Solution][Detections] UI and tests fixes of alert user assignments

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.test.tsx
@@ -23,7 +23,7 @@ const mockUserProfiles = [
   { uid: 'user-id-2', enabled: true, user: { username: 'user2' }, data: {} },
 ];
 
-const mockSuggestedUserProfiles: UserProfileWithAvatar[] = [
+const mockSuggestedUserProfiles = [
   ...mockUserProfiles,
   { uid: 'user-id-3', enabled: true, user: { username: 'user3' }, data: {} },
   { uid: 'user-id-4', enabled: true, user: { username: 'user4' }, data: {} },

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.tsx
@@ -72,7 +72,7 @@ export const useAlertAssigneesActions = ({
           alertItems: alertAssigneeData,
           refresh,
         });
-        return { title: panel.title, content, id: panel.id };
+        return { title: panel.title, content, id: panel.id, width: 414 };
       }),
     [alertAssigneeData, alertAssigneesPanels, closePopover, refresh]
   );

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.tsx
@@ -117,7 +117,7 @@ export const AssigneesPopover: FC<AssigneesPopoverProps> = memo(
         isOpen={isPopoverOpen}
         closePopover={onClosePopover}
         panelStyle={{
-          minWidth: 520,
+          minWidth: 414,
         }}
         selectableProps={{
           onSearchChange: (term: string) => {


### PR DESCRIPTION
## Summary

A few fixes:
1. Broken test fix as a followup to https://github.com/elastic/kibana/pull/169235
2. Make user profiles popover of a fixed size of 414px

