### PR TITLE
[8.11] [Security Solution] Enable Serverless for `entity_analytics` Cypress tests (#169209)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/enrichments.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_alerts/enrichments.cy.ts
@@ -36,8 +36,7 @@ import { enableRiskEngine } from '../../tasks/entity_analytics';
 const CURRENT_HOST_RISK_LEVEL = 'Current host risk level';
 const ORIGINAL_HOST_RISK_LEVEL = 'Original host risk level';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-describe('Enrichment', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Enrichment', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cleanKibana();
     cy.task('esArchiverUnload', 'risk_scores_new');
@@ -50,7 +49,8 @@ describe('Enrichment', { tags: ['@ess', '@serverless', '@brokenInServerless'] },
   });
 
   describe('Custom query rule', () => {
-    describe('from legacy risk scores', () => {
+    // FLAKY: https://github.com/elastic/kibana/issues/169154
+    describe.skip('from legacy risk scores', () => {
       beforeEach(() => {
         disableExpandableFlyout();
         cy.task('esArchiverLoad', { archiveName: 'risk_hosts' });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts
@@ -43,7 +43,7 @@ import {
 describe(
   'Entity analytics management page',
   {
-    tags: ['@ess', '@serverless', '@brokenInServerless'],
+    tags: ['@ess', '@serverless'],
   },
   () => {
     before(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution] Enable Serverless for `entity_analytics` Cypress tests (#169209)](https://github.com/elastic/kibana/pull/169209)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Juan Pablo Djeredjian","email":"jpdjeredjian@gmail.com"},"sourceCommit":{"committedDate":"2023-10-24T08:26:15Z","message":"[Security Solution] Enable Serverless for `entity_analytics` Cypress tests (#169209)\n\n## Summary\r\n\r\nRunning flaky test runner for\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/enrichments.cy.ts`\r\n**unskipped whole test suite in favour of failing test -> `Custom Query\r\nrule - from legacy risk scores`** (see below) **also enabled on\r\nServerless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts`\r\n**enabled on Serverless**\r\n\r\n## Related failing-test issues\r\n\r\n1. https://github.com/elastic/kibana/issues/169154\r\n**Marked as legit-flake and assigned to\r\n@elastic/security-detection-engine**\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3575","sha":"12975a5a0c6846d5cdbecc73beceba0346cd866b","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Detections and Resp","Team:Detection Engine","v8.12.0"],"number":169209,"url":"https://github.com/elastic/kibana/pull/169209","mergeCommit":{"message":"[Security Solution] Enable Serverless for `entity_analytics` Cypress tests (#169209)\n\n## Summary\r\n\r\nRunning flaky test runner for\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/enrichments.cy.ts`\r\n**unskipped whole test suite in favour of failing test -> `Custom Query\r\nrule - from legacy risk scores`** (see below) **also enabled on\r\nServerless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts`\r\n**enabled on Serverless**\r\n\r\n## Related failing-test issues\r\n\r\n1. https://github.com/elastic/kibana/issues/169154\r\n**Marked as legit-flake and assigned to\r\n@elastic/security-detection-engine**\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3575","sha":"12975a5a0c6846d5cdbecc73beceba0346cd866b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169209","number":169209,"mergeCommit":{"message":"[Security Solution] Enable Serverless for `entity_analytics` Cypress tests (#169209)\n\n## Summary\r\n\r\nRunning flaky test runner for\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/enrichments.cy.ts`\r\n**unskipped whole test suite in favour of failing test -> `Custom Query\r\nrule - from legacy risk scores`** (see below) **also enabled on\r\nServerless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/entity_analytics_management_page.cy.ts`\r\n**enabled on Serverless**\r\n\r\n## Related failing-test issues\r\n\r\n1. https://github.com/elastic/kibana/issues/169154\r\n**Marked as legit-flake and assigned to\r\n@elastic/security-detection-engine**\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3575","sha":"12975a5a0c6846d5cdbecc73beceba0346cd866b"}}]}] BACKPORT-->