### PR TITLE
[UnifiedSearch] PoC for clipboard-based time range transfer

### DIFF
--- a/src/plugins/unified_search/public/query_string_input/date_clipboard_items.tsx
+++ b/src/plugins/unified_search/public/query_string_input/date_clipboard_items.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ApplyTime, EuiFlexGroup, EuiCopy, EuiFlexItem, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import React, { useState } from 'react';
+import useRafLoop from 'react-use/lib/useRafLoop';
+
+const KIBANA_PREFIX = 'kibanaTimeRange:';
+const KIBANA_REGEX = new RegExp(`^${KIBANA_PREFIX}`);
+
+export function DateClipboardItems({
+  start,
+  end,
+  applyTime,
+}: {
+  applyTime?: ApplyTime;
+  start: string;
+  end: string;
+}) {
+  const [clipboardDate, setClipboardDate] = useState<string | undefined>();
+
+  useRafLoop(() => {
+    navigator.clipboard.readText().then((clipText) => {
+      if (KIBANA_REGEX.test(clipText)) {
+        setClipboardDate(clipText.replace(KIBANA_PREFIX, ''));
+      }
+    });
+  });
+
+  function applyPastedTimerange() {
+    const [newStart, newEnd] = clipboardDate?.split(' to ') || [];
+    if (newStart != null && newEnd != null) {
+      applyTime!({ start: newStart, end: newEnd });
+    }
+  }
+
+  return (
+    <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false} wrap>
+      <EuiFlexItem grow={false}>
+        <EuiCopy textToCopy={`${KIBANA_PREFIX}${start} to ${end}`}>
+          {(copy) => (
+            <EuiLink
+              onClick={() => {
+                copy();
+              }}
+            >
+              {i18n.translate('unifiedSearch.queryBarTopRow.datePicker.clipboardCopyLabel', {
+                defaultMessage: 'Copy time range',
+              })}
+            </EuiLink>
+          )}
+        </EuiCopy>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiLink onClick={applyPastedTimerange} disabled={!clipboardDate}>
+          {clipboardDate
+            ? i18n.translate('unifiedSearch.queryBarTopRow.datePicker.clipboardPasteLabel', {
+                defaultMessage: 'Paste time range',
+              })
+            : i18n.translate('unifiedSearch.queryBarTopRow.datePicker.clipboardNoPasteLabel', {
+                defaultMessage: 'No data in clipboard',
+              })}
+        </EuiLink>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}

--- a/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
+++ b/src/plugins/unified_search/public/query_string_input/query_bar_top_row.tsx
@@ -57,6 +57,7 @@ import type {
   SuggestionsListSize,
 } from '../typeahead/suggestions_component';
 import './query_bar.scss';
+import { DateClipboardItems } from './date_clipboard_items';
 
 export const strings = {
   getNeedsUpdatingLabel: () =>
@@ -478,6 +479,23 @@ export const QueryBarTopRow = React.memo(
           isQuickSelectOnly={isMobile ? false : isQueryInputFocused}
           width={isMobile ? 'full' : 'auto'}
           compressed={shouldShowDatePickerAsBadge()}
+          customQuickSelectPanels={
+            props.dateRangeFrom != null && props.dateRangeTo != null
+              ? [
+                  {
+                    title: i18n.translate(
+                      'unifiedSearch.queryBarTopRow.datePicker.clipboardPanelTitle',
+                      {
+                        defaultMessage: 'From clipboard',
+                      }
+                    ),
+                    content: (
+                      <DateClipboardItems start={props.dateRangeFrom} end={props.dateRangeTo} />
+                    ),
+                  },
+                ]
+              : undefined
+          }
         />
       );
       const component = getWrapperWithTooltip(datePicker, enableTooltip, props.query);


### PR DESCRIPTION
## Summary

PoC for #170374 

This PoC relies on clipboard permissions to read from it and detect there's a valid Kibana date range copied.
The detect logic is async and rely on the `rAF` idle callback, to reduce the number of rerenders of the super date picker dropdown.

Relative date ranges supports:

![date_time_clipboard_2](https://github.com/elastic/kibana/assets/924948/72d80577-bfe2-40ba-8340-defe34d76f2a)

Mixed absolute + relative ranges support:

![date_time_clipboard_3](https://github.com/elastic/kibana/assets/924948/b34aa53f-d294-4e21-83e0-73951d4b365b)

Copy from anywhere and paste it:

![date_time_clipboard_4](https://github.com/elastic/kibana/assets/924948/bc4dab52-5897-4828-9e29-646c9c92c117)