### PR TITLE
[8.11] [ObsUX] Fix hosts_view flaky test (#169823)

### DIFF
--- a/x-pack/test/functional/apps/infra/hosts_view.ts
+++ b/x-pack/test/functional/apps/infra/hosts_view.ts
@@ -471,11 +471,13 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
           await waitForPageToLoad();
         });
 
-        it('maintains selected date range when navigating to the individual host details', async () => {
+        it('should maintain the selected date range when navigating to the individual host details', async () => {
           const start = START_HOST_PROCESSES_DATE.format(DATE_PICKER_FORMAT);
           const end = END_HOST_PROCESSES_DATE.format(DATE_PICKER_FORMAT);
 
           await pageObjects.timePicker.setAbsoluteRange(start, end);
+
+          await waitForPageToLoad();
 
           const hostDetailLinks = await pageObjects.infraHostsView.getAllHostDetailLinks();
           expect(hostDetailLinks.length).not.to.equal(0);


### PR DESCRIPTION
fixes https://github.com/elastic/kibana/issues/166344

# Backport

This will backport the following commits from `main` to `8.11`:
 - [[ObsUX] Fix hosts_view flaky test (#169823)](https://github.com/elastic/kibana/pull/169823)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Carlos Crespo","email":"crespocarlos@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-10-27T10:29:23Z","message":"[ObsUX] Fix hosts_view flaky test (#169823)\n\nfixes: https://github.com/elastic/kibana/issues/166344\r\n\r\n## Summary\r\n\r\nFunctional test fix\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3739","sha":"22660304c69e9c1a27e2e700eafa22fd6fa29eeb","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","v8.12.0","Team:obs-ux-infra_services"],"number":169823,"url":"https://github.com/elastic/kibana/pull/169823","mergeCommit":{"message":"[ObsUX] Fix hosts_view flaky test (#169823)\n\nfixes: https://github.com/elastic/kibana/issues/166344\r\n\r\n## Summary\r\n\r\nFunctional test fix\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3739","sha":"22660304c69e9c1a27e2e700eafa22fd6fa29eeb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169823","number":169823,"mergeCommit":{"message":"[ObsUX] Fix hosts_view flaky test (#169823)\n\nfixes: https://github.com/elastic/kibana/issues/166344\r\n\r\n## Summary\r\n\r\nFunctional test fix\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3739","sha":"22660304c69e9c1a27e2e700eafa22fd6fa29eeb"}}]}] BACKPORT-->