### PR TITLE
use sha-256 for localisation files integrity hashes

### DIFF
--- a/src/plugins/kibana_usage_collection/server/collectors/localization/file_integrity.test.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/localization/file_integrity.test.ts
@@ -13,7 +13,7 @@ import { getIntegrityHash, getIntegrityHashes } from './file_integrity';
 describe('Integrity Hash', () => {
   it('creates a hash from a file given a file path', async () => {
     const filePath = 'somepath.json';
-    const expectedHash = '3295d40d2f35ac27145d37fcd5cdc80b';
+    const expectedHash = '9bcf0afb8da5b3193be0d359c543eeca8ee85de2446c36e3aa64caccec18f7e3';
     const integrityHash = await getIntegrityHash(filePath);
     expect(integrityHash).toEqual(expectedHash);
   });
@@ -30,8 +30,8 @@ describe('Integrity Hashes', () => {
     const filePaths = ['somepath1.json', 'somepath2.json'];
     const integrityHashes = await getIntegrityHashes(filePaths);
     expect(integrityHashes).toEqual({
-      'somepath1.json': '8cbfe6a9f8174b2d7e77c2111a84f0e6',
-      'somepath2.json': '4177c075ade448d6e69fd94b39d0be15',
+      'somepath1.json': '28482a9b0465621cc5ff3050abd4f87ae051afc5f0088b90d26dbaa62f5f57b5',
+      'somepath2.json': '2172443c25237c7f9a987f0ff460d360830452e32a14d97237fdddb52661e153',
     });
   });
 });

--- a/src/plugins/kibana_usage_collection/server/collectors/localization/file_integrity.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/localization/file_integrity.ts
@@ -27,7 +27,7 @@ export async function getIntegrityHashes(filepaths: string[]): Promise<Integriti
 
 export async function getIntegrityHash(filepath: string): Promise<Hash | null> {
   try {
-    const output = createHash('md5');
+    const output = createHash('sha256');
 
     await pipeline(fs.createReadStream(filepath), output);
     const data = output.read();


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/169737

use `sha-256` instead of `md5` when hashing the translation files. 

As discussed in the issue, those hash aren't checked against anywhere, and just used in telemetry to know if customers are using custom translation files.