### PR TITLE
[Cases] Fix filtering e2e flaky tests

### DIFF
--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -85,7 +85,6 @@ export function CasesTableServiceProvider(
 
     async validateCasesTableHasNthRows(nrRows: number) {
       await retry.waitFor(`the cases table to have ${nrRows} cases`, async () => {
-        await this.refreshTable();
         const rows = await find.allByCssSelector('[data-test-subj*="cases-table-row-"');
         return rows.length === nrRows;
       });

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import expect from '@kbn/expect';
 import { CaseSeverityWithAll } from '@kbn/cases-plugin/common/ui';
 import { CaseSeverity, CaseStatuses } from '@kbn/cases-plugin/common/types/domain';
 import { WebElementWrapper } from '../../../../../test/functional/services/lib/web_element_wrapper';
@@ -85,10 +84,13 @@ export function CasesTableServiceProvider(
     },
 
     async validateCasesTableHasNthRows(nrRows: number) {
-      await retry.tryForTime(3000, async () => {
+      await retry.waitFor(`the cases table to have ${nrRows} cases`, async () => {
+        await this.refreshTable();
         const rows = await find.allByCssSelector('[data-test-subj*="cases-table-row-"');
-        expect(rows.length).equal(nrRows);
+        return rows.length === nrRows;
       });
+
+      await header.waitUntilLoadingHasFinished();
     },
 
     async waitForCasesToBeListed() {

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -279,8 +279,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
       });
     });
 
-    // FLAKY: https://github.com/elastic/kibana/issues/152925
-    describe.skip('filtering', () => {
+    describe('filtering', () => {
       const caseTitle = 'matchme';
       const caseIds: string[] = [];
 
@@ -459,8 +458,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.existOrFail(`case-table-column-severity-${CaseSeverity.MEDIUM}`);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/152928
-      describe.skip('assignees filtering', () => {
+      describe('assignees filtering', () => {
         it('filters cases by the first cases all user assignee', async () => {
           await cases.casesTable.filterByAssignee('all');
           await cases.casesTable.validateCasesTableHasNthRows(1);


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.

Fixes: https://github.com/elastic/kibana/issues/152928, https://github.com/elastic/kibana/issues/152925, https://github.com/elastic/kibana/issues/152958

Flaky test runners: 
- ESS: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3863, https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3864, https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3876
- Security serverless: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3866
- Observability serverless: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3867

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->