### PR TITLE
[Security solution] AI connector changes 

### DIFF
--- a/x-pack/plugins/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -93,6 +93,7 @@ export class BedrockConnector extends SubActionConnector<Config, Secrets> {
         },
         body,
         path,
+        service: 'bedrock',
       },
       {
         secretAccessKey: this.secrets.secret,

--- a/x-pack/plugins/stack_connectors/server/connector_types/bedrock/bedrock.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/bedrock/bedrock.ts
@@ -93,6 +93,7 @@ export class BedrockConnector extends SubActionConnector<Config, Secrets> {
         },
         body,
         path,
+        // Despite AWS docs, this value does not always get inferred. We need to always send it
         service: 'bedrock',
       },
       {

--- a/x-pack/plugins/stack_connectors/server/connector_types/openai/openai.test.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/openai/openai.test.ts
@@ -85,6 +85,7 @@ describe('OpenAIConnector', () => {
         const response = await connector.runApi({ body: JSON.stringify(sampleOpenAiBody) });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://api.openai.com/v1/chat/completions',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -102,6 +103,7 @@ describe('OpenAIConnector', () => {
         const response = await connector.runApi({ body: JSON.stringify(requestBody) });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://api.openai.com/v1/chat/completions',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -118,6 +120,7 @@ describe('OpenAIConnector', () => {
         const response = await connector.runApi({ body: JSON.stringify(sampleOpenAiBody) });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://api.openai.com/v1/chat/completions',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -148,6 +151,7 @@ describe('OpenAIConnector', () => {
         });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://api.openai.com/v1/chat/completions',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -269,6 +273,7 @@ describe('OpenAIConnector', () => {
         const response = await connector.invokeAI(sampleOpenAiBody);
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://api.openai.com/v1/chat/completions',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -379,6 +384,7 @@ describe('OpenAIConnector', () => {
         const response = await connector.runApi({ body: JSON.stringify(sampleAzureAiBody) });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://My-test-resource-123.openai.azure.com/openai/deployments/NEW-DEPLOYMENT-321/chat/completions?api-version=2023-05-15',
           method: 'post',
           responseSchema: RunActionResponseSchema,
@@ -405,6 +411,7 @@ describe('OpenAIConnector', () => {
         });
         expect(mockRequest).toBeCalledTimes(1);
         expect(mockRequest).toHaveBeenCalledWith({
+          timeout: 120000,
           url: 'https://My-test-resource-123.openai.azure.com/openai/deployments/NEW-DEPLOYMENT-321/chat/completions?api-version=2023-05-15',
           method: 'post',
           responseSchema: RunActionResponseSchema,

--- a/x-pack/plugins/stack_connectors/server/connector_types/openai/openai.ts
+++ b/x-pack/plugins/stack_connectors/server/connector_types/openai/openai.ts
@@ -114,6 +114,8 @@ export class OpenAIConnector extends SubActionConnector<Config, Secrets> {
       method: 'post',
       responseSchema: RunActionResponseSchema,
       data: sanitizedBody,
+      // give up to 2 minutes for response
+      timeout: 120000,
       ...axiosOptions,
     });
     return response.data;


### PR DESCRIPTION
## Summary

Two quick 8.11 fixes for GenAI connectors:

1. Increase timeout for `runApi` sub-action of OpenAI connector, allowing for more time for the request to fulfill for non-streaming requests (https://github.com/elastic/kibana/issues/166561, https://github.com/elastic/security-team/issues/7873)
2. Adds the `service: bedrock` argument to the aws signature for bedrock requests. Their documentation said they could infer this value from the url, but this has proven to be false. Prevents this error that was happening for some regions:
<img width="291" alt="Screenshot 2023-10-30 at 10 49 39 AM" src="https://github.com/elastic/kibana/assets/6935300/46deecfe-3901-4ca0-beed-15df7b5ffdf4">



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->