### PR TITLE
fix(slo): remove groupBy on update

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -7,6 +7,7 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
@@ -136,6 +137,7 @@ export function ApmAvailabilityIndicatorTypeForm() {
       <IndexFieldSelector
         indexFields={partitionByFields}
         name="groupBy"
+        defaultValue={ALL_VALUE}
         label={
           <span>
             {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -7,6 +7,7 @@
 
 import { EuiFieldNumber, EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import React, { useEffect } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useFetchApmIndex } from '../../../../hooks/slo/use_fetch_apm_indices';
@@ -179,6 +180,7 @@ export function ApmLatencyIndicatorTypeForm() {
       <IndexFieldSelector
         indexFields={partitionByFields}
         name="groupBy"
+        defaultValue={ALL_VALUE}
         label={
           <span>
             {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/index_field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/index_field_selector.tsx
@@ -20,6 +20,7 @@ interface Props {
   isDisabled: boolean;
   isLoading: boolean;
   isRequired?: boolean;
+  defaultValue?: string;
 }
 export function IndexFieldSelector({
   indexFields,
@@ -29,6 +30,7 @@ export function IndexFieldSelector({
   isDisabled,
   isLoading,
   isRequired = false,
+  defaultValue = '',
 }: Props) {
   const { control, getFieldState } = useFormContext<CreateSLOForm>();
   const [options, setOptions] = useState<Option[]>(createOptionsFromFields(indexFields));
@@ -41,7 +43,7 @@ export function IndexFieldSelector({
     <EuiFlexItem>
       <EuiFormRow label={label} isInvalid={getFieldState(name).invalid}>
         <Controller
-          defaultValue=""
+          defaultValue={defaultValue}
           name={name}
           control={control}
           rules={{ required: isRequired }}
@@ -60,7 +62,7 @@ export function IndexFieldSelector({
                   return field.onChange(selected[0].value);
                 }
 
-                field.onChange('');
+                field.onChange(defaultValue);
               }}
               options={options}
               onSearchChange={(searchValue: string) => {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -7,6 +7,7 @@
 
 import { EuiFlexGroup, EuiFlexItem, EuiIconTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useFetchIndexPatternFields } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
@@ -138,6 +139,7 @@ export function CustomKqlIndicatorTypeForm() {
       <IndexFieldSelector
         indexFields={partitionByFields}
         name="groupBy"
+        defaultValue={ALL_VALUE}
         label={
           <span>
             {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useFetchIndexPatternFields } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
@@ -153,6 +154,7 @@ export function CustomMetricIndicatorTypeForm() {
         <IndexFieldSelector
           indexFields={partitionByFields}
           name="groupBy"
+          defaultValue={ALL_VALUE}
           label={
             <span>
               {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator_type_form.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useFetchIndexPatternFields } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
@@ -140,6 +141,7 @@ export function HistogramIndicatorTypeForm() {
         <IndexFieldSelector
           indexFields={partitionByFields}
           name="groupBy"
+          defaultValue={ALL_VALUE}
           label={
             <span>
               {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/timeslice_metric_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/timeslice_metric_indicator.tsx
@@ -18,6 +18,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { useFormContext } from 'react-hook-form';
+import { ALL_VALUE } from '@kbn/slo-schema/src/schema/common';
 import { useFetchIndexPatternFields } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import { CreateSLOForm } from '../../types';
 import { DataPreviewChart } from '../common/data_preview_chart';
@@ -130,6 +131,7 @@ export function TimesliceMetricIndicatorTypeForm() {
         <IndexFieldSelector
           indexFields={partitionByFields}
           name="groupBy"
+          defaultValue={ALL_VALUE}
           label={
             <span>
               {i18n.translate('xpack.observability.slo.sloEdit.groupBy.label', {


### PR DESCRIPTION
## 🌮  Summary

When unsetting the partitionBy (aka groupBy) value on the form, the value was set to `""` which the update API was considering as not specified, and therefore was keeping the previous groupBy value. Said otherwise, we could not remove a partition by field after it was set on an existing SLO.

This PR fixes this by setting the value to `"*"` when clearing the field selector, which is then handled correctly from the API.