### PR TITLE
chore(slo): auto refresh related alerts in slo details page

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_active_alerts.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_active_alerts.ts
@@ -49,6 +49,7 @@ type SloIdAndInstanceId = [string, string];
 
 interface Params {
   sloIdsAndInstanceIds: SloIdAndInstanceId[];
+  shouldRefetch?: boolean;
 }
 
 export interface UseFetchActiveAlerts {
@@ -70,9 +71,13 @@ interface FindApiResponse {
   };
 }
 
+const LONG_REFETCH_INTERVAL = 1000 * 60; // 1 minute
 const EMPTY_ACTIVE_ALERTS_MAP = new ActiveAlerts();
 
-export function useFetchActiveAlerts({ sloIdsAndInstanceIds = [] }: Params): UseFetchActiveAlerts {
+export function useFetchActiveAlerts({
+  sloIdsAndInstanceIds = [],
+  shouldRefetch = false,
+}: Params): UseFetchActiveAlerts {
   const { http } = useKibana().services;
 
   const { isInitialLoading, isLoading, isError, isSuccess, isRefetching, data } = useQuery({
@@ -136,6 +141,7 @@ export function useFetchActiveAlerts({ sloIdsAndInstanceIds = [] }: Params): Use
       }
     },
     refetchOnWindowFocus: false,
+    refetchInterval: shouldRefetch ? LONG_REFETCH_INTERVAL : undefined,
     enabled: Boolean(sloIdsAndInstanceIds.length),
   });
 

--- a/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/slo_details.tsx
@@ -42,6 +42,7 @@ export function SloDetails({ slo, isAutoRefreshing }: Props) {
   const { search } = useLocation();
   const { data: activeAlerts } = useFetchActiveAlerts({
     sloIdsAndInstanceIds: [[slo.id, slo.instanceId ?? ALL_VALUE]],
+    shouldRefetch: isAutoRefreshing,
   });
   const { isLoading: historicalSummaryLoading, data: historicalSummaries = [] } =
     useFetchHistoricalSummary({


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/170908

## Summary

This PR makes the fetch active alerts auto refresh when enabled