### PR TITLE
[APM] Add `beforeOrAfter` hook

### DIFF
--- a/x-pack/test/apm_api_integration/common/utils/before_or_after.ts
+++ b/x-pack/test/apm_api_integration/common/utils/before_or_after.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+// Helper function to run a callback before or after a test
+// depending on whether the --bail flag is passed.
+// With --bail flag the callback is run before
+// without --bail flag the callback is run after
+// This makes it easier to debug tests when they fail because data are still available
+export function beforeOrAfter(cb: () => Promise<unknown> | unknown) {
+  if (process.argv.includes('--bail')) {
+    before(cb);
+  } else {
+    after(cb);
+  }
+}

--- a/x-pack/test/apm_api_integration/configs/index.ts
+++ b/x-pack/test/apm_api_integration/configs/index.ts
@@ -14,36 +14,33 @@ const apmDebugLogger = {
   appenders: ['console'],
 };
 
+const kibanaConfig = {
+  'xpack.apm.forceSyntheticSource': 'true',
+  'logging.loggers': [apmDebugLogger],
+  'server.publicBaseUrl': 'http://mockedPublicBaseUrl',
+};
+
 const apmFtrConfigs = {
   basic: {
     license: 'basic' as const,
-    kibanaConfig: {
-      'xpack.apm.forceSyntheticSource': 'true',
-      'logging.loggers': [apmDebugLogger],
-      'server.publicBaseUrl': 'http://mockedPublicBaseUrl',
-    },
+    kibanaConfig,
   },
   trial: {
     license: 'trial' as const,
-    kibanaConfig: {
-      'xpack.apm.forceSyntheticSource': 'true',
-      'logging.loggers': [apmDebugLogger],
-    },
+    kibanaConfig,
   },
   rules: {
     license: 'trial' as const,
     kibanaConfig: {
+      ...kibanaConfig,
       'xpack.ruleRegistry.write.enabled': 'true',
-      'xpack.apm.forceSyntheticSource': 'true',
-      'logging.loggers': [apmDebugLogger],
     },
   },
   cloud: {
     license: 'basic' as const,
     kibanaConfig: {
+      ...kibanaConfig,
       'xpack.apm.agent.migrations.enabled': 'true',
-      'xpack.apm.forceSyntheticSource': 'true',
-      'logging.loggers': [apmDebugLogger],
     },
   },
 };

--- a/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
@@ -36,8 +36,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       const spikeEnd = moment().subtract(1, 'hours').valueOf();
 
       before(async () => {
-        await cleanup();
-
         const serviceA = apm
           .service({ name: 'a', environment: 'production', agentName: 'java' })
           .instance('a');
@@ -67,9 +65,9 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         await createAndRunApmMlJobs({ es, ml, environments: ['production'], logger });
       });
 
