### PR TITLE
[Security Solution][Detection Engine] updates outdated missing privileges callout

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management_ui/pages/rule_management/index.tsx
@@ -69,6 +69,7 @@ const RulesPageComponent: React.FC = () => {
     loading: listsConfigLoading,
     canWriteIndex: canWriteListsIndex,
     needsConfiguration: needsListsConfiguration,
+    indexExists: listIndexExists,
   } = useListsConfig();
   const loading = userInfoLoading || listsConfigLoading;
 
@@ -137,7 +138,7 @@ const RulesPageComponent: React.FC = () => {
                   <EuiButtonEmpty
                     data-test-subj="open-value-lists-modal-button"
                     iconType="importAction"
-                    isDisabled={!canWriteListsIndex || !canUserCRUD || loading}
+                    isDisabled={!canWriteListsIndex || !canUserCRUD || loading || !listIndexExists}
                     onClick={showValueListFlyout}
                   >
                     {i18n.IMPORT_VALUE_LISTS}

--- a/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/callouts/missing_privileges_callout/translations.tsx
@@ -53,10 +53,11 @@ const CANNOT_EDIT_ALERTS = i18n.translate(
 export const missingPrivilegesCallOutBody = ({
   indexPrivileges,
   featurePrivileges = [],
+  clusterPrivileges,
 }: MissingPrivileges) => (
   <FormattedMessage
     id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail"
-    defaultMessage="{essence} {indexPrivileges} {featurePrivileges} Related documentation: {docs}"
+    defaultMessage="{essence} {clusterPrivileges} {indexPrivileges} {featurePrivileges} Related documentation: {docs}"
     values={{
       essence: (
         <p>
@@ -66,6 +67,22 @@ export const missingPrivilegesCallOutBody = ({
           />
         </p>
       ),
+      clusterPrivileges:
+        clusterPrivileges.length > 0 ? (
+          <>
+            <FormattedMessage
+              id="xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.clusterPrivilegesTitle"
+              defaultMessage="Missing cluster privileges:"
+            />
+            <ul>
+              {clusterPrivileges.map((missingPrivilege) => (
+                <li key={missingPrivilege}>
+                  <EuiCode>{missingPrivilege}</EuiCode>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null,
       indexPrivileges:
         indexPrivileges.length > 0 ? (
           <>

--- a/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
+++ b/x-pack/plugins/security_solution/public/detections/containers/detection_engine/lists/use_lists_config.tsx
@@ -17,6 +17,7 @@ export interface UseListsConfigReturn {
   enabled: boolean;
   loading: boolean;
   needsConfiguration: boolean;
+  indexExists: boolean;
 }
 
 export const useListsConfig = (): UseListsConfigReturn => {
@@ -38,5 +39,12 @@ export const useListsConfig = (): UseListsConfigReturn => {
     }
   }, [canManageIndex, createIndex, needsIndex]);
 
-  return { canManageIndex, canWriteIndex, enabled, loading, needsConfiguration };
+  return {
+    canManageIndex,
+    canWriteIndex,
+    enabled,
+    loading,
+    needsConfiguration,
+    indexExists: !!indexExists,
+  };
 };

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -29205,7 +29205,7 @@
     "xpack.securitySolution.detectionEngine.createRule.stepDefineRule.threatMatchIndexForbiddenError": "索引模式不能是{forbiddenString}。请选择更具体的索引模式。",
     "xpack.securitySolution.detectionEngine.createRule.stepRuleActions.invalidMustacheTemplateErrorMessage": "{key} 不是有效的 Mustache 模板",
     "xpack.securitySolution.detectionEngine.createRule.stepRuleActions.snoozeDescription": "选择执行操作的时间，或暂停这些操作。没有为已暂停操作创建通知。{docs}。",
-    "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail": "{essence} {indexPrivileges} {featurePrivileges} 相关文档：{docs}",
+    "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.messageDetail": "{essence} {clusterPrivileges} {indexPrivileges} {featurePrivileges} 相关文档：{docs}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingFeaturePrivileges": "缺失 {privileges} 权限，无法使用 {index} 功能。{explanation}",
     "xpack.securitySolution.detectionEngine.missingPrivilegesCallOut.messageBody.missingIndexPrivileges": "缺失 {privileges} 权限，无法使用 {index} 索引。{explanation}",
     "xpack.securitySolution.detectionEngine.mlJobCompatibilityCallout.messageBody": "{summary} 相关文档：{docs}",


### PR DESCRIPTION
## Summary

- addresses https://github.com/elastic/kibana/issues/170590
- updates outdated list of index permissions according to https://www.elastic.co/guide/en/security/current/detections-permissions-section.html
- adds missing cluster permissions
- disables uploading lists, when list indices do not exist

### UI


<img width="1782" alt="Screenshot 2023-11-06 at 16 59 43" src="https://github.com/elastic/kibana/assets/92328789/339d1b3c-d872-4e2a-871a-7eea8f626fc2">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
