### PR TITLE
[Security Solution][Investigations] - Add check for changing alert status from bulk options

### DIFF
--- a/packages/kbn-es/src/serverless_resources/security_roles.json
+++ b/packages/kbn-es/src/serverless_resources/security_roles.json
@@ -1,4 +1,43 @@
 {
+  "viewer": {
+    "name": "viewer",
+    "elasticsearch": {
+      "cluster": [],
+      "indices": [
+        {
+          "names": ["*"],
+          "privileges": ["read"]
+        },
+        {
+          "names": ["/~(([.]|ilm-history-).*)/"],
+          "privileges": ["read", "view_index_metadata"]
+        },
+        {
+          "names": [".siem-signals*", ".lists-*", ".items-*"],
+          "privileges": ["read", "view_index_metadata"]
+        },
+        {
+          "names": [".alerts*", ".preview.alerts*"],
+          "privileges": ["read", "view_index_metadata"]
+        }
+      ],
+      "run_as": []
+    },
+    "kibana": [
+      {
+        "feature": {
+          "ml": ["read"],
+          "siem": ["read", "read_alerts"],
+          "securitySolutionAssistant": ["all"],
+          "securitySolutionCases": ["read"],
+          "actions": ["read"],
+          "builtInAlerts": ["read"]
+        },
+        "spaces": ["*"],
+        "base": []
+      }
+    ]
+  },
   "t1_analyst": {
     "name": "t1_analyst",
     "elasticsearch": {

--- a/packages/kbn-es/src/serverless_resources/users
+++ b/packages/kbn-es/src/serverless_resources/users
@@ -1,6 +1,7 @@
 elastic_serverless:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 system_indices_superuser:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 
+viewer:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t1_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t2_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t3_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW

--- a/packages/kbn-es/src/serverless_resources/users_roles
+++ b/packages/kbn-es/src/serverless_resources/users_roles
@@ -1,6 +1,7 @@
 superuser:elastic_serverless
 system_indices_superuser:system_indices_superuser
 
+viewer:viewer
 t1_analyst:t1_analyst
 t2_analyst:t2_analyst
 t3_analyst:t3_analyst

--- a/x-pack/plugins/security_solution/common/test/index.ts
+++ b/x-pack/plugins/security_solution/common/test/index.ts
@@ -18,6 +18,7 @@ export type SecurityRoleName = ServerlessSecurityRoleName | EssSecurityRoleName;
 
 export enum ROLES {
   // Serverless roles
+  viewer = 'viewer',
   t1_analyst = 't1_analyst',
   t2_analyst = 't2_analyst',
   t3_analyst = 't3_analyst',

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.test.tsx
@@ -19,6 +19,12 @@ import { useUiSetting$ } from '../../../lib/kibana';
 
 jest.mock('./use_set_alert_tags');
 jest.mock('../../../lib/kibana');
+jest.mock(
+  '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges',
+  () => ({
+    useAlertsPrivileges: jest.fn().mockReturnValue({ hasIndexWrite: true }),
+  })
+);
 
 const defaultProps: UseBulkAlertTagsItemsProps = {
   refetch: () => {},

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_tags_items.tsx
@@ -8,6 +8,7 @@
 import { EuiFlexGroup, EuiIconTip, EuiFlexItem } from '@elastic/eui';
 import type { RenderContentPanelProps } from '@kbn/triggers-actions-ui-plugin/public/types';
 import React, { useCallback, useMemo } from 'react';
+import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { BulkAlertTagsPanel } from './alert_bulk_tags';
 import * as i18n from './translations';
 import { useSetAlertTags } from './use_set_alert_tags';
@@ -24,6 +25,7 @@ export interface UseBulkAlertTagsPanel {
 }
 
 export const useBulkAlertTagsItems = ({ refetch }: UseBulkAlertTagsItemsProps) => {
+  const { hasIndexWrite } = useAlertsPrivileges();
   const setAlertTags = useSetAlertTags();
   const handleOnAlertTagsSubmit = useCallback(
     async (tags, ids, onSuccess, setIsLoading) => {
@@ -34,16 +36,18 @@ export const useBulkAlertTagsItems = ({ refetch }: UseBulkAlertTagsItemsProps) =
     [setAlertTags]
   );
 
-  const alertTagsItems = [
-    {
-      key: 'manage-alert-tags',
-      'data-test-subj': 'alert-tags-context-menu-item',
-      name: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
-      panel: 1,
-      label: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
-      disableOnQuery: true,
-    },
-  ];
+  const alertTagsItems = hasIndexWrite
+    ? [
+        {
+          key: 'manage-alert-tags',
+          'data-test-subj': 'alert-tags-context-menu-item',
+          name: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
+          panel: 1,
+          label: i18n.ALERT_TAGS_CONTEXT_MENU_ITEM_TITLE,
+          disableOnQuery: true,
+        },
+      ]
+    : [];
 
   const TitleContent = useMemo(
     () => (
@@ -79,15 +83,18 @@ export const useBulkAlertTagsItems = ({ refetch }: UseBulkAlertTagsItemsProps) =
   );
 
   const alertTagsPanels: UseBulkAlertTagsPanel[] = useMemo(
-    () => [
-      {
-        id: 1,
-        title: TitleContent,
-        'data-test-subj': 'alert-tags-context-menu-panel',
-        renderContent,
-      },
-    ],
-    [TitleContent, renderContent]
+    () =>
+      hasIndexWrite
+        ? [
+            {
+              id: 1,
+              title: TitleContent,
+              'data-test-subj': 'alert-tags-context-menu-panel',
+              renderContent,
+            },
+          ]
+        : [],
+    [TitleContent, hasIndexWrite, renderContent]
   );
 
   return {

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
@@ -19,6 +19,7 @@ import type { AlertWorkflowStatus } from '../../../common/types';
 import { FILTER_CLOSED, FILTER_OPEN, FILTER_ACKNOWLEDGED } from '../../../../common/types';
 import * as i18n from '../translations';
 import { buildTimeRangeFilter } from '../../components/alerts_table/helpers';
+import { useAlertsPrivileges } from '../../containers/detection_engine/alerts/use_alerts_privileges';
 
 interface UseBulkAlertActionItemsArgs {
   /* Table ID for which this hook is being used */
@@ -41,6 +42,7 @@ export const useBulkAlertActionItems = ({
   to,
   refetch: refetchProp,
 }: UseBulkAlertActionItemsArgs) => {
+  const { hasIndexWrite } = useAlertsPrivileges();
   const { startTransaction } = useStartTransaction();
 
   const { addSuccess, addError, addWarning } = useAppToasts();
@@ -172,7 +174,9 @@ export const useBulkAlertActionItems = ({
     [getOnAction]
   );
 
-  return [FILTER_OPEN, FILTER_CLOSED, FILTER_ACKNOWLEDGED].map((status) =>
-    getUpdateAlertStatusAction(status as AlertWorkflowStatus)
-  );
+  return hasIndexWrite
+    ? [FILTER_OPEN, FILTER_CLOSED, FILTER_ACKNOWLEDGED].map((status) =>
+        getUpdateAlertStatusAction(status as AlertWorkflowStatus)
+      )
+    : [];
 };

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/users
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/users
@@ -1,5 +1,6 @@
 elastic_serverless:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 system_indices_superuser:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
+viewer:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t1_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t2_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW
 t3_analyst:$2a$10$nN6sRtQl2KX9Gn8kV/.NpOLSk6Jwn8TehEDnZ7aaAgzyl/dy5PYzW

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/users_roles
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/roles_users/serverless/es_serverless_resources/users_roles
@@ -1,5 +1,6 @@
 superuser:elastic_serverless
 system_indices_superuser:system_indices_superuser
+viewer:viewer
 t1_analyst:t1_analyst
 t2_analyst:t2_analyst
 t3_analyst:t3_analyst

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -237,13 +237,13 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
     });
   });
 
-  context.only('User is readonly', () => {
+  context('User is readonly', () => {
     beforeEach(() => {
       login();
       visit(ALERTS_URL);
       deleteAlertsAndRules();
       createRule(getNewRule());
-      login(ROLES.reader);
+      login(ROLES.t1_analyst);
       visit(ALERTS_URL, { role: ROLES.reader });
       waitForAlertsToPopulate();
     });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -249,6 +249,7 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
     });
 
     it('should not allow users to change a single alert status', () => {
+      // This is due to the reader role which makes everything in security 'read only'
       cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -9,10 +9,8 @@ import { ROLES } from '@kbn/security-solution-plugin/common/test';
 import { getNewRule } from '../../../objects/rule';
 import {
   ALERTS_COUNT,
-  CLOSE_ALERT_BTN,
   CLOSE_SELECTED_ALERTS_BTN,
   MARK_ALERT_ACKNOWLEDGED_BTN,
-  OPEN_ALERT_BTN,
   SELECTED_ALERTS,
   TAKE_ACTION_POPOVER_BTN,
   TIMELINE_CONTEXT_MENU_BTN,
@@ -30,7 +28,6 @@ import {
   goToOpenedAlerts,
   openAlerts,
   openFirstAlert,
-  expandFirstAlertActions,
 } from '../../../tasks/alerts';
 import { createRule } from '../../../tasks/api_calls/rules';
 import { deleteAlertsAndRules } from '../../../tasks/common';

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -15,6 +15,7 @@ import {
   OPEN_ALERT_BTN,
   SELECTED_ALERTS,
   TAKE_ACTION_POPOVER_BTN,
+  TIMELINE_CONTEXT_MENU_BTN,
 } from '../../../screens/alerts';
 
 import {
@@ -45,226 +46,217 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
     cy.task('esArchiverLoad', { archiveName: 'auditbeat_big' });
   });
 
-  context('User can crud', () => {
-    context('Opening alerts', () => {
-      beforeEach(() => {
-        login();
-        deleteAlertsAndRules();
-        createRule(getNewRule());
-        visit(ALERTS_URL);
-        waitForAlertsToPopulate();
-        selectNumberOfAlerts(3);
-        cy.get(SELECTED_ALERTS).should('have.text', `Selected 3 alerts`);
-        closeAlerts();
-        waitForAlerts();
-      });
-
-      after(() => {
-        cy.task('esArchiverUnload', 'auditbeat_big');
-      });
-
-      it('can mark a closed alert as open', () => {
-        waitForAlertsToPopulate();
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((numberOfOpenedAlertsText) => {
-            const numberOfOpenedAlerts = parseInt(numberOfOpenedAlertsText, 10);
-            goToClosedAlerts();
-            waitForAlerts();
-            cy.get(ALERTS_COUNT)
-              .invoke('text')
-              .then((alertNumberString) => {
-                const numberOfAlerts = alertNumberString.split(' ')[0];
-                const numberOfAlertsToBeOpened = 1;
-
-                openFirstAlert();
-                waitForAlerts();
-
-                const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeOpened;
-                cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
-
-                goToOpenedAlerts();
-                waitForAlerts();
-
-                cy.get(ALERTS_COUNT).contains(`${numberOfOpenedAlerts + numberOfAlertsToBeOpened}`);
-              });
-          });
-      });
-
-      it('can bulk open alerts', () => {
-        waitForAlertsToPopulate();
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((numberOfOpenedAlertsText) => {
-            const numberOfOpenedAlerts = parseInt(numberOfOpenedAlertsText, 10);
-            goToClosedAlerts();
-            waitForAlerts();
-            cy.get(ALERTS_COUNT)
-              .invoke('text')
-              .then((alertNumberString) => {
-                const numberOfAlerts = alertNumberString.split(' ')[0];
-                const numberOfAlertsToBeOpened = 2;
-                const numberOfAlertsToBeSelected = 2;
-
-                selectNumberOfAlerts(numberOfAlertsToBeSelected);
-                cy.get(SELECTED_ALERTS).should(
-                  'have.text',
-                  `Selected ${numberOfAlertsToBeSelected} alerts`
-                );
-
-                openAlerts();
-                waitForAlerts();
-
-                const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeOpened;
-                cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
-
-                goToOpenedAlerts();
-                waitForAlerts();
-
-                cy.get(ALERTS_COUNT).contains(`${numberOfOpenedAlerts + numberOfAlertsToBeOpened}`);
-              });
-          });
-      });
-    });
-
-    context('Marking alerts as acknowledged', () => {
-      beforeEach(() => {
-        login();
-        deleteAlertsAndRules();
-        createRule(getNewRule());
-        visit(ALERTS_URL);
-        waitForAlertsToPopulate();
-      });
-
-      it('can mark alert as acknowledged', () => {
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((alertNumberString) => {
-            const numberOfAlerts = alertNumberString.split(' ')[0];
-            const numberOfAlertsToBeMarkedAcknowledged = 1;
-
-            markAcknowledgedFirstAlert();
-            waitForAlerts();
-            const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeMarkedAcknowledged;
-            cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
-
-            goToAcknowledgedAlerts();
-            waitForAlerts();
-
-            cy.get(ALERTS_COUNT).contains(`${numberOfAlertsToBeMarkedAcknowledged}`);
-          });
-      });
-
-      it('can bulk mark alerts as acknowledged', () => {
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((alertNumberString) => {
-            const numberOfAlerts = alertNumberString.split(' ')[0];
-            const numberOfAlertsToBeMarkedAcknowledged = 2;
-            const numberOfAlertsToBeSelected = 2;
-
-            selectNumberOfAlerts(numberOfAlertsToBeSelected);
-
-            markAlertsAcknowledged();
-            waitForAlerts();
-            const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeMarkedAcknowledged;
-            cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
-
-            goToAcknowledgedAlerts();
-            waitForAlerts();
-
-            cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeMarkedAcknowledged);
-          });
-      });
-    });
-
-    context('Closing alerts', () => {
-      beforeEach(() => {
-        login();
-        deleteAlertsAndRules();
-        createRule(getNewRule({ rule_id: '1', max_signals: 100 }));
-        visit(ALERTS_URL);
-        waitForAlertsToPopulate();
-      });
-      it('can close an alert', () => {
-        const numberOfAlertsToBeClosed = 1;
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((alertNumberString) => {
-            const numberOfAlerts = alertNumberString.split(' ')[0];
-            cy.get(ALERTS_COUNT).should('have.text', `${numberOfAlerts} alerts`);
-
-            selectNumberOfAlerts(numberOfAlertsToBeClosed);
-
-            cy.get(SELECTED_ALERTS).should(
-              'have.text',
-              `Selected ${numberOfAlertsToBeClosed} alert`
-            );
-
-            closeFirstAlert();
-            waitForAlerts();
-
-            const expectedNumberOfAlertsAfterClosing = +numberOfAlerts - numberOfAlertsToBeClosed;
-            cy.get(ALERTS_COUNT).contains(expectedNumberOfAlertsAfterClosing);
-
-            goToClosedAlerts();
-            waitForAlerts();
-
-            cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeClosed);
-          });
-      });
-
-      it('can bulk close alerts', () => {
-        const numberOfAlertsToBeClosed = 2;
-        cy.get(ALERTS_COUNT)
-          .invoke('text')
-          .then((alertNumberString) => {
-            const numberOfAlerts = alertNumberString.split(' ')[0];
-            cy.get(ALERTS_COUNT).should('have.text', `${numberOfAlerts} alerts`);
-
-            selectNumberOfAlerts(numberOfAlertsToBeClosed);
-
-            cy.get(SELECTED_ALERTS).should(
-              'have.text',
-              `Selected ${numberOfAlertsToBeClosed} alerts`
-            );
-
-            closeAlerts();
-            waitForAlerts();
-
-            const expectedNumberOfAlertsAfterClosing = +numberOfAlerts - numberOfAlertsToBeClosed;
-            cy.get(ALERTS_COUNT).contains(expectedNumberOfAlertsAfterClosing);
-
-            goToClosedAlerts();
-            waitForAlerts();
-
-            cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeClosed);
-          });
-      });
-    });
-  });
-
-  context('User is readonly', () => {
+  context('Opening alerts', () => {
     beforeEach(() => {
-      login(ROLES.reader);
+      login();
       deleteAlertsAndRules();
       createRule(getNewRule());
       visit(ALERTS_URL);
       waitForAlertsToPopulate();
+      selectNumberOfAlerts(3);
+      cy.get(SELECTED_ALERTS).should('have.text', `Selected 3 alerts`);
+      closeAlerts();
+      waitForAlerts();
     });
 
     after(() => {
       cy.task('esArchiverUnload', 'auditbeat_big');
     });
 
+    it('can mark a closed alert as open', () => {
+      waitForAlertsToPopulate();
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((numberOfOpenedAlertsText) => {
+          const numberOfOpenedAlerts = parseInt(numberOfOpenedAlertsText, 10);
+          goToClosedAlerts();
+          waitForAlerts();
+          cy.get(ALERTS_COUNT)
+            .invoke('text')
+            .then((alertNumberString) => {
+              const numberOfAlerts = alertNumberString.split(' ')[0];
+              const numberOfAlertsToBeOpened = 1;
+
+              openFirstAlert();
+              waitForAlerts();
+
+              const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeOpened;
+              cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
+
+              goToOpenedAlerts();
+              waitForAlerts();
+
+              cy.get(ALERTS_COUNT).contains(`${numberOfOpenedAlerts + numberOfAlertsToBeOpened}`);
+            });
+        });
+    });
+
+    it('can bulk open alerts', () => {
+      waitForAlertsToPopulate();
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((numberOfOpenedAlertsText) => {
+          const numberOfOpenedAlerts = parseInt(numberOfOpenedAlertsText, 10);
+          goToClosedAlerts();
+          waitForAlerts();
+          cy.get(ALERTS_COUNT)
+            .invoke('text')
+            .then((alertNumberString) => {
+              const numberOfAlerts = alertNumberString.split(' ')[0];
+              const numberOfAlertsToBeOpened = 2;
+              const numberOfAlertsToBeSelected = 2;
+
+              selectNumberOfAlerts(numberOfAlertsToBeSelected);
+              cy.get(SELECTED_ALERTS).should(
+                'have.text',
+                `Selected ${numberOfAlertsToBeSelected} alerts`
+              );
+
+              openAlerts();
+              waitForAlerts();
+
+              const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeOpened;
+              cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
+
+              goToOpenedAlerts();
+              waitForAlerts();
+
+              cy.get(ALERTS_COUNT).contains(`${numberOfOpenedAlerts + numberOfAlertsToBeOpened}`);
+            });
+        });
+    });
+  });
+
+  context('Marking alerts as acknowledged', () => {
+    beforeEach(() => {
+      login();
+      deleteAlertsAndRules();
+      createRule(getNewRule());
+      visit(ALERTS_URL);
+      waitForAlertsToPopulate();
+    });
+
+    it('can mark alert as acknowledged', () => {
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((alertNumberString) => {
+          const numberOfAlerts = alertNumberString.split(' ')[0];
+          const numberOfAlertsToBeMarkedAcknowledged = 1;
+
+          markAcknowledgedFirstAlert();
+          waitForAlerts();
+          const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeMarkedAcknowledged;
+          cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
+
+          goToAcknowledgedAlerts();
+          waitForAlerts();
+
+          cy.get(ALERTS_COUNT).contains(`${numberOfAlertsToBeMarkedAcknowledged}`);
+        });
+    });
+
+    it('can bulk mark alerts as acknowledged', () => {
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((alertNumberString) => {
+          const numberOfAlerts = alertNumberString.split(' ')[0];
+          const numberOfAlertsToBeMarkedAcknowledged = 2;
+          const numberOfAlertsToBeSelected = 2;
+
+          selectNumberOfAlerts(numberOfAlertsToBeSelected);
+
+          markAlertsAcknowledged();
+          waitForAlerts();
+          const expectedNumberOfAlerts = +numberOfAlerts - numberOfAlertsToBeMarkedAcknowledged;
+          cy.get(ALERTS_COUNT).contains(expectedNumberOfAlerts);
+
+          goToAcknowledgedAlerts();
+          waitForAlerts();
+
+          cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeMarkedAcknowledged);
+        });
+    });
+  });
+
+  context('Closing alerts', () => {
+    beforeEach(() => {
+      login();
+      deleteAlertsAndRules();
+      createRule(getNewRule({ rule_id: '1', max_signals: 100 }));
+      visit(ALERTS_URL);
+      waitForAlertsToPopulate();
+    });
+    it('can close an alert', () => {
+      const numberOfAlertsToBeClosed = 1;
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((alertNumberString) => {
+          const numberOfAlerts = alertNumberString.split(' ')[0];
+          cy.get(ALERTS_COUNT).should('have.text', `${numberOfAlerts} alerts`);
+
+          selectNumberOfAlerts(numberOfAlertsToBeClosed);
+
+          cy.get(SELECTED_ALERTS).should('have.text', `Selected ${numberOfAlertsToBeClosed} alert`);
+
+          closeFirstAlert();
+          waitForAlerts();
+
+          const expectedNumberOfAlertsAfterClosing = +numberOfAlerts - numberOfAlertsToBeClosed;
+          cy.get(ALERTS_COUNT).contains(expectedNumberOfAlertsAfterClosing);
+
+          goToClosedAlerts();
+          waitForAlerts();
+
+          cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeClosed);
+        });
+    });
+
+    it('can bulk close alerts', () => {
+      const numberOfAlertsToBeClosed = 2;
+      cy.get(ALERTS_COUNT)
+        .invoke('text')
+        .then((alertNumberString) => {
+          const numberOfAlerts = alertNumberString.split(' ')[0];
+          cy.get(ALERTS_COUNT).should('have.text', `${numberOfAlerts} alerts`);
+
+          selectNumberOfAlerts(numberOfAlertsToBeClosed);
+
+          cy.get(SELECTED_ALERTS).should(
+            'have.text',
+            `Selected ${numberOfAlertsToBeClosed} alerts`
+          );
+
+          closeAlerts();
+          waitForAlerts();
+
+          const expectedNumberOfAlertsAfterClosing = +numberOfAlerts - numberOfAlertsToBeClosed;
+          cy.get(ALERTS_COUNT).contains(expectedNumberOfAlertsAfterClosing);
+
+          goToClosedAlerts();
+          waitForAlerts();
+
+          cy.get(ALERTS_COUNT).contains(numberOfAlertsToBeClosed);
+        });
+    });
+  });
+
+  context.only('User is readonly', () => {
+    beforeEach(() => {
+      login();
+      visit(ALERTS_URL);
+      deleteAlertsAndRules();
+      createRule(getNewRule());
+      login(ROLES.reader);
+      visit(ALERTS_URL, { role: ROLES.reader });
+      waitForAlertsToPopulate();
+    });
+
     it('should not allow users to change a single alert status', () => {
-      expandFirstAlertActions();
-      cy.get(CLOSE_ALERT_BTN).should('not.exist');
-      cy.get(OPEN_ALERT_BTN).should('not.exist');
-      cy.get(MARK_ALERT_ACKNOWLEDGED_BTN).should('not.exist');
+      cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
     });
 
     it('should not allow users to bulk change the alert status', () => {
+      selectNumberOfAlerts(2);
       cy.get(TAKE_ACTION_POPOVER_BTN).first().click();
       cy.get(TAKE_ACTION_POPOVER_BTN).should('be.visible');
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -244,7 +244,7 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
       deleteAlertsAndRules();
       createRule(getNewRule());
       login(ROLES.t1_analyst);
-      visit(ALERTS_URL, { role: ROLES.reader });
+      visit(ALERTS_URL, { role: ROLES.t1_analyst });
       waitForAlertsToPopulate();
     });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/alert_status.cy.ts
@@ -243,8 +243,8 @@ describe('Changing alert status', { tags: ['@ess', '@serverless'] }, () => {
       visit(ALERTS_URL);
       deleteAlertsAndRules();
       createRule(getNewRule());
-      login(ROLES.t1_analyst);
-      visit(ALERTS_URL, { role: ROLES.t1_analyst });
+      login(ROLES.viewer);
+      visit(ALERTS_URL, { role: ROLES.viewer });
       waitForAlertsToPopulate();
     });
 


### PR DESCRIPTION
## Summary
Addresses https://github.com/elastic/kibana/issues/169684

The alert privileges need to be added for the alert table as it wasn't added when the migration took place. An example of the privileges elsewhere is below:
https://github.com/elastic/kibana/blob/75e9d46b4b3a6ff5be4ffc324ba282cea0faea0c/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alerts_actions.tsx#L33


Fix:

https://github.com/elastic/kibana/assets/17211684/7b354906-9b96-4ba8-b30f-4080cf7e7c2f





