### PR TITLE
Efficiently render user display names instead of IDs in the alerts table

### DIFF
--- a/x-pack/plugins/security_solution/common/types/timeline/cells/index.ts
+++ b/x-pack/plugins/security_solution/common/types/timeline/cells/index.ts
@@ -8,6 +8,7 @@
 import type { EuiDataGridCellValueElementProps } from '@elastic/eui';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { ColumnHeaderOptions, RowRenderer } from '../..';
+import type { RenderCellValueContext } from '../../../../public/detections/configurations/security_solution_detections/fetch_page_context';
 import type { BrowserFields, TimelineNonEcsData } from '../../../search_strategy';
 
 /** The following props are provided to the function called by `renderCellValue` */
@@ -28,4 +29,5 @@ export type CellValueElementProps = EuiDataGridCellValueElementProps & {
   truncate?: boolean;
   key?: string;
   closeCellPopover?: () => void;
+  context?: RenderCellValueContext;
 };

--- a/x-pack/plugins/security_solution/public/common/hooks/use_bulk_get_user_profiles.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_bulk_get_user_profiles.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SecurityPluginStart } from '@kbn/security-plugin/public';
+import type { UserProfile } from '@kbn/security-plugin/common';
+import type { UserProfileWithAvatar } from '@kbn/user-profile-components';
+import { useQuery } from '@tanstack/react-query';
+import { useKibana } from '../lib/kibana';
+
+export interface BulkGetUserProfilesArgs {
+  security: SecurityPluginStart;
+  uids: Set<string>;
+}
+
+export const bulkGetUserProfiles = async ({
+  security,
+  uids,
+}: BulkGetUserProfilesArgs): Promise<UserProfile[]> => {
+  if (uids.size === 0) {
+    return [];
+  }
+  return security.userProfiles.bulkGet({ uids, dataPath: 'avatar' });
+};
+
+export const useBulkGetUserProfiles = ({ uids }: { uids: Set<string> }) => {
+  const { security } = useKibana().services;
+
+  return useQuery<UserProfileWithAvatar[]>(
+    ['useBulkGetUserProfiles', ...uids],
+    async () => {
+      return bulkGetUserProfiles({ security, uids });
+    },
+    {
+      retry: false,
+      staleTime: Infinity,
+    }
+  );
+};

