### PR TITLE
[Cases] Change the error message for missing required custom fields.

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -550,7 +550,7 @@ describe('create', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'missing field 1',
               required: true,
             },
             {
@@ -566,7 +566,7 @@ describe('create', () => {
       await expect(
         create({ ...theCase }, clientArgs, casesClient)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: first_key"`
+        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\""`
       );
     });
 
@@ -578,13 +578,13 @@ describe('create', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'missing field 1',
               required: true,
             },
             {
               key: 'second_key',
               type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
+              label: 'missing field 2',
               required: true,
             },
           ],
@@ -612,7 +612,7 @@ describe('create', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: first_key,second_key"`
+        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 
@@ -695,7 +695,7 @@ describe('create', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: first_key"`
+        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -920,7 +920,7 @@ describe('update', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'missing field 1',
               required: true,
             },
             {
@@ -1156,7 +1156,7 @@ describe('update', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: Missing required custom fields: first_key"`
+        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: Missing required custom fields: \\"missing field 1\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -355,37 +355,7 @@ describe('validators', () => {
         {
           key: 'first_key',
           type: CustomFieldTypes.TEXT,
-          label: 'foo',
-          required: true,
-        },
-        {
-          key: 'second_key',
-          type: CustomFieldTypes.TOGGLE,
-          label: 'foo',
-          required: true,
-        },
-      ];
-      expect(() =>
-        validateRequiredCustomFields({
-          requestCustomFields,
-          customFieldsConfiguration,
-        })
-      ).toThrowErrorMatchingInlineSnapshot(`"Missing required custom fields: first_key"`);
-    });
-
-    it('throws if required custom fields have null value', () => {
-      const requestCustomFields: CaseCustomFields = [
-        {
-          key: 'second_key',
-          type: CustomFieldTypes.TOGGLE,
-          value: null,
-        },
-      ];
-      const customFieldsConfiguration: CustomFieldsConfiguration = [
-        {
-          key: 'first_key',
-          type: CustomFieldTypes.TEXT,
-          label: 'foo',
+          label: 'missing field 1',
           required: true,
         },
         {
@@ -401,7 +371,39 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields: first_key,second_key"`
+        `"Missing required custom fields: \\"missing field 1\\""`
+      );
+    });
+
+    it('throws if required custom fields have null value', () => {
+      const requestCustomFields: CaseCustomFields = [
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          value: null,
+        },
+      ];
+      const customFieldsConfiguration: CustomFieldsConfiguration = [
+        {
+          key: 'first_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'missing field 1',
+          required: true,
+        },
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'missing field 2',
+          required: true,
+        },
+      ];
+      expect(() =>
+        validateRequiredCustomFields({
+          requestCustomFields,
+          customFieldsConfiguration,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Missing required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 
@@ -425,7 +427,7 @@ describe('validators', () => {
         {
           key: 'first_key',
           type: CustomFieldTypes.TEXT,
-          label: 'foo',
+          label: 'missing field 1',
           required: true,
         },
       ];
@@ -433,7 +435,9 @@ describe('validators', () => {
         validateRequiredCustomFields({
           customFieldsConfiguration,
         })
-      ).toThrowErrorMatchingInlineSnapshot(`"Missing required custom fields: first_key"`);
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Missing required custom fields: \\"missing field 1\\""`
+      );
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -115,7 +115,7 @@ export const validateRequiredCustomFields = ({
     requiredCustomFields,
     requestCustomFields ?? [],
     (requiredVal, requestedVal) => requiredVal.key === requestedVal.key
-  ).map((e) => e.key);
+  ).map((e) => `"${e.label}"`);
 
   requiredCustomFields.forEach((requiredField) => {
     const found = requestCustomFields?.find(
@@ -123,11 +123,13 @@ export const validateRequiredCustomFields = ({
     );
 
     if (found && found.value === null) {
-      missingRequiredCustomFields.push(found.key);
+      missingRequiredCustomFields.push(`"${requiredField.label}"`);
     }
   });
 
   if (missingRequiredCustomFields.length) {
-    throw Boom.badRequest(`Missing required custom fields: ${missingRequiredCustomFields}`);
+    throw Boom.badRequest(
+      `Missing required custom fields: ${missingRequiredCustomFields.join(', ')}`
+    );
   }
 };


### PR DESCRIPTION
## Summary

Updated the error message when the user tried to update a case with missing required custom fields.

<details><summary>Before</summary><img width="606" alt="Screenshot 2023-10-24 at 14 42 18" src="https://github.com/elastic/kibana/assets/1533137/999272cb-b558-4b89-a100-6c5a80ec714c"></details>

<details><summary>After</summary>
<img width="393" alt="Screenshot 2023-10-25 at 10 38 14" src="https://github.com/elastic/kibana/assets/1533137/ea10b349-03cd-4ed3-bc52-7d1feb82abac"></details>


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->