### PR TITLE
[ci] Increase parallelism for defend workflows tests

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -102,7 +102,7 @@ steps:
           queue: n2-4-virt
         depends_on: build
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 6
         retry:
           automatic:
             - exit_status: '*'

--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -157,7 +157,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 8
+    parallelism: 10
     retry:
       automatic:
         - exit_status: '*'
@@ -169,7 +169,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 4
+    parallelism: 6
     retry:
       automatic:
         - exit_status: '*'

--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -135,7 +135,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 8
+    parallelism: 10
     retry:
       automatic:
         - exit_status: '*'
@@ -147,7 +147,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 4
+    parallelism: 6
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
These tests are timing out

https://buildkite.com/elastic/kibana-on-merge/builds/37377
https://buildkite.com/elastic/kibana-on-merge/builds/37374
https://buildkite.com/elastic/kibana-on-merge/builds/37373


@patrykkopycinski @MadameSheema when you get a chance can you help operations understand how the cypress parallelism balancing works?  There's enough compute prior to this change (although it's close), and some groups are running much faster than others.  Does it help to further split suites into smaller groups ?