### PR TITLE
[QA] Change default time interval in beats tests for stack integration

### DIFF
--- a/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
@@ -11,12 +11,17 @@ import { FtrProviderContext } from '../../../functional/ftr_provider_context';
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('check filebeat', function () {
     const retry = getService('retry');
+    const kibanaServer = getService('kibanaServer');
     const PageObjects = getPageObjects(['common', 'discover', 'timePicker']);
 
     it('filebeat- should have hit count GT 0', async function () {
+      await kibanaServer.uiSettings.update({
+        'timepicker:timeDefaults': `{ "from": "now-5y", "to": "now"}`,
+      });
       await PageObjects.common.navigateToApp('discover', { insertTimestamp: false });
       await PageObjects.discover.selectIndexPattern('filebeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+
       await retry.try(async () => {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/filebeat/filebeat.ts
@@ -20,8 +20,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
       await PageObjects.common.navigateToApp('discover', { insertTimestamp: false });
       await PageObjects.discover.selectIndexPattern('filebeat-*');
-      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
-
       await retry.try(async () => {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
@@ -30,7 +30,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       }
 
       await PageObjects.discover.selectIndexPattern('metricbeat-*');
-      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/metricbeat/_metricbeat.ts
@@ -12,12 +12,16 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
   const retry = getService('retry');
   const browser = getService('browser');
+  const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'discover', 'timePicker']);
   const appsMenu = getService('appsMenu');
 
   describe('check metricbeat', function () {
     it('metricbeat- should have hit count GT 0', async function () {
       const url = await browser.getCurrentUrl();
+      await kibanaServer.uiSettings.update({
+        'timepicker:timeDefaults': `{ "from": "now-5y", "to": "now"}`,
+      });
       log.debug(url);
       if (!url.includes('kibana')) {
         await PageObjects.common.navigateToApp('discover', { insertTimestamp: false });
@@ -26,7 +30,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       }
 
       await PageObjects.discover.selectIndexPattern('metricbeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
@@ -12,6 +12,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const log = getService('log');
   const retry = getService('retry');
   const browser = getService('browser');
+  const kibanaServer = getService('kibanaServer');
   const PageObjects = getPageObjects(['common', 'discover', 'timePicker']);
   const appsMenu = getService('appsMenu');
 
@@ -22,6 +23,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     it('packetbeat- should have hit count GT 0', async function () {
       const url = await browser.getCurrentUrl();
+      await kibanaServer.uiSettings.update({
+        'timepicker:timeDefaults': `{ "from": "now-5y", "to": "now"}`,
+      });
       log.debug(url);
       if (!url.includes('kibana')) {
         await PageObjects.common.navigateToApp('discover', { insertTimestamp: false });
@@ -30,7 +34,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await appsMenu.clickLink('Discover');
       }
       await PageObjects.discover.selectIndexPattern('packetbeat-*');
-      await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
+      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);

--- a/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
+++ b/x-pack/test/stack_functional_integration/apps/packetbeat/_packetbeat.ts
@@ -34,7 +34,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await appsMenu.clickLink('Discover');
       }
       await PageObjects.discover.selectIndexPattern('packetbeat-*');
-      //await PageObjects.timePicker.setCommonlyUsedTime('Last_1 year');
       await retry.try(async function () {
         const hitCount = await PageObjects.discover.getHitCountInt();
         expect(hitCount).to.be.greaterThan(0);


### PR DESCRIPTION
## Summary

It changes the default time interval for filebeat/metricbeat/packetbeat integration tests for the stack functional upgrade tests. The data used for creating the upgrade snapshots is out of the "Last 1 year" interval used before. Now the interval will be changed to Last 5 years (couldn't use an absolute date value due to the fact the same tests are used for regular smoke where the data is recent).


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->