### PR TITLE
[Security Solution] add handling for endpoint package spec v2

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/constants.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/constants.ts
@@ -29,14 +29,20 @@ export const metadataIndexPattern = 'metrics-endpoint.metadata-*';
 /** index that the metadata transform writes to (destination) and that is used by endpoint APIs */
 export const metadataCurrentIndexPattern = 'metrics-endpoint.metadata_current_*';
 
+// endpoint package V2 has an additional prefix in the transform names
+const PACKAGE_V2_PREFIX = 'logs-';
+
 /** The metadata Transform Name prefix with NO (package) version) */
 export const metadataTransformPrefix = 'endpoint.metadata_current-default';
+export const METADATA_CURRENT_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${metadataTransformPrefix}`;
 
 // metadata transforms pattern for matching all metadata transform ids
 export const METADATA_TRANSFORMS_PATTERN = 'endpoint.metadata_*';
+export const METADATA_TRANSFORMS_PATTERN_V2 = `${PACKAGE_V2_PREFIX}${METADATA_TRANSFORMS_PATTERN}`;
 
 // united metadata transform id
 export const METADATA_UNITED_TRANSFORM = 'endpoint.metadata_united-default';
+export const METADATA_UNITED_TRANSFORM_V2 = `${PACKAGE_V2_PREFIX}${METADATA_UNITED_TRANSFORM}`;
 
 // united metadata transform destination index
 export const METADATA_UNITED_INDEX = '.metrics-endpoint.metadata_united_default';

--- a/x-pack/plugins/security_solution/common/endpoint/index_data.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/index_data.ts
@@ -111,8 +111,8 @@ export const indexHostsAndAlerts = usageTracker.track(
 
     const shouldWaitForEndpointMetadataDocs = fleet;
     if (shouldWaitForEndpointMetadataDocs) {
-      await waitForMetadataTransformsReady(client);
-      await stopMetadataTransforms(client);
+      await waitForMetadataTransformsReady(client, epmEndpointPackage.version);
+      await stopMetadataTransforms(client, epmEndpointPackage.version);
     }
 
     for (let i = 0; i < numHosts; i++) {
@@ -147,7 +147,8 @@ export const indexHostsAndAlerts = usageTracker.track(
     if (shouldWaitForEndpointMetadataDocs) {
       await startMetadataTransforms(
         client,
-        response.agents.map((agent) => agent.agent?.id ?? '')
+        response.agents.map((agent) => agent.agent?.id ?? ''),
+        epmEndpointPackage.version
       );
     }
 

--- a/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/transforms.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import semverLte from 'semver/functions/lte';
+
 import type { Client } from '@elastic/elasticsearch';
 import type { TransformGetTransformStatsTransformStats } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 
@@ -12,21 +14,24 @@ import { usageTracker } from '../data_loaders/usage_tracker';
 import {
   metadataCurrentIndexPattern,
   metadataTransformPrefix,
+  METADATA_CURRENT_TRANSFORM_V2,
   METADATA_TRANSFORMS_PATTERN,
+  METADATA_TRANSFORMS_PATTERN_V2,
   METADATA_UNITED_TRANSFORM,
+  METADATA_UNITED_TRANSFORM_V2,
 } from '../constants';
 
 export const waitForMetadataTransformsReady = usageTracker.track(
   'waitForMetadataTransformsReady',
-  async (esClient: Client): Promise<void> => {
-    await waitFor(() => areMetadataTransformsReady(esClient));
+  async (esClient: Client, version: string): Promise<void> => {
+    await waitFor(() => areMetadataTransformsReady(esClient, version));
   }
 );
 
 export const stopMetadataTransforms = usageTracker.track(
   'stopMetadataTransforms',
-  async (esClient: Client): Promise<void> => {
-    const transformIds = await getMetadataTransformIds(esClient);
+  async (esClient: Client, version: string): Promise<void> => {
+    const transformIds = await getMetadataTransformIds(esClient, version);
 
     await Promise.all(
       transformIds.map((transformId) =>
@@ -46,14 +51,18 @@ export const startMetadataTransforms = usageTracker.track(
   async (
     esClient: Client,
     // agentIds to wait for
-    agentIds: string[]
+    agentIds: string[],
+    version: string
   ): Promise<void> => {
-    const transformIds = await getMetadataTransformIds(esClient);
+    const transformIds = await getMetadataTransformIds(esClient, version);
+    const isV2 = isEndpointPackageV2(version);
+    const currentTransformPrefix = isV2 ? METADATA_CURRENT_TRANSFORM_V2 : metadataTransformPrefix;
     const currentTransformId = transformIds.find((transformId) =>
-      transformId.startsWith(metadataTransformPrefix)
+      transformId.startsWith(currentTransformPrefix)
     );
+    const unitedTransformPrefix = isV2 ? METADATA_UNITED_TRANSFORM_V2 : METADATA_UNITED_TRANSFORM;
     const unitedTransformId = transformIds.find((transformId) =>
-      transformId.startsWith(METADATA_UNITED_TRANSFORM)
+      transformId.startsWith(unitedTransformPrefix)
     );
     if (!currentTransformId || !unitedTransformId) {
       // eslint-disable-next-line no-console
@@ -88,22 +97,26 @@ export const startMetadataTransforms = usageTracker.track(
 );
 
 async function getMetadataTransformStats(
-  esClient: Client
+  esClient: Client,
+  version: string
 ): Promise<TransformGetTransformStatsTransformStats[]> {
+  const transformId = isEndpointPackageV2(version)
+    ? METADATA_TRANSFORMS_PATTERN_V2
+    : METADATA_TRANSFORMS_PATTERN;
   return (
     await esClient.transform.getTransformStats({
-      transform_id: METADATA_TRANSFORMS_PATTERN,
+      transform_id: transformId,
       allow_no_match: true,
     })
   ).transforms;
 }
 
-async function getMetadataTransformIds(esClient: Client): Promise<string[]> {
-  return (await getMetadataTransformStats(esClient)).map((transform) => transform.id);
+async function getMetadataTransformIds(esClient: Client, version: string): Promise<string[]> {
+  return (await getMetadataTransformStats(esClient, version)).map((transform) => transform.id);
 }
 
-async function areMetadataTransformsReady(esClient: Client): Promise<boolean> {
-  const transforms = await getMetadataTransformStats(esClient);
+async function areMetadataTransformsReady(esClient: Client, version: string): Promise<boolean> {
+  const transforms = await getMetadataTransformStats(esClient, version);
   return !transforms.some(
     // TODO TransformGetTransformStatsTransformStats type needs to be updated to include health
     (transform: TransformGetTransformStatsTransformStats & { health?: { status: string } }) =>
@@ -158,4 +171,9 @@ async function waitFor(
       return;
     }
   }
+}
+
+const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.12.0';
+export function isEndpointPackageV2(version: string) {
+  return semverLte(MIN_ENDPOINT_PACKAGE_V2_VERSION, version);
 }

--- a/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.test.ts
@@ -70,6 +70,7 @@ describe('check metadata transforms task', () => {
           { type: ElasticsearchAssetType.transform } as EsAssetReference,
           { type: ElasticsearchAssetType.transform } as EsAssetReference,
         ],
+        version: '8.11.0',
       } as Installation);
   });
 

--- a/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/lib/metadata/check_metadata_transforms_task.ts
@@ -19,10 +19,14 @@ import type {
 import { throwUnrecoverableError } from '@kbn/task-manager-plugin/server';
 import { ElasticsearchAssetType, FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
 import type { EndpointAppContext } from '../../types';
-import { METADATA_TRANSFORMS_PATTERN } from '../../../../common/endpoint/constants';
+import {
+  METADATA_TRANSFORMS_PATTERN,
+  METADATA_TRANSFORMS_PATTERN_V2,
+} from '../../../../common/endpoint/constants';
 import { WARNING_TRANSFORM_STATES } from '../../../../common/constants';
 import { wrapErrorIfNeeded } from '../../utils';
 import { stateSchemaByVersion, emptyState, type LatestTaskStateSchema } from './task_state';
+import { isEndpointPackageV2 } from '../../../../common/endpoint/utils/transforms';
 
 const SCOPE = ['securitySolution'];
 const INTERVAL = '2h';
@@ -108,11 +112,21 @@ export class CheckMetadataTransformsTask {
     const [{ elasticsearch }] = await core.getStartServices();
     const esClient = elasticsearch.client.asInternalUser;
 
+    const packageClient = this.endpointAppContext.service.getInternalFleetServices().packages;
+    const installation = await packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE);
+    if (!installation) {
+      this.logger.info('no endpoint installation found');
+      return { state: taskInstance.state };
+    }
+
+    const transformName = isEndpointPackageV2(installation.version)
+      ? METADATA_TRANSFORMS_PATTERN_V2
+      : METADATA_TRANSFORMS_PATTERN;
     let transformStatsResponse: TransportResult<TransformGetTransformStatsResponse>;
     try {
       transformStatsResponse = await esClient?.transform.getTransformStats(
         {
-          transform_id: METADATA_TRANSFORMS_PATTERN,
+          transform_id: transformName,
         },
         { meta: true }
       );
@@ -124,12 +138,6 @@ export class CheckMetadataTransformsTask {
       return { state: taskInstance.state };
     }
 
-    const packageClient = this.endpointAppContext.service.getInternalFleetServices().packages;
-    const installation = await packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE);
-    if (!installation) {
-      this.logger.info('no endpoint installation found');
-      return { state: taskInstance.state };
-    }
     const expectedTransforms = installation.installed_es.filter(
       (asset) => asset.type === ElasticsearchAssetType.transform
     );

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/handlers.ts
@@ -7,6 +7,8 @@
 
 import type { TypeOf } from '@kbn/config-schema';
 import type { Logger, RequestHandler } from '@kbn/core/server';
+import { FLEET_ENDPOINT_PACKAGE } from '@kbn/fleet-plugin/common';
+
 import type {
   MetadataListResponse,
   EndpointSortableField,
@@ -25,7 +27,9 @@ import {
   ENDPOINT_DEFAULT_SORT_DIRECTION,
   ENDPOINT_DEFAULT_SORT_FIELD,
   METADATA_TRANSFORMS_PATTERN,
+  METADATA_TRANSFORMS_PATTERN_V2,
 } from '../../../../common/endpoint/constants';
+import { isEndpointPackageV2 } from '../../../../common/endpoint/utils/transforms';
 
 export const getLogger = (endpointAppContext: EndpointAppContext): Logger => {
   return endpointAppContext.logFactory.get('metadata');
@@ -99,13 +103,21 @@ export const getMetadataRequestHandler = function (
 };
 
 export function getMetadataTransformStatsHandler(
+  endpointAppContext: EndpointAppContext,
   logger: Logger
 ): RequestHandler<unknown, unknown, unknown, SecuritySolutionRequestHandlerContext> {
   return async (context, _, response) => {
     const esClient = (await context.core).elasticsearch.client.asInternalUser;
+    const packageClient = endpointAppContext.service.getInternalFleetServices().packages;
+    const installation = await packageClient.getInstallation(FLEET_ENDPOINT_PACKAGE);
+    const transformName =
+      installation?.version && !isEndpointPackageV2(installation.version)
+        ? METADATA_TRANSFORMS_PATTERN
+        : METADATA_TRANSFORMS_PATTERN_V2;
+
     try {
       const transformStats = await esClient.transform.getTransformStats({
-        transform_id: METADATA_TRANSFORMS_PATTERN,
+        transform_id: transformName,
         allow_no_match: true,
       });
       return response.ok({

--- a/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
+++ b/x-pack/plugins/security_solution/server/endpoint/routes/metadata/index.ts
@@ -103,7 +103,7 @@ export function registerEndpointRoutes(
       withEndpointAuthz(
         { all: ['canReadSecuritySolution'] },
         logger,
-        getMetadataTransformStatsHandler(logger)
+        getMetadataTransformStatsHandler(endpointAppContext, logger)
       )
     );
 }


### PR DESCRIPTION
## Summary

Endpoint package is being upgraded to package spec v2. This upgrade causes the package managed transform names to change (now prefixed with an additional `logs-`). This PR updates all the places we're using the transform names to conditionally either use the v1 transform names or the v2 transform names depending on the package version to maintain backwards compatibility.

Also unskips `x-pack/test/security_solution_endpoint_api_int/apis/metadata.ts` tests. Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3763 (x100 ✅ ).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
