### PR TITLE
[OAS] Remove redundant servers from data view APIs

### DIFF
--- a/src/plugins/data_views/docs/openapi/bundled.json
+++ b/src/plugins/data_views/docs/openapi/bundled.json
@@ -14,8 +14,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5601",
-      "description": "local"
+      "url": "/"
     }
   ],
   "security": [
@@ -96,12 +95,7 @@
             }
           }
         }
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
-        }
-      ]
+      }
     },
     "/api/data_views/data_view": {
       "post": {
@@ -152,18 +146,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/api/data_views/data_view/{viewId}": {
       "get": {
@@ -232,12 +216,7 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "post": {
         "summary": "Updates a data view.",
@@ -290,18 +269,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/api/data_views/data_view/{viewId}/fields": {
       "post": {
@@ -369,18 +338,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/api/data_views/data_view/{viewId}/runtime_field": {
       "post": {
@@ -512,18 +471,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/api/data_views/data_view/{viewId}/runtime_field/{fieldName}": {
       "get": {
@@ -664,18 +613,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/api/data_views/default": {
       "get": {
@@ -788,18 +727,8 @@
               }
             }
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     }
   },
   "components": {

--- a/src/plugins/data_views/docs/openapi/bundled.yaml
+++ b/src/plugins/data_views/docs/openapi/bundled.yaml
@@ -9,8 +9,7 @@ info:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: http://localhost:5601
-    description: local
+  - url: /
 security:
   - basicAuth: []
   - apiKeyAuth: []
@@ -60,8 +59,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-    servers:
-      - url: https://localhost:5601
   /api/data_views/data_view:
     post:
       summary: Creates a data view.
@@ -94,10 +91,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}:
     get:
       summary: Retrieves a single data view by identifier.
@@ -142,8 +135,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/404_response'
-      servers:
-        - url: https://localhost:5601
     post:
       summary: Updates a data view.
       operationId: updateDataView
@@ -176,10 +167,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}/fields:
     post:
       summary: Update fields presentation metadata such as count, customLabel and format.
@@ -222,10 +209,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}/runtime_field:
     post:
       summary: Creates a runtime field.
@@ -316,10 +299,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /api/data_views/data_view/{viewId}/runtime_field/{fieldName}:
     get:
       summary: Retrieves a runtime field.
@@ -413,10 +392,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /api/data_views/default:
     get:
       summary: Retrieves the default data view identifier.
@@ -491,10 +466,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/400_response'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
 components:
   securitySchemes:
     basicAuth:

--- a/src/plugins/data_views/docs/openapi/entrypoint.yaml
+++ b/src/plugins/data_views/docs/openapi/entrypoint.yaml
@@ -12,8 +12,7 @@ tags:
   - name: data views
     description: Data view APIs enable you to manage data views, formerly known as Kibana index patterns.
 servers:
-  - url: 'http://localhost:5601'
-    description: local
+  - url: /
 paths:
 # Default space
   '/api/data_views':

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views.yaml
@@ -39,5 +39,3 @@ get:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view.yaml
@@ -29,8 +29,4 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601
 
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}.yaml
@@ -43,8 +43,6 @@ delete:
         application/json:
           schema:
             $ref: '../components/schemas/404_response.yaml'
-  servers:
-    - url: https://localhost:5601
 
 post:
   summary: Updates a data view.
@@ -78,8 +76,3 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601
-
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@fields.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@fields.yaml
@@ -39,8 +39,3 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601
-
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field.yaml
@@ -88,8 +88,3 @@ put:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601
-
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@data_view@{viewid}@runtime_field@{fieldname}.yaml
@@ -92,7 +92,3 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601            
-servers:
-  - url: https://localhost:5601

--- a/src/plugins/data_views/docs/openapi/paths/api@data_views@default.yaml
+++ b/src/plugins/data_views/docs/openapi/paths/api@data_views@default.yaml
@@ -71,8 +71,3 @@ post:
         application/json:
           schema:
             $ref: '../components/schemas/400_response.yaml'
-  servers:
-    - url: https://localhost:5601
-
-servers:
-  - url: https://localhost:5601


### PR DESCRIPTION
## Summary

This PR removes redundant "servers" from the data view OpenAPI specifications.

This change is related to the following redocly linting message:

> [15] bundled.json:794:20 at #/paths/~1api~1data_views~1default/post/servers/0/url
> Server `url` should not point to example.com or localhost.
> 792 | "servers": [
793 |   {
794 |     "url": "https://localhost:5601"
795 |   }
796 | ]
> Warning was generated by the no-server-example.com rule.

Whether or not we end up with a URL folks can use as a test server for the APIs, at least the information is now in a single place in each OAS.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->