### PR TITLE
[Shareable Dashboards] Update spaces for new references on save

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -70,15 +70,10 @@ export const useDashboardMenuItems = ({
   const hasUnsavedChanges = dashboard.select((state) => state.componentState.hasUnsavedChanges);
   const hasOverlays = dashboard.select((state) => state.componentState.hasOverlays);
   const lastSavedId = dashboard.select((state) => state.componentState.lastSavedId);
-  const namespaces = dashboard.select((state) => state.componentState.namespaces);
   const dashboardTitle = dashboard.select((state) => state.explicitInput.title);
   const viewMode = dashboard.select((state) => state.explicitInput.viewMode);
   const managed = dashboard.select((state) => state.componentState.managed);
   const disableTopNav = isSaveInProgress || hasOverlays;
-
-  const isShared = spacesApi && lastSavedId && namespaces && namespaces.length > 1;
-
-  console.log({ isShared });
 
   /**
    * Show the Dashboard app's share menu
@@ -127,51 +122,32 @@ export const useDashboardMenuItems = ({
    * Save the dashboard without any UI or popups.
    */
   const quickSaveDashboard = useCallback(() => {
-    if (isShared) {
-      confirmSaveForSharedDashboard({
-        onSave: () => {
-          setIsSaveInProgress(true);
-          dashboard.runQuickSave().then(() => {
-            updateSpacesForReferences();
-            setTimeout(() => setIsSaveInProgress(false), CHANGE_CHECK_DEBOUNCE);
-          });
-        },
-        onClone: clone,
-      });
-    } else {
-      dashboard.runQuickSave().then(() => {
-        setTimeout(() => setIsSaveInProgress(false), CHANGE_CHECK_DEBOUNCE);
-      });
-    }
-  }, [clone, confirmSaveForSharedDashboard, dashboard, isShared, updateSpacesForReferences]);
+    confirmSaveForSharedDashboard({
+      onSave: () => {
+        setIsSaveInProgress(true);
+        dashboard.runQuickSave().then(() => {
+          updateSpacesForReferences();
+          setTimeout(() => setIsSaveInProgress(false), CHANGE_CHECK_DEBOUNCE);
+        });
+      },
+      onClone: clone,
+    });
+  }, [clone, confirmSaveForSharedDashboard, dashboard, updateSpacesForReferences]);
 
   /**
    * Show the dashboard's save modal
    */
   const saveDashboardAs = useCallback(() => {
-    if (isShared) {
-      confirmSaveForSharedDashboard({
-        onSave: () => {
-          dashboard.runSaveAs().then((result) => {
-            updateSpacesForReferences();
-            maybeRedirect(result);
-          });
-        },
-        onClone: clone,
-      });
-    } else {
-      dashboard.runSaveAs().then((result) => {
-        maybeRedirect(result);
-      });
-    }
-  }, [
-    isShared,
-    confirmSaveForSharedDashboard,
-    clone,
-    dashboard,
-    updateSpacesForReferences,
-    maybeRedirect,
-  ]);
+    confirmSaveForSharedDashboard({
+      onSave: () => {
+        dashboard.runSaveAs().then((result) => {
+          updateSpacesForReferences();
+          maybeRedirect(result);
+        });
+      },
+      onClone: clone,
+    });
+  }, [confirmSaveForSharedDashboard, clone, dashboard, updateSpacesForReferences, maybeRedirect]);
 
   /**
    * Show the dashboard's "Confirm reset changes" modal. If confirmed:

--- a/src/plugins/dashboard/public/dashboard_top_nav/can_save_to_shared_object.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/can_save_to_shared_object.test.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Reference } from '@kbn/content-management-utils';
+import { SpacesManager } from '@kbn/spaces-plugin/public';
+import { canSaveToSharedObject } from './can_save_to_shared_object';
+
+test('returns true if there are no references', async () => {
+  const savedObjectTarget = {
+    type: 'dashboard',
+    id: 'dashboard1',
+    namespaces: ['default'],
+  };
+  const references = [] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  } as SpacesManager;
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(true);
+});
+
+test('returns true if there are references and hasUnsharedReference is false', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+    type: 'dashboard',
+    id: 'dashboard1',
+    namespaces: ['default'],
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(true);
+});
+
+test('returns false if hasUnsharedReference is true and hasUnshareableReference is true', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns false if hasUnsharedReference is true and hasHiddenSpace is true', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns false if hasUnsharedReference is true, sharedWithAllSpaces is false, and cannotShareToAllSpaces is true', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns true if hasUnsharedReference is true, sharedWithAllSpaces is false, and cannotShareToAllSpaces is false', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns false if hasUnsharedReference is true, sharedWithAllSpaces is true, and cannotShareToAllSpaces is true', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns true if hasUnsharedReference is true, sharedWithAllSpaces is true, and cannotShareToAllSpaces is false', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});
+
+test('returns false if hasUnsharedReference is true and cannotShareToAllSpaces is true', async () => {
+  const savedObjectTarget = {
+    /* mock saved object target */
+  };
+  const references = [
+    /* mock references */
+  ] as Reference[];
+  const spacesManager = {
+    /* mock spaces manager */
+  };
+
+  const result = await canSaveToSharedObject({ savedObjectTarget, references, spacesManager });
+
+  expect(result).toBe(false);
+});

