### PR TITLE
Make alerts table row to fit user profile avatars by default

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_table/index.tsx
@@ -197,14 +197,11 @@ export const AlertsTableComponent: FC<DetectionEngineAlertTableProps> = ({
     [isEventRenderedView]
   );
 
-  const rowHeightsOptions: EuiDataGridRowHeightsOptions | undefined = useMemo(() => {
-    if (isEventRenderedView) {
-      return {
-        defaultHeight: 'auto',
-      };
-    }
-    return undefined;
-  }, [isEventRenderedView]);
+  const rowHeightsOptions: EuiDataGridRowHeightsOptions = useMemo(() => {
+    return {
+      defaultHeight: 'auto',
+    };
+  }, []);
 
   const alertColumns = useMemo(
     () => (columns.length ? columns : getColumns(license)),


### PR DESCRIPTION
## Summary

Allow alerts table to render user avatars without cutting them off.

Broken:
<img width="1590" alt="Screenshot 2023-11-03 at 12 12 05" src="https://github.com/elastic/kibana/assets/2700761/319e6391-4e09-4350-87cc-391d18d15927">

Fixed:
<img width="1600" alt="Screenshot 2023-11-03 at 12 11 52" src="https://github.com/elastic/kibana/assets/2700761/74258e7a-c7bb-4caf-8d90-367285213165">

Main ticket https://github.com/elastic/security-team/issues/2504