### PR TITLE
[Logs onboarding] Aligning back buttons in onboarding flows + removing disabled state

### DIFF
--- a/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/configure.cy.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/configure.cy.ts
@@ -12,6 +12,19 @@ describe('[Logs onboarding] Custom logs - configure step', () => {
       cy.visitKibana('/app/observabilityOnboarding/customLogs');
     });
 
+    describe('when user clicks on back button', () => {
+      beforeEach(() => {
+        cy.loginAsViewerUser();
+        cy.visitKibana('/app/observabilityOnboarding/customLogs');
+      });
+
+      it('navigates to observability logs onboarding page', () => {
+        cy.getByTestSubj('observabilityOnboardingBackButtonBackButton').click();
+
+        cy.url().should('include', '/app/observabilityOnboarding');
+      });
+    });
+
     it('Users shouldnt be able to continue if logFilePaths is empty', () => {
       cy.getByTestSubj('obltOnboardingLogFilePath-0')
         .find('input')

--- a/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
@@ -11,6 +11,19 @@ describe('[Logs onboarding] System logs', () => {
       cy.deleteIntegration('system');
     });
 
+    describe('when user clicks on back button', () => {
+      beforeEach(() => {
+        cy.loginAsViewerUser();
+        cy.visitKibana('/app/observabilityOnboarding/systemLogs');
+      });
+
+      it('navigates to observability logs onboarding page', () => {
+        cy.getByTestSubj('observabilityOnboardingBackButtonBackButton').click();
+
+        cy.url().should('include', '/app/observabilityOnboarding');
+      });
+    });
+
     describe('when user is missing privileges', () => {
       beforeEach(() => {
         cy.loginAsViewerUser();

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/configure_logs.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/configure_logs.tsx
@@ -41,7 +41,7 @@ import {
   StepPanelContent,
   StepPanelFooter,
 } from '../../shared/step_panel';
-import { BackButton } from './back_button';
+import { BackButton } from '../../shared/back_button';
 import { getFilename } from './get_filename';
 
 const customIntegrationsTestSubjects = {

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/inspect.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/inspect.tsx
@@ -13,7 +13,7 @@ import {
   StepPanelFooter,
 } from '../../shared/step_panel';
 import { useWizard } from '.';
-import { BackButton } from './back_button';
+import { BackButton } from '../../shared/back_button';
 
 export function Inspect() {
   const { goBack, getState, getPath, getUsage } = useWizard();

--- a/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/custom_logs/install_elastic_agent.tsx
@@ -37,7 +37,7 @@ import {
   StepPanelFooter,
 } from '../../shared/step_panel';
 import { ApiKeyBanner } from './api_key_banner';
-import { BackButton } from './back_button';
+import { BackButton } from '../../shared/back_button';
 import { WindowsInstallStep } from '../../shared/windows_install_step';
 import { TroubleshootingLink } from '../../shared/troubleshooting_link';
 

--- a/x-pack/plugins/observability_onboarding/public/components/app/system_logs/install_elastic_agent.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/app/system_logs/install_elastic_agent.tsx
@@ -24,8 +24,8 @@ import { useKibana } from '@kbn/kibana-react-plugin/public';
 import { default as React, useCallback, useEffect, useState } from 'react';
 import { useWizard } from '.';
 import { FETCH_STATUS, useFetcher } from '../../../hooks/use_fetcher';
-import { useKibanaNavigation } from '../../../hooks/use_kibana_navigation';
 import { ObservabilityOnboardingPluginSetupDeps } from '../../../plugin';
+import { BackButton } from '../../shared/back_button';
 import {
   ElasticAgentPlatform,
   getElasticAgentSetupCommand,
@@ -61,8 +61,7 @@ export function InstallElasticAgent() {
     ALL_DATASETS_LOCATOR_ID
   );
 
-  const { navigateToKibanaUrl } = useKibanaNavigation();
-  const { getState, setState } = useWizard();
+  const { goBack, getState, setState } = useWizard();
   const wizardState = getState();
   const [elasticAgentPlatform, setElasticAgentPlatform] =
     useState<ElasticAgentPlatform>('linux-tar');
@@ -77,10 +76,6 @@ export function InstallElasticAgent() {
   );
 
   const datasetName = 'system-logs';
-
-  function onBack() {
-    navigateToKibanaUrl('/app/observabilityOnboarding');
-  }
 
   async function onContinue() {
     if (systemIntegrationStatus === 'rejected') {
@@ -224,16 +219,7 @@ export function InstallElasticAgent() {
       panelFooter={
         <StepPanelFooter
           items={[
-            <EuiButton
-              data-test-subj="observabilityOnboardingInstallElasticAgentBackButton"
-              color="text"
-              onClick={onBack}
-            >
-              {i18n.translate(
-                'xpack.observability_onboarding.systemLogs.back',
-                { defaultMessage: 'Back' }
-              )}
-            </EuiButton>,
+            <BackButton onBack={goBack} />,
             <EuiFlexGroup justifyContent="flexEnd" alignItems="center">
               <EuiFlexItem grow={false}>
                 <EuiButton

--- a/x-pack/plugins/observability_onboarding/public/components/shared/back_button.tsx
+++ b/x-pack/plugins/observability_onboarding/public/components/shared/back_button.tsx
@@ -8,20 +8,14 @@
 import { EuiButtonEmpty } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import React from 'react';
-import { useHistory } from 'react-router-dom';
-import { useWizard } from '.';
 
 export function BackButton({ onBack }: { onBack: () => void }) {
-  const { getPath } = useWizard();
-  const history = useHistory();
-
   return (
     <EuiButtonEmpty
       data-test-subj="observabilityOnboardingBackButtonBackButton"
       iconType="arrowLeft"
       color="primary"
       onClick={onBack}
-      disabled={history.length === 1 || getPath().length === 1}
     >
       {i18n.translate('xpack.observability_onboarding.steps.back', {
         defaultMessage: 'Back',

--- a/x-pack/plugins/observability_onboarding/public/context/create_wizard_context.tsx
+++ b/x-pack/plugins/observability_onboarding/public/context/create_wizard_context.tsx
@@ -174,16 +174,17 @@ export function createWizardContext<
             }
           },
           goBack() {
-            if (history.length === 1 || pathRef.current.length === 1) {
-              return;
-            }
-            if (transitionDuration) {
-              setTimeout(() => {
-                history.goBack();
-              }, transitionDuration);
-            } else {
+            if (
+              history.length === 1 ||
+              pathRef.current.length === 1 ||
+              !transitionDuration
+            ) {
               history.goBack();
             }
+
+            setTimeout(() => {
+              history.goBack();
+            }, transitionDuration);
           },
           getState: () => state as T,
           setState: (_state: T | ((prevState: T) => T)) => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/169621.

### Changes
- Aligned `Back` buttons in the onboarding flows.
- Removing disabled state when in initial state of the flow.

### Demo
#### Before

https://github.com/elastic/kibana/assets/1313018/58c2ce40-a26c-4948-baa4-db977bbb5abe

#### After
##### `Back` button is aligned in onboarding flows

https://github.com/elastic/kibana/assets/1313018/4ef06241-8ee1-4e19-940f-75a0864e9440

##### `Back` button redirect users to landing page when they are in the initial state

https://github.com/elastic/kibana/assets/1313018/9f28bc15-e023-497c-9784-a858ea3afe7f

### How to test?
1. Go to [logs onboarding landing page](https://yngrdyn-deploy-kiban-pr169936.kb.us-west2.gcp.elastic-cloud.com/app/observabilityOnboarding).
2. Navigate into `Stream host system logs` or `Stream log files`.
3. Verify `Back` button is enabled and it redirects you to logs onboarding landing page.
