### PR TITLE
[7.17] redact ES client errors (#171018)

### DIFF
--- a/src/core/server/elasticsearch/client/configure_client.ts
+++ b/src/core/server/elasticsearch/client/configure_client.ts
@@ -15,8 +15,12 @@ import type {
 import { Logger } from '../../logging';
 import { parseClientOptions, ElasticsearchClientConfig } from './client_config';
 import { instrumentEsQueryAndDeprecationLogger } from './log_query_and_deprecation';
+import { patchElasticsearchClient } from './patch_client';
 
 const noop = () => undefined;
+
+// Apply ES client patches on module load
+patchElasticsearchClient();
 
 export const configureClient = (
   config: ElasticsearchClientConfig,

--- a/src/core/server/elasticsearch/client/patch_client.ts
+++ b/src/core/server/elasticsearch/client/patch_client.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { errors } from '@elastic/elasticsearch';
+
+export const patchElasticsearchClient = () => {
+  const baseErrorPrototype = errors.ElasticsearchClientError.prototype;
+  // @ts-expect-error
+  baseErrorPrototype.toJSON = function () {
+    return {
+      name: this.name,
+      message: this.message,
+    };
+  };
+};

--- a/src/core/server/elasticsearch/integration_tests/errors.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/errors.test.ts
@@ -42,7 +42,7 @@ describe('elasticsearch clients errors', () => {
       expect('should have thrown').toEqual('but it did not');
     } catch (e) {
       expect(JSON.stringify(e)).toMatchInlineSnapshot(
-        `"{\\"name\\":\\"ResponseError\\",\\"message\\":\\"parsing_exception\\\\n\\\\tCaused by:\\\\n\\\\t\\\\tnamed_object_not_found_exception: [1:30] unknown field [someInvalidQuery]\\\\n\\\\tRoot causes:\\\\n\\\\t\\\\tparsing_exception: unknown query [someInvalidQuery]\\"}"`
+        `"{\\"name\\":\\"ResponseError\\",\\"message\\":\\"illegal_argument_exception: [illegal_argument_exception] Reason: request [/.kibana/_search] contains unrecognized parameter: [query]\\"}"`
       );
     }
   });
@@ -58,13 +58,9 @@ describe('elasticsearch clients errors', () => {
       });
       expect('should have thrown').toEqual('but it did not');
     } catch (e) {
-      expect(String(e)).toMatchInlineSnapshot(`
-        "ResponseError: parsing_exception
-        	Caused by:
-        		named_object_not_found_exception: [1:30] unknown field [someInvalidQuery]
-        	Root causes:
-        		parsing_exception: unknown query [someInvalidQuery]"
-      `);
+      expect(String(e)).toMatchInlineSnapshot(
+        `{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/.kibana/_search] contains unrecognized parameter: [query]"}],"type":"illegal_argument_exception","reason":"request [/.kibana/_search] contains unrecognized parameter: [query]"},"status":400}`
+      );
     }
   });
 });

--- a/src/core/server/elasticsearch/integration_tests/errors.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/errors.test.ts
@@ -41,26 +41,9 @@ describe('elasticsearch clients errors', () => {
       });
       expect('should have thrown').toEqual('but it did not');
     } catch (e) {
-      expect(JSON.stringify(e)).toMatchInlineSnapshot(
-        `"{\\"name\\":\\"ResponseError\\",\\"message\\":\\"illegal_argument_exception: [illegal_argument_exception] Reason: request [/.kibana/_search] contains unrecognized parameter: [query]\\"}"`
-      );
-    }
-  });
-
-  it('has the proper string representation', async () => {
-    const esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
-
-    try {
-      await esClient.search({
-        index: '.kibana',
-        // @ts-expect-error yes this is invalid
-        query: { someInvalidQuery: { foo: 'bar' } },
-      });
-      expect('should have thrown').toEqual('but it did not');
-    } catch (e) {
-      expect(String(e)).toMatchInlineSnapshot(
-        `{"error":{"root_cause":[{"type":"illegal_argument_exception","reason":"request [/.kibana/_search] contains unrecognized parameter: [query]"}],"type":"illegal_argument_exception","reason":"request [/.kibana/_search] contains unrecognized parameter: [query]"},"status":400}`
-      );
+      const stringifiedError = JSON.stringify(e);
+      expect(stringifiedError).not.toContain("headers");
+      expect(stringifiedError).not.toContain("authorization");
     }
   });
 });

