### PR TITLE
ES query logging: do not compute logging data when not necessary

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.test.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.test.ts
@@ -68,6 +68,7 @@ describe('instrumentQueryAndDeprecationLogger', () => {
 
   beforeEach(() => {
     logger = loggingSystemMock.createLogger();
+    logger.isLevelEnabled.mockReturnValue(true);
     parseClientOptionsMock.mockReturnValue({});
     ClientMock.mockImplementation(() => createFakeClient());
   });
@@ -493,6 +494,29 @@ describe('instrumentQueryAndDeprecationLogger', () => {
         {\\"seq_no_primary_term\\":true,\\"query\\":{\\"term\\":{\\"user\\":\\"kimchy\\"}}}"
       `);
     });
+
+    it('does not log when debug level is disabled for the query logger', () => {
+      logger.isLevelEnabled.mockReturnValue(false);
+
+      instrumentEsQueryAndDeprecationLogger({
+        logger,
+        client,
+        type: 'test type',
+        apisToRedactInLogs: [],
+      });
+
+      const response = createResponseWithBody(
+        JSON.stringify({
+          seq_no_primary_term: true,
+          query: {
+            term: { user: 'kimchy' },
+          },
+        })
+      );
+
+      client.diagnostic.emit('response', null, response);
+      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`Array []`);
+    });
   });
 
   describe('deprecation warnings from response headers', () => {
@@ -710,6 +734,39 @@ describe('instrumentQueryAndDeprecationLogger', () => {
       expect(loggingSystemMock.collect(logger).debug[1][0]).toMatch(
         /Query:\n.*200\n.*GET \/_path\?hello\=dolly/
       );
+    });
+
+    it('does not log when debug level is disabled for the deprecation logger', () => {
+      logger.isLevelEnabled.mockReturnValue(false);
+
+      instrumentEsQueryAndDeprecationLogger({
+        logger,
+        client,
+        type: 'test type',
+        apisToRedactInLogs: [],
+      });
+
+      const response = createApiResponse({
+        statusCode: 200,
+        warnings: ['299 Elasticsearch-8.1.0 "GET /_path is deprecated"'],
+        params: {
+          method: 'GET',
+          path: '/_path',
+          querystring: { hello: 'dolly' },
+          // Set the request header to indicate to Elasticsearch that this is a request over which users have no control
+          headers: { 'x-elastic-product-origin': 'kibana' },
+        },
+        body: {
+          hits: [
+            {
+              _source: 'may the source be with you',
+            },
+          ],
+        },
+      });
+      client.diagnostic.emit('response', null, response);
+
+      expect(loggingSystemMock.collect(logger).debug).toMatchInlineSnapshot(`Array []`);
     });
 
     describe('Request body redaction on some APIs', () => {

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.ts
@@ -186,8 +186,8 @@ export const instrumentEsQueryAndDeprecationLogger = ({
   const deprecationLogger = logger.get('deprecation');
 
   client.diagnostic.on('response', (error, event) => {
-    // we could check this once and not even listen to response events,
-    // but then we would not be supported hot reload of the logging configuration
+    // we could check this once and not subscribe to response events if both are disabled,
+    // but then we would not be supporting hot reload of the logging configuration.
     const logQuery = queryLogger.isLevelEnabled('debug');
     const logDeprecation = deprecationLogger.isLevelEnabled('debug');
 

--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/log_query_and_deprecation.ts
@@ -153,6 +153,24 @@ export function getRequestDebugMeta(
  * */
 const isEsWarning = (warning: string) => /\d\d\d Elasticsearch-/.test(warning);
 
+function getQueryMessage(
+  bytes: number | undefined,
+  error: errors.ElasticsearchClientError | errors.ResponseError | null,
+  event: DiagnosticResult<unknown, unknown>,
+  apisToRedactInLogs: ElasticsearchApiToRedactInLogs[]
+) {
+  const bytesMsg = bytes ? ` - ${numeral(bytes).format('0.0b')}` : '';
+  if (error) {
+    if (error instanceof errors.ResponseError) {
+      return `${getResponseMessage(event, bytesMsg, apisToRedactInLogs)} ${getErrorMessage(error)}`;
+    } else {
+      return getErrorMessage(error);
+    }
+  } else {
+    return getResponseMessage(event, bytesMsg, apisToRedactInLogs);
+  }
+}
+
 export const instrumentEsQueryAndDeprecationLogger = ({
   logger,
   client,
@@ -166,28 +184,23 @@ export const instrumentEsQueryAndDeprecationLogger = ({
 }) => {
   const queryLogger = logger.get('query', type);
   const deprecationLogger = logger.get('deprecation');
-  client.diagnostic.on('response', (error, event) => {
-    if (event) {
-      const bytes = getContentLength(event.headers);
-      const bytesMsg = bytes ? ` - ${numeral(bytes).format('0.0b')}` : '';
-      const meta = getEcsResponseLog(event, bytes);
 
-      let queryMsg = '';
-      if (error) {
-        if (error instanceof errors.ResponseError) {
-          queryMsg = `${getResponseMessage(event, bytesMsg, apisToRedactInLogs)} ${getErrorMessage(
-            error
-          )}`;
-        } else {
-          queryMsg = getErrorMessage(error);
-        }
-      } else {
-        queryMsg = getResponseMessage(event, bytesMsg, apisToRedactInLogs);
+  client.diagnostic.on('response', (error, event) => {
+    // we could check this once and not even listen to response events,
+    // but then we would not be supported hot reload of the logging configuration
+    const logQuery = queryLogger.isLevelEnabled('debug');
+    const logDeprecation = deprecationLogger.isLevelEnabled('debug');
+
+    if (event && (logQuery || logDeprecation)) {
+      const bytes = getContentLength(event.headers);
+      const queryMsg = getQueryMessage(bytes, error, event, apisToRedactInLogs);
+
+      if (logQuery) {
+        const meta = getEcsResponseLog(event, bytes);
+        queryLogger.debug(queryMsg, meta);
       }
 
-      queryLogger.debug(queryMsg, meta);
-
-      if (event.warnings && event.warnings.filter(isEsWarning).length > 0) {
+      if (logDeprecation && event.warnings && event.warnings.filter(isEsWarning).length > 0) {
         // Plugins can explicitly mark requests as originating from a user by
         // removing the `'x-elastic-product-origin': 'kibana'` header that's
         // added by default. User requests will be shown to users in the


### PR DESCRIPTION
## Summary

Small performance optimization: don't compute the query/deprecation log messages and meta if the appropriate log level isn't enabled.  