### PR TITLE
[FTR] Fix / skip flaky tests on serverless MKI

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/alerting/summary_actions.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/alerting/summary_actions.ts
@@ -41,6 +41,9 @@ export default function ({ getService }: FtrProviderContext) {
   const esDeleteAllIndices = getService('esDeleteAllIndices');
 
   describe('Summary actions', function () {
+    // flaky on MKI, see https://github.com/elastic/kibana/issues/169204
+    this.tags(['failsOnMKI']);
+
     const RULE_TYPE_ID = '.es-query';
     const ALERT_ACTION_INDEX = 'alert-action-es-query';
     const ALERT_INDEX = '.alerts-stack.alerts-default';

--- a/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/transforms/search_bar_features.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import type { FtrProviderContext } from '../../../../ftr_provider_context';
 
 export default function ({ getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation']);
+  const PageObjects = getPageObjects(['header', 'svlCommonPage', 'svlCommonNavigation']);
 
   const allLabels = [{ search: 'transform', label: 'Data / Transforms', expected: true }];
   const expectedLabels = allLabels.filter((l) => l.expected);
@@ -26,6 +26,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
     describe('list features', () => {
       if (expectedLabels.length > 0) {
         it('has the correct features enabled', async () => {
+          await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.svlCommonNavigation.search.showSearch();
 
           for (const expectedLabel of expectedLabels) {
@@ -44,6 +45,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
 
       if (notExpectedLabels.length > 0) {
         it('has the correct features disabled', async () => {
+          await PageObjects.header.waitUntilLoadingHasFinished();
           await PageObjects.svlCommonNavigation.search.showSearch();
 
           for (const notExpectedLabel of notExpectedLabels) {

--- a/x-pack/test_serverless/functional/test_suites/observability/ml/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/ml/search_bar_features.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation']);
+  const PageObjects = getPageObjects(['header', 'svlCommonPage', 'svlCommonNavigation']);
 
   const allLabels = [
     { label: 'Machine Learning', expected: true },
@@ -49,6 +49,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
 
     describe('list features', () => {
       it('has the correct features enabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const expectedLabels = allLabels.filter((l) => l.expected).map((l) => l.label);
@@ -64,7 +65,9 @@ export default function ({ getPageObjects }: FtrProviderContext) {
         }
         await PageObjects.svlCommonNavigation.search.hideSearch();
       });
+
       it('has the correct features disabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const notExpectedLabels = allLabels.filter((l) => !l.expected).map((l) => l.label);

--- a/x-pack/test_serverless/functional/test_suites/search/ml/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/ml/search_bar_features.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation']);
+  const PageObjects = getPageObjects(['header', 'svlCommonPage', 'svlCommonNavigation']);
 
   const allLabels = [
     { label: 'Machine Learning', expected: true },
@@ -49,6 +49,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
 
     describe('list features', () => {
       it('has the correct features enabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const expectedLabels = allLabels.filter((l) => l.expected).map((l) => l.label);
@@ -64,7 +65,9 @@ export default function ({ getPageObjects }: FtrProviderContext) {
         }
         await PageObjects.svlCommonNavigation.search.hideSearch();
       });
+
       it('has the correct features disabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const notExpectedLabels = allLabels.filter((l) => !l.expected).map((l) => l.label);

--- a/x-pack/test_serverless/functional/test_suites/security/ml/search_bar_features.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ml/search_bar_features.ts
@@ -8,7 +8,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default function ({ getPageObjects }: FtrProviderContext) {
-  const PageObjects = getPageObjects(['svlCommonPage', 'svlCommonNavigation']);
+  const PageObjects = getPageObjects(['header', 'svlCommonPage', 'svlCommonNavigation']);
 
   const allLabels = [
     { label: 'Machine Learning', expected: true },
@@ -49,6 +49,7 @@ export default function ({ getPageObjects }: FtrProviderContext) {
 
     describe('list features', () => {
       it('has the correct features enabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const expectedLabels = allLabels.filter((l) => l.expected).map((l) => l.label);
@@ -64,7 +65,9 @@ export default function ({ getPageObjects }: FtrProviderContext) {
         }
         await PageObjects.svlCommonNavigation.search.hideSearch();
       });
+
       it('has the correct features disabled', async () => {
+        await PageObjects.header.waitUntilLoadingHasFinished();
         await PageObjects.svlCommonNavigation.search.showSearch();
 
         const notExpectedLabels = allLabels.filter((l) => !l.expected).map((l) => l.label);


### PR DESCRIPTION
## Summary

This PR deals with serverless tests that are flaky when running in MKI:
* Search bar tests have been stabilized by adding a wait for global loading before interacting with the search feature
* Summary actions API tests have been skipped for MKI runs again as the fix didn't fully work