### PR TITLE
[Shareable dashboards] Add share results flyout

### DIFF
--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/processing_share_to_space.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/processing_share_to_space.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiHorizontalRule, EuiText } from '@elastic/eui';
+import React from 'react';
+
+import type { SavedObjectsUpdateObjectsSpacesResponse } from '@kbn/core-saved-objects-api-server';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { ShareResult } from './share_result';
+import type { SpacesDataEntry } from '../../types';
+import type { ShareOptions } from '../types';
+
+interface Props {
+  shareResult?: SavedObjectsUpdateObjectsSpacesResponse;
+  spaces: SpacesDataEntry[];
+  shareOptions: ShareOptions;
+}
+
+export const ProcessingShareToSpace = (props: Props) => {
+  const {
+    shareOptions: { initiallySelectedSpaceIds, selectedSpaceIds },
+    shareResult,
+    spaces,
+  } = props;
+
+  const objects = shareResult?.objects || [];
+
+  const removeFromSpaceIds = props.shareOptions.initiallySelectedSpaceIds.filter(
+    (id) => !selectedSpaceIds.includes(id)
+  );
+  const addToSpaceIds = selectedSpaceIds.filter((id) => !initiallySelectedSpaceIds.includes(id));
+
+  return (
+    <div data-test-subj="share-to-space-processing">
+      {addToSpaceIds.length ? (
+        <>
+          <EuiHorizontalRule margin="m" />
+          <EuiText size="s">
+            <h5>
+              <FormattedMessage
+                id="xpack.spaces.management.shareToSpace.shareResultsLabel"
+                defaultMessage="Results (Shared)"
+              />
+            </h5>
+          </EuiText>
+          {addToSpaceIds.map((id) => {
+            const space = spaces.find((s) => s.id === id)!;
+            const addedObjects = objects.filter(({ spaces: namespaces }: { spaces: string[] }) =>
+              namespaces.includes(id)
+            );
+
+            return (
+              <ShareResult
+                space={space}
+                objects={addedObjects}
+                isLoading={!objects.length}
+                iconProps={{ type: 'checkInCircleFilled', color: 'success' }}
+              />
+            );
+          })}
+        </>
+      ) : null}
+      {removeFromSpaceIds.length ? (
+        <>
+          <EuiHorizontalRule margin="m" />
+          <EuiText size="s">
+            <h5>
+              <FormattedMessage
+                id="xpack.spaces.management.shareToSpace.unshareResultsLabel"
+                defaultMessage="Results (Unshared)"
+              />
+            </h5>
+          </EuiText>
+          {removeFromSpaceIds.map((id) => {
+            const space = spaces.find((s) => s.id === id)!;
+            const removedObjects = objects.filter(
+              ({ spaces: namespaces }: { spaces: string[] }) => !namespaces.includes(id)
+            );
+
+            return (
+              <ShareResult
+                space={space}
+                objects={removedObjects}
+                isLoading={!objects.length}
+                iconProps={{ type: 'checkInCircleFilled', color: 'primary' }}
+              />
+            );
+          })}
+        </>
+      ) : null}
+    </div>
+  );
+};

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_result.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/share_result.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  EuiAccordion,
+  EuiBadge,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiLoadingSpinner,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import React, { lazy, Suspense } from 'react';
+
+import type { SavedObjectsUpdateObjectsSpacesResponseObject } from '@kbn/core-saved-objects-api-server';
+
+import { getSpaceAvatarComponent } from '../../space_avatar';
+import type { SpacesDataEntry } from '../../types';
+
+// No need to wrap LazySpaceAvatar in an error boundary, because it is one of the first chunks loaded when opening Kibana.
+const LazySpaceAvatar = lazy(() =>
+  getSpaceAvatarComponent().then((component) => ({ default: component }))
+);
+
+interface Props {
+  space: SpacesDataEntry;
+  objects: SavedObjectsUpdateObjectsSpacesResponseObject[];
+  isLoading: boolean;
+  iconProps: {
+    type: string;
+    color: string;
+  };
+}
+
+export const ShareResult = ({ space, objects, isLoading, iconProps }: Props) => {
+  return (
+    <>
+      <EuiSpacer size="m" />
+
+      <EuiAccordion
+        id={`shareToSpace-${space.id}`}
+        data-test-subj={`sts-space-result-${space.id}`}
+        className="spcShareToSpaceResult"
+        buttonContent={
+          <EuiFlexGroup responsive={false}>
+            <EuiFlexItem grow={false}>
+              <Suspense fallback={<EuiLoadingSpinner />}>
+                <LazySpaceAvatar space={space} size="s" />
+              </Suspense>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText>{space.name}</EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        }
+        extraAction={
+          !isLoading ? (
+            <EuiFlexGroup gutterSize="xs">
+              <EuiFlexItem>
+                <EuiIcon type={iconProps.type} color={iconProps.color} />
+              </EuiFlexItem>
+              <EuiFlexItem>
+                <EuiBadge>{objects.length}</EuiBadge>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          ) : (
+            <EuiLoadingSpinner />
+          )
+        }
+      >
+        {objects.map((object: SavedObjectsUpdateObjectsSpacesResponseObject) => (
+          <>
+            <EuiSpacer size="s" />
+            <EuiFlexGroup>
+              <EuiFlexItem grow={false}>{object.type}</EuiFlexItem>
+              <EuiFlexItem grow={5}>{object.id}</EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiIcon type={iconProps.type} color={iconProps.color} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </>
+        ))}
+      </EuiAccordion>
+    </>
+  );
+};

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/types.ts
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { SavedObjectsImportResponse, SavedObjectsImportRetry } from '@kbn/core/public';
+import type { SavedObjectsUpdateObjectsSpacesResponse } from '@kbn/core-saved-objects-api-server';
 
 export interface ShareOptions {
   selectedSpaceIds: string[];
@@ -69,7 +70,7 @@ export interface ShareToSpaceFlyoutProps {
     objects: Array<{ type: string; id: string }>,
     spacesToAdd: string[],
     spacesToRemove: string[]
-  ) => Promise<void>;
+  ) => SavedObjectsUpdateObjectsSpacesResponse;
   /**
    * Optional callback when the target object and its relatives are updated.
    */

