### PR TITLE
Add unused AI Assistant feature flags to unusedFromRoot

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/server/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/index.ts
@@ -14,6 +14,26 @@ export type { ObservabilityAIAssistantServerRouteRepository } from './routes/get
 import { config as configSchema } from './config';
 
 export const config: PluginConfigDescriptor<ObservabilityAIAssistantConfig> = {
+  deprecations: ({ unusedFromRoot }) => [
+    unusedFromRoot('xpack.observability.aiAssistant.enabled', {
+      level: 'warning',
+    }),
+    unusedFromRoot('xpack.observability.aiAssistant.provider.azureOpenAI.deploymentId', {
+      level: 'warning',
+    }),
+    unusedFromRoot('xpack.observability.aiAssistant.provider.azureOpenAI.resourceName', {
+      level: 'warning',
+    }),
+    unusedFromRoot('xpack.observability.aiAssistant.provider.azureOpenAI.apiKey', {
+      level: 'warning',
+    }),
+    unusedFromRoot('xpack.observability.aiAssistant.provider.openAI.apiKey', {
+      level: 'warning',
+    }),
+    unusedFromRoot('xpack.observability.aiAssistant.provider.openAI.model', {
+      level: 'warning',
+    }),
+  ],
   exposeToBrowser: {},
   schema: configSchema,
 };


### PR DESCRIPTION
Resolves https://github.com/elastic/cloud/issues/118668

## Summary

The following feature flags for the Observability AI Assistant are no longer used:

* `xpack.observability.aiAssistant.enabled`
* `xpack.observability.aiAssistant.provider.azureOpenAI.deploymentId`
* `xpack.observability.aiAssistant.provider.azureOpenAI.resourceName`
* `xpack.observability.aiAssistant.provider.azureOpenAI.apiKey`
* `xpack.observability.aiAssistant.provider.openAI.apiKey`
* `xpack.observability.aiAssistant.provider.openAI.model`

Having them configured in Kibana config will trigger a warning in the console.

<!--ONMERGE {"backportTargets":["8.10","8.11"]} ONMERGE-->