### PR TITLE
Remove unnecessary backticks from API docs.

### DIFF
--- a/docs/user/api.asciidoc
+++ b/docs/user/api.asciidoc
@@ -14,7 +14,7 @@ For example:
 
 [source,sh]
 --------------------------------------------------
-`GET kbn:/api/index_management/indices`
+GET kbn:/api/index_management/indices
 --------------------------------------------------
 
 Note: this will automatically prefix `s/{space_id}/` on the API request if ran from a non-default Kibana Space.


### PR DESCRIPTION
Manual "frontport" that cherry-picks the changes from https://github.com/elastic/kibana/pull/170376 to ensure they land in `main` as well. 