### PR TITLE
[8.11] [ML] AIOps: Fix Change point embeddable reporting  (#169962)

### DIFF
--- a/x-pack/plugins/aiops/public/components/change_point_detection/charts_grid.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/charts_grid.tsx
@@ -52,7 +52,11 @@ export const ChartsGrid: FC<{
     Object.fromEntries(changePoints.map((v, i) => [i, true]))
   );
 
-  const onLoadCallback = useCallback(
+  /**
+   * Callback to track render of each chart component
+   * to report when all charts are ready.
+   */
+  const onChartRenderCompleteCallback = useCallback(
     (chartId: number, isLoading: boolean) => {
       if (!onRenderComplete) return;
       loadCounter.current[chartId] = isLoading;
@@ -141,7 +145,12 @@ export const ChartsGrid: FC<{
                 annotation={v}
                 interval={interval}
                 onLoading={(isLoading) => {
-                  onLoadCallback(index, isLoading);
+                  if (isLoading) {
+                    onChartRenderCompleteCallback(index, true);
+                  }
+                }}
+                onRenderComplete={() => {
+                  onChartRenderCompleteCallback(index, false);
                 }}
               />
             </EuiPanel>

--- a/x-pack/plugins/aiops/public/components/change_point_detection/fields_config.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/fields_config.tsx
@@ -236,6 +236,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                         }),
                   icon: 'plusInCircle',
                   panel: 'attachMainPanel',
+                  'data-test-subj': 'aiopsChangePointDetectionAttachButton',
                 },
               ]
             : []),
@@ -248,6 +249,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
             disabled: removeDisabled,
           },
         ],
+        'data=test-subj': 'aiopsChangePointDetectionContextMenuPanel',
       },
       {
         id: 'attachMainPanel',
@@ -269,6 +271,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                     defaultMessage: 'To dashboard',
                   }),
                   panel: 'attachToDashboardPanel',
+                  'data-test-subj': 'aiopsChangePointDetectionAttachToDashboardButton',
                 },
               ]
             : []),
@@ -290,6 +293,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                         ),
                       }
                     : {}),
+                  'data-test-subj': 'aiopsChangePointDetectionAttachToCaseButton',
                   onClick: () => {
                     openCasesModalCallback({
                       timeRange,
@@ -308,6 +312,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
               ]
             : []),
         ],
