### PR TITLE
[Security Solution] Unskip and enable for Serverless `rule_actions` Cypress tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_actions/rule_actions.cy.ts
@@ -28,53 +28,48 @@ import { visit } from '../../../tasks/navigation';
 import { openRuleManagementPageViaBreadcrumbs } from '../../../tasks/rules_management';
 import { CREATE_RULE_URL } from '../../../urls/navigation';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-describe(
-  'Rule actions during detection rule creation',
-  { tags: ['@ess', '@serverless', '@brokenInServerless'] },
-  () => {
-    const indexConnector = getIndexConnector();
+describe('Rule actions during detection rule creation', { tags: ['@ess', '@serverless'] }, () => {
+  const indexConnector = getIndexConnector();
 
-    before(() => {
-      cleanKibana();
+  before(() => {
+    cleanKibana();
+  });
+
+  beforeEach(() => {
+    login();
+    deleteAlertsAndRules();
+    deleteConnectors();
+    deleteIndex(indexConnector.index);
+    deleteDataView(indexConnector.index);
+  });
+
+  const rule = getSimpleCustomQueryRule();
+  const actions = { connectors: [indexConnector] };
+  const index = actions.connectors[0].index;
+  const initialNumberOfDocuments = 0;
+  const expectedJson = JSON.parse(actions.connectors[0].document);
+
+  it('Indexes a new document after the index action is triggered', function () {
+    visit(CREATE_RULE_URL);
+    fillDefineCustomRuleAndContinue(rule);
+    fillAboutRuleAndContinue(rule);
+    fillScheduleRuleAndContinue(rule);
+    fillRuleAction(actions);
+    createAndEnableRule();
+    openRuleManagementPageViaBreadcrumbs();
+
+    goToRuleDetailsOf(rule.name);
+
+    /* When the rule is executed, the action is triggered. We wait for the new document to be indexed */
+    waitForNewDocumentToBeIndexed(index, initialNumberOfDocuments);
+
+    /* We assert that the new indexed document is the one set on the index action */
+    cy.request({
+      method: 'GET',
+      url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_search`,
+      headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
+    }).then((response) => {
+      expect(response.body.hits.hits[0]._source).to.deep.equal(expectedJson);
     });
-
-    beforeEach(() => {
-      login();
-      deleteAlertsAndRules();
-      deleteConnectors();
-      deleteIndex(indexConnector.index);
-      deleteDataView(indexConnector.index);
-    });
-
-    const rule = getSimpleCustomQueryRule();
-    const actions = { connectors: [indexConnector] };
-    const index = actions.connectors[0].index;
-    const initialNumberOfDocuments = 0;
-    const expectedJson = JSON.parse(actions.connectors[0].document);
-
-    it('Indexes a new document after the index action is triggered', function () {
-      visit(CREATE_RULE_URL);
-      fillDefineCustomRuleAndContinue(rule);
-      fillAboutRuleAndContinue(rule);
-      fillScheduleRuleAndContinue(rule);
-      fillRuleAction(actions);
-      createAndEnableRule();
-      openRuleManagementPageViaBreadcrumbs();
-
-      goToRuleDetailsOf(rule.name);
-
-      /* When the rule is executed, the action is triggered. We wait for the new document to be indexed */
-      waitForNewDocumentToBeIndexed(index, initialNumberOfDocuments);
-
-      /* We assert that the new indexed document is the one set on the index action */
-      cy.request({
-        method: 'GET',
-        url: `${Cypress.env('ELASTICSEARCH_URL')}/${index}/_search`,
-        headers: { 'kbn-xsrf': 'cypress-creds', 'x-elastic-internal-origin': 'security-solution' },
-      }).then((response) => {
-        expect(response.body.hits.hits[0]._source).to.deep.equal(expectedJson);
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/test/security_solution_cypress/package.json
+++ b/x-pack/test/security_solution_cypress/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "cypress": "NODE_OPTIONS=--openssl-legacy-provider ../../../node_modules/.bin/cypress",
     "cypress:open:ess": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider node ../../plugins/security_solution/scripts/start_cypress_parallel open --spec './cypress/e2e/**/*.cy.ts' --config-file ../../test/security_solution_cypress/cypress/cypress.config.ts --ftr-config-file ../../test/security_solution_cypress/cli_config",
-    "cypress:run:ess": "yarn cypress:ess --spec './cypress/e2e/exceptions/shared_exception_lists_management/**/*.cy.ts'",
+    "cypress:run:ess": "yarn cypress:ess --spec './cypress/e2e/detection_response/rule_actions/*.cy.ts'",
     "cypress:run:cases:ess": "yarn cypress:ess --spec './cypress/e2e/explore/cases/*.cy.ts'",
     "cypress:ess": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider node ../../plugins/security_solution/scripts/start_cypress_parallel run --config-file ../../test/security_solution_cypress/cypress/cypress_ci.config.ts --ftr-config-file ../../test/security_solution_cypress/cli_config",
     "cypress:run:respops:ess": "yarn cypress:ess --spec './cypress/e2e/(detection_response|exceptions)/**/*.cy.ts'",
@@ -21,7 +21,7 @@
     "cypress:cloud:serverless": "TZ=UTC NODE_OPTIONS=--openssl-legacy-provider NODE_TLS_REJECT_UNAUTHORIZED=0 ../../../node_modules/.bin/cypress",
     "cypress:open:cloud:serverless": "yarn cypress:cloud:serverless open --config-file ./cypress/cypress_serverless.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:open:serverless": "yarn cypress:serverless open --config-file ../../test/security_solution_cypress/cypress/cypress_serverless.config.ts --spec './cypress/e2e/**/*.cy.ts'",
-    "cypress:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/exceptions/shared_exception_lists_management/**/*.cy.ts'",
+    "cypress:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/detection_response/rule_actions/*.cy.ts'",
     "cypress:run:cloud:serverless": "yarn cypress:cloud:serverless run --config-file ./cypress/cypress_ci_serverless.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:run:qa:serverless": "yarn cypress:cloud:serverless run --config-file ./cypress/cypress_ci_serverless_qa.config.ts --env CLOUD_SERVERLESS=true",
     "cypress:investigations:run:serverless": "yarn cypress:serverless --spec './cypress/e2e/investigations/**/*.cy.ts'",


### PR DESCRIPTION
Flaky test run: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3899

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
