### PR TITLE
`@kbn/config-schema`: add option to accept numeric values for `string` type

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/elasticsearch_config.ts
@@ -57,7 +57,7 @@ export const configSchema = schema.object({
       },
     })
   ),
-  password: schema.maybe(schema.string()),
+  password: schema.maybe(schema.string({ coerceFromNumber: true })),
   serviceAccountToken: schema.maybe(
     schema.conditional(
       schema.siblingRef('username'),

--- a/packages/kbn-config-schema/src/types/string_type.test.ts
+++ b/packages/kbn-config-schema/src/types/string_type.test.ts
@@ -22,6 +22,16 @@ test('is required by default', () => {
   );
 });
 
+test('reject numeric values if `coerceFromNumber` is unspecified', () => {
+  expect(() => schema.string({}).validate(1234)).toThrowErrorMatchingInlineSnapshot(
+    `"expected value of type [string] but got [number]"`
+  );
+});
+
+test('coerce numeric values if `coerceFromNumber` is `true`', () => {
+  expect(schema.string({ coerceFromNumber: true }).validate(1234)).toBe('1234');
+});
+
 test('includes namespace in failure', () => {
   expect(() =>
     schema.string().validate(undefined, {}, 'foo-namespace')


### PR DESCRIPTION
## Summary

Also use it for `elastic.password` config option.

Fix https://github.com/elastic/kibana/issues/55031