### PR TITLE
[Fleet] Fix type error when creating custom integration

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/custom_integrations/utils.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/custom_integrations/utils.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { convertStringToTitle } from './utils';
+
+describe('convertStringToTitle', () => {
+  it('works without underscore: test', () => {
+    expect(convertStringToTitle('test')).toBe('Test');
+  });
+
+  it('works with one underscore test_test', () => {
+    expect(convertStringToTitle('test_test')).toBe('Test Test');
+  });
+
+  it('works with double underscore: test__test', () => {
+    expect(convertStringToTitle('test__test')).toBe('Test Test');
+  });
+});

--- a/x-pack/plugins/fleet/server/services/epm/packages/custom_integrations/utils.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/custom_integrations/utils.ts
@@ -8,6 +8,7 @@
 export const convertStringToTitle = (name: string) => {
   return name
     .split('_')
+    .filter((word) => word.length > 0)
     .map((word) => {
       return word[0].toUpperCase() + word.substring(1);
     })


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/170191
Creating a custom integration with a double underscore like `test__test` result in a type error and a 500. That PR handle that case.

More info on custom integrations https://github.com/elastic/kibana/pull/160777

## How to reproduce?

Using the Fleet API create a custom integration with `__` it should succeed
```
curl -XPOST -u 'elastic:changeme' -H 'kbn-xsrf: something' -H 'elastic-api-version: 2023-10-31' -H 'content-type: application/json' -d '{
    "integrationName": "test__a",
    "datasets": [{"name": "test__a.access", "type": "logs"}]
}' 'http://localhost:5601/api/fleet/epm/custom_integrations'
```