### PR TITLE
Remove invalid license options from kbn/es

### DIFF
--- a/packages/kbn-es/README.mdx
+++ b/packages/kbn-es/README.mdx
@@ -68,7 +68,7 @@ es.run({
 
 Type: `String`
 
-License type, one of: trial, basic, gold, platinum
+License type, one of: basic, trial
 
 ##### options.version
 

--- a/packages/kbn-es/src/artifact.test.js
+++ b/packages/kbn-es/src/artifact.test.js
@@ -67,24 +67,18 @@ beforeEach(() => {
 
   MOCKS = {
     valid: {
-      archives: [createArchive({ license: 'oss' }), createArchive({ license: 'default' })],
+      archives: [createArchive({ license: 'default' })],
     },
     invalidArch: {
-      archives: [
-        createArchive({ license: 'oss', architecture: 'invalid_arch' }),
-        createArchive({ license: 'default', architecture: 'invalid_arch' }),
-      ],
+      archives: [createArchive({ license: 'default', architecture: 'invalid_arch' })],
     },
     differentVersion: {
-      archives: [
-        createArchive({ license: 'oss', version: 'another-version' }),
-        createArchive({ license: 'default', version: 'another-version' }),
-      ],
+      archives: [createArchive({ license: 'default', version: 'another-version' })],
     },
     multipleArch: {
       archives: [
-        createArchive({ architecture: 'fake_arch', license: 'oss' }),
-        createArchive({ architecture: ARCHITECTURE, license: 'oss' }),
+        createArchive({ architecture: 'fake_arch', license: 'default' }),
+        createArchive({ architecture: ARCHITECTURE, license: 'default' }),
       ],
     },
   };
@@ -116,8 +110,6 @@ describe('Artifact', () => {
         mockFetch(MOCKS.valid);
       });
 
-      it('should return artifact metadata for a daily oss artifact', artifactTest('oss', 'oss'));
-
       it(
         'should return artifact metadata for a daily default artifact',
         artifactTest('default', 'default')
@@ -148,11 +140,6 @@ describe('Artifact', () => {
       });
 
       it(
-        'should return artifact metadata for a permanent oss artifact',
-        artifactTest('oss', 'oss', 2)
-      );
-
-      it(
         'should return artifact metadata for a permanent default artifact',
         artifactTest('default', 'default', 2)
       );
@@ -181,8 +168,8 @@ describe('Artifact', () => {
       });
 
       it('should return artifact metadata for the correct architecture', async () => {
-        const artifact = await Artifact.getSnapshot('oss', MOCK_VERSION, log);
-        expect(artifact.spec.filename).toEqual(MOCK_FILENAME + `-${ARCHITECTURE}.oss`);
+        const artifact = await Artifact.getSnapshot('default', MOCK_VERSION, log);
+        expect(artifact.spec.filename).toEqual(MOCK_FILENAME + `-${ARCHITECTURE}.default`);
       });
     });
 
@@ -195,7 +182,7 @@ describe('Artifact', () => {
       });
 
       it('should use the custom URL when looking for a snapshot', async () => {
-        await Artifact.getSnapshot('oss', MOCK_VERSION, log);
+        await Artifact.getSnapshot('default', MOCK_VERSION, log);
         expect(fetch.mock.calls[0][0]).toEqual(CUSTOM_URL);
       });
 
@@ -211,7 +198,7 @@ describe('Artifact', () => {
       });
 
       it('should use the daily unverified URL when looking for a snapshot', async () => {
-        await Artifact.getSnapshot('oss', MOCK_VERSION, log);
+        await Artifact.getSnapshot('default', MOCK_VERSION, log);
         expect(fetch.mock.calls[0][0]).toEqual(
           `${DAILY_SNAPSHOT_BASE_URL}/${MOCK_VERSION}/manifest-latest.json`
         );

--- a/packages/kbn-es/src/artifact.ts
+++ b/packages/kbn-es/src/artifact.ts
@@ -27,7 +27,7 @@ const PERMANENT_SNAPSHOTS_BASE_URL =
   'https://storage.googleapis.com/kibana-ci-es-snapshots-permanent';
 
 type ChecksumType = 'sha512';
-export type ArtifactLicense = 'oss' | 'basic' | 'trial';
+export type ArtifactLicense = 'basic' | 'trial';
 
 interface ArtifactManifest {
   id: string;
@@ -122,7 +122,7 @@ async function getArtifactSpecForSnapshot(
   log: ToolingLog
 ): Promise<ArtifactSpec> {
   const desiredVersion = urlVersion.replace('-SNAPSHOT', '');
-  const desiredLicense = license === 'oss' ? 'oss' : 'default';
+  const desiredLicense = 'default';
 
   const customManifestUrl = process.env.ES_SNAPSHOT_MANIFEST;
   const primaryManifestUrl = `${DAILY_SNAPSHOTS_BASE_URL}/${desiredVersion}/manifest-latest${

--- a/packages/kbn-es/src/cli_commands/build_snapshots.ts
+++ b/packages/kbn-es/src/cli_commands/build_snapshots.ts
@@ -49,35 +49,33 @@ export const buildSnapshots: Command = {
     del.sync(outputDir);
     Fs.mkdirSync(outputDir, { recursive: true });
 
-    for (const license of ['oss', 'trial']) {
-      for (const platform of ['darwin', 'win32', 'linux']) {
-        log.info('Building', platform, license === 'trial' ? 'default' : 'oss', 'snapshot');
-        await log.indent(4, async () => {
-          const snapshotPath = await buildSnapshot({
-            license,
-            sourcePath: options.sourcePath,
-            log,
-            platform,
-          });
-
-          const filename = basename(snapshotPath);
-          const outputPath = resolve(outputDir, filename);
-          const hash = createHash('sha512');
-          await pipelineAsync(
-            Fs.createReadStream(snapshotPath),
-            new Transform({
-              transform(chunk, _, cb) {
-                hash.update(chunk);
-                cb(undefined, chunk);
-              },
-            }),
-            Fs.createWriteStream(outputPath)
-          );
-
-          Fs.writeFileSync(`${outputPath}.sha512`, `${hash.digest('hex')}  ${filename}`);
-          log.success('snapshot and shasum written to', outputPath);
+    for (const platform of ['darwin', 'win32', 'linux']) {
+      log.info('Building', platform, 'default snapshot');
+      await log.indent(4, async () => {
+        const snapshotPath = await buildSnapshot({
+          license: 'trial',
+          sourcePath: options.sourcePath,
+          log,
+          platform,
         });
-      }
+
+        const filename = basename(snapshotPath);
+        const outputPath = resolve(outputDir, filename);
+        const hash = createHash('sha512');
+        await pipelineAsync(
+          Fs.createReadStream(snapshotPath),
+          new Transform({
+            transform(chunk, _, cb) {
+              hash.update(chunk);
+              cb(undefined, chunk);
+            },
+          }),
+          Fs.createWriteStream(outputPath)
+        );
+
+        Fs.writeFileSync(`${outputPath}.sha512`, `${hash.digest('hex')}  ${filename}`);
+        log.success('snapshot and shasum written to', outputPath);
+      });
     }
   },
 };

--- a/packages/kbn-es/src/cli_commands/snapshot.ts
+++ b/packages/kbn-es/src/cli_commands/snapshot.ts
@@ -23,7 +23,7 @@ export const snapshot: Command = {
     return dedent`
     Options:
 
-      --license         Run with a 'oss', 'basic', or 'trial' license [default: ${license}]
+      --license         Run with a 'basic' or 'trial' license [default: ${license}]
       --version         Version of ES to download [default: ${defaults.version}]
       --base-path       Path containing cache/installations [default: ${basePath}]
       --install-path    Installation path, defaults to 'source' within base-path

--- a/packages/kbn-es/src/cli_commands/source.ts
+++ b/packages/kbn-es/src/cli_commands/source.ts
@@ -20,7 +20,7 @@ export const source: Command = {
     return dedent`
       Options:
 
-        --license         Run with a 'oss', 'basic', or 'trial' license [default: ${license}]
+        --license         Run with a 'basic' or 'trial' license [default: ${license}]
         --source-path     Path to ES source [default: ${defaults['source-path']}]
         --base-path       Path containing cache/installations [default: ${basePath}]
         --install-path    Installation path, defaults to 'source' within base-path

--- a/packages/kbn-es/src/custom_snapshots.ts
+++ b/packages/kbn-es/src/custom_snapshots.ts
@@ -42,7 +42,7 @@ export function resolveCustomSnapshotUrl(
 
   const ext = process.platform === 'win32' ? 'zip' : 'tar.gz';
   const os = process.platform === 'win32' ? 'windows' : process.platform;
-  const name = license === 'oss' ? 'elasticsearch-oss' : 'elasticsearch';
+  const name = 'elasticsearch';
   const overrideUrl = customSnapshotUrl
     .replace('{name}', name)
     .replace('{ext}', ext)

--- a/packages/kbn-es/src/install/install_archive.ts
+++ b/packages/kbn-es/src/install/install_archive.ts
@@ -66,17 +66,15 @@ export async function installArchive(archive: string, options?: InstallArchiveOp
   fs.mkdirSync(tmpdir, { recursive: true });
   log.info('created %s', chalk.bold(tmpdir));
 
-  if (license !== 'oss') {
-    // starting in 6.3, security is disabled by default. Since we bootstrap
-    // the keystore, we can enable security ourselves.
-    await appendToConfig(installPath, 'xpack.security.enabled', 'true');
+  // starting in 6.3, security is disabled by default. Since we bootstrap
+  // the keystore, we can enable security ourselves.
+  await appendToConfig(installPath, 'xpack.security.enabled', 'true');
 
-    await appendToConfig(installPath, 'xpack.license.self_generated.type', license);
-    await configureKeystore(installPath, log, [
-      ['bootstrap.password', password],
-      ...parseSettings(esArgs, { filter: SettingsFilter.SecureOnly }),
-    ]);
-  }
+  await appendToConfig(installPath, 'xpack.license.self_generated.type', license);
+  await configureKeystore(installPath, log, [
+    ['bootstrap.password', password],
+    ...parseSettings(esArgs, { filter: SettingsFilter.SecureOnly }),
+  ]);
 
   return { installPath };
 }

--- a/packages/kbn-es/src/utils/build_snapshot.ts
+++ b/packages/kbn-es/src/utils/build_snapshot.ts
@@ -31,9 +31,6 @@ interface BuildSnapshotOptions {
  *   :distribution:archives:darwin-tar:assemble
  *   :distribution:archives:linux-tar:assemble
  *   :distribution:archives:windows-zip:assemble
- *   :distribution:archives:oss-darwin-tar:assemble
- *   :distribution:archives:oss-linux-tar:assemble
- *   :distribution:archives:oss-windows-zip:assemble
  */
 export async function buildSnapshot({
   license,
@@ -67,15 +64,13 @@ export async function buildSnapshot({
 }
 
 export function archiveForPlatform(platform: NodeJS.Platform, license: string) {
-  const taskPrefix = license === 'oss' ? 'oss-' : '';
-
   switch (platform) {
     case 'darwin':
-      return { format: 'tar', ext: 'tar.gz', task: `${taskPrefix}darwin-tar`, platform: 'darwin' };
+      return { format: 'tar', ext: 'tar.gz', task: 'darwin-tar', platform: 'darwin' };
     case 'win32':
-      return { format: 'zip', ext: 'zip', task: `${taskPrefix}windows-zip`, platform: 'windows' };
+      return { format: 'zip', ext: 'zip', task: 'windows-zip', platform: 'windows' };
     case 'linux':
-      return { format: 'tar', ext: 'tar.gz', task: `${taskPrefix}linux-tar`, platform: 'linux' };
+      return { format: 'tar', ext: 'tar.gz', task: 'linux-tar', platform: 'linux' };
     default:
       throw new Error(`unsupported platform: ${platform}`);
   }


### PR DESCRIPTION
## Summary

- Removes invalid license options from docs.
- Removes invalid `oss` license from cli
