### PR TITLE
[Security Solution] Update CODEOWNERS for the Security Engineering Productivity team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1360,14 +1360,10 @@ x-pack/plugins/security_solution/server/usage/ @elastic/security-data-analytics
 x-pack/plugins/security_solution/server/lib/telemetry/ @elastic/security-data-analytics
 
 ## Security Solution sub teams - security-engineering-productivity
-x-pack/test/security_solution_cypress/cypress/README.md @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/es_archives @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/cli_config.ts @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/config.ts @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/runner.ts @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/serverless_config.ts @elastic/security-engineering-productivity
-x-pack/test/security_solution_cypress/cypress/tags.ts @elastic/security-engineering-productivity
-x-pack/plugins/security_solution/scripts/run_cypress @MadameSheema @patrykkopycinski @oatkiller @maximpn @banderror
+/x-pack/test/security_solution_cypress/* @elastic/security-engineering-productivity
+/x-pack/test/security_solution_cypress/cypress/* @elastic/security-engineering-productivity
+/x-pack/test/security_solution_cypress/es_archives @elastic/security-engineering-productivity
+/x-pack/plugins/security_solution/scripts/run_cypress @MadameSheema @patrykkopycinski @oatkiller @maximpn @banderror
 
 ## Security Solution sub teams - adaptive-workload-protection
 x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/kibana-cloud-security-posture


### PR DESCRIPTION
## Summary

This PR makes the @elastic/security-engineering-productivity team the owner of the `x-pack/test/security_solution_cypress/package.json` file to prevent accidentally merging temporary changes to this file like in https://github.com/elastic/kibana/pull/169182.

Also, it simplifies the ownership rules a bit. The following lines assign the team to all files under the two specified folders, but not files inside their subfolders, so you don't have to specify individual files:

```
/x-pack/test/security_solution_cypress/* @elastic/security-engineering-productivity
/x-pack/test/security_solution_cypress/cypress/* @elastic/security-engineering-productivity
```
