### PR TITLE
Added context_propagation_only APM agent setting

### DIFF
--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/__snapshots__/index.test.ts.snap
@@ -73,6 +73,11 @@ Array [
     "validationName": "(\\"true\\" | \\"false\\")",
   },
   Object {
+    "key": "context_propagation_only",
+    "type": "boolean",
+    "validationName": "(\\"true\\" | \\"false\\")",
+  },
+  Object {
     "key": "dedot_custom_metrics",
     "type": "boolean",
     "validationName": "(\\"true\\" | \\"false\\")",

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/general_settings.ts
@@ -337,6 +337,26 @@ export const generalSettings: RawSettingDefinition[] = [
     excludeAgents: ['nodejs', 'rum-js', 'js-base'],
   },
 
+  {
+    key: 'context_propagation_only',
+    type: 'boolean',
+    defaultValue: 'false',
+    label: i18n.translate(
+      'xpack.apm.agentConfig.context_propagation_only.label',
+      {
+        defaultMessage: 'Context Propagation Only',
+      }
+    ),
+    description: i18n.translate(
+      'xpack.apm.agentConfig.context_propagation_only.description',
+      {
+        defaultMessage:
+          'When set to true, disables log sending, metrics and trace collection. Trace context propagation and log correlation will stay active.',
+      }
+    ),
+    includeAgents: ['java'],
+  },
+
   // SERVER_TIMEOUT
   {
     key: 'server_timeout',

--- a/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/plugins/apm/common/agent_configuration/setting_definitions/index.test.ts
@@ -75,6 +75,7 @@ describe('filterByAgent', () => {
           'profiling_inferred_spans_min_duration',
           'profiling_inferred_spans_sampling_interval',
           'recording',
+          'context_propagation_only',
           'sanitize_field_names',
           'server_timeout',
           'span_frames_min_duration',


### PR DESCRIPTION
## Summary

In https://github.com/elastic/apm/pull/830 the new centrally configurable option `context_propagation_only` has been added. This PR adds this configuration option to Kibana. The option will very likely be available with the next APM Java Agent release, so I've included that agent already in this PR.

I've tried to locally test this PR by following the contribution guide and running `yarn es snapshot --license trial` and `yarn start` . Unfortunately Kibana fails to start with the following error:

```
[ERROR][elasticsearch-service] Unable to retrieve version information from Elasticsearch nodes. {"ok":false,"message":"Unknown resource."}
```

Some help here would be appreciated.

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->