--- a/src/plugins/dashboard/public/dashboard_top_nav/can_save_to_shared_object.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/can_save_to_shared_object.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Reference } from '@kbn/content-management-utils';
+import { ShareToSpaceSavedObjectTarget, SpacesManager } from '@kbn/spaces-plugin/public';
+
+export const canSaveToSharedObject = async ({
+  savedObjectTarget,
+  references,
+  spacesManager,
+}: {
+  savedObjectTarget: ShareToSpaceSavedObjectTarget;
+  references: Reference[];
+  spacesManager: SpacesManager;
+}): Promise<boolean> => {
+  if (references.length === 0) return true;
+
+  const { id, type, namespaces } = savedObjectTarget;
+  const hasHiddenSpace = namespaces.includes('?');
+  const sharedWithAllSpaces = namespaces.includes('*');
+
+  const shareableReferences = (
+    await spacesManager.getShareableReferences([{ type, id }, ...references])
+  ).objects;
+
+  const hasUnsharedReference = references.some(({ id: refId }) => {
+    const shareableRef = shareableReferences.find(
+      ({ id: shareableRefId }: { id: string }) => refId === shareableRefId
+    );
+
+    if (!shareableRef) return true;
+
+    return namespaces.some((sharedSpace) => !shareableRef.spaces.includes(sharedSpace));
+  });
+
+  if (!hasUnsharedReference) return true;
+
+  if (hasHiddenSpace) return false;
+
+  const hasUnshareableReference = shareableReferences.some(({ spaces }) => spaces.length === 0);
+
+  if (hasUnshareableReference) return false;
+
+  const allSpaces = sharedWithAllSpaces
+    ? await (await spacesManager.getSpaces()).map(({ id: spaceId }) => spaceId)
+    : namespaces;
+  const shareableSpaces = await spacesManager.getSpaces({
+    purpose: 'shareSavedObjectsIntoSpace',
+  });
+
+  const cannotShareToAllSpaces = allSpaces.some(
+    (spaceId) =>
+      !shareableSpaces.find(({ id: shareEnabledSpaceId }) => spaceId === shareEnabledSpaceId)
+  );
+
+  return !cannotShareToAllSpaces;
+};

