### PR TITLE
Follow up to #170527

### DIFF
--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.test.ts
@@ -10,7 +10,7 @@ import {
   usageCollectionPluginMock,
 } from '@kbn/usage-collection-plugin/server/mocks';
 import type { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
-import { createCloudUsageCollector } from './cloud_usage_collector';
+import { CloudUsageCollectorConfig, createCloudUsageCollector } from './cloud_usage_collector';
 import { CollectorFetchContext } from '@kbn/usage-collection-plugin/server';
 
 describe('createCloudUsageCollector', () => {
@@ -23,13 +23,17 @@ describe('createCloudUsageCollector', () => {
   });
 
   it('calls `makeUsageCollector`', () => {
-    createCloudUsageCollector(usageCollection, { isCloudEnabled: false });
+    createCloudUsageCollector(usageCollection, {
+      isCloudEnabled: false,
+    } as CloudUsageCollectorConfig);
     expect(usageCollection.makeUsageCollector).toBeCalledTimes(1);
   });
 
   describe('Fetched Usage data', () => {
     it('return isCloudEnabled boolean', async () => {
-      const collector = createCloudUsageCollector(usageCollection, { isCloudEnabled: true });
+      const collector = createCloudUsageCollector(usageCollection, {
+        isCloudEnabled: true,
+      } as CloudUsageCollectorConfig);
 
       expect(await collector.fetch(collectorFetchContext)).toStrictEqual({
         isCloudEnabled: true,
@@ -45,7 +49,7 @@ describe('createCloudUsageCollector', () => {
       const collector = createCloudUsageCollector(usageCollection, {
         isCloudEnabled: true,
         trialEndDate: '2020-10-01T14:30:16Z',
-      });
+      } as CloudUsageCollectorConfig);
 
       expect(await collector.fetch(collectorFetchContext)).toStrictEqual({
         isCloudEnabled: true,

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
@@ -7,13 +7,13 @@
 
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
-interface Config {
+export interface CloudUsageCollectorConfig {
   isCloudEnabled: boolean;
-  trialEndDate?: string;
-  isElasticStaffOwned?: boolean;
-  deploymentId?: string;
-  projectId?: string;
-  projectType?: string;
+  trialEndDate: string | undefined;
+  isElasticStaffOwned: boolean | undefined;
+  deploymentId: string | undefined;
+  projectId: string | undefined;
+  projectType: string | undefined;
 }
 
 interface CloudUsage {
@@ -26,7 +26,10 @@ interface CloudUsage {
   projectType?: string;
 }
 
-export function createCloudUsageCollector(usageCollection: UsageCollectionSetup, config: Config) {
+export function createCloudUsageCollector(
+  usageCollection: UsageCollectionSetup,
+  config: CloudUsageCollectorConfig
+) {
   const {
     isCloudEnabled,
     trialEndDate,
@@ -73,7 +76,7 @@ export function createCloudUsageCollector(usageCollection: UsageCollectionSetup,
 
 export function registerCloudUsageCollector(
   usageCollection: UsageCollectionSetup | undefined,
-  config: Config
+  config: CloudUsageCollectorConfig
 ) {
   if (!usageCollection) {
     return;

--- a/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
+++ b/x-pack/plugins/cloud/server/collectors/cloud_usage_collector.ts
@@ -9,6 +9,7 @@ import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/server';
 
 export interface CloudUsageCollectorConfig {
   isCloudEnabled: boolean;
+  // Using * | undefined instead of ?: to force the calling code to list all the options (even when they can be undefined)
   trialEndDate: string | undefined;
   isElasticStaffOwned: boolean | undefined;
   deploymentId: string | undefined;

--- a/x-pack/plugins/cloud/server/plugin.ts
+++ b/x-pack/plugins/cloud/server/plugin.ts
@@ -153,6 +153,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
   public setup(core: CoreSetup, { usageCollection }: PluginsSetup): CloudSetup {
     const isCloudEnabled = getIsCloudEnabled(this.config.id);
     const projectId = this.config.serverless?.project_id;
+    const projectType = this.config.serverless?.project_type;
     const isServerlessEnabled = !!projectId;
     const deploymentId = parseDeploymentIdFromDeploymentUrl(this.config.deployment_url);
 
@@ -163,6 +164,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       isElasticStaffOwned: this.config.is_elastic_staff_owned,
       deploymentId,
       projectId,
+      projectType,
     });
 
     let decodedId: DecodedCloudId | undefined;
@@ -190,7 +192,7 @@ export class CloudPlugin implements Plugin<CloudSetup, CloudStart> {
       serverless: {
         projectId,
         projectName: this.config.serverless?.project_name,
-        projectType: this.config.serverless?.project_type,
+        projectType,
       },
     };
   }


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/elastic/kibana/pull/170527 because it was missing an optional parameter in the registration of the collector.



### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
