### PR TITLE
[ML] AIOps: Fixes relative time bounds for the change point embeddable 

### DIFF
--- a/x-pack/plugins/aiops/public/components/change_point_detection/use_common_chart_props.ts
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/use_common_chart_props.ts
@@ -8,6 +8,7 @@
 import moment from 'moment';
 import { FilterStateStore, type TimeRange } from '@kbn/es-query';
 import { type TypedLensByValueInput } from '@kbn/lens-plugin/public';
+import { getAbsoluteTimeRange } from '@kbn/data-plugin/common';
 import { useMemo } from 'react';
 import { useFilerQueryUpdates } from '../../hooks/use_filters_query';
 import { fnOperationTypeMapping } from './constants';
@@ -38,9 +39,11 @@ export const useCommonChartProps = ({
    * we need to adjust time bound based on the change point timestamp.
    */
   const chartTimeRange = useMemo<TimeRange>(() => {
+    const absoluteTimeRange = getAbsoluteTimeRange(timeRange);
+
     return {
-      from: moment.min(moment(timeRange.from), moment(annotation.timestamp)).toISOString(),
-      to: moment.max(moment(timeRange.to), moment(annotation.timestamp)).toISOString(),
+      from: moment.min(moment(absoluteTimeRange.from), moment(annotation.timestamp)).toISOString(),
+      to: moment.max(moment(absoluteTimeRange.to), moment(annotation.timestamp)).toISOString(),
     };
   }, [timeRange, annotation.timestamp]);
 

--- a/x-pack/plugins/aiops/public/hooks/use_filters_query.tsx
+++ b/x-pack/plugins/aiops/public/hooks/use_filters_query.tsx
@@ -48,7 +48,7 @@ export const FilterQueryContextProvider: FC<{ timeRange?: TimeRange }> = ({
   const [resultFilters, setResultFilter] = useState<Filter[]>(filterManager.getFilters());
   const [resultQuery, setResultQuery] = useState<Query | AggregateQuery>(queryString.getQuery());
 
-  const timeRangeUpdates = useTimeRangeUpdates(true);
+  const timeRangeUpdates = useTimeRangeUpdates(false);
 
   useEffect(() => {
     const sub = filterManager.getUpdates$().subscribe(() => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/169736

<img width="1240" alt="image" src="https://github.com/elastic/kibana/assets/5236598/db86b0b9-ad29-450c-a973-a6c68b9725e7">


Fixes relative time bounds for the change point embeddable. 

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->