### PR TITLE
[SecuritySolution][DataQualityDashboard] Stats api returns 404

### DIFF
--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_ilm_explain.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_ilm_explain.ts
@@ -6,13 +6,13 @@
  */
 
 import { IRouter, Logger } from '@kbn/core/server';
-import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { GET_ILM_EXPLAIN, INTERNAL_API_VERSION } from '../../common/constants';
 import { fetchILMExplain } from '../lib';
 import { buildResponse } from '../lib/build_response';
 import { buildRouteValidation } from '../schemas/common';
 import { GetILMExplainParams } from '../schemas/get_ilm_explain';
+import { API_DEFAULT_ERROR_MESSAGE } from '../translations';
 
 export const getILMExplainRoute = (router: IRouter, logger: Logger) => {
   router.versioned
@@ -42,12 +42,11 @@ export const getILMExplainRoute = (router: IRouter, logger: Logger) => {
             body: ilmExplain.indices,
           });
         } catch (err) {
-          const error = transformError(err);
+          logger.error(JSON.stringify(err));
 
-          logger.error(error.message);
           return resp.error({
-            body: error.message,
-            statusCode: error.statusCode,
+            body: err.message ?? API_DEFAULT_ERROR_MESSAGE,
+            statusCode: err.statusCode ?? 500,
           });
         }
       }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_mappings.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_mappings.ts
@@ -6,13 +6,13 @@
  */
 
 import { IRouter, Logger } from '@kbn/core/server';
-import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { fetchMappings } from '../lib';
 import { buildResponse } from '../lib/build_response';
 import { GET_INDEX_MAPPINGS, INTERNAL_API_VERSION } from '../../common/constants';
 import { GetIndexMappingsParams } from '../schemas/get_index_mappings';
 import { buildRouteValidation } from '../schemas/common';
+import { API_DEFAULT_ERROR_MESSAGE } from '../translations';
 
 export const getIndexMappingsRoute = (router: IRouter, logger: Logger) => {
   router.versioned
@@ -38,12 +38,11 @@ export const getIndexMappingsRoute = (router: IRouter, logger: Logger) => {
             body: mappings,
           });
         } catch (err) {
-          const error = transformError(err);
-          logger.error(error.message);
+          logger.error(JSON.stringify(err));
 
           return resp.error({
-            body: error.message,
-            statusCode: error.statusCode,
+            body: err.message ?? API_DEFAULT_ERROR_MESSAGE,
+            statusCode: err.statusCode ?? 500,
           });
         }
       }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -6,7 +6,6 @@
  */
 import { i18n } from '@kbn/i18n';
 import { IRouter, Logger } from '@kbn/core/server';
-import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { IndicesStatsIndicesStats } from '@elastic/elasticsearch/lib/api/types';
 import { fetchStats, fetchAvailableIndices } from '../lib';
@@ -87,12 +86,15 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
             });
           }
         } catch (err) {
-          const error = transformError(err);
-          logger.error(error.message);
+          logger.error(JSON.stringify(err));
 
           return resp.error({
-            body: error.message,
-            statusCode: error.statusCode,
+            body:
+              err.message ??
+              i18n.translate('xpack.ecsDataQualityDashboard.getIndexStats.defaultErrorMessage', {
+                defaultMessage: 'Internal Server Error',
+              }),
+            statusCode: err.statusCode ?? 500,
           });
         }
       }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_index_stats.ts
@@ -13,6 +13,7 @@ import { buildResponse } from '../lib/build_response';
 import { GET_INDEX_STATS, INTERNAL_API_VERSION } from '../../common/constants';
 import { buildRouteValidation } from '../schemas/common';
 import { GetIndexStatsParams, GetIndexStatsQuery } from '../schemas/get_index_stats';
+import { API_DEFAULT_ERROR_MESSAGE } from '../translations';
 
 export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
   router.versioned
@@ -89,11 +90,7 @@ export const getIndexStatsRoute = (router: IRouter, logger: Logger) => {
           logger.error(JSON.stringify(err));
 
           return resp.error({
-            body:
-              err.message ??
-              i18n.translate('xpack.ecsDataQualityDashboard.getIndexStats.defaultErrorMessage', {
-                defaultMessage: 'Internal Server Error',
-              }),
+            body: err.message ?? API_DEFAULT_ERROR_MESSAGE,
             statusCode: err.statusCode ?? 500,
           });
         }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_unallowed_field_values.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/routes/get_unallowed_field_values.ts
@@ -6,13 +6,13 @@
  */
 
 import { IRouter, Logger } from '@kbn/core/server';
-import { transformError } from '@kbn/securitysolution-es-utils';
 
 import { getUnallowedFieldValues } from '../lib';
 import { buildResponse } from '../lib/build_response';
 import { GET_UNALLOWED_FIELD_VALUES, INTERNAL_API_VERSION } from '../../common/constants';
 import { buildRouteValidation } from '../schemas/common';
 import { GetUnallowedFieldValuesBody } from '../schemas/get_unallowed_field_values';
+import { API_DEFAULT_ERROR_MESSAGE } from '../translations';
 
 export const getUnallowedFieldValuesRoute = (router: IRouter, logger: Logger) => {
   router.versioned
@@ -37,12 +37,11 @@ export const getUnallowedFieldValuesRoute = (router: IRouter, logger: Logger) =>
             body: responses,
           });
         } catch (err) {
-          const error = transformError(err);
-          logger.error(error.message);
+          logger.error(JSON.stringify(err));
 
           return resp.error({
-            body: error.message,
-            statusCode: error.statusCode,
+            body: err.message ?? API_DEFAULT_ERROR_MESSAGE,
+            statusCode: err.statusCode ?? 500,
           });
         }
       }

--- a/x-pack/plugins/ecs_data_quality_dashboard/server/translations.ts
+++ b/x-pack/plugins/ecs_data_quality_dashboard/server/translations.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const API_DEFAULT_ERROR_MESSAGE = i18n.translate(
+  'xpack.ecsDataQualityDashboard.api.defaultErrorMessage',
+  {
+    defaultMessage: 'Internal Server Error',
+  }
+);

--- a/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
+++ b/x-pack/plugins/ecs_data_quality_dashboard/tsconfig.json
@@ -16,7 +16,6 @@
     "@kbn/core-http-server",
     "@kbn/licensing-plugin",
     "@kbn/core-http-request-handler-context-server",
-    "@kbn/securitysolution-es-utils",
     "@kbn/securitysolution-io-ts-utils",
     "@kbn/securitysolution-io-ts-types",
     "@kbn/i18n",


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/166271
https://github.com/elastic/kibana/pull/169037

This PR is to fix stats api always return 404 on serverless:

<img width="2553" alt="Screenshot 2023-10-23 at 21 23 01" src="https://github.com/elastic/kibana/assets/6295984/e3ee0bf5-2eaf-4a36-b299-7914baf7d51a">
