### PR TITLE
[8.11] [Security Solution] Unskip and enable for Serverless `shared_exception_lists_management` Cypress tests (#169182)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/list_detail_page/list_details.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/list_detail_page/list_details.cy.ts
@@ -41,94 +41,84 @@ const getExceptionList1 = () => ({
 
 const EXCEPTION_LIST_NAME = 'Newly created list';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-// FLAKY: https://github.com/elastic/kibana/issues/165640
-describe(
-  'Exception list detail page',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
-  () => {
-    before(() => {
-      cy.task('esArchiverResetKibana');
-      login();
+describe('Exception list detail page', { tags: ['@ess', '@serverless'] }, () => {
+  beforeEach(() => {
+    login();
 
-      // Create exception list associated with a rule
-      createExceptionList(getExceptionList1(), getExceptionList1().list_id).then((response) =>
-        createRule(
-          getNewRule({
-            exceptions_list: [
-              {
-                id: response.body.id,
-                list_id: getExceptionList1().list_id,
-                type: getExceptionList1().type,
-                namespace_type: getExceptionList1().namespace_type,
-              },
-            ],
-          })
-        )
-      );
-      createRule(getNewRule({ name: 'Rule to link to shared list' }));
+    // Create exception list associated with a rule
+    createExceptionList(getExceptionList1(), getExceptionList1().list_id).then((response) =>
+      createRule(
+        getNewRule({
+          exceptions_list: [
+            {
+              id: response.body.id,
+              list_id: getExceptionList1().list_id,
+              type: getExceptionList1().type,
+              namespace_type: getExceptionList1().namespace_type,
+            },
+          ],
+        })
+      )
+    );
+    createRule(getNewRule({ name: 'Rule to link to shared list' }));
+    visit(EXCEPTIONS_URL);
+  });
+
+  it('Should edit list details', () => {
+    visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
+    waitForExceptionListDetailToBeLoaded();
+    // Check list details are loaded
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', LIST_NAME);
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', LIST_DESCRIPTION);
+
+    // Update list details in edit modal
+    editExceptionLisDetails({
+      name: { original: LIST_NAME, updated: UPDATED_LIST_NAME },
+      description: { original: LIST_DESCRIPTION, updated: UPDATED_LIST_DESCRIPTION },
     });
 
-    beforeEach(() => {
-      login();
-      visit(EXCEPTIONS_URL);
+    // Ensure that list details were updated
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', UPDATED_LIST_NAME);
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', UPDATED_LIST_DESCRIPTION);
+
+    // Ensure that list details changes persisted
+    visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', UPDATED_LIST_NAME);
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', UPDATED_LIST_DESCRIPTION);
+
+    // Remove description
+    editExceptionLisDetails({
+      description: { original: UPDATED_LIST_DESCRIPTION, updated: null },
     });
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', 'Add a description');
 
-    it('Should edit list details', () => {
-      visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
-      waitForExceptionListDetailToBeLoaded();
-      // Check list details are loaded
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', LIST_NAME);
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', LIST_DESCRIPTION);
+    // Ensure description removal persisted
+    visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', 'Add a description');
+  });
 
-      // Update list details in edit modal
-      editExceptionLisDetails({
-        name: { original: LIST_NAME, updated: UPDATED_LIST_NAME },
-        description: { original: LIST_DESCRIPTION, updated: UPDATED_LIST_DESCRIPTION },
-      });
+  // TODO: Flaky in ESS and Serverless: https://github.com/elastic/kibana/pull/169182#issuecomment-1792597980
+  it.skip('Should create a new list and link it to two rules', () => {
+    createSharedExceptionList(
+      { name: 'Newly created list', description: 'This is my list.' },
+      true
+    );
 
-      // Ensure that list details were updated
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', UPDATED_LIST_NAME);
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', UPDATED_LIST_DESCRIPTION);
+    // After creation - directed to list detail page
+    cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
 
-      // Ensure that list details changes persisted
-      visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', UPDATED_LIST_NAME);
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', UPDATED_LIST_DESCRIPTION);
+    // Open Link rules flyout
+    cy.get(EXCEPTION_LIST_DETAILS_LINK_RULES_BTN).click();
 
-      // Remove description
-      editExceptionLisDetails({
-        description: { original: UPDATED_LIST_DESCRIPTION, updated: null },
-      });
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', 'Add a description');
+    // Link the first two Rules
+    linkSharedListToRulesFromListDetails(2);
 
-      // Ensure description removal persisted
-      visit(exceptionsListDetailsUrl(getExceptionList1().list_id));
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_DESCRIPTION).should('have.text', 'Add a description');
-    });
+    // Save the 2 linked Rules
+    saveLinkedRules();
 
-    it('Should create a new list and link it to two rules', () => {
-      createSharedExceptionList(
-        { name: 'Newly created list', description: 'This is my list.' },
-        true
-      );
+    const linkedRulesNames = ['Rule to link to shared list', 'New Rule Test'];
 
-      // After creation - directed to list detail page
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
-
-      // Open Link rules flyout
-      cy.get(EXCEPTION_LIST_DETAILS_LINK_RULES_BTN).click();
-
-      // Link the first two Rules
-      linkSharedListToRulesFromListDetails(2);
-
-      // Save the 2 linked Rules
-      saveLinkedRules();
-
-      const linkedRulesNames = ['Rule to link to shared list', 'New Rule Test'];
-
-      // Validate the number of linked rules as well as the Rules' names
-      validateSharedListLinkedRules(2, linkedRulesNames);
-    });
-  }
-);
+    // Validate the number of linked rules as well as the Rules' names
+    validateSharedListLinkedRules(2, linkedRulesNames);
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
@@ -39,114 +39,160 @@ import {
 } from '../../../tasks/exceptions_table';
 import { visitRuleDetailsPage } from '../../../tasks/rule_details';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-// FLAKY: https://github.com/elastic/kibana/issues/165795
-describe(
-  'Add, edit and delete exception',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
-  () => {
-    beforeEach(() => {
-      cy.task('esArchiverResetKibana');
-      cy.task('esArchiverLoad', { archiveName: 'exceptions' });
-      createRule(getNewRule()).as('createdRule');
+describe('Add, edit and delete exception', { tags: ['@ess', '@serverless'] }, () => {
+  beforeEach(() => {
+    login();
+    deleteExceptionLists();
+    deleteEndpointExceptionList();
+    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
+    createRule(getNewRule()).as('createdRule');
+    visit(EXCEPTIONS_URL);
+  });
 
-      login();
+  afterEach(() => {
+    cy.task('esArchiverUnload', 'exceptions');
+  });
+
+  const exceptionName = 'My item name';
+  const exceptionNameEdited = 'My item name edited';
+  const FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD = 'agent.name';
+  const EXCEPTION_LIST_NAME = 'Newly created list';
+
+  describe('Add, Edit and delete Exception item', () => {
+    it('should create exception item from Shared Exception List page and linked to a Rule', () => {
+      // Click on "Create shared exception list" button on the header
+      // Click on "Create exception item"
+      addExceptionListFromSharedExceptionListHeaderMenu();
+
+      // Add exception item name
+      addExceptionFlyoutItemName(exceptionName);
+
+      // Add Condition
+      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
+
+      // Confirm button should disabled until a rule(s) is selected
+      cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
+
+      // select rule
+      linkFirstRuleOnExceptionFlyout();
+
+      // should  be able to submit
+      cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
+
+      submitNewExceptionItem();
+
+      // Navigate to Rule details page
+      cy.get<Cypress.Response<RuleResponse>>('@createdRule').then((rule) =>
+        visitRuleDetailsPage(rule.body.id, { tab: 'rule_exceptions' })
+      );
+
+      // Only one Exception should generated
+      cy.get(EXCEPTION_ITEM_VIEWER_CONTAINER).should('have.length', 1);
+
+      // validate the And operator is displayed correctly
+      cy.get(EXCEPTION_CARD_ITEM_NAME).should('have.text', exceptionName);
+    });
+
+    it('should create exception item from Shared Exception List page, linked to a Shared List and validate Edit/delete in list detail page', function () {
+      createSharedExceptionList(
+        { name: 'Newly created list', description: 'This is my list.' },
+        true
+      );
+
+      // After creation - directed to list detail page
+      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
+
+      // Go back to Shared Exception List
       visit(EXCEPTIONS_URL);
-      waitForExceptionsTableToBeLoaded();
+
+      // Click on "Create shared exception list" button on the header
+      // Click on "Create exception item"
+      addExceptionListFromSharedExceptionListHeaderMenu();
+
+      // Add exception item name
+      addExceptionFlyoutItemName(exceptionName);
+
+      // Add Condition
+      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
+
+      // select shared list radio option and select the first one
+      linkFirstSharedListOnExceptionFlyout();
+
+      submitNewExceptionItem();
+
+      // New exception is added to the new List
+      findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
+
+      // Click on the first exception overflow menu items
+      // Open the edit modal
+      editFirstExceptionItemInListDetailPage();
+      // edit exception item name
+      editExceptionFlyoutItemName(exceptionNameEdited);
+
+      // submit
+      submitEditedExceptionItem();
+
+      // check the new name after edit
+      cy.get(EXECPTION_ITEM_CARD_HEADER_TITLE).should('have.text', exceptionNameEdited);
+
+      // Click on the first exception overflow menu items
+      // delete the exception
+      deleteFirstExceptionItemInListDetailPage();
+
+      cy.get(EMPTY_EXCEPTIONS_VIEWER).should('exist');
     });
 
-    afterEach(() => {
-      cy.task('esArchiverUnload', 'exceptions');
+    it('should handle huge text as a comment gracefully and allow user create exception item after user updates the comment', function () {
+      createSharedExceptionList(
+        { name: 'Newly created list', description: 'This is my list.' },
+        true
+      );
+
+      // After creation - directed to list detail page
+      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
+
+      // Go back to Shared Exception List
+      visit(EXCEPTIONS_URL);
+
+      // Click on "Create shared exception list" button on the header
+      // Click on "Create exception item"
+      addExceptionListFromSharedExceptionListHeaderMenu();
+
+      // Add exception item name
+      addExceptionFlyoutItemName(exceptionName);
+
+      // Add Condition
+      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
+
+      // select shared list radio option and select the first one
+      linkFirstSharedListOnExceptionFlyout();
+
+      // add exception comment which is super long
+      addExceptionHugeComment([...new Array(5000).keys()].map((_) => `Test text!`).join(''));
+
+      // submit
+      submitNewExceptionItemWithFailure();
+
+      // Failed to add exception due to comment length and submit button should be disabled
+      cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
+
+      // Close error toast
+      closeErrorToast();
+
+      // Dismiss error callout
+      dismissExceptionItemErrorCallOut();
+
+      // Submit button should be enabled after we dismissed error callout
+      cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
+
+      // update exception comment to a reasonable (length wise) text
+      editExceptionComment('Exceptional comment');
+
+      // submit
+      submitNewExceptionItem();
+
+      // New exception is added to the new List
+      findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
     });
-
-    const exceptionName = 'My item name';
-    const exceptionNameEdited = 'My item name edited';
-    const FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD = 'agent.name';
-    const EXCEPTION_LIST_NAME = 'Newly created list';
-
-    describe('Add, Edit and delete Exception item', () => {
-      it('should create exception item from Shared Exception List page and linked to a Rule', () => {
-        // Click on "Create shared exception list" button on the header
-        // Click on "Create exception item"
-        addExceptionListFromSharedExceptionListHeaderMenu();
-
-        // Add exception item name
-        addExceptionFlyoutItemName(exceptionName);
-
-        // Add Condition
-        editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
-
-        // Confirm button should disabled until a rule(s) is selected
-        cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
-
-        // select rule
-        linkFirstRuleOnExceptionFlyout();
-
-        // should  be able to submit
-        cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
-
-        submitNewExceptionItem();
-
-        // Navigate to Rule details page
-        cy.get<Cypress.Response<RuleResponse>>('@createdRule').then((rule) =>
-          visitRuleDetailsPage(rule.body.id, { tab: 'rule_exceptions' })
-        );
-
-        // Only one Exception should generated
-        cy.get(EXCEPTION_ITEM_VIEWER_CONTAINER).should('have.length', 1);
-
-        // validate the And operator is displayed correctly
-        cy.get(EXCEPTION_CARD_ITEM_NAME).should('have.text', exceptionName);
-      });
-
-      it('should create exception item from Shared Exception List page, linked to a Shared List and validate Edit/delete in list detail page', function () {
-        createSharedExceptionList(
-          { name: 'Newly created list', description: 'This is my list.' },
-          true
-        );
-
-        // After creation - directed to list detail page
-        cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
-
-        // Go back to Shared Exception List
-        visit(EXCEPTIONS_URL);
-
-        // Click on "Create shared exception list" button on the header
-        // Click on "Create exception item"
-        addExceptionListFromSharedExceptionListHeaderMenu();
-
-        // Add exception item name
-        addExceptionFlyoutItemName(exceptionName);
-
-        // Add Condition
-        editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
-
-        // select shared list radio option and select the first one
-        linkFirstSharedListOnExceptionFlyout();
-
-        submitNewExceptionItem();
-
-        // New exception is added to the new List
-        findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
-
-        // Click on the first exception overflow menu items
-        // Open the edit modal
-        editFirstExceptionItemInListDetailPage();
-        // edit exception item name
-        editExceptionFlyoutItemName(exceptionNameEdited);
-
-        // submit
-        submitEditedExceptionItem();
-
-        // check the new name after edit
-        cy.get(EXECPTION_ITEM_CARD_HEADER_TITLE).should('have.text', exceptionNameEdited);
-
-        // Click on the first exception overflow menu items
-        // delete the exception
-        deleteFirstExceptionItemInListDetailPage();
-
-        cy.get(EMPTY_EXCEPTIONS_VIEWER).should('exist');
-      });
-    });
-  }
-);
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts
@@ -39,160 +39,114 @@ import {
 } from '../../../tasks/exceptions_table';
 import { visitRuleDetailsPage } from '../../../tasks/rule_details';
 
-describe('Add, edit and delete exception', { tags: ['@ess', '@serverless'] }, () => {
-  beforeEach(() => {
-    login();
-    deleteExceptionLists();
-    deleteEndpointExceptionList();
-    cy.task('esArchiverLoad', { archiveName: 'exceptions' });
-    createRule(getNewRule()).as('createdRule');
-    visit(EXCEPTIONS_URL);
-  });
+// TODO: https://github.com/elastic/kibana/issues/161539
+// FLAKY: https://github.com/elastic/kibana/issues/165795
+describe(
+  'Add, edit and delete exception',
+  { tags: ['@ess', '@serverless', '@skipInServerless'] },
+  () => {
+    beforeEach(() => {
+      cy.task('esArchiverResetKibana');
+      cy.task('esArchiverLoad', { archiveName: 'exceptions' });
+      createRule(getNewRule()).as('createdRule');
 
-  afterEach(() => {
-    cy.task('esArchiverUnload', 'exceptions');
-  });
-
-  const exceptionName = 'My item name';
-  const exceptionNameEdited = 'My item name edited';
-  const FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD = 'agent.name';
-  const EXCEPTION_LIST_NAME = 'Newly created list';
-
-  describe('Add, Edit and delete Exception item', () => {
-    it('should create exception item from Shared Exception List page and linked to a Rule', () => {
-      // Click on "Create shared exception list" button on the header
-      // Click on "Create exception item"
-      addExceptionListFromSharedExceptionListHeaderMenu();
-
-      // Add exception item name
-      addExceptionFlyoutItemName(exceptionName);
-
-      // Add Condition
-      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
-
-      // Confirm button should disabled until a rule(s) is selected
-      cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
-
-      // select rule
-      linkFirstRuleOnExceptionFlyout();
-
-      // should  be able to submit
-      cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
-
-      submitNewExceptionItem();
-
-      // Navigate to Rule details page
-      cy.get<Cypress.Response<RuleResponse>>('@createdRule').then((rule) =>
-        visitRuleDetailsPage(rule.body.id, { tab: 'rule_exceptions' })
-      );
-
-      // Only one Exception should generated
-      cy.get(EXCEPTION_ITEM_VIEWER_CONTAINER).should('have.length', 1);
-
-      // validate the And operator is displayed correctly
-      cy.get(EXCEPTION_CARD_ITEM_NAME).should('have.text', exceptionName);
-    });
-
-    it('should create exception item from Shared Exception List page, linked to a Shared List and validate Edit/delete in list detail page', function () {
-      createSharedExceptionList(
-        { name: 'Newly created list', description: 'This is my list.' },
-        true
-      );
-
-      // After creation - directed to list detail page
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
-
-      // Go back to Shared Exception List
+      login();
       visit(EXCEPTIONS_URL);
-
-      // Click on "Create shared exception list" button on the header
-      // Click on "Create exception item"
-      addExceptionListFromSharedExceptionListHeaderMenu();
-
-      // Add exception item name
-      addExceptionFlyoutItemName(exceptionName);
-
-      // Add Condition
-      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
-
-      // select shared list radio option and select the first one
-      linkFirstSharedListOnExceptionFlyout();
-
-      submitNewExceptionItem();
-
-      // New exception is added to the new List
-      findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
-
-      // Click on the first exception overflow menu items
-      // Open the edit modal
-      editFirstExceptionItemInListDetailPage();
-      // edit exception item name
-      editExceptionFlyoutItemName(exceptionNameEdited);
-
-      // submit
-      submitEditedExceptionItem();
-
-      // check the new name after edit
-      cy.get(EXECPTION_ITEM_CARD_HEADER_TITLE).should('have.text', exceptionNameEdited);
-
-      // Click on the first exception overflow menu items
-      // delete the exception
-      deleteFirstExceptionItemInListDetailPage();
-
-      cy.get(EMPTY_EXCEPTIONS_VIEWER).should('exist');
+      waitForExceptionsTableToBeLoaded();
     });
 
-    it('should handle huge text as a comment gracefully and allow user create exception item after user updates the comment', function () {
-      createSharedExceptionList(
-        { name: 'Newly created list', description: 'This is my list.' },
-        true
-      );
-
-      // After creation - directed to list detail page
-      cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
-
-      // Go back to Shared Exception List
-      visit(EXCEPTIONS_URL);
-
-      // Click on "Create shared exception list" button on the header
-      // Click on "Create exception item"
-      addExceptionListFromSharedExceptionListHeaderMenu();
-
-      // Add exception item name
-      addExceptionFlyoutItemName(exceptionName);
-
-      // Add Condition
-      editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
-
-      // select shared list radio option and select the first one
-      linkFirstSharedListOnExceptionFlyout();
-
-      // add exception comment which is super long
-      addExceptionHugeComment([...new Array(5000).keys()].map((_) => `Test text!`).join(''));
-
-      // submit
-      submitNewExceptionItemWithFailure();
-
-      // Failed to add exception due to comment length and submit button should be disabled
-      cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
-
-      // Close error toast
-      closeErrorToast();
-
-      // Dismiss error callout
-      dismissExceptionItemErrorCallOut();
-
-      // Submit button should be enabled after we dismissed error callout
-      cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
-
-      // update exception comment to a reasonable (length wise) text
-      editExceptionComment('Exceptional comment');
-
-      // submit
-      submitNewExceptionItem();
-
-      // New exception is added to the new List
-      findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
+    afterEach(() => {
+      cy.task('esArchiverUnload', 'exceptions');
     });
-  });
-});
+
+    const exceptionName = 'My item name';
+    const exceptionNameEdited = 'My item name edited';
+    const FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD = 'agent.name';
+    const EXCEPTION_LIST_NAME = 'Newly created list';
+
+    describe('Add, Edit and delete Exception item', () => {
+      it('should create exception item from Shared Exception List page and linked to a Rule', () => {
+        // Click on "Create shared exception list" button on the header
+        // Click on "Create exception item"
+        addExceptionListFromSharedExceptionListHeaderMenu();
+
+        // Add exception item name
+        addExceptionFlyoutItemName(exceptionName);
+
+        // Add Condition
+        editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
+
+        // Confirm button should disabled until a rule(s) is selected
+        cy.get(CONFIRM_BTN).should('have.attr', 'disabled');
+
+        // select rule
+        linkFirstRuleOnExceptionFlyout();
+
+        // should  be able to submit
+        cy.get(CONFIRM_BTN).should('not.have.attr', 'disabled');
+
+        submitNewExceptionItem();
+
+        // Navigate to Rule details page
+        cy.get<Cypress.Response<RuleResponse>>('@createdRule').then((rule) =>
+          visitRuleDetailsPage(rule.body.id, { tab: 'rule_exceptions' })
+        );
+
+        // Only one Exception should generated
+        cy.get(EXCEPTION_ITEM_VIEWER_CONTAINER).should('have.length', 1);
+
+        // validate the And operator is displayed correctly
+        cy.get(EXCEPTION_CARD_ITEM_NAME).should('have.text', exceptionName);
+      });
+
+      it('should create exception item from Shared Exception List page, linked to a Shared List and validate Edit/delete in list detail page', function () {
+        createSharedExceptionList(
+          { name: 'Newly created list', description: 'This is my list.' },
+          true
+        );
+
+        // After creation - directed to list detail page
+        cy.get(EXCEPTIONS_LIST_MANAGEMENT_NAME).should('have.text', EXCEPTION_LIST_NAME);
+
+        // Go back to Shared Exception List
+        visit(EXCEPTIONS_URL);
+
+        // Click on "Create shared exception list" button on the header
+        // Click on "Create exception item"
+        addExceptionListFromSharedExceptionListHeaderMenu();
+
+        // Add exception item name
+        addExceptionFlyoutItemName(exceptionName);
+
+        // Add Condition
+        editException(FIELD_DIFFERENT_FROM_EXISTING_ITEM_FIELD, 0, 0);
+
+        // select shared list radio option and select the first one
+        linkFirstSharedListOnExceptionFlyout();
+
+        submitNewExceptionItem();
+
+        // New exception is added to the new List
+        findSharedExceptionListItemsByName(`${EXCEPTION_LIST_NAME}`, [exceptionName]);
+
+        // Click on the first exception overflow menu items
+        // Open the edit modal
+        editFirstExceptionItemInListDetailPage();
+        // edit exception item name
+        editExceptionFlyoutItemName(exceptionNameEdited);
+
+        // submit
+        submitEditedExceptionItem();
+
+        // check the new name after edit
+        cy.get(EXECPTION_ITEM_CARD_HEADER_TITLE).should('have.text', exceptionNameEdited);
+
+        // Click on the first exception overflow menu items
+        // delete the exception
+        deleteFirstExceptionItemInListDetailPage();
+
+        cy.get(EMPTY_EXCEPTIONS_VIEWER).should('exist');
+      });
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/duplicate_lists.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/duplicate_lists.cy.ts
@@ -41,9 +41,7 @@ const getExceptionList2 = () => ({
   list_id: 'exception_list_2',
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-// Flaky in serverless tests
-describe('Duplicate List', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Duplicate List', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     cy.task('esArchiverResetKibana');
     login();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/filter_table.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/filter_table.cy.ts
@@ -37,8 +37,7 @@ const getExceptionList2 = () => ({
   list_id: 'exception_list_2',
 });
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-describe('Filter Lists', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
+describe('Filter Lists', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {
     cy.task('esArchiverResetKibana');
     login();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/import_lists.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/import_lists.cy.ts
@@ -21,8 +21,6 @@ import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { EXCEPTIONS_URL } from '../../../../urls/navigation';
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-// Flaky in serverless
 describe('Import Lists', { tags: ['@ess', '@serverless', '@skipInServerless'] }, () => {
   const LIST_TO_IMPORT_FILENAME = 'cypress/fixtures/7_16_exception_list.ndjson';
   before(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts
@@ -48,11 +48,9 @@ const getExceptionList2 = () => ({
 
 let exceptionListResponse: Cypress.Response<ExceptionListSchema>;
 
-// TODO: https://github.com/elastic/kibana/issues/161539
-// FLAKY: https://github.com/elastic/kibana/issues/165690
 describe(
   'Manage lists from "Shared Exception Lists" page',
-  { tags: ['@ess', '@serverless', '@skipInServerless'] },
+  { tags: ['@ess', '@serverless'] },
   () => {
     describe('Create/Export/Delete List', () => {
       before(() => {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Security Solution] Unskip and enable for Serverless `shared_exception_lists_management` Cypress tests (#169182)](https://github.com/elastic/kibana/pull/169182)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Juan Pablo Djeredjian","email":"jpdjeredjian@gmail.com"},"sourceCommit":{"committedDate":"2023-11-03T22:35:09Z","message":"[Security Solution] Unskip and enable for Serverless `shared_exception_lists_management` Cypress tests (#169182)\n\n## Summary\r\n\r\nRunning flaky test runner for:\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/list_detail_page/list_details.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/filter_table.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/import_lists.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts`\r\n**unskipped and enabled in Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts`\r\n**removed from Serverless testing**\r\n\r\n\r\n## Related failing-test issues\r\n1. https://github.com/elastic/kibana/issues/165874\r\n2. https://github.com/elastic/kibana/issues/165838\r\n3. https://github.com/elastic/kibana/issues/165795\r\n4. https://github.com/elastic/kibana/issues/165743 - **Closed as\r\nduplicate of _#165640**\r\n5. https://github.com/elastic/kibana/issues/165690\r\n6. https://github.com/elastic/kibana/issues/165640\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3557#_\r\n(Only ESS) 🟢\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3564#_\r\n(ESS and Serverless)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3613\r\n(Serverless evaluated and corrected)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3878\r\n[V3]\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3891\r\n[V4]","sha":"c0c7d1365f9e034128de8cbb03ac5733aefcd22f","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Detections and Resp","Team:Detection Engine","v8.11.0","v8.12.0"],"number":169182,"url":"https://github.com/elastic/kibana/pull/169182","mergeCommit":{"message":"[Security Solution] Unskip and enable for Serverless `shared_exception_lists_management` Cypress tests (#169182)\n\n## Summary\r\n\r\nRunning flaky test runner for:\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/list_detail_page/list_details.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/filter_table.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/import_lists.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts`\r\n**unskipped and enabled in Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts`\r\n**removed from Serverless testing**\r\n\r\n\r\n## Related failing-test issues\r\n1. https://github.com/elastic/kibana/issues/165874\r\n2. https://github.com/elastic/kibana/issues/165838\r\n3. https://github.com/elastic/kibana/issues/165795\r\n4. https://github.com/elastic/kibana/issues/165743 - **Closed as\r\nduplicate of _#165640**\r\n5. https://github.com/elastic/kibana/issues/165690\r\n6. https://github.com/elastic/kibana/issues/165640\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3557#_\r\n(Only ESS) 🟢\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3564#_\r\n(ESS and Serverless)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3613\r\n(Serverless evaluated and corrected)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3878\r\n[V3]\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3891\r\n[V4]","sha":"c0c7d1365f9e034128de8cbb03ac5733aefcd22f"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169182","number":169182,"mergeCommit":{"message":"[Security Solution] Unskip and enable for Serverless `shared_exception_lists_management` Cypress tests (#169182)\n\n## Summary\r\n\r\nRunning flaky test runner for:\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management`\r\n\r\n## Changes\r\n\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/list_detail_page/list_details.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/manage_exceptions.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/filter_table.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/import_lists.cy.ts`\r\n**enabled on Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/manage_lists.cy.ts`\r\n**unskipped and enabled in Serverless**\r\n-\r\n`x-pack/test/security_solution_cypress/cypress/e2e/exceptions/shared_exception_lists_management/shared_exception_list_page/read_only.cy.ts`\r\n**removed from Serverless testing**\r\n\r\n\r\n## Related failing-test issues\r\n1. https://github.com/elastic/kibana/issues/165874\r\n2. https://github.com/elastic/kibana/issues/165838\r\n3. https://github.com/elastic/kibana/issues/165795\r\n4. https://github.com/elastic/kibana/issues/165743 - **Closed as\r\nduplicate of _#165640**\r\n5. https://github.com/elastic/kibana/issues/165690\r\n6. https://github.com/elastic/kibana/issues/165640\r\n\r\n### Flaky test runner link\r\n\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3557#_\r\n(Only ESS) 🟢\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3564#_\r\n(ESS and Serverless)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3613\r\n(Serverless evaluated and corrected)\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3878\r\n[V3]\r\n-\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3891\r\n[V4]","sha":"c0c7d1365f9e034128de8cbb03ac5733aefcd22f"}}]}] BACKPORT-->