### PR TITLE
[SecuritySolution] Panel Settings of visualizations not working

### DIFF
--- a/src/plugins/embeddable/common/types.ts
+++ b/src/plugins/embeddable/common/types.ts
@@ -71,6 +71,7 @@ export type EmbeddableInput = {
   syncTooltips?: boolean;
 
   executionContext?: KibanaExecutionContext;
+  withDefaultActions?: boolean;
 };
 
 export interface PanelState<

--- a/src/plugins/embeddable/public/embeddable_panel/embeddable_panel.tsx
+++ b/src/plugins/embeddable/public/embeddable_panel/embeddable_panel.tsx
@@ -72,6 +72,7 @@ export const EmbeddablePanel = (panelProps: UnwrappedEmbeddablePanelProps) => {
 
     const actions: PanelUniversalActions = {
       customizePanel: new CustomizePanelAction(
+        core.application,
         core.overlays,
         core.theme,
         editPanel,

--- a/src/plugins/embeddable/public/embeddable_panel/embeddable_panel.tsx
+++ b/src/plugins/embeddable/public/embeddable_panel/embeddable_panel.tsx
@@ -72,7 +72,6 @@ export const EmbeddablePanel = (panelProps: UnwrappedEmbeddablePanelProps) => {
 
     const actions: PanelUniversalActions = {
       customizePanel: new CustomizePanelAction(
-        core.application,
         core.overlays,
         core.theme,
         editPanel,

--- a/src/plugins/embeddable/public/embeddable_panel/panel_actions/customize_panel_action/customize_panel_action.test.ts
+++ b/src/plugins/embeddable/public/embeddable_panel/panel_actions/customize_panel_action/customize_panel_action.test.ts
@@ -40,28 +40,58 @@ function createHelloWorldContainer(input = { id: '123', panels: {} }) {
   return new HelloWorldContainer(input, { getEmbeddableFactory } as any);
 }
 
-beforeAll(async () => {
-  container = createHelloWorldContainer();
-  const contactCardEmbeddable = await container.addNewEmbeddable<
-    ContactCardEmbeddableInput,
-    ContactCardEmbeddableOutput,
-    ContactCardEmbeddable
-  >(CONTACT_CARD_EMBEDDABLE, {
-    id: 'robert',
-    firstName: 'Robert',
-    lastName: 'Baratheon',
+describe('customizePanelAction', () => {
+  beforeAll(async () => {
+    container = createHelloWorldContainer();
+    const contactCardEmbeddable = await container.addNewEmbeddable<
+      ContactCardEmbeddableInput,
+      ContactCardEmbeddableOutput,
+      ContactCardEmbeddable
+    >(CONTACT_CARD_EMBEDDABLE, {
+      id: 'robert',
+      firstName: 'Robert',
+      lastName: 'Baratheon',
+    });
+    if (isErrorEmbeddable(contactCardEmbeddable)) {
+      throw new Error('Error creating new hello world embeddable');
+    } else {
+      embeddable = contactCardEmbeddable;
+    }
   });
-  if (isErrorEmbeddable(contactCardEmbeddable)) {
-    throw new Error('Error creating new hello world embeddable');
-  } else {
-    embeddable = contactCardEmbeddable;
-  }
+
+  test('execute should open flyout', async () => {
+    const customizePanelAction = new CustomizePanelAction(overlays, theme, editPanelActionMock);
+    const spy = jest.spyOn(overlays, 'openFlyout');
+    await customizePanelAction.execute({ embeddable });
+
+    expect(spy).toHaveBeenCalled();
+  });
 });
 
-test('execute should open flyout', async () => {
-  const customizePanelAction = new CustomizePanelAction(overlays, theme, editPanelActionMock);
-  const spy = jest.spyOn(overlays, 'openFlyout');
-  await customizePanelAction.execute({ embeddable });
+describe('customizePanelAction and withDefaultActions is false', () => {
+  beforeAll(async () => {
+    container = createHelloWorldContainer();
+    const contactCardEmbeddable = await container.addNewEmbeddable<
+      ContactCardEmbeddableInput,
+      ContactCardEmbeddableOutput,
+      ContactCardEmbeddable
+    >(CONTACT_CARD_EMBEDDABLE, {
+      id: 'robert',
+      firstName: 'Robert',
+      lastName: 'Baratheon',
+      withDefaultActions: false,
+    });
+    if (isErrorEmbeddable(contactCardEmbeddable)) {
+      throw new Error('Error creating new hello world embeddable');
+    } else {
+      embeddable = contactCardEmbeddable;
+    }
+  });
 
-  expect(spy).toHaveBeenCalled();
+  test('should not be compatible', async () => {
+    const customizePanelAction = new CustomizePanelAction(overlays, theme, editPanelActionMock);
+    const result = await customizePanelAction.isCompatible({ embeddable });
+
+    expect(result).toBeFalsy();
+  });
 });

--- a/src/plugins/embeddable/public/embeddable_panel/panel_actions/customize_panel_action/customize_panel_action.tsx
+++ b/src/plugins/embeddable/public/embeddable_panel/panel_actions/customize_panel_action/customize_panel_action.tsx
@@ -99,8 +99,10 @@ export class CustomizePanelAction implements Action<CustomizePanelActionContext>
 
   public async isCompatible({ embeddable }: CustomizePanelActionContext) {
     // It should be possible to customize just the time range in View mode
+    const input = embeddable.getInput();
     return (
-      embeddable.getInput().viewMode === ViewMode.EDIT || this.isTimeRangeCompatible({ embeddable })
+      (input.viewMode === ViewMode.EDIT || this.isTimeRangeCompatible({ embeddable })) &&
+      input?.withDefaultActions !== false
     );
   }
 


### PR DESCRIPTION
## Summary

https://github.com/elastic/kibana/issues/168670

**Before**: Panel Settings displayed in SecuritySolution visualisations and SecuritySolution dashboards panel actions. However, the panel settings do not work with visualisations in SecuritySolution.


**After**: Panel Settings displayed in dashboards only (as we have `withDefaultActions` = false in SecuritySolution Lens Embeddables)

<img width="2542" alt="Screenshot 2023-10-31 at 14 12 26" src="https://github.com/elastic/kibana/assets/6295984/76f9f865-9e5f-4335-b684-badcdd6ec241">
<img width="2548" alt="Screenshot 2023-10-31 at 14 12 45" src="https://github.com/elastic/kibana/assets/6295984/412a08c7-355f-4bc4-9b1a-8ec7a79c82aa">


### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

