### PR TITLE
[7.17] Upgrades crypto-js@4.1.1→4.2.0 (#169976)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "**/html-minifier/uglify-js": "^3.14.3",
     "**/isomorphic-fetch/node-fetch": "^2.6.7",
     "**/json-schema": "^0.4.0",
-    "**/pdfkit/crypto-js": "4.0.0",
+    "**/pdfkit/crypto-js": "4.2.0",
     "**/react-syntax-highlighter": "^15.3.1",
     "**/recursive-readdir/minimatch": "^3.1.2",
     "**/remark-parse/trim": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10975,10 +10975,10 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
-crypto-js@4.0.0, crypto-js@^3.1.9-1:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
-  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+crypto-js@4.2.0, crypto-js@^3.1.9-1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -25291,7 +25291,7 @@ save-pixels@^2.3.2:
     pngjs-nozlib "^1.0.0"
     through "^2.3.4"
 
-sax@^1.2.4, sax@>=0.6.0:
+sax@>=0.6.0, sax@^1.2.4:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.3.0.tgz#a5dbe77db3be05c9d1ee7785dbd3ea9de51593d0"
   integrity sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==
@@ -27743,7 +27743,7 @@ tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
-tslib@^2.3.0, tslib@^2.0.3, tslib@^2.0.1, tslib@^2.0.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.3.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Upgrades crypto-js@4.1.1→4.2.0 (#169976)](https://github.com/elastic/kibana/pull/169976)

## Note:
I opted to update the existing resolution. The alternative is to update `pdfmake` and its dependencies, which means also migrating to a fork of pdfkit (`@foliojs-fork/pdfkit` like in main).

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jeramy Soucy","email":"jeramy.soucy@elastic.co"},"sourceCommit":{"committedDate":"2023-10-27T14:52:41Z","message":"Upgrades crypto-js@4.1.1→4.2.0 (#169976)\n\n## Summary\r\n\r\nUpgrades `crypto-js` transitive dependency from v4.1.1 to v4.2.0","sha":"92db12816a9f2f5908939bba66bcbb14e8eec62e","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","release_note:skip","backport:all-open","v8.12.0"],"number":169976,"url":"https://github.com/elastic/kibana/pull/169976","mergeCommit":{"message":"Upgrades crypto-js@4.1.1→4.2.0 (#169976)\n\n## Summary\r\n\r\nUpgrades `crypto-js` transitive dependency from v4.1.1 to v4.2.0","sha":"92db12816a9f2f5908939bba66bcbb14e8eec62e"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169976","number":169976,"mergeCommit":{"message":"Upgrades crypto-js@4.1.1→4.2.0 (#169976)\n\n## Summary\r\n\r\nUpgrades `crypto-js` transitive dependency from v4.1.1 to v4.2.0","sha":"92db12816a9f2f5908939bba66bcbb14e8eec62e"}},{"url":"https://github.com/elastic/kibana/pull/170039","number":170039,"branch":"8.11","state":"OPEN"}]}] BACKPORT-->