### PR TITLE
[Discover] Attempt to fix global state sync issue

### DIFF
--- a/src/plugins/data/public/query/state_sync/sync_state_with_url.test.ts
+++ b/src/plugins/data/public/query/state_sync/sync_state_with_url.test.ts
@@ -165,4 +165,12 @@ describe('sync_query_state_with_url', () => {
     expect(spy).not.toBeCalled();
     stop();
   });
+
+  test('an empty global state in URL should be overwritten by the filterManager global filter if given', () => {
+    history.push('/#?_g=()');
+    filterManager.setFilters([gF]);
+    const { stop } = syncQueryStateWithUrl(queryServiceStart, kbnUrlStateStorage);
+    expect(kbnUrlStateStorage.get<GlobalQueryStateFromUrl>('_g')?.filters).toHaveLength(1);
+    stop();
+  });
 });

--- a/src/plugins/data/public/query/state_sync/sync_state_with_url.ts
+++ b/src/plugins/data/public/query/state_sync/sync_state_with_url.ts
@@ -61,7 +61,7 @@ export const syncGlobalQueryStateWithUrl = (
 
   // if there weren't any initial state in url,
   // then put _g key into url
-  if (!initialStateFromUrl) {
+  if (!initialStateFromUrl || !hasInheritedQueryFromUrl) {
     kbnUrlStateStorage.set<GlobalQueryStateFromUrl>(GLOBAL_STATE_STORAGE_KEY, initialState, {
       replace: true,
     });

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
@@ -18,7 +18,10 @@ import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 describe('DiscoverSavedSearchContainer', () => {
   const savedSearch = savedSearchMock;
   const services = discoverServiceMock;
-  const globalStateContainer = getDiscoverGlobalStateContainer(createKbnUrlStateStorage());
+  const globalStateContainer = getDiscoverGlobalStateContainer(
+    createKbnUrlStateStorage(),
+    services
+  );
 
   describe('getTitle', () => {
     it('returns undefined for new saved searches', () => {

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -396,7 +396,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_a=(columns:!(bytes),index:the-data-view-id,interval:month,sort:!())&_g=()"`
+      `"/#?_a=(columns:!(bytes),index:the-data-view-id,interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
     unsubscribe();
@@ -411,7 +411,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_a=(columns:!(bytes),index:the-data-view-id,interval:month,sort:!())&_g=()"`
+      `"/#?_a=(columns:!(bytes),index:the-data-view-id,interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
     unsubscribe();
@@ -440,7 +440,7 @@ describe('Test discover state actions', () => {
     const unsubscribe = state.actions.initializeAndSync();
     await new Promise(process.nextTick);
     expect(getCurrentUrl()).toMatchInlineSnapshot(
-      `"/#?_a=(columns:!(message),index:the-data-view-id,interval:month,sort:!())&_g=()"`
+      `"/#?_a=(columns:!(message),index:the-data-view-id,interval:month,sort:!())&_g=(refreshInterval:(pause:!t,value:1000),time:(from:now-15d,to:now))"`
     );
     expect(state.savedSearchState.getHasChanged$().getValue()).toBe(true);
     unsubscribe();

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -227,7 +227,7 @@ export function getDiscoverStateContainer({
   /**
    * Global State Container, synced with the _g part URL
    */
-  const globalStateContainer = getDiscoverGlobalStateContainer(stateStorage);
+  const globalStateContainer = getDiscoverGlobalStateContainer(stateStorage, services);
 
   /**
    * Saved Search State Container, the persisted saved object of Discover


### PR DESCRIPTION
## Summary

WIP


resolves #165899
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
