### PR TITLE
[Fleet] Fix view agent activity for large action

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -26,6 +26,7 @@ import {
   EuiButtonEmpty,
   EuiFlyoutFooter,
   EuiSpacer,
+  EuiToolTip,
 } from '@elastic/eui';
 import styled from 'styled-components';
 
@@ -56,6 +57,8 @@ const FullHeightFlyoutBody = styled(EuiFlyoutBody)`
 const FlyoutFooterWPadding = styled(EuiFlyoutFooter)`
   padding: 16px 24px !important;
 `;
+
+const MAX_VIEW_AGENTS_COUNT = 250;
 
 export const AgentActivityFlyout: React.FunctionComponent<{
   onClose: () => void;
@@ -702,17 +705,42 @@ const ViewAgentsButton: React.FunctionComponent<{
   action: ActionStatus;
   onClickViewAgents: (action: ActionStatus) => void;
 }> = ({ action, onClickViewAgents }) => {
-  return action.type !== 'UPDATE_TAGS' ? (
+  if (action.type === 'UPDATE_TAGS') {
+    return null;
+  }
+
+  const button = (
     <EuiButtonEmpty
       size="m"
       onClick={() => onClickViewAgents(action)}
       flush="left"
       data-test-subj="agentActivityFlyout.viewAgentsButton"
+      disabled={action.nbAgentsActionCreated > MAX_VIEW_AGENTS_COUNT}
     >
       <FormattedMessage
         id="xpack.fleet.agentActivityFlyout.viewAgentsButton"
         defaultMessage="View Agents"
       />
     </EuiButtonEmpty>
-  ) : null;
+  );
+
+  if (action.nbAgentsActionCreated <= MAX_VIEW_AGENTS_COUNT) {
+    return button;
+  }
+
+  return (
+    <EuiToolTip
+      content={
+        <FormattedMessage
+          id="xpack.fleet.agentActivityFlyout.viewAgentsButtonDisabledMaxTooltip"
+          defaultMessage="The view agents feature is only available for action impacting less then {agentCount} agents"
+          values={{
+            agentCount: MAX_VIEW_AGENTS_COUNT,
+          }}
+        />
+      }
+    >
+      {button}
+    </EuiToolTip>
+  );
 };

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -58,7 +58,7 @@ const FlyoutFooterWPadding = styled(EuiFlyoutFooter)`
   padding: 16px 24px !important;
 `;
 
-const MAX_VIEW_AGENTS_COUNT = 250;
+const MAX_VIEW_AGENTS_COUNT = 2000;
 
 export const AgentActivityFlyout: React.FunctionComponent<{
   onClose: () => void;


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/157678

We are not able to filter for more than 250 agents by id in the agent list, while we found a proper solution that PR disable the view activity button for action with more than 250 agents to avoid showing errors to the user

## UI Changes

<img width="827" alt="Screenshot 2023-11-09 at 11 17 26 AM" src="https://github.com/elastic/kibana/assets/1336873/abbb6d1e-95f4-4cdd-a16e-81fffdf76db2">
<img width="935" alt="Screenshot 2023-11-09 at 11 17 39 AM" src="https://github.com/elastic/kibana/assets/1336873/7629be92-2776-47a6-9554-7ec54a72ef95">
