### PR TITLE
[8.11] [Controls] Fix flaky time slider test (#169553)

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/common/time_slider.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/time_slider.ts
@@ -106,7 +106,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         const valueAfter = await dashboardControls.getTimeSliceFromTimeSlider();
         expect(valueBefore).to.not.equal(valueAfter);
 
-        await dashboardControls.closeTimeSliderPopover();
         await dashboard.clickCancelOutOfEditMode();
         const valueNow = await dashboardControls.getTimeSliceFromTimeSlider();
         expect(valueNow).to.equal(valueBefore);

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -736,6 +736,7 @@ export class DashboardPageControls extends FtrService {
 
   // Time slider functions
   public async gotoNextTimeSlice() {
+    await this.closeTimeSliderPopover(); // prevents the pin tooltip from getting in the way
     await this.testSubjects.click('timeSlider-nextTimeWindow');
   }
 


### PR DESCRIPTION
# Backport

Fixes https://github.com/elastic/kibana/issues/169967

This will backport the following commits from `main` to `8.11`:
 - [[Controls] Fix flaky time slider test (#169553)](https://github.com/elastic/kibana/pull/169553)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Hannah Mudge","email":"Heenawter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-10-23T19:57:51Z","message":"[Controls] Fix flaky time slider test (#169553)\n\nCloses https://github.com/elastic/kibana/issues/169404\r\n\r\n## Summary\r\n\r\nThe `Pin start` tooltip has a tendency to get in the way of the\r\n`timeSlider-nextTimeWindow` button:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/dc4855ab-6c59-4003-83f1-de778f97b0f8)\r\n\r\nTo prevent this, I've made it so that the popover is closed **before**\r\nthe `next` button is pressed.\r\n\r\n\r\n### [Flaky Test\r\nRunner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3681)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/d339d256-dced-4bbd-b287-e04cd1268835)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"eea3b1b8f46071eb2f154b07d3fd472a9ae09964","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Presentation","loe:small","release_note:skip","impact:critical","backport:skip","v8.12.0"],"number":169553,"url":"https://github.com/elastic/kibana/pull/169553","mergeCommit":{"message":"[Controls] Fix flaky time slider test (#169553)\n\nCloses https://github.com/elastic/kibana/issues/169404\r\n\r\n## Summary\r\n\r\nThe `Pin start` tooltip has a tendency to get in the way of the\r\n`timeSlider-nextTimeWindow` button:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/dc4855ab-6c59-4003-83f1-de778f97b0f8)\r\n\r\nTo prevent this, I've made it so that the popover is closed **before**\r\nthe `next` button is pressed.\r\n\r\n\r\n### [Flaky Test\r\nRunner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3681)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/d339d256-dced-4bbd-b287-e04cd1268835)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"eea3b1b8f46071eb2f154b07d3fd472a9ae09964"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169553","number":169553,"mergeCommit":{"message":"[Controls] Fix flaky time slider test (#169553)\n\nCloses https://github.com/elastic/kibana/issues/169404\r\n\r\n## Summary\r\n\r\nThe `Pin start` tooltip has a tendency to get in the way of the\r\n`timeSlider-nextTimeWindow` button:\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/dc4855ab-6c59-4003-83f1-de778f97b0f8)\r\n\r\nTo prevent this, I've made it so that the popover is closed **before**\r\nthe `next` button is pressed.\r\n\r\n\r\n### [Flaky Test\r\nRunner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3681)\r\n\r\n\r\n![image](https://github.com/elastic/kibana/assets/8698078/d339d256-dced-4bbd-b287-e04cd1268835)\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"eea3b1b8f46071eb2f154b07d3fd472a9ae09964"}}]}] BACKPORT-->