### PR TITLE
[ObsUX] Remove "Check for new data" button from hosts table

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -8,10 +8,9 @@
 import React from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { NoData } from '../../../../components/empty_states';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import { HostNodeRow, useHostsTableContext } from '../hooks/use_hosts_table';
 import { useHostsViewContext } from '../hooks/use_hosts_view';
-import { useUnifiedSearchContext } from '../hooks/use_unified_search';
 import { FlyoutWrapper } from './host_details_flyout/flyout_wrapper';
 import { DEFAULT_PAGE_SIZE } from '../constants';
 import { FilterAction } from './table/filter_action';
@@ -20,7 +19,6 @@ const PAGE_SIZE_OPTIONS = [5, 10, 20];
 
 export const HostsTable = () => {
   const { loading } = useHostsViewContext();
-  const { onSubmit } = useUnifiedSearchContext();
 
   const {
     columns,
@@ -75,18 +73,21 @@ export const HostsTable = () => {
               defaultMessage: 'Loading data',
             })
           ) : (
-            <NoData
-              titleText={i18n.translate('xpack.infra.waffle.noDataTitle', {
-                defaultMessage: 'There is no data to display.',
-              })}
-              bodyText={i18n.translate('xpack.infra.waffle.noDataDescription', {
+            <EuiEmptyPrompt
+              body={i18n.translate('xpack.infra.waffle.noDataDescription', {
                 defaultMessage: 'Try adjusting your time or filter.',
               })}
-              refetchText={i18n.translate('xpack.infra.waffle.checkNewDataButtonLabel', {
-                defaultMessage: 'Check for new data',
-              })}
-              onRefetch={() => onSubmit()}
-              testString="noMetricsDataPrompt"
+              data-test-subj="hostsViewTableNoData"
+              layout="vertical"
+              title={
+                <h2>
+                  {i18n.translate('xpack.infra.waffle.noDataTitle', {
+                    defaultMessage: 'There is no data to display.',
+                  })}
+                </h2>
+              }
+              hasBorder={false}
+              titleSize="m"
             />
           )
         }

--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -587,6 +587,16 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHostsView.submitQuery('cloud.provider="gcp" A');
           await testSubjects.existOrFail('hostsViewErrorCallout');
         });
+
+        it('should show no data message in the table content', async () => {
+          await pageObjects.infraHostsView.submitQuery('host.name : "foo"');
+
+          await waitForPageToLoad();
+
+          await retry.try(async () => {
+            await testSubjects.exists('hostsViewTableNoData');
+          });
+        });
       });
 
       describe('Pagination and Sorting', () => {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/170125

## Summary

Removes the "Check for new data" button that appears in the table when the API returns nothing. 

<img width="1469" alt="image" src="https://github.com/elastic/kibana/assets/2767137/7873f4c8-4b7e-4dbe-865b-2b5091775792">


**Reason:** The Hosts View search submission needs to happen within the Unified Search scope because it's where the filter state is managed and updated. The submit button in the table triggers API calls with an unsynced state.


### How to test
- Setup a local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Filter by `host.name: foo`
