### PR TITLE
Update schema version from 8.11 to 8.12

### DIFF
--- a/x-pack/plugins/security_solution/common/api/detection_engine/model/alerts/8.12.0/index.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/model/alerts/8.12.0/index.ts
@@ -15,42 +15,42 @@ import type {
   NewTermsFields890,
 } from '../8.9.0';
 
-/* DO NOT MODIFY THIS SCHEMA TO ADD NEW FIELDS. These types represent the alerts that shipped in 8.11.0.
-Any changes to these types should be bug fixes so the types more accurately represent the alerts from 8.11.0.
+/* DO NOT MODIFY THIS SCHEMA TO ADD NEW FIELDS. These types represent the alerts that shipped in 8.12.0.
+Any changes to these types should be bug fixes so the types more accurately represent the alerts from 8.12.0.
 If you are adding new fields for a new release of Kibana, create a new sibling folder to this one
 for the version to be released and add the field(s) to the schema in that folder.
 Then, update `../index.ts` to import from the new folder that has the latest schemas, add the
 new schemas to the union of all alert schemas, and re-export the new schemas as the `*Latest` schemas.
 */
 
-export type { Ancestor890 as Ancestor8110 };
+export type { Ancestor890 as Ancestor8120 };
 
-export interface BaseFields8110 extends BaseFields890 {
+export interface BaseFields8120 extends BaseFields890 {
   [ALERT_WORKFLOW_ASSIGNEE_IDS]: string[] | undefined;
 }
 
-export interface WrappedFields8110<T extends BaseFields8110> {
+export interface WrappedFields8120<T extends BaseFields8120> {
   _id: string;
   _index: string;
   _source: T;
 }
 
-export type GenericAlert8110 = AlertWithCommonFields800<BaseFields8110>;
+export type GenericAlert8120 = AlertWithCommonFields800<BaseFields8120>;
 
-export type EqlShellFields8110 = EqlShellFields890 & BaseFields8110;
+export type EqlShellFields8120 = EqlShellFields890 & BaseFields8120;
 
-export type EqlBuildingBlockFields8110 = EqlBuildingBlockFields890 & BaseFields8110;
+export type EqlBuildingBlockFields8120 = EqlBuildingBlockFields890 & BaseFields8120;
 
-export type NewTermsFields8110 = NewTermsFields890 & BaseFields8110;
+export type NewTermsFields8120 = NewTermsFields890 & BaseFields8120;
 
-export type NewTermsAlert8110 = NewTermsFields890 & BaseFields8110;
+export type NewTermsAlert8120 = NewTermsFields890 & BaseFields8120;
 
-export type EqlBuildingBlockAlert8110 = AlertWithCommonFields800<EqlBuildingBlockFields890>;
+export type EqlBuildingBlockAlert8120 = AlertWithCommonFields800<EqlBuildingBlockFields890>;
 
-export type EqlShellAlert8110 = AlertWithCommonFields800<EqlShellFields8110>;
+export type EqlShellAlert8120 = AlertWithCommonFields800<EqlShellFields8120>;
 
-export type DetectionAlert8110 =
-  | GenericAlert8110
-  | EqlShellAlert8110
-  | EqlBuildingBlockAlert8110
-  | NewTermsAlert8110;
+export type DetectionAlert8120 =
+  | GenericAlert8120
+  | EqlShellAlert8120
+  | EqlBuildingBlockAlert8120
+  | NewTermsAlert8120;

--- a/x-pack/plugins/security_solution/common/api/detection_engine/model/alerts/index.ts
+++ b/x-pack/plugins/security_solution/common/api/detection_engine/model/alerts/index.ts
@@ -13,14 +13,14 @@ import type { DetectionAlert870 } from './8.7.0';
 import type { DetectionAlert880 } from './8.8.0';
 import type { DetectionAlert890 } from './8.9.0';
 import type {
-  Ancestor8110,
-  BaseFields8110,
-  DetectionAlert8110,
-  EqlBuildingBlockFields8110,
-  EqlShellFields8110,
-  NewTermsFields8110,
-  WrappedFields8110,
-} from './8.11.0';
+  Ancestor8120,
+  BaseFields8120,
+  DetectionAlert8120,
+  EqlBuildingBlockFields8120,
+  EqlShellFields8120,
+  NewTermsFields8120,
+  WrappedFields8120,
+} from './8.12.0';
 
 // When new Alert schemas are created for new Kibana versions, add the DetectionAlert type from the new version
 // here, e.g. `export type DetectionAlert = DetectionAlert800 | DetectionAlert820` if a new schema is created in 8.2.0
@@ -31,14 +31,14 @@ export type DetectionAlert =
   | DetectionAlert870
   | DetectionAlert880
   | DetectionAlert890
-  | DetectionAlert8110;
+  | DetectionAlert8120;
 
 export type {
-  Ancestor8110 as AncestorLatest,
-  BaseFields8110 as BaseFieldsLatest,
-  DetectionAlert8110 as DetectionAlertLatest,
-  WrappedFields8110 as WrappedFieldsLatest,
-  EqlBuildingBlockFields8110 as EqlBuildingBlockFieldsLatest,
-  EqlShellFields8110 as EqlShellFieldsLatest,
-  NewTermsFields8110 as NewTermsFieldsLatest,
+  Ancestor8120 as AncestorLatest,
+  BaseFields8120 as BaseFieldsLatest,
+  DetectionAlert8120 as DetectionAlertLatest,
+  WrappedFields8120 as WrappedFieldsLatest,
+  EqlBuildingBlockFields8120 as EqlBuildingBlockFieldsLatest,
+  EqlShellFields8120 as EqlShellFieldsLatest,
+  NewTermsFields8120 as NewTermsFieldsLatest,
 };


### PR DESCRIPTION
## Summary

We pushed feature release from 8.11 to 8.12, thus need to update kibana version in which new schema will be introduced.
