### PR TITLE
[8.11] [RAM] Reset rule settings modal on cancel (#169720)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.test.tsx
@@ -162,8 +162,9 @@ describe('rules_settings_modal', () => {
   test('reset flapping settings to initial state on cancel without triggering another server reload', async () => {
     const result = render(<RulesSettingsModalWithProviders {...modalProps} />);
     expect(getFlappingSettingsMock).toHaveBeenCalledTimes(1);
-    expect(getQueryDelaySettingsMock).toHaveBeenCalledTimes(1);
-    await waitForModalLoad();
+    await waitFor(() => {
+      expect(result.queryByTestId('centerJustifiedSpinner')).toBe(null);
+    });
 
     const lookBackWindowInput = result.getByTestId('lookBackWindowRangeInput');
     const statusChangeThresholdInput = result.getByTestId('statusChangeThresholdRangeInput');
@@ -181,12 +182,11 @@ describe('rules_settings_modal', () => {
     expect(updateFlappingSettingsMock).not.toHaveBeenCalled();
     expect(modalProps.onSave).not.toHaveBeenCalled();
 
-    expect(screen.queryByTestId('centerJustifiedSpinner')).toBe(null);
+    expect(result.queryByTestId('centerJustifiedSpinner')).toBe(null);
     expect(lookBackWindowInput.getAttribute('value')).toBe('10');
     expect(statusChangeThresholdInput.getAttribute('value')).toBe('10');
 
     expect(getFlappingSettingsMock).toHaveBeenCalledTimes(1);
-    expect(getQueryDelaySettingsMock).toHaveBeenCalledTimes(1);
   });
 
   test('should prevent statusChangeThreshold from being greater than lookBackWindow', async () => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.test.tsx
@@ -159,6 +159,36 @@ describe('rules_settings_modal', () => {
     expect(modalProps.onSave).toHaveBeenCalledTimes(1);
   });
 
+  test('reset flapping settings to initial state on cancel without triggering another server reload', async () => {
+    const result = render(<RulesSettingsModalWithProviders {...modalProps} />);
+    expect(getFlappingSettingsMock).toHaveBeenCalledTimes(1);
+    expect(getQueryDelaySettingsMock).toHaveBeenCalledTimes(1);
+    await waitForModalLoad();
+
+    const lookBackWindowInput = result.getByTestId('lookBackWindowRangeInput');
+    const statusChangeThresholdInput = result.getByTestId('statusChangeThresholdRangeInput');
+
+    fireEvent.change(lookBackWindowInput, { target: { value: 15 } });
+    fireEvent.change(statusChangeThresholdInput, { target: { value: 3 } });
+
+    expect(lookBackWindowInput.getAttribute('value')).toBe('15');
+    expect(statusChangeThresholdInput.getAttribute('value')).toBe('3');
+
+    // Try cancelling
+    userEvent.click(result.getByTestId('rulesSettingsModalCancelButton'));
+
+    expect(modalProps.onClose).toHaveBeenCalledTimes(1);
+    expect(updateFlappingSettingsMock).not.toHaveBeenCalled();
+    expect(modalProps.onSave).not.toHaveBeenCalled();
+
+    expect(screen.queryByTestId('centerJustifiedSpinner')).toBe(null);
+    expect(lookBackWindowInput.getAttribute('value')).toBe('10');
+    expect(statusChangeThresholdInput.getAttribute('value')).toBe('10');
+
+    expect(getFlappingSettingsMock).toHaveBeenCalledTimes(1);
+    expect(getQueryDelaySettingsMock).toHaveBeenCalledTimes(1);
+  });
+
   test('should prevent statusChangeThreshold from being greater than lookBackWindow', async () => {
     const result = render(<RulesSettingsModalWithProviders {...modalProps} />);
     await waitFor(() => {

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
@@ -246,7 +246,7 @@ export const RulesSettingsModal = memo((props: RulesSettingsModalProps) => {
 
   const handleSave = () => {
     if (canWriteFlappingSettings && hasFlappingChanged) {
-      mutate(flappingSettings);
+      mutate(flappingSettings!);
       setFlappingSettings(flappingSettings!, true);
     }
   };

--- a/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/components/rules_setting/rules_settings_modal.tsx
@@ -6,9 +6,7 @@
  */
 
 import React, { memo, useCallback, useState, useRef } from 'react';
-import {
-  RulesSettingsFlappingProperties,
-} from '@kbn/alerting-plugin/common';
+import { RulesSettingsFlappingProperties } from '@kbn/alerting-plugin/common';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import {
@@ -230,20 +228,20 @@ export const RulesSettingsModal = memo((props: RulesSettingsModalProps) => {
     key: keyof RulesSettingsFlappingProperties,
     value: number | boolean
   ) => {
-      if (!flappingSettings) {
-        return;
-      }
-      const newSettings = {
-        ...flappingSettings,
-        [key]: value,
-      };
-      setFlappingSettings({
-        ...newSettings,
-        statusChangeThreshold: Math.min(
-          newSettings.lookBackWindow,
-          newSettings.statusChangeThreshold
-        ),
-      });
+    if (!flappingSettings) {
+      return;
+    }
+    const newSettings = {
+      ...flappingSettings,
+      [key]: value,
+    };
+    setFlappingSettings({
+      ...newSettings,
+      statusChangeThreshold: Math.min(
+        newSettings.lookBackWindow,
+        newSettings.statusChangeThreshold
+      ),
+    });
   };
 
   const handleSave = () => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[RAM] Reset rule settings modal on cancel (#169720)](https://github.com/elastic/kibana/pull/169720)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Zacqary Adam Xeper","email":"Zacqary@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-10-25T17:12:06Z","message":"[RAM] Reset rule settings modal on cancel (#169720)\n\n## Summary\r\n\r\nFixes #169296 \r\n\r\n- Resets the rule settings modal when the user clicks Cancel, but caches\r\nthe initial pull from the server so that a second request isn't\r\nnecessary on reopen\r\n- Updates this cache on save so that the reset on modal close remains\r\naccurate\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"3a5d6cc92b157cf61a49c97b0c9f537285cc2299","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:ResponseOps","Feature:Alerting/RulesManagement","v8.11.0","v8.12.0"],"number":169720,"url":"https://github.com/elastic/kibana/pull/169720","mergeCommit":{"message":"[RAM] Reset rule settings modal on cancel (#169720)\n\n## Summary\r\n\r\nFixes #169296 \r\n\r\n- Resets the rule settings modal when the user clicks Cancel, but caches\r\nthe initial pull from the server so that a second request isn't\r\nnecessary on reopen\r\n- Updates this cache on save so that the reset on modal close remains\r\naccurate\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"3a5d6cc92b157cf61a49c97b0c9f537285cc2299"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169720","number":169720,"mergeCommit":{"message":"[RAM] Reset rule settings modal on cancel (#169720)\n\n## Summary\r\n\r\nFixes #169296 \r\n\r\n- Resets the rule settings modal when the user clicks Cancel, but caches\r\nthe initial pull from the server so that a second request isn't\r\nnecessary on reopen\r\n- Updates this cache on save so that the reset on modal close remains\r\naccurate\r\n\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"3a5d6cc92b157cf61a49c97b0c9f537285cc2299"}}]}] BACKPORT-->