### PR TITLE
`resolver_generator.js` Use optional chaining when checking if plugins exists on API response

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/common/stack_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/stack_services.ts
@@ -337,7 +337,7 @@ export const isServerlessKibanaFlavor = async (client: KbnClient | Client): Prom
     // If we don't have status for plugins, then error
     // the Status API will always return something (its an open API), but if auth was successful,
     // it will also return more data.
-    if (!kbnStatus.status.plugins) {
+    if (!kbnStatus?.status?.plugins) {
       throw new Error(
         `Unable to retrieve Kibana plugins status (likely an auth issue with the username being used for kibana)`
       );


### PR DESCRIPTION
## Summary
Tiny bug in the `resolver_generator.js` script I found on my travels. 

Changes error message from: 
```
TypeError: Cannot read properties of undefined (reading 'plugins')
```
To the intended:

```
Error: Unable to retrieve Kibana plugins status (likely an auth issue with the username being used for kibana)
```