### PR TITLE
[ObsUX] Hide Alerts and rules dropdown behind feature flag in serverless

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -280,6 +280,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.infra.featureFlags.metricThresholdAlertRuleEnabled (any)',
         'xpack.infra.featureFlags.logThresholdAlertRuleEnabled (any)',
         'xpack.infra.featureFlags.logsUIEnabled (any)',
+        'xpack.infra.featureFlags.alertsAndRulesDropdownEnabled (any)',
 
         'xpack.license_management.ui.enabled (boolean)',
         'xpack.maps.preserveDrawingBuffer (boolean)',

--- a/x-pack/plugins/infra/common/plugin_config_types.ts
+++ b/x-pack/plugins/infra/common/plugin_config_types.ts
@@ -33,6 +33,7 @@ export interface InfraConfig {
     inventoryThresholdAlertRuleEnabled: boolean;
     metricThresholdAlertRuleEnabled: boolean;
     logThresholdAlertRuleEnabled: boolean;
+    alertsAndRulesDropdownEnabled: boolean;
   };
 }
 

--- a/x-pack/plugins/infra/public/containers/plugin_config_context.test.tsx
+++ b/x-pack/plugins/infra/public/containers/plugin_config_context.test.tsx
@@ -27,6 +27,7 @@ describe('usePluginConfig()', () => {
         inventoryThresholdAlertRuleEnabled: true,
         metricThresholdAlertRuleEnabled: true,
         logThresholdAlertRuleEnabled: true,
+        alertsAndRulesDropdownEnabled: true,
       },
     };
     const { result } = renderHook(() => usePluginConfig(), {

--- a/x-pack/plugins/infra/public/pages/metrics/index.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/index.tsx
@@ -85,7 +85,9 @@ export const InfrastructurePage = () => {
                           {settingsTabTitle}
                         </EuiHeaderLink>
                         <Route path={'/inventory'} component={AnomalyDetectionFlyout} />
-                        <MetricsAlertDropdown />
+                        {config.featureFlags.alertsAndRulesDropdownEnabled && (
+                          <MetricsAlertDropdown />
+                        )}
                         <EuiHeaderLink
                           href={kibana.services?.application?.getUrlForApp('/integrations/browse')}
                           color="primary"

--- a/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/metric_threshold/metric_threshold_executor.test.ts
@@ -2271,6 +2271,7 @@ const createMockStaticConfiguration = (sources: any): InfraConfig => ({
     inventoryThresholdAlertRuleEnabled: true,
     metricThresholdAlertRuleEnabled: true,
     logThresholdAlertRuleEnabled: true,
+    alertsAndRulesDropdownEnabled: true,
   },
   enabled: true,
   sources,

--- a/x-pack/plugins/infra/server/lib/sources/sources.test.ts
+++ b/x-pack/plugins/infra/server/lib/sources/sources.test.ts
@@ -133,6 +133,7 @@ const createMockStaticConfiguration = (sources: any): InfraConfig => ({
     inventoryThresholdAlertRuleEnabled: true,
     metricThresholdAlertRuleEnabled: true,
     logThresholdAlertRuleEnabled: true,
+    alertsAndRulesDropdownEnabled: true,
   },
   sources,
   enabled: true,

--- a/x-pack/plugins/infra/server/plugin.ts
+++ b/x-pack/plugins/infra/server/plugin.ts
@@ -109,6 +109,10 @@ export const config: PluginConfigDescriptor<InfraConfig> = {
         traditional: schema.boolean({ defaultValue: true }),
         serverless: schema.boolean({ defaultValue: false }),
       }),
+      alertsAndRulesDropdownEnabled: offeringBasedSchema({
+        traditional: schema.boolean({ defaultValue: true }),
+        serverless: schema.boolean({ defaultValue: false }),
+      }),
     }),
   }),
   deprecations: configDeprecations,

--- a/x-pack/test/functional/page_objects/infra_home_page.ts
+++ b/x-pack/test/functional/page_objects/infra_home_page.ts
@@ -347,6 +347,10 @@ export function InfraHomePageProvider({ getService, getPageObjects }: FtrProvide
       await thresholdInput.type([threshold]);
     },
 
