### PR TITLE
[Enterprise Search][Connectors] Update depends_on for Jira and Confluence connectors configs

### DIFF
--- a/packages/kbn-search-connectors/types/native_connectors.ts
+++ b/packages/kbn-search-connectors/types/native_connectors.ts
@@ -450,7 +450,12 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       },
       use_document_level_security: {
         default_value: null,
-        depends_on: [],
+        depends_on: [
+          {
+            field: 'data_source',
+            value: 'confluence_cloud',
+          },
+        ],
         display: DisplayType.TOGGLE,
         label: ENABLE_DOCUMENT_LEVEL_SECURITY_LABEL,
         options: [],
@@ -1224,7 +1229,12 @@ export const NATIVE_CONNECTOR_DEFINITIONS: Record<string, NativeConnector | unde
       },
       use_document_level_security: {
         default_value: null,
-        depends_on: [],
+        depends_on: [
+          {
+            field: 'data_source',
+            value: 'jira_cloud',
+          },
+        ],
         display: DisplayType.TOGGLE,
         label: ENABLE_DOCUMENT_LEVEL_SECURITY_LABEL,
         options: [],


### PR DESCRIPTION
## Summary

I spotted that `use_document_level_security` config for Jira and Confluence native connectors is not respecting `depends_on` defined in connectors framework - and it might lead to buggy behaviour in certain edge case. I updated the config to match the source of truth.

Source of truth config:
- [Jira](https://github.com/elastic/connectors/blob/main/connectors/sources/jira.py#L388)
- [Confluence config](https://github.com/elastic/connectors/blob/main/connectors/sources/confluence.py#L313)



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->