### PR TITLE
[Index management] Skip for create enrich policies tests for MKI 

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/create_enrich_policy.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/create_enrich_policy.ts
@@ -20,6 +20,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const POLICY_NAME = `policy-${Math.random()}`;
 
   describe('Create enrich policy', function () {
+    // TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="enrichPoliciesEmptyPromptCreateButton"])
+    this.tags(['failsOnMKI']);
     before(async () => {
       log.debug('Creating test index');
       try {

--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/create_enrich_policy.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/create_enrich_policy.ts
@@ -20,7 +20,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const POLICY_NAME = `policy-${Math.random()}`;
 
   describe('Create enrich policy', function () {
-    // TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="enrichPoliciesEmptyPromptCreateButton"])
+    // TimeoutError:  Waiting for element to be located By(css selector, [data-test-subj="enrichPoliciesEmptyPromptCreateButton"])
     this.tags(['failsOnMKI']);
     before(async () => {
       log.debug('Creating test index');


### PR DESCRIPTION
Reverts elastic/kibana#171006 since the test still fails on MKI (different environment than where the flaky test runner or CI runs in)