### PR TITLE
Bring current user to the top of the user profiles list

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/assignees/utils.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/assignees/utils.test.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { NO_ASSIGNEES_VALUE } from './constants';
+import { mockUserProfiles } from './mocks';
+import { bringCurrentUserToFrontAndSort, removeNoAssigneesSelection } from './utils';
+
+describe('utils', () => {
+  describe('removeNoAssigneesSelection', () => {
+    it('should return user ids if `no assignees` has not been passed', () => {
+      const assignees = ['user1', 'user2', 'user3'];
+      const ids = removeNoAssigneesSelection(assignees);
+      expect(ids).toEqual(assignees);
+    });
+
+    it('should return user ids and remove `no assignees`', () => {
+      const assignees = [NO_ASSIGNEES_VALUE, 'user1', 'user2', NO_ASSIGNEES_VALUE, 'user3'];
+      const ids = removeNoAssigneesSelection(assignees);
+      expect(ids).toEqual(['user1', 'user2', 'user3']);
+    });
+  });
+
+  describe('bringCurrentUserToFrontAndSort', () => {
+    it('should return `undefined` if nothing has been passed', () => {
+      const sortedProfiles = bringCurrentUserToFrontAndSort();
+      expect(sortedProfiles).toBeUndefined();
+    });
+
+    it('should return passed profiles if current user is `undefined`', () => {
+      const sortedProfiles = bringCurrentUserToFrontAndSort(undefined, mockUserProfiles);
+      expect(sortedProfiles).toEqual(mockUserProfiles);
+    });
+
+    it('should return profiles with the current user on top', () => {
+      const currentUser = mockUserProfiles[1];
+      const sortedProfiles = bringCurrentUserToFrontAndSort(currentUser, mockUserProfiles);
+      expect(sortedProfiles).toEqual([currentUser, mockUserProfiles[0], mockUserProfiles[2]]);
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/components/assignees/utils.ts
+++ b/x-pack/plugins/security_solution/public/common/components/assignees/utils.ts
@@ -5,8 +5,55 @@
  * 2.0.
  */
 
+import { sortBy } from 'lodash';
+
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+
 import { NO_ASSIGNEES_VALUE } from './constants';
 import type { AssigneesIdsSelection } from './types';
+
+const getSortField = (profile: UserProfileWithAvatar) =>
+  profile.user?.full_name?.toLowerCase() ??
+  profile.user?.email?.toLowerCase() ??
+  profile.user?.username.toLowerCase();
+
+const sortProfiles = (profiles?: UserProfileWithAvatar[]) => {
+  if (!profiles) {
+    return;
+  }
+
+  return sortBy(profiles, getSortField);
+};
+
+const moveCurrentUserToBeginning = <T extends { uid: string }>(
+  currentUserProfile?: T,
+  profiles?: T[]
+) => {
+  if (!profiles) {
+    return;
+  }
+
+  if (!currentUserProfile) {
+    return profiles;
+  }
+
+  const currentProfileIndex = profiles.find((profile) => profile.uid === currentUserProfile.uid);
+
+  if (!currentProfileIndex) {
+    return profiles;
+  }
+
+  const profilesWithoutCurrentUser = profiles.filter(
+    (profile) => profile.uid !== currentUserProfile.uid
+  );
+
+  return [currentUserProfile, ...profilesWithoutCurrentUser];
+};
+
+export const bringCurrentUserToFrontAndSort = (
+  currentUserProfile?: UserProfileWithAvatar,
+  profiles?: UserProfileWithAvatar[]
+) => moveCurrentUserToBeginning(currentUserProfile, sortProfiles(profiles));
 
 export const removeNoAssigneesSelection = (assignees: AssigneesIdsSelection[]): string[] =>
   assignees.filter<string>((assignee): assignee is string => assignee !== NO_ASSIGNEES_VALUE);

--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.test.tsx
@@ -15,11 +15,13 @@ import type {
 } from './use_bulk_alert_assignees_items';
 import { useBulkAlertAssigneesItems } from './use_bulk_alert_assignees_items';
 import { useSetAlertAssignees } from './use_set_alert_assignees';
+import { useGetCurrentUser } from '../../../../detections/containers/detection_engine/user_profiles/use_get_current_user';
 import { useGetUserProfiles } from '../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles';
 import { useSuggestUsers } from '../../../../detections/containers/detection_engine/user_profiles/use_suggest_users';
 import { ASSIGNEES_APPLY_BUTTON_TEST_ID } from '../../assignees/test_ids';
 
 jest.mock('./use_set_alert_assignees');
+jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_get_current_user');
 jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_get_user_profiles');
 jest.mock('../../../../detections/containers/detection_engine/user_profiles/use_suggest_users');
 
@@ -52,6 +54,10 @@ const renderPanel = (panel: UseBulkAlertAssigneesPanel) => {
 describe('useBulkAlertAssigneesItems', () => {
   beforeEach(() => {
     (useSetAlertAssignees as jest.Mock).mockReturnValue(jest.fn());
+    (useGetCurrentUser as jest.Mock).mockReturnValue({
+      loading: false,
+      userProfile: mockUserProfiles[0],
+    });
     (useGetUserProfiles as jest.Mock).mockReturnValue({
       loading: false,
       userProfiles: mockUserProfiles,

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/timeline_actions/use_alert_assignees_actions.test.tsx
@@ -16,11 +16,13 @@ import React from 'react';
 import type { EuiContextMenuPanelDescriptor } from '@elastic/eui';
 import { EuiPopover, EuiContextMenu } from '@elastic/eui';
 import { useSetAlertAssignees } from '../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees';
+import { useGetCurrentUser } from '../../../containers/detection_engine/user_profiles/use_get_current_user';
 import { useGetUserProfiles } from '../../../containers/detection_engine/user_profiles/use_get_user_profiles';
 import { useSuggestUsers } from '../../../containers/detection_engine/user_profiles/use_suggest_users';
 
 jest.mock('../../../containers/detection_engine/alerts/use_alerts_privileges');
 jest.mock('../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees');
+jest.mock('../../../containers/detection_engine/user_profiles/use_get_current_user');
 jest.mock('../../../containers/detection_engine/user_profiles/use_get_user_profiles');
 jest.mock('../../../containers/detection_engine/user_profiles/use_suggest_users');
 
@@ -161,6 +163,10 @@ describe('useAlertAssigneesActions', () => {
 
   it('should render the nested panel', async () => {
     (useSetAlertAssignees as jest.Mock).mockReturnValue(jest.fn());
+    (useGetCurrentUser as jest.Mock).mockReturnValue({
+      loading: false,
+      userProfile: mockUserProfiles[0],
+    });
     (useGetUserProfiles as jest.Mock).mockReturnValue({
       loading: false,
       userProfiles: mockUserProfiles,

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/mock.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/mock.ts
@@ -5,6 +5,13 @@
  * 2.0.
  */
 
+export const mockCurrentUserProfile = {
+  uid: 'current-user',
+  enabled: true,
+  user: { username: 'current.user' },
+  data: {},
+};
+
 export const mockUserProfiles = [
   { uid: 'user-id-1', enabled: true, user: { username: 'user1' }, data: {} },
   { uid: 'user-id-2', enabled: true, user: { username: 'user2' }, data: {} },

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/translations.ts
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/translations.ts
@@ -7,7 +7,12 @@
 
 import { i18n } from '@kbn/i18n';
 
+export const CURRENT_USER_PROFILE_FAILURE = i18n.translate(
+  'xpack.securitySolution.containers.detectionEngine.currentUserProfile.failure',
+  { defaultMessage: 'Failed to find current user' }
+);
+
 export const USER_PROFILES_FAILURE = i18n.translate(
-  'xpack.securitySolution.containers.detectionEngine.userProfiles.title',
+  'xpack.securitySolution.containers.detectionEngine.userProfiles.failure',
   { defaultMessage: 'Failed to find users' }
 );

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_current_user.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_current_user.test.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { securityMock } from '@kbn/security-plugin/public/mocks';
+
+import { mockCurrentUserProfile } from './mock';
+import { useGetCurrentUser } from './use_get_current_user';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+import { useAppToastsMock } from '../../../../common/hooks/use_app_toasts.mock';
+import { createStartServicesMock } from '../../../../common/lib/kibana/kibana_react.mock';
+
+jest.mock('../../../../common/lib/kibana');
+jest.mock('../../../../common/hooks/use_app_toasts');
+
+describe('useGetCurrentUser hook', () => {
+  let appToastsMock: jest.Mocked<ReturnType<typeof useAppToastsMock.create>>;
+  beforeEach(() => {
+    jest.clearAllMocks();
+    appToastsMock = useAppToastsMock.create();
+    (useAppToasts as jest.Mock).mockReturnValue(appToastsMock);
+    const security = securityMock.createStart();
+    security.userProfiles.getCurrent.mockReturnValue(Promise.resolve(mockCurrentUserProfile));
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        ...createStartServicesMock(),
+        security,
+      },
+    });
+  });
+
+  it('returns current user', async () => {
+    const userProfiles = useKibana().services.security.userProfiles;
+    const spyOnUserProfiles = jest.spyOn(userProfiles, 'getCurrent');
+    const { result, waitForNextUpdate } = renderHook(() => useGetCurrentUser());
+    await waitForNextUpdate();
+
+    expect(spyOnUserProfiles).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual({
+      loading: false,
+      userProfile: mockCurrentUserProfile,
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_current_user.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/user_profiles/use_get_current_user.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { useEffect, useState } from 'react';
+
+import { CURRENT_USER_PROFILE_FAILURE } from './translations';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useAppToasts } from '../../../../common/hooks/use_app_toasts';
+
+interface GetCurrentUserReturn {
+  loading: boolean;
+  userProfile?: UserProfileWithAvatar;
+}
+
+export const useGetCurrentUser = (): GetCurrentUserReturn => {
+  const [loading, setLoading] = useState(false);
+  const [currentUser, setCurrentUser] = useState<UserProfileWithAvatar | undefined>(undefined);
+  const { addError } = useAppToasts();
+  const userProfiles = useKibana().services.security.userProfiles;
+
+  useEffect(() => {
+    // isMounted tracks if a component is mounted before changing state
+    let isMounted = true;
+    setLoading(true);
+    const fetchData = async () => {
+      try {
+        const profile = await userProfiles.getCurrent({ dataPath: 'avatar' });
+        if (isMounted) {
+          setCurrentUser(profile);
+        }
+      } catch (error) {
+        addError(error.message, { title: CURRENT_USER_PROFILE_FAILURE });
+      }
+      if (isMounted) {
+        setLoading(false);
+      }
+    };
+    fetchData();
+    return () => {
+      // updates to show component is unmounted
+      isMounted = false;
+    };
+  }, [addError, userProfiles]);
+  return { loading, userProfile: currentUser };
+};


### PR DESCRIPTION
## Summary

UI enhancement which shows current user at the top of the user profiles list.

Main ticket https://github.com/elastic/security-team/issues/2504
