### PR TITLE
[Cases] Add search to column selection popover

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
@@ -84,10 +84,13 @@ describe('ColumnsPopover', () => {
     userEvent.click(await screen.findByTestId('column-selection-popover-button'));
     userEvent.click(await screen.findByTestId('column-selection-popover-show-all-button'));
 
+    const onSelectedColumnsChangeCallParams = selectedColumns.map((column) => ({
+      ...column,
+      isChecked: true,
+    }));
+
     await waitFor(() => {
-      expect(onSelectedColumnsChange).toHaveBeenCalledWith(
-        selectedColumns.map((column) => ({ ...column, isChecked: true }))
-      );
+      expect(onSelectedColumnsChange).toHaveBeenCalledWith(onSelectedColumnsChangeCallParams);
     });
   });
 

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.test.tsx
@@ -6,34 +6,35 @@
  */
 
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { TestProviders } from '../../common/mock';
+import type { AppMockRenderer } from '../../common/mock';
+import { createAppMockRenderer } from '../../common/mock';
 import { ColumnsPopover } from './columns_popover';
 
 describe('ColumnsPopover', () => {
+  let appMockRenderer: AppMockRenderer;
+
   beforeEach(() => {
+    appMockRenderer = createAppMockRenderer();
     jest.clearAllMocks();
   });
 
   const selectedColumns = [
     { field: 'title', name: 'Title', isChecked: true },
     { field: 'category', name: 'Category', isChecked: false },
+    { field: 'tags', name: 'Tags', isChecked: false },
   ];
 
   it('renders correctly a list of selected columns', async () => {
-    render(
-      <TestProviders>
-        <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
-      </TestProviders>
+    appMockRenderer.render(
+      <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
     );
 
-    userEvent.click(screen.getByTestId('column-selection-popover-button'));
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
 
-    await waitFor(() => {
-      expect(screen.getByTestId('column-selection-popover')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('column-selection-popover')).toBeInTheDocument();
 
     selectedColumns.forEach(({ field, name, isChecked }) => {
       expect(screen.getByTestId(`column-selection-switch-${field}`)).toHaveAttribute(
@@ -47,18 +48,16 @@ describe('ColumnsPopover', () => {
   it('clicking a switch calls onSelectedColumnsChange with the right params', async () => {
     const onSelectedColumnsChange = jest.fn();
 
-    render(
-      <TestProviders>
-        <ColumnsPopover
-          selectedColumns={selectedColumns}
-          onSelectedColumnsChange={onSelectedColumnsChange}
-        />
-      </TestProviders>
+    appMockRenderer.render(
+      <ColumnsPopover
+        selectedColumns={selectedColumns}
+        onSelectedColumnsChange={onSelectedColumnsChange}
+      />
     );
 
-    userEvent.click(screen.getByTestId('column-selection-popover-button'));
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
     userEvent.click(
-      screen.getByTestId(`column-selection-switch-${selectedColumns[0].field}`),
+      await screen.findByTestId(`column-selection-switch-${selectedColumns[0].field}`),
       undefined,
       { skipPointerEventsCheck: true }
     );
@@ -67,7 +66,93 @@ describe('ColumnsPopover', () => {
       expect(onSelectedColumnsChange).toHaveBeenCalledWith([
         { ...selectedColumns[0], isChecked: false },
         selectedColumns[1],
+        selectedColumns[2],
       ]);
     });
+  });
+
+  it('clicking Show All calls onSelectedColumnsChange with the right params', async () => {
+    const onSelectedColumnsChange = jest.fn();
+
+    appMockRenderer.render(
+      <ColumnsPopover
+        selectedColumns={selectedColumns}
+        onSelectedColumnsChange={onSelectedColumnsChange}
+      />
+    );
+
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
+    userEvent.click(await screen.findByTestId('column-selection-popover-show-all-button'));
+
+    await waitFor(() => {
+      expect(onSelectedColumnsChange).toHaveBeenCalledWith(
+        selectedColumns.map((column) => ({ ...column, isChecked: true }))
+      );
+    });
+  });
+
+  it('clicking Hide All calls onSelectedColumnsChange with the right params', async () => {
+    const onSelectedColumnsChange = jest.fn();
+
+    appMockRenderer.render(
+      <ColumnsPopover
+        selectedColumns={selectedColumns}
+        onSelectedColumnsChange={onSelectedColumnsChange}
+      />
+    );
+
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
+    userEvent.click(await screen.findByTestId('column-selection-popover-hide-all-button'));
+
+    await waitFor(() => {
+      expect(onSelectedColumnsChange).toHaveBeenCalledWith(
+        selectedColumns.map((column) => ({ ...column, isChecked: false }))
+      );
+    });
+  });
+
+  it('searching for text changes the column list correctly', async () => {
+    appMockRenderer.render(
+      <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
+    );
+
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
+    userEvent.paste(await screen.findByTestId('column-selection-popover-search'), 'Title');
+
+    expect(await screen.findByTestId('column-selection-switch-title')).toBeInTheDocument();
+    expect(screen.queryByTestId('column-selection-switch-category')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('column-selection-switch-tags')).not.toBeInTheDocument();
+  });
+
+  it('searching for text does not change the list of selected columns', async () => {
+    const onSelectedColumnsChange = jest.fn();
+
+    appMockRenderer.render(
+      <ColumnsPopover
+        selectedColumns={selectedColumns}
+        onSelectedColumnsChange={onSelectedColumnsChange}
+      />
+    );
+
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
+    userEvent.paste(await screen.findByTestId('column-selection-popover-search'), 'Category');
+
+    expect(onSelectedColumnsChange).not.toHaveBeenCalled();
+  });
+
+  it('searching for text hides the drag and drop icons', async () => {
+    appMockRenderer.render(
+      <ColumnsPopover selectedColumns={selectedColumns} onSelectedColumnsChange={() => {}} />
+    );
+
+    userEvent.click(await screen.findByTestId('column-selection-popover-button'));
+
+    expect(await screen.findAllByTestId('column-selection-popover-draggable-icon')).toHaveLength(3);
+
+    userEvent.paste(await screen.findByTestId('column-selection-popover-search'), 'Foobar');
+
+    expect(
+      await screen.queryByTestId('column-selection-popover-draggable-icon')
+    ).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -125,7 +125,10 @@ export const ColumnsPopover: React.FC<Props> = ({
         />
       </EuiPopoverTitle>
       <EuiDragDropContext onDragEnd={onDragEnd}>
-        <EuiFlexGroup css={{ width: 300 }}>
+        <EuiFlexGroup
+          css={{ width: 300 }}
+          data-test-subj="column-selection-popover-drag-drop-context"
+        >
           <EuiFlexItem>
             <EuiDroppable
               droppableId="casesColumnDroppableArea"

--- a/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/columns_popover.tsx
@@ -9,9 +9,11 @@ import type { ChangeEvent } from 'react';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import type { DropResult } from '@elastic/eui';
+
 import {
+  EuiFieldSearch,
+  EuiHighlight,
   EuiPopoverFooter,
-  EuiFieldText,
   EuiPopoverTitle,
   EuiFlexGroup,
   EuiFlexItem,
@@ -113,7 +115,7 @@ export const ColumnsPopover: React.FC<Props> = ({
       }
     >
       <EuiPopoverTitle>
-        <EuiFieldText
+        <EuiFieldSearch
           compressed
           placeholder={i18n.SEARCH}
           aria-label={i18n.SEARCH_COLUMNS}
@@ -156,7 +158,11 @@ export const ColumnsPopover: React.FC<Props> = ({
                     <EuiFlexGroup alignItems="center" gutterSize="m" justifyContent="spaceBetween">
                       <EuiFlexItem grow={false}>
                         <EuiSwitch
-                          label={name}
+                          label={
+                            <EuiHighlight search={columnSearchText} title={name}>
+                              {name}
+                            </EuiHighlight>
+                          }
                           checked={isChecked}
                           data-test-subj={`column-selection-switch-${field}`}
                           onChange={(e) => toggleColumns({ field, isChecked: e.target.checked })}
@@ -168,7 +174,6 @@ export const ColumnsPopover: React.FC<Props> = ({
                               width: '190px',
                               overflow: 'hidden',
                             },
-                            title: name,
                           }}
                         />
                       </EuiFlexItem>

--- a/x-pack/plugins/cases/public/components/all_cases/translations.ts
+++ b/x-pack/plugins/cases/public/components/all_cases/translations.ts
@@ -180,3 +180,26 @@ export const NO_ATTACHMENTS_ADDED = i18n.translate(
 export const COLUMNS = i18n.translate('xpack.cases.allCasesView.columnSelection', {
   defaultMessage: 'Columns',
 });
+
+export const SHOW_ALL = i18n.translate('xpack.cases.allCasesView.columnSelectionShowAll', {
+  defaultMessage: 'Show All',
+});
+
+export const HIDE_ALL = i18n.translate('xpack.cases.allCasesView.columnSelectionHideAll', {
+  defaultMessage: 'Hide All',
+});
+
+export const SEARCH = i18n.translate('xpack.cases.allCasesView.columnSelectionSearch', {
+  defaultMessage: 'Search',
+});
+
+export const SEARCH_COLUMNS = i18n.translate(
+  'xpack.cases.allCasesView.columnSelectionSearchColumns',
+  {
+    defaultMessage: 'Search Columns',
+  }
+);
+
+export const DRAG_HANDLE = i18n.translate('xpack.cases.allCasesView.columnSelectionDragHandle', {
+  defaultMessage: 'Drag Handle',
+});

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -401,8 +401,12 @@ export function CasesTableServiceProvider(
       return column.length !== 0;
     },
 
-    async toggleColumnInPopover(columnId: string) {
+    async openColumnsPopover() {
       await testSubjects.click('column-selection-popover-button');
+    },
+
+    async toggleColumnInPopover(columnId: string) {
+      await this.openColumnsPopover();
 
       await testSubjects.existOrFail(`column-selection-switch-${columnId}`);
       await testSubjects.click(`column-selection-switch-${columnId}`);

--- a/x-pack/test/functional/services/cases/list.ts
+++ b/x-pack/test/functional/services/cases/list.ts
@@ -403,6 +403,11 @@ export function CasesTableServiceProvider(
 
     async openColumnsPopover() {
       await testSubjects.click('column-selection-popover-button');
+      await testSubjects.existOrFail('column-selection-popover-drag-drop-context');
+    },
+
+    async closeColumnsPopover() {
+      await testSubjects.click('column-selection-popover-button');
     },
 
     async toggleColumnInPopover(columnId: string) {

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -660,9 +660,6 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('Column Selection', () => {
       afterEach(async () => {
         await toasts.dismissAllToastsWithChecks();
-
-        // closes the popover
-        await browser.pressKeys(browser.keys.ESCAPE);
       });
 
       before(async () => {
@@ -702,6 +699,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         await testSubjects.click('column-selection-popover-hide-all-button');
 
+        await cases.casesTable.closeColumnsPopover();
+
         expect(await cases.casesTable.hasColumn('Name')).to.be(false);
         expect(await cases.casesTable.hasColumn('Assignees')).to.be(false);
         expect(await cases.casesTable.hasColumn('Tags')).to.be(false);
@@ -712,6 +711,8 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await cases.casesTable.openColumnsPopover();
 
         await testSubjects.click('column-selection-popover-show-all-button');
+
+        await cases.casesTable.closeColumnsPopover();
 
         expect(await cases.casesTable.hasColumn('Name')).to.be(true);
         expect(await cases.casesTable.hasColumn('Assignees')).to.be(true);

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -724,16 +724,11 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await cases.casesTable.openColumnsPopover();
 
         const input = await testSubjects.find('column-selection-popover-search');
-        await input.type('Name');
+        await input.type('name');
 
-        await testSubjects.existOrFail(`column-selection-switch-title`);
-
-        await testSubjects.missingOrFail(`column-selection-switch-closedAt`);
-        await testSubjects.missingOrFail(`column-selection-switch-category`);
-
-        await testSubjects.click(`column-selection-switch-title`);
-
-        expect(await cases.casesTable.hasColumn('Name')).to.be(false);
+        await testSubjects.existOrFail('column-selection-switch-title');
+        await testSubjects.missingOrFail('column-selection-switch-closedAt');
+        await testSubjects.missingOrFail('column-selection-switch-category');
       });
     });
   });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -660,6 +660,9 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     describe('Column Selection', () => {
       afterEach(async () => {
         await toasts.dismissAllToastsWithChecks();
+
+        // closes the popover
+        await browser.pressKeys(browser.keys.ESCAPE);
       });
 
       before(async () => {

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -674,7 +674,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await browser.clearLocalStorage();
       });
 
-      it('column selection popover exists', async () => {
+      it('column selection popover button exists', async () => {
         await testSubjects.existOrFail('column-selection-popover-button');
       });
 
@@ -690,6 +690,46 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         expect(await cases.casesTable.hasColumn('Name')).to.be(true);
 
         await cases.casesTable.toggleColumnInPopover('title');
+
+        expect(await cases.casesTable.hasColumn('Name')).to.be(false);
+      });
+
+      it('"Hide All" columns works correctly', async () => {
+        await cases.casesTable.openColumnsPopover();
+
+        await testSubjects.click('column-selection-popover-hide-all-button');
+
+        expect(await cases.casesTable.hasColumn('Name')).to.be(false);
+        expect(await cases.casesTable.hasColumn('Assignees')).to.be(false);
+        expect(await cases.casesTable.hasColumn('Tags')).to.be(false);
+        expect(await cases.casesTable.hasColumn('Category')).to.be(false);
+      });
+
+      it('"Show All" columns works correctly', async () => {
+        await cases.casesTable.openColumnsPopover();
+
+        await testSubjects.click('column-selection-popover-show-all-button');
+
+        expect(await cases.casesTable.hasColumn('Name')).to.be(true);
+        expect(await cases.casesTable.hasColumn('Assignees')).to.be(true);
+        expect(await cases.casesTable.hasColumn('Tags')).to.be(true);
+        expect(await cases.casesTable.hasColumn('Category')).to.be(true);
+        expect(await cases.casesTable.hasColumn('Closed on')).to.be(true);
+      });
+
+      it('search and toggle column works correctly', async () => {
+        await cases.casesTable.openColumnsPopover();
+
+        const input = await testSubjects.find('column-selection-popover-search');
+        await input.type('Name');
+        await input.pressKeys(browser.keys.ENTER);
+
+        await testSubjects.existOrFail(`column-selection-switch-title`);
+
+        await testSubjects.missingOrFail(`column-selection-switch-closedAt`);
+        await testSubjects.missingOrFail(`column-selection-switch-category`);
+
+        await testSubjects.click(`column-selection-switch-title`);
 
         expect(await cases.casesTable.hasColumn('Name')).to.be(false);
       });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/list_view.ts
@@ -725,7 +725,6 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
 
         const input = await testSubjects.find('column-selection-popover-search');
         await input.type('Name');
-        await input.pressKeys(browser.keys.ENTER);
 
         await testSubjects.existOrFail(`column-selection-switch-title`);
 


### PR DESCRIPTION
Connected to https://github.com/elastic/kibana/issues/167617

## Summary

In this PR I added:
- Search functionality to the column selection popover
- `Show all` and `Hide all` buttons
- Unit and e2e tests.

<details><summary>Screenshot here</summary>
<img width="355" alt="Screenshot 2023-11-06 at 20 26 46" src="https://github.com/elastic/kibana/assets/1533137/9ccc45c6-e029-4bdd-a8c2-6d2e76b82fc1">
</details>

As discussed offline with @mdefazio we display the same functionality and behavior as the [eui data grid toolbar](https://eui.elastic.co/#/tabular-content/data-grid-toolbar).

Most importantly, **the drag and drop is disabled during search**.

Another behavior I followed from the data grid table is clicking `Show all`/`Hide all` in the middle of a search, which will affect **all columns** and not just the ones displayed.

Finally, the `EuiSwitch` label does not allow us to highlight the search text like [in here](https://eui.elastic.co/#/forms/selectable#searchable) for example so I did not include it. If we decide it is worth the effort I can spend some time playing with the components to find an alternative solution. 

## Flaky test runner

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3956