### PR TITLE
[ML] Transforms: Serverless functional tests for transform list.

### DIFF
--- a/x-pack/test_serverless/functional/config.base.ts
+++ b/x-pack/test_serverless/functional/config.base.ts
@@ -69,6 +69,9 @@ export function createTestConfig(options: CreateTestConfigOptions) {
         indexManagement: {
           pathname: '/app/management/data/index_management',
         },
+        transform: {
+          pathname: '/app/management/data/transform',
+        },
         connectors: {
           pathname: '/app/management/insightsAndAlerting/triggersActionsConnectors/',
         },

--- a/x-pack/test_serverless/functional/services/deployment_agnostic_services.ts
+++ b/x-pack/test_serverless/functional/services/deployment_agnostic_services.ts
@@ -66,6 +66,7 @@ const deploymentAgnosticFunctionalServices = _.pick(functionalServices, [
   'snapshots',
   'supertest',
   'testSubjects',
+  'transform',
   'toasts',
   'uptime',
   'usageCollection',

--- a/x-pack/test_serverless/functional/test_suites/common/management/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index.ts
@@ -12,6 +12,7 @@ export default ({ loadTestFile }: FtrProviderContext) => {
     loadTestFile(require.resolve('./index_management/index_templates'));
     loadTestFile(require.resolve('./index_management/indices'));
     loadTestFile(require.resolve('./index_management/create_enrich_policy'));
+    loadTestFile(require.resolve('./transforms/transform_list'));
     loadTestFile(require.resolve('./advanced_settings'));
     loadTestFile(require.resolve('./data_view_mgmt'));
     loadTestFile(require.resolve('./disabled_uis'));

--- a/x-pack/test_serverless/functional/test_suites/common/management/index.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index.ts
@@ -12,6 +12,7 @@ export default ({ loadTestFile }: FtrProviderContext) => {
     loadTestFile(require.resolve('./index_management/index_templates'));
     loadTestFile(require.resolve('./index_management/indices'));
     loadTestFile(require.resolve('./index_management/create_enrich_policy'));
+    loadTestFile(require.resolve('./transforms/search_bar_features'));
     loadTestFile(require.resolve('./transforms/transform_list'));
     loadTestFile(require.resolve('./advanced_settings'));
     loadTestFile(require.resolve('./data_view_mgmt'));

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
@@ -38,7 +38,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
             );
           }
 
-          // await PageObjects.svlCommonNavigation.search.hideSearch();
+          await PageObjects.svlCommonNavigation.search.hideSearch();
         });
       }
 

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import expect from '@kbn/expect';
+import type { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default function ({ getPageObjects }: FtrProviderContext) {
+  const PageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation']);
+
+  const allLabels = [{ search: 'transform', label: 'Data / Transforms', expected: true }];
+  const expectedLabels = allLabels.filter((l) => l.expected);
+  const notExpectedLabels = allLabels.filter((l) => !l.expected);
+
+  describe('Search bar features', () => {
+    before(async () => {
+      await PageObjects.svlCommonPage.login();
+    });
+
+    after(async () => {
+      await PageObjects.svlCommonPage.forceLogout();
+    });
+
+    describe('list features', () => {
+      if (expectedLabels.length > 0) {
+        it('has the correct features enabled', async () => {
+          await PageObjects.svlCommonNavigation.search.showSearch();
+
+          for (const expectedLabel of expectedLabels) {
+            await PageObjects.svlCommonNavigation.search.searchFor(expectedLabel.search);
+            const [result] = await PageObjects.svlCommonNavigation.search.getDisplayedResults();
+            const label = result?.label;
+            expect(label).to.eql(
+              expectedLabel.label,
+              `First result should be ${expectedLabel.label} (got matching items '${label}')`
+            );
+          }
+
+          // await PageObjects.svlCommonNavigation.search.hideSearch();
+        });
+      }
+
+      if (notExpectedLabels.length > 0) {
+        it('has the correct features disabled', async () => {
+          await PageObjects.svlCommonNavigation.search.showSearch();
+
+          for (const notExpectedLabel of notExpectedLabels) {
+            await PageObjects.svlCommonNavigation.search.searchFor(notExpectedLabel.search);
+            const [result] = await PageObjects.svlCommonNavigation.search.getDisplayedResults();
+            const label = result?.label;
+            expect(label).to.not.eql(
+              notExpectedLabel.label,
+              `First result should not be ${notExpectedLabel.label} (got matching items '${label}')`
+            );
+          }
+
+          await PageObjects.svlCommonNavigation.search.hideSearch();
+        });
+      }
+    });
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import expect from '@kbn/expect';
+import { FtrProviderContext } from '../../../../ftr_provider_context';
+
+export default ({ getPageObjects, getService }: FtrProviderContext) => {
+  const pageObjects = getPageObjects(['svlCommonPage', 'common', 'header']);
+  const browser = getService('browser');
+  const security = getService('security');
+  const transform = getService('transform');
+
+  describe('Transform List', function () {
+    before(async () => {
+      await security.testUser.setRoles(['transform_user']);
+      await pageObjects.svlCommonPage.login();
+    });
+
+    it('renders the transform list', async () => {
+      await transform.testExecution.logTestStep('should load the Transform list page');
+      await pageObjects.common.navigateToApp('management/data/transform');
+      await transform.management.assertTransformListPageExists();
+
+      const url = await browser.getCurrentUrl();
+      expect(url).to.contain(`/transform`);
+
+      await transform.testExecution.logTestStep('should display the stats bar');
+      await transform.management.assertTransformStatsBarExists();
+
+      await transform.testExecution.logTestStep('should display the "No transforms found" message');
+      await transform.management.assertNoTransformsFoundMessageExists();
+
+      await transform.testExecution.logTestStep(
+        'should display a disabled "Create first transform" button'
+      );
+      await transform.management.assertCreateFirstTransformButtonExists();
+      await transform.management.assertCreateFirstTransformButtonEnabled(true);
+    });
+  });
+};

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
@@ -18,6 +18,10 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     before(async () => {
       await security.testUser.setRoles(['transform_user']);
       await pageObjects.svlCommonPage.login();
+
+      // For this test to work, make sure there are no pre-existing transform present.
+      // For example, solutions might set up transforms automatically.
+      await transform.api.cleanTransformIndices();
     });
 
     it('renders the transform list', async () => {

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/transform_list.ts
@@ -26,7 +26,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
     it('renders the transform list', async () => {
       await transform.testExecution.logTestStep('should load the Transform list page');
-      await pageObjects.common.navigateToApp('management/data/transform');
+      await transform.navigation.navigateTo();
       await transform.management.assertTransformListPageExists();
 
       const url = await browser.getCurrentUrl();


### PR DESCRIPTION
## Summary

Adds basic functional tests for serverless for the transform list. Since transforms are available in all project types, this adds the tests to `common` so they are run in all three project types.

- Navigates to the empty transform list and asserts the page.
- Checks `transform` is available as a search feature.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
