### PR TITLE
[Fleet] Bugfix - Navigate to policies list on agent policy deletion

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_delete_provider.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/components/agent_policy_delete_provider.tsx
@@ -10,8 +10,16 @@ import { EuiConfirmModal, EuiCallOut } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { useHistory } from 'react-router-dom';
+
 import { AGENTS_PREFIX } from '../../../constants';
-import { sendDeleteAgentPolicy, useStartServices, useConfig, sendRequest } from '../../../hooks';
+import {
+  sendDeleteAgentPolicy,
+  useStartServices,
+  useConfig,
+  sendRequest,
+  useLink,
+} from '../../../hooks';
 import { API_VERSIONS } from '../../../../../../common/constants';
 
 interface Props {
@@ -37,6 +45,8 @@ export const AgentPolicyDeleteProvider: React.FunctionComponent<Props> = ({
   const [agentsCount, setAgentsCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const onSuccessCallback = useRef<OnSuccessCallback | null>(null);
+  const { getPath } = useLink();
+  const history = useHistory();
 
   const deleteAgentPolicyPrompt: DeleteAgentPolicy = (
     agentPolicyToDelete,
@@ -92,6 +102,7 @@ export const AgentPolicyDeleteProvider: React.FunctionComponent<Props> = ({
       );
     }
     closeModal();
+    history.push(getPath('policies_list'));
   };
 
   const fetchAgentsCount = async (agentPolicyToCheck: string) => {


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/169227

## Summary
Fixed a small bug happening on agent policy deletion: instead of going to `app/fleet/policies`, the user remained on the deleted policy page. This PR reintroduces some code that got lost in [this PR](https://github.com/elastic/kibana/pull/165921/files#diff-59d06cb588d2a5c7214e509a999de43610cf83fc30f8851884cce151b206803dL176-L178).



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->