### PR TITLE
[Security solution] Fix non-langchain error handling

### DIFF
--- a/x-pack/plugins/elastic_assistant/server/lib/executor.test.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/executor.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { executeAction } from './executor';
+import { KibanaRequest } from '@kbn/core-http-server';
+import { RequestBody } from './langchain/types';
+import { PluginStartContract as ActionsPluginStart } from '@kbn/actions-plugin/server';
+const request = {
+  body: {
+    params: {},
+  },
+} as KibanaRequest<unknown, unknown, RequestBody>;
+
+describe('executeAction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it('should execute an action with the provided connectorId and request body params', async () => {
+    const actions = {
+      getActionsClientWithRequest: jest.fn().mockResolvedValue({
+        execute: jest.fn().mockResolvedValue({
+          status: 'ok',
+          data: {
+            message: 'Test message',
+          },
+        }),
+      }),
+    } as unknown as ActionsPluginStart;
+
+    const connectorId = '12345';
+
+    const response = await executeAction({ actions, request, connectorId });
+
+    expect(actions.getActionsClientWithRequest).toHaveBeenCalledWith(request);
+    expect(actions.getActionsClientWithRequest).toHaveBeenCalledTimes(1);
+    expect(response.connector_id).toBe(connectorId);
+    expect(response.data).toBe('Test message');
+    expect(response.status).toBe('ok');
+  });
+
+  it('should throw an error if action result status is "error"', async () => {
+    const actions = {
+      getActionsClientWithRequest: jest.fn().mockResolvedValue({
+        execute: jest.fn().mockResolvedValue({
+          status: 'error',
+          message: 'Error message',
+          serviceMessage: 'Service error message',
+        }),
+      }),
+    } as unknown as ActionsPluginStart;
+    const connectorId = '12345';
+
+    await expect(executeAction({ actions, request, connectorId })).rejects.toThrowError(
+      'Action result status is error: Error message - Service error message'
+    );
+  });
+
+  it('should throw an error if content of response data is not a string', async () => {
+    const actions = {
+      getActionsClientWithRequest: jest.fn().mockResolvedValue({
+        execute: jest.fn().mockResolvedValue({
+          status: 'ok',
+          data: {
+            message: 12345,
+          },
+        }),
+      }),
+    } as unknown as ActionsPluginStart;
+    const connectorId = '12345';
+
+    await expect(executeAction({ actions, request, connectorId })).rejects.toThrowError(
+      'Action result status is error: content should be a string, but it had an unexpected type: number'
+    );
+  });
+});

--- a/x-pack/plugins/elastic_assistant/server/lib/executor.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/executor.ts
@@ -31,13 +31,21 @@ export const executeAction = async ({
     actionId: connectorId,
     params: request.body.params,
   });
-  const content = get('data.message', actionResult);
-  if (typeof content === 'string') {
-    return {
-      connector_id: connectorId,
-      data: content, // the response from the actions framework
-      status: 'ok',
-    };
+
+  if (actionResult.status === 'error') {
+    throw new Error(
+      `Action result status is error: ${actionResult?.message} - ${actionResult?.serviceMessage}`
+    );
   }
-  throw new Error('Unexpected action result');
+  const content = get('data.message', actionResult);
+  if (typeof content !== 'string') {
+    throw new Error(
+      `Action result status is error: content should be a string, but it had an unexpected type: ${typeof content}`
+    );
+  }
+  return {
+    connector_id: connectorId,
+    data: content, // the response from the actions framework
+    status: 'ok',
+  };
 };

--- a/x-pack/plugins/elastic_assistant/server/lib/langchain/llm/actions_client_llm.ts
+++ b/x-pack/plugins/elastic_assistant/server/lib/langchain/llm/actions_client_llm.ts
@@ -92,7 +92,7 @@ export class ActionsClientLlm extends LLM {
         `${LLM_TYPE}: action result status is error: ${actionResult?.message} - ${actionResult?.serviceMessage}`
       );
     }
-    // TODO: handle errors from the connector
+
     const content = get('data.message', actionResult);
 
     if (typeof content !== 'string') {


### PR DESCRIPTION
## Summary

Adds a check that was present for the llm execute but not the non-llm execute to check if there was an error with the connector. Adds tests to validate the fix.

<img width="1286" alt="Screenshot 2023-11-06 at 9 49 19 AM" src="https://github.com/elastic/kibana/assets/6935300/40e7eb24-3f0e-4098-91d9-c04c24b9c1d2">


To test:

1. Create a connector with a bad model
2. Send a message to the assistant with the knowledge base turned OFF
3. Ensure proper error messaging

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->