### PR TITLE
[Synthetics] Supress API key errors when we have no monitors

### DIFF
--- a/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
+++ b/x-pack/plugins/synthetics/server/synthetics_service/synthetics_service.ts
@@ -423,6 +423,9 @@ export class SyntheticsService {
     };
 
     for await (const result of finder.find()) {
+      if (result.saved_objects.length === 0) {
+        return;
+      }
       try {
         if (!output) {
           output = await this.getOutput();


### PR DESCRIPTION
## Summary

Supress API key errors when we have no monitors !!

Start a fresh cluster and make sure there is no API key errors in logs !!

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->