### PR TITLE
[Security Solution][Analyzer] - Fix analyzer panel text

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
+++ b/x-pack/plugins/security_solution/public/resolver/view/panels/event_detail.tsx
@@ -330,6 +330,9 @@ function EventDetailBreadcrumbs({
 }
 
 const StyledDescriptionList = memo(styled(EuiDescriptionList)`
+  .euiDescriptionList__title {
+    word-break: normal;
+  }
   .euiDescriptionList__title,
   .euiDescriptionList__description {
     overflow-wrap: break-word;


### PR DESCRIPTION
## Summary

Fixes an issue where the analyzer panel description titles are vertical:

<img width="1436" alt="image" src="https://github.com/elastic/kibana/assets/17211684/2761016c-61fa-4355-b91f-53060640e3f6">


After this fix:

<img width="880" alt="Screenshot 2023-11-01 at 12 10 13 PM" src="https://github.com/elastic/kibana/assets/17211684/cd86ced0-a121-4687-af61-5ffdfe7b16fb">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->