### PR TITLE
Expandable flyout width

### DIFF
--- a/packages/kbn-expandable-flyout/README.md
+++ b/packages/kbn-expandable-flyout/README.md
@@ -16,8 +16,12 @@ The flyout is composed of 3 sections:
 The expandable-flyout package is designed to render a single flyout for an entire plugin. While displaying multiple flyouts might be feasible, it will be a bit complicated, and we recommend instead to build multiple panels, with each their own context to manage their data (for example, take a look at the Security Solution [setup](https://github.com/elastic/kibana/tree/main/x-pack/plugins/security_solution/public/flyout)).
 
 The expandable-flyout is making some strict UI design decisions:
-- when in collapsed mode (i.e. when only the right/preview section is open), the flyout's width is fixed to the EUI `s` size
-- when in expanded mode (i.e. when the left section is opened), the flyout's width is fixed to the EUI `l` size. Internally the right, left and preview sections' widths are set to a hardcoded percentage (40%, 60$ and 40% respectively)
+- when in collapsed mode (i.e. when only the right/preview section is open), the flyout's width linearly grows from its minimum value of 380px to its maximum value of 750px
+- when in expanded mode (i.e. when the left section is opened), the flyout's width changes depending on the browser's width:
+  - if the window is smaller than 1600px, the flyout takes the entire browser window (minus 48px of padding on the left)
+  - for windows bigger than 1600px, the flyout's width is 80% of the entire browser window (with a max width of 1500px for the left section, and 750px for the right section)
+
+> While the expandable-flyout will work on very small screens, having both the right and left sections visible at the same time will not be a good experience to the user. We recommend only showing the right panel, and therefore handling this situation when you build your panels by considering hiding the actions that could open the left panel (like the expand details button in the [FlyoutNavigation](https://github.com/elastic/kibana/tree/main/x-pack/plugins/security_solution/public/flyout/shared/components/flyout_navigation.tsx)).
 
 ## Package API
 

--- a/packages/kbn-expandable-flyout/src/components/left_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/left_section.tsx
@@ -26,7 +26,7 @@ interface LeftSectionProps {
  */
 export const LeftSection: React.FC<LeftSectionProps> = ({ component, width }: LeftSectionProps) => {
   const style = useMemo<React.CSSProperties>(
-    () => ({ height: '100%', width: `${width * 100}%` }),
+    () => ({ height: '100%', width: `${width}px` }),
     [width]
   );
   return (

--- a/packages/kbn-expandable-flyout/src/components/preview_section.test.tsx
+++ b/packages/kbn-expandable-flyout/src/components/preview_section.test.tsx
@@ -8,10 +8,11 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { PreviewSection } from './preview_section';
+import { PreviewBanner, PreviewSection } from './preview_section';
 import {
   PREVIEW_SECTION_BACK_BUTTON_TEST_ID,
   PREVIEW_SECTION_CLOSE_BUTTON_TEST_ID,
+  PREVIEW_SECTION_TEST_ID,
 } from './test_ids';
 import { ExpandableFlyoutContext } from '../context';
 
@@ -28,14 +29,15 @@ describe('PreviewSection', () => {
     },
   } as unknown as ExpandableFlyoutContext;
 
+  const component = <div>{'component'}</div>;
+  const left = 500;
+
   it('should render close button in header', () => {
-    const component = <div>{'component'}</div>;
-    const width = 500;
     const showBackButton = false;
 
     const { getByTestId } = render(
       <ExpandableFlyoutContext.Provider value={context}>
-        <PreviewSection component={component} width={width} showBackButton={showBackButton} />
+        <PreviewSection component={component} leftPosition={left} showBackButton={showBackButton} />
       </ExpandableFlyoutContext.Provider>
     );
 
@@ -43,16 +45,47 @@ describe('PreviewSection', () => {
   });
 
   it('should render back button in header', () => {
-    const component = <div>{'component'}</div>;
-    const width = 500;
     const showBackButton = true;
 
     const { getByTestId } = render(
       <ExpandableFlyoutContext.Provider value={context}>
-        <PreviewSection component={component} width={width} showBackButton={showBackButton} />
+        <PreviewSection component={component} leftPosition={left} showBackButton={showBackButton} />
       </ExpandableFlyoutContext.Provider>
     );
 
     expect(getByTestId(PREVIEW_SECTION_BACK_BUTTON_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('should render banner', () => {
+    const showBackButton = false;
+    const title = 'test';
+    const banner: PreviewBanner = {
+      title,
+      backgroundColor: 'primary',
+      textColor: 'red',
+    };
+
+    const { getByTestId, getByText } = render(
+      <ExpandableFlyoutContext.Provider value={context}>
+        <PreviewSection
+          component={component}
+          leftPosition={left}
+          showBackButton={showBackButton}
+          banner={banner}
+        />
+      </ExpandableFlyoutContext.Provider>
+    );
+
+    expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerPanel`)).toHaveClass(
+      `euiPanel--${banner.backgroundColor}`
+    );
+    // expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerText`)).toHaveProperty(
+    //   'style',
+    //   `color: ${banner.textColor}`
+    // );
+    expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerText`)).toHaveStyle(
+      `color: ${banner.textColor}`
+    );
+    expect(getByText(title)).toBeInTheDocument();
   });
 });

--- a/packages/kbn-expandable-flyout/src/components/preview_section.test.tsx
+++ b/packages/kbn-expandable-flyout/src/components/preview_section.test.tsx
@@ -79,10 +79,6 @@ describe('PreviewSection', () => {
     expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerPanel`)).toHaveClass(
       `euiPanel--${banner.backgroundColor}`
     );
-    // expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerText`)).toHaveProperty(
-    //   'style',
-    //   `color: ${banner.textColor}`
-    // );
     expect(getByTestId(`${PREVIEW_SECTION_TEST_ID}BannerText`)).toHaveStyle(
       `color: ${banner.textColor}`
     );

--- a/packages/kbn-expandable-flyout/src/components/preview_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/preview_section.tsx
@@ -65,9 +65,9 @@ interface PreviewSectionProps {
    */
   component: React.ReactElement;
   /**
-   * Width used when rendering the panel
+   * Left position used when rendering the panel
    */
-  width: number;
+  leftPosition: number;
   /**
    * Display the back button in the header
    */
@@ -85,12 +85,13 @@ interface PreviewSectionProps {
 export const PreviewSection: React.FC<PreviewSectionProps> = ({
   component,
   showBackButton,
-  width,
+  leftPosition,
   banner,
 }: PreviewSectionProps) => {
   const { euiTheme } = useEuiTheme();
   const { closePreviewPanel, previousPreviewPanel } = useExpandableFlyoutContext();
-  const left = `${(1 - width) * 100}%`;
+
+  const left = leftPosition + 4;
 
   const closeButton = (
     <EuiFlexItem grow={false}>
@@ -103,7 +104,7 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
     </EuiFlexItem>
   );
   const header = showBackButton ? (
-    <EuiFlexGroup justifyContent="spaceBetween">
+    <EuiFlexGroup justifyContent="spaceBetween" responsive={false}>
       <EuiFlexItem grow={false}>
         <EuiButtonEmpty
           size="xs"
@@ -119,32 +120,43 @@ export const PreviewSection: React.FC<PreviewSectionProps> = ({
       {closeButton}
     </EuiFlexGroup>
   ) : (
-    <EuiFlexGroup justifyContent="flexEnd">{closeButton}</EuiFlexGroup>
+    <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+      {closeButton}
+    </EuiFlexGroup>
   );
 
   return (
     <div
       css={css`
         position: absolute;
-        top: 0;
-        bottom: 0;
-        right: 0;
-        left: ${left};
+        top: 4px;
+        bottom: 12px;
+        right: 4px;
+        left: ${left}px;
         z-index: 1000;
       `}
     >
       <EuiSplitPanel.Outer
         css={css`
           margin: ${euiTheme.size.xs};
-          height: 99%;
-          box-shadow: 0px 0px 5px 5px ${euiTheme.colors.darkShade};
+          box-shadow: 0 0 4px 4px ${euiTheme.colors.darkShade};
         `}
         className="eui-yScroll"
         data-test-subj={PREVIEW_SECTION_TEST_ID}
       >
         {isPreviewBanner(banner) && (
-          <EuiSplitPanel.Inner grow={false} color={banner.backgroundColor} paddingSize="none">
-            <EuiText textAlign="center" color={banner.textColor} size="s">
+          <EuiSplitPanel.Inner
+            grow={false}
+            color={banner.backgroundColor}
+            paddingSize="none"
+            data-test-subj={`${PREVIEW_SECTION_TEST_ID}BannerPanel`}
+          >
+            <EuiText
+              textAlign="center"
+              color={banner.textColor}
+              size="s"
+              data-test-subj={`${PREVIEW_SECTION_TEST_ID}BannerText`}
+            >
               {banner.title}
             </EuiText>
           </EuiSplitPanel.Inner>

--- a/packages/kbn-expandable-flyout/src/components/right_section.tsx
+++ b/packages/kbn-expandable-flyout/src/components/right_section.tsx
@@ -29,7 +29,7 @@ export const RightSection: React.FC<RightSectionProps> = ({
   width,
 }: RightSectionProps) => {
   const style = useMemo<React.CSSProperties>(
-    () => ({ height: '100%', width: `${width * 100}%` }),
+    () => ({ height: '100%', width: `${width}px` }),
     [width]
   );
 

--- a/packages/kbn-expandable-flyout/src/hooks/use_sections_sizes.test.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_sections_sizes.test.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import type { RenderHookResult } from '@testing-library/react-hooks';
+import type { UserSectionsSizesParams, UserSectionsSizesResult } from './use_sections_sizes';
+import { useSectionSizes } from './use_sections_sizes';
+
+describe('useSectionSizes', () => {
+  let hookResult: RenderHookResult<UserSectionsSizesParams, UserSectionsSizesResult>;
+
+  describe('Right section', () => {
+    it('should return 0 for right section if it is hidden', () => {
+      const initialProps = {
+        windowWidth: 350,
+        showRight: false,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 0,
+        leftSectionWidth: 0,
+        flyoutWidth: '0px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return the window width for right section size for tiny screen', () => {
+      const initialProps = {
+        windowWidth: 350,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 350,
+        leftSectionWidth: 0,
+        flyoutWidth: '350px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return 380 for right section size for medium screen', () => {
+      const initialProps = {
+        windowWidth: 600,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 0,
+        flyoutWidth: '380px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return 500 for right section size for large screen', () => {
+      const initialProps = {
+        windowWidth: 1300,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current.rightSectionWidth).toBeGreaterThan(420);
+      expect(hookResult.result.current.rightSectionWidth).toBeLessThan(750);
+      expect(hookResult.result.current.leftSectionWidth).toEqual(0);
+      expect(hookResult.result.current.flyoutWidth).toEqual(
+        `${hookResult.result.current.rightSectionWidth}px`
+      );
+      expect(hookResult.result.current.previewSectionLeft).toEqual(0);
+    });
+
+    it('should return 750 for right section size for very large screen', () => {
+      const initialProps = {
+        windowWidth: 2500,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 750,
+        leftSectionWidth: 0,
+        flyoutWidth: '750px',
+        previewSectionLeft: 0,
+      });
+    });
+  });
+
+  describe('Left section', () => {
+    it('should return 0 for left section if it is hidden', () => {
+      const initialProps = {
+        windowWidth: 500,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 0,
+        flyoutWidth: '380px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return the remaining for left section', () => {
+      const initialProps = {
+        windowWidth: 500,
+        showRight: true,
+        showLeft: true,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 72,
+        flyoutWidth: '452px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return 80% of remaining for left section', () => {
+      const initialProps = {
+        windowWidth: 2500,
+        showRight: true,
+        showLeft: true,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current.rightSectionWidth).toEqual(750);
+      expect(hookResult.result.current.leftSectionWidth).toEqual((2500 - 750) * 0.8);
+      expect(hookResult.result.current.flyoutWidth).toEqual(
+        `${
+          hookResult.result.current.rightSectionWidth + hookResult.result.current.leftSectionWidth
+        }px`
+      );
+      expect(hookResult.result.current.previewSectionLeft).toEqual(0);
+    });
+
+    it('should return max out at 1500px for really big screens', () => {
+      const initialProps = {
+        windowWidth: 2700,
+        showRight: true,
+        showLeft: true,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current.rightSectionWidth).toEqual(750);
+      expect(hookResult.result.current.leftSectionWidth).toEqual(1500);
+      expect(hookResult.result.current.flyoutWidth).toEqual(
+        `${
+          hookResult.result.current.rightSectionWidth + hookResult.result.current.leftSectionWidth
+        }px`
+      );
+      expect(hookResult.result.current.previewSectionLeft).toEqual(0);
+    });
+  });
+
+  describe('Preview section', () => {
+    it('should return the 0 for preview section if it is hidden', () => {
+      const initialProps = {
+        windowWidth: 600,
+        showRight: true,
+        showLeft: false,
+        showPreview: false,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 0,
+        flyoutWidth: '380px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return the 0 for preview section when left section is hidden', () => {
+      const initialProps = {
+        windowWidth: 600,
+        showRight: true,
+        showLeft: false,
+        showPreview: true,
+      };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 0,
+        flyoutWidth: '380px',
+        previewSectionLeft: 0,
+      });
+    });
+
+    it('should return for preview section when left section is visible', () => {
+      const initialProps = { windowWidth: 600, showRight: true, showLeft: true, showPreview: true };
+      hookResult = renderHook((props: UserSectionsSizesParams) => useSectionSizes(props), {
+        initialProps,
+      });
+
+      expect(hookResult.result.current).toEqual({
+        rightSectionWidth: 380,
+        leftSectionWidth: 172,
+        flyoutWidth: '552px',
+        previewSectionLeft: 172,
+      });
+    });
+  });
+});

--- a/packages/kbn-expandable-flyout/src/hooks/use_sections_sizes.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_sections_sizes.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const RIGHT_SECTION_MIN_WIDTH = 380;
+const MIN_RESOLUTION_BREAKPOINT = 992;
+const RIGHT_SECTION_MAX_WIDTH = 750;
+const MAX_RESOLUTION_BREAKPOINT = 1920;
+
+const LEFT_SECTION_MAX_WIDTH = 1500;
+
+const FULL_WIDTH_BREAKPOINT = 1600;
+const FULL_WIDTH_PADDING = 48;
+
+export interface UserSectionsSizesParams {
+  /**
+   * The width of the browser window
+   */
+  windowWidth: number;
+  /**
+   * True if the right section is visible, false otherwise
+   */
+  showRight: boolean;
+  /**
+   * True if the left section is visible, false otherwise
+   */
+  showLeft: boolean;
+  /**
+   * True if the preview section is visible, false otherwise
+   */
+  showPreview: boolean;
+}
+
+export interface UserSectionsSizesResult {
+  /**
+   * Width of the right section in pixels
+   */
+  rightSectionWidth: number;
+  /**
+   * Width of the left section in pixels
+   */
+  leftSectionWidth: number;
+  /**
+   * Width of the flyout in pixels
+   */
+  flyoutWidth: string;
+  /**
+   * Left position of the preview section in pixels
+   */
+  previewSectionLeft: number;
+}
+
+/**
+ * Hook that calculate the different width for the sections of the flyout and the flyout itself
+ */
+export const useSectionSizes = ({
+  windowWidth,
+  showRight,
+  showLeft,
+  showPreview,
+}: UserSectionsSizesParams): UserSectionsSizesResult => {
+  // the right section's width will grow from 380px (at 992px resolution) to 750px (at 1920px resolution)
+  let rightSectionWidth: number = showRight
+    ? windowWidth < MIN_RESOLUTION_BREAKPOINT
+      ? RIGHT_SECTION_MIN_WIDTH
+      : RIGHT_SECTION_MIN_WIDTH +
+        (RIGHT_SECTION_MAX_WIDTH - RIGHT_SECTION_MIN_WIDTH) *
+          ((windowWidth - MIN_RESOLUTION_BREAKPOINT) /
+            (MAX_RESOLUTION_BREAKPOINT - MIN_RESOLUTION_BREAKPOINT))
+    : 0;
+
+  // handle tiny screens by not going smaller than the window width
+  if (rightSectionWidth > windowWidth) rightSectionWidth = windowWidth;
+
+  // never go bigger than 750px
+  if (rightSectionWidth > RIGHT_SECTION_MAX_WIDTH) rightSectionWidth = RIGHT_SECTION_MAX_WIDTH;
+
+  // the left section's width will be nearly the remaining space for resolution lower than 1600px, and 80% of the remaining space for resolution higher than 1600px
+  let leftSectionWidth: number = showLeft
+    ? windowWidth <= FULL_WIDTH_BREAKPOINT
+      ? windowWidth - rightSectionWidth - FULL_WIDTH_PADDING
+      : ((windowWidth - rightSectionWidth) * 80) / 100
+    : 0;
+
+  // never go bigger than 1500px
+  if (leftSectionWidth > LEFT_SECTION_MAX_WIDTH) leftSectionWidth = LEFT_SECTION_MAX_WIDTH;
+
+  const flyoutWidth: string =
+    showRight && showLeft ? `${rightSectionWidth + leftSectionWidth}px` : `${rightSectionWidth}px`;
+
+  // preview section's width should only be similar to the right section
+  const previewSectionLeft: number =
+    showPreview && showLeft
+      ? windowWidth <= MAX_RESOLUTION_BREAKPOINT
+        ? windowWidth - rightSectionWidth - FULL_WIDTH_PADDING
+        : ((windowWidth - rightSectionWidth) * 80) / 100
+      : 0;
+
+  return {
+    rightSectionWidth,
+    leftSectionWidth,
+    flyoutWidth,
+    previewSectionLeft,
+  };
+};

--- a/packages/kbn-expandable-flyout/src/hooks/use_window_size.test.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_window_size.test.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useWindowSize } from './use_window_size';
+
+describe('useWindowSize', () => {
+  it('should return the window size', () => {
+    const hookResult = renderHook(() => useWindowSize());
+    expect(hookResult.result.current).toEqual(1024);
+  });
+});

--- a/packages/kbn-expandable-flyout/src/hooks/use_window_size.ts
+++ b/packages/kbn-expandable-flyout/src/hooks/use_window_size.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { useLayoutEffect, useState } from 'react';
+
+/**
+ * Hook that returns the browser window width
+ */
+export const useWindowSize = (): number => {
+  const [width, setWidth] = useState(0);
+  useLayoutEffect(() => {
+    function updateSize() {
+      setWidth(window.innerWidth);
+    }
+    window.addEventListener('resize', updateSize);
+    updateSize();
+    return () => window.removeEventListener('resize', updateSize);
+  }, []);
+  return width;
+};

--- a/packages/kbn-expandable-flyout/src/index.tsx
+++ b/packages/kbn-expandable-flyout/src/index.tsx
@@ -7,14 +7,18 @@
  */
 
 import React, { useCallback, useMemo } from 'react';
-import type { EuiFlyoutProps } from '@elastic/eui';
+import { EuiFlyoutProps } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlyout } from '@elastic/eui';
+import { useSectionSizes } from './hooks/use_sections_sizes';
+import { useWindowSize } from './hooks/use_window_size';
 import { useExpandableFlyoutContext } from './context';
 import { PreviewSection } from './components/preview_section';
 import { RightSection } from './components/right_section';
 import type { FlyoutPanelProps, Panel } from './types';
 import { LeftSection } from './components/left_section';
 import { isPreviewBanner } from './components/preview_section';
+
+const flyoutInnerStyles = { height: '100%' };
 
 export interface ExpandableFlyoutProps extends Omit<EuiFlyoutProps, 'onClose'> {
   /**
@@ -26,8 +30,6 @@ export interface ExpandableFlyoutProps extends Omit<EuiFlyoutProps, 'onClose'> {
    */
   handleOnFlyoutClosed?: () => void;
 }
-
-const flyoutInnerStyles = { height: '100%' };
 
 /**
  * Expandable flyout UI React component.
@@ -41,6 +43,8 @@ export const ExpandableFlyout: React.FC<ExpandableFlyoutProps> = ({
   handleOnFlyoutClosed,
   ...flyoutProps
 }) => {
+  const windowWidth = useWindowSize();
+
   const { panels, closeFlyout } = useExpandableFlyoutContext();
   const { left, right, preview } = panels;
 
@@ -71,16 +75,21 @@ export const ExpandableFlyout: React.FC<ExpandableFlyoutProps> = ({
     [mostRecentPreview, registeredPanels]
   );
 
-  const hideFlyout = !left && !right && !preview.length;
+  const showRight = rightSection != null && right != null;
+  const showLeft = leftSection != null && left != null;
+  const showPreview = previewSection != null && preview != null;
 
+  const { rightSectionWidth, leftSectionWidth, flyoutWidth, previewSectionLeft } = useSectionSizes({
+    windowWidth,
+    showRight,
+    showLeft,
+    showPreview,
+  });
+
+  const hideFlyout = !left && !right && !preview.length;
   if (hideFlyout) {
     return null;
   }
-
-  const flyoutWidth: string = leftSection && rightSection ? 'l' : 's';
-  const rightSectionWidth: number = leftSection ? 0.4 : 1;
-  const leftSectionWidth: number = 0.6;
-  const previewSectionWidth: number = leftSection ? 0.4 : 1;
 
   return (
     <EuiFlyout {...flyoutProps} size={flyoutWidth} ownFocus={false} onClose={onClose}>
@@ -89,14 +98,15 @@ export const ExpandableFlyout: React.FC<ExpandableFlyoutProps> = ({
         wrap={false}
         gutterSize="none"
         style={flyoutInnerStyles}
+        responsive={false}
       >
-        {leftSection && left ? (
+        {showLeft ? (
           <LeftSection
             component={leftSection.component({ ...(left as FlyoutPanelProps) })}
             width={leftSectionWidth}
           />
         ) : null}
-        {rightSection && right ? (
+        {showRight ? (
           <RightSection
             component={rightSection.component({ ...(right as FlyoutPanelProps) })}
             width={rightSectionWidth}
@@ -104,11 +114,11 @@ export const ExpandableFlyout: React.FC<ExpandableFlyoutProps> = ({
         ) : null}
       </EuiFlexGroup>
 
-      {previewSection && preview ? (
+      {showPreview ? (
         <PreviewSection
           component={previewSection.component({ ...(mostRecentPreview as FlyoutPanelProps) })}
           showBackButton={showBackButton}
-          width={previewSectionWidth}
+          leftPosition={previewSectionLeft}
           banner={previewBanner}
         />
       ) : null}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/host_details.tsx
@@ -195,7 +195,7 @@ export const HostDetails: React.FC<HostDetailsProps> = ({ hostName, timestamp, s
 
   const relatedUsersCount = useMemo(
     () => (
-      <EuiFlexGroup alignItems="center" gutterSize="s">
+      <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
         <EuiFlexItem grow={false}>
           <EuiIcon type="user" />
         </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/left/components/user_details.tsx
@@ -196,7 +196,7 @@ export const UserDetails: React.FC<UserDetailsProps> = ({ userName, timestamp, s
 
   const relatedHostsCount = useMemo(
     () => (
-      <EuiFlexGroup alignItems="center" gutterSize="m">
+      <EuiFlexGroup alignItems="center" gutterSize="m" responsive={false}>
         <EuiFlexItem grow={false}>
           <EuiIcon type="storage" />
         </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/preview/components/rule_preview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/preview/components/rule_preview.tsx
@@ -34,6 +34,14 @@ const panelViewStyle = css`
     font-size: 90% !important;
   }
   text-overflow: ellipsis;
+  .euiFlexGroup {
+    flex-wrap: inherit;
+  }
+
+  .euiFlexItem {
+    inline-size: inherit;
+    flex-basis: inherit;
+  }
 `;
 
 /**

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/description.tsx
@@ -98,7 +98,12 @@ export const Description: FC = () => {
       <EuiFlexItem data-test-subj={DESCRIPTION_TITLE_TEST_ID}>
         <EuiTitle size="xxs">
           {isAlert ? (
-            <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+            <EuiFlexGroup
+              justifyContent="spaceBetween"
+              alignItems="center"
+              gutterSize="none"
+              responsive={false}
+            >
               <EuiFlexItem>
                 <h5>
                   <FormattedMessage

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/entities_overview.tsx
@@ -66,7 +66,7 @@ export const EntitiesOverview: React.FC = () => {
         data-test-subj={INSIGHTS_ENTITIES_TEST_ID}
       >
         {userName || hostName ? (
-          <EuiFlexGroup direction="column" gutterSize="s">
+          <EuiFlexGroup direction="column" gutterSize="s" responsive={false}>
             {userName && (
               <EuiFlexItem>
                 <UserEntityOverview userName={userName} />

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_title.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/header_title.tsx
@@ -73,7 +73,7 @@ export const HeaderTitle: FC = memo(() => {
       <EuiSpacer size="xs" />
       {isAlert && !isEmpty(ruleName) ? ruleTitle : eventTitle}
       <EuiSpacer size="m" />
-      <EuiFlexGroup direction="row" gutterSize="m">
+      <EuiFlexGroup direction="row" gutterSize="m" responsive={false}>
         <EuiFlexItem grow={false}>
           <DocumentStatus />
         </EuiFlexItem>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/host_entity_overview.tsx
@@ -156,7 +156,7 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
     return [
       {
         title: (
-          <EuiFlexGroup alignItems="flexEnd" gutterSize="none">
+          <EuiFlexGroup alignItems="flexEnd" gutterSize="none" responsive={false}>
             <EuiFlexItem grow={false}>{HOST_RISK_LEVEL}</EuiFlexItem>
             <EuiFlexItem grow={false}>
               <RiskScoreDocTooltip riskScoreEntity={RiskScoreEntity.host} />
@@ -177,9 +177,14 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
   }, [hostRisk]);
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s" data-test-subj={ENTITIES_HOST_OVERVIEW_TEST_ID}>
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      responsive={false}
+      data-test-subj={ENTITIES_HOST_OVERVIEW_TEST_ID}
+    >
       <EuiFlexItem>
-        <EuiFlexGroup gutterSize="m">
+        <EuiFlexGroup gutterSize="m" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiIcon type={HOST_ICON} />
           </EuiFlexItem>
@@ -207,7 +212,7 @@ export const HostEntityOverview: React.FC<HostEntityOverviewProps> = ({ hostName
         />
       ) : (
         <EuiFlexItem>
-          <EuiFlexGroup>
+          <EuiFlexGroup responsive={false}>
             <EuiFlexItem>
               <OverviewDescriptionList
                 dataTestSubj={ENTITIES_HOST_OVERVIEW_OS_FAMILY_TEST_ID}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_summary_row.tsx
@@ -95,28 +95,29 @@ export const InsightsSummaryRow: VFC<InsightsSummaryRowProps> = ({
   const colorDataTestSubj = `${dataTestSubj}Color`;
 
   return (
-    <EuiFlexGroup gutterSize="none" justifyContent={'spaceBetween'} alignItems={'center'}>
+    <EuiFlexGroup
+      gutterSize="none"
+      justifyContent={'spaceBetween'}
+      alignItems={'center'}
+      responsive={false}
+    >
       <EuiFlexItem grow={false}>
-        <EuiFlexGroup
+        <EuiIcon
           css={css`
-            padding: ${euiTheme.size.s};
+            margin: ${euiTheme.size.s};
           `}
-          alignItems={'center'}
-        >
-          <EuiIcon
-            data-test-subj={iconDataTestSubj}
-            aria-label={i18n.translate(
-              'xpack.securitySolution.flyout.right.insights.insightSummaryButtonIconAriaLabel',
-              {
-                defaultMessage: 'Insight summary row icon',
-              }
-            )}
-            color="text"
-            display="empty"
-            type={icon}
-            size="m"
-          />
-        </EuiFlexGroup>
+          data-test-subj={iconDataTestSubj}
+          aria-label={i18n.translate(
+            'xpack.securitySolution.flyout.right.insights.insightSummaryButtonIconAriaLabel',
+            {
+              defaultMessage: 'Insight summary row icon',
+            }
+          )}
+          color="text"
+          display="empty"
+          type={icon}
+          size="m"
+        />
       </EuiFlexItem>
       <EuiFlexItem
         data-test-subj={valueDataTestSubj}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/reason.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/reason.tsx
@@ -96,8 +96,13 @@ export const Reason: FC = () => {
         <EuiTitle size="xxs">
           <h5>
             {isAlert ? (
-              <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
-                <EuiFlexItem>
+              <EuiFlexGroup
+                justifyContent="spaceBetween"
+                alignItems="center"
+                gutterSize="none"
+                responsive={false}
+              >
+                <EuiFlexItem grow={false}>
                   <h5>
                     <FormattedMessage
                       id="xpack.securitySolution.flyout.right.about.reason.alertReasonTitle"

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/risk_score.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/risk_score.tsx
@@ -34,7 +34,7 @@ export const RiskScore: FC = memo(() => {
   }
 
   return (
-    <EuiFlexGroup alignItems="center" direction="row" gutterSize="xs">
+    <EuiFlexGroup alignItems="center" direction="row" gutterSize="xs" responsive={false}>
       <EuiFlexItem grow={false}>
         <EuiTitle size="xxs" data-test-subj={RISK_SCORE_TITLE_TEST_ID}>
           <h3>

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/user_entity_overview.tsx
@@ -155,7 +155,7 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
     return [
       {
         title: (
-          <EuiFlexGroup alignItems="flexEnd" gutterSize="none">
+          <EuiFlexGroup alignItems="flexEnd" gutterSize="none" responsive={false}>
             <EuiFlexItem grow={false}>{USER_RISK_LEVEL}</EuiFlexItem>
             <EuiFlexItem grow={false}>
               <RiskScoreDocTooltip riskScoreEntity={RiskScoreEntity.user} />
@@ -176,9 +176,14 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
   }, [userRisk]);
 
   return (
-    <EuiFlexGroup direction="column" gutterSize="s" data-test-subj={ENTITIES_USER_OVERVIEW_TEST_ID}>
+    <EuiFlexGroup
+      direction="column"
+      gutterSize="s"
+      responsive={false}
+      data-test-subj={ENTITIES_USER_OVERVIEW_TEST_ID}
+    >
       <EuiFlexItem>
-        <EuiFlexGroup gutterSize="m">
+        <EuiFlexGroup gutterSize="m" responsive={false}>
           <EuiFlexItem grow={false}>
             <EuiIcon type={USER_ICON} />
           </EuiFlexItem>
@@ -206,7 +211,7 @@ export const UserEntityOverview: React.FC<UserEntityOverviewProps> = ({ userName
             data-test-subj={ENTITIES_USER_OVERVIEW_LOADING_TEST_ID}
           />
         ) : (
-          <EuiFlexGroup>
+          <EuiFlexGroup responsive={false}>
             <EuiFlexItem>
               <OverviewDescriptionList
                 dataTestSubj={ENTITIES_USER_OVERVIEW_DOMAIN_TEST_ID}

--- a/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/shared/components/expandable_panel.tsx
@@ -124,6 +124,7 @@ export const ExpandablePanel: React.FC<ExpandablePanelPanelProps> = ({
         <EuiFlexGroup
           alignItems="center"
           gutterSize="s"
+          responsive={false}
           data-test-subj={`${dataTestSubj}LeftSection`}
         >
           <EuiFlexItem grow={false}>{expandable && children && toggleIcon}</EuiFlexItem>


### PR DESCRIPTION
## Summary

This PR changes the way the `kbn-expandable-flyout` package handles multiple screen resolutions.

Prior implementation was pretty basic and was following EUI's basic [flyout](https://eui.elastic.co/#/layout/flyout) sizes, using a small `size` when only the right section was rendered, and a `large` size when both right and left section were rendered (using a 60%-40% for the content).

The new implementation is a lot smarter regarding handling screen resolution, while also answering customer's feedback that the right section's width is often too small to be usable.
Here are the biggest changes:
- the right section's width will grow from a minimum of `380px` to a maximum of `750px` (unless the window size is smaller than `380px`, in which case the flyout takes the size of the browser window)
- the left section will take the remaining on the window width on resolutions lower than `1600px`. For higher resolutions, the left section takes 80% of the window width, with a maximum set at `1500px`

The PR also makes a couple of more minor changes:
- adding `responsive={false}` in a lot of `EuiFlexGroup` within the flyout to avoid the UI to change on smaller screen (now that we have a minimum fixed width)
- added unit tests to test the preview section

Right section only

https://github.com/elastic/kibana/assets/17276605/b21e91a1-4087-43d1-be33-c2fe8ed1ec72

Right and left section

https://github.com/elastic/kibana/assets/17276605/a1942927-9945-45c2-9568-572c7a5ad279

https://github.com/elastic/security-team/issues/7896