### PR TITLE
[Serverless Search] connectors callout

### DIFF
--- a/packages/kbn-search-api-panels/components/select_client.tsx
+++ b/packages/kbn-search-api-panels/components/select_client.tsx
@@ -29,6 +29,7 @@ export interface SelectClientPanelProps {
   http: HttpStart;
   isPanelLeft?: boolean;
   overviewPanelProps?: Partial<EuiPanelProps>;
+  callout?: React.ReactNode;
 }
 
 export const SelectClientPanel: React.FC<SelectClientPanelProps> = ({
@@ -37,6 +38,7 @@ export const SelectClientPanel: React.FC<SelectClientPanelProps> = ({
   http,
   isPanelLeft = true,
   overviewPanelProps,
+  callout,
 }) => {
   const panelContent = (
     <>
@@ -56,28 +58,30 @@ export const SelectClientPanel: React.FC<SelectClientPanelProps> = ({
         {children}
       </EuiFlexGroup>
       <EuiSpacer size="l" />
-      <EuiCallOut
-        title={i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.title', {
-          defaultMessage: 'Try it now in Console',
-        })}
-        size="m"
-        iconType="iInCircle"
-      >
-        <p>
-          {i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.description', {
-            defaultMessage:
-              'With Console, you can get started right away with our REST APIs. No installation required.',
+      {callout || (
+        <EuiCallOut
+          title={i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.title', {
+            defaultMessage: 'Try it now in Console',
           })}
+          size="m"
+          iconType="iInCircle"
+        >
+          <p>
+            {i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.description', {
+              defaultMessage:
+                'With Console, you can get started right away with our REST APIs. No installation required.',
+            })}
 
-          <span>
-            <EuiLink target="_blank" href={http.basePath.prepend(`/app/dev_tools#/console`)}>
-              {i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.link', {
-                defaultMessage: 'Try Console now',
-              })}
-            </EuiLink>
-          </span>
-        </p>
-      </EuiCallOut>
+            <span>
+              <EuiLink target="_blank" href={http.basePath.prepend(`/app/dev_tools#/console`)}>
+                {i18n.translate('searchApiPanels.welcomeBanner.selectClient.callout.link', {
+                  defaultMessage: 'Try Console now',
+                })}
+              </EuiLink>
+            </span>
+          </p>
+        </EuiCallOut>
+      )}
     </>
   );
   return (

--- a/x-pack/plugins/serverless_search/public/application/components/connectors_callout.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors_callout.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiIcon,
+  EuiText,
+  EuiToolTip,
+} from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+
+import { useConnectorTypes } from '../hooks/api/use_connector_types';
+import { useCreateConnector } from '../hooks/api/use_create_connector';
+
+const CONNECTOR_TYPES_DISPLAY = [
+  'azure_blob_storage',
+  'sharepoint_online',
+  's3',
+  'mongodb',
+  'google_cloud_storage',
+];
+
+export const ConnectorsCallout = () => {
+  const { data } = useConnectorTypes();
+  const { createConnector, isLoading } = useCreateConnector();
+
+  const allConnectorTypes = data?.connectors;
+  const connectorTypes = allConnectorTypes
+    ? CONNECTOR_TYPES_DISPLAY.map(
+        (type) => allConnectorTypes.find((connType) => connType.serviceType === type)!
+      )
+    : undefined;
+  const showConnectors = connectorTypes && connectorTypes.length;
+  return (
+    <EuiCallOut
+      title={i18n.translate('xpack.serverlessSearch.selectClient.connectorsCallout.title', {
+        defaultMessage: 'Sync your data using a connector client',
+      })}
+      size="m"
+      iconType="iInCircle"
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.serverlessSearch.selectClient.connectorsCallout.description"
+          defaultMessage="Sync a range of popular third-party data sources to Elasticsearch, by deploying open code Elastic connectors on your own infrastructure."
+        />
+      </p>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            color="primary"
+            fill
+            data-test-subj="connectors-callout-cta"
+            onClick={() => createConnector()}
+            isLoading={isLoading}
+          >
+            {i18n.translate('xpack.serverlessSearch.selectClient.connectorsCallout.cta', {
+              defaultMessage: 'Create a connector',
+            })}
+          </EuiButton>
+        </EuiFlexItem>
+        <EuiFlexItem />
+        {showConnectors &&
+          connectorTypes.map((connectorType) => (
+            <EuiFlexItem grow={false} key={connectorType.serviceType}>
+              <EuiToolTip content={connectorType.name}>
+                <EuiIcon
+                  size="xxl"
+                  title={connectorType.name}
+                  id={connectorType.serviceType}
+                  type={connectorType.iconPath}
+                />
+              </EuiToolTip>
+            </EuiFlexItem>
+          ))}
+        {showConnectors && (
+          <EuiFlexItem grow={false}>
+            <EuiText color="subdued" size="s">
+              <FormattedMessage
+                id="xpack.serverlessSearch.selectClient.connectorsCallout.etc"
+                defaultMessage="and more"
+              />
+            </EuiText>
+          </EuiFlexItem>
+        )}
+      </EuiFlexGroup>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/plugins/serverless_search/public/application/components/connectors_callout.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors_callout.tsx
@@ -53,19 +53,21 @@ export const ConnectorsCallout = () => {
           defaultMessage="Sync a range of popular third-party data sources to Elasticsearch, by deploying open code Elastic connectors on your own infrastructure."
         />
       </p>
-      <EuiFlexGroup alignItems="center">
+      <EuiFlexGroup alignItems="center" gutterSize="m">
         <EuiFlexItem grow={false}>
-          <EuiButton
-            color="primary"
-            fill
-            data-test-subj="connectors-callout-cta"
-            onClick={() => createConnector()}
-            isLoading={isLoading}
-          >
-            {i18n.translate('xpack.serverlessSearch.selectClient.connectorsCallout.cta', {
-              defaultMessage: 'Create a connector',
-            })}
-          </EuiButton>
+          <p>
+            <EuiButton
+              color="primary"
+              fill
+              data-test-subj="connectors-callout-cta"
+              onClick={() => createConnector()}
+              isLoading={isLoading}
+            >
+              {i18n.translate('xpack.serverlessSearch.selectClient.connectorsCallout.cta', {
+                defaultMessage: 'Create a connector',
+              })}
+            </EuiButton>
+          </p>
         </EuiFlexItem>
         <EuiFlexItem />
         {showConnectors &&
@@ -83,12 +85,14 @@ export const ConnectorsCallout = () => {
           ))}
         {showConnectors && (
           <EuiFlexItem grow={false}>
-            <EuiText color="subdued" size="s">
-              <FormattedMessage
-                id="xpack.serverlessSearch.selectClient.connectorsCallout.etc"
-                defaultMessage="and more"
-              />
-            </EuiText>
+            <p>
+              <EuiText color="subdued" size="s">
+                <FormattedMessage
+                  id="xpack.serverlessSearch.selectClient.connectorsCallout.etc"
+                  defaultMessage="and more"
+                />
+              </EuiText>
+            </p>
           </EuiFlexItem>
         )}
       </EuiFlexGroup>

--- a/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
@@ -14,49 +14,23 @@ import {
   EuiPageTemplate,
   EuiText,
 } from '@elastic/eui';
-import { Connector } from '@kbn/search-connectors';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useMutation } from '@tanstack/react-query';
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { generatePath } from 'react-router-dom';
 import { LEARN_MORE_LABEL } from '../../../common/i18n_string';
 import { PLUGIN_ID } from '../../../common';
 import { useConnectors } from '../hooks/api/use_connectors';
+import { useCreateConnector } from '../hooks/api/use_create_connector';
 import { useKibanaServices } from '../hooks/use_kibana';
 import { EmptyConnectorsPrompt } from './connectors/empty_connectors_prompt';
 import { ConnectorsTable } from './connectors/connectors_table';
-import { EDIT_CONNECTOR_PATH } from './connectors_router';
 
 export const ConnectorsOverview = () => {
   const { data, isLoading: connectorsLoading } = useConnectors();
-  const {
-    application: { navigateToUrl },
-    http,
-  } = useKibanaServices();
+  const { http } = useKibanaServices();
 
-  const {
-    data: connector,
-    isLoading,
-    isSuccess,
-    mutate,
-  } = useMutation({
-    mutationFn: async () => {
-      const result = await http.post<{ connector: Connector }>(
-        '/internal/serverless_search/connectors'
-      );
-      return result.connector;
-    },
-  });
-
-  useEffect(() => {
-    if (isSuccess) {
-      navigateToUrl(generatePath(EDIT_CONNECTOR_PATH, { id: connector?.id || '' }));
-    }
-  }, [connector, isSuccess, navigateToUrl]);
-
-  const createConnector = () => mutate();
+  const { createConnector, isLoading } = useCreateConnector();
 
   return (
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchConnectorsPage">

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -37,8 +37,6 @@ import type {
   LanguageDefinition,
   LanguageDefinitionSnippetArguments,
 } from '@kbn/search-api-panels';
-import { useQuery } from '@tanstack/react-query';
-import { Connector } from '@kbn/search-connectors';
 import { useLocation } from 'react-router-dom';
 import { docLinks } from '../../../common/doc_links';
 import { PLUGIN_ID } from '../../../common';
@@ -53,6 +51,7 @@ import { languageDefinitions } from './languages/languages';
 import { LanguageGrid } from './languages/language_grid';
 import './overview.scss';
 import { ApiKeyPanel } from './api_key/api_key';
+import { ConnectorsCallout } from './connectors_callout';
 
 export const ElasticsearchOverview = () => {
   const [selectedLanguage, setSelectedLanguage] = useState<LanguageDefinition>(javaDefinition);
@@ -82,12 +81,6 @@ export const ElasticsearchOverview = () => {
     }
   }, [hash]);
 
-  const { data: _data } = useQuery({
-    queryKey: ['fetchConnectors'],
-    queryFn: () =>
-      http.fetch<{ connectors: Connector[] }>('/internal/serverless_search/connectors'),
-  });
-
   return (
     <EuiPageTemplate offset={0} grow restrictWidth data-test-subj="svlSearchOverviewPage">
       <EuiPageTemplate.Section alignment="top" className="serverlessSearchHeaderSection">
@@ -100,7 +93,7 @@ export const ElasticsearchOverview = () => {
         bottomBorder="extended"
         data-test-subj="select-client-section"
       >
-        <SelectClientPanel docLinks={docLinks} http={http}>
+        <SelectClientPanel docLinks={docLinks} http={http} callout={<ConnectorsCallout />}>
           <EuiFlexItem>
             <LanguageGrid
               assetBasePath={assetBasePath}

--- a/x-pack/plugins/serverless_search/public/application/hooks/api/use_create_connector.tsx
+++ b/x-pack/plugins/serverless_search/public/application/hooks/api/use_create_connector.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { useEffect } from 'react';
+import { generatePath } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import { Connector } from '@kbn/search-connectors';
+import { EDIT_CONNECTOR_PATH } from '../../components/connectors_router';
+import { useKibanaServices } from '../use_kibana';
+
+export const useCreateConnector = () => {
+  const {
+    application: { navigateToUrl },
+    http,
+  } = useKibanaServices();
+  const {
+    data: connector,
+    isLoading,
+    isSuccess,
+    mutate,
+  } = useMutation({
+    mutationFn: async () => {
+      const result = await http.post<{ connector: Connector }>(
+        '/internal/serverless_search/connectors'
+      );
+      return result.connector;
+    },
+  });
+
+  useEffect(() => {
+    if (isSuccess) {
+      navigateToUrl(generatePath(EDIT_CONNECTOR_PATH, { id: connector?.id || '' }));
+    }
+  }, [connector, isSuccess, navigateToUrl]);
+
+  const createConnector = () => mutate();
+  return { createConnector, isLoading };
+};


### PR DESCRIPTION
## Summary

Replace console callout with Connectors callout on the Getting started page.

![image](https://github.com/elastic/kibana/assets/1972968/522268ce-62c3-464e-ae77-583a14b8ecdd)

### Notes
I had to wrap some things in `<p>` tags to match the bottom margin on the Icons. This is due to styles from EUI and may get resolved later and we would then remove these `<p>` tags.