### PR TITLE
[ci/cloud-deploy] Skip CDN assets build

### DIFF
--- a/.buildkite/scripts/steps/cloud/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/cloud/build_and_deploy.sh
@@ -37,6 +37,7 @@ else
     --skip-generic-folders \
     --skip-platform-folders \
     --skip-archives \
+    --skip-cdn-assets \
     --docker-images \
     --docker-tag-qualifier="$GIT_COMMIT" \
     --docker-push \


### PR DESCRIPTION
The cloud deploy image is created using a resume build, relying on an existing kibana.tar.gz.  The source files needed to build CDN assets are not available and this step is not needed.
