### PR TITLE
[CLI] Workaround to set a custom heap snapshot dir

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -128,6 +128,7 @@ COPY --chown=1000:0 config/serverless.oblt.yml /usr/share/kibana/config/serverle
 COPY --chown=1000:0 config/serverless.security.yml /usr/share/kibana/config/serverless.security.yml
 # Supportability enhancement: enable capturing heap snapshots. See https://nodejs.org/api/cli.html#--heapsnapshot-signalsignal
 RUN echo '\n--heapsnapshot-signal=SIGUSR2' >> config/node.options
+RUN echo '--diagnostic-dir=./data' >> config/node.options
 {{/serverless}}
 {{^opensslLegacyProvider}}
 RUN sed 's/\(--openssl-legacy-provider\)/#\1/' -i config/node.options

--- a/src/setup_node_env/heap_snapshot.js
+++ b/src/setup_node_env/heap_snapshot.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+var getopts = require('getopts');
+var v8 = require('node:v8');
+var worker = require('node:worker_threads');
+
+var execOpts = getopts(process.execArgv);
+var envOpts = getopts(process.env.NODE_OPTIONS ? process.env.NODE_OPTIONS.split(/\s+/) : []);
+var diagnosticDir = execOpts['diagnostic-dir'] || envOpts['diagnostic-dir'];
+var heapSnapshotSignal = execOpts['heapsnapshot-signal'] || envOpts['heapsnapshot-signal'];
+var heapSnapshotSerial = 0;
+
+function getHeapSnapshotPath() {
+  var now = new Date();
+
+  var year = now.getFullYear();
+  var month = String(now.getMonth() + 1).padStart(2, '0');
+  var day = String(now.getDate()).padStart(2, '0');
+  var hours = String(now.getHours()).padStart(2, '0');
+  var minutes = String(now.getMinutes()).padStart(2, '0');
+  var seconds = String(now.getSeconds()).padStart(2, '0');
+
+  var date = `${year}${month}${day}`;
+  var time = `${hours}${minutes}${seconds}`;
+  var pid = process.pid;
+  var threadId = worker.threadId;
+  var serial = (++heapSnapshotSerial).toString().padStart(3, '0');
+
+  return `${diagnosticDir}/Heap.${date}.${time}.${pid}.${threadId}.${serial}.heapsnapshot`;
+}
+
+if (diagnosticDir && heapSnapshotSignal) {
+  process.removeAllListeners(heapSnapshotSignal);
+
+  process.on(heapSnapshotSignal, function () {
+    var heapSnapshotPath = getHeapSnapshotPath();
+    v8.writeHeapSnapshot(heapSnapshotPath);
+  });
+}

--- a/src/setup_node_env/heap_snapshot.js
+++ b/src/setup_node_env/heap_snapshot.js
@@ -7,6 +7,7 @@
  */
 
 var getopts = require('getopts');
+var path = require('path');
 var v8 = require('node:v8');
 var worker = require('node:worker_threads');
 
@@ -32,7 +33,7 @@ function getHeapSnapshotPath() {
   var threadId = worker.threadId;
   var serial = (++heapSnapshotSerial).toString().padStart(3, '0');
 
-  return `${diagnosticDir}/Heap.${date}.${time}.${pid}.${threadId}.${serial}.heapsnapshot`;
+  return path.join(diagnosticDir, `Heap.${date}.${time}.${pid}.${threadId}.${serial}.heapsnapshot`);
 }
 
 if (diagnosticDir && heapSnapshotSignal) {

--- a/src/setup_node_env/setup_env.js
+++ b/src/setup_node_env/setup_env.js
@@ -11,6 +11,8 @@ require('./exit_on_warning');
 require('./harden');
 // The following require statements MUST be executed before any others - END
 
+// @todo Remove when migrated to Node 20 (#162696)
+require('./heap_snapshot');
 require('symbol-observable');
 require('source-map-support').install();
 require('./node_version_validator');


### PR DESCRIPTION
## Summary

When Kibana is running inside a Docker container, the root filesystem is read-only. If we try to use `--heapsnapshot-signal=SIGUSR2` in the `NODE_OPTIONS` and then send this signal to the Kibana process, the process crashes with an error complaining about the read-only filesystem.

The [`--diagnostic-dir`](https://nodejs.org/api/cli.html#--diagnostic-dirdirectory) parameter is supposed to set the destination folder for the heap snapshots, but there is a bug in Node <20 (nodejs/node#39493).

Since Kibana is running under non-root user, there is no way to work this around with `mount --bind`. And apparently, the Node 20 upgrade is not going to happen shortly (#162696). Due to those facts, the easiest option would be to use the [`writeHeapSnapshot()`](https://nodejs.org/api/v8.html#v8writeheapsnapshotfilenameoptions) call.

The proposed workaround takes place only if both options `--heapsnapshot-signal` and `--diagnostic-dir` are present at the same time, and can be safely removed right in #162696.

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
