### PR TITLE
[Search] Remove stray parantheses on the indices page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -319,7 +319,6 @@ export const SearchIndices: React.FC = () => {
           </>
         )}
       </EnterpriseSearchContentPageTemplate>
-      )
     </>
   );
 };


### PR DESCRIPTION
## Summary

Remove stray parenthesis on the indices page. 

<img width="1710" alt="Screenshot 2023-11-10 at 4 12 42 PM" src="https://github.com/elastic/kibana/assets/55930906/91f3b909-aeda-4482-93ce-478913ce6fa9">
