### PR TITLE
[Cloud Security] set rowHeight to 0 to fix the bug of large row height in Findings

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -223,8 +223,7 @@ export const CloudSecurityDataTable = ({
     height: `calc(100vh - ${filters.length > 0 ? 443 : 403}px)`,
   };
 
-  const rowHeightState =
-    uiSettings.get(ROW_HEIGHT_OPTION) === -1 ? 0 : uiSettings.get(ROW_HEIGHT_OPTION);
+  const rowHeightState = 0;
 
   const loadingStyle = {
     opacity: isLoading ? 1 : 0,

--- a/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/cloud_security_data_table/cloud_security_data_table.tsx
@@ -9,11 +9,7 @@ import { UnifiedDataTableSettings, useColumns } from '@kbn/unified-data-table';
 import { type DataView } from '@kbn/data-views-plugin/common';
 import { UnifiedDataTable, DataLoadingState } from '@kbn/unified-data-table';
 import { CellActionsProvider } from '@kbn/cell-actions';
-import {
-  ROW_HEIGHT_OPTION,
-  SHOW_MULTIFIELDS,
-  SORT_DEFAULT_ORDER_SETTING,
-} from '@kbn/discover-utils';
+import { SHOW_MULTIFIELDS, SORT_DEFAULT_ORDER_SETTING } from '@kbn/discover-utils';
 import { DataTableRecord } from '@kbn/discover-utils/types';
 import { EuiDataGridCellValueElementProps, EuiDataGridStyle, EuiProgress } from '@elastic/eui';
 import { AddFieldFilterHandler } from '@kbn/unified-field-list';


### PR DESCRIPTION
## Summary

fixes
- https://github.com/elastic/kibana/issues/170502

defaulting to row height 0 for the findings table. As the default was -1 before, we were defaulting to 0, but due to this change https://github.com/elastic/kibana/pull/169724/files the default became 3, which broke our table. I guess the logic of taking the UI setting if it's differnt from default -1 was to cater for users changing the row height somewhere in the settings, but we need to bring to product/design to see if we want to support it



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->