### PR TITLE
[EMS] Update to ems-client@8.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@elastic/charts": "60.0.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.9.1-canary.1",
-    "@elastic/ems-client": "8.5.0",
+    "@elastic/ems-client": "8.5.1",
     "@elastic/eui": "90.0.0",
     "@elastic/filesaver": "1.1.2",
     "@elastic/node-crypto": "1.2.1",

--- a/src/dev/license_checker/config.ts
+++ b/src/dev/license_checker/config.ts
@@ -84,7 +84,7 @@ export const PER_PACKAGE_ALLOWED_LICENSES = {
 export const LICENSE_OVERRIDES = {
   'jsts@1.6.2': ['Eclipse Distribution License - v 1.0'], // cf. https://github.com/bjornharrtell/jsts
   '@mapbox/jsonlint-lines-primitives@2.0.2': ['MIT'], // license in readme https://github.com/tmcw/jsonlint
-  '@elastic/ems-client@8.5.0': ['Elastic License 2.0'],
+  '@elastic/ems-client@8.5.1': ['Elastic License 2.0'],
   '@elastic/eui@90.0.0': ['SSPL-1.0 OR Elastic License 2.0'],
   'language-subtag-registry@0.3.21': ['CC-BY-4.0'], // retired ODC‑By license https://github.com/mattcg/language-subtag-registry
   'buffers@0.1.1': ['MIT'], // license in importing module https://www.npmjs.com/package/binary

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@
     "@elastic/transport" "^8.3.3"
     tslib "^2.4.0"
 
-"@elastic/ems-client@8.5.0":
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.5.0.tgz#5e3988ab01dee54bace9f8c2f9e71470b26a1bfa"
-  integrity sha512-uEI8teyS3gWErlEL4mEYh0MDHms9Rp3eEHKnMMSdMtAkaa3xs60SOm3Vd0ld9sIPsyarQHrAybAw30GXVXXRjw==
+"@elastic/ems-client@8.5.1":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@elastic/ems-client/-/ems-client-8.5.1.tgz#60c179e53ad81f5e26680e7e1c6cbffe4fb64aed"
+  integrity sha512-lc65i/cW6fGuRMt3pUte35sL8HxXM7TbYJwx1bHWcWn4aN3zv8i5RhPKFz+Wr/1ubfFOTrIoFYCP4h1uq2O/dQ==
   dependencies:
     "@types/geojson" "^7946.0.10"
     "@types/lru-cache" "^5.1.0"


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/ems-client/pull/208

Update to a version of `ems-client` that supports Node 20.

I'm creating new PRs for:

* `@elastic/ems-client@8.4.1` in Kibana `8.11` branch
* `@elastic/ems-client@7.17.1` for Kibana `7.17` branch

Sorry for the small overhead on reviewing; this way, it seems faster to get CI running in parallel for the three releases and unblock the operations team on this issue.