### PR TITLE
[ci/on-merge] Remove serverless image build trigger

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -299,9 +299,3 @@ steps:
       queue: kibana-default
 
   - wait
-
-  - command: '.buildkite/scripts/steps/artifacts/docker_image_trigger.sh'
-    label: Trigger container image build
-    timeout_in_minutes: 10
-    agents:
-      queue: 'kibana-default'


### PR DESCRIPTION
After enabling the merge queue, this pipeline will run on commit instead.