### PR TITLE
[Security Solution] Fixes problematic test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/header/search_bar.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/header/search_bar.cy.ts
@@ -25,16 +25,9 @@ import { waitForAllHostsToBeLoaded } from '../../tasks/hosts/all_hosts';
 
 describe('SearchBar', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
-    cy.task('esArchiverResetKibana');
-    cy.task('esArchiverLoad', { archiveName: 'auditbeat' });
-
     login();
     visitWithTimeRange(hostsUrl('allHosts'));
     waitForAllHostsToBeLoaded();
-  });
-
-  afterEach(() => {
-    cy.task('esArchiverUnload', 'auditbeat');
   });
 
   it('adds correctly a filter to the global search bar', () => {


### PR DESCRIPTION
## Summary

After the merge of https://github.com/elastic/kibana/pull/169563 seems that there is a test still using resetKibana (I don't know the reason).

In this PR we are fixing that.

Execution in ESS:

<img width="2560" alt="Screenshot 2023-10-31 at 12 46 55" src="https://github.com/elastic/kibana/assets/17427073/dc14eb9a-9ef5-4c35-be83-9f76d9812f8e">

Execution in Serverless:

<img width="2552" alt="Screenshot 2023-10-31 at 12 49 14" src="https://github.com/elastic/kibana/assets/17427073/28594862-1c0d-40f5-9b9e-dfe7f97584cc">
