### PR TITLE
[Serverless FTRs] Ensure security index exists before running the tests

### DIFF
--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -688,7 +688,10 @@ export async function runServerlessCluster(log: ToolingLog, options: ServerlessO
         : {}),
     });
     await waitUntilClusterReady({ client, expectedStatus: 'green', log });
-    await waitForSecurityIndex({ client, log });
+    if (!options.esArgs || !options.esArgs.includes('xpack.security.enabled=false')) {
+      // If security is not disabled, make sure the security index exists before running the test to avoid flakiness
+      await waitForSecurityIndex({ client, log });
+    }
   }
 
   if (!options.background) {

--- a/packages/kbn-es/src/utils/docker.ts
+++ b/packages/kbn-es/src/utils/docker.ts
@@ -21,6 +21,7 @@ import {
   kibanaDevServiceAccount,
 } from '@kbn/dev-utils';
 
+import { waitForSecurityIndex } from './wait_for_security_index';
 import { createCliError } from '../errors';
 import { EsClusterExecOptions } from '../cluster_exec_options';
 import {
@@ -687,6 +688,7 @@ export async function runServerlessCluster(log: ToolingLog, options: ServerlessO
         : {}),
     });
     await waitUntilClusterReady({ client, expectedStatus: 'green', log });
+    await waitForSecurityIndex({ client, log });
   }
 
   if (!options.background) {

--- a/packages/kbn-es/src/utils/wait_for_security_index.test.ts
+++ b/packages/kbn-es/src/utils/wait_for_security_index.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { ToolingLog, ToolingLogCollectingWriter } from '@kbn/tooling-log';
+import { waitForSecurityIndex } from './wait_for_security_index';
+
+jest.mock('@elastic/elasticsearch', () => {
+  return {
+    Client: jest.fn(),
+  };
+});
+
+const log = new ToolingLog();
+const logWriter = new ToolingLogCollectingWriter();
+log.setWriters([logWriter]);
+
+const createApiKey = jest.fn();
+const invalidateApiKey = jest.fn();
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  jest
+    .requireMock('@elastic/elasticsearch')
+    .Client.mockImplementation(() => ({ security: { createApiKey, invalidateApiKey } }));
+  log.indent(-log.getIndent());
+  logWriter.messages.length = 0;
+  createApiKey.mockResolvedValue({ id: 'test-id' });
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('waitForSecurityIndex', () => {
+  test(`waits for the security request to succeed`, async () => {
+    invalidateApiKey.mockImplementationOnce(() => Promise.reject(new Error('foo')));
+    invalidateApiKey.mockImplementationOnce(() => Promise.resolve({}));
+
+    const client = new Client({});
+
+    await waitForSecurityIndex({ client, log });
+    expect(invalidateApiKey).toHaveBeenCalledTimes(2);
+    expect(logWriter.messages).toMatchInlineSnapshot(`
+      Array [
+        " [34minfo[39m waiting for ES cluster to bootstrap the security index",
+        " [33mwarn[39m waiting for ES cluster to bootstrap the security index, attempt 1 failed with: foo",
+        " [32msucc[39m ES security index is ready",
+      ]
+    `);
+  }, 10000);
+
+  test(`rejects when 'readyTimeout' is exceeded`, async () => {
+    invalidateApiKey.mockImplementationOnce(() => Promise.reject(new Error('foo')));
+    invalidateApiKey.mockImplementationOnce(() => Promise.reject(new Error('foo')));
+    const client = new Client({});
+    await expect(waitForSecurityIndex({ client, log, readyTimeout: 1000 })).rejects.toThrow(
+      'ES cluster failed to bootstrap the security index with the 1 second timeout'
+    );
+  });
+});

--- a/packages/kbn-es/src/utils/wait_for_security_index.ts
+++ b/packages/kbn-es/src/utils/wait_for_security_index.ts
@@ -32,11 +32,11 @@ export async function waitForSecurityIndex({
 
   log.info(`waiting for ES cluster to bootstrap the security index`);
 
+  // Hack to force the creation of the index `.security-7` index
+  const response = await client.security.createApiKey({ name: 'test-api-key-to-delete' });
   while (true) {
     attempt += 1;
 
-    // Hack to force the creation of the index `.security-7` index
-    const response = await client.security.createApiKey({ name: 'test-api-key-to-delete' });
     try {
       await client.security.invalidateApiKey({ ids: [response.id] });
       log.success('ES security index is ready');

--- a/packages/kbn-es/src/utils/wait_for_security_index.ts
+++ b/packages/kbn-es/src/utils/wait_for_security_index.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Client } from '@elastic/elasticsearch';
+import { ToolingLog } from '@kbn/tooling-log';
+const DEFAULT_READY_TIMEOUT = 10 * 1000; // 10 seconds
+
+export interface WaitOptions {
+  client: Client;
+  log: ToolingLog;
+  readyTimeout?: number;
+}
+
+/**
+ * General method to wait for the ES cluster status to be yellow or green
+ */
+export async function waitForSecurityIndex({
+  client,
+  log,
+  readyTimeout = DEFAULT_READY_TIMEOUT,
+}: WaitOptions) {
+  let attempt = 0;
+  const start = Date.now();
+
+  // The loop will continue until timeout even if SIGINT is signaled, so force exit
+  process.on('SIGINT', () => process.exit());
+
+  log.info(`waiting for ES cluster to bootstrap the security index`);
+
+  while (true) {
+    attempt += 1;
+
+    // Hack to force the creation of the index `.security-7` index
+    const response = await client.security.createApiKey({ name: 'test-api-key-to-delete' });
+    try {
+      await client.security.invalidateApiKey({ ids: [response.id] });
+      log.success('ES security index is ready');
+      return;
+    } catch (error) {
+      const timeSinceStart = Date.now() - start;
+      if (timeSinceStart > readyTimeout) {
+        const sec = readyTimeout / 1000;
+        throw new Error(
+          `ES cluster failed to bootstrap the security index with the ${sec} second timeout`
+        );
+      }
+
+      log.warning(
+        `waiting for ES cluster to bootstrap the security index, attempt ${attempt} failed with: ${error?.message}`
+      );
+
+      const waitSec = attempt * 1.5;
+      await new Promise((resolve) => setTimeout(resolve, waitSec * 1000));
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Resolves #169161

🟢 Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3760
🟢 Flaky test runner (on the latest commit): https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3766

The first tests of each suite in the Serverless FTRs are flaky because sometimes ES takes longer than expected to assign shards to the index `.security-7`.

Apparently, the index is created on the first write, meaning we are exposed to that flakiness as we run the first authenticated request.

This PR forces a "write" so that the security index is created before starting Kibana.

In Serverless production, the index should be there because it's created when applying the role mappings for the beats agents (using JWT).

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
