### PR TITLE
[Security Solution] [Timelines] Adds timeline SO model version for serverless

### DIFF
--- a/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
+++ b/src/core/server/integration_tests/saved_objects/migrations/group2/check_registered_types.test.ts
@@ -139,7 +139,7 @@ describe('checking migration metadata changes on all registered SO types', () =>
         "security-rule": "07abb4d7e707d91675ec0495c73816394c7b521f",
         "security-solution-signals-migration": "9d99715fe5246f19de2273ba77debd2446c36bb1",
         "siem-detection-engine-rule-actions": "54f08e23887b20da7c805fab7c60bc67c428aff9",
-        "siem-ui-timeline": "2d9925f7286a9e947a008eff8e61118dadd8229b",
+        "siem-ui-timeline": "d3de8ff3617be8f2a799d66b1471b9be6124bf40",
         "siem-ui-timeline-note": "0a32fb776907f596bedca292b8c646496ae9c57b",
         "siem-ui-timeline-pinned-event": "082daa3ce647b33873f6abccf340bdfa32057c8d",
         "slo": "2048ab6791df2e1ae0936f29c20765cb8d2fcfaa",

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object_mappings/timelines.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object_mappings/timelines.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import type { SavedObjectsModelVersion } from '@kbn/core-saved-objects-server';
 import { SECURITY_SOLUTION_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
 import type { SavedObjectsType } from '@kbn/core/server';
 import { timelinesMigrations } from './migrations/timelines';
@@ -322,6 +323,19 @@ export const timelineSavedObjectMappings: SavedObjectsType['mappings'] = {
   },
 };
 
+const timelineSOVersion1: SavedObjectsModelVersion = {
+  changes: [
+    {
+      type: 'mappings_addition',
+      addedMappings: {
+        savedSearchId: {
+          type: 'text',
+        },
+      },
+    },
+  ],
+};
+
 export const timelineType: SavedObjectsType = {
   name: timelineSavedObjectType,
   indexPattern: SECURITY_SOLUTION_SAVED_OBJECT_INDEX,
@@ -330,4 +344,7 @@ export const timelineType: SavedObjectsType = {
   convertToMultiNamespaceTypeVersion: '8.0.0',
   mappings: timelineSavedObjectMappings,
   migrations: timelinesMigrations,
+  modelVersions: {
+    1: timelineSOVersion1,
+  },
 };


### PR DESCRIPTION
## Summary

In a [recent PR](https://github.com/elastic/kibana/pull/165596/files#diff-a2fb9c3ba1b24bab5df29ddc440dc4a8623b1e8850c9ca7da3b20f9b9631d7daR319), a new property called `savedSearchId` was added to the timeline Saved object. Although, it works correctly in ESS and new projects created in serverless, it does not work as intended in previously created serverless projects.

To make sure, the newly added field is migrated to the old projects, we must follow [these guidelines](https://github.com/elastic/kibana/blob/9b59e84d3e3601a12fa5ff33814393b8f7644010/packages/core/saved-objects/core-saved-objects-server/docs/model_versions.md#changes) to create appropriate model versions so that migration can happen incrementally as an when changes are done to the saved object.

This PR creates a model version for a newly created field `savedSearchId`.
