### PR TITLE
[Ops] Fix cache build

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -29,7 +29,7 @@ KIBANA_PKG_VERSION="$(jq -r .version "$KIBANA_DIR/package.json")"
 export KIBANA_PKG_VERSION
 
 # Detects and exports the final target branch when using a merge queue
-if [[ "$BUILDKITE_BRANCH" == "gh-readonly-queue"* ]]; then
+if [[ "${BUILDKITE_BRANCH:-}" == "gh-readonly-queue"* ]]; then
   # removes gh-readonly-queue/
   BKBRANCH_WITHOUT_GH_MQ_PREFIX="${BUILDKITE_BRANCH#gh-readonly-queue/}"
 
@@ -42,7 +42,7 @@ export MERGE_QUEUE_TARGET_BRANCH
 
 # Exports BUILDKITE_BRANCH_MERGE_QUEUE which will use the value from MERGE_QUEUE_TARGET_BRANCH if defined otherwise
 # will fallback to BUILDKITE_BRANCH.
-BUILDKITE_BRANCH_MERGE_QUEUE="${MERGE_QUEUE_TARGET_BRANCH:-$BUILDKITE_BRANCH}"
+BUILDKITE_BRANCH_MERGE_QUEUE="${MERGE_QUEUE_TARGET_BRANCH:-${BUILDKITE_BRANCH:-}}"
 export BUILDKITE_BRANCH_MERGE_QUEUE
 
 


### PR DESCRIPTION
## Summary
There was a small change introduced in https://github.com/elastic/kibana/pull/170918 that exposes a custom env var, that started to fail on cache builds on CI (https://buildkite.com/elastic/kibana-agent-packer-cache/builds/474#018bb945-4910-4f5e-b78b-f020574c5b89). Apparently the BUILDKITE_BRANCH is not available in the script, it's because it's the same build script called not from buildkite, but through packer, which probably doesn't forward all the environment variables.

In this case, we can probably default to `""` and let the script ignore that section where this variable is exported, because this export is probably not meant for the cache build. However, we should keep this in mind, that the packer/cache build is invoking some scripts with a different env context (might lead to different results if we depend on some of these vars).

chore: use an empty default when missing BUILDKITE_BRANCH to prevent error
