### PR TITLE
feat(slo): return early when no update is made

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/update_slo.test.ts
@@ -8,7 +8,7 @@
 import { ElasticsearchClient } from '@kbn/core/server';
 import { elasticsearchServiceMock } from '@kbn/core/server/mocks';
 import { UpdateSLOParams } from '@kbn/slo-schema';
-import { cloneDeep } from 'lodash';
+import { cloneDeep, pick, omit } from 'lodash';
 
 import {
   getSLOTransformId,
@@ -40,30 +40,121 @@ describe('UpdateSLO', () => {
     updateSLO = new UpdateSLO(mockRepository, mockTransformManager, mockEsClient);
   });
 
-  it('does nothing when no changes are provided', async () => {
-    const slo = createSLO();
-    mockRepository.findById.mockResolvedValueOnce(slo);
+  describe('when the update payload does not change the original SLO', () => {
+    function expectNoCallsToAnyMocks() {
+      expect(mockTransformManager.stop).not.toBeCalled();
+      expect(mockTransformManager.uninstall).not.toBeCalled();
+      expect(mockTransformManager.install).not.toBeCalled();
+      expect(mockTransformManager.preview).not.toBeCalled();
+      expect(mockTransformManager.start).not.toBeCalled();
+      expect(mockEsClient.deleteByQuery).not.toBeCalled();
+    }
 
-    const exactSameSlo: UpdateSLOParams = cloneDeep(slo);
-    // @ts-ignore
-    delete exactSameSlo.id;
-    // @ts-ignore
-    delete exactSameSlo.revision;
-    // @ts-ignore
-    delete exactSameSlo.createdAt;
-    // @ts-ignore
-    delete exactSameSlo.updatedAt;
-    // @ts-ignore
-    delete exactSameSlo.enabled;
+    it('returns early with a full identical SLO payload', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = omit(cloneDeep(slo), [
+        'id',
+        'revision',
+        'createdAt',
+        'updatedAt',
+        'enabled',
+      ]);
 
-    await updateSLO.execute(slo.id, exactSameSlo);
+      await updateSLO.execute(slo.id, updatePayload);
 
-    expect(mockTransformManager.stop).not.toBeCalled();
-    expect(mockTransformManager.uninstall).not.toBeCalled();
-    expect(mockTransformManager.install).not.toBeCalled();
-    expect(mockTransformManager.preview).not.toBeCalled();
-    expect(mockTransformManager.start).not.toBeCalled();
-    expect(mockEsClient.deleteByQuery).not.toBeCalled();
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical name', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['name']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical indicator', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['indicator']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical timeWindow', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['timeWindow']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical budgetingMethod', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['budgetingMethod']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical description', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['description']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical groupBy', async () => {
+      const slo = createSLO({ groupBy: 'project.id' });
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['groupBy']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical objective', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['objective']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical tags', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['tags']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
+
+    it('returns early with identical settings', async () => {
+      const slo = createSLO();
+      mockRepository.findById.mockResolvedValueOnce(slo);
+      const updatePayload: UpdateSLOParams = pick(cloneDeep(slo), ['settings']);
+
+      await updateSLO.execute(slo.id, updatePayload);
+
+      expectNoCallsToAnyMocks();
+    });
   });
 
   it('updates the settings correctly', async () => {


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/169530

## 🌮 Summary

This PR adds shortcut in the update SLO flow in case the update payload does not change the original SLO.
