### PR TITLE
[Unified search][Dashboard] truncate filter pills to 10 lines

### DIFF
--- a/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
+++ b/src/plugins/dashboard/public/dashboard_actions/filters_notification_popover_contents.tsx
@@ -80,6 +80,7 @@ export function FiltersNotificationPopoverContents({
           <EuiFormRow
             label={dashboardFilterNotificationActionStrings.getQueryTitle()}
             display="rowCompressed"
+            fullWidth
           >
             <EuiCodeBlock
               language={queryLanguage}
@@ -92,7 +93,7 @@ export function FiltersNotificationPopoverContents({
           </EuiFormRow>
         )}
         {filters && filters.length > 0 && (
-          <EuiFormRow label={dashboardFilterNotificationActionStrings.getFiltersTitle()}>
+          <EuiFormRow label={dashboardFilterNotificationActionStrings.getFiltersTitle()} fullWidth>
             <EuiFlexGroup wrap={true} gutterSize="xs">
               <FilterItems filters={filters} indexPatterns={dataViews} readOnly={true} />
             </EuiFlexGroup>

--- a/src/plugins/unified_search/public/filter_badge/filter_badge.tsx
+++ b/src/plugins/unified_search/public/filter_badge/filter_badge.tsx
@@ -7,10 +7,11 @@
  */
 
 import React from 'react';
-import { EuiBadge, EuiTextColor, useEuiTheme } from '@elastic/eui';
+import { EuiBadge, EuiTextBlockTruncate, EuiTextColor, useEuiTheme } from '@elastic/eui';
 import type { DataView } from '@kbn/data-views-plugin/common';
 import type { Filter } from '@kbn/es-query';
 import { isCombinedFilter } from '@kbn/es-query';
+import { css } from '@emotion/react';
 import { FilterBadgeGroup } from './filter_badge_group';
 import type { FilterLabelStatus } from '../filter_bar/filter_item/filter_item';
 import { badgePaddingCss, marginLeftLabelCss } from './filter_badge.styles';
@@ -59,24 +60,32 @@ function FilterBadge({
       iconSide="right"
       {...rest}
     >
-      {!hideAlias && filter.meta.alias !== null ? (
-        <>
-          <span className={marginLeftLabelCss(euiTheme)}>
-            {prefix}
-            {filter.meta.alias}
-            {filterLabelStatus && <>: {filterLabelValue}</>}
-          </span>
-        </>
-      ) : (
-        <div>
-          {isCombinedFilter(filter) && prefix}
-          <FilterBadgeGroup
-            filters={[filter]}
-            dataViews={dataViews}
-            filterLabelStatus={valueLabel}
-          />
-        </div>
-      )}
+      <span
+        css={css`
+          white-space: normal;
+        `}
+      >
+        <EuiTextBlockTruncate lines={3}>
+          {!hideAlias && filter.meta.alias !== null ? (
+            <>
+              <span className={marginLeftLabelCss(euiTheme)}>
+                {prefix}
+                {filter.meta.alias}
+                {filterLabelStatus && <>: {filterLabelValue}</>}
+              </span>
+            </>
+          ) : (
+            <div>
+              {isCombinedFilter(filter) && prefix}
+              <FilterBadgeGroup
+                filters={[filter]}
+                dataViews={dataViews}
+                filterLabelStatus={valueLabel}
+              />
+            </div>
+          )}
+        </EuiTextBlockTruncate>
+      </span>
     </EuiBadge>
   );
 }

--- a/src/plugins/unified_search/public/filter_badge/filter_badge.tsx
+++ b/src/plugins/unified_search/public/filter_badge/filter_badge.tsx
@@ -65,7 +65,7 @@ function FilterBadge({
           white-space: normal;
         `}
       >
-        <EuiTextBlockTruncate lines={3}>
+        <EuiTextBlockTruncate lines={10}>
           {!hideAlias && filter.meta.alias !== null ? (
             <>
               <span className={marginLeftLabelCss(euiTheme)}>


### PR DESCRIPTION
## Summary

Solves 1/3 of https://github.com/elastic/kibana/issues/170398 

After assessing with @teresaalvarezsoler we decided to wrap to 10 lines and autoexpand.

(Ignore the missing 'x' in some filter pills, it was not impacted 🙏🏼 ) 

<img width="1479" alt="Screenshot 2023-11-10 at 11 20 32" src="https://github.com/elastic/kibana/assets/4283304/11da80df-92e2-4ea7-9efe-5e352bb95add">
<img width="396" alt="Screenshot 2023-11-10 at 11 20 08" src="https://github.com/elastic/kibana/assets/4283304/0b37f2c1-d736-4507-ae12-0f3f0a3b11f5">
<img width="980" alt="Screenshot 2023-11-10 at 11 19 58" src="https://github.com/elastic/kibana/assets/4283304/07dc61f6-92fa-4569-b5ee-011a9078006a">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
