### PR TITLE
Rename document count aggregation and add default filter title

### DIFF
--- a/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
@@ -38,6 +38,11 @@ interface MetricRowWithAggProps extends MetricRowBaseProps {
   fields: NormalizedFields;
 }
 
+const DEFAULT_COUNT_FILTER_TITLE = i18n.translate(
+  'xpack.observability.customThreshold.rule.alertFlyout.customEquationEditor.defaultCountFilterTitle',
+  { defaultMessage: 'all documents' }
+);
+
 export function MetricRowWithAgg({
   name,
   aggType = Aggregators.COUNT,
@@ -126,7 +131,9 @@ export function MetricRowWithAgg({
                 <EuiExpression
                   data-test-subj="aggregationName"
                   description={aggregationTypes[aggType].text}
-                  value={aggType === Aggregators.COUNT ? filter : field}
+                  value={
+                    aggType === Aggregators.COUNT ? filter || DEFAULT_COUNT_FILTER_TITLE : field
+                  }
                   isActive={aggTypePopoverOpen}
                   display="columns"
                   onClick={() => {

--- a/x-pack/plugins/observability/public/components/custom_threshold/components/expression_row.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/expression_row.tsx
@@ -292,7 +292,7 @@ export const aggregationType: { [key: string]: AggregationType } = {
     text: i18n.translate(
       'xpack.observability.customThreshold.rule.alertFlyout.aggregationText.count',
       {
-        defaultMessage: 'Document count',
+        defaultMessage: 'Count',
       }
     ),
     fieldRequired: false,


### PR DESCRIPTION
Closes #166472

## Summary

Rename document count aggregation and add default filter title.


https://github.com/elastic/kibana/assets/12370520/134b9253-eb09-4613-85c4-b262af062338