-      // after(async () => {
-      //   await cleanup();
-      // });
+      after(async () => {
+        await cleanup();
+      });
 
       async function cleanup() {
         await synthtraceEsClient.clean();

--- a/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/anomaly_alert.spec.ts
@@ -16,6 +16,7 @@ import { createAndRunApmMlJobs } from '../../common/utils/create_and_run_apm_ml_
 import { createApmRule } from './helpers/alerting_api_helper';
 import { waitForActiveRule } from './helpers/wait_for_active_rule';
 import { cleanupRuleAndAlertState } from './helpers/cleanup_rule_and_alert_state';
+import { beforeOrAfter } from '../../common/utils/before_or_after';
 
 export default function ApiTest({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -34,6 +35,10 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       const spikeStart = moment().subtract(2, 'hours').valueOf();
       const spikeEnd = moment().subtract(1, 'hours').valueOf();
+
+      beforeOrAfter(async () => {
+        await cleanup();
+      });
 
       before(async () => {
         const serviceA = apm
@@ -63,10 +68,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         await synthtraceEsClient.index(events);
 
         await createAndRunApmMlJobs({ es, ml, environments: ['production'], logger });
-      });
-
-      after(async () => {
-        await cleanup();
       });
 
       async function cleanup() {

--- a/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/error_count_threshold.spec.ts
@@ -14,16 +14,13 @@ import { omit } from 'lodash';
 import { FtrProviderContext } from '../../common/ftr_provider_context';
 import {
   createApmRule,
-  deleteRuleById,
-  deleteAlertsByRuleId,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
   ApmAlertFields,
   createIndexConnector,
-  deleteActionConnector,
   getIndexAction,
 } from './helpers/alerting_api_helper';
-import { cleanupAllState } from './helpers/cleanup_state';
+import { cleanupRuleAndAlertState } from './helpers/cleanup_rule_and_alert_state';
 import { waitForAlertsForRule } from './helpers/wait_for_alerts_for_rule';
 import { waitForIndexConnectorResults } from './helpers/wait_for_index_connector_results';
 import { waitForActiveRule } from './helpers/wait_for_active_rule';
@@ -55,8 +52,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     };
 
     before(async () => {
-      cleanupAllState({ es, supertest });
-
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -134,13 +129,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteActionConnector({ supertest, es, actionId });
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule or action connector', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('checks if rule is active', async () => {
@@ -285,12 +274,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('produces one alert for the opbeans-php service', async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/helpers/cleanup_rule_and_alert_state.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/helpers/cleanup_rule_and_alert_state.ts
@@ -6,6 +6,7 @@
  */
 
 import { Client } from '@elastic/elasticsearch';
+import { ToolingLog } from '@kbn/tooling-log';
 import type { SuperTest, Test } from 'supertest';
 import {
   clearKibanaApmEventLog,
@@ -14,12 +15,14 @@ import {
   deleteActionConnectorIndex,
 } from './alerting_api_helper';
 
-export async function cleanupAllState({
+export async function cleanupRuleAndAlertState({
   es,
   supertest,
+  logger,
 }: {
   es: Client;
   supertest: SuperTest<Test>;
+  logger: ToolingLog;
 }) {
   try {
     await Promise.all([
@@ -29,7 +32,6 @@ export async function cleanupAllState({
       await clearKibanaApmEventLog(es),
     ]);
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error(`An error occured while cleaning up the state: ${e}`);
+    logger.error(`An error occured while cleaning up the state: ${e}`);
   }
 }

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
@@ -15,7 +15,6 @@ import {
   createApmRule,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
-  clearKibanaApmEventLog,
   ApmAlertFields,
   createIndexConnector,
   getIndexAction,

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
@@ -15,15 +15,12 @@ import {
   createApmRule,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
-  deleteAlertsByRuleId,
-  deleteRuleById,
   clearKibanaApmEventLog,
   ApmAlertFields,
   createIndexConnector,
   getIndexAction,
-  deleteActionConnector,
 } from './helpers/alerting_api_helper';
-import { cleanupAllState } from './helpers/cleanup_state';
+import { cleanupRuleAndAlertState } from './helpers/cleanup_rule_and_alert_state';
 import { waitForAlertsForRule } from './helpers/wait_for_alerts_for_rule';
 import { waitForActiveRule } from './helpers/wait_for_active_rule';
 import { waitForIndexConnectorResults } from './helpers/wait_for_index_connector_results';
@@ -49,8 +46,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when('transaction duration alert', { config: 'basic', archives: [] }, () => {
     before(async () => {
-      cleanupAllState({ es, supertest });
-
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -77,12 +72,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      try {
-        await synthtraceEsClient.clean();
-        await clearKibanaApmEventLog(es);
-      } catch (e) {
-        logger.info('Could not clear apm event log', e);
-      }
+      await synthtraceEsClient.clean();
     });
 
     describe('create rule for opbeans-java without kql filter', () => {
@@ -111,13 +101,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteActionConnector({ supertest, es, actionId });
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule or action connector', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('checks if rule is active', async () => {
@@ -229,12 +213,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteAlertsByRuleId({ es, ruleId });
-          await deleteRuleById({ supertest, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule or action connector', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('checks if rule is active', async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -15,15 +15,12 @@ import {
   createApmRule,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
-  deleteAlertsByRuleId,
   clearKibanaApmEventLog,
-  deleteRuleById,
   ApmAlertFields,
   getIndexAction,
   createIndexConnector,
-  deleteActionConnector,
 } from './helpers/alerting_api_helper';
-import { cleanupAllState } from './helpers/cleanup_state';
+import { cleanupRuleAndAlertState } from './helpers/cleanup_rule_and_alert_state';
 import { waitForAlertsForRule } from './helpers/wait_for_alerts_for_rule';
 import { waitForActiveRule } from './helpers/wait_for_active_rule';
 import { waitForIndexConnectorResults } from './helpers/wait_for_index_connector_results';
@@ -38,8 +35,6 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
   registry.when('transaction error rate alert', { config: 'basic', archives: [] }, () => {
     before(async () => {
-      cleanupAllState({ es, supertest });
-
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -76,12 +71,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      try {
-        await synthtraceEsClient.clean();
-        await clearKibanaApmEventLog(es);
-      } catch (e) {
-        logger.info('Could not clean up apm event log', e);
-      }
+      await synthtraceEsClient.clean();
     });
 
     describe('create rule without kql query', () => {
@@ -121,13 +111,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteActionConnector({ supertest, es, actionId });
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule or action connector', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('checks if rule is active', async () => {
@@ -250,12 +234,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        try {
-          await deleteRuleById({ supertest, ruleId });
-          await deleteAlertsByRuleId({ es, ruleId });
-        } catch (e) {
-          logger.info('Could not delete rule', e);
-        }
+        await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
       it('indexes alert document with all group-by fields', async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -15,7 +15,6 @@ import {
   createApmRule,
   fetchServiceInventoryAlertCounts,
   fetchServiceTabAlertCount,
-  clearKibanaApmEventLog,
   ApmAlertFields,
   getIndexAction,
   createIndexConnector,

--- a/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/anomalies/anomaly_charts.spec.ts
@@ -252,6 +252,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               )
             );
           });
+
           it('returns model plots with latest bucket matching the end time', () => {
             expect(allAnomalyTimeseries.every((spec) => last(spec.bounds)?.x === endTimeMs));
           });


### PR DESCRIPTION
When debugging a flaky test locally it's possible to run it multiple times with `--times 50` and stop the process when an error is encountered using `--bail`. However, since cleanup always happens in the `after` hook there is not much to inspect.

By running the cleanup before the test instead of after it, it is possible to inspect and debug what went wrong and why the test is not passing.

This PR introduces `beforeOrAfter()` hook that will behave as a `before()` hook when running with `--bail`, otherwise as an `after()` hook

Flaky test runner:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3818