### PR TITLE
[8.9] [DOCS] Clarify required privileges to create CSV reports when using index aliases (#170524)

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -72,6 +72,8 @@ NOTE: If you use the default settings, you can still create a custom role that g
 +
 Access to data is an index-level privilege. For each index that contains the data you want to include in reports, add a line, then give each index `read` and `view_index_metadata` privileges.
 +
+NOTE: If you use index aliases, you must also grant `read` and `view_index_metadata` privileges to underlying indices to generate CSV reports.
++
 For more information, refer to {ref}/security-privileges.html[Security privileges].
 
 . Add the {kib} privileges.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Clarify required privileges to create CSV reports when using index aliases (#170524)](https://github.com/elastic/kibana/pull/170524)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Fabio Busatto","email":"52658645+bytebilly@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-11-03T16:47:21Z","message":"[DOCS] Clarify required privileges to create CSV reports when using index aliases (#170524)\n\n## Summary\r\n\r\nIf a CSV export is performed on an index alias, it also requires read\r\naccess to underlying indices.\r\nThis PR adds a note in Kibana docs to make users aware of this\r\nrequirement.","sha":"ef67add16c2baadc15ca0a1c7d7e4e1322a8fe36","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","docs","v8.6.0","v8.7.0","v8.9.0","v8.10.0","v8.11.0","v8.12.0"],"number":170524,"url":"https://github.com/elastic/kibana/pull/170524","mergeCommit":{"message":"[DOCS] Clarify required privileges to create CSV reports when using index aliases (#170524)\n\n## Summary\r\n\r\nIf a CSV export is performed on an index alias, it also requires read\r\naccess to underlying indices.\r\nThis PR adds a note in Kibana docs to make users aware of this\r\nrequirement.","sha":"ef67add16c2baadc15ca0a1c7d7e4e1322a8fe36"}},"sourceBranch":"main","suggestedTargetBranches":["8.6","8.7","8.9","8.10","8.11"],"targetPullRequestStates":[{"branch":"8.6","label":"v8.6.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.7","label":"v8.7.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.9","label":"v8.9.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.10","label":"v8.10.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/170524","number":170524,"mergeCommit":{"message":"[DOCS] Clarify required privileges to create CSV reports when using index aliases (#170524)\n\n## Summary\r\n\r\nIf a CSV export is performed on an index alias, it also requires read\r\naccess to underlying indices.\r\nThis PR adds a note in Kibana docs to make users aware of this\r\nrequirement.","sha":"ef67add16c2baadc15ca0a1c7d7e4e1322a8fe36"}}]}] BACKPORT-->