### PR TITLE
[ci/on-merge] Adjust check types queue

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -254,7 +254,7 @@ steps:
   - command: .buildkite/scripts/steps/check_types.sh
     label: 'Check Types'
     agents:
-      queue: n2-2-spot
+      queue: n2-4-spot
     timeout_in_minutes: 60
     retry:
       automatic:

--- a/.buildkite/scripts/steps/check_types.sh
+++ b/.buildkite/scripts/steps/check_types.sh
@@ -7,4 +7,4 @@ source .buildkite/scripts/common/util.sh
 .buildkite/scripts/bootstrap.sh
 
 echo --- Check Types
-node --max-old-space-size=4096 scripts/type_check
+node scripts/type_check


### PR DESCRIPTION
n2-2-spot preemption are frequent enough that this is causing pipeline instability.  This moves the instance size up to n2-4

This also removes the max-old-space-size definition I previously set. delanni helped me understand that we're spawning a tsc process with a memory limit already defined.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->