### PR TITLE
[Security Solution][Endpoint] Fix error when checking fleet-server standalone is registered with ES

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
@@ -290,7 +290,7 @@ const startFleetServerWithDocker = async ({
       await updateFleetElasticsearchOutputHostNames(kbnClient, log);
 
       if (isServerless) {
-        log.info(`Waiting for server to register with Elasticsearch`);
+        log.info(`Waiting for server [${hostname}] to register with Elasticsearch`);
 
         await waitForFleetServerToRegisterWithElasticsearch(kbnClient, hostname, 120000);
       } else {
@@ -684,7 +684,7 @@ const waitForFleetServerToRegisterWithElasticsearch = async (
         .then((response) => response.data)
         .catch(catchAxiosErrorFormatAndThrow);
 
-      return (fleetServerRecord.hits.total as estypes.SearchTotalHits).value === 1;
+      return ((fleetServerRecord?.hits?.total as estypes.SearchTotalHits)?.value ?? 0) === 1;
     }, RETRYABLE_TRANSIENT_ERRORS);
 
     if (!found) {


### PR DESCRIPTION
## Summary

- Fixes an error in fleet-server standalone (serverless) CLI service when query to ES returns "index not found" (expected if there are no servers registered)

