### PR TITLE
[POC][DO NOT MERGE] Add fine-grained RBAC to Connector sub-actions for SentinelOne

### DIFF
--- a/x-pack/plugins/actions/server/action_type_registry.ts
+++ b/x-pack/plugins/actions/server/action_type_registry.ts
@@ -165,14 +165,15 @@ export class ActionTypeRegistry {
       );
     }
 
-    if (!actionType.isSystemActionType && actionType.getKibanaPrivileges) {
-      throw new Error(
-        i18n.translate('xpack.actions.actionTypeRegistry.register.invalidKibanaPrivileges', {
-          defaultMessage:
-            'Kibana privilege authorization is only supported for system action types',
-        })
-      );
-    }
+    // TODO:PT cleanup --- Let's allow `getKibanaPrivileges()` for all
+    // if (!actionType.isSystemActionType && actionType.getKibanaPrivileges) {
+    //   throw new Error(
+    //     i18n.translate('xpack.actions.actionTypeRegistry.register.invalidKibanaPrivileges', {
+    //       defaultMessage:
+    //         'Kibana privilege authorization is only supported for system action types',
+    //     })
+    //   );
+    // }
 
     const maxAttempts = this.actionsConfigUtils.getMaxAttempts({
       actionTypeId: actionType.id,

--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -585,7 +585,7 @@ const ensureAuthorizedToExecute = async ({
     const actionType = actionTypeRegistry.get(actionTypeId);
 
     if (actionType.getKibanaPrivileges) {
-      additionalPrivileges.push(...actionType.getKibanaPrivileges(params));
+      additionalPrivileges.push(...actionType.getKibanaPrivileges({ params }));
     }
 
     // FIXME:PT If the above method gets exposed to all Connectors, then this code below can be removed

--- a/x-pack/plugins/actions/server/sub_action_framework/register.ts
+++ b/x-pack/plugins/actions/server/sub_action_framework/register.ts
@@ -40,5 +40,6 @@ export const register = <Config extends ActionTypeConfig, Secrets extends Action
     validate: validators,
     executor,
     renderParameterTemplates: connector.renderParameterTemplates,
+    getKibanaPrivileges: connector.getKibanaPrivileges,
   });
 };

--- a/x-pack/plugins/actions/server/sub_action_framework/types.ts
+++ b/x-pack/plugins/actions/server/sub_action_framework/types.ts
@@ -69,7 +69,11 @@ export type Validators<Config, Secrets> = Array<
   ConfigValidator<Config> | SecretsValidator<Secrets>
 >;
 
-export interface SubActionConnectorType<Config, Secrets> {
+export interface SubActionConnectorType<
+  Config,
+  Secrets,
+  Params extends ActionTypeParams = ActionTypeParams
+> {
   id: string;
   name: string;
   minimumLicenseRequired: LicenseType;
@@ -81,6 +85,7 @@ export interface SubActionConnectorType<Config, Secrets> {
   validators?: Array<ConfigValidator<Config> | SecretsValidator<Secrets>>;
   getService: (params: ServiceParams<Config, Secrets>) => SubActionConnector<Config, Secrets>;
   renderParameterTemplates?: RenderParameterTemplates<ExecutorParams>;
+  getKibanaPrivileges?: (args?: { params?: Params }) => string[];
 }
 
 export interface ExecutorParams extends ActionTypeParams {

--- a/x-pack/plugins/stack_connectors/public/connector_types/index.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/index.ts
@@ -29,6 +29,7 @@ import { getTorqConnectorType } from './torq';
 import { getWebhookConnectorType } from './webhook';
 import { getXmattersConnectorType } from './xmatters';
 import { getD3SecurityConnectorType } from './d3security';
+import { getSentinelOneConnectorType } from './sentinelone';
 
 export interface RegistrationServices {
   validateEmailAddresses: (
@@ -66,4 +67,5 @@ export function registerConnectorTypes({
   connectorTypeRegistry.register(getTorqConnectorType());
   connectorTypeRegistry.register(getTinesConnectorType());
   connectorTypeRegistry.register(getD3SecurityConnectorType());
+  connectorTypeRegistry.register(getSentinelOneConnectorType());
 }

--- a/x-pack/plugins/stack_connectors/server/connector_types/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/index.ts
@@ -31,6 +31,7 @@ import { getConnectorType as getD3SecurityConnectorType } from './d3security';
 import { getOpsgenieConnectorType } from './opsgenie';
 import type { ActionParamsType as ServiceNowITSMActionParams } from './servicenow_itsm';
 import type { ActionParamsType as ServiceNowSIRActionParams } from './servicenow_sir';
+import { getSentinelOneConnectorType } from './sentinelone';
 
 export { ConnectorTypeId as CasesWebhookConnectorTypeId } from './cases_webhook';
 export type { ActionParamsType as CasesWebhookActionParams } from './cases_webhook';
@@ -104,4 +105,5 @@ export function registerConnectorTypes({
   actions.registerSubActionConnectorType(getOpenAIConnectorType());
   actions.registerSubActionConnectorType(getBedrockConnectorType());
   actions.registerSubActionConnectorType(getD3SecurityConnectorType());
+  actions.registerSubActionConnectorType(getSentinelOneConnectorType());
 }

--- a/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/index.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  ExecutorParams,
   SubActionConnectorType,
   ValidatorType,
 } from '@kbn/actions-plugin/server/sub_action_framework/types';
@@ -22,7 +23,8 @@ import { renderParameterTemplates } from './render';
 
 export const getSentinelOneConnectorType = (): SubActionConnectorType<
   SentinelOneConfig,
-  SentinelOneSecrets
+  SentinelOneSecrets,
+  ExecutorParams
 > => ({
   id: SENTINELONE_CONNECTOR_ID,
   name: SENTINELONE_TITLE,
@@ -35,4 +37,19 @@ export const getSentinelOneConnectorType = (): SubActionConnectorType<
   supportedFeatureIds: [SecurityConnectorFeatureId],
   minimumLicenseRequired: 'enterprise' as const,
   renderParameterTemplates,
+  getKibanaPrivileges: (options) => {
+    const subAction = options?.params?.subAction;
+
+    if (!subAction) {
+      return [];
+    }
+
+    switch (subAction) {
+      case 'isolateAgent':
+      case 'releaseAgent':
+        return ['api:securitySolution-writeHostIsolationRelease'];
+      default:
+        return ['denied-access'];
+    }
+  },
 });

--- a/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/index.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/sentinelone/index.ts
@@ -37,7 +37,7 @@ export const getSentinelOneConnectorType = (): SubActionConnectorType<
   supportedFeatureIds: [SecurityConnectorFeatureId],
   minimumLicenseRequired: 'enterprise' as const,
   renderParameterTemplates,
-  getKibanaPrivileges: (options) => {
+  getKibanaPrivileges: (options = {}) => {
     const subAction = options?.params?.subAction;
 
     if (!subAction) {


### PR DESCRIPTION
# 🛑 🛑  DO NOT MERGE - POC ONLY 🔴 🔴 

## Summary

This POC attempts to answer the question: 

➡️  **Can the Security Solution Kibana Feature control privileges be used to control access to SentinelOne's set of Sub-Actions?**

➡️  The answer: **Yes**  ✅ 

This POC is being done in support of the Security Solution Bi-Directional Response Actions feature.


Example of API response when user does not have Security Solution "Host Isolation" privilege:

```JSON
{
    "status": "error",
    "message": "Unauthorized to execute actions",
    "retry": false,
    "connector_id": "4b4e2de0-7340-11ee-922e-dd7eccf43bf7"
}
```


## Background

Security Solution would like to start providing users the ability to execute actions against 3rd party integrations that are running agents (non-elastic) on host machines - SentinelOne being the first. These actions include things like isolating a host, releasing a host (1st iteration), kill processes, execute shell commands, etc. These actions _(sent to host machines managed by these 3rd party systems)_ need to be gated using the existing Security Solution RBAC (implemented as Kibana feature privileges) so that customers have full controls over who can access these types of actions.


## POC changes

In this POC, I found that the Actions plugin already has a method called `getKibanaPrivileges()` ([link](https://github.com/elastic/kibana/blob/e9777f67bffd37c7ffe4f986df326d595112a661/x-pack/plugins/actions/server/types.ts#L155)) on each `ActionType`. This method, however, is only supported for Kibana System Actions (I'm a n00b to Actions/Connectors, so not sure what this means).

With the above knowledge, the following was done in this POC:

1. Allow connector registration to define their own `getKibanaPrivileges()` method. This method takes in the same arguments as the one defined for `ActionType`
2. Added `getKibanaPrivileges()` to the SentinelOne Connector type
    1. It returns the additional kibana privileges that the user must have in order to execute the requested SentinelOne `subAction`
3. Altered the `ensureAuthorizedToExecute()` method to check and use the values returned by the Action Type `getKibanaPrivileges()`

With these changes in place, any Connector can define additional kibana privileges needed to execute a connection's sub-actions.


## How to tests

1. Create a new instance of the SentinelOne Connector (under `Stack Management > Connectors`). For the purposes of just validating this POC, you can just enter anything for the SentinelOne URL and Token
2. Create a new Role:
    1.  Ensure access to Actions and Connectors: <img width="716" alt="image" src="https://github.com/elastic/kibana/assets/56442535/4eb861f5-9509-46a3-b64c-c01261e62ace">
    2. Ensure access to Security Solution Host Isolation privilege (under Security Solution > expand Security > toggle "Customize sub features") : <img width="661" alt="image" src="https://github.com/elastic/kibana/assets/56442535/9e24d6be-ecc6-4d12-a04c-f67a2d2d2fb2">
3. Create a new user that is assigned only the above new role
4. Use new user/password to call the API. You will need the ID of the connector instance craeted during Step 1 above. Example:
    1. `post('/api/actions/connector/4b4e2de0-7340-11ee-922e-dd7eccf43bf7/_execute', { body: JSON.stringify({ params: { subAction: 'isolateAgent' } }) })`




### What's missing

#### Remove dependency on Stack Management "Actions and Connectors" privilege

Currently, a user still needs to be granted privileges to "Actions and Connectors" (at least `READ`) in order to execute sub-actions. The implementation done above **is** in addition to this setting. However, It would be desired if we could also control full access to the ability to execute these sub-action solely based on security solution privileges, so that our users of security did not have to be given access to Actions and Connectors under the stack management - that could translate in an increase in system level access that is really not necessary for this use case.

This is something that will need to be discussed further, and not aboslutely needed for the first iteration of this feature (v8.12.0).


#### Re-use current Endpoint `auth` module

We currently have a common `authz` module ([here](https://github.com/elastic/kibana/blob/a8de031ddf9b9d172a4901db85341930702cb1c8/x-pack/plugins/security_solution/common/endpoint/service/authz/authz.ts#L48)) that calculates the set of feature access based on license levels and user's privileges. That module, however, can not currently be used used due to the set of dependencies it requires on input (primarily - it needs Fleet's `FleetAuthz` interface. 

This however, should be fine for the feature requirement - to add RBAC to individual sub-actions. The connector is already being registered for `enterprise` license and implementation under the Action plugin will be simpler if we can just define the additional Kibana feature privileges directly from the connector so that the existing `checkPrivilegesDynamicallyWithRequest()` can continue to be used as it is today.








