### PR TITLE
[Cases] Toggle columns in the cases table

### DIFF
--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -184,7 +184,6 @@ export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
   { field: 'externalIncident', name: '', isChecked: true },
   { field: 'status', name: '', isChecked: true },
   { field: 'severity', name: '', isChecked: true },
-  { field: 'actions', name: '', isChecked: true },
 ];
 
 export const SELECTOR_VIEW_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -168,7 +168,8 @@ export const CASES_CONNECTORS_CAPABILITY = 'cases_connectors' as const;
  * Cases UI Constants
  */
 
-// The name comes from the cases columns configuration
+// We just need the default ids(field) and isChecked.
+// The name comes from the cases columns configuration.
 export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
   { field: 'title', name: '', isChecked: true },
   { field: 'assignees', name: '', isChecked: true },
@@ -186,7 +187,6 @@ export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
   { field: 'actions', name: '', isChecked: true },
 ];
 
-// The name comes from the cases columns configuration
 export const SELECTOR_VIEW_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
   { field: 'title', name: '', isChecked: true },
   { field: 'category', name: '', isChecked: true },

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -167,29 +167,32 @@ export const CASES_CONNECTORS_CAPABILITY = 'cases_connectors' as const;
 /**
  * Cases UI Constants
  */
+
+// The name comes from the cases columns configuration
 export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
-  { field: 'title', isChecked: true },
-  { field: 'assignees', isChecked: true },
-  { field: 'tags', isChecked: true },
-  { field: 'totalAlerts', isChecked: true },
-  { field: 'totalComment', isChecked: true },
-  { field: 'category', isChecked: true },
-  { field: 'owner', isChecked: false },
-  { field: 'createdAt', isChecked: true },
-  { field: 'updatedAt', isChecked: true },
-  { field: 'closedAt', isChecked: false },
-  { field: 'externalIncident', isChecked: true },
-  { field: 'status', isChecked: true },
-  { field: 'severity', isChecked: true },
-  { field: 'actions', isChecked: true },
+  { field: 'title', name: '', isChecked: true },
+  { field: 'assignees', name: '', isChecked: true },
+  { field: 'tags', name: '', isChecked: true },
+  { field: 'totalAlerts', name: '', isChecked: true },
+  { field: 'totalComment', name: '', isChecked: true },
+  { field: 'category', name: '', isChecked: true },
+  { field: 'owner', name: '', isChecked: false },
+  { field: 'createdAt', name: '', isChecked: true },
+  { field: 'updatedAt', name: '', isChecked: true },
+  { field: 'closedAt', name: '', isChecked: false },
+  { field: 'externalIncident', name: '', isChecked: true },
+  { field: 'status', name: '', isChecked: true },
+  { field: 'severity', name: '', isChecked: true },
+  { field: 'actions', name: '', isChecked: true },
 ];
 
+// The name comes from the cases columns configuration
 export const SELECTOR_VIEW_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
-  { field: 'title', isChecked: true },
-  { field: 'category', isChecked: true },
-  { field: 'createdAt', isChecked: true },
-  { field: 'severity', isChecked: true },
-  { field: 'assignCaseAction', isChecked: true },
+  { field: 'title', name: '', isChecked: true },
+  { field: 'category', name: '', isChecked: true },
+  { field: 'createdAt', name: '', isChecked: true },
+  { field: 'severity', name: '', isChecked: true },
+  { field: 'assignCaseAction', name: '', isChecked: true },
 ];
 
 /**
@@ -230,6 +233,7 @@ export const SEARCH_DEBOUNCE_MS = 500;
 export const LOCAL_STORAGE_KEYS = {
   casesQueryParams: 'cases.list.queryParams',
   casesFilterOptions: 'cases.list.filterOptions',
+  casesTableColumns: 'cases.list.tableColumns',
 };
 
 /**

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { CasesFeaturesAllRequired } from '../ui/types';
+import type { CasesColumnSelection, CasesFeaturesAllRequired } from '../ui/types';
 
 export * from './owners';
 export * from './files';
@@ -163,6 +163,34 @@ export const UPDATE_CASES_CAPABILITY = 'update_cases' as const;
 export const DELETE_CASES_CAPABILITY = 'delete_cases' as const;
 export const PUSH_CASES_CAPABILITY = 'push_cases' as const;
 export const CASES_CONNECTORS_CAPABILITY = 'cases_connectors' as const;
+
+/**
+ * Cases UI Constants
+ */
+export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
+  { field: 'title', isChecked: true },
+  { field: 'assignees', isChecked: true },
+  { field: 'tags', isChecked: true },
+  { field: 'totalAlerts', isChecked: true },
+  { field: 'totalComment', isChecked: true },
+  { field: 'category', isChecked: true },
+  { field: 'owner', isChecked: false },
+  { field: 'createdAt', isChecked: true },
+  { field: 'updatedAt', isChecked: true },
+  { field: 'closedAt', isChecked: false },
+  { field: 'externalIncident', isChecked: true },
+  { field: 'status', isChecked: true },
+  { field: 'severity', isChecked: true },
+  { field: 'actions', isChecked: true },
+];
+
+export const SELECTOR_VIEW_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
+  { field: 'title', isChecked: true },
+  { field: 'category', isChecked: true },
+  { field: 'createdAt', isChecked: true },
+  { field: 'severity', isChecked: true },
+  { field: 'assignCaseAction', isChecked: true },
+];
 
 /**
  * Cases API Tags

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -169,30 +169,26 @@ export const CASES_CONNECTORS_CAPABILITY = 'cases_connectors' as const;
  * Cases UI Constants
  */
 
-// We just need the default ids(field) and isChecked.
-// The name comes from the cases columns configuration.
 export const DEFAULT_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
-  { field: 'title', name: '', isChecked: true },
-  { field: 'assignees', name: '', isChecked: true },
-  { field: 'tags', name: '', isChecked: true },
-  { field: 'totalAlerts', name: '', isChecked: true },
-  { field: 'totalComment', name: '', isChecked: true },
-  { field: 'category', name: '', isChecked: true },
-  { field: 'owner', name: '', isChecked: false },
-  { field: 'createdAt', name: '', isChecked: true },
-  { field: 'updatedAt', name: '', isChecked: true },
-  { field: 'closedAt', name: '', isChecked: false },
-  { field: 'externalIncident', name: '', isChecked: true },
-  { field: 'status', name: '', isChecked: true },
-  { field: 'severity', name: '', isChecked: true },
+  { field: 'title', name: 'title', isChecked: true },
+  { field: 'assignees', name: 'assignees', isChecked: true },
+  { field: 'tags', name: 'tags', isChecked: true },
+  { field: 'totalAlerts', name: 'totalAlerts', isChecked: true },
+  { field: 'totalComment', name: 'totalComment', isChecked: true },
+  { field: 'category', name: 'category', isChecked: true },
+  { field: 'createdAt', name: 'createdAt', isChecked: true },
+  { field: 'updatedAt', name: 'updatedAt', isChecked: true },
+  { field: 'closedAt', name: 'closedAt', isChecked: false },
+  { field: 'externalIncident', name: 'externalIncident', isChecked: true },
+  { field: 'status', name: 'status', isChecked: true },
+  { field: 'severity', name: 'severity', isChecked: true },
 ];
 
 export const SELECTOR_VIEW_CASES_TABLE_COLUMNS: CasesColumnSelection[] = [
-  { field: 'title', name: '', isChecked: true },
-  { field: 'category', name: '', isChecked: true },
-  { field: 'createdAt', name: '', isChecked: true },
-  { field: 'severity', name: '', isChecked: true },
-  { field: 'assignCaseAction', name: '', isChecked: true },
+  { field: 'title', name: 'title', isChecked: true },
+  { field: 'category', name: 'category', isChecked: true },
+  { field: 'createdAt', name: 'createdAt', isChecked: true },
+  { field: 'severity', name: 'severity', isChecked: true },
 ];
 
 /**

--- a/x-pack/plugins/cases/common/constants/index.ts
+++ b/x-pack/plugins/cases/common/constants/index.ts
@@ -5,7 +5,8 @@
  * 2.0.
  */
 
-import type { CasesColumnSelection, CasesFeaturesAllRequired } from '../ui/types';
+import type { CasesColumnSelection } from '../../public/components/all_cases/types';
+import type { CasesFeaturesAllRequired } from '../ui/types';
 
 export * from './owners';
 export * from './files';

--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -312,5 +312,6 @@ export interface CasesCapabilities {
 
 export interface CasesColumnSelection {
   field: string;
+  name: string;
   isChecked: boolean;
 }

--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -309,3 +309,8 @@ export interface CasesCapabilities {
   [PUSH_CASES_CAPABILITY]: boolean;
   [CASES_CONNECTORS_CAPABILITY]: boolean;
 }
+
+export interface CasesColumnSelection {
+  field: string;
+  isChecked: boolean;
+}

--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -309,9 +309,3 @@ export interface CasesCapabilities {
   [PUSH_CASES_CAPABILITY]: boolean;
   [CASES_CONNECTORS_CAPABILITY]: boolean;
 }
-
-export interface CasesColumnSelection {
-  field: string;
-  name: string;
-  isChecked: boolean;
-}

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -102,6 +102,7 @@ describe('AllCasesListGeneric', () => {
     isSelectorView: false,
     userProfiles: new Map(),
     currentUserProfile: undefined,
+    selectedColumns: [],
   };
 
   const removeMsFromDate = (value: string) => moment(value).format('YYYY-MM-DDTHH:mm:ss[Z]');

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -1120,4 +1120,18 @@ describe('AllCasesListGeneric', () => {
       });
     });
   });
