### PR TITLE
[8.11] [Enterprise Search]Disable syncs for native connectors when EnterpriseSearch is down (#169671)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/syncs_context_menu.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/components/header_actions/syncs_context_menu.tsx
@@ -23,16 +23,17 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { Status } from '../../../../../../../common/types/api';
+import { HttpLogic } from '../../../../../shared/http';
 import { KibanaLogic } from '../../../../../shared/kibana';
 import { CancelSyncsApiLogic } from '../../../../api/connector/cancel_syncs_api_logic';
 import { IngestionStatus } from '../../../../types';
 import { CancelSyncsLogic } from '../../connector/cancel_syncs_logic';
-import { ConnectorConfigurationLogic } from '../../connector/connector_configuration_logic';
 import { IndexViewLogic } from '../../index_view_logic';
 
 export const SyncsContextMenu: React.FC = () => {
-  const { productFeatures } = useValues(KibanaLogic);
+  const { config, productFeatures } = useValues(KibanaLogic);
   const {
+    connector,
     hasDocumentLevelSecurityFeature,
     hasIncrementalSyncFeature,
     ingestionMethod,
@@ -44,7 +45,7 @@ export const SyncsContextMenu: React.FC = () => {
   const { cancelSyncs } = useActions(CancelSyncsLogic);
   const { status } = useValues(CancelSyncsApiLogic);
   const { startSync, startIncrementalSync, startAccessControlSync } = useActions(IndexViewLogic);
-  const { configState } = useValues(ConnectorConfigurationLogic);
+  const { errorConnectingMessage } = useValues(HttpLogic);
 
   const [isPopoverOpen, setPopover] = useState(false);
   const togglePopover = () => setPopover(!isPopoverOpen);
@@ -76,6 +77,13 @@ export const SyncsContextMenu: React.FC = () => {
   const shouldShowIncrementalSync =
     productFeatures.hasIncrementalSyncEnabled && hasIncrementalSyncFeature;
 
+  const isEnterpriseSearchNotAvailable = Boolean(
+    config.host && config.canDeployEntSearch && errorConnectingMessage
+  );
+  const isSyncsDisabled =
+    (connector?.is_native && isEnterpriseSearchNotAvailable) ||
+    ingestionStatus === IngestionStatus.INCOMPLETE;
+
   const panels: EuiContextMenuProps['panels'] = [
     {
       id: 0,
@@ -87,7 +95,7 @@ export const SyncsContextMenu: React.FC = () => {
                 // @ts-ignore - data-* attributes are applied but doesn't exist on types
                 'data-telemetry-id': `entSearchContent-${ingestionMethod}-header-sync-startSync`,
                 'data-test-subj': `entSearchContent-${ingestionMethod}-header-sync-startSync`,
-                disabled: ingestionStatus === IngestionStatus.INCOMPLETE,
+                disabled: isSyncsDisabled,
                 icon: 'play',
                 name: i18n.translate('xpack.enterpriseSearch.index.header.more.fullSync', {
                   defaultMessage: 'Full Content',
@@ -106,7 +114,7 @@ export const SyncsContextMenu: React.FC = () => {
                   'entSearchContent-${ingestionMethod}-header-sync-more-incrementalSync',
                 'data-test-subj':
                   'entSearchContent-${ingestionMethod}-header-sync-more-incrementalSync',
-                disabled: ingestionStatus === IngestionStatus.INCOMPLETE,
+                disabled: isSyncsDisabled,
                 icon: 'play',
                 name: i18n.translate('xpack.enterpriseSearch.index.header.more.incrementalSync', {
                   defaultMessage: 'Incremental Content',
@@ -126,9 +134,9 @@ export const SyncsContextMenu: React.FC = () => {
                   'entSearchContent-${ingestionMethod}-header-sync-more-accessControlSync',
                 'data-test-subj':
                   'entSearchContent-${ingestionMethod}-header-sync-more-accessControlSync',
-                disabled:
-                  ingestionStatus === IngestionStatus.INCOMPLETE ||
-                  !configState.use_document_level_security?.value,
+                disabled: Boolean(
+                  isSyncsDisabled || !connector?.configuration.use_document_level_security?.value
+                ),
                 icon: 'play',
                 name: i18n.translate('xpack.enterpriseSearch.index.header.more.accessControlSync', {
                   defaultMessage: 'Access Control',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { useValues } from 'kea';
 
 import {
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiIcon,
@@ -25,7 +26,9 @@ import { i18n } from '@kbn/i18n';
 
 import { BetaConnectorCallout } from '../../../../../shared/beta/beta_connector_callout';
 import { docLinks } from '../../../../../shared/doc_links';
+import { HttpLogic } from '../../../../../shared/http';
 import { CONNECTOR_ICONS } from '../../../../../shared/icons/connector_icons';
+import { KibanaLogic } from '../../../../../shared/kibana';
 
 import { hasConfiguredConfiguration } from '../../../../utils/has_configured_configuration';
 import { isConnectorIndex } from '../../../../utils/indices';
@@ -40,6 +43,8 @@ import { ResearchConfiguration } from './research_configuration';
 
 export const NativeConnectorConfiguration: React.FC = () => {
   const { index } = useValues(IndexViewLogic);
+  const { config } = useValues(KibanaLogic);
+  const { errorConnectingMessage } = useValues(HttpLogic);
 
   if (!isConnectorIndex(index)) {
     return <></>;
@@ -95,6 +100,33 @@ export const NativeConnectorConfiguration: React.FC = () => {
               </EuiFlexItem>
             </EuiFlexGroup>
             <EuiSpacer />
+            {config.host && config.canDeployEntSearch && errorConnectingMessage && (
+              <>
+                <EuiCallOut
+                  color="warning"
+                  size="m"
+                  title={i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.entSearchWarning.title',
+                    {
+                      defaultMessage: 'No running Enterprise Search instance detected',
+                    }
+                  )}
+                  iconType="warning"
+                >
+                  <p>
+                    {i18n.translate(
+                      'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.entSearchWarning.text',
+                      {
+                        defaultMessage:
+                          'Native connectors require a running Enterprise Search instance to sync content from source.',
+                      }
+                    )}
+                  </p>
+                </EuiCallOut>
+
+                <EuiSpacer />
+              </>
+            )}
             <EuiSteps
               steps={[
                 {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Enterprise Search]Disable syncs for native connectors when EnterpriseSearch is down (#169671)](https://github.com/elastic/kibana/pull/169671)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Efe Gürkan YALAMAN","email":"efeguerkan.yalaman@elastic.co"},"sourceCommit":{"committedDate":"2023-10-25T12:02:28Z","message":"[Enterprise Search]Disable syncs for native connectors when EnterpriseSearch is down (#169671)\n\n## Summary\r\n\r\nDisable syncs when Enterprise Search is down for native connectors.\r\n\r\n<img width=\"1227\" alt=\"Screenshot 2023-10-24 at 17 15 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/d1bca68a-a746-4ee3-9dbd-a79ab1cac205\">\r\n<img width=\"1546\" alt=\"Screenshot 2023-10-24 at 17 15 07\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/48aea67f-d857-4bd8-bbfc-c1fd35eac7a9\">\r\n<img width=\"1235\" alt=\"Screenshot 2023-10-24 at 17 15 32\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/7e45c0cd-2551-4cca-a040-84ab959c81ac\">\r\n<img width=\"1244\" alt=\"Screenshot 2023-10-24 at 17 15 20\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bceb8792-5a4f-487b-a8f1-0d6758473e49\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))","sha":"980162b0b0138fb572a32c4f3901da3df7f53017","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.11.0","v8.12.0"],"number":169671,"url":"https://github.com/elastic/kibana/pull/169671","mergeCommit":{"message":"[Enterprise Search]Disable syncs for native connectors when EnterpriseSearch is down (#169671)\n\n## Summary\r\n\r\nDisable syncs when Enterprise Search is down for native connectors.\r\n\r\n<img width=\"1227\" alt=\"Screenshot 2023-10-24 at 17 15 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/d1bca68a-a746-4ee3-9dbd-a79ab1cac205\">\r\n<img width=\"1546\" alt=\"Screenshot 2023-10-24 at 17 15 07\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/48aea67f-d857-4bd8-bbfc-c1fd35eac7a9\">\r\n<img width=\"1235\" alt=\"Screenshot 2023-10-24 at 17 15 32\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/7e45c0cd-2551-4cca-a040-84ab959c81ac\">\r\n<img width=\"1244\" alt=\"Screenshot 2023-10-24 at 17 15 20\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bceb8792-5a4f-487b-a8f1-0d6758473e49\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))","sha":"980162b0b0138fb572a32c4f3901da3df7f53017"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169671","number":169671,"mergeCommit":{"message":"[Enterprise Search]Disable syncs for native connectors when EnterpriseSearch is down (#169671)\n\n## Summary\r\n\r\nDisable syncs when Enterprise Search is down for native connectors.\r\n\r\n<img width=\"1227\" alt=\"Screenshot 2023-10-24 at 17 15 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/d1bca68a-a746-4ee3-9dbd-a79ab1cac205\">\r\n<img width=\"1546\" alt=\"Screenshot 2023-10-24 at 17 15 07\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/48aea67f-d857-4bd8-bbfc-c1fd35eac7a9\">\r\n<img width=\"1235\" alt=\"Screenshot 2023-10-24 at 17 15 32\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/7e45c0cd-2551-4cca-a040-84ab959c81ac\">\r\n<img width=\"1244\" alt=\"Screenshot 2023-10-24 at 17 15 20\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1410658/bceb8792-5a4f-487b-a8f1-0d6758473e49\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [x] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [x] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [x] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))","sha":"980162b0b0138fb572a32c4f3901da3df7f53017"}}]}] BACKPORT-->