### PR TITLE
[EBT] Click's target circuit-breakers

### DIFF
--- a/packages/core/analytics/core-analytics-browser-internal/src/track_clicks.test.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/track_clicks.test.ts
@@ -84,6 +84,38 @@ describe('trackClicks', () => {
     `);
   });
 
+  test('trims values longer than 256 chars', async () => {
+    // Gather an actual "click" event
+    const event$ = new ReplaySubject<MouseEvent>(1);
+    const parent = document.createElement('div');
+    parent.setAttribute('data-test-subj', 'test-click-target-parent');
+    const element = document.createElement('button');
+    parent.appendChild(element);
+    const reallyLongText = `test-click-target-${new Array(10000).fill('0').join('')}`;
+    element.setAttribute('data-test-subj', reallyLongText);
+    element.innerText = 'test'; // Only to validate that it is not included in the event.
+    element.value = 'test'; // Only to validate that it is not included in the event.
+    element.addEventListener('click', (e) => event$.next(e));
+    element.click();
+    // Using an observable because the event might not be immediately available
+    const event = await firstValueFrom(event$.pipe(take(1)));
+    event$.complete(); // No longer needed
+
+    trackClicks(analyticsClientMock, true);
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    (addEventListenerSpy.mock.calls[0][1] as EventListener)(event);
+    expect(analyticsClientMock.reportEvent).toHaveBeenCalledTimes(1);
+    expect(analyticsClientMock.reportEvent).toHaveBeenCalledWith('click', {
+      target: [
+        'DIV',
+        'data-test-subj=test-click-target-parent',
+        'BUTTON',
+        `data-test-subj=test-click-target-${new Array(256 - 33).fill('0').join('')}`,
+      ],
+    });
+  });
+
   test('swallows any processing errors when not in dev mode', async () => {
     trackClicks(analyticsClientMock, false);
     expect(addEventListenerSpy).toHaveBeenCalledTimes(1);

--- a/packages/core/analytics/core-analytics-browser-internal/src/track_clicks.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/track_clicks.ts
@@ -19,6 +19,7 @@ const HTML_ATTRIBUTES_TO_REMOVE = [
   'data-rfd-draggable-id',
   'href',
   'value',
+  'title',
 ];
 
 /**
@@ -81,6 +82,6 @@ function getTargetDefinition(target: HTMLElement): string[] {
     target.tagName,
     ...[...target.attributes]
       .filter((attr) => !HTML_ATTRIBUTES_TO_REMOVE.includes(attr.name))
-      .map((attr) => `${attr.name}=${attr.value}`),
+      .map((attr) => `${attr.name}=${attr.value}`.slice(0, 256)),
   ];
 }


### PR DESCRIPTION
## Summary

We've noticed some DOM values captured by the `click`'s target are just too large.

This PR adds a circuit-breaker to truncate each value to 256 chars max.

It also adds `title` as a property to not capture due to being potentially sensitive to contain users' data in it.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->