### PR TITLE
[OAS] Update tech preview text in case APIs

### DIFF
--- a/x-pack/plugins/cases/docs/openapi/bundled.json
+++ b/x-pack/plugins/cases/docs/openapi/bundled.json
@@ -5549,7 +5549,7 @@
       },
       "alert_identifiers": {
         "title": "Alert identifiers",
-        "description": "The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "oneOf": [
           {
             "type": "string"
@@ -5567,7 +5567,7 @@
       },
       "alert_indices": {
         "title": "Alert indices",
-        "description": "The alert indices. It is required only when `type` is `alert`.  If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The alert indices. It is required only when `type` is `alert`. If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array.  This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "oneOf": [
           {
             "type": "string"
@@ -5584,7 +5584,7 @@
       },
       "rule": {
         "title": "Alerting rule",
-        "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
+        "description": "The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.\n",
         "type": "object",
         "x-technical-preview": true,
         "properties": {

--- a/x-pack/plugins/cases/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/cases/docs/openapi/bundled.yaml
@@ -3760,7 +3760,7 @@ components:
     alert_identifiers:
       title: Alert identifiers
       description: |
-        The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The alert identifiers. It is required only when `type` is `alert`. You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       oneOf:
         - type: string
         - type: array
@@ -3772,7 +3772,7 @@ components:
     alert_indices:
       title: Alert indices
       description: |
-        The alert indices. It is required only when `type` is `alert`.  If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The alert indices. It is required only when `type` is `alert`. If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array.  This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       oneOf:
         - type: string
         - type: array
@@ -3783,7 +3783,7 @@ components:
     rule:
       title: Alerting rule
       description: |
-        The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        The rule that is associated with the alerts. It is required only when `type` is `alert`. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       type: object
       x-technical-preview: true
       properties:

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_identifiers.yaml
@@ -1,11 +1,11 @@
 title: Alert identifiers
 description: >
-  The alert identifiers. It is required only when `type` is `alert`. You can use
-  an array of strings to add multiple alerts to a case, provided that they all
-  relate to the same rule; `index` must also be an array with the same length or number of elements. Adding multiple alerts in this manner is recommended
-  rather than calling the API multiple times. This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply
-  best effort to fix any issues, but features in technical preview are not
-  subject to the support SLA of official GA features.
+  The alert identifiers.
+  It is required only when `type` is `alert`.
+  You can use an array of strings to add multiple alerts to a case, provided that they all relate to the same rule; `index` must also be an array with the same length or number of elements.
+  Adding multiple alerts in this manner is recommended rather than calling the API multiple times.
+  This functionality is in technical preview and may be changed or removed in a future release.
+  Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 oneOf:
   - type: string
   - type: array

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/alert_indices.yaml
@@ -1,12 +1,10 @@
 title: Alert indices
 description: >
-  The alert indices. It is required only when `type` is `alert`.  If you are
-  adding multiple alerts to a case, use an array of strings; the position of
-  each index name in the array must match the position of the corresponding
-  alert identifier in the `alertId` array. This functionality is in technical
-  preview and may be changed or removed in a future release. Elastic will apply
-  best effort to fix any issues, but features in technical preview are not
-  subject to the support SLA of official GA features.
+  The alert indices.
+  It is required only when `type` is `alert`.
+  If you are adding multiple alerts to a case, use an array of strings; the position of each index name in the array must match the position of the corresponding alert identifier in the `alertId` array. 
+  This functionality is in technical preview and may be changed or removed in a future release.
+  Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 oneOf:
   - type: string
   - type: array

--- a/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
+++ b/x-pack/plugins/cases/docs/openapi/components/schemas/rule.yaml
@@ -1,10 +1,9 @@
 title: Alerting rule
 description: >
-  The rule that is associated with the alerts. It is required only when
-  `type` is `alert`. This functionality is in technical preview and may be
-  changed or removed in a future release. Elastic will apply best effort to
-  fix any issues, but features in technical preview are not subject to the
-  support SLA of official GA features.
+  The rule that is associated with the alerts.
+  It is required only when `type` is `alert`.
+  This functionality is in technical preview and may be changed or removed in a future release.
+  Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
 type: object
 x-technical-preview: true
 properties:


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/docs/pull/2807, which adjusts the copy for the preview admonition.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->