### PR TITLE
Disable moment deprecation warnings in production

### DIFF
--- a/src/setup_node_env/mute_libraries.js
+++ b/src/setup_node_env/mute_libraries.js
@@ -6,8 +6,6 @@
  * Side Public License, v 1.
  */
 
-require('../setup_node_env/dist');
-require('./apm')();
-require('../setup_node_env/root');
-require('../setup_node_env/mute_libraries');
-require('./cli');
+// disable moment deprecation warnings
+var moment = require('moment');
+moment.suppressDeprecationWarnings = true;


### PR DESCRIPTION
## Summary

Disable `momentjs` deprecation warnings in production environment to avoid unexpected `console.log` entries. 


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->