### PR TITLE
[OAS] Simplify server declaration for case APIs

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -14,12 +14,7 @@
   },
   "servers": [
     {
-      "url": "https://{kibanaUrl}",
-      "variables": {
-        "kibanaUrl": {
-          "default": "localhost:5601"
-        }
-      }
+      "url": "/"
     }
   ],
   "security": [

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -9,10 +9,7 @@ info:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: https://{kibanaUrl}
-    variables:
-      kibanaUrl:
-        default: localhost:5601
+  - url: /
 security:
   - basicAuth: []
   - apiKeyAuth: []

--- a/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/cases/docs/openapi/entrypoint.yaml
@@ -12,10 +12,7 @@ tags:
   - name: cases
     description: Case APIs enable you to open and track issues.
 servers:
-  - url: https://{kibanaUrl}
-    variables:
-      kibanaUrl:
-        default: localhost:5601
+  - url: /
 paths:
 # Paths in the default space
   '/api/cases':


### PR DESCRIPTION
This PR removes localhost from the "servers" property for case OpenAPI specifications. Relates to similar changes being made to all our Kibana OAS.



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->