### PR TITLE
[ftr/functional tests] read username from config

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/rules/rule_details.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/rules/rule_details.ts
@@ -32,6 +32,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
   const retry = getService('retry');
   const toasts = getService('toasts');
   const comboBox = getService('comboBox');
+  const config = getService('config');
 
   const openFirstRule = async (ruleName: string) => {
     await svlTriggersActionsUI.searchRules(ruleName);
@@ -118,7 +119,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         const ruleType = await testSubjects.getVisibleText('ruleTypeLabel');
         expect(ruleType).toEqual('Elasticsearch query');
         const owner = await testSubjects.getVisibleText('apiKeyOwnerLabel');
-        expect(owner).toEqual('elastic_serverless');
+        expect(owner).toEqual(config.get('servers.kibana.username'));
       });
 
       it('should disable the rule', async () => {


### PR DESCRIPTION
## Summary

The test was failing on MKI because username was hardcoded. It is not obvious, but MKI uses difference users from the ones we define and use in Kibana CI. FTR config is the source of truth.

Verified on my existing Search project (~10 days old)