### PR TITLE
Upgrades crypto-js@4.1.1→4.2.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13576,9 +13576,9 @@ crypto-browserify@^3.11.0:
     randomfill "^1.0.3"
 
 crypto-js@^4.0.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
-  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

Upgrades `crypto-js` transitive dependency from v4.1.1 to v4.2.0

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->