### PR TITLE
[Synthetics] Fix Pagination error for stderr table

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/stderr_logs.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/common/components/stderr_logs.tsx
@@ -139,6 +139,7 @@ export const StdErrorLogs = ({
         }}
         pagination={{
           pageSize,
+          pageSizeOptions: [2, 5, 10, 20, 50],
         }}
       />
     </>


### PR DESCRIPTION
## Summary

Provide pagesize as part of pageSizeOptions to fix EUI Error.

<img width="1499" alt="image" src="https://github.com/elastic/kibana/assets/3505601/525c4aaa-f0d9-4ea1-8727-e693b3a28fb5">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->