### PR TITLE
[ES|QL] Displays a dismissible callout

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -467,6 +467,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
       luceneQuerySyntax: `${ELASTICSEARCH_DOCS}query-dsl-query-string-query.html#query-string-syntax`,
       percolate: `${ELASTICSEARCH_DOCS}query-dsl-percolate-query.html`,
       queryDsl: `${ELASTICSEARCH_DOCS}query-dsl.html`,
+      queryESQL: `${ELASTICSEARCH_DOCS}esql.html`,
     },
     search: {
       sessions: `${KIBANA_DOCS}search-sessions.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -358,6 +358,7 @@ export interface DocLinks {
     readonly luceneQuerySyntax: string;
     readonly percolate: string;
     readonly queryDsl: string;
+    readonly queryESQL: string;
   };
   readonly date: {
     readonly dateMath: string;

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -67,7 +67,6 @@ import { useSavedSearchInitial } from '../../services/discover_state_provider';
 import { useFetchMoreRecords } from './use_fetch_more_records';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { SelectedVSAvailableCallout } from './selected_vs_available_callout';
-import { TechPreviewCallout } from './esql_tech_preview_callout';
 
 const containerStyles = css`
   position: relative;
@@ -113,7 +112,7 @@ function DiscoverDocumentsComponent({
   const services = useDiscoverServices();
   const documents$ = stateContainer.dataState.data$.documents$;
   const savedSearch = useSavedSearchInitial();
-  const { dataViews, capabilities, uiSettings, uiActions, docLinks } = services;
+  const { dataViews, capabilities, uiSettings, uiActions } = services;
   const [query, sort, rowHeight, rowsPerPage, grid, columns, index, sampleSizeState] =
     useAppStateSelector((state) => {
       return [
@@ -273,7 +272,7 @@ function DiscoverDocumentsComponent({
             data-test-subj="discoverMainError"
           />
         )}
-        <TechPreviewCallout isPlainRecord={isTextBasedQuery} docLinks={docLinks} />
+        {/* <TechPreviewCallout isPlainRecord={isTextBasedQuery} docLinks={docLinks} /> */}
         <SelectedVSAvailableCallout
           isPlainRecord={isTextBasedQuery}
           textBasedQueryColumns={documents?.textBasedQueryColumns}
@@ -291,7 +290,6 @@ function DiscoverDocumentsComponent({
     [
       dataState.error,
       isTextBasedQuery,
-      docLinks,
       documents?.textBasedQueryColumns,
       currentColumns,
       documentState.interceptedWarnings,

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -67,6 +67,7 @@ import { useSavedSearchInitial } from '../../services/discover_state_provider';
 import { useFetchMoreRecords } from './use_fetch_more_records';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { SelectedVSAvailableCallout } from './selected_vs_available_callout';
+import { TechPreviewCallout } from './esql_tech_preview_callout';
 
 const containerStyles = css`
   position: relative;
@@ -112,7 +113,7 @@ function DiscoverDocumentsComponent({
   const services = useDiscoverServices();
   const documents$ = stateContainer.dataState.data$.documents$;
   const savedSearch = useSavedSearchInitial();
-  const { dataViews, capabilities, uiSettings, uiActions } = services;
+  const { dataViews, capabilities, uiSettings, uiActions, docLinks } = services;
   const [query, sort, rowHeight, rowsPerPage, grid, columns, index, sampleSizeState] =
     useAppStateSelector((state) => {
       return [
@@ -272,6 +273,7 @@ function DiscoverDocumentsComponent({
             data-test-subj="discoverMainError"
           />
         )}
+        <TechPreviewCallout isPlainRecord={isTextBasedQuery} docLinks={docLinks} />
         <SelectedVSAvailableCallout
           isPlainRecord={isTextBasedQuery}
           textBasedQueryColumns={documents?.textBasedQueryColumns}
@@ -289,8 +291,9 @@ function DiscoverDocumentsComponent({
     [
       dataState.error,
       isTextBasedQuery,
-      currentColumns,
+      docLinks,
       documents?.textBasedQueryColumns,
+      currentColumns,
       documentState.interceptedWarnings,
     ]
   );

--- a/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_documents.tsx
@@ -272,7 +272,6 @@ function DiscoverDocumentsComponent({
             data-test-subj="discoverMainError"
           />
         )}
-        {/* <TechPreviewCallout isPlainRecord={isTextBasedQuery} docLinks={docLinks} /> */}
         <SelectedVSAvailableCallout
           isPlainRecord={isTextBasedQuery}
           textBasedQueryColumns={documents?.textBasedQueryColumns}
@@ -290,8 +289,8 @@ function DiscoverDocumentsComponent({
     [
       dataState.error,
       isTextBasedQuery,
-      documents?.textBasedQueryColumns,
       currentColumns,
+      documents?.textBasedQueryColumns,
       documentState.interceptedWarnings,
     ]
   );

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -54,6 +54,7 @@ import { DiscoverHistogramLayout } from './discover_histogram_layout';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { addLog } from '../../../../utils/add_log';
 import { DiscoverResizableLayout } from './discover_resizable_layout';
+import { TechPreviewCallout } from './esql_tech_preview_callout';
 
 const SidebarMemoized = React.memo(DiscoverSidebarResponsive);
 const TopNavMemoized = React.memo(DiscoverTopNav);
@@ -73,6 +74,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     history,
     spaces,
     inspector,
+    docLinks,
   } = useDiscoverServices();
   const { euiTheme } = useEuiTheme();
   const pageBackgroundColor = useEuiBackgroundColor('plain');
@@ -206,6 +208,8 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
 
     return (
       <>
+        {/* Temporarily display a tech preview callout for ES|QL*/}
+        <TechPreviewCallout isPlainRecord={isPlainRecord} docLinks={docLinks} />
         <DiscoverHistogramLayout
           isPlainRecord={isPlainRecord}
           dataView={dataView}
@@ -223,6 +227,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
   }, [
     currentColumns,
     dataView,
+    docLinks,
     isPlainRecord,
     mainContainer,
     onAddFilter,

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -54,7 +54,7 @@ import { DiscoverHistogramLayout } from './discover_histogram_layout';
 import { ErrorCallout } from '../../../../components/common/error_callout';
 import { addLog } from '../../../../utils/add_log';
 import { DiscoverResizableLayout } from './discover_resizable_layout';
-import { TechPreviewCallout } from './esql_tech_preview_callout';
+import { ESQLTechPreviewCallout } from './esql_tech_preview_callout';
 
 const SidebarMemoized = React.memo(DiscoverSidebarResponsive);
 const TopNavMemoized = React.memo(DiscoverTopNav);
@@ -209,7 +209,7 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     return (
       <>
         {/* Temporarily display a tech preview callout for ES|QL*/}
-        <TechPreviewCallout isPlainRecord={isPlainRecord} docLinks={docLinks} />
+        {isPlainRecord && <ESQLTechPreviewCallout docLinks={docLinks} />}
         <DiscoverHistogramLayout
           isPlainRecord={isPlainRecord}
           dataView={dataView}

--- a/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
@@ -33,7 +33,7 @@ export const TechPreviewCallout = ({ isPlainRecord, docLinks }: SelectedVSAvaila
             title={
               <FormattedMessage
                 id="discover.textBasedMode.techPreviewCalloutMessage"
-                defaultMessage="ES|QL is currently in technical preview. Please review the {link}."
+                defaultMessage="ES|QL is currently in technical preview. Find more information in the {link}."
                 values={{
                   link: (
                     <EuiLink href={docLinks.links.query.queryESQL} target="_blank">

--- a/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
@@ -33,7 +33,7 @@ export const TechPreviewCallout = ({ isPlainRecord, docLinks }: SelectedVSAvaila
             title={
               <FormattedMessage
                 id="discover.textBasedMode.techPreviewCalloutMessage"
-                defaultMessage="ES|QL is currently in technical preview. Please review the {link} before proceeding."
+                defaultMessage="ES|QL is currently in technical preview. Please review the {link}."
                 values={{
                   link: (
                     <EuiLink href={docLinks.links.query.queryESQL} target="_blank">

--- a/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import React, { useCallback } from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import type { DocLinksStart } from '@kbn/core/public';
+
+const ESQL_TECH_PREVIEW_CALLOUT = 'ESQL_TECH_PREVIEW_CALLOUT_HIDDEN';
+
+interface SelectedVSAvailableCallout {
+  isPlainRecord: boolean;
+  docLinks: DocLinksStart;
+}
+
+export const TechPreviewCallout = ({ isPlainRecord, docLinks }: SelectedVSAvailableCallout) => {
+  const [hideCallout, setHideCallout] = useLocalStorage(ESQL_TECH_PREVIEW_CALLOUT, false);
+
+  const onDismiss = useCallback(() => {
+    setHideCallout(!hideCallout);
+  }, [hideCallout, setHideCallout]);
+
+  return (
+    <>
+      {isPlainRecord && !hideCallout && (
+        <>
+          <EuiCallOut
+            title={
+              <FormattedMessage
+                id="discover.textBasedMode.techPreviewCalloutMessage"
+                defaultMessage="ES|QL is currently in technical preview. Please review the {link} before proceeding."
+                values={{
+                  link: (
+                    <EuiLink href={docLinks.links.query.queryESQL} target="_blank">
+                      <FormattedMessage
+                        id="discover.textBasedMode.techPreviewCalloutLink"
+                        defaultMessage="documentation"
+                      />
+                    </EuiLink>
+                  ),
+                }}
+              />
+            }
+            color="primary"
+            iconType="beaker"
+            onDismiss={onDismiss}
+            size="s"
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/esql_tech_preview_callout.tsx
@@ -11,48 +11,45 @@ import useLocalStorage from 'react-use/lib/useLocalStorage';
 import { EuiCallOut, EuiLink } from '@elastic/eui';
 import type { DocLinksStart } from '@kbn/core/public';
 
-const ESQL_TECH_PREVIEW_CALLOUT = 'ESQL_TECH_PREVIEW_CALLOUT_HIDDEN';
+const ESQL_TECH_PREVIEW_CALLOUT = 'discover.esqlTechPreviewCalloutHidden';
 
-interface SelectedVSAvailableCallout {
-  isPlainRecord: boolean;
+interface ESQLTechPreviewCallout {
   docLinks: DocLinksStart;
 }
 
-export const TechPreviewCallout = ({ isPlainRecord, docLinks }: SelectedVSAvailableCallout) => {
+export const ESQLTechPreviewCallout = ({ docLinks }: ESQLTechPreviewCallout) => {
   const [hideCallout, setHideCallout] = useLocalStorage(ESQL_TECH_PREVIEW_CALLOUT, false);
 
   const onDismiss = useCallback(() => {
-    setHideCallout(!hideCallout);
-  }, [hideCallout, setHideCallout]);
+    setHideCallout(true);
+  }, [setHideCallout]);
+
+  if (hideCallout) {
+    return null;
+  }
 
   return (
-    <>
-      {isPlainRecord && !hideCallout && (
-        <>
-          <EuiCallOut
-            title={
-              <FormattedMessage
-                id="discover.textBasedMode.techPreviewCalloutMessage"
-                defaultMessage="ES|QL is currently in technical preview. Find more information in the {link}."
-                values={{
-                  link: (
-                    <EuiLink href={docLinks.links.query.queryESQL} target="_blank">
-                      <FormattedMessage
-                        id="discover.textBasedMode.techPreviewCalloutLink"
-                        defaultMessage="documentation"
-                      />
-                    </EuiLink>
-                  ),
-                }}
-              />
-            }
-            color="primary"
-            iconType="beaker"
-            onDismiss={onDismiss}
-            size="s"
-          />
-        </>
-      )}
-    </>
+    <EuiCallOut
+      title={
+        <FormattedMessage
+          id="discover.textBasedMode.techPreviewCalloutMessage"
+          defaultMessage="ES|QL is currently in technical preview. Find more information in the {link}."
+          values={{
+            link: (
+              <EuiLink href={docLinks.links.query.queryESQL} target="_blank">
+                <FormattedMessage
+                  id="discover.textBasedMode.techPreviewCalloutLink"
+                  defaultMessage="documentation"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      }
+      color="primary"
+      iconType="beaker"
+      onDismiss={onDismiss}
+      size="s"
+    />
   );
 };


### PR DESCRIPTION
## Summary

Although we are displaying the Technical preview badge in the dataview picker we want to make it more prominent in the UI due to some concerns on the scalability.  This PR adds a dismissible callout (state stored in local storage).

<img width="828" alt="image" src="https://github.com/elastic/kibana/assets/17003240/9287c9d8-0e67-4498-a544-b17eea9569b4">

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->