### PR TITLE
[ResponseOps] Add target to Connectors documentation link

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_home.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/actions_connectors_list/components/actions_connectors_home.tsx
@@ -99,6 +99,7 @@ export const ActionsConnectorsHome: React.FunctionComponent<RouteComponentProps<
           <EuiButtonEmpty
             data-test-subj="documentationButton"
             key="documentation-button"
+            target="_blank"
             href={docLinks.links.alerting.actionTypes}
             iconType="help"
           >


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/166111

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->