### PR TITLE
[ci/artifacts] Fix docker context args

### DIFF
--- a/.buildkite/scripts/steps/artifacts/docker_context.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_context.sh
@@ -11,7 +11,7 @@ KIBANA_DOCKER_CONTEXT="${KIBANA_DOCKER_CONTEXT:="default"}"
 
 echo "--- Create contexts"
 mkdir -p target
-node scripts/build --skip-initialize --skip-generic-folders --skip-platform-folders --skip-archives --skip-cdn-assets --docker-context-use-local-artifact
+node scripts/build --skip-initialize --skip-generic-folders --skip-platform-folders --skip-archives --skip-cdn-assets --docker-context-use-local-artifact "${BUILD_ARGS[@]}"
 
 echo "--- Setup context"
 DOCKER_BUILD_FOLDER=$(mktemp -d)


### PR DESCRIPTION
I incorrectly removed this previously, not finding any arguments missing.  There was one - the `--release` flag, used to remove snapshot from the filename.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/3472
~https://buildkite.com/elastic/kibana-artifacts-staging/builds/2337~ I'll verify on the backport, the failure here is expected.

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->