### PR TITLE
[ci] Remove --fix from precommit_hook

### DIFF
--- a/.buildkite/scripts/steps/checks/precommit_hook.sh
+++ b/.buildkite/scripts/steps/checks/precommit_hook.sh
@@ -19,8 +19,4 @@ If you want, you can still manually install the pre-commit hook locally by runni
 node scripts/precommit_hook.js \
   --ref HEAD~1..HEAD \
   --max-files 200 \
-  --verbose \
-  --fix \
-  --no-stage # we have to disable staging or check_for_changed_files won't see the changes
-
-check_for_changed_files 'node scripts/precommit_hook.js --ref HEAD~1..HEAD --fix' true
+  --verbose


### PR DESCRIPTION
Currently on CI, the precommit_hook will fix lint warnings against the most recent commit.  When multiple commits are pushed up at once, lint warnings on earlier commits may go unnoticed until they are squashed and merged.  The on-merge pipeline will fail due to changed files, and pull requests based on the squashed commit will see unrelated changes auto-fixed.

This removes the --fix flag from the precommit hook check.

Closes https://github.com/elastic/kibana/issues/169966

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->