### PR TITLE
[SecuritySolution] [8.11] Fix fleet_integration.ts API integration test flake

### DIFF
--- a/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/fleet_integration.ts
+++ b/x-pack/test/detection_engine_api_integration/security_and_spaces/prebuilt_rules/fleet_integration.ts
@@ -12,7 +12,7 @@ import {
   getPrebuiltRulesAndTimelinesStatus,
 } from '../../utils';
 import { deleteAllPrebuiltRuleAssets } from '../../utils/prebuilt_rules/delete_all_prebuilt_rule_assets';
-import { installPrebuiltRulesFleetPackage } from '../../utils/prebuilt_rules/install_prebuilt_rules_fleet_package';
+import { installPrebuiltRulesPackageViaFleetAPI } from '../../utils/prebuilt_rules/install_fleet_package_by_url';
 import { installPrebuiltRulesAndTimelines } from '../../utils/prebuilt_rules/install_prebuilt_rules_and_timelines';
 import { deletePrebuiltRulesFleetPackage } from '../../utils/prebuilt_rules/delete_prebuilt_rules_fleet_package';
 
@@ -41,11 +41,7 @@ export default ({ getService }: FtrProviderContext): void => {
       expect(statusBeforePackageInstallation.rules_not_installed).toBe(0);
       expect(statusBeforePackageInstallation.rules_not_updated).toBe(0);
 
-      await installPrebuiltRulesFleetPackage({
-        es,
-        supertest,
-        overrideExistingPackage: true,
-      });
+      await installPrebuiltRulesPackageViaFleetAPI(es, supertest);
 
       // Verify that status is updated after package installation
       const statusAfterPackageInstallation = await getPrebuiltRulesAndTimelinesStatus(supertest);

--- a/x-pack/test/detection_engine_api_integration/utils/index.ts
+++ b/x-pack/test/detection_engine_api_integration/utils/index.ts
@@ -112,3 +112,4 @@ export * from './prebuilt_rules/install_prebuilt_rules';
 export * from './prebuilt_rules/upgrade_prebuilt_rules';
 export * from './prebuilt_rules/install_mock_prebuilt_rules';
 export * from './prebuilt_rules/install_prebuilt_rules_and_timelines';
+export * from './prebuilt_rules/get_prebuilt_rules_and_timelines_status';


### PR DESCRIPTION
Fixes: https://github.com/elastic/kibana/issues/167056

**See [comment](https://github.com/elastic/kibana/issues/167056#issuecomment-1792287701) in ticket.** 
**This is only the fix for 8.11.**

## Summary

- Changes the installation of the `security_detection_engine` package from the current Fleet bulk install packages endpoint to use the endpoint that installs a single package, in order to get to a more stable test
- Notice that the errors reported that Kibana machine are socket hangups/timeouts and are solved on retry, so they do not block any pipelines)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
