### PR TITLE
[Fleet] handle ESO errors in message signing key pair generation

### DIFF
--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -473,6 +473,7 @@ export class FleetPlugin
 
   public start(core: CoreStart, plugins: FleetStartDeps): FleetStartContract {
     const messageSigningService = new MessageSigningService(
+      this.initializerContext.logger,
       plugins.encryptedSavedObjects.getClient({
         includedHiddenTypes: [MESSAGE_SIGNING_KEYS_SAVED_OBJECT_TYPE],
       })

--- a/x-pack/plugins/fleet/server/services/security/message_signing_service.ts
+++ b/x-pack/plugins/fleet/server/services/security/message_signing_service.ts
@@ -5,8 +5,11 @@
  * 2.0.
  */
 
+import { backOff } from 'exponential-backoff';
+
 import { generateKeyPairSync, createSign, randomBytes } from 'crypto';
 
+import type { LoggerFactory, Logger } from '@kbn/core/server';
 import type { KibanaRequest } from '@kbn/core-http-server';
 import type {
   SavedObjectsClientContract,
@@ -39,8 +42,11 @@ export interface MessageSigningServiceInterface {
 
 export class MessageSigningService implements MessageSigningServiceInterface {
   private _soClient: SavedObjectsClientContract | undefined;
+  private logger: Logger;
 
-  constructor(private esoClient: EncryptedSavedObjectsClient) {}
+  constructor(loggerFactory: LoggerFactory, private esoClient: EncryptedSavedObjectsClient) {
+    this.logger = loggerFactory.get('messageSigningService');
+  }
 
   public get isEncryptionAvailable(): MessageSigningServiceInterface['isEncryptionAvailable'] {
     return appContextService.getEncryptedSavedObjectsSetup()?.canEncrypt ?? false;
@@ -188,6 +194,30 @@ export class MessageSigningService implements MessageSigningServiceInterface {
     return this._soClient;
   }
 
+  private async getCurrentKeyPairObjWithRetry() {
+    let soDoc: SavedObjectsFindResult<MessageSigningKeys> | undefined;
+
+    await backOff(
+      async () => {
+        soDoc = await this.getCurrentKeyPairObj();
+      },
+      {
+        maxDelay: 60 * 60 * 1000, // 1 hour in milliseconds
+        startingDelay: 1000, // 1 second
+        jitter: 'full',
+        numOfAttempts: Infinity,
+        retry: (_err: Error, attempt: number) => {
+          // not logging the error since we don't control what's in the error and it might contain sensitive data
+          // ESO already logs specific caught errors before passing the error along
+          this.logger.warn(`failed to get message signing key pair. retrying attempt: ${attempt}`);
+          return true;
+        },
+      }
+    );
+
+    return soDoc;
+  }
+
   private async getCurrentKeyPairObj(): Promise<
     SavedObjectsFindResult<MessageSigningKeys> | undefined
   > {
@@ -205,6 +235,10 @@ export class MessageSigningService implements MessageSigningServiceInterface {
     }
     finder.close();
 
+    if (soDoc?.error) {
+      throw soDoc.error;
+    }
+
     return soDoc;
   }
 
@@ -216,7 +250,7 @@ export class MessageSigningService implements MessageSigningServiceInterface {
       }
     | undefined
   > {
-    const currentKeyPair = await this.getCurrentKeyPairObj();
+    const currentKeyPair = await this.getCurrentKeyPairObjWithRetry();
     if (!currentKeyPair) {
       return;
     }


### PR DESCRIPTION
## Summary

If there was a transient error while fetching the key pair from ESO, the `MessageSigningService` would generate brand new key pair. This would cause existing endpoints to stop working since the messages would be signed by the new key. This PR adds retry logic with backoff for fetching key pairs from ESO so that a new key isn't generated unless we know for sure there isn't an existing key pair. Key pairs can still be manually rotated using the rotate keys API.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
