### PR TITLE
[ObsUx] Metadata flaky test fix

### DIFF
--- a/x-pack/test/api_integration/apis/metrics_ui/constants.ts
+++ b/x-pack/test/api_integration/apis/metrics_ui/constants.ts
@@ -40,7 +40,7 @@ export const DATES = {
     },
     logs_and_metrics_with_aws: {
       min: 1564083185000,
-      max: 1564083493080,
+      max: 1564083705100,
     },
   },
   'alert-test-data': {


### PR DESCRIPTION
Closes #167710 

## Summary

This PR changes the `max` date to avoid conflict with the metadata fixture (checking that the fixture date is *after* the constant date defined which currently matches)

## Testing
Test server run: `node scripts/functional_tests_server --config x-pack/test/api_integration/config`
Test run: ` node scripts/functional_test_runner --config=x-pack/test/api_integration/apis/metrics_ui/config --grep="metadata"`