### PR TITLE
[Controls] Fix flaky `a11y` test

### DIFF
--- a/x-pack/test/accessibility/apps/dashboard_controls.ts
+++ b/x-pack/test/accessibility/apps/dashboard_controls.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'dashboard', 'home', 'dashboardControls']);
   const browser = getService('browser');
 
-  describe.only('Dashboard controls a11y tests', () => {
+  describe('Dashboard controls a11y tests', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await PageObjects.common.navigateToUrl('home', '/tutorial_directory/sampleData', {

--- a/x-pack/test/accessibility/apps/dashboard_controls.ts
+++ b/x-pack/test/accessibility/apps/dashboard_controls.ts
@@ -15,7 +15,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'dashboard', 'home', 'dashboardControls']);
   const browser = getService('browser');
 
-  describe('Dashboard controls a11y tests', () => {
+  describe.only('Dashboard controls a11y tests', () => {
     before(async () => {
       await kibanaServer.savedObjects.cleanStandardList();
       await PageObjects.common.navigateToUrl('home', '/tutorial_directory/sampleData', {
@@ -23,8 +23,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await PageObjects.home.addSampleDataSet('flights');
       await PageObjects.common.navigateToApp('dashboard');
-      await testSubjects.click('dashboardListingTitleLink-[Flights]-Global-Flight-Dashboard');
-      await testSubjects.click('dashboardEditMode');
+      await PageObjects.dashboard.loadSavedDashboard('[Flights] Global Flight Dashboard');
+      await PageObjects.dashboard.switchToEditMode();
     });
 
     after(async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/169542

## Summary

For some reason, the search session popover was being opened, which blocked the controls button from being clickable:

![image](https://github.com/elastic/kibana/assets/8698078/6882e67e-6f17-4820-8e71-14e84c3d04c2)

I'm unsure why this popover is open to begin with; this should **only** happen when the `searchSessionIndicator` button is clicked, but this button is **not** interacted with in **any** of the accessibility tests (that I could find). This makes me suspicious that this is actually a **misclick** - i.e. the element that was meant to be clicked gets moved (possibly the Dashboard "edit" button?), which causes the `searchSessionIndicator` button to be clicked instead.

Going off this theory, I've switched the controls `a11y` tests to use the Dashboard page's methods (which have more safeguards in place) to navigate to the desired dashboard rather than clicking elements solely based off of the `data-test-subj` like we were previously.

### [Flaky Test Runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3686)

![image](https://github.com/elastic/kibana/assets/8698078/74fb0d27-9cb2-4650-ba91-97865a3bd962)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->