### PR TITLE
[8.11] [EDR Workflows] Fix wrong sort value in live query results (#169248)

### DIFF
--- a/x-pack/plugins/osquery/common/api/live_query/get_live_query_results_route.ts
+++ b/x-pack/plugins/osquery/common/api/live_query/get_live_query_results_route.ts
@@ -7,13 +7,14 @@
 
 import * as t from 'io-ts';
 import { toNumberRt } from '@kbn/io-ts-utils';
+import { Direction } from '../../search_strategy';
 
 export const getLiveQueryResultsRequestQuerySchema = t.type({
   kuery: t.union([t.string, t.undefined]),
   page: t.union([toNumberRt, t.undefined]),
   pageSize: t.union([toNumberRt, t.undefined]),
   sort: t.union([t.string, t.undefined]),
-  sortOrder: t.union([t.union([t.literal('asc'), t.literal('desc')]), t.undefined]),
+  sortOrder: t.union([t.literal(Direction.asc), t.literal(Direction.desc), t.undefined]),
 });
 
 export type GetLiveQueryResultsRequestQuerySchema = t.OutputOf<

--- a/x-pack/plugins/osquery/cypress/e2e/api/live_query_results.cy.ts
+++ b/x-pack/plugins/osquery/cypress/e2e/api/live_query_results.cy.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { request } from '../../tasks/common';
+import { loadLiveQuery } from '../../tasks/api_fixtures';
+import { API_VERSIONS } from '../../../common/constants';
+import { ServerlessRoleName } from '../../support/roles';
+
+describe('Live query', { tags: ['@ess', '@serverless'] }, () => {
+  let liveQueryId: string;
+  let queriesQueryActionId: string;
+
+  beforeEach(() => {
+    cy.login(ServerlessRoleName.SOC_MANAGER);
+    loadLiveQuery().then((liveQuery) => {
+      liveQueryId = liveQuery.action_id;
+      queriesQueryActionId = liveQuery.queries?.[0].action_id;
+    });
+  });
+
+  context('GET getLiveQueryDetailsRoute', () => {
+    it('validates we get successful response', () => {
+      request({
+        url: `/api/osquery/live_queries/${liveQueryId}`,
+        headers: {
+          'Elastic-Api-Version': API_VERSIONS.public.v1,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+      });
+    });
+  });
+  context('GET getLiveQueryResultsRoute', () => {
+    it('validates we get successful response', () => {
+      request({
+        url: `/api/osquery/live_queries/${liveQueryId}/results/${queriesQueryActionId}`,
+        headers: {
+          'Elastic-Api-Version': API_VERSIONS.public.v1,
+        },
+      }).then((response) => {
+        expect(response.status).to.eq(200);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/osquery/server/routes/live_query/get_live_query_results_route.ts
+++ b/x-pack/plugins/osquery/server/routes/live_query/get_live_query_results_route.ts
@@ -20,8 +20,10 @@ import { PLUGIN_ID } from '../../../common';
 import type {
   ActionDetailsRequestOptions,
   ActionDetailsStrategyResponse,
+  ResultsRequestOptions,
+  ResultsStrategyResponse,
 } from '../../../common/search_strategy';
-import { OsqueryQueries } from '../../../common/search_strategy';
+import { Direction, OsqueryQueries } from '../../../common/search_strategy';
 import { generateTablePaginationOptions } from '../../../common/utils/build_query';
 import { getActionResponses } from './utils';
 import {
@@ -79,7 +81,7 @@ export const getLiveQueryResultsRoute = (router: IRouter<DataRequestHandlerConte
           );
 
           const res = await lastValueFrom(
-            search.search<{}>(
+            search.search<ResultsRequestOptions, ResultsStrategyResponse>(
               {
                 actionId: request.params.actionId,
                 factoryQueryType: OsqueryQueries.results,
@@ -88,10 +90,12 @@ export const getLiveQueryResultsRoute = (router: IRouter<DataRequestHandlerConte
                   request.query.page ?? 0,
                   request.query.pageSize ?? 100
                 ),
-                sort: {
-                  direction: request.query.sortOrder ?? 'desc',
-                  field: request.query.sort ?? '@timestamp',
-                },
+                sort: [
+                  {
+                    direction: request.query.sortOrder ?? Direction.desc,
+                    field: request.query.sort ?? '@timestamp',
+                  },
+                ],
               },
               { abortSignal, strategy: 'osquerySearchStrategy' }
             )


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[EDR Workflows] Fix wrong sort value in live query results (#169248)](https://github.com/elastic/kibana/pull/169248)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tomasz Ciecierski","email":"tomasz.ciecierski@elastic.co"},"sourceCommit":{"committedDate":"2023-10-24T11:34:36Z","message":"[EDR Workflows] Fix wrong sort value in live query results (#169248)","sha":"e7d43c89a5794f6ced294255a299e6cf814abddf","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["chore","release_note:skip","Team:Defend Workflows","v8.12.0","v8.11.1"],"number":169248,"url":"https://github.com/elastic/kibana/pull/169248","mergeCommit":{"message":"[EDR Workflows] Fix wrong sort value in live query results (#169248)","sha":"e7d43c89a5794f6ced294255a299e6cf814abddf"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/169248","number":169248,"mergeCommit":{"message":"[EDR Workflows] Fix wrong sort value in live query results (#169248)","sha":"e7d43c89a5794f6ced294255a299e6cf814abddf"}},{"branch":"8.11","label":"v8.11.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->