### PR TITLE
[Cases] Enhance Multi Select Component Interface for Custom Fields

### DIFF
--- a/x-pack/plugins/cases/public/components/all_cases/multi_select_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/multi_select_filter.test.tsx
@@ -9,15 +9,19 @@ import { MultiSelectFilter } from './multi_select_filter';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
-import type { FilterOptions } from '../../../common/ui/types';
 
 describe('multi select filter', () => {
   it('should render the amount of options available', async () => {
     const onChange = jest.fn();
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b', 'tag c', 'tag d'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+        { label: 'tag c', key: 'tag c' },
+        { label: 'tag d', key: 'tag d' },
+      ],
       onChange,
     };
 
@@ -32,11 +36,14 @@ describe('multi select filter', () => {
   it('hides the limit reached warning when a selected tag is removed', async () => {
     const onChange = jest.fn();
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+      ],
       onChange,
-      selectedOptions: ['tag a'],
+      selectedOptionKeys: ['tag a'],
       limit: 1,
       limitReachedMessage: 'Limit reached',
     };
@@ -50,8 +57,8 @@ describe('multi select filter', () => {
 
     userEvent.click(screen.getByRole('option', { name: 'tag a' }));
 
-    expect(onChange).toHaveBeenCalledWith({ filterId: 'tags', options: [] });
-    rerender(<MultiSelectFilter {...props} selectedOptions={[]} />);
+    expect(onChange).toHaveBeenCalledWith({ filterId: 'tags', selectedOptionKeys: [] });
+    rerender(<MultiSelectFilter {...props} selectedOptionKeys={[]} />);
 
     expect(screen.queryByText('Limit reached')).not.toBeInTheDocument();
   });
@@ -59,11 +66,14 @@ describe('multi select filter', () => {
   it('displays the limit reached warning when the maximum number of tags is selected', async () => {
     const onChange = jest.fn();
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+      ],
       onChange,
-      selectedOptions: ['tag a'],
+      selectedOptionKeys: ['tag a'],
       limit: 2,
       limitReachedMessage: 'Limit reached',
     };
@@ -77,8 +87,11 @@ describe('multi select filter', () => {
 
     userEvent.click(screen.getByRole('option', { name: 'tag b' }));
 
-    expect(onChange).toHaveBeenCalledWith({ filterId: 'tags', options: ['tag a', 'tag b'] });
-    rerender(<MultiSelectFilter {...props} selectedOptions={['tag a', 'tag b']} />);
+    expect(onChange).toHaveBeenCalledWith({
+      filterId: 'tags',
+      selectedOptionKeys: ['tag a', 'tag b'],
+    });
+    rerender(<MultiSelectFilter {...props} selectedOptionKeys={['tag a', 'tag b']} />);
 
     expect(screen.getByText('Limit reached')).toBeInTheDocument();
   });
@@ -86,11 +99,14 @@ describe('multi select filter', () => {
   it('should not call onChange when the limit has been reached', async () => {
     const onChange = jest.fn();
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+      ],
       onChange,
-      selectedOptions: ['tag a'],
+      selectedOptionKeys: ['tag a'],
       limit: 1,
       limitReachedMessage: 'Limit reached',
     };
@@ -110,16 +126,19 @@ describe('multi select filter', () => {
   it('should remove selected option if it suddenly disappeared from the list', async () => {
     const onChange = jest.fn();
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+      ],
       onChange,
-      selectedOptions: ['tag b'],
+      selectedOptionKeys: ['tag b'],
     };
 
     const { rerender } = render(<MultiSelectFilter {...props} />);
-    rerender(<MultiSelectFilter {...props} options={['tag a']} />);
-    expect(onChange).toHaveBeenCalledWith({ filterId: 'tags', options: [] });
+    rerender(<MultiSelectFilter {...props} options={[{ key: 'tag a', label: 'tag a' }]} />);
+    expect(onChange).toHaveBeenCalledWith({ filterId: 'tags', selectedOptionKeys: [] });
   });
 
   it('activates custom renderOption when set', async () => {
@@ -127,9 +146,12 @@ describe('multi select filter', () => {
     const onChange = jest.fn();
     const renderOption = () => <div data-test-subj={TEST_ID} />;
     const props = {
-      id: 'tags' as keyof FilterOptions,
+      id: 'tags',
       buttonLabel: 'Tags',
-      options: ['tag a', 'tag b'],
+      options: [
+        { label: 'tag a', key: 'tag a' },
+        { label: 'tag b', key: 'tag b' },
+      ],
       onChange,
       renderOption,
     };

--- a/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
@@ -49,7 +49,7 @@ describe('Severity form field', () => {
     userEvent.click(screen.getByRole('option', { name: 'high' }));
 
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({ filterId: 'severity', options: ['high'] });
+      expect(onChange).toHaveBeenCalledWith({ filterId: 'severity', selectedOptionKeys: ['high'] });
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/severity_filter.test.tsx
@@ -18,7 +18,7 @@ describe('Severity form field', () => {
   const onChange = jest.fn();
   let appMockRender: AppMockRenderer;
   const props = {
-    selectedOptions: [],
+    selectedOptionKeys: [],
     onChange,
   };
 

--- a/x-pack/plugins/cases/public/components/all_cases/severity_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/severity_filter.tsx
@@ -8,24 +8,26 @@
 import { EuiFlexGroup, EuiFlexItem, EuiHealth } from '@elastic/eui';
 import React from 'react';
 import type { CaseSeverity } from '../../../common/types/domain';
-import type { FilterOptions } from '../../containers/types';
 import { severities } from '../severity/config';
-import { MultiSelectFilter } from './multi_select_filter';
+import type { MultiSelectFilterOption } from './multi_select_filter';
+import { MultiSelectFilter, mapToMultiSelectOption } from './multi_select_filter';
 import * as i18n from './translations';
 
-interface SeverityOption {
-  label: CaseSeverity;
-}
-
 interface Props {
-  selectedOptions: CaseSeverity[];
-  onChange: ({ filterId, options }: { filterId: keyof FilterOptions; options: string[] }) => void;
+  selectedOptionKeys: CaseSeverity[];
+  onChange: ({
+    filterId,
+    selectedOptionKeys,
+  }: {
+    filterId: string;
+    selectedOptionKeys: string[];
+  }) => void;
 }
 
-const options = Object.keys(severities) as CaseSeverity[];
+const options = mapToMultiSelectOption(Object.keys(severities) as CaseSeverity[]);
 
-export const SeverityFilter: React.FC<Props> = ({ selectedOptions, onChange }) => {
-  const renderOption = (option: SeverityOption) => {
+export const SeverityFilter: React.FC<Props> = ({ selectedOptionKeys, onChange }) => {
+  const renderOption = (option: MultiSelectFilterOption<CaseSeverity>) => {
     const severityData = severities[option.label];
     return (
       <EuiFlexGroup gutterSize="xs" alignItems={'center'} responsive={false}>
@@ -37,13 +39,13 @@ export const SeverityFilter: React.FC<Props> = ({ selectedOptions, onChange }) =
   };
 
   return (
-    <MultiSelectFilter<SeverityOption>
+    <MultiSelectFilter<CaseSeverity>
       buttonLabel={i18n.SEVERITY}
       id={'severity'}
       onChange={onChange}
       options={options}
       renderOption={renderOption}
-      selectedOptions={selectedOptions}
+      selectedOptionKeys={selectedOptionKeys}
     />
   );
 };

--- a/x-pack/plugins/cases/public/components/all_cases/solution_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/solution_filter.test.tsx
@@ -69,7 +69,10 @@ describe('SolutionFilter ', () => {
 
       userEvent.click(getByTestId(`options-filter-popover-item-${solutions[0]}`));
 
-      expect(onChange).toHaveBeenCalledWith({ filterId: 'owner', options: [solutions[0]] });
+      expect(onChange).toHaveBeenCalledWith({
+        filterId: 'owner',
+        selectedOptionKeys: [solutions[0]],
+      });
     });
 
     it('should call onChange with [owner] when the last solution option selected is deselected', async () => {
@@ -87,7 +90,10 @@ describe('SolutionFilter ', () => {
 
       userEvent.click(getByTestId(`options-filter-popover-item-${solutions[0]}`));
 
-      expect(onChange).toHaveBeenCalledWith({ filterId: 'owner', options: [solutions[0]] });
+      expect(onChange).toHaveBeenCalledWith({
+        filterId: 'owner',
+        selectedOptionKeys: [solutions[0]],
+      });
     });
   });
 
@@ -123,7 +129,10 @@ describe('SolutionFilter ', () => {
 
       userEvent.click(getByTestId(`options-filter-popover-item-${solutions[0]}`));
 
-      expect(onChange).toHaveBeenCalledWith({ filterId: 'owner', options: [solutions[0]] });
+      expect(onChange).toHaveBeenCalledWith({
+        filterId: 'owner',
+        selectedOptionKeys: [solutions[0]],
+      });
     });
 
     it('should call onChange with [all solutions] when the last solution option selected is deselected', async () => {
@@ -143,7 +152,7 @@ describe('SolutionFilter ', () => {
 
       expect(onChange).toHaveBeenCalledWith({
         filterId: 'owner',
-        options: [solutions[0], solutions[1]],
+        selectedOptionKeys: [solutions[0], solutions[1]],
       });
     });
   });

--- a/x-pack/plugins/cases/public/components/all_cases/solution_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/solution_filter.test.tsx
@@ -28,7 +28,7 @@ describe('SolutionFilter ', () => {
 
   it('renders button correctly', () => {
     const { getByTestId } = appMockRender.render(
-      <SolutionFilter onChange={onChange} selectedOptions={[]} availableSolutions={solutions} />
+      <SolutionFilter onChange={onChange} selectedOptionKeys={[]} availableSolutions={solutions} />
     );
 
     expect(getByTestId('options-filter-popover-button-owner')).toBeInTheDocument();
@@ -43,7 +43,11 @@ describe('SolutionFilter ', () => {
 
     it('renders options correctly', async () => {
       appMockRender.render(
-        <SolutionFilter onChange={onChange} selectedOptions={[]} availableSolutions={solutions} />
+        <SolutionFilter
+          onChange={onChange}
+          selectedOptionKeys={[]}
+          availableSolutions={solutions}
+        />
       );
 
       expect(screen.getByTestId('options-filter-popover-button-owner')).toBeInTheDocument();
@@ -60,7 +64,11 @@ describe('SolutionFilter ', () => {
 
     it('should call onChange with selected solution id when no option selected yet', async () => {
       const { getByTestId } = appMockRender.render(
-        <SolutionFilter onChange={onChange} selectedOptions={[]} availableSolutions={solutions} />
+        <SolutionFilter
+          onChange={onChange}
+          selectedOptionKeys={[]}
+          availableSolutions={solutions}
+        />
       );
 
       userEvent.click(getByTestId('options-filter-popover-button-owner'));
@@ -79,7 +87,7 @@ describe('SolutionFilter ', () => {
       const { getByTestId } = appMockRender.render(
         <SolutionFilter
           onChange={onChange}
-          selectedOptions={[solutions[0]]}
+          selectedOptionKeys={[solutions[0]]}
           availableSolutions={solutions}
         />
       );
@@ -105,7 +113,11 @@ describe('SolutionFilter ', () => {
 
     it('renders options correctly', async () => {
       const { getByTestId } = appMockRender.render(
-        <SolutionFilter onChange={onChange} selectedOptions={[]} availableSolutions={solutions} />
+        <SolutionFilter
+          onChange={onChange}
+          selectedOptionKeys={[]}
+          availableSolutions={solutions}
+        />
       );
 
       expect(getByTestId('options-filter-popover-button-owner')).toBeInTheDocument();
@@ -120,7 +132,11 @@ describe('SolutionFilter ', () => {
 
     it('should call onChange with selected solution id when no option selected yet', async () => {
       const { getByTestId } = appMockRender.render(
-        <SolutionFilter onChange={onChange} selectedOptions={[]} availableSolutions={solutions} />
+        <SolutionFilter
+          onChange={onChange}
+          selectedOptionKeys={[]}
+          availableSolutions={solutions}
+        />
       );
 
       userEvent.click(getByTestId('options-filter-popover-button-owner'));
@@ -139,7 +155,7 @@ describe('SolutionFilter ', () => {
       const { getByTestId } = appMockRender.render(
         <SolutionFilter
           onChange={onChange}
-          selectedOptions={[solutions[0]]}
+          selectedOptionKeys={[solutions[0]]}
           availableSolutions={solutions}
         />
       );

--- a/x-pack/plugins/cases/public/components/all_cases/solution_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/solution_filter.tsx
@@ -10,15 +10,20 @@ import type { EuiSelectableOption } from '@elastic/eui';
 import { EuiFlexGroup, EuiFlexItem, EuiIcon } from '@elastic/eui';
 
 import { OWNER_INFO } from '../../../common/constants';
-import type { FilterOptions } from '../../../common/ui';
 import * as i18n from './translations';
 import type { Solution } from './types';
-import { MultiSelectFilter } from './multi_select_filter';
+import { MultiSelectFilter, mapToMultiSelectOption } from './multi_select_filter';
 import type { CasesOwners } from '../../client/helpers/can_use_cases';
 import { useCasesContext } from '../cases_context/use_cases_context';
 
 interface FilterPopoverProps {
-  onChange: ({ filterId, options }: { filterId: keyof FilterOptions; options: string[] }) => void;
+  onChange: ({
+    filterId,
+    selectedOptionKeys,
+  }: {
+    filterId: string;
+    selectedOptionKeys: string[];
+  }) => void;
   selectedOptions: string[];
   availableSolutions: string[];
 }
@@ -41,7 +46,7 @@ export const SolutionFilterComponent = ({
 }: FilterPopoverProps) => {
   const { owner } = useCasesContext();
   const hasOwner = Boolean(owner.length);
-  const options = hasOwner ? owner : availableSolutions;
+  const options = mapToMultiSelectOption(hasOwner ? owner : availableSolutions);
   const solutions = availableSolutions.map((solution) => mapToReadableSolutionName(solution));
 
   /**
@@ -54,15 +59,21 @@ export const SolutionFilterComponent = ({
    */
   const _onChange = ({
     filterId,
-    options: newOptions,
+    selectedOptionKeys: newOptions,
   }: {
-    filterId: keyof FilterOptions;
-    options: string[];
+    filterId: string;
+    selectedOptionKeys: string[];
   }) => {
     if (hasOwner) {
-      onChange({ filterId, options: newOptions.length === 0 ? owner : newOptions });
+      onChange({
+        filterId,
+        selectedOptionKeys: newOptions.length === 0 ? owner : newOptions,
+      });
     } else {
-      onChange({ filterId, options: newOptions.length === 0 ? availableSolutions : newOptions });
+      onChange({
+        filterId,
+        selectedOptionKeys: newOptions.length === 0 ? availableSolutions : newOptions,
+      });
     }
   };
 
@@ -88,7 +99,7 @@ export const SolutionFilterComponent = ({
       onChange={_onChange}
       options={options}
       renderOption={renderOption}
-      selectedOptions={selectedOptionsInFilter}
+      selectedOptionKeys={selectedOptionsInFilter}
     />
   );
 };

--- a/x-pack/plugins/cases/public/components/all_cases/solution_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/solution_filter.tsx
@@ -24,7 +24,7 @@ interface FilterPopoverProps {
     filterId: string;
     selectedOptionKeys: string[];
   }) => void;
-  selectedOptions: string[];
+  selectedOptionKeys: string[];
   availableSolutions: string[];
 }
 
@@ -41,7 +41,7 @@ const mapToReadableSolutionName = (solution: string): Solution => {
 
 export const SolutionFilterComponent = ({
   onChange,
-  selectedOptions,
+  selectedOptionKeys,
   availableSolutions,
 }: FilterPopoverProps) => {
   const { owner } = useCasesContext();
@@ -78,7 +78,7 @@ export const SolutionFilterComponent = ({
   };
 
   const selectedOptionsInFilter =
-    selectedOptions.length === availableSolutions.length ? [] : selectedOptions;
+    selectedOptionKeys.length === availableSolutions.length ? [] : selectedOptionKeys;
 
   const renderOption = (option: EuiSelectableOption) => {
     const solution = solutions.find((solutionData) => solutionData.id === option.label) as Solution;

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.test.tsx
@@ -15,7 +15,7 @@ import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
 describe('StatusFilter', () => {
   const onChange = jest.fn();
   const defaultProps = {
-    selectedOptions: [],
+    selectedOptionKeys: [],
     countClosedCases: 7,
     countInProgressCases: 5,
     countOpenCases: 2,
@@ -49,7 +49,10 @@ describe('StatusFilter', () => {
     userEvent.click(screen.getByRole('option', { name: CaseStatuses.open }));
 
     await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith({ filterId: 'status', options: [CaseStatuses.open] });
+      expect(onChange).toHaveBeenCalledWith({
+        filterId: 'status',
+        selectedOptionKeys: [CaseStatuses.open],
+      });
     });
   });
 

--- a/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/status_filter.tsx
@@ -10,21 +10,23 @@ import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { Status } from '@kbn/cases-components/src/status/status';
 import { CaseStatuses } from '../../../common/types/domain';
 import { statuses } from '../status';
-import type { FilterOptions } from '../../../common/ui/types';
-import { MultiSelectFilter } from './multi_select_filter';
+import type { MultiSelectFilterOption } from './multi_select_filter';
+import { MultiSelectFilter, mapToMultiSelectOption } from './multi_select_filter';
 import * as i18n from './translations';
-
-interface StatusOption {
-  label: CaseStatuses;
-}
 
 interface Props {
   countClosedCases: number | null;
   countInProgressCases: number | null;
   countOpenCases: number | null;
   hiddenStatuses?: CaseStatuses[];
-  onChange: ({ filterId, options }: { filterId: keyof FilterOptions; options: string[] }) => void;
-  selectedOptions: string[];
+  onChange: ({
+    filterId,
+    selectedOptionKeys,
+  }: {
+    filterId: string;
+    selectedOptionKeys: string[];
+  }) => void;
+  selectedOptionKeys: string[];
 }
 
 const caseStatuses = Object.keys(statuses) as CaseStatuses[];
@@ -35,7 +37,7 @@ export const StatusFilterComponent = ({
   countOpenCases,
   hiddenStatuses = [],
   onChange,
-  selectedOptions,
+  selectedOptionKeys,
 }: Props) => {
   const stats = useMemo(
     () => ({
@@ -45,11 +47,14 @@ export const StatusFilterComponent = ({
     }),
     [countClosedCases, countInProgressCases, countOpenCases]
   );
-  const options: CaseStatuses[] = useMemo(
-    () => [...caseStatuses].filter((status) => !hiddenStatuses.includes(status)),
+  const options = useMemo(
+    () =>
+      mapToMultiSelectOption(
+        [...caseStatuses].filter((status) => !hiddenStatuses.includes(status))
+      ),
     [hiddenStatuses]
   );
-  const renderOption = (option: StatusOption) => {
+  const renderOption = (option: MultiSelectFilterOption<CaseStatuses>) => {
     const selectedStatus = option.label;
     return (
       <EuiFlexGroup gutterSize="xs" alignItems={'center'} responsive={false}>
@@ -63,13 +68,13 @@ export const StatusFilterComponent = ({
     );
   };
   return (
-    <MultiSelectFilter<StatusOption>
+    <MultiSelectFilter<CaseStatuses>
       buttonLabel={i18n.STATUS}
       id={'status'}
       onChange={onChange}
       options={options}
       renderOption={renderOption}
-      selectedOptions={selectedOptions}
+      selectedOptionKeys={selectedOptionKeys}
     />
   );
 };

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
@@ -12,7 +12,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiFieldSearch, EuiFilterGroup, EuiButton } 
 import type { CaseStatuses } from '../../../common/types/domain';
 import { MAX_TAGS_FILTER_LENGTH, MAX_CATEGORY_FILTER_LENGTH } from '../../../common/constants';
 import type { FilterOptions } from '../../containers/types';
-import { MultiSelectFilter } from './multi_select_filter';
+import { MultiSelectFilter, mapToMultiSelectOption } from './multi_select_filter';
 import { SolutionFilter } from './solution_filter';
 import { StatusFilter } from './status_filter';
 import * as i18n from './translations';
@@ -59,14 +59,14 @@ const CasesTableFiltersComponent = ({
 
   const onChange = ({
     filterId,
-    options,
+    selectedOptionKeys,
   }: {
-    filterId: keyof FilterOptions;
-    options: string[];
+    filterId: string;
+    selectedOptionKeys: string[];
   }) => {
     const newFilters = {
       ...filterOptions,
-      [filterId]: options,
+      [filterId]: selectedOptionKeys,
     };
 
     if (!isEqual(newFilters, filterOptions)) {
@@ -129,9 +129,9 @@ const CasesTableFiltersComponent = ({
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiFilterGroup>
-          <SeverityFilter selectedOptions={filterOptions.severity} onChange={onChange} />
+          <SeverityFilter selectedOptionKeys={filterOptions.severity} onChange={onChange} />
           <StatusFilter
-            selectedOptions={filterOptions?.status}
+            selectedOptionKeys={filterOptions?.status}
             onChange={onChange}
             hiddenStatuses={hiddenStatuses}
             countClosedCases={countClosedCases}
@@ -152,8 +152,8 @@ const CasesTableFiltersComponent = ({
             limit={MAX_TAGS_FILTER_LENGTH}
             limitReachedMessage={i18n.MAX_SELECTED_FILTER(MAX_TAGS_FILTER_LENGTH, 'tags')}
             onChange={onChange}
-            options={tags}
-            selectedOptions={filterOptions?.tags}
+            options={mapToMultiSelectOption(tags)}
+            selectedOptionKeys={filterOptions?.tags}
           />
           <MultiSelectFilter
             buttonLabel={i18n.CATEGORIES}
@@ -161,8 +161,8 @@ const CasesTableFiltersComponent = ({
             limit={MAX_CATEGORY_FILTER_LENGTH}
             limitReachedMessage={i18n.MAX_SELECTED_FILTER(MAX_CATEGORY_FILTER_LENGTH, 'categories')}
             onChange={onChange}
-            options={categories}
-            selectedOptions={filterOptions?.category}
+            options={mapToMultiSelectOption(categories)}
+            selectedOptionKeys={filterOptions?.category}
           />
           {availableSolutions.length > 1 && (
             <SolutionFilter

--- a/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
+++ b/x-pack/plugins/cases/public/components/all_cases/table_filters.tsx
@@ -167,7 +167,7 @@ const CasesTableFiltersComponent = ({
           {availableSolutions.length > 1 && (
             <SolutionFilter
               onChange={onChange}
-              selectedOptions={filterOptions?.owner}
+              selectedOptionKeys={filterOptions?.owner}
               availableSolutions={availableSolutions}
             />
           )}


### PR DESCRIPTION
Meta issue: https://github.com/elastic/kibana/issues/167651

## Summary
We need to make a small update to our multi select component. Right now, it only allows options with labels, but for custom fields, we might have situations where different fields have the same label. So, we're going to adjust it to work with options that have both {key, label}.

For our system filters (status, category, severity, ...) we'll keep using the label as the key. This is important because it helps us maintain our current way of handling the global state of our filters without any issues

## QA
An exhaustive QA is not required for this PR, as it's only going into a feature branch. The filters should continue working

