### PR TITLE
[8.11] [Security Solution] Unskipping `x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/` working tests on serverless (#169474)

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -63,7 +63,7 @@ steps:
           queue: n2-4-spot
         depends_on: build
         timeout_in_minutes: 60
-        parallelism: 2
+        parallelism: 4
         retry:
           automatic:
             - exit_status: '*'

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/pagination.cy.ts
@@ -22,7 +22,7 @@ import { ALL_USERS_TABLE } from '../../../screens/users/all_users';
 import { goToTablePage, sortFirstTableColumn } from '../../../tasks/table_pagination';
 
 // FLAKY: https://github.com/elastic/kibana/issues/165968
-describe('Pagination', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Pagination', { tags: ['@ess', '@serverless'] }, () => {
   describe('Host uncommon processes table)', () => {
     before(() => {
       cy.task('esArchiverLoad', { archiveName: 'host_uncommon_processes' });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution] Unskipping `x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/` working tests on serverless (#169474)](https://github.com/elastic/kibana/pull/169474)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Gloria Hornero","email":"gloria.hornero@elastic.co"},"sourceCommit":{"committedDate":"2023-10-24T10:48:55Z","message":"[Security Solution] Unskipping `x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/` working tests on serverless (#169474)","sha":"6db8f5fe6901bff9c80c461aeb077987ca8c9492","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting","Team: SecuritySolution","Team:Threat Hunting:Explore","v8.11.0","v8.12.0"],"number":169474,"url":"https://github.com/elastic/kibana/pull/169474","mergeCommit":{"message":"[Security Solution] Unskipping `x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/` working tests on serverless (#169474)","sha":"6db8f5fe6901bff9c80c461aeb077987ca8c9492"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169474","number":169474,"mergeCommit":{"message":"[Security Solution] Unskipping `x-pack/test/security_solution_cypress/cypress/e2e/explore/pagination/` working tests on serverless (#169474)","sha":"6db8f5fe6901bff9c80c461aeb077987ca8c9492"}}]}] BACKPORT-->