### PR TITLE
[8.11] [Synthetics] Project monitor retest on failure updates (#167979)

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -1586,6 +1586,7 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
     component: Switch,
     controlled: true,
     props: ({ setValue, field, trigger }): EuiSwitchProps => ({
+      disabled: readOnly,
       id: 'syntheticsMonitorConfigMaxAttempts',
       label: i18n.translate('xpack.synthetics.monitorConfig.retest.label', {
         defaultMessage: 'Enable retest on failure',

--- a/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/project_monitor/normalizers/common_fields.ts
@@ -306,6 +306,7 @@ export const normalizeYamlConfig = (monitor: NormalizedProjectProps['monitor']) 
     privateLocations: _privateLocations,
     content: _content,
     id: _id,
+    retestOnFailure: _retestOnFailure,
     ...yamlConfig
   } = flattenedConfig;
   const unsupportedKeys = Object.keys(yamlConfig).filter((key) => !supportedKeys.includes(key));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Synthetics] Project monitor retest on failure updates (#167979)](https://github.com/elastic/kibana/pull/167979)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2023-10-04T17:50:37Z","message":"[Synthetics] Project monitor retest on failure updates (#167979)","sha":"035ae0e04e6b5ec6d70c49be8dc7321157c67a2f","branchLabelMapping":{"^v8.11.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:uptime","release_note:skip","v8.11.0","v8.12.0"],"number":167979,"url":"https://github.com/elastic/kibana/pull/167979","mergeCommit":{"message":"[Synthetics] Project monitor retest on failure updates (#167979)","sha":"035ae0e04e6b5ec6d70c49be8dc7321157c67a2f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.11.0","labelRegex":"^v8.11.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/167979","number":167979,"mergeCommit":{"message":"[Synthetics] Project monitor retest on failure updates (#167979)","sha":"035ae0e04e6b5ec6d70c49be8dc7321157c67a2f"}},{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->