### PR TITLE
[Synthetics] Adjust Errors metric and sparklines query for retests

### DIFF
--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -110,7 +110,7 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         columnFilters: [
           {
             language: 'kuery',
-            query: `summary.down > 0`,
+            query: `${FINAL_SUMMARY_KQL} and summary.down > 0`,
           },
         ],
       },

--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/single_metric_config.ts
@@ -135,7 +135,7 @@ export function getSyntheticsSingleMetricConfig({ dataView }: ConfigProps): Seri
           palette: getColorPalette('danger'),
         },
         columnType: FORMULA_COLUMN,
-        formula: 'unique_count(state.id, kql=\'monitor.status: "down"\')',
+        formula: `unique_count(state.id, kql='${FINAL_SUMMARY_KQL} and monitor.status: "down"')`,
         format: 'number',
       },
       {


### PR DESCRIPTION
Fixes #169933 

## Summary

The PR adjusts the query for Errors count metric and Errors sparklines metric to account for retests.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->