### PR TITLE
[Security Solution ] Fix flake in `bundled_prebuilt_rules_package/prerelease_packages.ts` API Integration test

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import expect from 'expect';
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
@@ -41,7 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import expect from 'expect';
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
@@ -41,7 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -5,11 +5,11 @@
  * 2.0.
  */
 import expect from 'expect';
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
 import { getPrebuiltRulesStatus } from '../../utils/prebuilt_rules/get_prebuilt_rules_status';
+import { installPrebuiltRulesPackageViaFleetAPI } from '../../utils/prebuilt_rules/install_fleet_package_by_url';
 import { installPrebuiltRules } from '../../utils/prebuilt_rules/install_prebuilt_rules';
 
 // eslint-disable-next-line import/no-default-export
@@ -38,16 +38,20 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.stats.num_prebuilt_rules_to_install).toBe(0);
       expect(statusBeforePackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
 
+      await installPrebuiltRulesPackageViaFleetAPI(es, supertest);
+
+      const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);
+      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_installed).toBe(0);
+      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_to_install).toBe(1); // 1 rule in package 99.0.0
+      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
+
       await installPrebuiltRules(es, supertest);
 
-      // Refresh ES indices to avoid race conditions between write and reading of indeces
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
-
       // Verify that status is updated after package installation
-      const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);
-      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_installed).toBe(1); // 1 rule in package 99.0.0
-      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_to_install).toBe(0);
-      expect(statusAfterPackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
+      const statusAfterRulesInstallation = await getPrebuiltRulesStatus(supertest);
+      expect(statusAfterRulesInstallation.stats.num_prebuilt_rules_installed).toBe(1); // 1 rule in package 99.0.0
+      expect(statusAfterRulesInstallation.stats.num_prebuilt_rules_to_install).toBe(0);
+      expect(statusAfterRulesInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
 
       // Get installed rules
       const rulesResponse = await getInstalledRules(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import expect from 'expect';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
@@ -38,6 +39,9 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.stats.num_prebuilt_rules_to_upgrade).toBe(0);
 
       await installPrebuiltRules(es, supertest);
+
+      // Refresh ES indices to avoid race conditions between write and reading of indeces
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -4,9 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import expect from 'expect';
-// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import expect from 'expect';
 // import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -42,7 +42,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import expect from 'expect';
 // import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
@@ -41,7 +42,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -41,7 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/bundled_prebuilt_rules_package/prerelease_packages.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import expect from 'expect';
-// import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
+import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import { deleteAllPrebuiltRuleAssets, deleteAllRules } from '../../utils';
 import { getInstalledRules } from '../../utils/prebuilt_rules/get_installed_rules';
@@ -41,7 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
       await installPrebuiltRules(es, supertest);
 
       // Refresh ES indices to avoid race conditions between write and reading of indeces
-      // await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+      await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
@@ -18,13 +18,12 @@ import { InstallPackageResponse } from '@kbn/fleet-plugin/common/types';
  * @returns Fleet install package response
  */
 
-export const installPrebuiltRulesPackageByVersion = async (
+export const installPrebuiltRulesPackageViaFleetAPI = async (
   es: Client,
-  supertest: SuperTest.SuperTest<SuperTest.Test>,
-  version: string
+  supertest: SuperTest.SuperTest<SuperTest.Test>
 ): Promise<InstallPackageResponse> => {
   const fleetResponse = await supertest
-    .post(`/api/fleet/epm/packages/security_detection_engine/${version}`)
+    .post(`/api/fleet/epm/packages/security_detection_engine`)
     .set('kbn-xsrf', 'xxxx')
     .type('application/json')
     .send({ force: true })
@@ -44,6 +43,31 @@ export const installPrebuiltRulesPackageByVersion = async (
   // the next refresh. Also, probably the refresh time can be delayed when ES is under load?
   // Anyway, this can cause race condition between a write and subsequent read operation, and to
   // fix it deterministically we have to refresh saved object indices and wait until it's done.
+  await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
+
+  return fleetResponse.body as InstallPackageResponse;
+};
+/**
+ * Installs prebuilt rules package `security_detection_engine` by version.
+ *
+ * @param es Elasticsearch client
+ * @param supertest SuperTest instance
+ * @param version Semver version of the `security_detection_engine` package to install
+ * @returns Fleet install package response
+ */
+
+export const installPrebuiltRulesPackageByVersion = async (
+  es: Client,
+  supertest: SuperTest.SuperTest<SuperTest.Test>,
+  version: string
+): Promise<InstallPackageResponse> => {
+  const fleetResponse = await supertest
+    .post(`/api/fleet/epm/packages/security_detection_engine/${version}`)
+    .set('kbn-xsrf', 'xxxx')
+    .type('application/json')
+    .send({ force: true })
+    .expect(200);
+
   await es.indices.refresh({ index: ALL_SAVED_OBJECT_INDICES });
 
   return fleetResponse.body as InstallPackageResponse;

--- a/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/prebuilt_rules/install_fleet_package_by_url.ts
@@ -10,7 +10,7 @@ import { ALL_SAVED_OBJECT_INDICES } from '@kbn/core-saved-objects-server';
 import { InstallPackageResponse } from '@kbn/fleet-plugin/common/types';
 
 /**
- * Installs prebuilt rules package `security_detection_engine` by version.
+ * Installs latest available non-prerelease prebuilt rules package `security_detection_engine`.
  *
  * @param es Elasticsearch client
  * @param supertest SuperTest instance
@@ -48,7 +48,8 @@ export const installPrebuiltRulesPackageViaFleetAPI = async (
   return fleetResponse.body as InstallPackageResponse;
 };
 /**
- * Installs prebuilt rules package `security_detection_engine` by version.
+ * Installs prebuilt rules package `security_detection_engine`, passing in the version
+ * of the package as a parameter to the utl.
  *
  * @param es Elasticsearch client
  * @param supertest SuperTest instance


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/162192

## Summary

Removes flake by explicitly calling the Fleet endpoint to install the latest package, and doing assertions before actually installing the rules.

Previously we were calling directly `installPrebuiltRules` without having explicitly installed the package before. The old installation endpoint would check that the package was installed before proceeding, but the new install method doesn't. So the explicit installation is required.

## Flaky test runs

- ~https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3721~
- ~https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3730 [CONTROL - NO CHANGES]~
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3773 [After refactor]


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->