### PR TITLE
ES|QL in-product help fixes

### DIFF
--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -53,6 +53,7 @@ export const sourceCommands = {
       ),
       description: (
         <Markdown
+          openLinksInNewTab={true}
           markdown={i18n.translate(
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.from.markdown',
             {
@@ -197,6 +198,7 @@ export const processingCommands = {
       ),
       description: (
         <Markdown
+          openLinksInNewTab={true}
           markdown={i18n.translate(
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.dissect.markdown',
             {
@@ -260,6 +262,7 @@ FROM employees
       ),
       description: (
         <Markdown
+          openLinksInNewTab={true}
           markdown={i18n.translate(
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.enrich.markdown',
             {
@@ -353,6 +356,7 @@ FROM employees
       ),
       description: (
         <Markdown
+          openLinksInNewTab={true}
           markdown={i18n.translate(
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.grok.markdown',
             {
@@ -2866,6 +2870,7 @@ NOTE: There isn’t yet a \`COUNT(*)\`. Please count a single valued field if yo
       ),
       description: (
         <Markdown
+          openLinksInNewTab={true}
           markdown={i18n.translate(
             'textBasedEditor.query.textBasedLanguagesEditor.documentationESQL.countDistinctFunction.markdown',
             {

--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -1093,8 +1093,8 @@ ROW a=1.8
 Extracts parts of a date, like year, month, day, hour. The supported field types are those provided by Java's \`java.time.temporal.ChronoField\`.
 
 \`\`\`
-ROW date = DATE_PARSE("2022-05-06", "yyyy-MM-dd")
-| EVAL year = DATE_EXTRACT(date, "year")
+ROW date = DATE_PARSE("yyyy-MM-dd", "2022-05-06")
+| EVAL year = DATE_EXTRACT("year", date)
 \`\`\`
               `,
               description:
@@ -1122,7 +1122,7 @@ Returns a string representation of a date in the provided format. If no format i
 \`\`\`
 FROM employees
 | KEEP first_name, last_name, hire_date
-| EVAL hired = DATE_FORMAT(hire_date, "YYYY-MM-dd")
+| EVAL hired = DATE_FORMAT("YYYY-MM-dd", hire_date)
 \`\`\`
               `,
               description:
@@ -1149,7 +1149,7 @@ Converts a string to a date, in the provided format. If no format is specified, 
 
 \`\`\`
 ROW date_string = "2022-05-06"
-| EVAL date = DATE_PARSE(date_string, "yyyy-MM-dd")
+| EVAL date = DATE_PARSE("yyyy-MM-dd", date_string)
 \`\`\`
               `,
               description:


### PR DESCRIPTION
Changes the ES|QL in-product help:

- opens links to the documentation in a new tab
- swaps the arguments for the DATE_* functions

Closes https://github.com/elastic/kibana/issues/169428

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->