### PR TITLE
[ci] Increase parallelism for cypress suite

### DIFF
--- a/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
+++ b/.buildkite/pipelines/es_serverless/verify_es_serverless_image.yml
@@ -63,7 +63,7 @@ steps:
           queue: n2-4-spot
         depends_on: build
         timeout_in_minutes: 60
-        parallelism: 4
+        parallelism: 6
         retry:
           automatic:
             - exit_status: '*'


### PR DESCRIPTION
Tests are timing out on the
kibana-elasticsearch-serverless-verify-and-promote pipeline.