### PR TITLE
[Security Solution] unskip serverless for expandable flyout right panel

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout/common.ts
@@ -10,18 +10,13 @@ import {
   getDataTestSubjectSelectorStartWith,
 } from '../../helpers/common';
 
-export const KIBANA_NAVBAR_ALERTS_PAGE = getDataTestSubjectSelector(
-  'solutionSideNavItemLink-alerts'
-);
-export const KIBANA_NAVBAR_CASES_PAGE = getDataTestSubjectSelector('solutionSideNavItemLink-cases');
 export const VIEW_CASE_TOASTER_LINK = getDataTestSubjectSelector('toaster-content-case-view-link');
-export const CREATE_CASE_BUTTON = `[data-test-subj="createNewCaseBtn"]`;
 export const NEW_CASE_NAME_INPUT = `[data-test-subj="input"][aria-describedby="caseTitle"]`;
 export const NEW_CASE_DESCRIPTION_INPUT = getDataTestSubjectSelector('euiMarkdownEditorTextArea');
-export const NEW_CASE_CREATE_BUTTON = getDataTestSubjectSelector('create-case-submit');
 export const EXISTING_CASE_SELECT_BUTTON =
   getDataTestSubjectSelectorStartWith('cases-table-row-select-');
 export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT = NEW_CASE_NAME_INPUT;
 export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT =
   NEW_CASE_DESCRIPTION_INPUT;
-export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON = NEW_CASE_CREATE_BUTTON;
+export const DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON =
+  getDataTestSubjectSelector('create-case-submit');

--- a/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/alert_details_right_panel.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/alert_details_right_panel.ts
@@ -13,9 +13,15 @@ import {
   DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON_DROPDOWN,
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB,
-  DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB,
   DOCUMENT_DETAILS_FLYOUT_TABLE_TAB,
 } from '../../screens/expandable_flyout/alert_details_right_panel';
+import {
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT,
+  DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT,
+  VIEW_CASE_TOASTER_LINK,
+} from '../../screens/expandable_flyout/common';
+import { TOASTER_CLOSE_ICON } from '../../screens/alerts_detection_rules';
 
 /* Header */
 
@@ -33,14 +39,6 @@ export const expandDocumentDetailsExpandableFlyoutLeftSection = () => {
 export const collapseDocumentDetailsExpandableFlyoutLeftSection = () => {
   cy.get(DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON).scrollIntoView();
   cy.get(DOCUMENT_DETAILS_FLYOUT_COLLAPSE_DETAILS_BUTTON).click();
-};
-
-/**
- * Open the Overview tab in the document details expandable flyout right section
- */
-export const openOverviewTab = () => {
-  cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).scrollIntoView();
-  cy.get(DOCUMENT_DETAILS_FLYOUT_OVERVIEW_TAB).click();
 };
 
 /**
@@ -94,4 +92,17 @@ export const selectTakeActionItem = (option: string) => {
   cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_TAKE_ACTION_BUTTON_DROPDOWN)
     .should('be.visible')
     .within(() => cy.get(option).should('be.visible').click());
+};
+
+/**
+ * Create new case from the expandable flyout take action button
+ */
+export const fillOutFormToCreateNewCase = () => {
+  cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT).type('case');
+  cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT).type('case description');
+
+  cy.get(DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON).click();
+
+  cy.get(VIEW_CASE_TOASTER_LINK).should('be.visible');
+  cy.get(TOASTER_CLOSE_ICON).should('be.visible').click();
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout/common.ts
@@ -8,50 +8,18 @@
 import { EXPAND_ALERT_BTN } from '../../screens/alerts';
 import { DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE } from '../../screens/expandable_flyout/alert_details_right_panel';
 import {
-  CREATE_CASE_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_CREATE_BUTTON,
   DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_DESCRIPTION_INPUT,
   DOCUMENT_DETAILS_FLYOUT_FOOTER_ADD_TO_NEW_CASE_NAME_INPUT,
-  KIBANA_NAVBAR_ALERTS_PAGE,
-  KIBANA_NAVBAR_CASES_PAGE,
-  NEW_CASE_CREATE_BUTTON,
-  NEW_CASE_DESCRIPTION_INPUT,
-  NEW_CASE_NAME_INPUT,
   VIEW_CASE_TOASTER_LINK,
 } from '../../screens/expandable_flyout/common';
 import { openTakeActionButtonAndSelectItem } from './alert_details_right_panel';
-
-/**
- * Navigates to the alerts page by clicking on the Kibana sidenav entry
- */
-export const navigateToAlertsPage = () => {
-  cy.get(KIBANA_NAVBAR_ALERTS_PAGE).should('be.visible').click();
-};
-
-/**
- * Navigates to the cases page by clicking on the Kibana sidenav entry
- */
-export const navigateToCasesPage = () => {
-  cy.get(KIBANA_NAVBAR_CASES_PAGE).click();
-};
 
 /**
  * Find the first alert row in the alerts table then click on the expand icon button to open the flyout
  */
 export const expandFirstAlertExpandableFlyout = () => {
   cy.get(EXPAND_ALERT_BTN).first().click();
-};
-
-/**
- * Create a new case from the cases page
- */
-export const createNewCaseFromCases = () => {
-  cy.get(CREATE_CASE_BUTTON).should('be.visible').click();
-  cy.get(NEW_CASE_NAME_INPUT).should('be.visible').click();
-  cy.get(NEW_CASE_NAME_INPUT).type('case');
-  cy.get(NEW_CASE_DESCRIPTION_INPUT).should('be.visible').click();
-  cy.get(NEW_CASE_DESCRIPTION_INPUT).type('case description');
-  cy.get(NEW_CASE_CREATE_BUTTON).should('be.visible').click();
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR unskips a lot of test that were broken in serverless.
The reason was that the left navigation items don't have the same `data-test-subj` values in serverless as in ess, so the navigation to the cases page to create a new case was broken.

![Screenshot 2023-10-30 at 4 00 31 PM](https://github.com/elastic/kibana/assets/17276605/6fecb3fa-3e05-48df-a9f5-e2d536bc8bc9)

https://github.com/elastic/kibana/issues/168317