### PR TITLE
[APM] Add `beforeOrAfter` hook

### DIFF
--- a/x-pack/test/apm_api_integration/common/utils/before_or_after.ts
+++ b/x-pack/test/apm_api_integration/common/utils/before_or_after.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Helper function to run a callback before or after a test
+// depending on whether the --bail flag is passed.
+// With --bail flag the callback is run before
+// without --bail flag the callback is run after
+// This makes it easier to debug tests when they fail because data are still available
+export function beforeOrAfter(cb: () => Promise<unknown> | unknown) {
+  if (process.argv.includes('--bail')) {
+    before(cb);
+  } else {
+    after(cb);
+  }
+}

--- a/x-pack/test/apm_api_integration/tests/alerts/helpers/cleanup_state.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/helpers/cleanup_state.ts
@@ -6,6 +6,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
+import { ToolingLog } from '@kbn/tooling-log';
 import type { SuperTest, Test } from 'supertest';
 import {
   clearKibanaApmEventLog,
@@ -14,12 +15,14 @@ import {
   deleteActionConnectorIndex,
 } from './alerting_api_helper';
 
-export async function cleanupAllState({
+export async function cleanupRuleAndAlertState({
   es,
   supertest,
+  logger,
 }: {
   es: Client;
   supertest: SuperTest<Test>;
+  logger: ToolingLog;
 }) {
   try {
     await Promise.all([
@@ -29,7 +32,6 @@ export async function cleanupAllState({
       await clearKibanaApmEventLog(es),
     ]);
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(`An error occured while cleaning up the state: ${e}`);
+    logger.error(`An error occured while cleaning up the alerting state: ${e}`);
   }
 }

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -15,18 +15,15 @@ import {
   createApmRule,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
-  deleteAlertsByRuleId,
-  clearKibanaApmEventLog,
-  deleteRuleById,
   ApmAlertFields,
   getIndexAction,
   createIndexConnector,
-  deleteActionConnector,
 } from './helpers/alerting_api_helper';
-import { cleanupAllState } from './helpers/cleanup_state';
+import { cleanupRuleAndAlertState } from './helpers/cleanup_state';
 import { waitForAlertsForRule } from './helpers/wait_for_alerts_for_rule';
 import { waitForActiveRule } from './helpers/wait_for_active_rule';
 import { waitForIndexConnectorResults } from './helpers/wait_for_index_connector_results';
+import { beforeOrAfter } from '../../common/utils/before_or_after';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -37,9 +34,11 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const synthtraceEsClient = getService('synthtraceEsClient');
 
   registry.when('transaction error rate alert', { config: 'basic', archives: [] }, () => {
-    before(async () => {
-      cleanupAllState({ es, supertest });
+    beforeOrAfter(async () => {
+      await synthtraceEsClient.clean();
+    });
 
+    before(async () => {
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -75,19 +74,14 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       await synthtraceEsClient.index(events);
     });
 
-    after(async () => {
-      try {
-        await synthtraceEsClient.clean();
-        await clearKibanaApmEventLog(es);
-      } catch (e) {
-        logger.info('Could not clean up apm event log', e);
-      }
-    });
-
     describe('create rule without kql query', () => {
       let ruleId: string;
       let actionId: string;
       let alerts: ApmAlertFields[];
+
+      beforeOrAfter(async () => {
+        await cleanupRuleAndAlertState({ es, supertest, logger });
+      });
 
       before(async () => {
         actionId = await createIndexConnector({ supertest, name: 'Transation error rate' });
@@ -118,16 +112,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
         ruleId = createdRule.id;
         alerts = await waitForAlertsForRule({ es, ruleId });
-      });
-
-      after(async () => {
-        try {
-          await deleteActionConnector({ supertest, es, actionId });
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule or action connector', e);
-        }
       });
 
       it('checks if rule is active', async () => {
@@ -217,6 +201,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       let ruleId: string;
       let alerts: ApmAlertFields[];
 
+      beforeOrAfter(async () => {
+        await cleanupRuleAndAlertState({ es, supertest, logger });
+      });
+
       before(async () => {
         const createdRule = await createApmRule({
           supertest,
@@ -247,15 +235,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
         ruleId = createdRule.id;
         alerts = await waitForAlertsForRule({ es, ruleId });
-      });
-
-      after(async () => {
-        try {
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule', e);
-        }
       });
 
       it('indexes alert document with all group-by fields', async () => {


### PR DESCRIPTION
When debugging a flaky test locally it's possible to run it multiple times with `--times 50` and stop the process when an error is encountered using `--bail`. However, since cleanup always happens in the `after` hook there is not much to inspect.

By running the cleanup before the test instead of after it, it is possible to inspect and debug what went wrong and why the test is not passing.

This PR introduces `beforeOrAfter()` hook that will behave as a `before()` hook when running with `--bail`, otherwise as an `after()` hook