+
+  describe('Columns Popover', () => {
+    it('renders the columns popover correctly', async () => {
+      appMockRenderer.render(<AllCasesList isSelectorView={false} />);
+
+      expect(await screen.findByTestId('column-selection-popover')).toBeInTheDocument();
+    });
+
+    it('does not render the columns popover when isSelectorView=true', () => {
+      appMockRenderer.render(<AllCasesList isSelectorView={true} />);
+
+      expect(screen.queryByTestId('column-selection-popover')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -48,7 +48,10 @@ import { userProfiles, userProfilesMap } from '../../containers/user_profiles/ap
 import { useBulkGetUserProfiles } from '../../containers/user_profiles/use_bulk_get_user_profiles';
 import { useLicense } from '../../common/use_license';
 import * as api from '../../containers/api';
+import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
+import { useCaseConfigureResponse } from '../configure_cases/__mock__';
 
+jest.mock('../../containers/configure/use_get_case_configuration');
 jest.mock('../../containers/use_get_cases');
 jest.mock('../../containers/use_get_action_license');
 jest.mock('../../containers/use_get_tags');
@@ -64,6 +67,7 @@ jest.mock('../app/use_available_owners', () => ({
 jest.mock('../../containers/use_update_case');
 jest.mock('../../common/use_license');
 
+const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
 const useGetCasesMock = useGetCases as jest.Mock;
 const useGetTagsMock = useGetTags as jest.Mock;
 const useGetCurrentUserProfileMock = useGetCurrentUserProfile as jest.Mock;
@@ -99,6 +103,7 @@ describe('AllCasesListGeneric', () => {
     filterStatus: CaseStatuses.open,
     handleIsLoading: jest.fn(),
     isLoadingCases: [],
+    isFetchingColumns: false,
     isSelectorView: false,
     userProfiles: new Map(),
     currentUserProfile: undefined,
@@ -157,8 +162,9 @@ describe('AllCasesListGeneric', () => {
     useGetTagsMock.mockReturnValue({ data: ['coke', 'pepsi'], isLoading: false });
     useGetCategoriesMock.mockReturnValue({ data: ['twix', 'snickers'], isLoading: false });
     useGetCurrentUserProfileMock.mockReturnValue({ data: userProfiles[0], isLoading: false });
-    useBulkGetUserProfilesMock.mockReturnValue({ data: userProfilesMap });
     useGetConnectorsMock.mockImplementation(() => ({ data: connectorsMock, isLoading: false }));
+    useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+    useBulkGetUserProfilesMock.mockReturnValue({ data: userProfilesMap });
     useUpdateCaseMock.mockReturnValue({ mutate: updateCaseProperty });
     useLicenseMock.mockReturnValue({ isAtLeastPlatinum: () => false });
     mockKibana();

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -1131,13 +1131,13 @@ describe('AllCasesListGeneric', () => {
     it('renders the columns popover correctly', async () => {
       appMockRenderer.render(<AllCasesList isSelectorView={false} />);
 
-      expect(await screen.findByTestId('column-selection-popover')).toBeInTheDocument();
+      expect(await screen.findByTestId('column-selection-popover-button')).toBeInTheDocument();
     });
 
     it('does not render the columns popover when isSelectorView=true', () => {
       appMockRenderer.render(<AllCasesList isSelectorView={true} />);
 
-      expect(screen.queryByTestId('column-selection-popover')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('column-selection-popover-button')).not.toBeInTheDocument();
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.test.tsx
@@ -103,7 +103,7 @@ describe('AllCasesListGeneric', () => {
     filterStatus: CaseStatuses.open,
     handleIsLoading: jest.fn(),
     isLoadingCases: [],
-    isFetchingColumns: false,
+    isLoadingColumns: false,
     isSelectorView: false,
     userProfiles: new Map(),
     currentUserProfile: undefined,

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -16,14 +16,13 @@ import type {
   CaseStatusWithAllStatus,
   FilterOptions,
   CasesUI,
-  CasesColumnSelection,
 } from '../../../common/ui/types';
 import type { CasesOwners } from '../../client/helpers/can_use_cases';
 import type { EuiBasicTableOnChange, Solution } from './types';
 
 import { SortFieldCase, StatusAll } from '../../../common/ui/types';
 import { CaseStatuses, caseStatuses } from '../../../common/types/domain';
-import { DEFAULT_CASES_TABLE_COLUMNS, OWNER_INFO } from '../../../common/constants';
+import { OWNER_INFO } from '../../../common/constants';
 import { useAvailableCasesOwners } from '../app/use_available_owners';
 import { useCasesColumns } from './use_cases_columns';
 import { CasesTableFilters } from './table_filters';
@@ -38,6 +37,7 @@ import { useGetCurrentUserProfile } from '../../containers/user_profiles/use_get
 import { getAllPermissionsExceptFrom, isReadOnlyPermissions } from '../../utils/permissions';
 import { useIsLoadingCases } from './use_is_loading_cases';
 import { useAllCasesState } from './use_all_cases_state';
+import { useCasesColumnsSelection } from './use_cases_columns_selection';
 
 const ProgressLoader = styled(EuiProgress)`
   ${({ $isShow }: { $isShow: boolean }) =>
@@ -210,9 +210,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       ]
     );
 
-    const [selectedColumns, setSelectedColumns] = useState<CasesColumnSelection[]>(
-      DEFAULT_CASES_TABLE_COLUMNS
-    );
+    const { selectedColumns, setSelectedColumns } = useCasesColumnsSelection();
 
     const { columns } = useCasesColumns({
       filterStatus: filterOptions.status ?? StatusAll,

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -212,7 +212,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
 
     const { selectedColumns, setSelectedColumns } = useCasesColumnsSelection();
 
-    const { columns } = useCasesColumns({
+    const { columns, isFetchingColumns } = useCasesColumns({
       filterStatus: filterOptions.status ?? StatusAll,
       userProfiles: userProfiles ?? new Map(),
       isSelectorView,
@@ -264,7 +264,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           size="xs"
           color="accent"
           className="essentialAnimation"
-          $isShow={isLoading || isLoadingCases}
+          $isShow={isLoading || isLoadingCases || isFetchingColumns}
         />
         {!isSelectorView ? <CasesMetrics /> : null}
         <CasesTableFilters
@@ -295,6 +295,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           data={data}
           goToCreateCase={onRowClick ? onCreateCasePressed : undefined}
           isCasesLoading={isLoadingCases}
+          isFetchingColumns={isFetchingColumns}
           isCommentUpdating={isLoadingCases}
           isDataEmpty={isDataEmpty}
           isSelectorView={isSelectorView}

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -16,13 +16,14 @@ import type {
   CaseStatusWithAllStatus,
   FilterOptions,
   CasesUI,
+  CasesColumnSelection,
 } from '../../../common/ui/types';
 import type { CasesOwners } from '../../client/helpers/can_use_cases';
 import type { EuiBasicTableOnChange, Solution } from './types';
 
 import { SortFieldCase, StatusAll } from '../../../common/ui/types';
 import { CaseStatuses, caseStatuses } from '../../../common/types/domain';
-import { OWNER_INFO } from '../../../common/constants';
+import { DEFAULT_CASES_TABLE_COLUMNS, OWNER_INFO } from '../../../common/constants';
 import { useAvailableCasesOwners } from '../app/use_available_owners';
 import { useCasesColumns } from './use_cases_columns';
 import { CasesTableFilters } from './table_filters';
@@ -209,6 +210,10 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       ]
     );
 
+    const [selectedColumns, setSelectedColumns] = useState<CasesColumnSelection[]>(
+      DEFAULT_CASES_TABLE_COLUMNS
+    );
+
     const { columns } = useCasesColumns({
       filterStatus: filterOptions.status ?? StatusAll,
       userProfiles: userProfiles ?? new Map(),
@@ -217,6 +222,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       onRowClick,
       showSolutionColumn: !hasOwner && availableSolutions.length > 1,
       disableActions: selectedCases.length > 0,
+      selectedColumns,
     });
 
     const pagination = useMemo(
@@ -302,6 +308,8 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           tableRef={tableRef}
           tableRowProps={tableRowProps}
           deselectCases={deselectCases}
+          selectedColumns={selectedColumns}
+          onSelectedColumnsChange={setSelectedColumns}
         />
       </>
     );

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -212,7 +212,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
 
     const { selectedColumns, setSelectedColumns } = useCasesColumnsSelection();
 
-    const { columns, isFetchingColumns } = useCasesColumns({
+    const { columns, isLoadingColumns } = useCasesColumns({
       filterStatus: filterOptions.status ?? StatusAll,
       userProfiles: userProfiles ?? new Map(),
       isSelectorView,
@@ -264,7 +264,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           size="xs"
           color="accent"
           className="essentialAnimation"
-          $isShow={isLoading || isLoadingCases || isFetchingColumns}
+          $isShow={isLoading || isLoadingCases || isLoadingColumns}
         />
         {!isSelectorView ? <CasesMetrics /> : null}
         <CasesTableFilters
@@ -295,7 +295,7 @@ export const AllCasesList = React.memo<AllCasesListProps>(
           data={data}
           goToCreateCase={onRowClick ? onCreateCasePressed : undefined}
           isCasesLoading={isLoadingCases}
-          isFetchingColumns={isFetchingColumns}
+          isLoadingColumns={isLoadingColumns}
           isCommentUpdating={isLoadingCases}
           isDataEmpty={isDataEmpty}
           isSelectorView={isSelectorView}

--- a/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/all_cases_list.tsx
@@ -218,7 +218,6 @@ export const AllCasesList = React.memo<AllCasesListProps>(
       isSelectorView,
       connectors,
       onRowClick,
-      showSolutionColumn: !hasOwner && availableSolutions.length > 1,
       disableActions: selectedCases.length > 0,
       selectedColumns,
     });

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TestProviders } from '../../common/mock';
+import { ColumnsPopover } from './columns_popover';
+
+describe('ColumnsPopover', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const selectedColumns = [
+    { field: 'title', name: 'Title', isChecked: true },
+    { field: 'category', name: 'Category', isChecked: false },
+  ];
+
+  it('renders correctly a list of selected columns', () => {
+    render(
+      <TestProviders>
+        <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
+      </TestProviders>
+    );
+
+    userEvent.click(screen.getByTestId('column-selection-popover'));
+
+    selectedColumns.forEach(({ field, name, isChecked }) => {
+      expect(screen.getByTestId(`column-selection-switch-${field}`)).toHaveAttribute(
+        'aria-checked',
+        isChecked.toString()
+      );
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
+  });
+
+  it('clicking a switch calls onSelectedColumnsChange with the right params', async () => {
+    const onSelectedColumnsChange = jest.fn();
+
+    render(
+      <TestProviders>
+        <ColumnsPopover
+          selectedColumns={selectedColumns}
+          onSelectedColumnsChange={onSelectedColumnsChange}
+        />
+      </TestProviders>
+    );
+
+    userEvent.click(screen.getByTestId('column-selection-popover'));
+    userEvent.click(
+      screen.getByTestId(`column-selection-switch-${selectedColumns[0].field}`),
+      undefined,
+      { skipPointerEventsCheck: true }
+    );
+
+    await waitFor(() => {
+      expect(onSelectedColumnsChange).toHaveBeenCalledWith([
+        { ...selectedColumns[0], isChecked: false },
+        selectedColumns[1],
+      ]);
+    });
+  });
+
+  it.skip('drag and rop calls onSelectedColumnsChange with the right params', async () => {});
+});

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
@@ -22,14 +22,18 @@ describe('ColumnsPopover', () => {
     { field: 'category', name: 'Category', isChecked: false },
   ];
 
-  it('renders correctly a list of selected columns', () => {
+  it('renders correctly a list of selected columns', async () => {
     render(
       <TestProviders>
         <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
       </TestProviders>
     );
 
-    userEvent.click(screen.getByTestId('column-selection-popover'));
+    userEvent.click(screen.getByTestId('column-selection-popover-button'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('column-selection-popover')).toBeInTheDocument();
+    });
 
     selectedColumns.forEach(({ field, name, isChecked }) => {
       expect(screen.getByTestId(`column-selection-switch-${field}`)).toHaveAttribute(
@@ -52,7 +56,7 @@ describe('ColumnsPopover', () => {
       </TestProviders>
     );
 
-    userEvent.click(screen.getByTestId('column-selection-popover'));
+    userEvent.click(screen.getByTestId('column-selection-popover-button'));
     userEvent.click(
       screen.getByTestId(`column-selection-switch-${selectedColumns[0].field}`),
       undefined,

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
@@ -66,6 +66,4 @@ describe('ColumnsPopover', () => {
       ]);
     });
   });
-
-  it.skip('drag and rop calls onSelectedColumnsChange with the right params', async () => {});
 });

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { difference } from 'lodash';
+import React, { useCallback, useState } from 'react';
+import type { DropResult } from '@elastic/eui';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiDragDropContext,
+  EuiButtonEmpty,
+  EuiDraggable,
+  EuiDroppable,
+  EuiPanel,
+  euiDragDropReorder,
+  EuiIcon,
+  EuiSwitch,
+} from '@elastic/eui';
+
+import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
+import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+import type { CasesColumnSelection } from '../../../common/ui/types';
+
+interface Props {
+  selectedColumns: CasesColumnSelection[];
+  onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
+}
+
+const mergeSelectedColumnsWithConfiguration = ({
+  selectedColumns,
+  casesColumnsConfig,
+}: {
+  selectedColumns: CasesColumnSelection[];
+  casesColumnsConfig: CasesColumnsConfiguration;
+}): Array<{ field: string; name: string; isChecked: boolean; canDisplay: boolean }> => {
+  // selectedColumns is the master
+  // iterate over selectedColumns
+  //   filter out those not in the configuration
+  //   add canDisplay
+  //   add columnName
+  // add missing fields from configuration
+
+  const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
+    if (field in casesColumnsConfig && casesColumnsConfig[field].name !== '') {
+      accumulator.push({
+        ...casesColumnsConfig[field],
+        isChecked,
+      });
+    }
+    return accumulator;
+  }, [] as Array<{ field: string; name: string; isChecked: boolean; canDisplay: boolean }>);
+
+  // in case the configuration was updated we need to append these to the end of the list
+  // can also apply to custom fields
+  const missingColumns = difference(
+    Object.keys(casesColumnsConfig),
+    selectedColumns.map(({ field }) => field)
+  );
+
+  return result;
+};
+
+export const ColumnsPopover: React.FC<Props> = ({
+  selectedColumns,
+  onSelectedColumnsChange,
+}: Props) => {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
+  const closePopover = useCallback(() => setIsPopoverOpen(false), []);
+
+  const casesColumnsConfig = useCasesColumnsConfiguration();
+  const columnsList = mergeSelectedColumnsWithConfiguration({
+    selectedColumns,
+    casesColumnsConfig,
+  });
+
+  const onDragEnd = ({ source, destination }: DropResult) => {
+    if (source && destination) {
+      const newSelectedColumns = euiDragDropReorder(
+        selectedColumns,
+        source.index,
+        destination.index
+      );
+
+      onSelectedColumnsChange(newSelectedColumns);
+    }
+  };
+
+  const toggleColumn = useCallback(
+    ({ field, isChecked }) => {
+      const newSelectedColumns = selectedColumns.map((column) => {
+        if (column.field === field) {
+          return { ...column, isChecked };
+        }
+        return column;
+      });
+
+      onSelectedColumnsChange(newSelectedColumns);
+    },
+    [selectedColumns, onSelectedColumnsChange]
+  );
+
+  return (
+    <EuiPopover
+      button={
+        <EuiButtonEmpty
+          aria-label="Columns"
+          className="columns"
+          data-test-subj="show-field-browser"
+          iconType="indexOpen"
+          iconSide="left"
+          onClick={togglePopover}
+          size="xs"
+        >
+          {'Columns'}
+        </EuiButtonEmpty>
+      }
+      isOpen={isPopoverOpen}
+      closePopover={closePopover}
+      panelPaddingSize="none"
+      hasDragDrop
+    >
+      <EuiDragDropContext onDragEnd={onDragEnd}>
+        <EuiFlexGroup style={{ width: 300 }}>
+          <EuiFlexItem>
+            <EuiDroppable droppableId="DROPPABLE_AREA_BARE" style={{ paddingBottom: 15 }}>
+              {columnsList.map(({ field, name: columnName, isChecked, canDisplay }, idx) =>
+                canDisplay ? (
+                  <EuiDraggable
+                    key={field}
+                    index={idx}
+                    draggableId={field}
+                    customDragHandle={true}
+                    hasInteractiveChildren={true}
+                    style={{ height: 35, paddingLeft: 16 }}
+                  >
+                    {(provided) => (
+                      <EuiFlexGroup
+                        alignItems="center"
+                        gutterSize="m"
+                        justifyContent="spaceBetween"
+                      >
+                        <EuiFlexItem>
+                          <EuiSwitch
+                            label={columnName}
+                            checked={isChecked}
+                            onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiPanel
+                            color="transparent"
+                            {...provided.dragHandleProps}
+                            aria-label="Drag Handle"
+                          >
+                            <EuiIcon type="grab" />
+                          </EuiPanel>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    )}
+                  </EuiDraggable>
+                ) : (
+                  <span key={field} />
+                )
+              )}
+            </EuiDroppable>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiDragDropContext>
+    </EuiPopover>
+  );
+};
+ColumnsPopover.displayName = 'ColumnsPopover';

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -69,7 +69,7 @@ export const ColumnsPopover: React.FC<Props> = ({
         <EuiButtonEmpty
           aria-label="Columns"
           className="columns"
-          data-test-subj="show-field-browser"
+          data-test-subj="column-selection-popover"
           iconType="indexOpen"
           iconSide="left"
           onClick={togglePopover}
@@ -102,6 +102,7 @@ export const ColumnsPopover: React.FC<Props> = ({
                         <EuiSwitch
                           label={name}
                           checked={isChecked}
+                          data-test-subj={`column-selection-switch-${field}`}
                           onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
                           compressed
                         />

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -103,6 +103,7 @@ export const ColumnsPopover: React.FC<Props> = ({
                           label={name}
                           checked={isChecked}
                           onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
+                          compressed
                         />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { difference } from 'lodash';
 import React, { useCallback, useState } from 'react';
 import type { DropResult } from '@elastic/eui';
 import {
@@ -22,48 +21,12 @@ import {
   EuiSwitch,
 } from '@elastic/eui';
 
-import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
-import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
 import type { CasesColumnSelection } from '../../../common/ui/types';
 
 interface Props {
   selectedColumns: CasesColumnSelection[];
   onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
 }
-
-const mergeSelectedColumnsWithConfiguration = ({
-  selectedColumns,
-  casesColumnsConfig,
-}: {
-  selectedColumns: CasesColumnSelection[];
-  casesColumnsConfig: CasesColumnsConfiguration;
-}): Array<{ field: string; name: string; isChecked: boolean; canDisplay: boolean }> => {
-  // selectedColumns is the master
-  // iterate over selectedColumns
-  //   filter out those not in the configuration
-  //   add canDisplay
-  //   add columnName
-  // add missing fields from configuration
-
-  const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
-    if (field in casesColumnsConfig && casesColumnsConfig[field].name !== '') {
-      accumulator.push({
-        ...casesColumnsConfig[field],
-        isChecked,
-      });
-    }
-    return accumulator;
-  }, [] as Array<{ field: string; name: string; isChecked: boolean; canDisplay: boolean }>);
-
-  // in case the configuration was updated we need to append these to the end of the list
-  // can also apply to custom fields
-  const missingColumns = difference(
-    Object.keys(casesColumnsConfig),
-    selectedColumns.map(({ field }) => field)
-  );
-
-  return result;
-};
 
 export const ColumnsPopover: React.FC<Props> = ({
   selectedColumns,
@@ -73,12 +36,6 @@ export const ColumnsPopover: React.FC<Props> = ({
 
   const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
-
-  const casesColumnsConfig = useCasesColumnsConfiguration();
-  const columnsList = mergeSelectedColumnsWithConfiguration({
-    selectedColumns,
-    casesColumnsConfig,
-  });
 
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (source && destination) {
@@ -130,45 +87,37 @@ export const ColumnsPopover: React.FC<Props> = ({
         <EuiFlexGroup style={{ width: 300 }}>
           <EuiFlexItem>
             <EuiDroppable droppableId="DROPPABLE_AREA_BARE" style={{ paddingBottom: 15 }}>
-              {columnsList.map(({ field, name: columnName, isChecked, canDisplay }, idx) =>
-                canDisplay ? (
-                  <EuiDraggable
-                    key={field}
-                    index={idx}
-                    draggableId={field}
-                    customDragHandle={true}
-                    hasInteractiveChildren={true}
-                    style={{ height: 35, paddingLeft: 16 }}
-                  >
-                    {(provided) => (
-                      <EuiFlexGroup
-                        alignItems="center"
-                        gutterSize="m"
-                        justifyContent="spaceBetween"
-                      >
-                        <EuiFlexItem>
-                          <EuiSwitch
-                            label={columnName}
-                            checked={isChecked}
-                            onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
-                          />
-                        </EuiFlexItem>
-                        <EuiFlexItem grow={false}>
-                          <EuiPanel
-                            color="transparent"
-                            {...provided.dragHandleProps}
-                            aria-label="Drag Handle"
-                          >
-                            <EuiIcon type="grab" />
-                          </EuiPanel>
-                        </EuiFlexItem>
-                      </EuiFlexGroup>
-                    )}
-                  </EuiDraggable>
-                ) : (
-                  <span key={field} />
-                )
-              )}
+              {selectedColumns.map(({ field, name, isChecked }, idx) => (
+                <EuiDraggable
+                  key={field}
+                  index={idx}
+                  draggableId={field}
+                  customDragHandle={true}
+                  hasInteractiveChildren={true}
+                  style={{ height: 35, paddingLeft: 16 }}
+                >
+                  {(provided) => (
+                    <EuiFlexGroup alignItems="center" gutterSize="m" justifyContent="spaceBetween">
+                      <EuiFlexItem>
+                        <EuiSwitch
+                          label={name}
+                          checked={isChecked}
+                          onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
+                        />
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiPanel
+                          color="transparent"
+                          {...provided.dragHandleProps}
+                          aria-label="Drag Handle"
+                        >
+                          <EuiIcon type="grab" />
+                        </EuiPanel>
+                      </EuiFlexItem>
+                    </EuiFlexGroup>
+                  )}
+                </EuiDraggable>
+              ))}
             </EuiDroppable>
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -6,7 +6,9 @@
  */
 
 import React, { useCallback, useState } from 'react';
+
 import type { DropResult } from '@elastic/eui';
+
 import {
   EuiFlexGroup,
   EuiFlexItem,
@@ -81,7 +83,9 @@ export const ColumnsPopover: React.FC<Props> = ({
       isOpen={isPopoverOpen}
       closePopover={closePopover}
       panelPaddingSize="none"
+      anchorPosition="leftUp"
       hasDragDrop
+      zIndex={0}
     >
       <EuiDragDropContext onDragEnd={onDragEnd}>
         <EuiFlexGroup style={{ width: 300 }}>
@@ -105,6 +109,15 @@ export const ColumnsPopover: React.FC<Props> = ({
                           data-test-subj={`column-selection-switch-${field}`}
                           onChange={(e) => toggleColumn({ field, isChecked: e.target.checked })}
                           compressed
+                          labelProps={{
+                            style: {
+                              textOverflow: 'ellipsis',
+                              whiteSpace: 'nowrap',
+                              width: '190px',
+                              overflow: 'hidden',
+                            },
+                            title: name,
+                          }}
                         />
                       </EuiFlexItem>
                       <EuiFlexItem grow={false}>

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -21,9 +21,10 @@ import {
   euiDragDropReorder,
   EuiIcon,
   EuiSwitch,
+  useEuiTheme,
 } from '@elastic/eui';
 
-import type { CasesColumnSelection } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
 
 import * as i18n from './translations';
 
@@ -36,20 +37,18 @@ export const ColumnsPopover: React.FC<Props> = ({
   selectedColumns,
   onSelectedColumnsChange,
 }: Props) => {
+  const { euiTheme } = useEuiTheme();
+
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const togglePopover = useCallback(() => setIsPopoverOpen(!isPopoverOpen), [isPopoverOpen]);
+  const togglePopover = useCallback(() => setIsPopoverOpen((prevValue) => !prevValue), []);
   const closePopover = useCallback(() => setIsPopoverOpen(false), []);
 
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (source && destination) {
-      const newSelectedColumns = euiDragDropReorder(
-        selectedColumns,
-        source.index,
-        destination.index
-      );
+      const reorderedColumns = euiDragDropReorder(selectedColumns, source.index, destination.index);
 
-      onSelectedColumnsChange(newSelectedColumns);
+      onSelectedColumnsChange(reorderedColumns);
     }
   };
 
@@ -90,9 +89,12 @@ export const ColumnsPopover: React.FC<Props> = ({
       zIndex={0}
     >
       <EuiDragDropContext onDragEnd={onDragEnd}>
-        <EuiFlexGroup style={{ width: 300 }}>
+        <EuiFlexGroup css={{ width: 300 }}>
           <EuiFlexItem>
-            <EuiDroppable droppableId="DROPPABLE_AREA_BARE" style={{ paddingBottom: 15 }}>
+            <EuiDroppable
+              droppableId="DROPPABLE_AREA_BARE"
+              css={{ paddingBottom: euiTheme.size.base }}
+            >
               {selectedColumns.map(({ field, name, isChecked }, idx) => (
                 <EuiDraggable
                   key={field}
@@ -100,7 +102,7 @@ export const ColumnsPopover: React.FC<Props> = ({
                   draggableId={field}
                   customDragHandle={true}
                   hasInteractiveChildren={true}
-                  style={{ height: 35, paddingLeft: 16 }}
+                  css={{ height: euiTheme.size.xl, paddingLeft: euiTheme.size.base }}
                 >
                   {(provided) => (
                     <EuiFlexGroup alignItems="center" gutterSize="m" justifyContent="spaceBetween">

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -72,7 +72,7 @@ export const ColumnsPopover: React.FC<Props> = ({
         <EuiButtonEmpty
           aria-label="Columns"
           className="columns"
-          data-test-subj="column-selection-popover"
+          data-test-subj="column-selection-popover-button"
           iconType="indexOpen"
           iconSide="left"
           onClick={togglePopover}
@@ -87,12 +87,13 @@ export const ColumnsPopover: React.FC<Props> = ({
       anchorPosition="leftUp"
       hasDragDrop
       zIndex={0}
+      data-test-subj="column-selection-popover"
     >
       <EuiDragDropContext onDragEnd={onDragEnd}>
         <EuiFlexGroup css={{ width: 300 }}>
           <EuiFlexItem>
             <EuiDroppable
-              droppableId="DROPPABLE_AREA_BARE"
+              droppableId="casesColumnDroppableArea"
               css={{ paddingBottom: euiTheme.size.base }}
             >
               {selectedColumns.map(({ field, name, isChecked }, idx) => (

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -25,6 +25,8 @@ import {
 
 import type { CasesColumnSelection } from '../../../common/ui/types';
 
+import * as i18n from './translations';
+
 interface Props {
   selectedColumns: CasesColumnSelection[];
   onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
@@ -77,7 +79,7 @@ export const ColumnsPopover: React.FC<Props> = ({
           onClick={togglePopover}
           size="xs"
         >
-          {'Columns'}
+          {i18n.COLUMNS}
         </EuiButtonEmpty>
       }
       isOpen={isPopoverOpen}

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -14,7 +14,12 @@ import styled from 'styled-components';
 
 import { CasesTableUtilityBar } from './utility_bar';
 import { LinkButton } from '../links';
-import type { CasesFindResponseUI, CasesUI, CaseUI } from '../../../common/ui/types';
+import type {
+  CasesColumnSelection,
+  CasesFindResponseUI,
+  CasesUI,
+  CaseUI,
+} from '../../../common/ui/types';
 import * as i18n from './translations';
 import { useCreateCaseNavigation } from '../../common/navigation';
 import { useCasesContext } from '../cases_context/use_cases_context';
@@ -35,6 +40,8 @@ interface CasesTableProps {
   tableRef: MutableRefObject<EuiBasicTable | null>;
   tableRowProps: EuiBasicTableProps<CaseUI>['rowProps'];
   deselectCases: () => void;
+  selectedColumns: CasesColumnSelection[];
+  onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
 }
 
 const Div = styled.div`
@@ -57,6 +64,8 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
   tableRef,
   tableRowProps,
   deselectCases,
+  selectedColumns,
+  onSelectedColumnsChange,
 }) => {
   const { permissions } = useCasesContext();
   const { getCreateCaseUrl, navigateToCreateCase } = useCreateCaseNavigation();
@@ -84,6 +93,8 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
         totalCases={data.total ?? 0}
         selectedCases={selectedCases}
         deselectCases={deselectCases}
+        selectedColumns={selectedColumns}
+        onSelectedColumnsChange={onSelectedColumnsChange}
       />
       <EuiBasicTable
         className={classnames({ isSelectorView })}

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -42,6 +42,7 @@ interface CasesTableProps {
   deselectCases: () => void;
   selectedColumns: CasesColumnSelection[];
   onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
+  isFetchingColumns: boolean;
 }
 
 const Div = styled.div`
@@ -66,6 +67,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
   deselectCases,
   selectedColumns,
   onSelectedColumnsChange,
+  isFetchingColumns,
 }) => {
   const { permissions } = useCasesContext();
   const { getCreateCaseUrl, navigateToCreateCase } = useCreateCaseNavigation();
@@ -81,7 +83,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
     [goToCreateCase, navigateToCreateCase]
   );
 
-  return isCasesLoading && isDataEmpty ? (
+  return (isCasesLoading && isDataEmpty) || isFetchingColumns ? (
     <Div>
       <EuiSkeletonText data-test-subj="initialLoadingPanelAllCases" lines={10} />
     </Div>

--- a/x-pack/plugins/cases/public/components/all_cases/table.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table.tsx
@@ -14,12 +14,10 @@ import styled from 'styled-components';
 
 import { CasesTableUtilityBar } from './utility_bar';
 import { LinkButton } from '../links';
-import type {
-  CasesColumnSelection,
-  CasesFindResponseUI,
-  CasesUI,
-  CaseUI,
-} from '../../../common/ui/types';
+
+import type { CasesFindResponseUI, CasesUI, CaseUI } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
+
 import * as i18n from './translations';
 import { useCreateCaseNavigation } from '../../common/navigation';
 import { useCasesContext } from '../cases_context/use_cases_context';
@@ -42,7 +40,7 @@ interface CasesTableProps {
   deselectCases: () => void;
   selectedColumns: CasesColumnSelection[];
   onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
-  isFetchingColumns: boolean;
+  isLoadingColumns: boolean;
 }
 
 const Div = styled.div`
@@ -67,7 +65,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
   deselectCases,
   selectedColumns,
   onSelectedColumnsChange,
-  isFetchingColumns,
+  isLoadingColumns,
 }) => {
   const { permissions } = useCasesContext();
   const { getCreateCaseUrl, navigateToCreateCase } = useCreateCaseNavigation();
@@ -83,7 +81,7 @@ export const CasesTable: FunctionComponent<CasesTableProps> = ({
     [goToCreateCase, navigateToCreateCase]
   );
 
-  return (isCasesLoading && isDataEmpty) || isFetchingColumns ? (
+  return (isCasesLoading && isDataEmpty) || isLoadingColumns ? (
     <Div>
       <EuiSkeletonText data-test-subj="initialLoadingPanelAllCases" lines={10} />
     </Div>

--- a/x-pack/plugins/cases/public/components/all_cases/translations.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/translations.ts
@@ -176,3 +176,7 @@ export const NO_ATTACHMENTS_ADDED = i18n.translate(
     defaultMessage: 'No attachments added to the case',
   }
 );
+
+export const COLUMNS = i18n.translate('xpack.cases.allCasesView.columnSelection', {
+  defaultMessage: 'Columns',
+});

--- a/x-pack/plugins/cases/public/components/all_cases/types.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/types.ts
@@ -26,3 +26,9 @@ export interface Solution {
   label: string;
   iconType: string;
 }
+
+export interface CasesColumnSelection {
+  field: string;
+  name: string;
+  isChecked: boolean;
+}

--- a/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
@@ -43,7 +43,6 @@ describe('useActions', () => {
           "align": "right",
           "name": "Actions",
           "render": [Function],
-          "shouldDisplay": true,
         },
       }
     `);
@@ -395,7 +394,6 @@ describe('useActions', () => {
           "align": "right",
           "name": "Actions",
           "render": [Function],
-          "shouldDisplay": false,
         }
       `);
     });

--- a/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
@@ -383,19 +383,13 @@ describe('useActions', () => {
       });
     });
 
-    it('sets shouldDisplay to false if the user does not have update or delete permissions', async () => {
+    it('returns null if the user does not have update or delete permissions', async () => {
       appMockRender = createAppMockRenderer({ permissions: readCasesPermissions() });
       const { result } = renderHook(() => useActions({ disableActions: false }), {
         wrapper: appMockRender.AppWrapper,
       });
 
-      expect(result.current.actions).toMatchInlineSnapshot(`
-        Object {
-          "align": "right",
-          "name": "Actions",
-          "render": [Function],
-        }
-      `);
+      expect(result.current.actions).toBe(null);
     });
 
     it('disables the action correctly', async () => {

--- a/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_actions.test.tsx
@@ -43,6 +43,7 @@ describe('useActions', () => {
           "align": "right",
           "name": "Actions",
           "render": [Function],
+          "shouldDisplay": true,
         },
       }
     `);
@@ -383,13 +384,20 @@ describe('useActions', () => {
       });
     });
 
-    it('returns null if the user does not have update or delete permissions', async () => {
+    it('sets shouldDisplay to false if the user does not have update or delete permissions', async () => {
       appMockRender = createAppMockRenderer({ permissions: readCasesPermissions() });
       const { result } = renderHook(() => useActions({ disableActions: false }), {
         wrapper: appMockRender.AppWrapper,
       });
 
-      expect(result.current.actions).toBe(null);
+      expect(result.current.actions).toMatchInlineSnapshot(`
+        Object {
+          "align": "right",
+          "name": "Actions",
+          "render": [Function],
+          "shouldDisplay": false,
+        }
+      `);
     });
 
     it('disables the action correctly', async () => {

--- a/x-pack/plugins/cases/public/components/all_cases/use_actions.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_actions.tsx
@@ -20,7 +20,6 @@ import { useStatusAction } from '../actions/status/use_status_action';
 import { useRefreshCases } from './use_on_refresh_cases';
 import * as i18n from './translations';
 import { statuses } from '../status';
-import { useCasesContext } from '../cases_context/use_cases_context';
 import { useSeverityAction } from '../actions/severity/use_severity_action';
 import { severities } from '../severity/config';
 import { useTagsAction } from '../actions/tags/use_tags_action';
@@ -223,7 +222,7 @@ ActionColumnComponent.displayName = 'ActionColumnComponent';
 const ActionColumn = React.memo(ActionColumnComponent);
 
 interface UseBulkActionsReturnValue {
-  actions: EuiTableComputedColumnType<CaseUI> | null;
+  actions: EuiTableComputedColumnType<CaseUI>;
 }
 
 interface UseBulkActionsProps {
@@ -231,20 +230,13 @@ interface UseBulkActionsProps {
 }
 
 export const useActions = ({ disableActions }: UseBulkActionsProps): UseBulkActionsReturnValue => {
-  const { permissions } = useCasesContext();
-  const shouldShowActions = permissions.update || permissions.delete;
-
   return {
-    actions: shouldShowActions
-      ? {
-          name: i18n.ACTIONS,
-          align: 'right',
-          render: (theCase: CaseUI) => {
-            return (
-              <ActionColumn theCase={theCase} key={theCase.id} disableActions={disableActions} />
-            );
-          },
-        }
-      : null,
+    actions: {
+      name: i18n.ACTIONS,
+      align: 'right',
+      render: (theCase: CaseUI) => {
+        return <ActionColumn theCase={theCase} key={theCase.id} disableActions={disableActions} />;
+      },
+    },
   };
 };

--- a/x-pack/plugins/cases/public/components/all_cases/use_actions.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_actions.tsx
@@ -20,6 +20,7 @@ import { useStatusAction } from '../actions/status/use_status_action';
 import { useRefreshCases } from './use_on_refresh_cases';
 import * as i18n from './translations';
 import { statuses } from '../status';
+import { useCasesContext } from '../cases_context/use_cases_context';
 import { useSeverityAction } from '../actions/severity/use_severity_action';
 import { severities } from '../severity/config';
 import { useTagsAction } from '../actions/tags/use_tags_action';
@@ -222,7 +223,7 @@ ActionColumnComponent.displayName = 'ActionColumnComponent';
 const ActionColumn = React.memo(ActionColumnComponent);
 
 interface UseBulkActionsReturnValue {
-  actions: EuiTableComputedColumnType<CaseUI>;
+  actions: EuiTableComputedColumnType<CaseUI> | null;
 }
 
 interface UseBulkActionsProps {
@@ -230,13 +231,20 @@ interface UseBulkActionsProps {
 }
 
 export const useActions = ({ disableActions }: UseBulkActionsProps): UseBulkActionsReturnValue => {
+  const { permissions } = useCasesContext();
+  const shouldShowActions = permissions.update || permissions.delete;
+
   return {
-    actions: {
-      name: i18n.ACTIONS,
-      align: 'right',
-      render: (theCase: CaseUI) => {
-        return <ActionColumn theCase={theCase} key={theCase.id} disableActions={disableActions} />;
-      },
-    },
+    actions: shouldShowActions
+      ? {
+          name: i18n.ACTIONS,
+          align: 'right',
+          render: (theCase: CaseUI) => {
+            return (
+              <ActionColumn theCase={theCase} key={theCase.id} disableActions={disableActions} />
+            );
+          },
+        }
+      : null,
   };
 };

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -153,6 +153,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -246,6 +247,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -299,6 +301,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -346,6 +349,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -393,6 +397,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -477,6 +482,7 @@ describe('useCasesColumns ', () => {
             "width": "90px",
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });
@@ -497,6 +503,7 @@ describe('useCasesColumns ', () => {
           { key: toggleKey, label: toggleLabel, type: CustomFieldTypes.TOGGLE },
         ],
       },
+      isFetching: false,
     }));
 
     const { result } = renderHook(
@@ -595,6 +602,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
+        "isFetchingColumns": false,
       }
     `);
   });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -19,6 +19,7 @@ import { createAppMockRenderer, readCasesPermissions, TestProviders } from '../.
 import { renderHook } from '@testing-library/react-hooks';
 import { CaseStatuses } from '../../../common/types/domain';
 import { userProfilesMap } from '../../containers/user_profiles/api.mock';
+import { DEFAULT_CASES_TABLE_COLUMNS } from '../../../common/constants';
 
 describe('useCasesColumns ', () => {
   let appMockRender: AppMockRenderer;
@@ -27,6 +28,7 @@ describe('useCasesColumns ', () => {
     userProfiles: userProfilesMap,
     isSelectorView: false,
     showSolutionColumn: true,
+    selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
   };
 
   beforeEach(() => {

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -13,13 +13,18 @@ import '../../common/mock/match_media';
 import type { GetCasesColumn } from './use_cases_columns';
 import { ExternalServiceColumn, useCasesColumns } from './use_cases_columns';
 import { useGetCasesMockState } from '../../containers/mock';
-import { connectors } from '../configure_cases/__mock__';
+import { connectors, useCaseConfigureResponse } from '../configure_cases/__mock__';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer, readCasesPermissions, TestProviders } from '../../common/mock';
 import { renderHook } from '@testing-library/react-hooks';
-import { CaseStatuses } from '../../../common/types/domain';
+import { CaseStatuses, CustomFieldTypes } from '../../../common/types/domain';
 import { userProfilesMap } from '../../containers/user_profiles/api.mock';
 import { DEFAULT_CASES_TABLE_COLUMNS } from '../../../common/constants';
+import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
+
+jest.mock('../../containers/configure/use_get_case_configuration');
+
+const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
 
 describe('useCasesColumns ', () => {
   let appMockRender: AppMockRenderer;
@@ -34,9 +39,125 @@ describe('useCasesColumns ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     appMockRender = createAppMockRenderer();
+    useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
   });
 
-  it('return all columns correctly', async () => {
+  it('return all selected columns correctly', async () => {
+    const license = licensingMock.createLicense({
+      license: { type: 'platinum' },
+    });
+
+    appMockRender = createAppMockRenderer({ license });
+
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          selectedColumns: DEFAULT_CASES_TABLE_COLUMNS.map((element) => ({
+            ...element,
+            isChecked: true,
+          })),
+        }),
+      {
+        wrapper: appMockRender.AppWrapper,
+      }
+    );
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          Object {
+            "field": "title",
+            "name": "Name",
+            "render": [Function],
+            "sortable": true,
+            "width": "20%",
+          },
+          Object {
+            "field": "assignees",
+            "name": "Assignees",
+            "render": [Function],
+            "width": "180px",
+          },
+          Object {
+            "field": "tags",
+            "name": "Tags",
+            "render": [Function],
+            "width": "15%",
+          },
+          Object {
+            "align": "right",
+            "field": "totalAlerts",
+            "name": "Alerts",
+            "render": [Function],
+            "width": "80px",
+          },
+          Object {
+            "align": "right",
+            "field": "totalComment",
+            "name": "Comments",
+            "render": [Function],
+          },
+          Object {
+            "field": "category",
+            "name": "Category",
+            "render": [Function],
+            "sortable": true,
+            "width": "100px",
+          },
+          Object {
+            "align": "right",
+            "field": "owner",
+            "name": "Solution",
+            "render": [Function],
+          },
+          Object {
+            "field": "createdAt",
+            "name": "Created on",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "field": "updatedAt",
+            "name": "Updated on",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "field": "closedAt",
+            "name": "Closed on",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "name": "External incident",
+            "render": [Function],
+            "width": undefined,
+          },
+          Object {
+            "field": "status",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "field": "severity",
+            "name": "Severity",
+            "render": [Function],
+            "sortable": true,
+            "width": "90px",
+          },
+          Object {
+            "align": "right",
+            "name": "Actions",
+            "render": [Function],
+          },
+        ],
+      }
+    `);
+  });
+
+  it('only returns selected columns', async () => {
     const license = licensingMock.createLicense({
       license: { type: 'platinum' },
     });
@@ -75,12 +196,6 @@ describe('useCasesColumns ', () => {
             "name": "Alerts",
             "render": [Function],
             "width": "80px",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
           },
           Object {
             "align": "right",
@@ -181,373 +296,6 @@ describe('useCasesColumns ', () => {
           },
           Object {
             "align": "right",
-            "render": [Function],
-          },
-        ],
-      }
-    `);
-  });
-
-  it('does not render the solution columns', async () => {
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-
-    appMockRender = createAppMockRenderer({ license });
-
-    const { result } = renderHook(
-      () => useCasesColumns({ ...useCasesColumnsProps, showSolutionColumn: false }),
-      {
-        wrapper: appMockRender.AppWrapper,
-      }
-    );
-
-    expect(result.current).toMatchInlineSnapshot(`
-      Object {
-        "columns": Array [
-          Object {
-            "field": "title",
-            "name": "Name",
-            "render": [Function],
-            "sortable": true,
-            "width": "20%",
-          },
-          Object {
-            "field": "assignees",
-            "name": "Assignees",
-            "render": [Function],
-            "width": "180px",
-          },
-          Object {
-            "field": "tags",
-            "name": "Tags",
-            "render": [Function],
-            "width": "15%",
-          },
-          Object {
-            "align": "right",
-            "field": "totalAlerts",
-            "name": "Alerts",
-            "render": [Function],
-            "width": "80px",
-          },
-          Object {
-            "align": "right",
-            "field": "totalComment",
-            "name": "Comments",
-            "render": [Function],
-          },
-          Object {
-            "field": "category",
-            "name": "Category",
-            "render": [Function],
-            "sortable": true,
-            "width": "100px",
-          },
-          Object {
-            "field": "createdAt",
-            "name": "Created on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "updatedAt",
-            "name": "Updated on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "name": "External incident",
-            "render": [Function],
-            "width": undefined,
-          },
-          Object {
-            "field": "status",
-            "name": "Status",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "severity",
-            "name": "Severity",
-            "render": [Function],
-            "sortable": true,
-            "width": "90px",
-          },
-          Object {
-            "align": "right",
-            "name": "Actions",
-            "render": [Function],
-          },
-        ],
-      }
-    `);
-  });
-
-  it('does not return the alerts column', async () => {
-    const license = licensingMock.createLicense({
-      license: { type: 'platinum' },
-    });
-
-    appMockRender = createAppMockRenderer({ license, features: { alerts: { enabled: false } } });
-
-    const { result } = renderHook(() => useCasesColumns(useCasesColumnsProps), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current).toMatchInlineSnapshot(`
-      Object {
-        "columns": Array [
-          Object {
-            "field": "title",
-            "name": "Name",
-            "render": [Function],
-            "sortable": true,
-            "width": "20%",
-          },
-          Object {
-            "field": "assignees",
-            "name": "Assignees",
-            "render": [Function],
-            "width": "180px",
-          },
-          Object {
-            "field": "tags",
-            "name": "Tags",
-            "render": [Function],
-            "width": "15%",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
-          },
-          Object {
-            "align": "right",
-            "field": "totalComment",
-            "name": "Comments",
-            "render": [Function],
-          },
-          Object {
-            "field": "category",
-            "name": "Category",
-            "render": [Function],
-            "sortable": true,
-            "width": "100px",
-          },
-          Object {
-            "field": "createdAt",
-            "name": "Created on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "updatedAt",
-            "name": "Updated on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "name": "External incident",
-            "render": [Function],
-            "width": undefined,
-          },
-          Object {
-            "field": "status",
-            "name": "Status",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "severity",
-            "name": "Severity",
-            "render": [Function],
-            "sortable": true,
-            "width": "90px",
-          },
-          Object {
-            "align": "right",
-            "name": "Actions",
-            "render": [Function],
-          },
-        ],
-      }
-    `);
-  });
-
-  it('does not return the assignees column', async () => {
-    const { result } = renderHook(() => useCasesColumns(useCasesColumnsProps), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current).toMatchInlineSnapshot(`
-      Object {
-        "columns": Array [
-          Object {
-            "field": "title",
-            "name": "Name",
-            "render": [Function],
-            "sortable": true,
-            "width": "20%",
-          },
-          Object {
-            "field": "tags",
-            "name": "Tags",
-            "render": [Function],
-            "width": "15%",
-          },
-          Object {
-            "align": "right",
-            "field": "totalAlerts",
-            "name": "Alerts",
-            "render": [Function],
-            "width": "80px",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
-          },
-          Object {
-            "align": "right",
-            "field": "totalComment",
-            "name": "Comments",
-            "render": [Function],
-          },
-          Object {
-            "field": "category",
-            "name": "Category",
-            "render": [Function],
-            "sortable": true,
-            "width": "100px",
-          },
-          Object {
-            "field": "createdAt",
-            "name": "Created on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "updatedAt",
-            "name": "Updated on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "name": "External incident",
-            "render": [Function],
-            "width": undefined,
-          },
-          Object {
-            "field": "status",
-            "name": "Status",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "severity",
-            "name": "Severity",
-            "render": [Function],
-            "sortable": true,
-            "width": "90px",
-          },
-          Object {
-            "align": "right",
-            "name": "Actions",
-            "render": [Function],
-          },
-        ],
-      }
-    `);
-  });
-
-  it('shows the closedAt column if the filterStatus=closed', async () => {
-    appMockRender = createAppMockRenderer();
-
-    const { result } = renderHook(
-      () => useCasesColumns({ ...useCasesColumnsProps, filterStatus: CaseStatuses.closed }),
-      {
-        wrapper: appMockRender.AppWrapper,
-      }
-    );
-
-    expect(result.current).toMatchInlineSnapshot(`
-      Object {
-        "columns": Array [
-          Object {
-            "field": "title",
-            "name": "Name",
-            "render": [Function],
-            "sortable": true,
-            "width": "20%",
-          },
-          Object {
-            "field": "tags",
-            "name": "Tags",
-            "render": [Function],
-            "width": "15%",
-          },
-          Object {
-            "align": "right",
-            "field": "totalAlerts",
-            "name": "Alerts",
-            "render": [Function],
-            "width": "80px",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
-          },
-          Object {
-            "align": "right",
-            "field": "totalComment",
-            "name": "Comments",
-            "render": [Function],
-          },
-          Object {
-            "field": "category",
-            "name": "Category",
-            "render": [Function],
-            "sortable": true,
-            "width": "100px",
-          },
-          Object {
-            "field": "closedAt",
-            "name": "Closed on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "updatedAt",
-            "name": "Updated on",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "name": "External incident",
-            "render": [Function],
-            "width": undefined,
-          },
-          Object {
-            "field": "status",
-            "name": "Status",
-            "render": [Function],
-            "sortable": true,
-          },
-          Object {
-            "field": "severity",
-            "name": "Severity",
-            "render": [Function],
-            "sortable": true,
-            "width": "90px",
-          },
-          Object {
-            "align": "right",
-            "name": "Actions",
             "render": [Function],
           },
         ],
@@ -667,6 +415,12 @@ describe('useCasesColumns ', () => {
             "width": "20%",
           },
           Object {
+            "field": "assignees",
+            "name": "Assignees",
+            "render": [Function],
+            "width": "180px",
+          },
+          Object {
             "field": "tags",
             "name": "Tags",
             "render": [Function],
@@ -678,12 +432,6 @@ describe('useCasesColumns ', () => {
             "name": "Alerts",
             "render": [Function],
             "width": "80px",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
           },
           Object {
             "align": "right",
@@ -727,6 +475,124 @@ describe('useCasesColumns ', () => {
             "render": [Function],
             "sortable": true,
             "width": "90px",
+          },
+        ],
+      }
+    `);
+  });
+
+  it('returns custom field columns', async () => {
+    const textKey = 'text_key';
+    const toggleKey = 'toggle_key';
+
+    const textLabel = 'Text Label';
+    const toggleLabel = 'Toggle Label';
+
+    appMockRender = createAppMockRenderer({ permissions: readCasesPermissions() });
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [
+          { key: textKey, label: textLabel, type: CustomFieldTypes.TEXT },
+          { key: toggleKey, label: toggleLabel, type: CustomFieldTypes.TOGGLE },
+        ],
+      },
+    }));
+
+    const { result } = renderHook(
+      () =>
+        useCasesColumns({
+          ...useCasesColumnsProps,
+          selectedColumns: [
+            ...DEFAULT_CASES_TABLE_COLUMNS,
+            { field: textKey, name: textLabel, isChecked: true },
+            { field: toggleKey, name: toggleLabel, isChecked: true },
+          ],
+        }),
+      {
+        wrapper: appMockRender.AppWrapper,
+      }
+    );
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "columns": Array [
+          Object {
+            "field": "title",
+            "name": "Name",
+            "render": [Function],
+            "sortable": true,
+            "width": "20%",
+          },
+          Object {
+            "field": "assignees",
+            "name": "Assignees",
+            "render": [Function],
+            "width": "180px",
+          },
+          Object {
+            "field": "tags",
+            "name": "Tags",
+            "render": [Function],
+            "width": "15%",
+          },
+          Object {
+            "align": "right",
+            "field": "totalAlerts",
+            "name": "Alerts",
+            "render": [Function],
+            "width": "80px",
+          },
+          Object {
+            "align": "right",
+            "field": "totalComment",
+            "name": "Comments",
+            "render": [Function],
+          },
+          Object {
+            "field": "category",
+            "name": "Category",
+            "render": [Function],
+            "sortable": true,
+            "width": "100px",
+          },
+          Object {
+            "field": "createdAt",
+            "name": "Created on",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "field": "updatedAt",
+            "name": "Updated on",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "name": "External incident",
+            "render": [Function],
+            "width": undefined,
+          },
+          Object {
+            "field": "status",
+            "name": "Status",
+            "render": [Function],
+            "sortable": true,
+          },
+          Object {
+            "field": "severity",
+            "name": "Severity",
+            "render": [Function],
+            "sortable": true,
+            "width": "90px",
+          },
+          Object {
+            "name": "Text Label",
+            "render": [Function],
+          },
+          Object {
+            "name": "Toggle Label",
+            "render": [Function],
           },
         ],
       }

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -32,7 +32,6 @@ describe('useCasesColumns ', () => {
     filterStatus: CaseStatuses.open,
     userProfiles: userProfilesMap,
     isSelectorView: false,
-    showSolutionColumn: true,
     selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
   };
 
@@ -104,12 +103,6 @@ describe('useCasesColumns ', () => {
             "render": [Function],
             "sortable": true,
             "width": "100px",
-          },
-          Object {
-            "align": "right",
-            "field": "owner",
-            "name": "Solution",
-            "render": [Function],
           },
           Object {
             "field": "createdAt",
@@ -420,12 +413,6 @@ describe('useCasesColumns ', () => {
             "width": "20%",
           },
           Object {
-            "field": "assignees",
-            "name": "Assignees",
-            "render": [Function],
-            "width": "180px",
-          },
-          Object {
             "field": "tags",
             "name": "Tags",
             "render": [Function],
@@ -532,12 +519,6 @@ describe('useCasesColumns ', () => {
             "width": "20%",
           },
           Object {
-            "field": "assignees",
-            "name": "Assignees",
-            "render": [Function],
-            "width": "180px",
-          },
-          Object {
             "field": "tags",
             "name": "Tags",
             "render": [Function],
@@ -596,10 +577,12 @@ describe('useCasesColumns ', () => {
           Object {
             "name": "Text Label",
             "render": [Function],
+            "width": "100px",
           },
           Object {
             "name": "Toggle Label",
             "render": [Function],
+            "width": "100px",
           },
         ],
         "isLoadingColumns": false,

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -153,7 +153,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
@@ -247,7 +247,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
@@ -301,7 +301,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
@@ -349,12 +349,12 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
 
-  it('does not shows the actions if isSelectorView=true', async () => {
+  it('shows the correct columns if isSelectorView=true', async () => {
     const { result } = renderHook(
       () => useCasesColumns({ ...useCasesColumnsProps, isSelectorView: true }),
       {
@@ -397,7 +397,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
@@ -482,7 +482,7 @@ describe('useCasesColumns ', () => {
             "width": "90px",
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });
@@ -602,7 +602,7 @@ describe('useCasesColumns ', () => {
             "render": [Function],
           },
         ],
-        "isFetchingColumns": false,
+        "isLoadingColumns": false,
       }
     `);
   });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.test.tsx
@@ -577,7 +577,7 @@ describe('useCasesColumns ', () => {
           Object {
             "name": "Text Label",
             "render": [Function],
-            "width": "100px",
+            "width": "250px",
           },
           Object {
             "name": "Toggle Label",

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
@@ -26,7 +26,7 @@ import { Status } from '@kbn/cases-components/src/status/status';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 
-import type { ActionConnector } from '../../../common/types/domain';
+import type { ActionConnector, CustomFieldTypes } from '../../../common/types/domain';
 import { CaseSeverity } from '../../../common/types/domain';
 import type { CasesColumnSelection, CaseUI } from '../../../common/ui/types';
 import { OWNER_INFO, SELECTOR_VIEW_CASES_TABLE_COLUMNS } from '../../../common/constants';
@@ -42,6 +42,7 @@ import { getConnectorIcon } from '../utils';
 import type { CasesOwners } from '../../client/helpers/can_use_cases';
 import { severities } from '../severity/config';
 import { AssigneesColumn } from './assignees_column';
+import { builderMap } from '../custom_fields/builder';
 
 type CasesColumns =
   | EuiTableActionsColumnType<CaseUI>
@@ -103,9 +104,6 @@ export const useCasesColumns = ({
     [onRowClick]
   );
 
-  // Some elements do not have a field on purpose.
-  // They are supposed to be EuiTableComputedColumnType
-  // and don't match specific Case attributes.
   const columnsDict: Record<string, CasesColumns> = {
     title: {
       field: casesColumnsConfig.title.field,
@@ -353,14 +351,13 @@ export const useCasesColumns = ({
     });
   } else {
     selectedColumns.forEach(({ field, isChecked }) => {
-      if (
-        field in columnsDict &&
-        field in casesColumnsConfig &&
-        casesColumnsConfig[field].canDisplay &&
-        isChecked
-      ) {
+      if (field in columnsDict && isChecked) {
         columns.push(columnsDict[field]);
       }
+      // else if (field in casesColumnsConfig && casesColumnsConfig[field].isCustomField) {
+      //   columns.push(renderTypeColumn(casesColumnsConfig[field].type));
+      //   probably a custom field
+      // }
     });
   }
 

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
@@ -83,6 +83,7 @@ export interface GetCasesColumn {
 
 export interface UseCasesColumnsReturnValue {
   columns: CasesColumns[];
+  isFetchingColumns: boolean;
 }
 
 export const useCasesColumns = ({
@@ -98,6 +99,7 @@ export const useCasesColumns = ({
 
   const {
     data: { customFields },
+    isFetching: isFetchingColumns,
   } = useGetCaseConfiguration();
 
   const assignCaseAction = useCallback(
@@ -373,7 +375,7 @@ export const useCasesColumns = ({
     }
   }
 
-  return { columns };
+  return { columns, isFetchingColumns };
 };
 
 interface Props {

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
@@ -345,12 +345,8 @@ export const useCasesColumns = ({
           return getEmptyTagValue();
         },
       },
-      actions: {
-        // no field
-        ...actions,
-      },
     }),
-    [actions, assignCaseAction, casesColumnsConfig, connectors, isSelectorView, userProfiles]
+    [assignCaseAction, casesColumnsConfig, connectors, isSelectorView, userProfiles]
   );
 
   // we need to extend the columnsDict with the columns of
@@ -371,6 +367,10 @@ export const useCasesColumns = ({
         columns.push(columnsDict[field]);
       }
     });
+
+    if (actions) {
+      columns.push(actions);
+    }
   }
 
   return { columns };

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
@@ -354,7 +354,7 @@ export const useCasesColumns = ({
   // we need to extend the columnsDict with the columns of
   // the customFields
   customFields.forEach(({ key, type, label }) => {
-    columnsDict[key] = customFieldsBuilderMap[type]().getColumn({ key, label });
+    columnsDict[key] = customFieldsBuilderMap[type]().getEuiTableColumn({ key, label });
   });
 
   const columns: CasesColumns[] = [];

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns.tsx
@@ -28,7 +28,8 @@ import { euiStyled } from '@kbn/kibana-react-plugin/common';
 
 import type { ActionConnector } from '../../../common/types/domain';
 import { CaseSeverity } from '../../../common/types/domain';
-import type { CasesColumnSelection, CaseUI } from '../../../common/ui/types';
+import type { CaseUI } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
 import { OWNER_INFO, SELECTOR_VIEW_CASES_TABLE_COLUMNS } from '../../../common/constants';
 import { getEmptyTagValue } from '../empty_value';
 import { FormattedRelativePreferenceDate } from '../formatted_date';
@@ -83,7 +84,7 @@ export interface GetCasesColumn {
 
 export interface UseCasesColumnsReturnValue {
   columns: CasesColumns[];
-  isFetchingColumns: boolean;
+  isLoadingColumns: boolean;
 }
 
 export const useCasesColumns = ({
@@ -99,7 +100,7 @@ export const useCasesColumns = ({
 
   const {
     data: { customFields },
-    isFetching: isFetchingColumns,
+    isFetching: isLoadingColumns,
   } = useGetCaseConfiguration();
 
   const assignCaseAction = useCallback(
@@ -375,7 +376,7 @@ export const useCasesColumns = ({
     }
   }
 
-  return { columns, isFetchingColumns };
+  return { columns, isLoadingColumns };
 };
 
 interface Props {

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -46,11 +46,6 @@ describe('useCasesColumnsConfiguration ', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "actions": Object {
-          "canDisplay": true,
-          "field": "actions",
-          "name": "Actions",
-        },
         "assignCaseAction": Object {
           "canDisplay": true,
           "field": "",
@@ -121,34 +116,6 @@ describe('useCasesColumnsConfiguration ', () => {
           "field": "updatedAt",
           "name": "Updated on",
         },
-      }
-    `);
-  });
-
-  it('cannot display actions without update permissions', async () => {
-    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current.actions).toMatchInlineSnapshot(`
-      Object {
-        "canDisplay": true,
-        "field": "actions",
-        "name": "Actions",
-      }
-    `);
-  });
-
-  it('cannot display actions without delete permissions', async () => {
-    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current.actions).toMatchInlineSnapshot(`
-      Object {
-        "canDisplay": true,
-        "field": "actions",
-        "name": "Actions",
       }
     `);
   });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -1,0 +1,201 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
+import { renderHook } from '@testing-library/react-hooks';
+
+import type { AppMockRenderer } from '../../common/mock';
+import { createAppMockRenderer } from '../../common/mock';
+import { useCasesFeatures } from '../../common/use_cases_features';
+
+import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+
+jest.mock('../../common/use_cases_features');
+
+const useCasesFeaturesMock = useCasesFeatures as jest.Mock;
+
+describe('useCasesColumnsConfiguration ', () => {
+  let appMockRender: AppMockRenderer;
+  const license = licensingMock.createLicense({
+    license: { type: 'platinum' },
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appMockRender = createAppMockRenderer({ license });
+    useCasesFeaturesMock.mockReturnValue({
+      caseAssignmentAuthorized: true,
+      isAlertsEnabled: true,
+    });
+  });
+
+  it('returns all columns correctly', async () => {
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "actions": Object {
+          "canDisplay": true,
+          "field": "actions",
+          "name": "Actions",
+        },
+        "assignCaseAction": Object {
+          "canDisplay": true,
+          "field": "",
+          "name": "",
+        },
+        "assignees": Object {
+          "canDisplay": true,
+          "field": "assignees",
+          "name": "Assignees",
+        },
+        "category": Object {
+          "canDisplay": true,
+          "field": "category",
+          "name": "Category",
+        },
+        "closedAt": Object {
+          "canDisplay": true,
+          "field": "closedAt",
+          "name": "Closed on",
+        },
+        "createdAt": Object {
+          "canDisplay": true,
+          "field": "createdAt",
+          "name": "Created on",
+        },
+        "externalIncident": Object {
+          "canDisplay": true,
+          "field": "externalIncident",
+          "name": "External incident",
+        },
+        "owner": Object {
+          "canDisplay": false,
+          "field": "owner",
+          "name": "Solution",
+        },
+        "severity": Object {
+          "canDisplay": true,
+          "field": "severity",
+          "name": "Severity",
+        },
+        "status": Object {
+          "canDisplay": true,
+          "field": "status",
+          "name": "Status",
+        },
+        "tags": Object {
+          "canDisplay": true,
+          "field": "tags",
+          "name": "Tags",
+        },
+        "title": Object {
+          "canDisplay": true,
+          "field": "title",
+          "name": "Name",
+        },
+        "totalAlerts": Object {
+          "canDisplay": true,
+          "field": "totalAlerts",
+          "name": "Alerts",
+        },
+        "totalComment": Object {
+          "canDisplay": true,
+          "field": "totalComment",
+          "name": "Comments",
+        },
+        "updatedAt": Object {
+          "canDisplay": true,
+          "field": "updatedAt",
+          "name": "Updated on",
+        },
+      }
+    `);
+  });
+
+  it('cannot display actions without update permissions', async () => {
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current.actions).toMatchInlineSnapshot(`
+      Object {
+        "canDisplay": true,
+        "field": "actions",
+        "name": "Actions",
+      }
+    `);
+  });
+
+  it('cannot display actions without delete permissions', async () => {
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current.actions).toMatchInlineSnapshot(`
+      Object {
+        "canDisplay": true,
+        "field": "actions",
+        "name": "Actions",
+      }
+    `);
+  });
+
+  it('cannot display assignees when case assignment is not authorized', async () => {
+    useCasesFeaturesMock.mockReturnValue({
+      caseAssignmentAuthorized: false,
+      isAlertsEnabled: true,
+    });
+
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current.assignees).toMatchInlineSnapshot(`
+      Object {
+        "canDisplay": false,
+        "field": "assignees",
+        "name": "Assignees",
+      }
+    `);
+  });
+
+  it('cannot display alerts if alerts are not enabled', async () => {
+    useCasesFeaturesMock.mockReturnValue({
+      caseAssignmentAuthorized: true,
+      isAlertsEnabled: false,
+    });
+
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current.totalAlerts).toMatchInlineSnapshot(`
+      Object {
+        "canDisplay": false,
+        "field": "totalAlerts",
+        "name": "Alerts",
+      }
+    `);
+  });
+
+  it('cannot display owner if none is available', async () => {
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current.owner).toMatchInlineSnapshot(`
+      Object {
+        "canDisplay": false,
+        "field": "owner",
+        "name": "Solution",
+      }
+    `);
+  });
+});

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -13,9 +13,14 @@ import { createAppMockRenderer } from '../../common/mock';
 import { useCasesFeatures } from '../../common/use_cases_features';
 
 import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
+import { useCaseConfigureResponse } from '../configure_cases/__mock__';
+import { CustomFieldTypes } from '../../../common/types/domain';
 
 jest.mock('../../common/use_cases_features');
+jest.mock('../../containers/configure/use_get_case_configuration');
 
+const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
 const useCasesFeaturesMock = useCasesFeatures as jest.Mock;
 
 describe('useCasesColumnsConfiguration ', () => {
@@ -31,6 +36,7 @@ describe('useCasesColumnsConfiguration ', () => {
       caseAssignmentAuthorized: true,
       isAlertsEnabled: true,
     });
+    useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
   });
 
   it('returns all columns correctly', async () => {
@@ -197,5 +203,34 @@ describe('useCasesColumnsConfiguration ', () => {
         "name": "Solution",
       }
     `);
+  });
+
+  it('includes custom field columns correctly', async () => {
+    const textKey = 'text_key';
+    const toggleKey = 'toggle_key';
+
+    const textLabel = 'Text Label';
+    const toggleLabel = 'Toggle Label';
+
+    useGetCaseConfigurationMock.mockImplementation(() => ({
+      data: {
+        ...useCaseConfigureResponse.data,
+        customFields: [
+          { key: textKey, label: textLabel, type: CustomFieldTypes.TEXT },
+          { key: toggleKey, label: toggleLabel, type: CustomFieldTypes.TOGGLE },
+        ],
+      },
+    }));
+
+    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current[textKey]).toEqual({ field: textKey, name: textLabel, canDisplay: true });
+    expect(result.current[toggleKey]).toEqual({
+      field: toggleKey,
+      name: toggleLabel,
+      canDisplay: true,
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.test.tsx
@@ -46,11 +46,6 @@ describe('useCasesColumnsConfiguration ', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       Object {
-        "assignCaseAction": Object {
-          "canDisplay": true,
-          "field": "",
-          "name": "",
-        },
         "assignees": Object {
           "canDisplay": true,
           "field": "assignees",
@@ -75,11 +70,6 @@ describe('useCasesColumnsConfiguration ', () => {
           "canDisplay": true,
           "field": "externalIncident",
           "name": "External incident",
-        },
-        "owner": Object {
-          "canDisplay": false,
-          "field": "owner",
-          "name": "Solution",
         },
         "severity": Object {
           "canDisplay": true,
@@ -154,20 +144,6 @@ describe('useCasesColumnsConfiguration ', () => {
         "canDisplay": false,
         "field": "totalAlerts",
         "name": "Alerts",
-      }
-    `);
-  });
-
-  it('cannot display owner if none is available', async () => {
-    const { result } = renderHook(() => useCasesColumnsConfiguration(), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(result.current.owner).toMatchInlineSnapshot(`
-      Object {
-        "canDisplay": false,
-        "field": "owner",
-        "name": "Solution",
       }
     `);
   });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import * as i18n from './translations';
+import { ALERTS } from '../../common/translations';
+import { useCasesFeatures } from '../../common/use_cases_features';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import { getAllPermissionsExceptFrom } from '../../utils/permissions';
+
+export type CasesColumnsConfiguration = Record<
+  string,
+  {
+    field: string;
+    name: string;
+    canDisplay: boolean;
+  }
+>;
+
+export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
+  const { isAlertsEnabled, caseAssignmentAuthorized } = useCasesFeatures();
+
+  const { owner, permissions } = useCasesContext();
+  const availableSolutions = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
+
+  const canDisplayDefault = true;
+  const canDisplayActions = permissions.update || permissions.delete;
+  const canDisplayOwner = !!owner.length && availableSolutions.length > 1;
+
+  return {
+    title: {
+      field: 'title',
+      name: i18n.NAME,
+      canDisplay: canDisplayDefault,
+    },
+    assignees: {
+      field: 'assignees',
+      name: i18n.ASSIGNEES,
+      canDisplay: caseAssignmentAuthorized,
+    },
+    tags: {
+      field: 'tags',
+      name: i18n.TAGS,
+      canDisplay: canDisplayDefault,
+    },
+    totalAlerts: {
+      field: 'totalAlerts',
+      name: ALERTS,
+      canDisplay: isAlertsEnabled,
+    },
+    owner: {
+      field: 'owner',
+      name: i18n.SOLUTION,
+      canDisplay: canDisplayOwner,
+    },
+    totalComment: {
+      field: 'totalComment',
+      name: i18n.COMMENTS,
+      canDisplay: canDisplayDefault,
+    },
+    category: {
+      field: 'category',
+      name: i18n.CATEGORY,
+      canDisplay: canDisplayDefault,
+    },
+    closedAt: {
+      field: 'closedAt',
+      name: i18n.CLOSED_ON,
+      canDisplay: canDisplayDefault,
+    },
+    createdAt: {
+      field: 'createdAt',
+      name: i18n.CREATED_ON,
+      canDisplay: canDisplayDefault,
+    },
+    updatedAt: {
+      field: 'updatedAt',
+      name: i18n.UPDATED_ON,
+      canDisplay: canDisplayDefault,
+    },
+    externalIncident: {
+      field: 'externalIncident',
+      name: i18n.EXTERNAL_INCIDENT,
+      canDisplay: canDisplayDefault,
+    },
+    status: {
+      field: 'status',
+      name: i18n.STATUS,
+      canDisplay: canDisplayDefault,
+    },
+    severity: {
+      field: 'severity',
+      name: i18n.SEVERITY,
+      canDisplay: canDisplayDefault,
+    },
+    assignCaseAction: {
+      field: '',
+      name: '',
+      canDisplay: canDisplayDefault,
+    },
+    actions: {
+      field: 'actions',
+      name: i18n.ACTIONS,
+      canDisplay: canDisplayActions,
+    },
+  };
+};

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -28,11 +28,10 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
     data: { customFields },
   } = useGetCaseConfiguration();
 
-  const { owner, permissions } = useCasesContext();
+  const { owner } = useCasesContext();
   const availableSolutions = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
 
   const canDisplayDefault = true;
-  const canDisplayActions = permissions.update || permissions.delete;
   const canDisplayOwner = !!owner.length && availableSolutions.length > 1;
 
   const result: CasesColumnsConfiguration = {
@@ -105,11 +104,6 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
       field: '',
       name: '',
       canDisplay: canDisplayDefault,
-    },
-    actions: {
-      field: 'actions',
-      name: i18n.ACTIONS,
-      canDisplay: canDisplayActions,
     },
   };
 

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -11,6 +11,7 @@ import { useCasesFeatures } from '../../common/use_cases_features';
 import { useAvailableCasesOwners } from '../app/use_available_owners';
 import { useCasesContext } from '../cases_context/use_cases_context';
 import { getAllPermissionsExceptFrom } from '../../utils/permissions';
+import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 
 export type CasesColumnsConfiguration = Record<
   string,
@@ -23,6 +24,9 @@ export type CasesColumnsConfiguration = Record<
 
 export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
   const { isAlertsEnabled, caseAssignmentAuthorized } = useCasesFeatures();
+  const {
+    data: { customFields },
+  } = useGetCaseConfiguration();
 
   const { owner, permissions } = useCasesContext();
   const availableSolutions = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
@@ -31,7 +35,7 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
   const canDisplayActions = permissions.update || permissions.delete;
   const canDisplayOwner = !!owner.length && availableSolutions.length > 1;
 
-  return {
+  const result: CasesColumnsConfiguration = {
     title: {
       field: 'title',
       name: i18n.NAME,
@@ -108,4 +112,15 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
       canDisplay: canDisplayActions,
     },
   };
+
+  // we need to extend the configuration with the customFields
+  customFields.forEach(({ key, label }) => {
+    result[key] = {
+      field: key,
+      name: label,
+      canDisplay: canDisplayDefault,
+    };
+  });
+
+  return result;
 };

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_configuration.tsx
@@ -8,9 +8,6 @@
 import * as i18n from './translations';
 import { ALERTS } from '../../common/translations';
 import { useCasesFeatures } from '../../common/use_cases_features';
-import { useAvailableCasesOwners } from '../app/use_available_owners';
-import { useCasesContext } from '../cases_context/use_cases_context';
-import { getAllPermissionsExceptFrom } from '../../utils/permissions';
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
 
 export type CasesColumnsConfiguration = Record<
@@ -28,11 +25,7 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
     data: { customFields },
   } = useGetCaseConfiguration();
 
-  const { owner } = useCasesContext();
-  const availableSolutions = useAvailableCasesOwners(getAllPermissionsExceptFrom('delete'));
-
   const canDisplayDefault = true;
-  const canDisplayOwner = !!owner.length && availableSolutions.length > 1;
 
   const result: CasesColumnsConfiguration = {
     title: {
@@ -54,11 +47,6 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
       field: 'totalAlerts',
       name: ALERTS,
       canDisplay: isAlertsEnabled,
-    },
-    owner: {
-      field: 'owner',
-      name: i18n.SOLUTION,
-      canDisplay: canDisplayOwner,
     },
     totalComment: {
       field: 'totalComment',
@@ -98,11 +86,6 @@ export const useCasesColumnsConfiguration = (): CasesColumnsConfiguration => {
     severity: {
       field: 'severity',
       name: i18n.SEVERITY,
-      canDisplay: canDisplayDefault,
-    },
-    assignCaseAction: {
-      field: '',
-      name: '',
       canDisplay: canDisplayDefault,
     },
   };

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.test.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { licensingMock } from '@kbn/licensing-plugin/public/mocks';
+import { renderHook } from '@testing-library/react-hooks';
+
+import type { AppMockRenderer } from '../../common/mock';
+
+import { createAppMockRenderer } from '../../common/mock';
+import { useCasesColumnsSelection } from './use_cases_columns_selection';
+import { mergeSelectedColumnsWithConfiguration } from './utils';
+import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+import { DEFAULT_CASES_TABLE_COLUMNS } from '../../../common/constants';
+
+jest.mock('./use_cases_columns_configuration');
+jest.mock('./utils');
+
+const useCasesColumnsConfigurationMock = useCasesColumnsConfiguration as jest.Mock;
+const mergeSelectedColumnsWithConfigurationMock =
+  mergeSelectedColumnsWithConfiguration as jest.Mock;
+
+const localStorageKey = 'testAppId.cases.list.tableColumns';
+const casesColumnsConfig = {
+  title: {
+    field: 'title',
+    name: 'Name',
+    isChecked: false,
+  },
+  assignees: {
+    field: 'assignees',
+    name: 'Assignees',
+    isChecked: false,
+  },
+  tags: {
+    field: 'tags',
+    name: 'Tags',
+    isChecked: false,
+  },
+};
+
+describe('useCasesColumnsSelection ', () => {
+  let appMockRender: AppMockRenderer;
+  const license = licensingMock.createLicense({
+    license: { type: 'platinum' },
+  });
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer({ license });
+
+    useCasesColumnsConfigurationMock.mockReturnValue(casesColumnsConfig);
+    mergeSelectedColumnsWithConfigurationMock.mockReturnValue([
+      {
+        field: 'title',
+        name: 'Name',
+        isChecked: true,
+      },
+      {
+        field: 'assignees',
+        name: 'Assignees',
+        isChecked: true,
+      },
+      {
+        field: 'tags',
+        name: 'Tags',
+        isChecked: true,
+      },
+    ]);
+
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the expected selectedColumns', async () => {
+    const { result } = renderHook(() => useCasesColumnsSelection(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "selectedColumns": Array [
+          Object {
+            "field": "title",
+            "isChecked": true,
+            "name": "Name",
+          },
+          Object {
+            "field": "assignees",
+            "isChecked": true,
+            "name": "Assignees",
+          },
+          Object {
+            "field": "tags",
+            "isChecked": true,
+            "name": "Tags",
+          },
+        ],
+        "setSelectedColumns": [Function],
+      }
+    `);
+  });
+
+  it('calls mergeSelectedColumnsWithConfiguration with existing localstorage value', async () => {
+    const selectedColumns = [
+      {
+        field: 'title',
+        name: 'Name',
+        isChecked: false,
+      },
+    ];
+
+    localStorage.setItem(localStorageKey, JSON.stringify(selectedColumns));
+
+    renderHook(() => useCasesColumnsSelection(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(mergeSelectedColumnsWithConfigurationMock).toBeCalledWith({
+      selectedColumns,
+      casesColumnsConfig,
+    });
+  });
+
+  it('calls mergeSelectedColumnsWithConfiguration with the default params when the localstorage is empty', async () => {
+    renderHook(() => useCasesColumnsSelection(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    expect(mergeSelectedColumnsWithConfigurationMock).toBeCalledWith({
+      selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
+      casesColumnsConfig,
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.test.tsx
@@ -12,33 +12,28 @@ import type { AppMockRenderer } from '../../common/mock';
 
 import { createAppMockRenderer } from '../../common/mock';
 import { useCasesColumnsSelection } from './use_cases_columns_selection';
-import { mergeSelectedColumnsWithConfiguration } from './utils';
 import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
-import { DEFAULT_CASES_TABLE_COLUMNS } from '../../../common/constants';
 
 jest.mock('./use_cases_columns_configuration');
-jest.mock('./utils');
 
 const useCasesColumnsConfigurationMock = useCasesColumnsConfiguration as jest.Mock;
-const mergeSelectedColumnsWithConfigurationMock =
-  mergeSelectedColumnsWithConfiguration as jest.Mock;
 
 const localStorageKey = 'testAppId.cases.list.tableColumns';
 const casesColumnsConfig = {
   title: {
     field: 'title',
     name: 'Name',
-    isChecked: false,
+    canDisplay: true,
   },
   assignees: {
     field: 'assignees',
     name: 'Assignees',
-    isChecked: false,
+    canDisplay: true,
   },
   tags: {
     field: 'tags',
     name: 'Tags',
-    isChecked: false,
+    canDisplay: true,
   },
 };
 
@@ -52,23 +47,6 @@ describe('useCasesColumnsSelection ', () => {
     appMockRender = createAppMockRenderer({ license });
 
     useCasesColumnsConfigurationMock.mockReturnValue(casesColumnsConfig);
-    mergeSelectedColumnsWithConfigurationMock.mockReturnValue([
-      {
-        field: 'title',
-        name: 'Name',
-        isChecked: true,
-      },
-      {
-        field: 'assignees',
-        name: 'Assignees',
-        isChecked: true,
-      },
-      {
-        field: 'tags',
-        name: 'Tags',
-        isChecked: true,
-      },
-    ]);
 
     localStorage.clear();
   });
@@ -77,7 +55,7 @@ describe('useCasesColumnsSelection ', () => {
     jest.clearAllMocks();
   });
 
-  it('returns the expected selectedColumns', async () => {
+  it('returns the expected selectedColumns when the localstorage is empty', async () => {
     const { result } = renderHook(() => useCasesColumnsSelection(), {
       wrapper: appMockRender.AppWrapper,
     });
@@ -117,24 +95,31 @@ describe('useCasesColumnsSelection ', () => {
 
     localStorage.setItem(localStorageKey, JSON.stringify(selectedColumns));
 
-    renderHook(() => useCasesColumnsSelection(), {
+    const { result } = renderHook(() => useCasesColumnsSelection(), {
       wrapper: appMockRender.AppWrapper,
     });
 
-    expect(mergeSelectedColumnsWithConfigurationMock).toBeCalledWith({
-      selectedColumns,
-      casesColumnsConfig,
-    });
-  });
-
-  it('calls mergeSelectedColumnsWithConfiguration with the default params when the localstorage is empty', async () => {
-    renderHook(() => useCasesColumnsSelection(), {
-      wrapper: appMockRender.AppWrapper,
-    });
-
-    expect(mergeSelectedColumnsWithConfigurationMock).toBeCalledWith({
-      selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
-      casesColumnsConfig,
-    });
+    expect(result.current).toMatchInlineSnapshot(`
+      Object {
+        "selectedColumns": Array [
+          Object {
+            "field": "title",
+            "isChecked": false,
+            "name": "Name",
+          },
+          Object {
+            "field": "assignees",
+            "isChecked": false,
+            "name": "Assignees",
+          },
+          Object {
+            "field": "tags",
+            "isChecked": false,
+            "name": "Tags",
+          },
+        ],
+        "setSelectedColumns": [Function],
+      }
+    `);
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -48,12 +48,21 @@ const mergeSelectedColumnsWithConfiguration = ({
     return accumulator;
   }, [] as Array<{ field: string; name: string; isChecked: boolean }>);
 
-  // in case the configuration was updated we need to append these to the end of the list
-  // can also apply to custom fields
+  // This will include any new customFields and/or changes to the case attributes
   const missingColumns = difference(
     Object.keys(casesColumnsConfig),
     selectedColumns.map(({ field }) => field)
   );
+
+  missingColumns.forEach((field) => {
+    // can be an empty string
+    if (casesColumnsConfig[field].field) {
+      result.push({
+        ...casesColumnsConfig[field],
+        isChecked: false,
+      });
+    }
+  });
 
   return result;
 };

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -22,11 +22,6 @@ const getTableColumnsLocalStorageKey = (appId: string) => {
 export function useCasesColumnsSelection() {
   const { appId } = useCasesContext();
   const casesColumnsConfig = useCasesColumnsConfiguration();
-  const defaultSelectedColumns = mergeSelectedColumnsWithConfiguration({
-    selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
-    casesColumnsConfig,
-  });
-
   const [selectedColumns, setSelectedColumns] = useLocalStorage<CasesColumnSelection[]>(
     getTableColumnsLocalStorageKey(appId)
   );
@@ -37,7 +32,10 @@ export function useCasesColumnsSelection() {
           selectedColumns,
           casesColumnsConfig,
         })
-      : defaultSelectedColumns,
+      : mergeSelectedColumnsWithConfiguration({
+          selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
+          casesColumnsConfig,
+        }),
     setSelectedColumns,
   };
 }

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -7,64 +7,16 @@
 
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
-import { difference } from 'lodash';
 import type { CasesColumnSelection } from '../../../common/ui/types';
 
 import { DEFAULT_CASES_TABLE_COLUMNS, LOCAL_STORAGE_KEYS } from '../../../common/constants';
 import { useCasesContext } from '../cases_context/use_cases_context';
-import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
 import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+import { mergeSelectedColumnsWithConfiguration } from './utils';
 
 const getTableColumnsLocalStorageKey = (appId: string) => {
   const filteringKey = LOCAL_STORAGE_KEYS.casesTableColumns;
   return `${appId}.${filteringKey}`;
-};
-
-const mergeSelectedColumnsWithConfiguration = ({
-  selectedColumns,
-  casesColumnsConfig,
-}: {
-  selectedColumns: CasesColumnSelection[];
-  casesColumnsConfig: CasesColumnsConfiguration;
-}): CasesColumnSelection[] => {
-  // selectedColumns is the master
-  // iterate over selectedColumns
-  //   filter out those not in the configuration
-  //   filter out those that !canDisplay
-  //   add columnName
-  // add missing fields/columns from configuration
-
-  const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
-    if (
-      field in casesColumnsConfig &&
-      casesColumnsConfig[field].name !== '' &&
-      casesColumnsConfig[field].canDisplay
-    ) {
-      accumulator.push({
-        ...casesColumnsConfig[field],
-        isChecked,
-      });
-    }
-    return accumulator;
-  }, [] as Array<{ field: string; name: string; isChecked: boolean }>);
-
-  // This will include any new customFields and/or changes to the case attributes
-  const missingColumns = difference(
-    Object.keys(casesColumnsConfig),
-    selectedColumns.map(({ field }) => field)
-  );
-
-  missingColumns.forEach((field) => {
-    // can be an empty string
-    if (casesColumnsConfig[field].field) {
-      result.push({
-        ...casesColumnsConfig[field],
-        isChecked: false,
-      });
-    }
-  });
-
-  return result;
 };
 
 export function useCasesColumnsSelection() {

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
+import { difference } from 'lodash';
+import type { CasesColumnSelection } from '../../../common/ui/types';
+
+import { DEFAULT_CASES_TABLE_COLUMNS, LOCAL_STORAGE_KEYS } from '../../../common/constants';
+import { useCasesContext } from '../cases_context/use_cases_context';
+import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
+import { useCasesColumnsConfiguration } from './use_cases_columns_configuration';
+
+const getTableColumnsLocalStorageKey = (appId: string) => {
+  const filteringKey = LOCAL_STORAGE_KEYS.casesTableColumns;
+  return `${appId}.${filteringKey}`;
+};
+
+const mergeSelectedColumnsWithConfiguration = ({
+  selectedColumns,
+  casesColumnsConfig,
+}: {
+  selectedColumns: CasesColumnSelection[];
+  casesColumnsConfig: CasesColumnsConfiguration;
+}): CasesColumnSelection[] => {
+  // selectedColumns is the master
+  // iterate over selectedColumns
+  //   filter out those not in the configuration
+  //   filter out those that !canDisplay
+  //   add columnName
+  // add missing fields/columns from configuration
+
+  const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
+    if (
+      field in casesColumnsConfig &&
+      casesColumnsConfig[field].name !== '' &&
+      casesColumnsConfig[field].canDisplay
+    ) {
+      accumulator.push({
+        ...casesColumnsConfig[field],
+        isChecked,
+      });
+    }
+    return accumulator;
+  }, [] as Array<{ field: string; name: string; isChecked: boolean }>);
+
+  // in case the configuration was updated we need to append these to the end of the list
+  // can also apply to custom fields
+  const missingColumns = difference(
+    Object.keys(casesColumnsConfig),
+    selectedColumns.map(({ field }) => field)
+  );
+
+  return result;
+};
+
+export function useCasesColumnsSelection() {
+  const { appId } = useCasesContext();
+  const casesColumnsConfig = useCasesColumnsConfiguration();
+  const defaultSelectedColumns = mergeSelectedColumnsWithConfiguration({
+    selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
+    casesColumnsConfig,
+  });
+
+  const [selectedColumns, setSelectedColumns] = useLocalStorage<CasesColumnSelection[]>(
+    getTableColumnsLocalStorageKey(appId)
+  );
+
+  return {
+    selectedColumns: selectedColumns
+      ? mergeSelectedColumnsWithConfiguration({
+          selectedColumns,
+          casesColumnsConfig,
+        })
+      : defaultSelectedColumns,
+    setSelectedColumns,
+  };
+}

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -22,6 +22,7 @@ const getTableColumnsLocalStorageKey = (appId: string) => {
 export function useCasesColumnsSelection() {
   const { appId } = useCasesContext();
   const casesColumnsConfig = useCasesColumnsConfiguration();
+
   const [selectedColumns, setSelectedColumns] = useLocalStorage<CasesColumnSelection[]>(
     getTableColumnsLocalStorageKey(appId)
   );

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -26,16 +26,13 @@ export function useCasesColumnsSelection() {
     getTableColumnsLocalStorageKey(appId)
   );
 
+  const columns = selectedColumns || DEFAULT_CASES_TABLE_COLUMNS;
+
   return {
-    selectedColumns: selectedColumns
-      ? mergeSelectedColumnsWithConfiguration({
-          selectedColumns,
-          casesColumnsConfig,
-        })
-      : mergeSelectedColumnsWithConfiguration({
-          selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
-          casesColumnsConfig,
-        }),
+    selectedColumns: mergeSelectedColumnsWithConfiguration({
+      selectedColumns: columns,
+      casesColumnsConfig,
+    }),
     setSelectedColumns,
   };
 }

--- a/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/use_cases_columns_selection.tsx
@@ -7,7 +7,7 @@
 
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 
-import type { CasesColumnSelection } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
 
 import { DEFAULT_CASES_TABLE_COLUMNS, LOCAL_STORAGE_KEYS } from '../../../common/constants';
 import { useCasesContext } from '../cases_context/use_cases_context';

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.test.tsx
@@ -9,7 +9,7 @@ import { act, waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import type { AppMockRenderer } from '../../common/mock';
-import { MAX_DOCS_PER_PAGE } from '../../../common/constants';
+import { DEFAULT_CASES_TABLE_COLUMNS, MAX_DOCS_PER_PAGE } from '../../../common/constants';
 import {
   noCasesPermissions,
   onlyDeleteCasesPermission,
@@ -34,6 +34,8 @@ describe('Severity form field', () => {
       pageSize: 10,
       totalItemCount: 5,
     },
+    selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
+    onSelectedColumnsChange: jest.fn(),
   };
 
   beforeEach(() => {
@@ -88,6 +90,8 @@ describe('Severity form field', () => {
         pageIndex: 1,
         totalItemCount: 0,
       },
+      selectedColumns: DEFAULT_CASES_TABLE_COLUMNS,
+      onSelectedColumnsChange: jest.fn(),
     };
     appMockRender.render(<CasesTableUtilityBar {...updatedProps} />);
     expect(screen.getByText('Showing 0 of 0 cases')).toBeInTheDocument();

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.test.tsx
@@ -97,6 +97,16 @@ describe('Severity form field', () => {
     expect(screen.getByText('Showing 0 of 0 cases')).toBeInTheDocument();
   });
 
+  it('renders columns popover button when isSelectorView=False', async () => {
+    appMockRender.render(<CasesTableUtilityBar {...props} />);
+    expect(screen.getByTestId('column-selection-popover-button')).toBeInTheDocument();
+  });
+
+  it('does not render columns popover button when isSelectorView=True', async () => {
+    appMockRender.render(<CasesTableUtilityBar {...props} isSelectorView={true} />);
+    expect(screen.queryByTestId('column-selection-popover-button')).not.toBeInTheDocument();
+  });
+
   it('opens the bulk actions correctly', async () => {
     appMockRender.render(<CasesTableUtilityBar {...props} />);
 

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
@@ -22,11 +22,12 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import * as i18n from './translations';
-import type { CasesUI } from '../../../common/ui/types';
+import type { CasesColumnSelection, CasesUI } from '../../../common/ui/types';
 import { MAX_DOCS_PER_PAGE } from '../../../common/constants';
 import { useRefreshCases } from './use_on_refresh_cases';
 import { useBulkActions } from './use_bulk_actions';
 import { useCasesContext } from '../cases_context/use_cases_context';
+import { ColumnsPopover } from './columns_popover';
 
 interface Props {
   isSelectorView?: boolean;
@@ -34,10 +35,20 @@ interface Props {
   selectedCases: CasesUI;
   deselectCases: () => void;
   pagination: Pagination;
+  selectedColumns: CasesColumnSelection[];
+  onSelectedColumnsChange: (columns: CasesColumnSelection[]) => void;
 }
 
 export const CasesTableUtilityBar: FunctionComponent<Props> = React.memo(
-  ({ isSelectorView, totalCases, selectedCases, deselectCases, pagination }) => {
+  ({
+    isSelectorView,
+    totalCases,
+    selectedCases,
+    deselectCases,
+    pagination,
+    selectedColumns,
+    onSelectedColumnsChange,
+  }) => {
     const { euiTheme } = useEuiTheme();
     const refreshCases = useRefreshCases();
     const { permissions, appId } = useCasesContext();
@@ -126,8 +137,8 @@ export const CasesTableUtilityBar: FunctionComponent<Props> = React.memo(
     return (
       <>
         <EuiFlexGroup
+          justifyContent="spaceBetween"
           alignItems="center"
-          justifyContent="flexStart"
           gutterSize="s"
           css={{
             borderBottom: euiTheme.border.thin,
@@ -137,69 +148,81 @@ export const CasesTableUtilityBar: FunctionComponent<Props> = React.memo(
             paddingBottom: euiTheme.size.s,
           }}
         >
-          <EuiFlexItem
-            data-test-subj="case-table-case-count"
-            grow={false}
-            css={{
-              borderRight: euiTheme.border.thin,
-              paddingRight: euiTheme.size.s,
-            }}
-          >
-            <EuiText size="xs" color="subdued">
-              {i18n.SHOWING_CASES(totalCases, visibleCases)}
-            </EuiText>
-          </EuiFlexItem>
-          <EuiFlexItem data-test-subj="case-table-utility-bar-actions" grow={false}>
-            <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
-              {!isSelectorView && showBulkActions && (
-                <>
-                  <EuiFlexItem data-test-subj="case-table-selected-case-count" grow={false}>
-                    <EuiText size="xs" color="subdued">
-                      {i18n.SHOWING_SELECTED_CASES(selectedCases.length)}
-                    </EuiText>
-                  </EuiFlexItem>
-                  <EuiFlexItem grow={false}>
-                    <EuiPopover
-                      isOpen={isPopoverOpen}
-                      closePopover={closePopover}
-                      panelPaddingSize="none"
-                      data-test-subj="case-table-bulk-actions-popover"
-                      button={
-                        <EuiButtonEmpty
-                          onClick={togglePopover}
-                          size="xs"
-                          iconSide="right"
-                          iconType="arrowDown"
-                          flush="left"
-                          data-test-subj="case-table-bulk-actions-link-icon"
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup justifyContent="flexStart" gutterSize="s" alignItems="center">
+              <EuiFlexItem
+                data-test-subj="case-table-case-count"
+                grow={false}
+                css={{
+                  borderRight: euiTheme.border.thin,
+                  paddingRight: euiTheme.size.s,
+                }}
+              >
+                <EuiText size="xs" color="subdued">
+                  {i18n.SHOWING_CASES(totalCases, visibleCases)}
+                </EuiText>
+              </EuiFlexItem>
+              <EuiFlexItem data-test-subj="case-table-utility-bar-actions" grow={false}>
+                <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
+                  {!isSelectorView && showBulkActions && (
+                    <>
+                      <EuiFlexItem data-test-subj="case-table-selected-case-count" grow={false}>
+                        <EuiText size="xs" color="subdued">
+                          {i18n.SHOWING_SELECTED_CASES(selectedCases.length)}
+                        </EuiText>
+                      </EuiFlexItem>
+                      <EuiFlexItem grow={false}>
+                        <EuiPopover
+                          isOpen={isPopoverOpen}
+                          closePopover={closePopover}
+                          panelPaddingSize="none"
+                          data-test-subj="case-table-bulk-actions-popover"
+                          button={
+                            <EuiButtonEmpty
+                              onClick={togglePopover}
+                              size="xs"
+                              iconSide="right"
+                              iconType="arrowDown"
+                              flush="left"
+                              data-test-subj="case-table-bulk-actions-link-icon"
+                            >
+                              {i18n.BULK_ACTIONS}
+                            </EuiButtonEmpty>
+                          }
                         >
-                          {i18n.BULK_ACTIONS}
-                        </EuiButtonEmpty>
-                      }
+                          <EuiContextMenu
+                            panels={panels}
+                            initialPanelId={0}
+                            data-test-subj="case-table-bulk-actions-context-menu"
+                          />
+                        </EuiPopover>
+                      </EuiFlexItem>
+                    </>
+                  )}
+                  <EuiFlexItem grow={false}>
+                    <EuiButtonEmpty
+                      onClick={onRefresh}
+                      size="xs"
+                      iconSide="left"
+                      iconType="refresh"
+                      flush="left"
+                      data-test-subj="all-cases-refresh-link-icon"
                     >
-                      <EuiContextMenu
-                        panels={panels}
-                        initialPanelId={0}
-                        data-test-subj="case-table-bulk-actions-context-menu"
-                      />
-                    </EuiPopover>
+                      {i18n.REFRESH}
+                    </EuiButtonEmpty>
                   </EuiFlexItem>
-                </>
-              )}
-              <EuiFlexItem grow={false}>
-                <EuiButtonEmpty
-                  onClick={onRefresh}
-                  size="xs"
-                  iconSide="left"
-                  iconType="refresh"
-                  flush="left"
-                  data-test-subj="all-cases-refresh-link-icon"
-                >
-                  {i18n.REFRESH}
-                </EuiButtonEmpty>
+                </EuiFlexGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiFlexItem>
+          {!isSelectorView && (
+            <EuiFlexItem grow={false}>
+              <ColumnsPopover
+                selectedColumns={selectedColumns}
+                onSelectedColumnsChange={onSelectedColumnsChange}
+              />
+            </EuiFlexItem>
+          )}
         </EuiFlexGroup>
         {modals}
         {flyouts}

--- a/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utility_bar.tsx
@@ -22,7 +22,8 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import * as i18n from './translations';
-import type { CasesColumnSelection, CasesUI } from '../../../common/ui/types';
+import type { CasesUI } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
 import { MAX_DOCS_PER_PAGE } from '../../../common/constants';
 import { useRefreshCases } from './use_on_refresh_cases';
 import { useBulkActions } from './use_bulk_actions';

--- a/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
@@ -5,7 +5,10 @@
  * 2.0.
  */
 
-import { parseUrlQueryParams } from './utils';
+import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
+import type { CasesColumnSelection } from '../../containers/types';
+
+import { mergeSelectedColumnsWithConfiguration, parseUrlQueryParams } from './utils';
 import { DEFAULT_QUERY_PARAMS } from '../../containers/use_get_cases';
 
 const DEFAULT_STRING_QUERY_PARAMS = {
@@ -66,6 +69,65 @@ describe('utils', () => {
           foo: 'bar',
         })
       ).toStrictEqual(DEFAULT_QUERY_PARAMS);
+    });
+  });
+
+  describe('mergeSelectedColumnsWithConfiguration', () => {
+    const mockConfiguration: CasesColumnsConfiguration = {
+      foo: { field: 'foo', name: 'foo', canDisplay: true },
+      bar: { field: 'bar', name: 'bar', canDisplay: true },
+    };
+    const mockSelectedColumns: CasesColumnSelection[] = [
+      { field: 'foo', name: 'foo', isChecked: true },
+      { field: 'bar', name: 'bar', isChecked: true },
+    ];
+
+    it('does not return selectedColumns without a matching configuration', () => {
+      expect(
+        mergeSelectedColumnsWithConfiguration({
+          selectedColumns: [
+            ...mockSelectedColumns,
+            { field: 'foobar', name: 'foobar', isChecked: true },
+          ],
+          casesColumnsConfig: mockConfiguration,
+        })
+      ).toStrictEqual(mockSelectedColumns);
+    });
+
+    it('does not return selectedColumns with canDisplay value false in configuration', () => {
+      expect(
+        mergeSelectedColumnsWithConfiguration({
+          selectedColumns: mockSelectedColumns,
+          casesColumnsConfig: {
+            ...mockConfiguration,
+            bar: { ...mockConfiguration.bar, canDisplay: false },
+          },
+        })
+      ).toStrictEqual([mockSelectedColumns[0]]);
+    });
+
+    it('does not return selectedColumns without a field in the configuration', () => {
+      expect(
+        mergeSelectedColumnsWithConfiguration({
+          selectedColumns: mockSelectedColumns,
+          casesColumnsConfig: {
+            ...mockConfiguration,
+            bar: { ...mockConfiguration.bar, field: '' },
+          },
+        })
+      ).toStrictEqual([mockSelectedColumns[0]]);
+    });
+
+    it('result contains columns missing in the selectedColumns with isChecked false', () => {
+      expect(
+        mergeSelectedColumnsWithConfiguration({
+          selectedColumns: [],
+          casesColumnsConfig: mockConfiguration,
+        })
+      ).toStrictEqual([
+        { field: 'foo', name: 'foo', isChecked: false },
+        { field: 'bar', name: 'bar', isChecked: false },
+      ]);
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
-import type { CasesColumnSelection } from '../../containers/types';
+import type { CasesColumnSelection } from './types';
 
 import { mergeSelectedColumnsWithConfiguration, parseUrlQueryParams } from './utils';
 import { DEFAULT_QUERY_PARAMS } from '../../containers/use_get_cases';

--- a/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.test.tsx
@@ -129,5 +129,20 @@ describe('utils', () => {
         { field: 'bar', name: 'bar', isChecked: false },
       ]);
     });
+
+    it('result does not include columns missing in the selectedColumns when canDisplay=false', () => {
+      expect(
+        mergeSelectedColumnsWithConfiguration({
+          selectedColumns: [],
+          casesColumnsConfig: {
+            ...mockConfiguration,
+            foobar: { field: 'foobar', name: 'foobar', canDisplay: false },
+          },
+        })
+      ).toStrictEqual([
+        { field: 'foo', name: 'foo', isChecked: false },
+        { field: 'bar', name: 'bar', isChecked: false },
+      ]);
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/utils.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.ts
@@ -6,11 +6,8 @@
  */
 
 import { difference } from 'lodash';
-import type {
-  CasesColumnSelection,
-  ParsedUrlQueryParams,
-  PartialQueryParams,
-} from '../../../common/ui/types';
+import type { ParsedUrlQueryParams, PartialQueryParams } from '../../../common/ui/types';
+import type { CasesColumnSelection } from './types';
 import type { CasesColumnsConfiguration } from './use_cases_columns_configuration';
 
 export const parseUrlQueryParams = (parsedUrlParams: ParsedUrlQueryParams): PartialQueryParams => {

--- a/x-pack/plugins/cases/public/components/all_cases/utils.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.ts
@@ -42,13 +42,6 @@ export const mergeSelectedColumnsWithConfiguration = ({
   selectedColumns: CasesColumnSelection[];
   casesColumnsConfig: CasesColumnsConfiguration;
 }): CasesColumnSelection[] => {
-  // selectedColumns is the master
-  // iterate over selectedColumns
-  //   filter out those not in the configuration
-  //   filter out those that !canDisplay
-  //   add columnName
-  // add missing fields/columns from configuration
-
   const result = selectedColumns.reduce((accumulator, { field, isChecked }) => {
     if (
       field in casesColumnsConfig &&

--- a/x-pack/plugins/cases/public/components/all_cases/utils.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/utils.ts
@@ -72,7 +72,7 @@ export const mergeSelectedColumnsWithConfiguration = ({
 
   missingColumns.forEach((field) => {
     // can be an empty string
-    if (casesColumnsConfig[field].field) {
+    if (casesColumnsConfig[field].field && casesColumnsConfig[field].canDisplay) {
       result.push({
         field: casesColumnsConfig[field].field,
         name: casesColumnsConfig[field].name,

--- a/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
@@ -32,6 +32,7 @@ export const useCaseConfigureResponse = {
     id: '',
   },
   isLoading: false,
+  isFetching: false,
   refetch: jest.fn(),
 };
 

--- a/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.test.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.test.ts
@@ -18,6 +18,7 @@ describe('configureTextCustomFieldFactory ', () => {
     expect(builder).toEqual({
       id: 'text',
       label: 'Text',
+      getColumn: expect.any(Function),
       build: expect.any(Function),
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.test.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.test.ts
@@ -18,7 +18,7 @@ describe('configureTextCustomFieldFactory ', () => {
     expect(builder).toEqual({
       id: 'text',
       label: 'Text',
-      getColumn: expect.any(Function),
+      getEuiTableColumn: expect.any(Function),
       build: expect.any(Function),
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.ts
@@ -4,11 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
 import type { CustomFieldFactory } from '../types';
 import type { CaseCustomFieldText } from '../../../../common/types/domain';
+
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import * as i18n from '../translations';
+import { getColumn } from './get_column';
 import { Edit } from './edit';
 import { View } from './view';
 import { Configure } from './configure';
@@ -17,6 +18,7 @@ import { Create } from './create';
 export const configureTextCustomFieldFactory: CustomFieldFactory<CaseCustomFieldText> = () => ({
   id: CustomFieldTypes.TEXT,
   label: i18n.TEXT_LABEL,
+  getColumn,
   build: () => ({
     Configure,
     Edit,

--- a/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/configure_text_field.ts
@@ -9,7 +9,7 @@ import type { CaseCustomFieldText } from '../../../../common/types/domain';
 
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import * as i18n from '../translations';
-import { getColumn } from './get_column';
+import { getEuiTableColumn } from './get_eui_table_column';
 import { Edit } from './edit';
 import { View } from './view';
 import { Configure } from './configure';
@@ -18,7 +18,7 @@ import { Create } from './create';
 export const configureTextCustomFieldFactory: CustomFieldFactory<CaseCustomFieldText> = () => ({
   id: CustomFieldTypes.TEXT,
   label: i18n.TEXT_LABEL,
-  getColumn,
+  getEuiTableColumn,
   build: () => ({
     Configure,
     Edit,

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_column.test.tsx
@@ -41,6 +41,18 @@ describe('getColumn ', () => {
     expect(screen.getByTestId(`text-custom-field-column-view-${key}`)).toHaveTextContent(value);
   });
 
+  it('render function renders a null text column correctly', async () => {
+    const key = 'test_key_1';
+    const column = getColumn({ key, label: 'MockLabel' });
+    const theCase = { ...basicCase };
+
+    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value: null }];
+
+    render(<TestProviders>{column.render(theCase)}</TestProviders>);
+
+    expect(screen.getByTestId(`empty-text-custom-field-column-view-${key}`)).toBeInTheDocument();
+  });
+
   it('render function handles a missing custom field correctly', async () => {
     const key = 'test_key_1';
     const column = getColumn({ key, label: 'MockLabel' });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_column.test.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { CustomFieldTypes } from '../../../../common/types/domain';
+import { basicCase } from '../../../containers/mock';
+import { TestProviders } from '../../../common/mock';
+import { getColumn } from './get_column';
+
+describe('getColumn ', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a name and a render function', async () => {
+    const label = 'MockLabel';
+
+    expect(getColumn({ key: 'test_key_1', label })).toEqual({
+      name: label,
+      render: expect.any(Function),
+    });
+  });
+
+  it('render function renders a text column correctly', async () => {
+    const key = 'test_key_1';
+    const value = 'foobar';
+    const column = getColumn({ key, label: 'MockLabel' });
+    const theCase = { ...basicCase };
+
+    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value }];
+
+    render(<TestProviders>{column.render(theCase)}</TestProviders>);
+
+    expect(screen.getByTestId(`text-custom-field-column-view-${key}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`text-custom-field-column-view-${key}`)).toHaveTextContent(value);
+  });
+
+  it('render function handles a missing custom field correctly', async () => {
+    const key = 'test_key_1';
+    const column = getColumn({ key, label: 'MockLabel' });
+    const theCase = basicCase;
+
+    render(<TestProviders>{column.render(theCase)}</TestProviders>);
+
+    expect(screen.getByTestId(`empty-text-custom-field-column-view-${key}`)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import type { EuiTableComputedColumnType } from '@elastic/eui';
+import type { CaseUI } from '../../../containers/types';
+
+export const getColumn = ({
+  key,
+  label,
+}: {
+  key: string;
+  label: string;
+}): EuiTableComputedColumnType<CaseUI> => ({
+  name: label,
+  render: (theCase: CaseUI) => {
+    const index = theCase.customFields.findIndex((element) => element.key === key);
+
+    if (index !== -1) {
+      return <p>{theCase.customFields[index].value}</p>;
+    }
+  },
+});

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import type { EuiTableComputedColumnType } from '@elastic/eui';
 import type { CaseUI } from '../../../containers/types';
+import { getEmptyTagValue } from '../../empty_value';
 
 export const getColumn = ({
   key,
@@ -22,7 +23,15 @@ export const getColumn = ({
     const index = theCase.customFields.findIndex((element) => element.key === key);
 
     if (index !== -1) {
-      return <p>{theCase.customFields[index].value}</p>;
+      return (
+        <p data-test-subj={`text-custom-field-column-view-${key}`}>
+          {theCase.customFields[index].value}
+        </p>
+      );
     }
+
+    return (
+      <div data-test-subj={`empty-text-custom-field-column-view-${key}`}>{getEmptyTagValue()}</div>
+    );
   },
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_column.tsx
@@ -20,7 +20,9 @@ export const getColumn = ({
 }): EuiTableComputedColumnType<CaseUI> => ({
   name: label,
   render: (theCase: CaseUI) => {
-    const index = theCase.customFields.findIndex((element) => element.key === key);
+    const index = theCase.customFields.findIndex(
+      (element) => element.key === key && element.value !== null
+    );
 
     if (index !== -1) {
       return (

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
@@ -11,9 +11,9 @@ import { render, screen } from '@testing-library/react';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import { basicCase } from '../../../containers/mock';
 import { TestProviders } from '../../../common/mock';
-import { getColumn } from './get_column';
+import { getEuiTableColumn } from './get_eui_table_column';
 
-describe('getColumn ', () => {
+describe('getEuiTableColumn ', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -21,7 +21,7 @@ describe('getColumn ', () => {
   it('returns a name and a render function', async () => {
     const label = 'MockLabel';
 
-    expect(getColumn({ key: 'test_key_1', label })).toEqual({
+    expect(getEuiTableColumn({ key: 'test_key_1', label })).toEqual({
       name: label,
       render: expect.any(Function),
     });
@@ -30,7 +30,7 @@ describe('getColumn ', () => {
   it('render function renders a text column correctly', async () => {
     const key = 'test_key_1';
     const value = 'foobar';
-    const column = getColumn({ key, label: 'MockLabel' });
+    const column = getEuiTableColumn({ key, label: 'MockLabel' });
     const theCase = { ...basicCase };
 
     theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value }];
@@ -43,7 +43,7 @@ describe('getColumn ', () => {
 
   it('render function renders a null text column correctly', async () => {
     const key = 'test_key_1';
-    const column = getColumn({ key, label: 'MockLabel' });
+    const column = getEuiTableColumn({ key, label: 'MockLabel' });
     const theCase = { ...basicCase };
 
     theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value: null }];
@@ -55,7 +55,7 @@ describe('getColumn ', () => {
 
   it('render function handles a missing custom field correctly', async () => {
     const key = 'test_key_1';
-    const column = getColumn({ key, label: 'MockLabel' });
+    const column = getEuiTableColumn({ key, label: 'MockLabel' });
     const theCase = basicCase;
 
     render(<TestProviders>{column.render(theCase)}</TestProviders>);

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
@@ -28,7 +28,7 @@ describe('getEuiTableColumn ', () => {
     expect(getEuiTableColumn({ label })).toEqual({
       name: label,
       render: expect.any(Function),
-      width: '100px',
+      width: '250px',
     });
   });
 

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.test.tsx
@@ -6,60 +6,40 @@
  */
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { CustomFieldTypes } from '../../../../common/types/domain';
-import { basicCase } from '../../../containers/mock';
-import { TestProviders } from '../../../common/mock';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 import { getEuiTableColumn } from './get_eui_table_column';
 
 describe('getEuiTableColumn ', () => {
+  let appMockRender: AppMockRenderer;
+
   beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+
     jest.clearAllMocks();
   });
 
   it('returns a name and a render function', async () => {
     const label = 'MockLabel';
 
-    expect(getEuiTableColumn({ key: 'test_key_1', label })).toEqual({
+    expect(getEuiTableColumn({ label })).toEqual({
       name: label,
       render: expect.any(Function),
+      width: '100px',
     });
   });
 
   it('render function renders a text column correctly', async () => {
     const key = 'test_key_1';
     const value = 'foobar';
-    const column = getEuiTableColumn({ key, label: 'MockLabel' });
-    const theCase = { ...basicCase };
+    const column = getEuiTableColumn({ label: 'MockLabel' });
 
-    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value }];
-
-    render(<TestProviders>{column.render(theCase)}</TestProviders>);
+    appMockRender.render(<div>{column.render({ key, type: CustomFieldTypes.TEXT, value })}</div>);
 
     expect(screen.getByTestId(`text-custom-field-column-view-${key}`)).toBeInTheDocument();
     expect(screen.getByTestId(`text-custom-field-column-view-${key}`)).toHaveTextContent(value);
-  });
-
-  it('render function renders a null text column correctly', async () => {
-    const key = 'test_key_1';
-    const column = getEuiTableColumn({ key, label: 'MockLabel' });
-    const theCase = { ...basicCase };
-
-    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT, value: null }];
-
-    render(<TestProviders>{column.render(theCase)}</TestProviders>);
-
-    expect(screen.getByTestId(`empty-text-custom-field-column-view-${key}`)).toBeInTheDocument();
-  });
-
-  it('render function handles a missing custom field correctly', async () => {
-    const key = 'test_key_1';
-    const column = getEuiTableColumn({ key, label: 'MockLabel' });
-    const theCase = basicCase;
-
-    render(<TestProviders>{column.render(theCase)}</TestProviders>);
-
-    expect(screen.getByTestId(`empty-text-custom-field-column-view-${key}`)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
@@ -11,7 +11,7 @@ import type { EuiTableComputedColumnType } from '@elastic/eui';
 import type { CaseUI } from '../../../containers/types';
 import { getEmptyTagValue } from '../../empty_value';
 
-export const getColumn = ({
+export const getEuiTableColumn = ({
   key,
   label,
 }: {

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
@@ -7,33 +7,18 @@
 
 import React from 'react';
 
-import type { EuiTableComputedColumnType } from '@elastic/eui';
-import type { CaseUI } from '../../../containers/types';
-import { getEmptyTagValue } from '../../empty_value';
+import type { CaseCustomField } from '../../../../common/types/domain';
+import type { CustomFieldEuiTableColumn } from '../types';
 
-export const getEuiTableColumn = ({
-  key,
-  label,
-}: {
-  key: string;
-  label: string;
-}): EuiTableComputedColumnType<CaseUI> => ({
+export const getEuiTableColumn = ({ label }: { label: string }): CustomFieldEuiTableColumn => ({
   name: label,
-  render: (theCase: CaseUI) => {
-    const index = theCase.customFields.findIndex(
-      (element) => element.key === key && element.value !== null
-    );
-
-    if (index !== -1) {
-      return (
-        <p data-test-subj={`text-custom-field-column-view-${key}`}>
-          {theCase.customFields[index].value}
-        </p>
-      );
-    }
-
-    return (
-      <div data-test-subj={`empty-text-custom-field-column-view-${key}`}>{getEmptyTagValue()}</div>
-    );
-  },
+  width: '100px',
+  render: (customField: CaseCustomField) => (
+    <p
+      className="eui-textTruncate"
+      data-test-subj={`text-custom-field-column-view-${customField.key}`}
+    >
+      {customField.value}
+    </p>
+  ),
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/get_eui_table_column.tsx
@@ -12,7 +12,7 @@ import type { CustomFieldEuiTableColumn } from '../types';
 
 export const getEuiTableColumn = ({ label }: { label: string }): CustomFieldEuiTableColumn => ({
   name: label,
-  width: '100px',
+  width: '250px',
   render: (customField: CaseCustomField) => (
     <p
       className="eui-textTruncate"

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_text_field.test.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_text_field.test.ts
@@ -18,6 +18,7 @@ describe('configureToggleCustomFieldFactory ', () => {
     expect(builder).toEqual({
       id: 'toggle',
       label: 'Toggle',
+      getColumn: expect.any(Function),
       build: expect.any(Function),
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_text_field.test.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_text_field.test.ts
@@ -18,7 +18,7 @@ describe('configureToggleCustomFieldFactory ', () => {
     expect(builder).toEqual({
       id: 'toggle',
       label: 'Toggle',
-      getColumn: expect.any(Function),
+      getEuiTableColumn: expect.any(Function),
       build: expect.any(Function),
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_toggle_field.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_toggle_field.ts
@@ -7,8 +7,10 @@
 
 import type { CustomFieldFactory } from '../types';
 import type { CaseCustomFieldToggle } from '../../../../common/types/domain';
+
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import * as i18n from '../translations';
+import { getColumn } from './get_column';
 import { Edit } from './edit';
 import { View } from './view';
 import { Configure } from './configure';
@@ -17,6 +19,7 @@ import { Create } from './create';
 export const configureToggleCustomFieldFactory: CustomFieldFactory<CaseCustomFieldToggle> = () => ({
   id: CustomFieldTypes.TOGGLE,
   label: i18n.TOGGLE_LABEL,
+  getColumn,
   build: () => ({
     Configure,
     Edit,

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_toggle_field.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/configure_toggle_field.ts
@@ -10,7 +10,7 @@ import type { CaseCustomFieldToggle } from '../../../../common/types/domain';
 
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import * as i18n from '../translations';
-import { getColumn } from './get_column';
+import { getEuiTableColumn } from './get_eui_table_column';
 import { Edit } from './edit';
 import { View } from './view';
 import { Configure } from './configure';
@@ -19,7 +19,7 @@ import { Create } from './create';
 export const configureToggleCustomFieldFactory: CustomFieldFactory<CaseCustomFieldToggle> = () => ({
   id: CustomFieldTypes.TOGGLE,
   label: i18n.TOGGLE_LABEL,
-  getColumn,
+  getEuiTableColumn,
   build: () => ({
     Configure,
     Edit,

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.test.tsx
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { CustomFieldTypes } from '../../../../common/types/domain';
+import { TestProviders } from '../../../common/mock';
+import { basicCase } from '../../../containers/mock';
+import { getColumn } from './get_column';
+
+describe('getColumn ', () => {
+  const key = 'test_key_1';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a name and a render function', async () => {
+    const label = 'MockLabel';
+
+    expect(getColumn({ key: 'test_key_1', label })).toEqual({
+      name: label,
+      render: expect.any(Function),
+    });
+  });
+
+  it.each([
+    ['true', 'true', [{ key, type: CustomFieldTypes.TOGGLE as const, value: true }]],
+    ['false', 'false', [{ key, type: CustomFieldTypes.TOGGLE as const, value: false }]],
+    ['null', 'false', [{ key, type: CustomFieldTypes.TOGGLE as const, value: null }]],
+    ['missing', 'false', []],
+  ])(
+    'render function renders a toggle column with value %s correctly',
+    async (_, expectedResult, customFields) => {
+      const label = 'MockLabel';
+      const column = getColumn({ key, label });
+      const theCase = { ...basicCase };
+
+      theCase.customFields = customFields;
+
+      render(<TestProviders>{column.render(theCase)}</TestProviders>);
+
+      expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toHaveAttribute(
+        'aria-checked',
+        expectedResult
+      );
+    }
+  );
+
+  it('render function handles a wrong type custom field error correctly', async () => {
+    const column = getColumn({ key, label: 'MockLabel' });
+    const theCase = { ...basicCase };
+
+    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT as const, value: 'true' }];
+
+    render(<TestProviders>{column.render(theCase)}</TestProviders>);
+
+    expect(screen.getByTestId(`empty-toggle-custom-field-column-view-${key}`)).toBeInTheDocument();
+  });
+});

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import type { EuiTableComputedColumnType } from '@elastic/eui';
+import { EuiSwitch } from '@elastic/eui';
+
+import type { CaseUI } from '../../../containers/types';
+import { CustomFieldTypes } from '../../../../common/types/domain';
+
+export const getColumn = ({
+  key,
+  label,
+}: {
+  key: string;
+  label: string;
+}): EuiTableComputedColumnType<CaseUI> => ({
+  name: label,
+  render: (theCase: CaseUI) => {
+    const index = theCase.customFields.findIndex((element) => element.key === key);
+
+    if (index !== -1 && theCase.customFields[index].type !== CustomFieldTypes.TOGGLE) {
+      // should never happen, means something went wrong
+      return;
+    }
+
+    const value = theCase.customFields[index].value;
+    const isChecked = index !== -1 && value !== null && typeof value !== 'string' && value;
+
+    return <EuiSwitch label={''} checked={isChecked} onChange={() => {}} compressed />;
+  },
+});

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_column.tsx
@@ -12,6 +12,7 @@ import { EuiSwitch } from '@elastic/eui';
 
 import type { CaseUI } from '../../../containers/types';
 import { CustomFieldTypes } from '../../../../common/types/domain';
+import { getEmptyTagValue } from '../../empty_value';
 
 export const getColumn = ({
   key,
@@ -24,14 +25,38 @@ export const getColumn = ({
   render: (theCase: CaseUI) => {
     const index = theCase.customFields.findIndex((element) => element.key === key);
 
-    if (index !== -1 && theCase.customFields[index].type !== CustomFieldTypes.TOGGLE) {
+    if (index === -1) {
+      return (
+        <EuiSwitch
+          data-test-subj={`toggle-custom-field-column-view-${key}`}
+          label={''}
+          checked={false}
+          onChange={() => {}}
+          compressed
+        />
+      );
+    }
+
+    if (theCase.customFields[index].type !== CustomFieldTypes.TOGGLE) {
       // should never happen, means something went wrong
-      return;
+      return (
+        <div data-test-subj={`empty-toggle-custom-field-column-view-${key}`}>
+          {getEmptyTagValue()}
+        </div>
+      );
     }
 
     const value = theCase.customFields[index].value;
-    const isChecked = index !== -1 && value !== null && typeof value !== 'string' && value;
+    const isChecked = typeof value === 'boolean' && value;
 
-    return <EuiSwitch label={''} checked={isChecked} onChange={() => {}} compressed />;
+    return (
+      <EuiSwitch
+        data-test-subj={`toggle-custom-field-column-view-${key}`}
+        label={''}
+        checked={isChecked}
+        onChange={() => {}}
+        compressed
+      />
+    );
   },
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
@@ -11,9 +11,9 @@ import { render, screen } from '@testing-library/react';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import { TestProviders } from '../../../common/mock';
 import { basicCase } from '../../../containers/mock';
-import { getColumn } from './get_column';
+import { getEuiTableColumn } from './get_eui_table_column';
 
-describe('getColumn ', () => {
+describe('getEuiTableColumn ', () => {
   const key = 'test_key_1';
 
   beforeEach(() => {
@@ -23,7 +23,7 @@ describe('getColumn ', () => {
   it('returns a name and a render function', async () => {
     const label = 'MockLabel';
 
-    expect(getColumn({ key: 'test_key_1', label })).toEqual({
+    expect(getEuiTableColumn({ key: 'test_key_1', label })).toEqual({
       name: label,
       render: expect.any(Function),
     });
@@ -38,7 +38,7 @@ describe('getColumn ', () => {
     'render function renders a toggle column with value %s correctly',
     async (_, expectedResult, customFields) => {
       const label = 'MockLabel';
-      const column = getColumn({ key, label });
+      const column = getEuiTableColumn({ key, label });
       const theCase = { ...basicCase };
 
       theCase.customFields = customFields;
@@ -54,7 +54,7 @@ describe('getColumn ', () => {
   );
 
   it('render function handles a wrong type custom field error correctly', async () => {
-    const column = getColumn({ key, label: 'MockLabel' });
+    const column = getEuiTableColumn({ key, label: 'MockLabel' });
     const theCase = { ...basicCase };
 
     theCase.customFields = [{ key, type: CustomFieldTypes.TEXT as const, value: 'true' }];

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
@@ -6,44 +6,43 @@
  */
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 import { CustomFieldTypes } from '../../../../common/types/domain';
-import { TestProviders } from '../../../common/mock';
-import { basicCase } from '../../../containers/mock';
+import type { AppMockRenderer } from '../../../common/mock';
+import { createAppMockRenderer } from '../../../common/mock';
 import { getEuiTableColumn } from './get_eui_table_column';
 
 describe('getEuiTableColumn ', () => {
+  let appMockRender: AppMockRenderer;
   const key = 'test_key_1';
 
   beforeEach(() => {
+    appMockRender = createAppMockRenderer();
     jest.clearAllMocks();
   });
 
   it('returns a name and a render function', async () => {
     const label = 'MockLabel';
 
-    expect(getEuiTableColumn({ key: 'test_key_1', label })).toEqual({
+    expect(getEuiTableColumn({ label })).toEqual({
       name: label,
       render: expect.any(Function),
+      width: '100px',
     });
   });
 
   it.each([
-    ['true', 'true', [{ key, type: CustomFieldTypes.TOGGLE as const, value: true }]],
-    ['false', 'false', [{ key, type: CustomFieldTypes.TOGGLE as const, value: false }]],
-    ['null', 'false', [{ key, type: CustomFieldTypes.TOGGLE as const, value: null }]],
-    ['missing', 'false', []],
+    ['true', 'true', { key, type: CustomFieldTypes.TOGGLE as const, value: true }],
+    ['false', 'false', { key, type: CustomFieldTypes.TOGGLE as const, value: false }],
+    ['null', 'false', { key, type: CustomFieldTypes.TOGGLE as const, value: null }],
   ])(
     'render function renders a toggle column with value %s correctly',
-    async (_, expectedResult, customFields) => {
+    async (_, expectedResult, customField) => {
       const label = 'MockLabel';
-      const column = getEuiTableColumn({ key, label });
-      const theCase = { ...basicCase };
+      const column = getEuiTableColumn({ label });
 
-      theCase.customFields = customFields;
-
-      render(<TestProviders>{column.render(theCase)}</TestProviders>);
+      appMockRender.render(<div>{column.render(customField)}</div>);
 
       expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toBeInTheDocument();
       expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toHaveAttribute(
@@ -52,15 +51,4 @@ describe('getEuiTableColumn ', () => {
       );
     }
   );
-
-  it('render function handles a wrong type custom field error correctly', async () => {
-    const column = getEuiTableColumn({ key, label: 'MockLabel' });
-    const theCase = { ...basicCase };
-
-    theCase.customFields = [{ key, type: CustomFieldTypes.TEXT as const, value: 'true' }];
-
-    render(<TestProviders>{column.render(theCase)}</TestProviders>);
-
-    expect(screen.getByTestId(`empty-toggle-custom-field-column-view-${key}`)).toBeInTheDocument();
-  });
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.test.tsx
@@ -33,9 +33,9 @@ describe('getEuiTableColumn ', () => {
   });
 
   it.each([
-    ['true', 'true', { key, type: CustomFieldTypes.TOGGLE as const, value: true }],
-    ['false', 'false', { key, type: CustomFieldTypes.TOGGLE as const, value: false }],
-    ['null', 'false', { key, type: CustomFieldTypes.TOGGLE as const, value: null }],
+    ['true', 'check', { key, type: CustomFieldTypes.TOGGLE as const, value: true }],
+    ['false', 'cross', { key, type: CustomFieldTypes.TOGGLE as const, value: false }],
+    ['null', 'cross', { key, type: CustomFieldTypes.TOGGLE as const, value: null }],
   ])(
     'render function renders a toggle column with value %s correctly',
     async (_, expectedResult, customField) => {
@@ -44,11 +44,9 @@ describe('getEuiTableColumn ', () => {
 
       appMockRender.render(<div>{column.render(customField)}</div>);
 
-      expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toBeInTheDocument();
-      expect(screen.getByTestId(`toggle-custom-field-column-view-${key}`)).toHaveAttribute(
-        'aria-checked',
-        expectedResult
-      );
+      expect(
+        screen.getByTestId(`toggle-custom-field-column-view-${key}-${expectedResult}`)
+      ).toBeInTheDocument();
     }
   );
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
@@ -14,7 +14,7 @@ import type { CaseUI } from '../../../containers/types';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import { getEmptyTagValue } from '../../empty_value';
 
-export const getColumn = ({
+export const getEuiTableColumn = ({
   key,
   label,
 }: {

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-import { EuiSwitch } from '@elastic/eui';
+import { EuiIcon } from '@elastic/eui';
 
 import type { CaseCustomField } from '../../../../common/types/domain';
 import type { CustomFieldEuiTableColumn } from '../types';
@@ -16,12 +16,11 @@ export const getEuiTableColumn = ({ label }: { label: string }): CustomFieldEuiT
   name: label,
   width: '100px',
   render: (customField: CaseCustomField) => (
-    <EuiSwitch
-      data-test-subj={`toggle-custom-field-column-view-${customField.key}`}
-      label={''}
-      checked={Boolean(customField?.value)}
-      onChange={() => {}}
-      compressed
+    <EuiIcon
+      data-test-subj={`toggle-custom-field-column-view-${customField.key}-${
+        customField?.value ? 'check' : 'cross'
+      }`}
+      type={customField?.value ? 'check' : 'cross'}
     />
   ),
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/get_eui_table_column.tsx
@@ -7,56 +7,21 @@
 
 import React from 'react';
 
-import type { EuiTableComputedColumnType } from '@elastic/eui';
 import { EuiSwitch } from '@elastic/eui';
 
-import type { CaseUI } from '../../../containers/types';
-import { CustomFieldTypes } from '../../../../common/types/domain';
-import { getEmptyTagValue } from '../../empty_value';
+import type { CaseCustomField } from '../../../../common/types/domain';
+import type { CustomFieldEuiTableColumn } from '../types';
 
-export const getEuiTableColumn = ({
-  key,
-  label,
-}: {
-  key: string;
-  label: string;
-}): EuiTableComputedColumnType<CaseUI> => ({
+export const getEuiTableColumn = ({ label }: { label: string }): CustomFieldEuiTableColumn => ({
   name: label,
-  render: (theCase: CaseUI) => {
-    const index = theCase.customFields.findIndex((element) => element.key === key);
-
-    if (index === -1) {
-      return (
-        <EuiSwitch
-          data-test-subj={`toggle-custom-field-column-view-${key}`}
-          label={''}
-          checked={false}
-          onChange={() => {}}
-          compressed
-        />
-      );
-    }
-
-    if (theCase.customFields[index].type !== CustomFieldTypes.TOGGLE) {
-      // should never happen, means something went wrong
-      return (
-        <div data-test-subj={`empty-toggle-custom-field-column-view-${key}`}>
-          {getEmptyTagValue()}
-        </div>
-      );
-    }
-
-    const value = theCase.customFields[index].value;
-    const isChecked = typeof value === 'boolean' && value;
-
-    return (
-      <EuiSwitch
-        data-test-subj={`toggle-custom-field-column-view-${key}`}
-        label={''}
-        checked={isChecked}
-        onChange={() => {}}
-        compressed
-      />
-    );
-  },
+  width: '100px',
+  render: (customField: CaseCustomField) => (
+    <EuiSwitch
+      data-test-subj={`toggle-custom-field-column-view-${customField.key}`}
+      label={''}
+      checked={Boolean(customField?.value)}
+      onChange={() => {}}
+      compressed
+    />
+  ),
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/types.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/types.ts
@@ -6,8 +6,14 @@
  */
 
 import type React from 'react';
+import type { EuiTableComputedColumnType } from '@elastic/eui';
+
 import type { CustomFieldTypes } from '../../../common/types/domain';
-import type { CasesConfigurationUICustomField, CaseUICustomField } from '../../containers/types';
+import type {
+  CasesConfigurationUICustomField,
+  CaseUICustomField,
+  CaseUI,
+} from '../../containers/types';
 
 export interface CustomFieldType<T extends CaseUICustomField> {
   Configure: React.FC;
@@ -30,6 +36,7 @@ export interface CustomFieldType<T extends CaseUICustomField> {
 export type CustomFieldFactory<T extends CaseUICustomField> = () => {
   id: string;
   label: string;
+  getColumn: (params: { key: string; label: string }) => EuiTableComputedColumnType<CaseUI>;
   build: () => CustomFieldType<T>;
 };
 

--- a/x-pack/plugins/cases/public/components/custom_fields/types.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/types.ts
@@ -36,7 +36,7 @@ export interface CustomFieldType<T extends CaseUICustomField> {
 export type CustomFieldFactory<T extends CaseUICustomField> = () => {
   id: string;
   label: string;
-  getColumn: (params: { key: string; label: string }) => EuiTableComputedColumnType<CaseUI>;
+  getEuiTableColumn: (params: { key: string; label: string }) => EuiTableComputedColumnType<CaseUI>;
   build: () => CustomFieldType<T>;
 };
 

--- a/x-pack/plugins/cases/public/components/custom_fields/types.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/types.ts
@@ -8,11 +8,11 @@
 import type React from 'react';
 import type { EuiTableComputedColumnType } from '@elastic/eui';
 
-import type { CustomFieldTypes } from '../../../common/types/domain';
+import type { CaseCustomField, CustomFieldTypes } from '../../../common/types/domain';
 import type {
   CasesConfigurationUICustomField,
-  CaseUICustomField,
   CaseUI,
+  CaseUICustomField,
 } from '../../containers/types';
 
 export interface CustomFieldType<T extends CaseUICustomField> {
@@ -33,10 +33,17 @@ export interface CustomFieldType<T extends CaseUICustomField> {
   }>;
 }
 
+export type CustomFieldEuiTableColumn = Pick<
+  EuiTableComputedColumnType<CaseUI>,
+  'name' | 'width'
+> & {
+  render: (customField: CaseCustomField) => React.ReactNode;
+};
+
 export type CustomFieldFactory<T extends CaseUICustomField> = () => {
   id: string;
   label: string;
-  getEuiTableColumn: (params: { key: string; label: string }) => EuiTableComputedColumnType<CaseUI>;
+  getEuiTableColumn: (params: { label: string }) => CustomFieldEuiTableColumn;
   build: () => CustomFieldType<T>;
 };
 

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -20,6 +20,7 @@ export function CasesTableServiceProvider(
   const testSubjects = getService('testSubjects');
   const find = getService('find');
   const header = getPageObject('header');
+  const browser = getService('browser');
   const retry = getService('retry');
   const config = getService('config');
 
@@ -390,6 +391,23 @@ export function CasesTableServiceProvider(
       ).findByTestSubject('case-details-link');
 
       return await titleElement.getVisibleText();
+    },
+
+    async hasColumn(columnName: string) {
+      const column = await find.allByCssSelector(
+        `th.euiTableHeaderCell span[title="${columnName}"]`
+      );
+      return column.length !== 0;
+    },
+
+    async toggleColumnInPopover(columnId: string) {
+      await testSubjects.click('column-selection-popover');
+
+      await testSubjects.existOrFail(`column-selection-switch-${columnId}`);
+      await testSubjects.click(`column-selection-switch-${columnId}`);
+
+      // closes the popover
+      await browser.pressKeys(browser.keys.ESCAPE);
     },
   };
 }

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -401,7 +401,7 @@ export function CasesTableServiceProvider(
     },
 
     async toggleColumnInPopover(columnId: string) {
-      await testSubjects.click('column-selection-popover');
+      await testSubjects.click('column-selection-popover-button');
 
       await testSubjects.existOrFail(`column-selection-switch-${columnId}`);
       await testSubjects.click(`column-selection-switch-${columnId}`);

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -6,11 +6,7 @@
  */
 
 import expect from '@kbn/expect';
-import {
-  CaseSeverity,
-  CaseStatuses,
-  CustomFieldTypes,
-} from '@kbn/cases-plugin/common/types/domain';
+import { CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { SeverityAll } from '@kbn/cases-plugin/common/ui';
 import { UserProfile } from '@kbn/user-profile-components';
 import { FtrProviderContext } from '../../../ftr_provider_context';

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -6,7 +6,11 @@
  */
 
 import expect from '@kbn/expect';
-import { CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
+import {
+  CaseSeverity,
+  CaseStatuses,
+  CustomFieldTypes,
+} from '@kbn/cases-plugin/common/types/domain';
 import { SeverityAll } from '@kbn/cases-plugin/common/ui';
 import { UserProfile } from '@kbn/user-profile-components';
 import { FtrProviderContext } from '../../../ftr_provider_context';
@@ -656,6 +660,44 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
           await cases.casesTable.waitForTableToFinishLoading();
           await cases.casesTable.validateCasesTableHasNthRows(0);
         });
+      });
+    });
+
+    describe('Column Selection', () => {
+      afterEach(async () => {
+        await toasts.dismissAllToastsWithChecks();
+      });
+
+      before(async () => {
+        await cases.api.createNthRandomCases(1);
+        await header.waitUntilLoadingHasFinished();
+        await cases.casesTable.waitForCasesToBeListed();
+      });
+
+      after(async () => {
+        await cases.api.deleteAllCases();
+        await cases.casesTable.waitForCasesToBeDeleted();
+        await browser.clearLocalStorage();
+      });
+
+      it('column selection popover exists', async () => {
+        await testSubjects.existOrFail('column-selection-popover');
+      });
+
+      it('selecting a column works correctly', async () => {
+        expect(await cases.casesTable.hasColumn('Closed on')).to.be(false);
+
+        await cases.casesTable.toggleColumnInPopover('closedAt');
+
+        expect(await cases.casesTable.hasColumn('Closed on')).to.be(true);
+      });
+
+      it('deselecting columns works correctly', async () => {
+        expect(await cases.casesTable.hasColumn('Name')).to.be(true);
+
+        await cases.casesTable.toggleColumnInPopover('title');
+
+        expect(await cases.casesTable.hasColumn('Name')).to.be(false);
       });
     });
   });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -677,7 +677,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
 
       it('column selection popover exists', async () => {
-        await testSubjects.existOrFail('column-selection-popover');
+        await testSubjects.existOrFail('column-selection-popover-button');
       });
 
       it('selecting a column works correctly', async () => {


### PR DESCRIPTION
Connected to #167617

This PR is being merged into a feature branch

## Summary

This PR allows users to configure which columns are displayed in the cases table and in which order.

The configuration is persisted in local storage and is application-specific.

Custom fields can also be selected.

https://github.com/elastic/kibana/assets/1533137/da386a6c-b2d9-4a86-948f-79903163ff3c

## Coming later in the Feature Branch

The scope of this PR is limited to the Summary above. There are still some things under consideration and some coming later. These are:
- The display of the toggle in the table. Right now it looks clickable when it isn't. I will discuss it with @mdefazio and pick a different design.
- Scrolling inside the popover
- Search inside the popover
- `Show all` and `Hide all` functionality
- In the final PR I will play with the column widths and try to find the best size for each attribute.
