### PR TITLE
[Security Solution][Endpoint] Disable vagrantfile check update

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/endpoint_agent_runner/Vagrantfile
+++ b/x-pack/plugins/security_solution/scripts/endpoint/endpoint_agent_runner/Vagrantfile
@@ -5,6 +5,7 @@ cachedAgentFilename = ENV["CACHED_AGENT_FILENAME"] || ''
 Vagrant.configure("2") do |config|
   config.vm.hostname = hostname
   config.vm.box = 'ubuntu/jammy64'
+  config.vm.box_check_update = false
 
   config.vm.provider :virtualbox do |vb|
     vb.memory = 4096


### PR DESCRIPTION
## Summary

Set `config.vm.box_check_update` vagrant option to `false` in order to use cached images.

