### PR TITLE
[8.11] [SLO] Account for the built-in delay for burn rate alerting (#169011)

### DIFF
--- a/x-pack/plugins/observability/public/components/slo/error_rate_chart/error_rate_chart.tsx
+++ b/x-pack/plugins/observability/public/components/slo/error_rate_chart/error_rate_chart.tsx
@@ -10,6 +10,7 @@ import { SLOResponse } from '@kbn/slo-schema';
 import moment from 'moment';
 import React from 'react';
 import { useKibana } from '../../../utils/kibana_react';
+import { getDelayInSecondsFromSLO } from '../../../utils/slo/get_delay_in_seconds_from_slo';
 import { useLensDefinition } from './use_lens_definition';
 
 interface Props {
@@ -22,14 +23,18 @@ export function ErrorRateChart({ slo, fromRange }: Props) {
     lens: { EmbeddableComponent },
   } = useKibana().services;
   const lensDef = useLensDefinition(slo);
+  const delayInSeconds = getDelayInSecondsFromSLO(slo);
+
+  const from = moment(fromRange).subtract(delayInSeconds, 'seconds').toISOString();
+  const to = moment().subtract(delayInSeconds, 'seconds').toISOString();
 
   return (
     <EmbeddableComponent
       id="sloErrorRateChart"
       style={{ height: 190 }}
       timeRange={{
-        from: fromRange.toISOString(),
-        to: moment().toISOString(),
+        from,
+        to,
       }}
       attributes={lensDef}
       viewMode={ViewMode.VIEW}

--- a/x-pack/plugins/observability/public/components/slo/error_rate_chart/use_lens_definition.ts
+++ b/x-pack/plugins/observability/public/components/slo/error_rate_chart/use_lens_definition.ts
@@ -7,10 +7,14 @@
 
 import { useEuiTheme } from '@elastic/eui';
 import { TypedLensByValueInput } from '@kbn/lens-plugin/public';
-import { ALL_VALUE, SLOResponse } from '@kbn/slo-schema';
+import { ALL_VALUE, SLOResponse, timeslicesBudgetingMethodSchema } from '@kbn/slo-schema';
 
 export function useLensDefinition(slo: SLOResponse): TypedLensByValueInput['attributes'] {
   const { euiTheme } = useEuiTheme();
+
+  const interval = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
+    ? slo.objective.timesliceWindow
+    : '60s';
 
   return {
     title: 'SLO Error Rate',
@@ -125,7 +129,7 @@ export function useLensDefinition(slo: SLOResponse): TypedLensByValueInput['attr
                   scale: 'interval',
                   params: {
                     // @ts-ignore
-                    interval: 'auto',
+                    interval,
                     includeEmptyRows: true,
                     dropPartials: false,
                   },

--- a/x-pack/plugins/observability/public/utils/slo/get_delay_in_seconds_from_slo.ts
+++ b/x-pack/plugins/observability/public/utils/slo/get_delay_in_seconds_from_slo.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { SLOResponse, timeslicesBudgetingMethodSchema, durationType } from '@kbn/slo-schema';
+import { isLeft } from 'fp-ts/lib/Either';
+
+export function getDelayInSecondsFromSLO(slo: SLOResponse) {
+  const fixedInterval = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
+    ? durationStringToSeconds(slo.objective.timesliceWindow)
+    : 60;
+  const syncDelay = durationStringToSeconds(slo.settings.syncDelay);
+  const frequency = durationStringToSeconds(slo.settings.frequency);
+  return fixedInterval + syncDelay + frequency;
+}
+
+function durationStringToSeconds(duration: string | undefined) {
+  if (!duration) {
+    return 0;
+  }
+  const result = durationType.decode(duration);
+  if (isLeft(result)) {
+    throw new Error(`Invalid duration string: ${duration}`);
+  }
+  return result.right.asSeconds();
+}

--- a/x-pack/plugins/observability/server/domain/services/get_delay_in_seconds_from_slo.ts
+++ b/x-pack/plugins/observability/server/domain/services/get_delay_in_seconds_from_slo.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { timeslicesBudgetingMethodSchema } from '@kbn/slo-schema';
+import { SLO } from '../models';
+
+export function getDelayInSecondsFromSLO(slo: SLO) {
+  const fixedInterval = timeslicesBudgetingMethodSchema.is(slo.budgetingMethod)
+    ? slo.objective.timesliceWindow!.asSeconds()
+    : 60;
+  const syncDelay = slo.settings.syncDelay.asSeconds();
+  const frequency = slo.settings.frequency.asSeconds();
+  return fixedInterval + syncDelay + frequency;
+}

--- a/x-pack/plugins/observability/server/domain/services/get_lookback_date_range.ts
+++ b/x-pack/plugins/observability/server/domain/services/get_lookback_date_range.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import moment from 'moment';
+import { Duration, toMomentUnitOfTime } from '../models';
+export function getLookbackDateRange(
+  startedAt: Date,
+  duration: Duration,
+  delayInSeconds = 0
+): { from: Date; to: Date } {
+  const unit = toMomentUnitOfTime(duration.unit);
+  const now = moment(startedAt).subtract(delayInSeconds, 'seconds').startOf('minute');
+  const from = now.clone().subtract(duration.value, unit).startOf('minute');
+
+  return {
+    from: from.toDate(),
+    to: now.toDate(),
+  };
+}

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/lib/__snapshots__/build_query.test.ts.snap
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/lib/__snapshots__/build_query.test.ts.snap
@@ -21,8 +21,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T22:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -70,8 +70,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:55:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:52:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -119,8 +119,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -168,8 +168,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:30:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:27:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -217,8 +217,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-30T23:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -266,8 +266,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T22:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T21:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -315,8 +315,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-29T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-28T23:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -364,8 +364,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -445,8 +445,8 @@ Object {
         Object {
           "range": Object {
             "@timestamp": Object {
-              "gte": "2022-12-29T00:00:00.000Z",
-              "lt": "2023-01-01T00:00:00.000Z",
+              "gte": "2022-12-28T23:57:00.000Z",
+              "lt": "2022-12-31T23:57:00.000Z",
             },
           },
         },
@@ -478,8 +478,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T22:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -505,7 +505,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -527,8 +527,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:55:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:51:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -554,7 +554,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -576,8 +576,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -603,7 +603,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -625,8 +625,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:30:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:26:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -652,7 +652,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -674,8 +674,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-30T23:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -701,7 +701,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -723,8 +723,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T22:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T21:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -750,7 +750,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -772,8 +772,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-29T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-28T23:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -799,7 +799,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -821,8 +821,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:56:00.000Z",
+                "lt": "2022-12-31T23:56:00.000Z",
               },
             },
           },
@@ -848,7 +848,7 @@ Object {
             },
             "script": Object {
               "params": Object {
-                "target": 0.999,
+                "target": 0.98,
               },
               "source": "params.total != null && params.total > 0 ? (1 - (params.good / params.total)) / (1 - params.target) : 0",
             },
@@ -902,8 +902,8 @@ Object {
         Object {
           "range": Object {
             "@timestamp": Object {
-              "gte": "2022-12-29T00:00:00.000Z",
-              "lt": "2023-01-01T00:00:00.000Z",
+              "gte": "2022-12-28T23:56:00.000Z",
+              "lt": "2022-12-31T23:56:00.000Z",
             },
           },
         },
@@ -935,8 +935,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T22:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -984,8 +984,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:55:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:52:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1033,8 +1033,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1082,8 +1082,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T23:30:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T23:27:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1131,8 +1131,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-30T23:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1180,8 +1180,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T22:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T21:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1229,8 +1229,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-29T00:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-28T23:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1278,8 +1278,8 @@ Object {
           "filter": Object {
             "range": Object {
               "@timestamp": Object {
-                "gte": "2022-12-31T18:00:00.000Z",
-                "lt": "2023-01-01T00:00:00.000Z",
+                "gte": "2022-12-31T17:57:00.000Z",
+                "lt": "2022-12-31T23:57:00.000Z",
               },
             },
           },
@@ -1362,8 +1362,8 @@ Object {
         Object {
           "range": Object {
             "@timestamp": Object {
-              "gte": "2022-12-29T00:00:00.000Z",
-              "lt": "2023-01-01T00:00:00.000Z",
+              "gte": "2022-12-28T23:57:00.000Z",
+              "lt": "2022-12-31T23:57:00.000Z",
             },
           },
         },

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/lib/build_query.test.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/lib/build_query.test.ts
@@ -7,7 +7,11 @@
 
 import { createBurnRateRule } from '../fixtures/rule';
 import { buildQuery } from './build_query';
-import { createKQLCustomIndicator, createSLO } from '../../../../services/slo/fixtures/slo';
+import {
+  createKQLCustomIndicator,
+  createSLO,
+  createSLOWithTimeslicesBudgetingMethod,
+} from '../../../../services/slo/fixtures/slo';
 
 const STARTED_AT = new Date('2023-01-01T00:00:00.000Z');
 
@@ -29,10 +33,9 @@ describe('buildQuery()', () => {
     expect(buildQuery(STARTED_AT, slo, rule, { instanceId: 'example' })).toMatchSnapshot();
   });
   it('should return a valid query for timeslices', () => {
-    const slo = createSLO({
+    const slo = createSLOWithTimeslicesBudgetingMethod({
       id: 'test-slo',
       indicator: createKQLCustomIndicator(),
-      budgetingMethod: 'timeslices',
     });
     const rule = createBurnRateRule(slo);
     expect(buildQuery(STARTED_AT, slo, rule)).toMatchSnapshot();

--- a/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
+++ b/x-pack/plugins/observability/server/services/slo/sli_client.test.ts
@@ -27,11 +27,18 @@ const commonEsResponse = {
   },
 };
 
+const TEST_DATE = new Date('2023-01-01T00:00:00.000Z');
+
 describe('SummaryClient', () => {
   let esClientMock: ElasticsearchClientMock;
 
   beforeEach(() => {
     esClientMock = elasticsearchServiceMock.createElasticsearchClient();
+    jest.useFakeTimers().setSystemTime(TEST_DATE);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
   });
 
   describe('fetchSLIDataFrom', () => {
@@ -51,11 +58,11 @@ describe('SummaryClient', () => {
             [LONG_WINDOW]: {
               buckets: [
                 {
-                  key: '2022-11-08T13:53:00.000Z-2022-11-08T14:53:00.000Z',
-                  from: 1667915580000,
-                  from_as_string: '2022-11-08T13:53:00.000Z',
-                  to: 1667919180000,
-                  to_as_string: '2022-11-08T14:53:00.000Z',
+                  key: '2022-12-31T22:54:00.000Z-2022-12-31T23:54:00.000Z',
+                  from: 1672527240000,
+                  from_as_string: '2022-12-31T22:54:00.000Z',
+                  to: 1672530840000,
+                  to_as_string: '2022-12-31T23:54:00.000Z',
                   doc_count: 60,
                   total: {
                     value: 32169,
@@ -69,11 +76,11 @@ describe('SummaryClient', () => {
             [SHORT_WINDOW]: {
               buckets: [
                 {
-                  key: '2022-11-08T14:48:00.000Z-2022-11-08T14:53:00.000Z',
-                  from: 1667918880000,
-                  from_as_string: '2022-11-08T14:48:00.000Z',
-                  to: 1667919180000,
-                  to_as_string: '2022-11-08T14:53:00.000Z',
+                  key: '2022-12-31T23:49:00.000Z-2022-12-31T23:54:00.000Z',
+                  from: 1672530540000,
+                  from_as_string: '2022-12-31T23:49:00.000Z',
+                  to: 1672530840000,
+                  to_as_string: '2022-12-31T23:54:00.000Z',
                   doc_count: 5,
                   total: {
                     value: 2211,
@@ -95,7 +102,12 @@ describe('SummaryClient', () => {
             [LONG_WINDOW]: {
               date_range: {
                 field: '@timestamp',
-                ranges: [{ from: 'now-1h/m', to: 'now/m' }],
+                ranges: [
+                  {
+                    from: '2022-12-31T22:54:00.000Z',
+                    to: '2022-12-31T23:54:00.000Z',
+                  },
+                ],
               },
               aggs: {
                 good: { sum: { field: 'slo.numerator' } },
@@ -105,7 +117,12 @@ describe('SummaryClient', () => {
             [SHORT_WINDOW]: {
               date_range: {
                 field: '@timestamp',
-                ranges: [{ from: 'now-5m/m', to: 'now/m' }],
+                ranges: [
+                  {
+                    from: '2022-12-31T23:49:00.000Z',
+                    to: '2022-12-31T23:54:00.000Z',
+                  },
+                ],
               },
               aggs: {
                 good: { sum: { field: 'slo.numerator' } },
@@ -141,11 +158,11 @@ describe('SummaryClient', () => {
             [LONG_WINDOW]: {
               buckets: [
                 {
-                  key: '2022-11-08T13:53:00.000Z-2022-11-08T14:53:00.000Z',
-                  from: 1667915580000,
-                  from_as_string: '2022-11-08T13:53:00.000Z',
-                  to: 1667919180000,
-                  to_as_string: '2022-11-08T14:53:00.000Z',
+                  key: '2022-12-31T22:36:00.000Z-2022-12-31T23:36:00.000Z',
+                  from: 1672526160000,
+                  from_as_string: '2022-12-31T22:36:00.000Z',
+                  to: 1672529760000,
+                  to_as_string: '2022-12-31T23:36:00.000Z',
                   doc_count: 60,
                   total: {
                     value: 32169,
@@ -159,11 +176,11 @@ describe('SummaryClient', () => {
             [SHORT_WINDOW]: {
               buckets: [
                 {
-                  key: '2022-11-08T14:48:00.000Z-2022-11-08T14:53:00.000Z',
-                  from: 1667918880000,
-                  from_as_string: '2022-11-08T14:48:00.000Z',
-                  to: 1667919180000,
-                  to_as_string: '2022-11-08T14:53:00.000Z',
+                  key: '2022-12-31T23:31:00.000Z-2022-12-31T23:36:00.000Z',
+                  from: 1672529460000,
+                  from_as_string: '2022-12-31T23:31:00.000Z',
+                  to: 1672529760000,
+                  to_as_string: '2022-12-31T23:36:00.000Z',
                   doc_count: 5,
                   total: {
                     value: 2211,
@@ -185,7 +202,12 @@ describe('SummaryClient', () => {
             [LONG_WINDOW]: {
               date_range: {
                 field: '@timestamp',
-                ranges: [{ from: 'now-1h/m', to: 'now/m' }],
+                ranges: [
+                  {
+                    from: '2022-12-31T22:36:00.000Z',
+                    to: '2022-12-31T23:36:00.000Z',
+                  },
+                ],
               },
               aggs: {
                 good: {
@@ -203,7 +225,12 @@ describe('SummaryClient', () => {
             [SHORT_WINDOW]: {
               date_range: {
                 field: '@timestamp',
-                ranges: [{ from: 'now-5m/m', to: 'now/m' }],
+                ranges: [
+                  {
+                    from: '2022-12-31T23:31:00.000Z',
+                    to: '2022-12-31T23:36:00.000Z',
+                  },
+                ],
               },
               aggs: {
                 good: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[SLO] Account for the built-in delay for burn rate alerting (#169011)](https://github.com/elastic/kibana/pull/169011)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Chris Cowan","email":"chris@elastic.co"},"sourceCommit":{"committedDate":"2023-10-19T20:09:18Z","message":"[SLO] Account for the built-in delay for burn rate alerting (#169011)\n\n## Summary\r\n\r\nThis PR introduces a delay based on:\r\n\r\n- The interval of the date histogram which defaults to `1m`\r\n- The sync delay of the transform which defaults to `1m`\r\n- The frequency of the transform which defaults to `1m`\r\n\r\nOn average the SLO data is about `180s` behind for occurances. If the\r\nuser uses `5m` time slices then the delay is around `420s`. This PR\r\nattempts to mitigate this delay by subtracting the `interval + syncDelay\r\n+ frequency` from `now` on any calculation for the burn rate so that the\r\nlast 5 minutes is aligned with the data. Below is a visualization that\r\nshows how much delay we are seeing in an optimal environment.\r\n\r\n<img width=\"884\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/41702/2a1587cd-c789-403c-97e2-f48c65db2b89\">\r\n\r\nUsing `interval + syncDelay + frequency` accounts for the \"best case\r\nscenario\". Due to the nature of the transform system, the delays varies\r\nfrom best case of `180s` for occurrences to worst case of around `240s`\r\nwhich happens right before the next scheduled query; the transform query\r\nruns every `60s` which accounts for the variation between the worst and\r\nbest case delay. Since the rules run on a seperate schedule, it's hard\r\nto know where we are in the `60s` cycle so the best we can do is account\r\nfor the \"best case\".\r\n\r\nThis PR also fixes #168747\r\n\r\n### Note to the reviewer\r\n\r\nThe changes made to `evaluate.ts` and `build_query.ts` look more\r\nextensive than they really are. I felt like #168735 made some\r\nunnecessary refactors when they simply could have done a minimal change\r\nand left the rest of the code alone; it would have been less risky. This\r\nalso cause several issues during the merge which is why I ultimately\r\ndecided to revert the changes from #168735.","sha":"dce8eedf561409c2209bae58ecc330d8f245fa91","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team: Actionable Observability","backport:prev-minor","v8.12.0"],"number":169011,"url":"https://github.com/elastic/kibana/pull/169011","mergeCommit":{"message":"[SLO] Account for the built-in delay for burn rate alerting (#169011)\n\n## Summary\r\n\r\nThis PR introduces a delay based on:\r\n\r\n- The interval of the date histogram which defaults to `1m`\r\n- The sync delay of the transform which defaults to `1m`\r\n- The frequency of the transform which defaults to `1m`\r\n\r\nOn average the SLO data is about `180s` behind for occurances. If the\r\nuser uses `5m` time slices then the delay is around `420s`. This PR\r\nattempts to mitigate this delay by subtracting the `interval + syncDelay\r\n+ frequency` from `now` on any calculation for the burn rate so that the\r\nlast 5 minutes is aligned with the data. Below is a visualization that\r\nshows how much delay we are seeing in an optimal environment.\r\n\r\n<img width=\"884\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/41702/2a1587cd-c789-403c-97e2-f48c65db2b89\">\r\n\r\nUsing `interval + syncDelay + frequency` accounts for the \"best case\r\nscenario\". Due to the nature of the transform system, the delays varies\r\nfrom best case of `180s` for occurrences to worst case of around `240s`\r\nwhich happens right before the next scheduled query; the transform query\r\nruns every `60s` which accounts for the variation between the worst and\r\nbest case delay. Since the rules run on a seperate schedule, it's hard\r\nto know where we are in the `60s` cycle so the best we can do is account\r\nfor the \"best case\".\r\n\r\nThis PR also fixes #168747\r\n\r\n### Note to the reviewer\r\n\r\nThe changes made to `evaluate.ts` and `build_query.ts` look more\r\nextensive than they really are. I felt like #168735 made some\r\nunnecessary refactors when they simply could have done a minimal change\r\nand left the rest of the code alone; it would have been less risky. This\r\nalso cause several issues during the merge which is why I ultimately\r\ndecided to revert the changes from #168735.","sha":"dce8eedf561409c2209bae58ecc330d8f245fa91"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169011","number":169011,"mergeCommit":{"message":"[SLO] Account for the built-in delay for burn rate alerting (#169011)\n\n## Summary\r\n\r\nThis PR introduces a delay based on:\r\n\r\n- The interval of the date histogram which defaults to `1m`\r\n- The sync delay of the transform which defaults to `1m`\r\n- The frequency of the transform which defaults to `1m`\r\n\r\nOn average the SLO data is about `180s` behind for occurances. If the\r\nuser uses `5m` time slices then the delay is around `420s`. This PR\r\nattempts to mitigate this delay by subtracting the `interval + syncDelay\r\n+ frequency` from `now` on any calculation for the burn rate so that the\r\nlast 5 minutes is aligned with the data. Below is a visualization that\r\nshows how much delay we are seeing in an optimal environment.\r\n\r\n<img width=\"884\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/41702/2a1587cd-c789-403c-97e2-f48c65db2b89\">\r\n\r\nUsing `interval + syncDelay + frequency` accounts for the \"best case\r\nscenario\". Due to the nature of the transform system, the delays varies\r\nfrom best case of `180s` for occurrences to worst case of around `240s`\r\nwhich happens right before the next scheduled query; the transform query\r\nruns every `60s` which accounts for the variation between the worst and\r\nbest case delay. Since the rules run on a seperate schedule, it's hard\r\nto know where we are in the `60s` cycle so the best we can do is account\r\nfor the \"best case\".\r\n\r\nThis PR also fixes #168747\r\n\r\n### Note to the reviewer\r\n\r\nThe changes made to `evaluate.ts` and `build_query.ts` look more\r\nextensive than they really are. I felt like #168735 made some\r\nunnecessary refactors when they simply could have done a minimal change\r\nand left the rest of the code alone; it would have been less risky. This\r\nalso cause several issues during the merge which is why I ultimately\r\ndecided to revert the changes from #168735.","sha":"dce8eedf561409c2209bae58ecc330d8f245fa91"}}]}] BACKPORT-->