### PR TITLE
[8.11] Disable change based serverless tests

### DIFF
--- a/.buildkite/pipelines/pull_request/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/defend_workflows.yml
@@ -11,29 +11,6 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless.sh
-    label: 'Defend Workflows Cypress Tests on Serverless'
-    agents:
-      queue: n2-4-virt
-    depends_on: build
-    timeout_in_minutes: 120
-    parallelism: 2
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
-  - command: .buildkite/scripts/steps/functional/defend_workflows_serverless_burn.sh
-    label: 'Defend Workflows Cypress Tests on Serverless, burning changed specs'
-    agents:
-      queue: n2-4-virt
-    depends_on: build
-    timeout_in_minutes: 60
-    soft_fail: true
-    parallelism: 1
-    retry:
-      automatic: false
-
   - command: .buildkite/scripts/steps/functional/defend_workflows_burn.sh
     label: 'Defend Workflows Cypress Tests, burning changed specs'
     agents:

--- a/.buildkite/pipelines/pull_request/osquery_cypress.yml
+++ b/.buildkite/pipelines/pull_request/osquery_cypress.yml
@@ -24,17 +24,3 @@ steps:
       automatic: false
     artifact_paths:
       - "target/kibana-osquery/**/*"
-
-  - command: .buildkite/scripts/steps/functional/security_serverless_osquery.sh
-    label: 'Serverless Osquery Cypress Tests'
-    agents:
-      queue: n2-4-spot
-    depends_on: build
-    timeout_in_minutes: 50
-    parallelism: 6
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-    artifact_paths:
-      - "target/kibana-osquery/**/*"


### PR DESCRIPTION
Disables a few more tests that I missed in https://github.com/elastic/kibana/pull/168285.

These tests could have unpredictable behavior as the elasticsearch image only tracks main.