+        'data-test-subj': 'aiopsChangePointDetectionAttachChartPanel',
       },
       {
         id: 'attachToDashboardPanel',
@@ -318,7 +323,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
         content: (
           <EuiPanel paddingSize={'s'}>
             <EuiSpacer size={'s'} />
-            <EuiForm>
+            <EuiForm data-test-subj="aiopsChangePointDetectionDashboardAttachmentForm">
               <EuiFormRow fullWidth>
                 <EuiSwitch
                   label={i18n.translate('xpack.aiops.changePointDetection.applyTimeRangeLabel', {
@@ -334,6 +339,7 @@ const FieldPanel: FC<FieldPanelProps> = ({
                     })
                   }
                   compressed
+                  data-test-subj="aiopsChangePointDetectionAttachToDashboardApplyTimeRangeSwitch"
                 />
               </EuiFormRow>
               {isDefined(fieldConfig.splitField) && selectedPartitions.length === 0 ? (

--- a/x-pack/plugins/aiops/public/components/change_point_detection/partitions_selector.tsx
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/partitions_selector.tsx
@@ -140,8 +140,8 @@ export const PartitionsSelector: FC<PartitionsSelectorProps> = ({
 
   useEffect(
     function onSplitFieldChange() {
-      if (splitField !== prevSplitField) {
-        fetchResults('');
+      fetchResults('');
+      if (prevSplitField !== undefined && splitField !== prevSplitField) {
         onChange([]);
       }
     },

--- a/x-pack/plugins/aiops/public/embeddable/change_point_chart_initializer.tsx
+++ b/x-pack/plugins/aiops/public/embeddable/change_point_chart_initializer.tsx
@@ -205,7 +205,7 @@ export const FormControls: FC<{
         return;
       }
 
-      if (metricFieldOptions === prevMetricFieldOptions) return;
+      if (!prevMetricFieldOptions || metricFieldOptions === prevMetricFieldOptions) return;
 
       onChange({
         fn: formInput.fn,

--- a/x-pack/plugins/aiops/public/embeddable/embeddable_change_point_chart.tsx
+++ b/x-pack/plugins/aiops/public/embeddable/embeddable_change_point_chart.tsx
@@ -111,6 +111,9 @@ export class EmbeddableChangePointChart extends AbstractEmbeddable<
     // required for the export feature to work
     this.node.setAttribute('data-shared-item', '');
 
+    // test subject selector for functional tests
+    this.node.setAttribute('data-test-subj', 'aiopsEmbeddableChangePointChart');
+
     const I18nContext = this.deps.i18n.Context;
 
     const datePickerDeps = {

--- a/x-pack/plugins/aiops/public/embeddable/embeddable_chart_component_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/embeddable/embeddable_chart_component_wrapper.tsx
@@ -170,7 +170,7 @@ export const ChartGridEmbeddableWrapper: FC<
       },
     });
 
-    if (partitions && fieldConfig.splitField) {
+    if (Array.isArray(partitions) && partitions.length > 0 && fieldConfig.splitField) {
       mergedQuery.bool?.filter.push({
         terms: {
           [fieldConfig.splitField]: partitions,

--- a/x-pack/test/functional/apps/aiops/change_point_detection.ts
+++ b/x-pack/test/functional/apps/aiops/change_point_detection.ts
@@ -94,5 +94,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await aiops.changePointDetectionPage.addChangePointConfig();
       await aiops.changePointDetectionPage.assertPanelExist(1);
     });
+
+    it('attaches change point charts to a dashboard', async () => {
+      await aiops.changePointDetectionPage.assertPanelExist(0);
+      await aiops.changePointDetectionPage.attachChartsToDashboard(0, {
+        applyTimeRange: true,
+        maxSeries: 1,
+      });
+    });
   });
 }

--- a/x-pack/test/functional/services/aiops/change_point_detection_page.ts
+++ b/x-pack/test/functional/services/aiops/change_point_detection_page.ts
@@ -9,6 +9,11 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { MlTableService } from '../ml/common_table_service';
 
+export interface DashboardAttachmentOptions {
+  applyTimeRange: boolean;
+  maxSeries: number;
+}
+
 export function ChangePointDetectionPageProvider(
   { getService, getPageObject }: FtrProviderContext,
   tableService: MlTableService
@@ -18,6 +23,7 @@ export function ChangePointDetectionPageProvider(
   const comboBox = getService('comboBox');
   const browser = getService('browser');
   const elasticChart = getService('elasticChart');
+  const dashboardPage = getPageObject('dashboard');
 
   return {
     async navigateToIndexPatternSelection() {
@@ -122,6 +128,128 @@ export function ChangePointDetectionPageProvider(
       await retry.tryForTime(30 * 1000, async () => {
         await testSubjects.existOrFail(`aiopsChangePointPanel_${index}`);
       });
+    },
+
+    async openPanelContextMenu(panelIndex: number) {
+      await testSubjects.click(
+        `aiopsChangePointPanel_${panelIndex} > aiopsChangePointDetectionContextMenuButton`
+      );
+      await retry.tryForTime(30 * 1000, async () => {
+        await testSubjects.existOrFail(`aiopsChangePointDetectionAttachButton`);
+      });
+    },
+
+    async clickAttachChartsButton() {
+      await testSubjects.click('aiopsChangePointDetectionAttachButton');
+      await retry.tryForTime(30 * 1000, async () => {
+        await testSubjects.missingOrFail(`aiopsChangePointDetectionAttachButton`);
+        await testSubjects.existOrFail(`aiopsChangePointDetectionAttachToDashboardButton`);
+      });
+    },
+
+    async clickAttachDashboardButton() {
+      await testSubjects.click('aiopsChangePointDetectionAttachToDashboardButton');
+      await retry.tryForTime(30 * 1000, async () => {
+        await testSubjects.existOrFail(`aiopsChangePointDetectionDashboardAttachmentForm`);
+      });
+    },
+
+    async assertApplyTimeRangeControl(expectedValue: boolean) {
+      const isChecked = await testSubjects.isEuiSwitchChecked(
+        `aiopsChangePointDetectionAttachToDashboardApplyTimeRangeSwitch`
+      );
+      expect(isChecked).to.eql(
+        expectedValue,
+        `Expected apply time range to be ${expectedValue ? 'enabled' : 'disabled'}`
+      );
+    },
+
+    async assertMaxSeriesControl(expectedValue: number) {
+      const currentValue = Number(
+        await testSubjects.getAttribute('aiopsMaxSeriesControlFieldNumber', 'value')
+      );
+      expect(currentValue).to.eql(
+        expectedValue,
+        `Expected max series control to be ${expectedValue} (got ${currentValue})`
+      );
+    },
+
+    async toggleApplyTimeRangeControl(isChecked: boolean) {
+      await testSubjects.setEuiSwitch(
+        `aiopsChangePointDetectionAttachToDashboardApplyTimeRangeSwitch`,
+        isChecked ? 'check' : 'uncheck'
+      );
+      await this.assertApplyTimeRangeControl(isChecked);
+    },
+
+    async setMaxSeriesControl(value: number) {
+      await testSubjects.setValue('aiopsMaxSeriesControlFieldNumber', value.toString());
+      await this.assertMaxSeriesControl(value);
+    },
+
+    async completeDashboardAttachmentForm(attachmentOptions: DashboardAttachmentOptions) {
+      // assert default values
+      await this.assertApplyTimeRangeControl(false);
+      await this.assertMaxSeriesControl(6);
+
+      if (attachmentOptions.applyTimeRange) {
+        await this.toggleApplyTimeRangeControl(attachmentOptions.applyTimeRange);
+      }
+
+      if (attachmentOptions.maxSeries) {
+        await this.setMaxSeriesControl(attachmentOptions.maxSeries);
+      }
+
+      await testSubjects.click('aiopsChangePointDetectionSubmitDashboardAttachButton');
+
+      await retry.tryForTime(30 * 1000, async () => {
+        // await testSubjects.missingOrFail(`aiopsChangePointDetectionSubmitDashboardAttachButton`);
+        await testSubjects.existOrFail('savedObjectSaveModal');
+      });
+    },
+
+    async completeSaveToDashboardForm(options?: { createNew: boolean; dashboardName?: string }) {
+      await retry.tryForTime(30 * 1000, async () => {
+        const dashboardSelector = await testSubjects.find('add-to-dashboard-options');
+
+        if (options?.createNew) {
+          const label = await dashboardSelector.findByCssSelector(
+            `label[for="new-dashboard-option"]`
+          );
+          await label.click();
+        }
+
+        await testSubjects.click('confirmSaveSavedObjectButton');
+        await retry.waitForWithTimeout('Save modal to disappear', 1000, () =>
+          testSubjects
+            .missingOrFail('confirmSaveSavedObjectButton')
+            .then(() => true)
+            .catch(() => false)
+        );
+
+        // make sure the dashboard page actually loaded
+        const dashboardItemCount = await dashboardPage.getSharedItemsCount();
+        expect(dashboardItemCount).to.not.eql(undefined);
+      });
+      // changing to the dashboard app might take some time
+      const embeddable = await testSubjects.find('aiopsEmbeddableChangePointChart', 30 * 1000);
+      const lensChart = await embeddable.findByClassName('lnsExpressionRenderer');
+      expect(await lensChart.isDisplayed()).to.eql(
+        true,
+        'Change point detection chart should be displayed in dashboard'
+      );
+    },
+
+    async attachChartsToDashboard(
+      panelIndex: number,
+      attachmentOptions: DashboardAttachmentOptions
+    ) {
+      await this.assertPanelExist(panelIndex);
+      await this.openPanelContextMenu(panelIndex);
+      await this.clickAttachChartsButton();
+      await this.clickAttachDashboardButton();
+      await this.completeDashboardAttachmentForm(attachmentOptions);
+      await this.completeSaveToDashboardForm({ createNew: true });
     },
 
     getTable(index: number) {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ML] AIOps: Fix Change point embeddable reporting  (#169962)](https://github.com/elastic/kibana/pull/169962)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dima Arnautov","email":"dmitrii.arnautov@elastic.co"},"sourceCommit":{"committedDate":"2023-10-27T15:13:52Z","message":"[ML] AIOps: Fix Change point embeddable reporting  (#169962)\n\n## Summary\r\n\r\nFixes #169733\r\n\r\n#### Reporting fix\r\n\r\nChange point detection embeddable was incorrectly reporting render\r\ncompletion. It was relying on the `onLoad` callback from the Lens\r\nembeddable responsible for chart rendering, which only indicates that\r\ndata fetching is complete, but not the actual rendering. Current\r\nimplementation relies on the `renderComplete` event from each child\r\nembeddable. Both PNG and PDF exports tested and work as expected.\r\n\r\n\r\n![DASHBOARDDDD](https://github.com/elastic/kibana/assets/5236598/fb718f31-5862-43ab-82e3-60ebb795b8eb)\r\n\r\n#### Additional fixes\r\n\r\n- Fixes the metric and split field controls states when editing existing\r\nChange point embeddable from a dashboard\r\n- Fixes `filter` query if partitions input is initialized as an empty\r\narray.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"80d382a22f2adc39a63146d3ffb5cb7763090c2e","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Reporting",":ml","Team:ML","Feature:ML/AIOps","Feature:Embeddables","v8.11.0","v8.12.0"],"number":169962,"url":"https://github.com/elastic/kibana/pull/169962","mergeCommit":{"message":"[ML] AIOps: Fix Change point embeddable reporting  (#169962)\n\n## Summary\r\n\r\nFixes #169733\r\n\r\n#### Reporting fix\r\n\r\nChange point detection embeddable was incorrectly reporting render\r\ncompletion. It was relying on the `onLoad` callback from the Lens\r\nembeddable responsible for chart rendering, which only indicates that\r\ndata fetching is complete, but not the actual rendering. Current\r\nimplementation relies on the `renderComplete` event from each child\r\nembeddable. Both PNG and PDF exports tested and work as expected.\r\n\r\n\r\n![DASHBOARDDDD](https://github.com/elastic/kibana/assets/5236598/fb718f31-5862-43ab-82e3-60ebb795b8eb)\r\n\r\n#### Additional fixes\r\n\r\n- Fixes the metric and split field controls states when editing existing\r\nChange point embeddable from a dashboard\r\n- Fixes `filter` query if partitions input is initialized as an empty\r\narray.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"80d382a22f2adc39a63146d3ffb5cb7763090c2e"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169962","number":169962,"mergeCommit":{"message":"[ML] AIOps: Fix Change point embeddable reporting  (#169962)\n\n## Summary\r\n\r\nFixes #169733\r\n\r\n#### Reporting fix\r\n\r\nChange point detection embeddable was incorrectly reporting render\r\ncompletion. It was relying on the `onLoad` callback from the Lens\r\nembeddable responsible for chart rendering, which only indicates that\r\ndata fetching is complete, but not the actual rendering. Current\r\nimplementation relies on the `renderComplete` event from each child\r\nembeddable. Both PNG and PDF exports tested and work as expected.\r\n\r\n\r\n![DASHBOARDDDD](https://github.com/elastic/kibana/assets/5236598/fb718f31-5862-43ab-82e3-60ebb795b8eb)\r\n\r\n#### Additional fixes\r\n\r\n- Fixes the metric and split field controls states when editing existing\r\nChange point embeddable from a dashboard\r\n- Fixes `filter` query if partitions input is initialized as an empty\r\narray.\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"80d382a22f2adc39a63146d3ffb5cb7763090c2e"}}]}] BACKPORT-->