--- a/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
@@ -18,15 +18,16 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SpacesApi } from '@kbn/spaces-plugin/public';
 import React, { useMemo } from 'react';
 
 export const ConfirmShareModal = ({
   canSave,
-  message,
   namespaces,
   spacesApi,
+  noun,
   title,
   onSave,
   onClone,
@@ -34,8 +35,8 @@ export const ConfirmShareModal = ({
   onClose,
 }: {
   canSave: boolean;
-  message: string;
   namespaces: string[];
+  noun: string;
   spacesApi: SpacesApi;
   title: string;
   onCancel?: () => void;
@@ -49,6 +50,23 @@ export const ConfirmShareModal = ({
     () => spacesApi.ui.components.getSpaceList,
     [spacesApi.ui.components.getSpaceList]
   );
+
+  let message;
+
+  if (canSave) {
+    message = i18n.translate('xpack.spaces.confirmShareModal.shareableChangesDescription', {
+      defaultMessage: `This {noun} is shared between {spacesCount} spaces. Any changes will also
+        be reflected in those spaces. Save as a new {noun} if you don't want the changes to be
+        reflected in the rest of spaces.`,
+      values: { spacesCount: namespaces.length, noun },
+    });
+  } else {
+    message = i18n.translate('xpack.spaces.confirmShareModal.unshareableChangesDescription', {
+      defaultMessage: `This {noun} is shared between {spacesCount} spaces, and some of your changes cannot 
+          be shared. Please save as a new {noun} to save your changes into the current space.`,
+      values: { spacesCount: namespaces.length, noun },
+    });
+  }
 
   return (
     <SpacesContextWrapper>

--- a/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
@@ -15,13 +15,16 @@ import {
   EuiModalBody,
   EuiModalFooter,
   EuiModalHeader,
+  EuiPagination,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SpacesApi } from '@kbn/spaces-plugin/public';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
+
+const ROWS_PER_PAGE = 5;
 
 export const ConfirmShareModal = ({
   canSave,
@@ -44,14 +47,13 @@ export const ConfirmShareModal = ({
   onClose: () => void;
   onSave: () => void;
 }) => {
+  let message;
+  const [activePage, setActivePage] = useState(0);
   const SpacesContextWrapper = spacesApi.ui.components.getSpacesContextProvider;
-
   const LazySpaceList = useMemo(
     () => spacesApi.ui.components.getSpaceList,
     [spacesApi.ui.components.getSpaceList]
   );
-
-  let message;
 
   if (canSave) {
     message = i18n.translate('xpack.spaces.confirmShareModal.shareableChangesDescription', {
@@ -67,6 +69,15 @@ export const ConfirmShareModal = ({
       values: { spacesCount: namespaces.length, noun },
     });
   }
+
+  const visibleSpaces = namespaces.slice(
+    activePage * ROWS_PER_PAGE,
+    Math.min(namespaces.length + 1, (activePage + 1) * ROWS_PER_PAGE)
+  );
+
+  const pageCount = Math.ceil(namespaces.length / ROWS_PER_PAGE);
+
+  console.log({ visibleSpaces });
 
   return (
     <SpacesContextWrapper>
@@ -87,10 +98,15 @@ export const ConfirmShareModal = ({
         </EuiModalHeader>
         <EuiModalBody>
           <LazySpaceList
-            namespaces={namespaces}
+            namespaces={visibleSpaces}
             behaviorContext="outside-space"
             direction="vertical"
-            displayLimit={4}
+            displayLimit={ROWS_PER_PAGE}
+          />
+          <EuiPagination
+            pageCount={pageCount}
+            activePage={activePage}
+            onPageClick={setActivePage}
           />
         </EuiModalBody>
         <EuiModalFooter>

--- a/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
@@ -25,6 +25,7 @@ import { SpacesApi } from '@kbn/spaces-plugin/public';
 import React, { useMemo, useState } from 'react';
 
 const ROWS_PER_PAGE = 5;
+const UNKNOWN_SPACE = '?';
 
 export const ConfirmShareModal = ({
   canSave,
@@ -70,14 +71,15 @@ export const ConfirmShareModal = ({
     });
   }
 
-  const visibleSpaces = namespaces.slice(
+  const hiddenSpaces = namespaces.filter((spaceId) => spaceId === UNKNOWN_SPACE);
+  const visibleSpaces = namespaces.filter((spaceId) => spaceId !== UNKNOWN_SPACE);
+
+  const spacesOnActivePage = visibleSpaces.slice(
     activePage * ROWS_PER_PAGE,
     Math.min(namespaces.length + 1, (activePage + 1) * ROWS_PER_PAGE)
   );
 
-  const pageCount = Math.ceil(namespaces.length / ROWS_PER_PAGE);
-
-  console.log({ visibleSpaces });
+  const pageCount = Math.ceil(visibleSpaces.length / ROWS_PER_PAGE);
 
   return (
     <SpacesContextWrapper>
@@ -98,16 +100,18 @@ export const ConfirmShareModal = ({
         </EuiModalHeader>
         <EuiModalBody>
           <LazySpaceList
-            namespaces={visibleSpaces}
+            namespaces={[...spacesOnActivePage, ...hiddenSpaces]}
             behaviorContext="outside-space"
             direction="vertical"
             displayLimit={ROWS_PER_PAGE}
           />
-          <EuiPagination
-            pageCount={pageCount}
-            activePage={activePage}
-            onPageClick={setActivePage}
-          />
+          {pageCount > 1 ? (
+            <EuiPagination
+              pageCount={pageCount}
+              activePage={activePage}
+              onPageClick={setActivePage}
+            />
+          ) : null}
         </EuiModalBody>
         <EuiModalFooter>
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">

--- a/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_modal.tsx
@@ -18,12 +18,11 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import { SpacesApi, SpacesContextProps } from '@kbn/spaces-plugin/public';
-import React from 'react';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { SpacesApi } from '@kbn/spaces-plugin/public';
+import React, { useMemo } from 'react';
 
-const getEmptyFunctionComponent: React.FC<SpacesContextProps> = ({ children }) => <>{children}</>;
-
-export const ConfirmShareSaveModal = ({
+export const ConfirmShareModal = ({
   canSave,
   message,
   namespaces,
@@ -37,15 +36,19 @@ export const ConfirmShareSaveModal = ({
   canSave: boolean;
   message: string;
   namespaces: string[];
-  spacesApi?: SpacesApi;
+  spacesApi: SpacesApi;
   title: string;
   onCancel?: () => void;
   onClone: () => void;
   onClose: () => void;
   onSave: () => void;
 }) => {
-  const SpacesContextWrapper =
-    spacesApi?.ui.components.getSpacesContextProvider ?? getEmptyFunctionComponent;
+  const SpacesContextWrapper = spacesApi.ui.components.getSpacesContextProvider;
+
+  const LazySpaceList = useMemo(
+    () => spacesApi.ui.components.getSpaceList,
+    [spacesApi.ui.components.getSpaceList]
+  );
 
   return (
     <SpacesContextWrapper>
@@ -65,12 +68,12 @@ export const ConfirmShareSaveModal = ({
           </EuiFlexGroup>
         </EuiModalHeader>
         <EuiModalBody>
-          {spacesApi?.ui.components.getSpaceList({
-            namespaces,
-            behaviorContext: 'outside-space',
-            direction: 'vertical',
-            displayLimit: 4,
-          })}
+          <LazySpaceList
+            namespaces={namespaces}
+            behaviorContext="outside-space"
+            direction="vertical"
+            displayLimit={4}
+          />
         </EuiModalBody>
         <EuiModalFooter>
           <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
@@ -82,7 +85,10 @@ export const ConfirmShareSaveModal = ({
                   onClose();
                 }}
               >
-                Cancel
+                <FormattedMessage
+                  id="xpack.spaces.confirmSaveModal.cancelButtonLabel"
+                  defaultMessage="Cancel"
+                />
               </EuiButtonEmpty>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
@@ -94,7 +100,10 @@ export const ConfirmShareSaveModal = ({
                   onClose();
                 }}
               >
-                Clone
+                <FormattedMessage
+                  id="xpack.spaces.confirmSaveModal.cloneButtonLabel"
+                  defaultMessage="Clone"
+                />
               </EuiButton>
             </EuiFlexItem>
             {canSave ? (
@@ -107,7 +116,10 @@ export const ConfirmShareSaveModal = ({
                     onClose();
                   }}
                 >
-                  Save
+                  <FormattedMessage
+                    id="xpack.spaces.confirmSaveModal.SaveButtonLabel"
+                    defaultMessage="Save"
+                  />
                 </EuiButton>
               </EuiFlexItem>
             ) : null}

--- a/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_save_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/confirm_share_save_modal.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiText,
+  EuiTitle,
+} from '@elastic/eui';
+import { SpacesApi, SpacesContextProps } from '@kbn/spaces-plugin/public';
+import React from 'react';
+
+const getEmptyFunctionComponent: React.FC<SpacesContextProps> = ({ children }) => <>{children}</>;
+
+export const ConfirmShareSaveModal = ({
+  canSave,
+  message,
+  namespaces,
+  spacesApi,
+  title,
+  onSave,
+  onClone,
+  onCancel,
+  onClose,
+}: {
+  canSave: boolean;
+  message: string;
+  namespaces: string[];
+  spacesApi?: SpacesApi;
+  title: string;
+  onCancel?: () => void;
+  onClone: () => void;
+  onClose: () => void;
+  onSave: () => void;
+}) => {
+  const SpacesContextWrapper =
+    spacesApi?.ui.components.getSpacesContextProvider ?? getEmptyFunctionComponent;
+
+  return (
+    <SpacesContextWrapper>
+      <EuiModal onClose={onClose}>
+        <EuiModalHeader>
+          <EuiFlexGroup gutterSize="m" direction="column">
+            <EuiFlexItem>
+              <EuiTitle>
+                <h1>{title}</h1>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiText>
+                <p>{message}</p>
+              </EuiText>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiModalHeader>
+        <EuiModalBody>
+          {spacesApi?.ui.components.getSpaceList({
+            namespaces,
+            behaviorContext: 'outside-space',
+            direction: 'vertical',
+            displayLimit: 4,
+          })}
+        </EuiModalBody>
+        <EuiModalFooter>
+          <EuiFlexGroup gutterSize="s" justifyContent="flexEnd">
+            <EuiFlexItem grow={false}>
+              <EuiButtonEmpty
+                color="danger"
+                onClick={() => {
+                  if (onCancel) onCancel();
+                  onClose();
+                }}
+              >
+                Cancel
+              </EuiButtonEmpty>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              <EuiButton
+                color="primary"
+                fill={!canSave}
+                onClick={() => {
+                  onClone();
+                  onClose();
+                }}
+              >
+                Clone
+              </EuiButton>
+            </EuiFlexItem>
+            {canSave ? (
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  color="primary"
+                  fill
+                  onClick={() => {
+                    onSave();
+                    onClose();
+                  }}
+                >
+                  Save
+                </EuiButton>
+              </EuiFlexItem>
+            ) : null}
+          </EuiFlexGroup>
+        </EuiModalFooter>
+      </EuiModal>
+    </SpacesContextWrapper>
+  );
+};

--- a/src/plugins/dashboard/public/dashboard_top_nav/dashboard_top_nav_with_context.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/dashboard_top_nav_with_context.tsx
@@ -6,9 +6,11 @@
  * Side Public License, v 1.
  */
 
+import { SpacesContextProps } from '@kbn/spaces-plugin/public';
 import React from 'react';
 import { DashboardAPIContext } from '../dashboard_app/dashboard_app';
 import { DashboardContainer } from '../dashboard_container';
+import { pluginServices } from '../services/plugin_services';
 import {
   InternalDashboardTopNav,
   InternalDashboardTopNavProps,
@@ -17,11 +19,22 @@ export interface DashboardTopNavProps extends InternalDashboardTopNavProps {
   dashboardContainer: DashboardContainer;
 }
 
-export const DashboardTopNavWithContext = (props: DashboardTopNavProps) => (
-  <DashboardAPIContext.Provider value={props.dashboardContainer}>
-    <InternalDashboardTopNav {...props} />
-  </DashboardAPIContext.Provider>
-);
+const getEmptyFunctionComponent: React.FC<SpacesContextProps> = ({ children }) => <>{children}</>;
+
+export const DashboardTopNavWithContext = (props: DashboardTopNavProps) => {
+  const {
+    spaces: { spacesApi },
+  } = pluginServices.getServices();
+  const SpacesContextWrapper =
+    spacesApi?.ui.components.getSpacesContextProvider ?? getEmptyFunctionComponent;
+  return (
+    <SpacesContextWrapper>
+      <DashboardAPIContext.Provider value={props.dashboardContainer}>
+        <InternalDashboardTopNav {...props} />
+      </DashboardAPIContext.Provider>
+    </SpacesContextWrapper>
+  );
+};
 
 // eslint-disable-next-line import/no-default-export
 export default DashboardTopNavWithContext;

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -315,8 +315,6 @@ export function InternalDashboardTopNav({
         purpose: 'shareSavedObjectsIntoSpace',
       });
 
-      console.log({ spacesPermissions });
-
       const shareableReferences = (
         await spacesManager.getShareableReferences([
           {

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -311,6 +311,12 @@ export function InternalDashboardTopNav({
         saveOptions: {},
       });
 
+      const shareableSpaces = await spacesManager.getSpaces({
+        purpose: 'shareSavedObjectsIntoSpace',
+      });
+
+      console.log({ spacesPermissions });
+
       const shareableReferences = (
         await spacesManager.getShareableReferences([
           {

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -320,7 +320,7 @@ export function InternalDashboardTopNav({
         ])
       ).objects;
 
-      const hasNewReference = references.some(({ id }) => {
+      const hasUnsharedReference = references.some(({ id }) => {
         const shareableRef = shareableReferences.find(
           ({ id: refId }: { id: string }) => id === refId
         );
@@ -330,32 +330,22 @@ export function InternalDashboardTopNav({
         return namespaces.some((sharedSpace) => !shareableRef.spaces.includes(sharedSpace));
       });
 
-      if (!hasNewReference) {
-        // no unshared references added
+      // User cannot save when the changes include an unshared reference and the user is missing access to
+      // one of the shared spaces
+      const canSave = !(hasUnsharedReference && hasHiddenSpace);
+      if (canSave) {
         message = i18n.translate('dashboard.topNav.confirmSaveModal.shareableChangesDescription', {
           defaultMessage: `This dashboard is shared between {spacesCount} spaces. Any changes will also
             be reflected in those spaces. Clone the dashboard if you don't want the changes to be
             reflected in the rest of spaces.`,
           values: { spacesCount: namespaces.length },
         });
-      } else if (!hasHiddenSpace) {
-        // unshared shareable references added
-        message = i18n.translate(
-          'dashboard.topNav.confirmSaveModal.shareableReferenceDescription',
-          {
-            defaultMessage: `This dashboard is shared between {spacesCount} spaces, and the changes you are making involve sharing other 
-            saved objects too. You can choose to share them or you can clone the dashboard to keep your changes 
-            within the current space only.`,
-            values: { spacesCount: namespaces.length },
-          }
-        );
       } else {
-        // unshareable references added
         message = i18n.translate(
           'dashboard.topNav.confirmSaveModal.unshareableReferenceDescription',
           {
-            defaultMessage: `This dashboard is shared between {spacesCount} spaces, and some of your changes cannot be shared. 
-                    Please clone this dashboard to save your changes into the current space.`,
+            defaultMessage: `This dashboard is shared between {spacesCount} spaces, and some of your changes cannot 
+              be shared. Please clone this dashboard to save your changes into the current space.`,
             values: { spacesCount: namespaces.length },
           }
         );
@@ -371,7 +361,7 @@ export function InternalDashboardTopNav({
             message={message}
             title={modalTitle}
             spacesApi={spacesApi}
-            canSave={!(hasNewReference && hasHiddenSpace)}
+            canSave={canSave}
             namespaces={namespaces}
           />,
           {

--- a/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/dashboard_top_nav/internal_dashboard_top_nav.tsx
@@ -333,23 +333,6 @@ export function InternalDashboardTopNav({
       // User cannot save when the changes include an unshared reference and the user is missing access to
       // one of the shared spaces
       const canSave = !(hasUnsharedReference && hasHiddenSpace);
-      if (canSave) {
-        message = i18n.translate('dashboard.topNav.confirmSaveModal.shareableChangesDescription', {
-          defaultMessage: `This dashboard is shared between {spacesCount} spaces. Any changes will also
-            be reflected in those spaces. Clone the dashboard if you don't want the changes to be
-            reflected in the rest of spaces.`,
-          values: { spacesCount: namespaces.length },
-        });
-      } else {
-        message = i18n.translate(
-          'dashboard.topNav.confirmSaveModal.unshareableReferenceDescription',
-          {
-            defaultMessage: `This dashboard is shared between {spacesCount} spaces, and some of your changes cannot 
-              be shared. Please clone this dashboard to save your changes into the current space.`,
-            values: { spacesCount: namespaces.length },
-          }
-        );
-      }
 
       const session = openModal(
         toMountPoint(
@@ -358,11 +341,11 @@ export function InternalDashboardTopNav({
             onSave={onSave}
             onCancel={onCancel}
             onClose={() => session.close()}
-            message={message}
             title={modalTitle}
             spacesApi={spacesApi}
             canSave={canSave}
             namespaces={namespaces}
+            noun="dashboard"
           />,
           {
             theme$,

--- a/src/plugins/dashboard/public/services/dashboard_content_management/dashboard_content_management_service.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/dashboard_content_management_service.ts
@@ -26,6 +26,7 @@ import { deleteDashboards } from './lib/delete_dashboards';
 import { loadDashboardState } from './lib/load_dashboard_state';
 import { updateDashboardMeta } from './lib/update_dashboard_meta';
 import { DashboardContentManagementCache } from './dashboard_content_management_cache';
+import { getAttributesAndReferences } from './lib/get_attributes_and_references';
 
 export type DashboardContentManagementServiceFactory = KibanaPluginServiceFactory<
   DashboardContentManagementService,
@@ -88,5 +89,14 @@ export const dashboardContentManagementServiceFactory: DashboardContentManagemen
     deleteDashboards: (ids) => deleteDashboards(ids, contentManagement),
     updateDashboardMeta: (props) =>
       updateDashboardMeta(props, { contentManagement, savedObjectsTagging, embeddable }),
+    getAttributesAndReferences: ({ currentState, lastSavedId, saveOptions }) =>
+      getAttributesAndReferences({
+        currentState,
+        lastSavedId,
+        saveOptions,
+        data,
+        embeddable,
+        savedObjectsTagging,
+      }),
   };
 };

--- a/src/plugins/dashboard/public/services/dashboard_content_management/lib/get_attributes_and_references.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/lib/get_attributes_and_references.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { pick } from 'lodash';
+import moment, { Moment } from 'moment';
+
+import {
+  getDefaultControlGroupInput,
+  persistableControlGroupInputIsEqual,
+  controlGroupInputToRawControlGroupAttributes,
+  generateNewControlIds,
+} from '@kbn/controls-plugin/common';
+import { isFilterPinned } from '@kbn/es-query';
+import { extractSearchSourceReferences, RefreshInterval } from '@kbn/data-plugin/public';
+
+import { DashboardAttributesAndReferences } from '../../../../common/types';
+import {
+  extractReferences,
+  DashboardContainerInput,
+  convertPanelMapToSavedPanels,
+} from '../../../../common';
+import { SaveDashboardProps, DashboardContentManagementRequiredServices } from '../types';
+import { convertDashboardVersionToNumber } from './dashboard_versioning';
+import { LATEST_DASHBOARD_CONTAINER_VERSION } from '../../../dashboard_container';
+import { generateNewPanelIds } from '../../../../common/lib/dashboard_panel_converters';
+import { DashboardAttributes } from '../../../../common/content_management';
+
+export const serializeControlGroupInput = (
+  controlGroupInput: DashboardContainerInput['controlGroupInput']
+) => {
+  // only save to saved object if control group is not default
+  if (
+    !controlGroupInput ||
+    persistableControlGroupInputIsEqual(controlGroupInput, getDefaultControlGroupInput())
+  ) {
+    return undefined;
+  }
+  return controlGroupInputToRawControlGroupAttributes(controlGroupInput);
+};
+
+export const convertTimeToUTCString = (time?: string | Moment): undefined | string => {
+  if (moment(time).isValid()) {
+    return moment(time).utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]');
+  } else {
+    // If it's not a valid moment date, then it should be a string representing a relative time
+    // like 'now' or 'now-15m'.
+    return time as string;
+  }
+};
+
+type SaveDashboardStateProps = SaveDashboardProps & {
+  data: DashboardContentManagementRequiredServices['data'];
+  embeddable: DashboardContentManagementRequiredServices['embeddable'];
+  savedObjectsTagging: DashboardContentManagementRequiredServices['savedObjectsTagging'];
+};
+
+export const getAttributesAndReferences = async ({
+  data,
+  embeddable,
+  lastSavedId,
+  saveOptions,
+  currentState,
+  savedObjectsTagging,
+}: SaveDashboardStateProps): Promise<DashboardAttributesAndReferences> => {
+  const {
+    search: dataSearchService,
+    query: {
+      timefilter: { timefilter },
+    },
+  } = data;
+
+  const {
+    tags,
+    query,
+    title,
+    filters,
+    version,
+    timeRestore,
+    description,
+
+    // Dashboard options
+    useMargins,
+    syncColors,
+    syncCursor,
+    syncTooltips,
+    hidePanelTitles,
+  } = currentState;
+
+  let { panels, controlGroupInput } = currentState;
+  if (saveOptions.saveAsCopy) {
+    panels = generateNewPanelIds(panels);
+    controlGroupInput = generateNewControlIds(controlGroupInput);
+  }
+
+  /**
+   * Stringify filters and query into search source JSON
+   */
+  const { searchSourceJSON, searchSourceReferences } = await (async () => {
+    const searchSource = await dataSearchService.searchSource.create();
+    searchSource.setField(
+      'filter', // save only unpinned filters
+      filters.filter((filter) => !isFilterPinned(filter))
+    );
+    searchSource.setField('query', query);
+
+    const rawSearchSourceFields = searchSource.getSerializedFields();
+    const [fields, references] = extractSearchSourceReferences(rawSearchSourceFields);
+    return { searchSourceReferences: references, searchSourceJSON: JSON.stringify(fields) };
+  })();
+
+  /**
+   * Stringify options and panels
+   */
+  const optionsJSON = JSON.stringify({
+    useMargins,
+    syncColors,
+    syncCursor,
+    syncTooltips,
+    hidePanelTitles,
+  });
+  const panelsJSON = JSON.stringify(convertPanelMapToSavedPanels(panels, true));
+
+  /**
+   * Parse global time filter settings
+   */
+  const { from, to } = timefilter.getTime();
+  const timeFrom = timeRestore ? convertTimeToUTCString(from) : undefined;
+  const timeTo = timeRestore ? convertTimeToUTCString(to) : undefined;
+  const refreshInterval = timeRestore
+    ? (pick(timefilter.getRefreshInterval(), [
+        'display',
+        'pause',
+        'section',
+        'value',
+      ]) as RefreshInterval)
+    : undefined;
+
+  const rawDashboardAttributes: DashboardAttributes = {
+    version: convertDashboardVersionToNumber(version ?? LATEST_DASHBOARD_CONTAINER_VERSION),
+    controlGroupInput: serializeControlGroupInput(controlGroupInput),
+    kibanaSavedObjectMeta: { searchSourceJSON },
+    description: description ?? '',
+    refreshInterval,
+    timeRestore,
+    optionsJSON,
+    panelsJSON,
+    timeFrom,
+    title,
+    timeTo,
+  };
+
+  /**
+   * Extract references from raw attributes and tags into the references array.
+   */
+  const { attributes, references: dashboardReferences } = extractReferences(
+    {
+      attributes: rawDashboardAttributes,
+      references: searchSourceReferences,
+    },
+    { embeddablePersistableStateService: embeddable }
+  );
+
+  const references = savedObjectsTagging.updateTagsReferences
+    ? savedObjectsTagging.updateTagsReferences(dashboardReferences, tags)
+    : dashboardReferences;
+
+  return { attributes, references };
+};

--- a/src/plugins/dashboard/public/services/dashboard_content_management/types.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/types.ts
@@ -25,6 +25,7 @@ import { DashboardInitializerContextService } from '../initializer_context/types
 import { DashboardSavedObjectsTaggingService } from '../saved_objects_tagging/types';
 import { DashboardBackupServiceType } from '../dashboard_backup/types';
 import { DashboardDuplicateTitleCheckProps } from './lib/check_for_duplicate_dashboard_title';
+import { DashboardAttributesAndReferences } from '@kbn/dashboard-plugin/common/types';
 
 export interface DashboardContentManagementRequiredServices {
   data: DashboardDataService;
@@ -46,6 +47,7 @@ export interface DashboardContentManagementService {
   updateDashboardMeta: (
     props: Pick<DashboardContainerInput, 'id' | 'title' | 'description' | 'tags'>
   ) => Promise<void>;
+  getAttributesAndReferences:(props: SaveDashboardProps)=> Promise<DashboardAttributesAndReferences>}
 }
 
 /**

--- a/src/plugins/dashboard/public/services/spaces/spaces.stub.ts
+++ b/src/plugins/dashboard/public/services/spaces/spaces.stub.ts
@@ -16,8 +16,6 @@ export const spacesServiceFactory: SpacesServiceFactory = () => {
   const pluginMock = spacesPluginMock.createStartContract();
 
   return {
-    getActiveSpace$: pluginMock.getActiveSpace$,
-    getLegacyUrlConflict: pluginMock.ui.components.getLegacyUrlConflict,
-    redirectLegacyUrl: pluginMock.ui.redirectLegacyUrl,
+    spacesApi: pluginMock,
   };
 };

--- a/src/plugins/dashboard/public/services/spaces/spaces_service.ts
+++ b/src/plugins/dashboard/public/services/spaces/spaces_service.ts
@@ -16,21 +16,9 @@ export type SpacesServiceFactory = KibanaPluginServiceFactory<
 >;
 export const spacesServiceFactory: SpacesServiceFactory = ({ startPlugins }) => {
   const { spaces } = startPlugins;
-  if (!spaces || !spaces.ui) return {};
+  if (!spaces) return {};
 
-  const {
-    getActiveSpace$,
-    ui: {
-      components: { getLegacyUrlConflict, getSpacesContextProvider },
-      redirectLegacyUrl,
-      useSpaces,
-    },
-  } = spaces;
   return {
-    getActiveSpace$,
-    getLegacyUrlConflict,
-    getSpacesContextProvider,
-    redirectLegacyUrl,
-    useSpaces,
+    spacesApi: spaces,
   };
 };

--- a/src/plugins/dashboard/public/services/spaces/types.ts
+++ b/src/plugins/dashboard/public/services/spaces/types.ts
@@ -6,12 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
 
 export interface DashboardSpacesService {
-  getActiveSpace$?: SpacesPluginStart['getActiveSpace$'];
-  getLegacyUrlConflict?: SpacesPluginStart['ui']['components']['getLegacyUrlConflict'];
-  getSpacesContextProvider?: SpacesPluginStart['ui']['components']['getSpacesContextProvider'];
-  redirectLegacyUrl?: SpacesPluginStart['ui']['redirectLegacyUrl'];
-  useSpaces?: SpacesPluginStart['ui']['useSpaces'];
+  spacesApi?: SpacesApi;
 }

--- a/src/plugins/dashboard/tsconfig.json
+++ b/src/plugins/dashboard/tsconfig.json
@@ -68,7 +68,8 @@
     "@kbn/no-data-page-plugin",
     "@kbn/react-kibana-mount",
     "@kbn/core-lifecycle-browser",
-    "@kbn/logging"
+    "@kbn/logging",
+    "@kbn/dashboard-plugin"
   ],
   "exclude": ["target/**/*"]
 }

--- a/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/selectable_spaces_control.tsx
+++ b/x-pack/plugins/spaces/public/share_saved_objects_to_space/components/selectable_spaces_control.tsx
@@ -49,7 +49,7 @@ interface Props {
 type SpaceOption = EuiSelectableOption & { ['data-space-id']: string };
 
 const ROW_HEIGHT = 40;
-const APPEND_ACTIVE_SPACE = (
+export const APPEND_ACTIVE_SPACE = (
   <EuiBadge color="hollow">
     {i18n.translate('xpack.spaces.shareToSpace.currentSpaceBadge', {
       defaultMessage: 'This space',

--- a/x-pack/plugins/spaces/public/space_list/types.ts
+++ b/x-pack/plugins/spaces/public/space_list/types.ts
@@ -36,4 +36,8 @@ export interface SpaceListProps {
    * Style for the cursor when mousing over space avatars.
    */
   cursorStyle?: string;
+  /**
+   * The direction the list of space avatars is displayed
+   */
+  direction?: 'vertical' | 'horizontal';
 }

--- a/x-pack/plugins/spaces/public/spaces_context/types.ts
+++ b/x-pack/plugins/spaces/public/spaces_context/types.ts
@@ -33,9 +33,9 @@ export interface InternalProps {
 /**
  * Properties for the SpacesContext.
  */
-export interface SpacesContextProps {
+export type SpacesContextProps = React.PropsWithChildren<{
   /**
    * If a feature is specified, all Spaces components will treat it appropriately if the feature is disabled in a given Space.
    */
   feature?: string;
-}
+}>;


### PR DESCRIPTION
## Summary

Feature Branch: https://github.com/elastic/kibana/pull/168166
Related to https://github.com/elastic/kibana/issues/168241.
Related to https://github.com/elastic/kibana/issues/168287

This updates spaces for any new references added to a shared dashboard on save. This currently shares nested panels without any warning to the user that the sharing has occurred. Adding a confirmation modal warning the user that saving will share their newly added references to the same spaces as its parent dashboard in a separate PR.

This also introduced a confirmation modal warning the user when they are saving changes on a shared dashboard.

<img width="784" alt="Screenshot 2023-11-22 at 11 53 41 AM" src="https://github.com/elastic/kibana/assets/1697105/7f5781c3-8eb7-4c5b-9acb-b1d21a089292">

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