--- a/x-pack/plugins/spaces/public/spaces_manager/spaces_manager.ts
+++ b/x-pack/plugins/spaces/public/spaces_manager/spaces_manager.ts
@@ -10,7 +10,10 @@ import { BehaviorSubject } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
 
 import type { HttpSetup } from '@kbn/core/public';
-import type { SavedObjectsCollectMultiNamespaceReferencesResponse } from '@kbn/core-saved-objects-api-server';
+import type {
+  SavedObjectsCollectMultiNamespaceReferencesResponse,
+  SavedObjectsUpdateObjectsSpacesResponse,
+} from '@kbn/core-saved-objects-api-server';
 import type { LegacyUrlAliasTarget } from '@kbn/core-saved-objects-common';
 
 import type { GetAllSpacesOptions, GetSpaceResult, Space } from '../../common';
@@ -171,7 +174,7 @@ export class SpacesManager {
     objects: SavedObjectTarget[],
     spacesToAdd: string[],
     spacesToRemove: string[]
-  ): Promise<void> {
+  ): Promise<SavedObjectsUpdateObjectsSpacesResponse> {
     return this.http.post(`/api/spaces/_update_objects_spaces`, {
       body: JSON.stringify({ objects, spacesToAdd, spacesToRemove }),
     });


### PR DESCRIPTION
## Summary

~Feature branch: https://github.com/elastic/kibana/pull/168166.~
This PR is going to be merged into main as it's own enhancement independent of the shared dashboards effort.
Closes #167956.
Blocked by #171456.

This updates the `Share to spaces` flyout with an additional view showing the details results of the share action. Similar to the `Copy to spaces` flyout, this view shows which objects were shared and unshared from each selected/delected space.

<img width="516" alt="Screenshot 2023-11-01 at 4 54 19 PM" src="https://github.com/elastic/kibana/assets/1697105/521eef16-6587-41ca-b417-94a346ab1954">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
