### PR TITLE
[Discover] Update mapping conflict popover with types list

### DIFF
--- a/packages/kbn-field-utils/src/types.ts
+++ b/packages/kbn-field-utils/src/types.ts
@@ -21,6 +21,7 @@ export interface FieldBase {
   timeSeriesMetric?: DataViewField['timeSeriesMetric'];
   esTypes?: DataViewField['esTypes'];
   scripted?: DataViewField['scripted'];
+  conflictDescriptions?: Record<string, string[]>;
 }
 
 export type GetCustomFieldType<T extends FieldBase> = (field: T) => FieldTypeKnown;

--- a/packages/kbn-unified-field-list/src/components/field_item_button/__snapshots__/field_item_button.test.tsx.snap
+++ b/packages/kbn-unified-field-list/src/components/field_item_button/__snapshots__/field_item_button.test.tsx.snap
@@ -166,7 +166,20 @@ exports[`UnifiedFieldList <FieldItemButton /> renders properly when a conflict f
       type="conflict"
     />
   }
-  fieldInfoIcon={<FieldConflictInfoIcon />}
+  fieldInfoIcon={
+    <FieldConflictInfoIcon
+      conflictDescriptions={
+        Object {
+          "keyword": Array [
+            "index_a",
+          ],
+          "long": Array [
+            "index_b",
+          ],
+        }
+      }
+    />
+  }
   fieldName={
     <EuiHighlight
       data-test-subj="field-custom_user_field"

--- a/packages/kbn-unified-field-list/src/components/field_item_button/field_item_button.tsx
+++ b/packages/kbn-unified-field-list/src/components/field_item_button/field_item_button.tsx
@@ -175,7 +175,10 @@ export function FieldItemButton<T extends FieldListItem = DataViewField>({
         </EuiToolTip>
       );
 
-  const conflictInfoIcon = field.type === 'conflict' ? <FieldConflictInfoIcon /> : null;
+  const conflictInfoIcon =
+    field.type === 'conflict' ? (
+      <FieldConflictInfoIcon conflictDescriptions={field.conflictDescriptions} />
+    ) : null;
 
   return (
     <FieldButton
@@ -211,24 +214,35 @@ export function FieldItemButton<T extends FieldListItem = DataViewField>({
   );
 }
 
-function FieldConflictInfoIcon() {
+function FieldConflictInfoIcon({
+  conflictDescriptions,
+}: {
+  conflictDescriptions?: Record<string, string[]>;
+}) {
+  const types = conflictDescriptions ? Object.keys(conflictDescriptions) : [];
   return (
     <EuiToolTip
       position="bottom"
-      content={i18n.translate('unifiedFieldList.fieldItemButton.mappingConflictDescription', {
-        defaultMessage:
-          'This field is defined as several types (string, integer, etc) across the indices that match this pattern.' +
-          'You may still be able to use this conflicting field, but it will be unavailable for functions that require Kibana to know their type. Correcting this issue will require reindexing your data.',
+      title={i18n.translate('unifiedFieldList.fieldItemButton.mappingConflictTitle', {
+        defaultMessage: 'Mapping Conflict',
       })}
+      content={
+        types.length
+          ? i18n.translate('unifiedFieldList.fieldItemButton.mappingConflictWithTypesDescription', {
+              defaultMessage:
+                'This field is defined as several types ({types}) across the indices that match this pattern. You may still be able to use this conflicting field, but it will be unavailable for functions that require Kibana to know their type. Correcting this issue will require reindexing your data.',
+              values: {
+                types: types.join(', '),
+              },
+            })
+          : i18n.translate('unifiedFieldList.fieldItemButton.mappingConflictDescription', {
+              defaultMessage:
+                'This field is defined as several types (string, integer, etc) across the indices that match this pattern.' +
+                'You may still be able to use this conflicting field, but it will be unavailable for functions that require Kibana to know their type. Correcting this issue will require reindexing your data.',
+            })
+      }
     >
-      <EuiIcon
-        tabIndex={0}
-        type="warning"
-        title={i18n.translate('unifiedFieldList.fieldItemButton.mappingConflictTitle', {
-          defaultMessage: 'Mapping Conflict',
-        })}
-        size="s"
-      />
+      <EuiIcon tabIndex={0} type="warning" size="s" />
     </EuiToolTip>
   );
 }

--- a/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
+++ b/src/plugins/data_views/common/data_views/__snapshots__/data_view.test.ts.snap
@@ -233,6 +233,14 @@ Object {
     },
     "custom_user_field": Object {
       "aggregatable": true,
+      "conflictDescriptions": Object {
+        "keyword": Array [
+          "index_a",
+        ],
+        "long": Array [
+          "index_b",
+        ],
+      },
       "count": 0,
       "esTypes": Array [
         "conflict",

--- a/src/plugins/data_views/common/field.stub.ts
+++ b/src/plugins/data_views/common/field.stub.ts
@@ -344,6 +344,7 @@ export const stubLogstashFieldSpecMap: Record<string, FieldSpec> = {
     name: 'custom_user_field',
     type: 'conflict',
     esTypes: ['conflict'],
+    conflictDescriptions: { keyword: ['index_a'], long: ['index_b'] },
     aggregatable: true,
     searchable: true,
     count: 0,


### PR DESCRIPTION
- Related to https://github.com/elastic/kibana/issues/168874

## Summary

This PR updates the popover to include conflicting types list.

<img width="487" alt="Screenshot 2023-10-25 at 18 46 42" src="https://github.com/elastic/kibana/assets/1415710/a68e5364-a784-4320-a68c-e7ba0c19d2f3">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
