### PR TITLE
[DOCS] Clarify required privileges to create CSV reports when using index aliases

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -72,6 +72,8 @@ NOTE: If you use the default settings, you can still create a custom role that g
 +
 Access to data is an index-level privilege. For each index that contains the data you want to include in reports, add a line, then give each index `read` and `view_index_metadata` privileges.
 +
+NOTE: If you use index aliases, you must also grant `read` and `view_index_metadata` privileges to underlying indices to generate CSV reports.
++
 For more information, refer to {ref}/security-privileges.html[Security privileges].
 
 . Add the {kib} privileges.


### PR DESCRIPTION
## Summary

If a CSV export is performed on an index alias, it also requires read access to underlying indices.
This PR adds a note in Kibana docs to make users aware of this requirement.

<!--ONMERGE {"backportTargets":["8.10","8.11","8.6","8.7","8.9"]} ONMERGE-->