### PR TITLE
[Unified Data Table] Stop escaping column names when copying

### DIFF
--- a/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
+++ b/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.test.tsx
@@ -93,7 +93,7 @@ describe('copyValueToClipboard', () => {
       columnDisplayName: 'text_message',
     });
 
-    expect(result).toBe('"text_message"');
+    expect(result).toBe('text_message');
     expect(execCommandMock).toHaveBeenCalledWith('copy');
     expect(servicesMock.toastNotifications.addInfo).toHaveBeenCalledWith({
       title: 'Copied to clipboard',

--- a/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.ts
+++ b/packages/kbn-unified-data-table/src/utils/copy_value_to_clipboard.ts
@@ -131,9 +131,7 @@ export const copyColumnNameToClipboard = ({
   columnDisplayName: string;
   toastNotifications: ToastsStart;
 }): string | null => {
-  const nameFormattedResult = convertNameToString(columnDisplayName);
-  const textToCopy = nameFormattedResult.formattedString;
-  const copied = copyToClipboard(textToCopy);
+  const copied = copyToClipboard(columnDisplayName);
 
   if (!copied) {
     toastNotifications.addWarning({
@@ -147,16 +145,9 @@ export const copyColumnNameToClipboard = ({
     defaultMessage: 'Copied to clipboard',
   });
 
-  if (nameFormattedResult.withFormula) {
-    toastNotifications.addWarning({
-      title: toastTitle,
-      text: WARNING_FOR_FORMULAS,
-    });
-  } else {
-    toastNotifications.addInfo({
-      title: toastTitle,
-    });
-  }
+  toastNotifications.addInfo({
+    title: toastTitle,
+  });
 
-  return textToCopy;
+  return columnDisplayName;
 };

--- a/test/functional/apps/discover/group2/_data_grid_copy_to_clipboard.ts
+++ b/test/functional/apps/discover/group2/_data_grid_copy_to_clipboard.ts
@@ -79,7 +79,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await dataGrid.clickCopyColumnName('@timestamp');
       if (canReadClipboard) {
         const copiedTimestampName = await browser.getClipboardValue();
-        expect(copiedTimestampName).to.be('"\'@timestamp"');
+        expect(copiedTimestampName).to.be('@timestamp');
       }
 
       expect(await toasts.getToastCount()).to.be(1);


### PR DESCRIPTION
## Summary

When support for copying column values was added to Discover in #132330, it was designed for copying into spreadsheets, so column names and values are escaped when copied. We used the same approach for the the "Copy name" button, but this functionality isn't specific to spreadsheets and is more likely used for copying into search bars, etc. This PR updates the copy name functionality to stop escaping field names.

Resolves #170957.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)