### PR TITLE
[Dashboard] Rename Dashboard to Dashboards

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
+++ b/src/plugins/dashboard/public/dashboard_app/_dashboard_app_strings.ts
@@ -152,7 +152,7 @@ export const shareModalStrings = {
 */
 export const getDashboardBreadcrumb = () =>
   i18n.translate('dashboard.dashboardAppBreadcrumbsTitle', {
-    defaultMessage: 'Dashboard',
+    defaultMessage: 'Dashboards',
   });
 
 export const topNavStrings = {

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -229,7 +229,7 @@ export class DashboardPlugin
 
     const app: App = {
       id: DASHBOARD_APP_ID,
-      title: 'Dashboard',
+      title: 'Dashboards',
       order: 2500,
       euiIconType: 'logoKibana',
       defaultPath: `#${LANDING_PAGE_PATH}`,

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
@@ -96,7 +96,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('only shows the dashboard navlink', async () => {
         const navLinks = await appsMenu.readLinks();
-        expect(navLinks.map((link) => link.text)).to.eql(['Dashboard', 'Stack Management']);
+        expect(navLinks.map((link) => link.text)).to.eql(['Dashboards', 'Stack Management']);
       });
 
       it(`landing page shows "Create new Dashboard" button`, async () => {
@@ -286,7 +286,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows dashboard navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Dashboard']);
+        expect(navLinks).to.eql(['Dashboards']);
       });
 
       it(`landing page doesn't show "Create new Dashboard" button`, async () => {
@@ -398,7 +398,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('shows dashboard navlink', async () => {
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.eql(['Dashboard']);
+        expect(navLinks).to.eql(['Dashboards']);
       });
 
       it(`landing page doesn't show "Create new Dashboard" button`, async () => {

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_spaces.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_spaces.ts
@@ -45,7 +45,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
           basePath: '/s/custom_space',
         });
         const navLinks = (await appsMenu.readLinks()).map((link) => link.text);
-        expect(navLinks).to.contain('Dashboard');
+        expect(navLinks).to.contain('Dashboards');
       });
 
       it(`landing page shows "Create new Dashboard" button`, async () => {

--- a/x-pack/test/functional/apps/management/feature_controls/management_security.ts
+++ b/x-pack/test/functional/apps/management/feature_controls/management_security.ts
@@ -36,7 +36,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
       it('should not show the Stack Management nav link', async () => {
         const links = await appsMenu.readLinks();
-        expect(links.map((link) => link.text)).to.eql(['Dashboard']);
+        expect(links.map((link) => link.text)).to.eql(['Dashboards']);
       });
 
       it('should render the "application not found" view when navigating to management directly', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/163152

## Summary

This PR renames the "Dashboard" app to "Dashboards" in both the side navigation and the breadcrumbs, like so:

| Before | After |
|--------|--------|
| <img width="344" alt="Screenshot 2023-11-10 at 10 53 37 AM" src="https://github.com/elastic/kibana/assets/8698078/a8b821f6-925d-4589-a763-ca70950a5b8b"> | <img width="344" alt="Screenshot 2023-11-10 at 10 54 12 AM" src="https://github.com/elastic/kibana/assets/8698078/0812627e-8cf4-48df-b9fc-8ce435b09dd0"> |
| <img width="508" alt="Screenshot 2023-11-10 at 10 57 51 AM" src="https://github.com/elastic/kibana/assets/8698078/970636ab-c48a-4204-bb59-c0a6f50fb0f4"> | <img width="508" alt="Screenshot 2023-11-10 at 10 57 14 AM" src="https://github.com/elastic/kibana/assets/8698078/48ceb444-38ec-4c6c-8885-8cc504eee2c5"> | 

This is more consistent with Visualizations, Maps, etc., the dashboard listing page, and dashboard URLs.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
