### PR TITLE
[8.11] [ObsUX] Remove "Check for new data" button from hosts table (#170126)

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/hosts_table.tsx
@@ -8,10 +8,9 @@
 import React from 'react';
 import { EuiBasicTable } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import { NoData } from '../../../../components/empty_states';
+import { EuiEmptyPrompt } from '@elastic/eui';
 import { HostNodeRow, useHostsTableContext } from '../hooks/use_hosts_table';
 import { useHostsViewContext } from '../hooks/use_hosts_view';
-import { useUnifiedSearchContext } from '../hooks/use_unified_search';
 import { FlyoutWrapper } from './host_details_flyout/flyout_wrapper';
 import { DEFAULT_PAGE_SIZE } from '../constants';
 import { FilterAction } from './table/filter_action';
@@ -20,7 +19,6 @@ const PAGE_SIZE_OPTIONS = [5, 10, 20];
 
 export const HostsTable = () => {
   const { loading } = useHostsViewContext();
-  const { onSubmit } = useUnifiedSearchContext();
 
   const {
     columns,
@@ -75,18 +73,21 @@ export const HostsTable = () => {
               defaultMessage: 'Loading data',
             })
           ) : (
-            <NoData
-              titleText={i18n.translate('xpack.infra.waffle.noDataTitle', {
-                defaultMessage: 'There is no data to display.',
-              })}
-              bodyText={i18n.translate('xpack.infra.waffle.noDataDescription', {
+            <EuiEmptyPrompt
+              body={i18n.translate('xpack.infra.waffle.noDataDescription', {
                 defaultMessage: 'Try adjusting your time or filter.',
               })}
-              refetchText={i18n.translate('xpack.infra.waffle.checkNewDataButtonLabel', {
-                defaultMessage: 'Check for new data',
-              })}
-              onRefetch={() => onSubmit()}
-              testString="noMetricsDataPrompt"
+              data-test-subj="hostsViewTableNoData"
+              layout="vertical"
+              title={
+                <h2>
+                  {i18n.translate('xpack.infra.waffle.noDataTitle', {
+                    defaultMessage: 'There is no data to display.',
+                  })}
+                </h2>
+              }
+              hasBorder={false}
+              titleSize="m"
             />
           )
         }

--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -686,6 +686,16 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await pageObjects.infraHostsView.submitQuery('cloud.provider="gcp" A');
           await testSubjects.existOrFail('hostsViewErrorCallout');
         });
+
+        it('should show no data message in the table content', async () => {
+          await pageObjects.infraHostsView.submitQuery('host.name : "foo"');
+
+          await waitForPageToLoad();
+
+          await retry.try(async () => {
+            await testSubjects.exists('hostsViewTableNoData');
+          });
+        });
       });
 
       describe('Pagination and Sorting', () => {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/166344
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ObsUX] Remove "Check for new data" button from hosts table (#170126)](https://github.com/elastic/kibana/pull/170126)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-11-01T12:15:37Z","message":"[ObsUX] Remove \"Check for new data\" button from hosts table (#170126)\n\ncloses https://github.com/elastic/kibana/issues/170125\r\n\r\n## Summary\r\n\r\nRemoves the \"Check for new data\" button that appears in the table when\r\nthe API returns nothing.\r\n\r\n<img width=\"1469\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/7873f4c8-4b7e-4dbe-865b-2b5091775792\">\r\n\r\n\r\n**Reason:** The Hosts View search submission needs to happen within the\r\nUnified Search scope because it's where the filter state is managed and\r\nupdated. The submit button in the table triggers API calls with an\r\nunsynced state.\r\n\r\n\r\n### How to test\r\n- Setup a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Filter by `host.name: foo`","sha":"0fcf683e31fb34817632d61bd807eb6d8bb177e7","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Metrics UI","release_note:skip","backport:skip","Feature:ObsHosts","v8.12.0","Team:obs-ux-infra_services"],"number":170126,"url":"https://github.com/elastic/kibana/pull/170126","mergeCommit":{"message":"[ObsUX] Remove \"Check for new data\" button from hosts table (#170126)\n\ncloses https://github.com/elastic/kibana/issues/170125\r\n\r\n## Summary\r\n\r\nRemoves the \"Check for new data\" button that appears in the table when\r\nthe API returns nothing.\r\n\r\n<img width=\"1469\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/7873f4c8-4b7e-4dbe-865b-2b5091775792\">\r\n\r\n\r\n**Reason:** The Hosts View search submission needs to happen within the\r\nUnified Search scope because it's where the filter state is managed and\r\nupdated. The submit button in the table triggers API calls with an\r\nunsynced state.\r\n\r\n\r\n### How to test\r\n- Setup a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Filter by `host.name: foo`","sha":"0fcf683e31fb34817632d61bd807eb6d8bb177e7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/170126","number":170126,"mergeCommit":{"message":"[ObsUX] Remove \"Check for new data\" button from hosts table (#170126)\n\ncloses https://github.com/elastic/kibana/issues/170125\r\n\r\n## Summary\r\n\r\nRemoves the \"Check for new data\" button that appears in the table when\r\nthe API returns nothing.\r\n\r\n<img width=\"1469\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/2767137/7873f4c8-4b7e-4dbe-865b-2b5091775792\">\r\n\r\n\r\n**Reason:** The Hosts View search submission needs to happen within the\r\nUnified Search scope because it's where the filter state is managed and\r\nupdated. The submit button in the table triggers API calls with an\r\nunsynced state.\r\n\r\n\r\n### How to test\r\n- Setup a local Kibana instance\r\n- Navigate to `Infrastructure` > `Hosts`\r\n- Filter by `host.name: foo`","sha":"0fcf683e31fb34817632d61bd807eb6d8bb177e7"}}]}] BACKPORT-->