### PR TITLE
[SecuritySolution] Hide data quality dashboard link from serverless side nav

### DIFF
--- a/x-pack/plugins/security_solution_serverless/public/navigation/links/app_links.ts
+++ b/x-pack/plugins/security_solution_serverless/public/navigation/links/app_links.ts
@@ -10,7 +10,7 @@ import type {
   LinkItem,
 } from '@kbn/security-solution-plugin/public/common/links/types';
 import { SecurityPageName } from '@kbn/security-solution-navigation';
-import { cloneDeep, remove } from 'lodash';
+import { cloneDeep, find, remove } from 'lodash';
 import { createInvestigationsLinkFromTimeline } from './sections/investigations_links';
 import { mlAppLink } from './sections/ml_links';
 import { createAssetsLinkFromManage } from './sections/assets_links';
@@ -27,6 +27,12 @@ export const projectAppLinksSwitcher: AppLinksSwitcher = (appLinks) => {
   if (timelineLinkItem) {
     // Add investigations link
     projectAppLinks.push(createInvestigationsLinkFromTimeline(timelineLinkItem));
+  }
+
+  // Remove data quality dashboard link
+  const dashboardLinkItem = find(projectAppLinks, { id: SecurityPageName.dashboards });
+  if (dashboardLinkItem && dashboardLinkItem.links) {
+    remove(dashboardLinkItem.links, { id: SecurityPageName.dataQuality });
   }
 
   // Remove manage link


### PR DESCRIPTION
## Summary


Issue: Data Quality dashboard not working on serverless
https://github.com/elastic/kibana/issues/166271

In this PR:

### Serverless - No Data Quality Dashboard link on the dashboard landing page or the side nav.
<img width="2554" alt="Screenshot 2023-10-26 at 14 18 00" src="https://github.com/elastic/kibana/assets/6295984/a796987c-6260-40db-aae8-4a8c4701789d">

### ESS - Data Quality Dashboard links available on the landing page and the side nav.
<img width="2559" alt="Screenshot 2023-10-26 at 14 12 01" src="https://github.com/elastic/kibana/assets/6295984/272cd910-7871-4826-8320-92181f78f565">
<img width="2541" alt="Screenshot 2023-10-26 at 14 34 48" src="https://github.com/elastic/kibana/assets/6295984/eee5c966-4f6b-4974-b1ac-c94245d0341c">


