### PR TITLE
[ResponseOps] Elasticsearch query rule with ES|QL threshold validation

### DIFF
--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.test.ts
@@ -354,6 +354,31 @@ describe('ruleType Params validate()', () => {
     expect(onValidate()).not.toThrow();
   });
 
+  describe('esqlQuery search type', () => {
+    beforeEach(() => {
+      params = { ...DefaultParams, searchType: 'esqlQuery', esqlQuery: { esql: 'from test' } };
+      delete params.esQuery;
+      delete params.index;
+    });
+
+    it('fails for invalid thresholdComparator', async () => {
+      params.thresholdComparator = Comparator.LT;
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(
+        `"[thresholdComparator]: is required to be greater than"`
+      );
+    });
+
+    it('fails for invalid threshold', async () => {
+      params.threshold = [7];
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(`"[threshold]: is required to be 0"`);
+    });
+
+    it('fails for undefined timeField', async () => {
+      params.timeField = undefined;
+      expect(onValidate()).toThrowErrorMatchingInlineSnapshot(`"[timeField]: is required"`);
+    });
+  });
+
   function onValidate(): () => void {
     return () => validate();
   }

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/rule_type_params.ts
@@ -159,7 +159,28 @@ function validateParams(anyParams: unknown): string | undefined {
     }
   }
 
-  if (isSearchSourceRule(searchType) || isEsqlQueryRule(searchType)) {
+  if (isSearchSourceRule(searchType)) {
+    return;
+  }
+
+  if (isEsqlQueryRule(searchType)) {
+    const { timeField } = anyParams as EsQueryRuleParams;
+
+    if (!timeField) {
+      return i18n.translate('xpack.stackAlerts.esQuery.esqlTimeFieldErrorMessage', {
+        defaultMessage: '[timeField]: is required',
+      });
+    }
+    if (thresholdComparator !== Comparator.GT) {
+      return i18n.translate('xpack.stackAlerts.esQuery.esqlThresholdComparatorErrorMessage', {
+        defaultMessage: '[thresholdComparator]: is required to be greater than',
+      });
+    }
+    if (threshold && threshold[0] !== 0) {
+      return i18n.translate('xpack.stackAlerts.esQuery.esqlThresholdErrorMessage', {
+        defaultMessage: '[threshold]: is required to be 0',
+      });
+    }
     return;
   }
 


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/170360

## Summary

We should be throwing an error if a user tries to create an ESQL es query rule where `thresholdCompartor != '>'` or `threshold != 0` or `timeField` is not defined.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### To verify

- Go to [dev tools](http://localhost:5601/app/dev_tools#/console)
- Run the following and edit thresholdComparator, threshold, or timeField and verify that you see errors thrown.
```
POST kbn:/api/alerting/rule
{
  "params": {
    "searchType": "esqlQuery",
    "esqlQuery": {
      "esql": """from kibana_sample_data_logs
| keep bytes, clientip, host, geo.dest
| where geo.dest != "GB"
| stats sumbytes = sum(bytes) by clientip, host
| WHERE sumbytes > 5000
| sort sumbytes desc
| limit 10"""
    },
    "timeWindowSize": 1,
    "timeWindowUnit": "d",
    "thresholdComparator": "<",
    "threshold": [
      1000
    ],
    "size": 10,
    "timeField": "date"
  },
  "consumer": "stackAlerts",
  "rule_type_id": ".es-query",
  "schedule": {
    "interval": "5d"
  },
  "name": "test rule"
}
```

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->