### PR TITLE
[Serverless] Improve fleet and integrations serverless breadcrumbs

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/hooks/use_breadcrumbs.tsx
@@ -24,6 +24,7 @@ const BASE_BREADCRUMB: Breadcrumb = {
   text: i18n.translate('xpack.fleet.breadcrumbs.appTitle', {
     defaultMessage: 'Fleet',
   }),
+  deepLinkId: 'fleet',
 };
 
 const INTEGRATIONS_BASE_BREADCRUMB: Breadcrumb = {
@@ -32,6 +33,7 @@ const INTEGRATIONS_BASE_BREADCRUMB: Breadcrumb = {
     defaultMessage: 'Integrations',
   }),
   useIntegrationsBasePath: true,
+  deepLinkId: 'integrations',
 };
 
 const breadcrumbGetters: {

--- a/x-pack/plugins/fleet/public/applications/integrations/hooks/use_breadcrumbs.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/hooks/use_breadcrumbs.tsx
@@ -19,6 +19,7 @@ const BASE_BREADCRUMB: ChromeBreadcrumb = {
   text: i18n.translate('xpack.fleet.breadcrumbs.integrationsAppTitle', {
     defaultMessage: 'Integrations',
   }),
+  deepLinkId: 'integrations',
 };
 
 const breadcrumbGetters: {

--- a/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/navigation.ts
@@ -128,5 +128,20 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       });
       await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Cases', 'Settings']);
     });
+
+    it('navigates to integrations', async () => {
+      await svlCommonNavigation.sidenav.openSection('project_settings_project_nav');
+      await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'integrations' });
+      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts([
+        'Integrations',
+        'Browse integrations',
+      ]);
+    });
+
+    it('navigates to fleet', async () => {
+      await svlCommonNavigation.sidenav.openSection('project_settings_project_nav');
+      await svlCommonNavigation.sidenav.clickLink({ deepLinkId: 'fleet' });
+      await svlCommonNavigation.breadcrumbs.expectBreadcrumbTexts(['Fleet', 'Agents']);
+    });
   });
 }


### PR DESCRIPTION
## Summary

This fixes deeper context breadcrumbs in serverless navigation for fleet and integration apps. 
This builds on top of https://github.com/elastic/kibana/pull/169513 where we added merging of navigational project breadcrumbs with deeper context breadcrumbs set by `chrome.setBreadcrumbs`. The merging is based on `deepLinkId`, so we're adding it to base breadcrumbs. The `deepLinkId` is type checked. 


Example Before/After: 

Before:

![Screenshot 2023-10-25 at 12 05 33](https://github.com/elastic/kibana/assets/7784120/4a6a0bab-1cef-4b24-8349-246b9612563e)

![Screenshot 2023-10-25 at 12 05 37](https://github.com/elastic/kibana/assets/7784120/63435c3c-1397-4b41-8d46-3d0e9bd32515)


After:
![Screenshot 2023-10-25 at 12 06 10](https://github.com/elastic/kibana/assets/7784120/a7519fdd-b21a-40e7-a774-d867bb4e79ec)

![Screenshot 2023-10-25 at 12 06 14](https://github.com/elastic/kibana/assets/7784120/1e99e005-1317-4c62-af1e-c445c9038fc4)


