### PR TITLE
[Cloud Security] Configure Transforms to auto-retry on failure

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
@@ -16,7 +16,7 @@ export const latestFindingsTransform: TransformPutTransformRequest = {
   transform_id: 'cloud_security_posture.findings_latest-default-8.8.0',
   description: 'Defines findings transformation to view only the latest finding per resource',
   source: {
-    index: "foo",
+    index: FINDINGS_INDEX_PATTERN,
   },
   dest: {
     index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
@@ -38,7 +38,7 @@ export const latestFindingsTransform: TransformPutTransformRequest = {
     sort: '@timestamp',
     unique_key: ['resource.id', 'rule.id'],
   },
-  settings: {unattended: true},
+  settings: { unattended: true },
   _meta: {
     package: {
       name: CLOUD_SECURITY_POSTURE_PACKAGE_NAME,

--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_findings_transform.ts
@@ -16,7 +16,7 @@ export const latestFindingsTransform: TransformPutTransformRequest = {
   transform_id: 'cloud_security_posture.findings_latest-default-8.8.0',
   description: 'Defines findings transformation to view only the latest finding per resource',
   source: {
-    index: FINDINGS_INDEX_PATTERN,
+    index: "foo",
   },
   dest: {
     index: LATEST_FINDINGS_INDEX_DEFAULT_NS,
@@ -38,6 +38,7 @@ export const latestFindingsTransform: TransformPutTransformRequest = {
     sort: '@timestamp',
     unique_key: ['resource.id', 'rule.id'],
   },
+  settings: {unattended: true},
   _meta: {
     package: {
       name: CLOUD_SECURITY_POSTURE_PACKAGE_NAME,

--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
@@ -40,6 +40,7 @@ export const latestVulnerabilitiesTransform: TransformPutTransformRequest = {
     sort: '@timestamp',
     unique_key: ['vulnerability.id', 'resource.id', 'package.name', 'package.version'],
   },
+  settings: {unattended: true},
   _meta: {
     package: {
       name: CLOUD_SECURITY_POSTURE_PACKAGE_NAME,

--- a/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
+++ b/x-pack/plugins/cloud_security_posture/server/create_transforms/latest_vulnerabilities_transforms.ts
@@ -40,7 +40,7 @@ export const latestVulnerabilitiesTransform: TransformPutTransformRequest = {
     sort: '@timestamp',
     unique_key: ['vulnerability.id', 'resource.id', 'package.name', 'package.version'],
   },
-  settings: {unattended: true},
+  settings: { unattended: true },
   _meta: {
     package: {
       name: CLOUD_SECURITY_POSTURE_PACKAGE_NAME,


### PR DESCRIPTION
solves https://github.com/elastic/security-team/issues/7226
This configures the transform to automatically restart in the event of any prolonged platform instability.

https://www.elastic.co/guide/en/elasticsearch/reference/current/put-transform.html

## How to test it
Add an allocation rule to the input indices that makes it impossible to allocate the shards of those indices to any node in the cluster. 


### Step 1
Use the dev tools to update cloud security index template component with error in the settings of the shard aloocation.
```JSON
PUT _component_template/logs-cloud_security_posture.findings@custom
{
  "template": {
    "settings": {
    "index.routing.allocation.include._host_ip": "123.214.214.24",
    "index.routing.allocation.require._id": "fooboo"
    }
  }
}
```

### Step 2
Update the Transform to run every 5 seconds for now waiting too much for the failure.

```JSON
POST _transform/cloud_security_posture.findings_latest-default-8.8.0/_update
{
 "frequency": "5s"
}
```

After ~35 minutes, check the transform status via the transform page, the input indices will all go to red health.

### Step 3
Revert changes and check the transform is back to work - if it's the status it means the retry mechanism works.
