### PR TITLE
[RAM] Fix flaky test get_global_execution_kpi

### DIFF
--- a/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/get_global_execution_kpi.ts
+++ b/x-pack/test/alerting_api_integration/security_and_spaces/group2/tests/alerting/get_global_execution_kpi.ts
@@ -17,8 +17,7 @@ export default function getGlobalExecutionKpiTests({ getService }: FtrProviderCo
 
   const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/153112
-  describe.skip('getGlobalExecutionKpi', () => {
+  describe('getGlobalExecutionKpi', () => {
     const objectRemover = new ObjectRemover(supertest);
 
     afterEach(() => objectRemover.removeAll());
@@ -298,7 +297,7 @@ export default function getGlobalExecutionKpiTests({ getService }: FtrProviderCo
         'triggeredActions',
       ]);
       expect(kpiLogs.success).to.be.above(1);
-      expect(kpiLogs.failure).to.be.above(2);
+      expect(kpiLogs.failure).to.be.above(1);
     });
   });
 }


### PR DESCRIPTION
## Summary

Fix -> https://github.com/elastic/kibana/issues/153112

I think it is possible to only have two errors, one for each rule.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->