### PR TITLE
[ci/checks] Remove bootstrap from security_solution_codegen.sh

### DIFF
--- a/.buildkite/scripts/steps/code_generation/security_solution_codegen.sh
+++ b/.buildkite/scripts/steps/code_generation/security_solution_codegen.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 
 source .buildkite/scripts/common/util.sh
 
-.buildkite/scripts/bootstrap.sh
-
 echo --- Security Solution OpenAPI Code Generation
 
 (cd x-pack/plugins/security_solution && yarn openapi:generate)


### PR DESCRIPTION
This was originally running with its own step but was recently moved to `Checks`.  The checks step already runs bootstrap.

Fixes https://buildkite.com/elastic/kibana-on-merge/builds/37406#018b6c1f-13a8-4ec7-9300-3c6ef0deb0fc/8195