+    async ensureAlertsAndRulesDropdownIsMissing() {
+      await testSubjects.missingOrFail('infrastructure-alerts-and-rules');
+    },
+
     async clickAlertsAndRules() {
       await testSubjects.click('infrastructure-alerts-and-rules');
     },

--- a/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.feature_flags.ts
@@ -18,7 +18,11 @@ export default createTestConfig({
   },
   suiteTags: { exclude: ['skipSvlOblt'] },
   // add feature flags
-  kbnServerArgs: [],
+  kbnServerArgs: [
+    '--xpack.infra.enabled=true',
+    '--xpack.infra.featureFlags.customThresholdAlertsEnabled=true',
+    '--xpack.observability.unsafe.thresholdRule.enabled=true',
+  ],
   // load tests in the index file
   testFiles: [require.resolve('./index.feature_flags.ts')],
 

--- a/x-pack/test_serverless/functional/test_suites/observability/config.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/config.ts
@@ -18,9 +18,5 @@ export default createTestConfig({
   // include settings from project controller
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
   esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
-  kbnServerArgs: [
-    '--xpack.infra.enabled=true',
-    '--xpack.infra.featureFlags.customThresholdAlertsEnabled=true',
-    '--xpack.observability.unsafe.thresholdRule.enabled=true',
-  ],
+  kbnServerArgs: [],
 });

--- a/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.feature_flags.ts
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-export default function () {
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+export default function ({ loadTestFile }: FtrProviderContext) {
   describe('serverless observability UI - feature flags', function () {
     // add tests that require feature flags, defined in config.feature_flags.ts
-    // loadTestFile(require.resolve(<path_to_test_file>));
+    loadTestFile(require.resolve('./infra'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/index.ts
@@ -15,7 +15,6 @@ export default function ({ loadTestFile }: FtrProviderContext) {
     loadTestFile(require.resolve('./rules/rules_list'));
     loadTestFile(require.resolve('./cases'));
     loadTestFile(require.resolve('./advanced_settings'));
-    loadTestFile(require.resolve('./infra'));
     loadTestFile(require.resolve('./ml'));
   });
 }

--- a/x-pack/test_serverless/functional/test_suites/observability/infra/header_menu.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/infra/header_menu.ts
@@ -30,11 +30,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
         await pageObjects.header.waitUntilLoadingHasFinished();
       });
 
-      it('should have menu item to create a custom threshold alert', async () => {
-        await pageObjects.infraHome.clickAlertsAndRules();
-        await pageObjects.infraHome.ensurePopoverOpened();
-        await pageObjects.infraHome.ensureCustomThresholdAlertMenuItemIsVisible();
-        await pageObjects.infraHome.clickAlertsAndRules();
+      it('is hidden', async () => {
+        await pageObjects.infraHome.ensureAlertsAndRulesDropdownIsMissing();
       });
     });
   });

--- a/x-pack/test_serverless/functional/test_suites/observability/infra/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/infra/index.ts
@@ -9,8 +9,6 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ loadTestFile }: FtrProviderContext) {
   describe('Observability Infra', function () {
-    //  TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="infrastructure-alerts-and-rules"])
-    this.tags(['failsOnMKI']);
     loadTestFile(require.resolve('./header_menu'));
     loadTestFile(require.resolve('./node_details'));
     loadTestFile(require.resolve('./hosts_page'));


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/169339

## Summary

* Hides the "Alerts and rule" dropdown in the Infra header behind a feature flag in serverless
* Moves serverless infra tests to the `index.feature_flags.ts` to prevent failures on MKI

![CleanShot 2023-10-24 at 09 38 40@2x](https://github.com/elastic/kibana/assets/793851/f9d47dcb-4b6c-4a39-a8cd-7fcd1a69ba80)


## How to test

* Run in serverless
* Make sure the Alerts and rules dropdown is not there anymore
* Run in stateful
* Make sure dropdown works as before