### PR TITLE
[DOCS] breaking change 7.17.15

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -101,7 +101,7 @@ Breaking changes can prevent your application from optimal operation and perform
 [%collapsible]
 ====
 *Details*  +
-TSVB has been updated to use the most recent version of Less (from v2.7.3 to v4.2.0), which could result in markdowns displaying incorrect styling. For more information, refer to {kibana-pull}167831[#167831]
+TSVB has been updated to use the most recent version of Less (from v2.7.3 to v4.2.0), which could result in markdowns displaying incorrect styling. For more information, refer to {kibana-pull}167831[#167831].
 ====
 
 [[release-notes-7.17.14]]
@@ -706,7 +706,7 @@ Security::
 
 For information about the features introduced in 7.17.0, refer to <<whats-new,What's new in 7.17>>.
 
-////
+/////
 [[release-notes-7.16.3]]
 == {kib} 7.16.3
 

--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -13,6 +13,7 @@ Review important information about the {kib} 7.17.x releases.
 // Best practices:
 // * When there are changes to kibana.yml settings, include the links to the new settings.
 
+* <<release-notes-7.17.15>>
 * <<release-notes-7.17.14>>
 * <<release-notes-7.17.13>>
 * <<release-notes-7.17.12>>
@@ -84,6 +85,25 @@ Review important information about the {kib} 7.17.x releases.
 //* <<release-notes-7.0.0-alpha1>>
 
 --
+[[release-notes-7.17.15]]
+== {kib} 7.17.15
+
+Review the following information about the {kib} 7.17.15 release.
+
+[float]
+[[breaking-changes-v7.17.15]]
+=== Breaking changes
+Breaking changes can prevent your application from optimal operation and performance. Before you upgrade to 7.17.15, review the breaking changes, then mitigate the impact to your application.
+
+[discrete]
+[[breaking-167831]]
+.Less version updated for TSVB
+[%collapsible]
+====
+*Details*  +
+TSVB has been updated to use the most recent version of Less (from v2.7.3 to v4.2.0), which could result in markdowns displaying incorrect styling. For more information, refer to {kibana-pull}167831[#167831]
+====
+
 [[release-notes-7.17.14]]
 == {kib} 7.17.14
 
@@ -686,7 +706,7 @@ Security::
 
 For information about the features introduced in 7.17.0, refer to <<whats-new,What's new in 7.17>>.
 
-/////
+////
 [[release-notes-7.16.3]]
 == {kib} 7.16.3
 


### PR DESCRIPTION
## Summary

Making of a note of the breaking change coming in 7.17.15 where markdowns may have incorrect styling due to a Less.je update to TSVB. 

Relates to:#167831

