### PR TITLE
[7.17] [docs] Update docker image version

### DIFF
--- a/docs/setup/docker.asciidoc
+++ b/docs/setup/docker.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Docker images for {kib} are available from the Elastic Docker registry. The
-base image is https://hub.docker.com/_/ubuntu[ubuntu:20.04].
+base image is https://hub.docker.com/_/ubuntu[ubuntu:22.04].
 
 A list of all published Docker images and tags is available at
 https://www.docker.elastic.co[www.docker.elastic.co]. The source code is in


### PR DESCRIPTION
To be merged after https://github.com/elastic/kibana/pull/169581 is released.