### PR TITLE
Exclude DGA integration from serverless projects

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -47,14 +47,19 @@ xpack.fleet.internal.registry.excludePackages: [
     'endpoint',
     'beaconing',
     'osquery_manager',
+
     # synthetics is not enabled yet
     'synthetics',
     'synthetics_dashboards',
+
     # Removed in 8.11 integrations
     'cisco',
     'microsoft',
     'symantec',
     'cyberark',
+
+    # ML integrations
+    'dga',
   ]
 
 ## Required for force installation of APM Package

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -48,11 +48,15 @@ xpack.fleet.internal.registry.excludePackages: [
     'apm',
     'synthetics',
     'synthetics_dashboards',
+
     # Removed in 8.11 integrations
     'cisco',
     'microsoft',
     'symantec',
     'cyberark',
+
+    # ML integrations
+    'dga',
   ]
 # fleet_server package installed to publish agent metrics
 xpack.fleet.packages:


### PR DESCRIPTION
## Summary

Excludes the DGA integration from serverless projects, as it can cause issues due to the size of its trained ML model assets. 



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->