### PR TITLE
[Synthetics] Fix monitor availability sparkline

### DIFF
--- a/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
+++ b/x-pack/plugins/exploratory_view/public/components/shared/exploratory_view/configurations/synthetics/kpi_over_time_config.ts
@@ -96,7 +96,7 @@ export function getSyntheticsKPIConfig({ dataView }: ConfigProps): SeriesConfig 
         label: 'Monitor availability',
         id: 'monitor_availability',
         columnType: FORMULA_COLUMN,
-        formula: "1- (count(kql='summary.down > 0') / count(kql='summary: *'))",
+        formula: `1- (count(kql='${FINAL_SUMMARY_KQL} and summary.down > 0') / count(kql='summary: *'))`,
         columnFilter: {
           language: 'kuery',
           query: FINAL_SUMMARY_KQL,

--- a/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/test_runs_table_header.tsx
@@ -35,7 +35,7 @@ export const TestRunsTableHeader = ({
   const { monitor } = useSelectedMonitor();
 
   return (
-    <EuiFlexGroup alignItems="center" gutterSize="l">
+    <EuiFlexGroup alignItems="center" gutterSize="l" wrap={true}>
       <EuiFlexItem grow={false}>
         <EuiTitle size="xs">
           <h3>{paginable || pings?.length < 10 ? TEST_RUNS : LAST_10_TEST_RUNS}</h3>


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/169790

## Summary

The PR fixes the query for Monitor Availability sparkline chart to account for retests.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->