### PR TITLE
Fix the empty space in the project header in some cases

### DIFF
--- a/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
+++ b/packages/core/chrome/core-chrome-browser-internal/src/ui/project/header.tsx
@@ -197,10 +197,6 @@ export const ProjectHeader = ({
               </EuiHeaderSectionItem>
 
               <EuiHeaderSectionItem>
-                <HeaderNavControls navControls$={observables.navControlsLeft$} />
-              </EuiHeaderSectionItem>
-
-              <EuiHeaderSectionItem>
                 <RedirectAppLinks coreStart={{ application }}>
                   <Breadcrumbs breadcrumbs$={observables.breadcrumbs$} />
                 </RedirectAppLinks>


### PR DESCRIPTION
## Summary

Fixes this empty space issue in some cases: 

<img width="1144" alt="Screenshot 2023-11-08 at 10 38 09" src="https://github.com/elastic/kibana/assets/7784120/eb8a37de-988b-4fd7-a84b-1c93ecbf2b84">


To keep it simple, let's just remove this section from DOM until or if we need it. 
Previously this was used for spaces, but if we support spaces in serverless they will become part of breadcrumbs anyways 
