### PR TITLE
Fix the custom threshold flyout validation style

### DIFF
--- a/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/custom_equation_editor.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/custom_equation_editor.tsx
@@ -167,7 +167,6 @@ export function CustomEquationEditor({
                 { defaultMessage: 'Equation and threshold' }
               )}
               error={[errors.equation]}
-              isInvalid={errors.equation != null}
             >
               <>
                 <EuiSpacer size="xs" />
@@ -182,6 +181,7 @@ export function CustomEquationEditor({
                   onClick={() => {
                     setCustomEqPopoverOpen(true);
                   }}
+                  isInvalid={errors.equation != null}
                 />
               </>
             </EuiFormRow>

--- a/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/custom_equation/metric_row_with_agg.tsx
@@ -121,7 +121,6 @@ export function MetricRowWithAgg({
                   'xpack.observability.customThreshold.rule.alertFlyout.customEquationEditor.aggregationLabel',
                   { defaultMessage: 'Aggregation {name}', values: { name } }
                 )}
-                isInvalid={aggType !== Aggregators.COUNT && !field}
               >
                 <EuiExpression
                   data-test-subj="aggregationName"
@@ -132,6 +131,7 @@ export function MetricRowWithAgg({
                   onClick={() => {
                     setAggTypePopoverOpen(true);
                   }}
+                  isInvalid={aggType !== Aggregators.COUNT && !field}
                 />
               </EuiFormRow>
             }
@@ -160,7 +160,6 @@ export function MetricRowWithAgg({
                       'xpack.observability.customThreshold.rule.alertFlyout.customEquationEditor.aggregationType',
                       { defaultMessage: 'Aggregation type' }
                     )}
-                    isInvalid={isAggInvalid}
                   >
                     <EuiSelect
                       data-test-subj="aggregationTypeSelect"
@@ -176,6 +175,7 @@ export function MetricRowWithAgg({
                           value,
                         };
                       })}
+                      isInvalid={isAggInvalid}
                     />
                   </EuiFormRow>
                 </EuiFlexItem>
@@ -201,7 +201,6 @@ export function MetricRowWithAgg({
                         'xpack.observability.customThreshold.rule.alertFlyout.customEquationEditor.fieldLabel',
                         { defaultMessage: 'Field name' }
                       )}
-                      isInvalid={isFieldInvalid}
                     >
                       <EuiComboBox
                         fullWidth


### PR DESCRIPTION
Closes #166275

## Summary

This PR fixes the custom threshold flyout validation style.


|Before|After|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/907a29d5-e593-4e75-a53a-a65fb7604659)|![image](https://github.com/elastic/kibana/assets/12370520/f16cbd67-d177-446e-9612-61fa7eaf1549)|