### PR TITLE
[Security Solution] fix weird page height scroll due to timeline bottom bar

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/bottom_bar/index.tsx
@@ -6,13 +6,10 @@
  */
 
 import React from 'react';
-import type { EuiBottomBarProps } from '@elastic/eui';
 import { useKibana } from '../../../../common/lib/kibana/kibana_react';
 import { TimelineId } from '../../../../../common/types/timeline';
 import { Flyout } from '../../../../timelines/components/flyout';
 import { useResolveRedirect } from '../../../../common/hooks/use_resolve_redirect';
-
-export const BOTTOM_BAR_CLASSNAME = 'timeline-bottom-bar';
 
 // eslint-disable-next-line react/display-name
 export const SecuritySolutionBottomBar = React.memo(() => {
@@ -22,10 +19,3 @@ export const SecuritySolutionBottomBar = React.memo(() => {
 
   return <Flyout timelineId={TimelineId.active} onAppLeave={onAppLeave} />;
 });
-
-export const SecuritySolutionBottomBarProps: EuiBottomBarProps & {
-  restrictWidth?: boolean | number | string;
-} = {
-  className: BOTTOM_BAR_CLASSNAME,
-  'data-test-subj': 'timeline-bottom-bar-container',
-};

--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -17,11 +17,7 @@ import { TimelineId } from '../../../../common/types/timeline';
 import { getTimelineShowStatusByIdSelector } from '../../../timelines/components/flyout/selectors';
 import { useDeepEqualSelector } from '../../../common/hooks/use_selector';
 import { GlobalKQLHeader } from './global_kql_header';
-import {
-  BOTTOM_BAR_CLASSNAME,
-  SecuritySolutionBottomBar,
-  SecuritySolutionBottomBarProps,
-} from './bottom_bar';
+import { SecuritySolutionBottomBar } from './bottom_bar';
 import { useShowTimeline } from '../../../common/utils/timeline/use_show_timeline';
 
 /**
@@ -38,14 +34,6 @@ const StyledKibanaPageTemplate = styled(KibanaPageTemplate)<
   .kbnSolutionNav {
     background-color: ${({ theme }) => theme.colors.emptyShade};
   }
-
-  .${BOTTOM_BAR_CLASSNAME} {
-    animation: 'none !important'; // disable the default bottom bar slide animation
-    background: ${({ theme }) => theme.colors.emptyShade}; // Override bottom bar black background
-    color: inherit; // Necessary to override the bottom bar 'white text'
-    transform: ${(
-      { $isShowingTimelineOverlay } // Since the bottom bar wraps the whole overlay now, need to override any transforms when it is open
-    ) => ($isShowingTimelineOverlay ? 'none' : 'translateY(calc(100% - 50px))')};
 
     .${IS_DRAGGING_CLASS_NAME} & {
       // When a drag is in process the bottom flyout should slide up to allow a drop
@@ -95,7 +83,7 @@ export const SecuritySolutionTemplateWrapper: React.FC<Omit<KibanaPageTemplatePr
             {children}
           </KibanaPageTemplate.Section>
           {isTimelineBottomBarVisible && (
-            <KibanaPageTemplate.BottomBar {...SecuritySolutionBottomBarProps}>
+            <KibanaPageTemplate.BottomBar data-test-subj="timeline-bottom-bar-container">
               <EuiThemeProvider colorMode={globalColorMode}>
                 <SecuritySolutionBottomBar />
               </EuiThemeProvider>


### PR DESCRIPTION
## Summary

This PR fixes a height issue due to the timeline bottom bar having some unwanted css. During my testing, removing the CSS fixes the issue (primarily visible on the alerts page) without changing the behavior or UI on any other page where the timeline bottom bar is displayed.


https://github.com/elastic/kibana/assets/17276605/c62a4d22-ab4b-461e-8c47-ec994b55b9ad

