### PR TITLE
[DOCS] refer to Enterprise Search service in release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -129,8 +129,8 @@ Discover::
 * Adds resize support to the Discover field list sidebar ({kibana-pull}167066[#167066]).
 Elastic Security::
 For the Elastic Security 8.11.0 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
-Enterprise Search::
-For the Elastic Enterprise Search 8.11.0 release information, refer to {enterprise-search-ref}/changelog.html[_Elastic Enterprise Search Documentation Release notes_].
+Enterprise Search service::
+For the Elastic Enterprise Search service 8.11.0 release information, refer to {enterprise-search-ref}/changelog.html[_Elastic Enterprise Search Release notes_].
 Fleet::
 * Set env variable `ELASTIC_NETINFO:false` in {kib} ({kibana-pull}166156[#166156]).
 * Added restart upgrade action ({kibana-pull}166154[#166154]).


### PR DESCRIPTION
One of the tiniest PRs ever created.

Enterprise Search now refers exclusively to tools that require the Enterprise Search _service_. This PR clarifies that in release notes link.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->