### PR TITLE
fix(slo): remove react query cache for slo list page

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/__storybook_mocks__/use_fetch_slo_list.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/__storybook_mocks__/use_fetch_slo_list.ts
@@ -16,6 +16,5 @@ export const useFetchSloList = (): UseFetchSloListResponse => {
     isError: false,
     isSuccess: true,
     data: sloList,
-    refetch: function () {} as UseFetchSloListResponse['refetch'],
   };
 };

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_list.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_slo_list.ts
@@ -5,16 +5,10 @@
  * 2.0.
  */
 
-import { useState } from 'react';
-import {
-  QueryObserverResult,
-  RefetchOptions,
-  RefetchQueryFilters,
-  useQuery,
-  useQueryClient,
-} from '@tanstack/react-query';
 import { i18n } from '@kbn/i18n';
 import { FindSLOResponse } from '@kbn/slo-schema';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 
 import { useKibana } from '../../utils/kibana_react';
 import { sloKeys } from './query_key_factory';
@@ -34,9 +28,6 @@ export interface UseFetchSloListResponse {
   isSuccess: boolean;
   isError: boolean;
   data: FindSLOResponse | undefined;
-  refetch: <TPageData>(
-    options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined
-  ) => Promise<QueryObserverResult<FindSLOResponse | undefined, unknown>>;
 }
 
 const SHORT_REFETCH_INTERVAL = 1000 * 5; // 5 seconds
@@ -56,56 +47,53 @@ export function useFetchSloList({
   const queryClient = useQueryClient();
   const [stateRefetchInterval, setStateRefetchInterval] = useState<number>(SHORT_REFETCH_INTERVAL);
 
-  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data, refetch } = useQuery(
-    {
-      queryKey: sloKeys.list({ kqlQuery, page, sortBy, sortDirection }),
-      queryFn: async ({ signal }) => {
-        const response = await http.get<FindSLOResponse>(`/api/observability/slos`, {
-          query: {
-            ...(kqlQuery && { kqlQuery }),
-            ...(sortBy && { sortBy }),
-            ...(sortDirection && { sortDirection }),
-            ...(page && { page }),
-          },
-          signal,
-        });
+  const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
+    queryKey: sloKeys.list({ kqlQuery, page, sortBy, sortDirection }),
+    queryFn: async ({ signal }) => {
+      const response = await http.get<FindSLOResponse>(`/api/observability/slos`, {
+        query: {
+          ...(kqlQuery && { kqlQuery }),
+          ...(sortBy && { sortBy }),
+          ...(sortDirection && { sortDirection }),
+          ...(page && { page }),
+        },
+        signal,
+      });
 
-        return response;
-      },
-      keepPreviousData: true,
-      refetchOnWindowFocus: false,
-      refetchInterval: shouldRefetch ? stateRefetchInterval : undefined,
-      staleTime: 1000,
-      retry: (failureCount, error) => {
-        if (String(error) === 'Error: Forbidden') {
-          return false;
-        }
-        return failureCount < 4;
-      },
-      onSuccess: ({ results }: FindSLOResponse) => {
-        queryClient.invalidateQueries({ queryKey: sloKeys.historicalSummaries(), exact: false });
-        queryClient.invalidateQueries({ queryKey: sloKeys.activeAlerts(), exact: false });
-        queryClient.invalidateQueries({ queryKey: sloKeys.rules(), exact: false });
+      return response;
+    },
+    cacheTime: 0,
+    refetchOnWindowFocus: false,
+    refetchInterval: shouldRefetch ? stateRefetchInterval : undefined,
+    retry: (failureCount, error) => {
+      if (String(error) === 'Error: Forbidden') {
+        return false;
+      }
+      return failureCount < 4;
+    },
+    onSuccess: ({ results }: FindSLOResponse) => {
+      queryClient.invalidateQueries({ queryKey: sloKeys.historicalSummaries(), exact: false });
+      queryClient.invalidateQueries({ queryKey: sloKeys.activeAlerts(), exact: false });
+      queryClient.invalidateQueries({ queryKey: sloKeys.rules(), exact: false });
 
-        if (!shouldRefetch) {
-          return;
-        }
+      if (!shouldRefetch) {
+        return;
+      }
 
-        if (results.find((slo) => slo.summary.status === 'NO_DATA' || !slo.summary)) {
-          setStateRefetchInterval(SHORT_REFETCH_INTERVAL);
-        } else {
-          setStateRefetchInterval(LONG_REFETCH_INTERVAL);
-        }
-      },
-      onError: (error: Error) => {
-        toasts.addError(error, {
-          title: i18n.translate('xpack.observability.slo.list.errorNotification', {
-            defaultMessage: 'Something went wrong while fetching SLOs',
-          }),
-        });
-      },
-    }
-  );
+      if (results.find((slo) => slo.summary.status === 'NO_DATA' || !slo.summary)) {
+        setStateRefetchInterval(SHORT_REFETCH_INTERVAL);
+      } else {
+        setStateRefetchInterval(LONG_REFETCH_INTERVAL);
+      }
+    },
+    onError: (error: Error) => {
+      toasts.addError(error, {
+        title: i18n.translate('xpack.observability.slo.list.errorNotification', {
+          defaultMessage: 'Something went wrong while fetching SLOs',
+        }),
+      });
+    },
+  });
 
   return {
     data,
@@ -114,6 +102,5 @@ export function useFetchSloList({
     isRefetching,
     isSuccess,
     isError,
-    refetch,
   };
 }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/170317

## 🥡  Summary

When changing pages, we observed a weird behaviour where the result of the API was not fully taken into account, and was kind of merged with the previous results. After some investigation, it seems the cacheTime (default to 5min) was problematic in our case.
This PR forces `cacheTime` to 0, so when changing page, we only use the result from the API.