### PR TITLE
Revert #169420

### DIFF
--- a/src/plugins/data/common/search/utils.ts
+++ b/src/plugins/data/common/search/utils.ts
@@ -23,9 +23,7 @@ export const isAbortResponse = (response?: IKibanaSearchResponse) => {
 /**
  * @returns true if request is still running
  */
-export const isRunningResponse = (response?: IKibanaSearchResponse) => {
-  return response?.isRunning ?? false;
-};
+export const isRunningResponse = (response?: IKibanaSearchResponse) => response?.isRunning ?? false;
 
 export const getUserTimeZone = (
   getConfig: AggTypesDependencies['getConfig'],

--- a/src/plugins/data/server/search/routes/bsearch.ts
+++ b/src/plugins/data/server/search/routes/bsearch.ts
@@ -11,7 +11,6 @@ import { catchError } from 'rxjs/operators';
 import { BfetchServerSetup } from '@kbn/bfetch-plugin/server';
 import type { ExecutionContextSetup } from '@kbn/core/server';
 import apm from 'elastic-apm-node';
-import { getRequestAbortedSignal } from '../..';
 import {
   IKibanaSearchRequest,
   IKibanaSearchResponse,
@@ -29,7 +28,6 @@ export function registerBsearchRoute(
     IKibanaSearchResponse
   >('/internal/bsearch', (request) => {
     const search = getScoped(request);
-    const abortSignal = getRequestAbortedSignal(request.events.aborted$);
     return {
       /**
        * @param requestOptions
@@ -41,7 +39,7 @@ export function registerBsearchRoute(
           apm.addLabels(executionContextService.getAsLabels());
 
           return firstValueFrom(
-            search.search(requestData, { ...restOptions, abortSignal }).pipe(
+            search.search(requestData, restOptions).pipe(
               catchError((err) => {
                 // Re-throw as object, to get attributes passed to the client
                 // eslint-disable-next-line no-throw-literal

--- a/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.test.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.test.ts
@@ -259,38 +259,6 @@ describe('ES search strategy', () => {
 
         expect(mockApiCaller).toBeCalledTimes(0);
       });
-
-      it('should delete when aborted', async () => {
-        mockSubmitCaller.mockResolvedValueOnce({
-          ...mockAsyncResponse,
-          body: {
-            ...mockAsyncResponse.body,
-            is_running: true,
-          },
-        });
-
-        const params = { index: 'logstash-*', body: { query: {} } };
-        const esSearch = await enhancedEsSearchStrategyProvider(
-          mockLegacyConfig$,
-          mockSearchConfig,
-          mockLogger
-        );
-        const abortController = new AbortController();
-        const abortSignal = abortController.signal;
-
-        // Abort after an incomplete first response is returned
-        setTimeout(() => abortController.abort(), 100);
-
-        let err: KbnServerError | undefined;
-        try {
-          await esSearch.search({ params }, { abortSignal }, mockDeps).toPromise();
-        } catch (e) {
-          err = e;
-        }
-        expect(mockSubmitCaller).toBeCalled();
-        expect(err).not.toBeUndefined();
-        expect(mockDeleteCaller).toBeCalled();
-      });
     });
 
     describe('with sessionId', () => {
@@ -397,44 +365,6 @@ describe('ES search strategy', () => {
         expect(request.id).toEqual('foo');
         expect(request).toHaveProperty('wait_for_completion_timeout');
         expect(request).not.toHaveProperty('keep_alive');
-      });
-
-      it('should not delete a saved session when aborted', async () => {
-        mockSubmitCaller.mockResolvedValueOnce({
-          ...mockAsyncResponse,
-          body: {
-            ...mockAsyncResponse.body,
-            is_running: true,
-          },
-        });
-
-        const params = { index: 'logstash-*', body: { query: {} } };
-        const esSearch = await enhancedEsSearchStrategyProvider(
-          mockLegacyConfig$,
-          mockSearchConfig,
-          mockLogger
-        );
-        const abortController = new AbortController();
-        const abortSignal = abortController.signal;
-
-        // Abort after an incomplete first response is returned
-        setTimeout(() => abortController.abort(), 100);
-
-        let err: KbnServerError | undefined;
-        try {
-          await esSearch
-            .search(
-              { params },
-              { abortSignal, sessionId: '1', isSearchStored: true, isStored: true },
-              mockDeps
-            )
-            .toPromise();
-        } catch (e) {
-          err = e;
-        }
-        expect(mockSubmitCaller).toBeCalled();
-        expect(err).not.toBeUndefined();
-        expect(mockDeleteCaller).not.toBeCalled();
       });
     });
 

--- a/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
@@ -82,7 +82,7 @@ export const enhancedEsSearchStrategyProvider = (
     };
 
     const cancel = async () => {
-      if (id && !options.isStored) {
+      if (id) {
         await cancelAsyncSearch(id, esClient);
       }
     };


### PR DESCRIPTION
## Summary

This reverts commit 29bdcab36695f943fd6abbc3832057dc408456a5 (#169420).

This PR caused additional test flakiness and introduced a situation in which the Kibana server could crash. We already have https://github.com/elastic/kibana/pull/168929 to make sure ES|QL queries cannot run longer than 2 mins, so we have some space to revisit the changes in that PR.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
