### PR TITLE
[8.11] [OAS] Remove repeated servers from connector APIs (#169710)

### DIFF
--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -14,8 +14,7 @@
   },
   "servers": [
     {
-      "url": "http://localhost:5601",
-      "description": "local"
+      "url": "/"
     }
   ],
   "security": [
@@ -173,18 +172,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/connector/{connectorId}": {
       "get": {
@@ -222,35 +211,9 @@
             "$ref": "#/components/responses/401"
           },
           "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "example": "Not Found"
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
-                    },
-                    "statusCode": {
-                      "type": "integer",
-                      "example": 404
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/components/responses/404"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "delete": {
         "summary": "Deletes a connector.",
@@ -278,35 +241,9 @@
             "$ref": "#/components/responses/401"
           },
           "404": {
-            "description": "Object is not found.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "example": "Not Found"
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
-                    },
-                    "statusCode": {
-                      "type": "integer",
-                      "example": 404
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/components/responses/404"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "post": {
         "summary": "Creates a connector.",
@@ -439,12 +376,7 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "put": {
         "summary": "Updates the attributes for a connector.",
@@ -586,18 +518,8 @@
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/connectors": {
       "get": {
@@ -683,18 +605,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/connector_types": {
       "get": {
@@ -783,18 +695,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/connector/{connectorId}/_execute": {
       "post": {
@@ -966,18 +868,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/action/{actionId}": {
       "delete": {
@@ -1006,12 +898,7 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "get": {
         "summary": "Retrieves a connector by ID.",
@@ -1036,12 +923,7 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "put": {
         "summary": "Updates the attributes for a connector.",
@@ -1095,18 +977,8 @@
           "404": {
             "$ref": "#/components/responses/404"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions": {
       "get": {
@@ -1139,12 +1011,7 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
+        }
       },
       "post": {
         "summary": "Creates a connector.",
@@ -1198,18 +1065,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/list_action_types": {
       "get": {
@@ -1271,18 +1128,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     },
     "/s/{spaceId}/api/actions/action/{actionId}/_execute": {
       "post": {
@@ -1364,18 +1211,8 @@
           "401": {
             "$ref": "#/components/responses/401"
           }
-        },
-        "servers": [
-          {
-            "url": "https://localhost:5601"
-          }
-        ]
-      },
-      "servers": [
-        {
-          "url": "https://localhost:5601"
         }
-      ]
+      }
     }
   },
   "components": {

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -9,8 +9,7 @@ info:
     name: Elastic License 2.0
     url: https://www.elastic.co/licensing/elastic-license
 servers:
-  - url: http://localhost:5601
-    description: local
+  - url: /
 security:
   - basicAuth: []
   - apiKeyAuth: []
@@ -88,10 +87,6 @@ paths:
                   $ref: '#/components/examples/create_xmatters_connector_response'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/connector/{connectorId}:
     get:
       summary: Retrieves a connector by ID.
@@ -116,23 +111,7 @@ paths:
         '401':
           $ref: '#/components/responses/401'
         '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: Not Found
-                  message:
-                    type: string
-                    example: Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found
-                  statusCode:
-                    type: integer
-                    example: 404
-      servers:
-        - url: https://localhost:5601
+          $ref: '#/components/responses/404'
     delete:
       summary: Deletes a connector.
       operationId: deleteConnector
@@ -150,23 +129,7 @@ paths:
         '401':
           $ref: '#/components/responses/401'
         '404':
-          description: Object is not found.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: Not Found
-                  message:
-                    type: string
-                    example: Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found
-                  statusCode:
-                    type: integer
-                    example: 404
-      servers:
-        - url: https://localhost:5601
+          $ref: '#/components/responses/404'
     post:
       summary: Creates a connector.
       operationId: createConnectorId
@@ -231,8 +194,6 @@ paths:
                   $ref: '#/components/examples/create_index_connector_response'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
     put:
       summary: Updates the attributes for a connector.
       operationId: updateConnector
@@ -303,10 +264,6 @@ paths:
           $ref: '#/components/responses/401'
         '404':
           $ref: '#/components/responses/404'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/connectors:
     get:
       summary: Retrieves all connectors.
@@ -369,10 +326,6 @@ paths:
                   $ref: '#/components/examples/get_connectors_response'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/connector_types:
     get:
       summary: Retrieves a list of all connector types.
@@ -436,10 +389,6 @@ paths:
                   $ref: '#/components/examples/get_connector_types_response'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/connector/{connectorId}/_execute:
     post:
       summary: Runs a connector.
@@ -536,10 +485,6 @@ paths:
                   $ref: '#/components/examples/run_swimlane_connector_response'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/action/{actionId}:
     delete:
       summary: Deletes a connector.
@@ -558,8 +503,6 @@ paths:
           description: Indicates a successful call.
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
     get:
       summary: Retrieves a connector by ID.
       operationId: legacyGetConnector
@@ -575,8 +518,6 @@ paths:
           $ref: '#/components/responses/200_actions'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
     put:
       summary: Updates the attributes for a connector.
       operationId: legacyUpdateConnector
@@ -611,10 +552,6 @@ paths:
           $ref: '#/components/responses/200_actions'
         '404':
           $ref: '#/components/responses/404'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions:
     get:
       summary: Retrieves all connectors.
@@ -636,8 +573,6 @@ paths:
                   $ref: '#/components/schemas/action_response_properties'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
     post:
       summary: Creates a connector.
       operationId: legacyCreateConnector
@@ -674,10 +609,6 @@ paths:
           $ref: '#/components/responses/200_actions'
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/list_action_types:
     get:
       summary: Retrieves a list of all connector types.
@@ -721,10 +652,6 @@ paths:
                       description: The name of the connector type.
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
   /s/{spaceId}/api/actions/action/{actionId}/_execute:
     post:
       summary: Runs a connector.
@@ -775,10 +702,6 @@ paths:
                     description: The status of the action.
         '401':
           $ref: '#/components/responses/401'
-      servers:
-        - url: https://localhost:5601
-    servers:
-      - url: https://localhost:5601
 components:
   securitySchemes:
     basicAuth:

--- a/x-pack/plugins/actions/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/actions/docs/openapi/entrypoint.yaml
@@ -12,8 +12,7 @@ tags:
   - name: connectors
     description: Connector APIs enable you to create and manage connectors.
 servers:
-  - url: 'http://localhost:5601'
-    description: local
+  - url: /
 paths:
    '/s/{spaceId}/api/actions/connector':
     $ref: 'paths/s@{spaceid}@api@actions@connector.yaml'

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions.yaml
@@ -18,8 +18,6 @@ get:
               $ref: '../components/schemas/action_response_properties.yaml' 
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
 
 post:
   summary: Creates a connector.
@@ -59,8 +57,3 @@ post:
       $ref: '../components/responses/200_actions.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601
-

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@action@{actionid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@action@{actionid}.yaml
@@ -16,8 +16,6 @@ delete:
       description: Indicates a successful call.
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
 
 get:
   summary: Retrieves a connector by ID.
@@ -34,8 +32,6 @@ get:
       $ref: '../components/responses/200_actions.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
 
 put:
   summary: Updates the attributes for a connector.
@@ -71,8 +67,3 @@ put:
       $ref: '../components/responses/200_actions.yaml'
     '404':
       $ref: '../components/responses/404.yaml'
-  servers:
-    - url: https://localhost:5601
-
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@action@{actionid}@_execute.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@action@{actionid}@_execute.yaml
@@ -47,7 +47,3 @@ post:
                 description: The status of the action.
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector.yaml
@@ -67,7 +67,3 @@ post:
               $ref: '../components/examples/create_xmatters_connector_response.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -21,23 +21,7 @@ get:
     '401':
       $ref: '../components/responses/401.yaml'
     '404':
-      description: Object is not found.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-                example: Not Found
-              message:
-                type: string
-                example: "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
-              statusCode:
-                type: integer
-                example: 404
-  servers:
-    - url: https://localhost:5601
+      $ref: '../components/responses/404.yaml'
 
 delete:
   summary: Deletes a connector.
@@ -57,23 +41,7 @@ delete:
     '401':
       $ref: '../components/responses/401.yaml'
     '404':
-      description: Object is not found.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              error:
-                type: string
-                example: Not Found
-              message:
-                type: string
-                example: "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
-              statusCode:
-                type: integer
-                example: 404
-  servers:
-    - url: https://localhost:5601
+      $ref: '../components/responses/404.yaml'
 
 post:
   summary: Creates a connector.
@@ -139,8 +107,6 @@ post:
               $ref: '../components/examples/create_index_connector_response.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
 
 put:
   summary: Updates the attributes for a connector.
@@ -212,7 +178,3 @@ put:
       $ref: '../components/responses/401.yaml'
     '404':
       $ref: '../components/responses/404.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}@_execute.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}@_execute.yaml
@@ -95,7 +95,3 @@ post:
               $ref: '../components/examples/run_swimlane_connector_response.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector_types.yaml
@@ -60,7 +60,3 @@ get:
               $ref: '../components/examples/get_connector_types_response.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
@@ -59,7 +59,3 @@ get:
               $ref: '../components/examples/get_connectors_response.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@list_action_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@list_action_types.yaml
@@ -40,7 +40,3 @@ get:
                   description: The name of the connector type.
     '401':
       $ref: '../components/responses/401.yaml'
-  servers:
-    - url: https://localhost:5601
-servers:
-  - url: https://localhost:5601


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[OAS] Remove repeated servers from connector APIs (#169710)](https://github.com/elastic/kibana/pull/169710)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2023-11-02T15:54:54Z","message":"[OAS] Remove repeated servers from connector APIs (#169710)","sha":"161e129fa3e08e4e701356e7be92a8574f06620b","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","release_note:skip","docs","Feature:Actions/ConnectorsManagement","backport:prev-minor","v8.12.0"],"number":169710,"url":"https://github.com/elastic/kibana/pull/169710","mergeCommit":{"message":"[OAS] Remove repeated servers from connector APIs (#169710)","sha":"161e129fa3e08e4e701356e7be92a8574f06620b"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169710","number":169710,"mergeCommit":{"message":"[OAS] Remove repeated servers from connector APIs (#169710)","sha":"161e129fa3e08e4e701356e7be92a8574f06620b"}}]}] BACKPORT-->