### PR TITLE
[Fleet] Add serverless project type to telemetry

### DIFF
--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -462,7 +462,7 @@ export class FleetPlugin
 
     registerRoutes(fleetAuthzRouter, config);
 
-    this.telemetryEventsSender.setup(deps.telemetry);
+    this.telemetryEventsSender.setup(deps.telemetry, this.cloud);
     this.bulkActionsResolver = new BulkActionsResolver(deps.taskManager, core);
     this.checkDeletedFilesTask = new CheckDeletedFilesTask({
       core,

--- a/x-pack/plugins/fleet/server/telemetry/sender.ts
+++ b/x-pack/plugins/fleet/server/telemetry/sender.ts
@@ -17,7 +17,8 @@ import type { InfoResponse } from '@elastic/elasticsearch/lib/api/types';
 import { TelemetryQueue } from './queue';
 
 import type { FleetTelemetryChannel, FleetTelemetryChannelEvents } from './types';
-import { CloudSetup, CloudStart } from '@kbn/cloud-plugin/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
+import {} from '@kbn/cloud-plugin/server';
 
 /**
  * Simplified version of https://github.com/elastic/kibana/blob/master/x-pack/plugins/security_solution/server/lib/telemetry/sender.ts


### PR DESCRIPTION
## Summary

Depends on https://github.com/elastic/kibana/pull/170527
Closes https://github.com/elastic/ingest-dev/issues/2576

Add serverless project type to telemetry event sent by fleet.

## TODO

- [ ] Update fleet telemetry mappings
- [ ] Add tests