--- a/x-pack/plugins/security_solution/public/common/lib/triggers_actions_ui/register_alerts_table_configuration.tsx
+++ b/x-pack/plugins/security_solution/public/common/lib/triggers_actions_ui/register_alerts_table_configuration.tsx
@@ -23,6 +23,7 @@ import {
 import { getDataTablesInStorageByIds } from '../../../timelines/containers/local_storage';
 import { getColumns } from '../../../detections/configurations/security_solution_detections';
 import { getRenderCellValueHook } from '../../../detections/configurations/security_solution_detections/render_cell_value';
+import { useFetchPageContext } from '../../../detections/configurations/security_solution_detections/fetch_page_context';
 import { SourcererScopeName } from '../../store/sourcerer/model';
 
 const registerAlertsTableConfiguration = (
@@ -64,6 +65,7 @@ const registerAlertsTableConfiguration = (
     sort,
     useFieldBrowserOptions: getUseTriggersActionsFieldBrowserOptions(SourcererScopeName.detections),
     showInspectButton: true,
+    useFetchPageContext,
   });
 
   // register Alert Table on RuleDetails Page
@@ -79,6 +81,7 @@ const registerAlertsTableConfiguration = (
     sort,
     useFieldBrowserOptions: getUseTriggersActionsFieldBrowserOptions(SourcererScopeName.detections),
     showInspectButton: true,
+    useFetchPageContext,
   });
 
   registerIfNotAlready(registry, {
@@ -91,6 +94,7 @@ const registerAlertsTableConfiguration = (
     useCellActions: getUseCellActionsHook(TableId.alertsOnCasePage),
     sort,
     showInspectButton: true,
+    useFetchPageContext,
   });
 
   registerIfNotAlready(registry, {
@@ -104,13 +108,14 @@ const registerAlertsTableConfiguration = (
     usePersistentControls: getPersistentControlsHook(TableId.alertsRiskInputs),
     sort,
     showInspectButton: true,
+    useFetchPageContext,
   });
 };
 
-const registerIfNotAlready = (
+const registerIfNotAlready: <T extends object>(
   registry: AlertsTableConfigurationRegistryContract,
-  registryArgs: AlertsTableConfigurationRegistry
-) => {
+  registryArgs: AlertsTableConfigurationRegistry<T>
+) => void = (registry, registryArgs) => {
   if (!registry.has(registryArgs.id)) {
     registry.register(registryArgs);
   }

--- a/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/fetch_page_context.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/fetch_page_context.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { UserProfile } from '@kbn/security-plugin/common';
+import type { UserProfileAvatarData } from '@kbn/user-profile-components';
+import type { PreFetchPageContext } from '@kbn/triggers-actions-ui-plugin/public/types';
+import { useBulkGetUserProfiles } from '../../../common/hooks/use_bulk_get_user_profiles';
+
+export interface RenderCellValueContext {
+  profiles: Array<UserProfile<{ avatar: UserProfileAvatarData }>> | undefined;
+  isLoading: boolean;
+}
+
+// Add new columns names to this array to render the user's display name instead of profile_uid
+export const profileUidColumns = ['kibana.alert.workflow_user'];
+
+export const useFetchPageContext: PreFetchPageContext<RenderCellValueContext> = ({
+  alerts,
+  columns,
+}) => {
+  const uids = new Set<string>();
+  alerts.forEach((alert) => {
+    profileUidColumns.forEach((columnId) => {
+      if (columns.find((column) => column.id === columnId) != null) {
+        const userUids = alert[columnId];
+        userUids?.forEach((uid) => uids.add(uid as string));
+      }
+    });
+  });
+  const result = useBulkGetUserProfiles({ uids });
+  return { profiles: result.data, isLoading: result.isLoading };
+};

--- a/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
+++ b/x-pack/plugins/security_solution/public/detections/configurations/security_solution_detections/render_cell_value.tsx
@@ -37,15 +37,16 @@ import { SUPPRESSED_ALERT_TOOLTIP } from './translations';
 import { VIEW_SELECTION } from '../../../../common/constants';
 import { getAllFieldsByName } from '../../../common/containers/source';
 import { eventRenderedViewColumns, getColumns } from './columns';
+import type { RenderCellValueContext } from './fetch_page_context';
 
 /**
  * This implementation of `EuiDataGrid`'s `renderCellValue`
  * accepts `EuiDataGridCellValueElementProps`, plus `data`
  * from the TGrid
  */
-export const RenderCellValue: React.FC<EuiDataGridCellValueElementProps & CellValueElementProps> = (
-  props
-) => {
+export const RenderCellValue: React.FC<
+  EuiDataGridCellValueElementProps & CellValueElementProps & { context?: RenderCellValueContext }
+> = (props) => {
   const { columnId, rowIndex, scopeId } = props;
   const isTourAnchor = useMemo(
     () =>
@@ -114,7 +115,7 @@ export const getRenderCellValueHook = ({
   scopeId: SourcererScopeName;
   tableId: TableId;
 }) => {
-  const useRenderCellValue: GetRenderCellValue = () => {
+  const useRenderCellValue: GetRenderCellValue<RenderCellValueContext> = ({ context }) => {
     const { browserFields } = useSourcererDataView(scopeId);
     const browserFieldsByName = useMemo(() => getAllFieldsByName(browserFields), [browserFields]);
     const getTable = useMemo(() => dataTableSelectors.getTableByIdSelector(), []);
@@ -192,10 +193,11 @@ export const getRenderCellValueHook = ({
             scopeId={tableId}
             truncate={truncate}
             asPlainText={false}
+            context={context}
           />
         );
       },
-      [browserFieldsByName, columnHeaders, browserFields]
+      [browserFieldsByName, columnHeaders, browserFields, context]
     );
     return result;
   };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/column_renderer.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/column_renderer.ts
@@ -11,6 +11,7 @@ import type { Filter } from '@kbn/es-query';
 import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
 import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
 import type { TimelineNonEcsData } from '../../../../../../common/search_strategy/timeline';
+import type { RenderCellValueContext } from '../../../../../detections/configurations/security_solution_detections/fetch_page_context';
 
 export interface ColumnRenderer {
   isInstance: (columnName: string, data: TimelineNonEcsData[]) => boolean;
@@ -28,6 +29,7 @@ export interface ColumnRenderer {
     truncate,
     values,
     key,
+    context,
   }: {
     asPlainText?: boolean;
     className?: string;
@@ -44,5 +46,6 @@ export interface ColumnRenderer {
     truncate?: boolean;
     values: string[] | null | undefined;
     key?: string;
+    context?: RenderCellValueContext;
   }) => React.ReactNode;
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/index.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/index.ts
@@ -18,6 +18,7 @@ import { systemRowRenderers } from './system/generic_row_renderer';
 import { threatMatchRowRenderer } from './cti/threat_match_row_renderer';
 import { reasonColumnRenderer } from './reason_column_renderer';
 import { eventSummaryColumnRenderer } from './event_summary_column_renderer';
+import { userProfileColumnRenderer } from './user_profile_renderer';
 
 // The row renderers are order dependent and will return the first renderer
 // which returns true from its isInstance call. The bottom renderers which
@@ -38,6 +39,7 @@ export const defaultRowRenderers: RowRenderer[] = [
 export const columnRenderers: ColumnRenderer[] = [
   reasonColumnRenderer,
   eventSummaryColumnRenderer,
+  userProfileColumnRenderer,
   plainColumnRenderer,
   emptyColumnRenderer,
   unknownColumnRenderer,

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_profile_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_profile_renderer.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiLoadingSpinner } from '@elastic/eui';
+import React from 'react';
+
+import type { EcsSecurityExtension as Ecs } from '@kbn/securitysolution-ecs';
+import { getUserDisplayName } from '@kbn/user-profile-components';
+import type { ColumnHeaderOptions, RowRenderer } from '../../../../../../common/types';
+import type { ColumnRenderer } from './column_renderer';
+import { plainColumnRenderer } from './plain_column_renderer';
+import { profileUidColumns } from '../../../../../detections/configurations/security_solution_detections/fetch_page_context';
+import type { RenderCellValueContext } from '../../../../../detections/configurations/security_solution_detections/fetch_page_context';
+
+export const userProfileColumnRenderer: ColumnRenderer = {
+  isInstance: (columnName) => profileUidColumns.includes(columnName),
+  renderColumn: ({
+    columnName,
+    ecsData,
+    eventId,
+    field,
+    isDetails,
+    isDraggable = true,
+    linkValues,
+    rowRenderers = [],
+    scopeId,
+    truncate,
+    values,
+    context,
+  }: {
+    columnName: string;
+    ecsData?: Ecs;
+    eventId: string;
+    field: ColumnHeaderOptions;
+    isDetails?: boolean;
+    isDraggable?: boolean;
+    linkValues?: string[] | null | undefined;
+    rowRenderers?: RowRenderer[];
+    scopeId: string;
+    truncate?: boolean;
+    values: string[] | undefined | null;
+    context?: RenderCellValueContext;
+  }) => {
+    // Show spinner if loading profiles or if there are no fetched profiles yet
+    // Do not show the loading spinner if context is not provided at all
+    if (context?.isLoading) {
+      return <EuiLoadingSpinner size="s" />;
+    }
+
+    const displayNames = values?.map((uid) => {
+      const userProfile = context?.profiles?.find((user) => uid === user.uid)?.user;
+      return userProfile ? getUserDisplayName(userProfile) : uid;
+    });
+    return plainColumnRenderer.renderColumn({
+      columnName,
+      eventId,
+      field,
+      isDetails,
+      isDraggable,
+      linkValues,
+      scopeId,
+      truncate,
+      values: displayNames,
+    });
+  },
+};

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/cell_rendering/default_cell_renderer.tsx
@@ -33,6 +33,7 @@ export const DefaultCellRenderer: React.FC<CellValueElementProps> = ({
   scopeId,
   truncate,
   asPlainText,
+  context,
 }) => {
   const asPlainTextDefault = useMemo(() => {
     return (
@@ -62,6 +63,7 @@ export const DefaultCellRenderer: React.FC<CellValueElementProps> = ({
         scopeId,
         truncate,
         values,
+        context,
       })}
     </StyledContent>
   );

--- a/x-pack/plugins/triggers_actions_ui/public/application/alert_table_config_registry.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/application/alert_table_config_registry.ts
@@ -15,7 +15,7 @@ import {
 export class AlertTableConfigRegistry {
   private readonly objectTypes: Map<
     string,
-    AlertsTableConfigurationRegistry | AlertsTableConfigurationRegistryWithActions
+    AlertsTableConfigurationRegistry<any> | AlertsTableConfigurationRegistryWithActions
   > = new Map();
 
   /**
@@ -28,7 +28,7 @@ export class AlertTableConfigRegistry {
   /**
    * Registers an object type to the type registry
    */
-  public register(objectType: AlertsTableConfigurationRegistry) {
+  public register<T extends object>(objectType: AlertsTableConfigurationRegistry<T>) {
     if (this.has(objectType.id)) {
       throw new Error(
         i18n.translate(

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/alerts_table/alerts_table.tsx
@@ -90,6 +90,11 @@ const AlertsTable: React.FunctionComponent<AlertsTableProps> = (props: AlertsTab
       options: props.alertsTableConfiguration.useActionsColumn,
     });
 
+  const renderCellContext = props.alertsTableConfiguration.useFetchPageContext?.({
+    alerts,
+    columns: props.columns,
+  });
+
   const {
     isBulkActionsColumnActive,
     getBulkActionsLeadingControlColumn,
@@ -318,9 +323,10 @@ const AlertsTable: React.FunctionComponent<AlertsTableProps> = (props: AlertsTab
       props.alertsTableConfiguration?.getRenderCellValue
         ? props.alertsTableConfiguration?.getRenderCellValue({
             setFlyoutAlert: handleFlyoutAlert,
+            context: renderCellContext,
           })
         : basicRenderCellValue,
-    [handleFlyoutAlert, props.alertsTableConfiguration]
+    [handleFlyoutAlert, props.alertsTableConfiguration, renderCellContext]
   )();
 
   const handleRenderCellValue = useCallback(

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -570,11 +570,21 @@ export type AlertsTableProps = {
 } & Partial<Pick<EuiDataGridProps, 'gridStyle' | 'rowHeightsOptions'>>;
 
 // TODO We need to create generic type between our plugin, right now we have different one because of the old alerts table
-export type GetRenderCellValue = ({
+export type GetRenderCellValue<T = unknown> = ({
   setFlyoutAlert,
+  context,
 }: {
   setFlyoutAlert?: (data: unknown) => void;
+  context?: T;
 }) => (props: unknown) => React.ReactNode;
+
+export type PreFetchPageContext<T> = ({
+  alerts,
+  columns,
+}: {
+  alerts: Alerts;
+  columns: EuiDataGridColumn[];
+}) => T;
 
 export type AlertTableFlyoutComponent =
   | React.FunctionComponent<AlertsTableFlyoutBaseProps>
@@ -671,7 +681,7 @@ export interface UseFieldBrowserOptionsArgs {
 
 export type UseFieldBrowserOptions = (args: UseFieldBrowserOptionsArgs) => FieldBrowserOptions;
 
-export interface AlertsTableConfigurationRegistry {
+export interface AlertsTableConfigurationRegistry<T extends object = object> {
   id: string;
   cases?: {
     featureId: string;
@@ -685,7 +695,7 @@ export interface AlertsTableConfigurationRegistry {
     footer: AlertTableFlyoutComponent;
   };
   sort?: SortCombinations[];
-  getRenderCellValue?: GetRenderCellValue;
+  getRenderCellValue?: GetRenderCellValue<T>;
   useActionsColumn?: UseActionsColumnRegistry;
   useBulkActions?: UseBulkActionsRegistry;
   useCellActions?: UseCellActions;
@@ -694,6 +704,7 @@ export interface AlertsTableConfigurationRegistry {
   };
   useFieldBrowserOptions?: UseFieldBrowserOptions;
   showInspectButton?: boolean;
+  useFetchPageContext?: PreFetchPageContext<T>;
 }
 
 export interface AlertsTableConfigurationRegistryWithActions


### PR DESCRIPTION
## Summary

Cherry-pick from @marshallmain branch to render cells efficiently inside the alerts table.