--- a/src/core/server/elasticsearch/integration_tests/errors.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/errors.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import {
+  createTestServers,
+  type TestElasticsearchUtils,
+  type TestKibanaUtils,
+} from '../../../test_helpers/kbn_server';
+
+describe('elasticsearch clients errors', () => {
+  let esServer: TestElasticsearchUtils;
+  let kibanaServer: TestKibanaUtils;
+
+  beforeAll(async () => {
+    const { startES, startKibana } = createTestServers({
+      adjustTimeout: jest.setTimeout,
+    });
+
+    esServer = await startES();
+    kibanaServer = await startKibana();
+  });
+
+  afterAll(async () => {
+    await kibanaServer.stop();
+    await esServer.stop();
+  });
+
+  it('has the proper JSON representation', async () => {
+    const esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
+
+    try {
+      await esClient.search({
+        index: '.kibana',
+        // @ts-expect-error yes this is invalid
+        query: { someInvalidQuery: { foo: 'bar' } },
+      });
+      expect('should have thrown').toEqual('but it did not');
+    } catch (e) {
+      expect(JSON.stringify(e)).toMatchInlineSnapshot(
+        `"{\\"name\\":\\"ResponseError\\",\\"message\\":\\"parsing_exception\\\\n\\\\tCaused by:\\\\n\\\\t\\\\tnamed_object_not_found_exception: [1:30] unknown field [someInvalidQuery]\\\\n\\\\tRoot causes:\\\\n\\\\t\\\\tparsing_exception: unknown query [someInvalidQuery]\\"}"`
+      );
+    }
+  });
+
+  it('has the proper string representation', async () => {
+    const esClient = kibanaServer.coreStart.elasticsearch.client.asInternalUser;
+
+    try {
+      await esClient.search({
+        index: '.kibana',
+        // @ts-expect-error yes this is invalid
+        query: { someInvalidQuery: { foo: 'bar' } },
+      });
+      expect('should have thrown').toEqual('but it did not');
+    } catch (e) {
+      expect(String(e)).toMatchInlineSnapshot(`
+        "ResponseError: parsing_exception
+        	Caused by:
+        		named_object_not_found_exception: [1:30] unknown field [someInvalidQuery]
+        	Root causes:
+        		parsing_exception: unknown query [someInvalidQuery]"
+      `);
+    }
+  });
+});

--- a/src/core/server/elasticsearch/integration_tests/errors.test.ts
+++ b/src/core/server/elasticsearch/integration_tests/errors.test.ts
@@ -42,8 +42,8 @@ describe('elasticsearch clients errors', () => {
       expect('should have thrown').toEqual('but it did not');
     } catch (e) {
       const stringifiedError = JSON.stringify(e);
-      expect(stringifiedError).not.toContain("headers");
-      expect(stringifiedError).not.toContain("authorization");
+      expect(stringifiedError).not.toContain('headers');
+      expect(stringifiedError).not.toContain('authorization');
     }
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [redact ES client errors (#171018)](https://github.com/elastic/kibana/pull/171018)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2023-11-10T14:42:14Z","message":"redact ES client errors (#171018)\n\n## Summary\r\n\r\nDefine a custom `toJSON` method on errors from the ES client to have\r\nbetter control of the format of the output of their JSON serialization","sha":"c43e6997af35492577b07f196d25d11a6bec6f14","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:elasticsearch","Team:Core","release_note:skip","backport:prev-minor","v8.12.0"],"number":171018,"url":"https://github.com/elastic/kibana/pull/171018","mergeCommit":{"message":"redact ES client errors (#171018)\n\n## Summary\r\n\r\nDefine a custom `toJSON` method on errors from the ES client to have\r\nbetter control of the format of the output of their JSON serialization","sha":"c43e6997af35492577b07f196d25d11a6bec6f14"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/171018","number":171018,"mergeCommit":{"message":"redact ES client errors (#171018)\n\n## Summary\r\n\r\nDefine a custom `toJSON` method on errors from the ES client to have\r\nbetter control of the format of the output of their JSON serialization","sha":"c43e6997af35492577b07f196d25d11a6bec6f14"}}]}] BACKPORT-->