### PR TITLE
[Security Solution] Move user profiles related hooks into a separate folder

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.test.tsx
@@ -32,7 +32,7 @@ const mockUserProfiles = [
     data: {},
   },
 ];
-jest.mock('../../../detections/containers/detection_engine/alerts/use_suggest_users', () => {
+jest.mock('../../../detections/containers/detection_engine/user_profiles/use_suggest_users', () => {
   return {
     useSuggestUsers: () => ({
       loading: false,

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
@@ -13,7 +13,7 @@ import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { UserProfilesPopover } from '@kbn/user-profile-components';
 
 import { EuiFilterButton } from '@elastic/eui';
-import { useSuggestUsers } from '../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useSuggestUsers } from '../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import { TEST_IDS } from './constants';
 
 export interface FilterByAssigneesPopoverProps {

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.test.tsx
@@ -9,14 +9,14 @@ import type { TimelineItem } from '@kbn/timelines-plugin/common';
 import { act, fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { TestProviders } from '../../../mock';
-import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/alerts/use_get_user_profiles';
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 
 import { BulkAlertAssigneesPanel } from './alert_bulk_assignees';
 import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
 
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_get_user_profiles');
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_suggest_users');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_suggest_users');
 
 const mockUserProfiles = [
   { uid: 'user-id-1', enabled: true, user: { username: 'user1' }, data: {} },

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/alert_bulk_assignees.tsx
@@ -13,8 +13,8 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { ALERT_WORKFLOW_ASSIGNEE_IDS } from '@kbn/rule-data-utils';
 import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { UserProfilesSelectable } from '@kbn/user-profile-components';
-import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/alerts/use_get_user_profiles';
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import * as i18n from './translations';
 import type { SetAlertAssigneesFunc } from './use_set_alert_assignees';
 

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
@@ -15,12 +15,12 @@ import type {
 } from './use_bulk_alert_assignees_items';
 import { useBulkAlertAssigneesItems } from './use_bulk_alert_assignees_items';
 import { useSetAlertAssignees } from './use_set_alert_assignees';
-import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/alerts/use_get_user_profiles';
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 
 jest.mock('./use_set_alert_assignees');
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_get_user_profiles');
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_suggest_users');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_suggest_users');
 
 const mockUserProfiles = [
   { uid: 'user-id-1', enabled: true, user: { username: 'fakeUser1' }, data: {} },

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
@@ -16,13 +16,13 @@ import React from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiPopover, EuiContextMenu } from '@elastic/eui';
 import { useSetAlertAssignees } from '../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees';
-import { useGetUserProfiles } from '../../../containers/detection_engine/alerts/use_get_user_profiles';
-import { useSuggestUsers } from '../../../containers/detection_engine/alerts/use_suggest_users';
+import { useGetUserProfiles } from '../../../containers/detection_engine/user_profiles/use_get_user_profiles';
+import { useSuggestUsers } from '../../../containers/detection_engine/user_profiles/use_suggest_users';
 
 jest.mock('../../../containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees');
-jest.mock('../../../containers/detection_engine/alerts/use_get_user_profiles');
-jest.mock('../../../containers/detection_engine/alerts/use_suggest_users');
+jest.mock('../../../containers/detection_engine/user_profiles/use_get_user_profiles');
+jest.mock('../../../containers/detection_engine/user_profiles/use_suggest_users');
 
 const mockUserProfiles = [
   { uid: 'user-id-1', enabled: true, user: { username: 'fakeUser1' }, data: {} },

--- a/x-pack/plugins/security_solution/public/detections/components/detection_page_filters/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/detection_page_filters/index.test.tsx
@@ -43,7 +43,7 @@ const mockUserProfiles = [
     data: {},
   },
 ];
-jest.mock('../../containers/detection_engine/alerts/use_suggest_users', () => {
+jest.mock('../../containers/detection_engine/user_profiles/use_suggest_users', () => {
   return {
     useSuggestUsers: () => ({
       loading: false,

--- a/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
@@ -44,7 +44,7 @@ import { SUPPRESSED_ALERT_TOOLTIP } from './translations';
 import { VIEW_SELECTION } from '../../../../common/constants';
 import { getAllFieldsByName } from '../../../common/containers/source';
 import { eventRenderedViewColumns, getColumns } from './columns';
-import { useGetUserProfiles } from '../../containers/detection_engine/alerts/use_get_user_profiles';
+import { useGetUserProfiles } from '../../containers/detection_engine/user_profiles/use_get_user_profiles';
 
 /**
  * This implementation of `EuiDataGrid`'s `renderCellValue`

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/__mocks__/api.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/__mocks__/api.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import type {
   QueryAlerts,
   AlertSearchResponse,
@@ -14,13 +13,7 @@ import type {
   Privilege,
   CasesFromAlertsResponse,
 } from '../types';
-import {
-  alertsMock,
-  mockSignalIndex,
-  mockUserPrivilege,
-  mockCaseIdsFromAlertId,
-  mockUserProfiles,
-} from '../mock';
+import { alertsMock, mockSignalIndex, mockUserPrivilege, mockCaseIdsFromAlertId } from '../mock';
 
 export const fetchQueryAlerts = async <Hit, Aggregations>({
   query,
@@ -43,9 +36,3 @@ export const getCaseIdsFromAlertId = async ({
 }: {
   alertId: string;
 }): Promise<CasesFromAlertsResponse> => Promise.resolve(mockCaseIdsFromAlertId);
-
-export const suggestUsers = async ({
-  searchTerm,
-}: {
-  searchTerm: string;
-}): Promise<UserProfileWithAvatar[]> => Promise.resolve(mockUserProfiles);

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/api.test.ts
@@ -13,7 +13,6 @@ import {
   mockSignalIndex,
   mockUserPrivilege,
   mockHostIsolation,
-  mockUserProfiles,
 } from './mock';
 import {
   fetchQueryAlerts,
@@ -23,7 +22,6 @@ import {
   createHostIsolation,
   updateAlertStatusByQuery,
   updateAlertStatusByIds,
-  suggestUsers,
 } from './api';
 import { coreMock } from '@kbn/core/public/mocks';
 
@@ -264,30 +262,6 @@ describe('Detections Alerts API', () => {
         caseIds: ['88c04a90-b19c-11eb-b838-bf3c7840b969'],
       });
       expect(hostIsolationResponse).toEqual(mockHostIsolation);
-    });
-  });
-
-  describe('suggestUsers', () => {
-    beforeEach(() => {
-      fetchMock.mockClear();
-      fetchMock.mockResolvedValue(mockUserProfiles);
-    });
-
-    test('check parameter url', async () => {
-      await suggestUsers({ searchTerm: 'name1' });
-      expect(fetchMock).toHaveBeenCalledWith(
-        '/api/detection_engine/signals/suggest_users',
-        expect.objectContaining({
-          method: 'GET',
-          version: '2023-10-31',
-          query: { searchTerm: 'name1' },
-        })
-      );
-    });
-
-    test('happy path', async () => {
-      const alertsResp = await suggestUsers({ searchTerm: '' });
-      expect(alertsResp).toEqual(mockUserProfiles);
     });
   });
 });

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/alerts/mock.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import type { HostIsolationResponse } from '../../../../../common/endpoint/types/actions';
 import type { AlertSearchResponse, AlertsIndex, Privilege, CasesFromAlertsResponse } from './types';
 
@@ -1334,9 +1333,4 @@ export const mockHostIsolation: HostIsolationResponse = {
 export const mockCaseIdsFromAlertId: CasesFromAlertsResponse = [
   { id: '818601a0-b26b-11eb-8759-6b318e8cf4bc', title: 'Case 1' },
   { id: '8a774850-b26b-11eb-8759-6b318e8cf4bc', title: 'Case 2' },
-];
-
-export const mockUserProfiles: UserProfileWithAvatar[] = [
-  { uid: 'user-id-1', enabled: true, user: { username: 'user1' }, data: {} },
-  { uid: 'user-id-2', enabled: true, user: { username: 'user2' }, data: {} },
 ];

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/__mocks__/api.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/__mocks__/api.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { mockUserProfiles } from '../mock';
+
+export const suggestUsers = async ({
+  searchTerm,
+}: {
+  searchTerm: string;
+}): Promise<UserProfileWithAvatar[]> => Promise.resolve(mockUserProfiles);

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/api.test.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/api.test.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { coreMock } from '@kbn/core/public/mocks';
+
+import { mockUserProfiles } from './mock';
+import { suggestUsers } from './api';
+import { KibanaServices } from '../../../../common/lib/kibana';
+
+const mockKibanaServices = KibanaServices.get as jest.Mock;
+jest.mock('../../../../common/lib/kibana');
+
+const coreStartMock = coreMock.createStart({ basePath: '/mock' });
+mockKibanaServices.mockReturnValue(coreStartMock);
+const fetchMock = coreStartMock.http.fetch;
+
+describe('Detections Alerts API', () => {
+  describe('suggestUsers', () => {
+    beforeEach(() => {
+      fetchMock.mockClear();
+      fetchMock.mockResolvedValue(mockUserProfiles);
+    });
+
+    test('check parameter url', async () => {
+      await suggestUsers({ searchTerm: 'name1' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/detection_engine/signals/suggest_users',
+        expect.objectContaining({
+          method: 'GET',
+          version: '2023-10-31',
+          query: { searchTerm: 'name1' },
+        })
+      );
+    });
+
+    test('happy path', async () => {
+      const alertsResp = await suggestUsers({ searchTerm: '' });
+      expect(alertsResp).toEqual(mockUserProfiles);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/api.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/api.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
+import type { SuggestUsersProps } from './types';
+import { DETECTION_ENGINE_ALERT_SUGGEST_USERS_URL } from '../../../../../common/constants';
+import { KibanaServices } from '../../../../common/lib/kibana';
+
+/**
+ * Fetches suggested user profiles
+ */
+export const suggestUsers = async ({
+  searchTerm,
+}: SuggestUsersProps): Promise<UserProfileWithAvatar[]> => {
+  return KibanaServices.get().http.fetch<UserProfileWithAvatar[]>(
+    DETECTION_ENGINE_ALERT_SUGGEST_USERS_URL,
+    {
+      method: 'GET',
+      version: '2023-10-31',
+      query: { searchTerm },
+    }
+  );
+};

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/mock.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const mockUserProfiles = [
+  { uid: 'user-id-1', enabled: true, user: { username: 'user1' }, data: {} },
+  { uid: 'user-id-2', enabled: true, user: { username: 'user2' }, data: {} },
+];

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/translations.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const USER_PROFILES_FAILURE = i18n.translate(
+  'xpack.securitySolution.containers.detectionEngine.userProfiles.title',
+  { defaultMessage: 'Failed to find users' }
+);

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/types.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/types.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export interface SuggestUsersProps {
+  searchTerm: string;
+}

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_user_profiles.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_user_profiles.test.tsx
@@ -6,13 +6,14 @@
  */
 
 import { renderHook } from '@testing-library/react-hooks';
+import { securityMock } from '@kbn/security-plugin/public/mocks';
+
+import { mockUserProfiles } from './mock';
 import { useGetUserProfiles } from './use_get_user_profiles';
 import { useKibana } from '../../../../common/lib/kibana';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
-import { mockUserProfiles } from './mock';
 import { createStartServicesMock } from '../../../../common/lib/kibana/kibana_react.mock';
-import { securityMock } from '@kbn/security-plugin/public/mocks';
 
 jest.mock('../../../../common/lib/kibana');
 jest.mock('../../../../common/hooks/use_app_toasts');

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_suggest_users.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_suggest_users.test.tsx
@@ -7,10 +7,11 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 import { useSuggestUsers } from './use_suggest_users';
+
 import * as api from './api';
+import { mockUserProfiles } from './mock';
 import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
 import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
-import { mockUserProfiles } from './mock';
 
 jest.mock('./api');
 jest.mock('../../../../common/hooks/use_app_toasts');

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.test.tsx
@@ -18,14 +18,14 @@ import {
 } from './test_ids';
 import { Assignees } from './assignees';
 
-import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/alerts/use_get_user_profiles';
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import type { SetAlertAssigneesFunc } from '../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees';
 import { useSetAlertAssignees } from '../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees';
 import { TestProviders } from '../../../../common/mock';
 
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_get_user_profiles');
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_suggest_users');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_suggest_users');
 jest.mock('../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees');
 
 const mockUserProfiles: UserProfileWithAvatar[] = [

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
@@ -17,7 +17,7 @@ import {
 import { FormattedMessage } from '@kbn/i18n-react';
 import { UserAvatar } from '@kbn/user-profile-components';
 import { noop } from 'lodash';
-import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/alerts/use_get_user_profiles';
+import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
 import { useSetAlertAssignees } from '../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees';
 import {
   ASSIGNEE_AVATAR_TEST_ID,

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.test.tsx
@@ -12,10 +12,10 @@ import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { ASSIGNEES_ADD_BUTTON_TEST_ID } from './test_ids';
 import { AssigneesPopover } from './assignees_popover';
 
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import { TestProviders } from '../../../../common/mock';
 
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_suggest_users');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_suggest_users');
 
 const mockUserProfiles: UserProfileWithAvatar[] = [
   {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees_popover.tsx
@@ -13,7 +13,7 @@ import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
 import { UserProfilesPopover } from '@kbn/user-profile-components';
 
 import { EuiButtonIcon, EuiToolTip } from '@elastic/eui';
-import { useSuggestUsers } from '../../../../detections/containers/detection_engine/alerts/use_suggest_users';
+import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import { ASSIGNEES_ADD_BUTTON_TEST_ID } from './test_ids';
 
 const PopoverButton: FC<{ togglePopover: () => void; isDisabled: boolean }> = memo(

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
@@ -73,17 +73,23 @@ jest.mock(
   }
 );
 
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_get_user_profiles', () => {
-  return {
-    useGetUserProfiles: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
-  };
-});
+jest.mock(
+  '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles',
+  () => {
+    return {
+      useGetUserProfiles: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
+    };
+  }
+);
 
-jest.mock('../../../../detections/containers/detection_engine/alerts/use_suggest_users', () => {
-  return {
-    useSuggestUsers: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
-  };
-});
+jest.mock(
+  '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users',
+  () => {
+    return {
+      useSuggestUsers: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
+    };
+  }
+);
 
 jest.mock('../../../../common/hooks/use_experimental_features', () => ({
   useIsExperimentalFeatureEnabled: jest.fn().mockReturnValue(true),

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/index.test.tsx
@@ -30,13 +30,16 @@ jest.mock('../../../common/containers/use_search_strategy', () => ({
   useSearchStrategy: jest.fn(),
 }));
 
-jest.mock('../../../detections/containers/detection_engine/alerts/use_get_user_profiles', () => {
-  return {
-    useGetUserProfiles: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
-  };
-});
+jest.mock(
+  '../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles',
+  () => {
+    return {
+      useGetUserProfiles: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
+    };
+  }
+);
 
-jest.mock('../../../detections/containers/detection_engine/alerts/use_suggest_users', () => {
+jest.mock('../../../detections/containers/detection_engine/user_profiles/use_suggest_users', () => {
   return {
     useSuggestUsers: jest.fn().mockReturnValue({ loading: false, userProfiles: [] }),
   };


### PR DESCRIPTION
## Summary

These changes move user profiles hooks into a separate folder. Before it was part of the `containers/detection_engine/alerts/`.