### PR TITLE
Stop preboot plugins only once on stop()

### DIFF
--- a/packages/core/plugins/core-plugins-server-internal/src/plugins_service.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugins_service.ts
@@ -201,7 +201,7 @@ export class PluginsService
     this.log.debug('Stopping plugins service');
 
     if (!this.arePrebootPluginsStopped) {
-      this.arePrebootPluginsStopped = false;
+      this.arePrebootPluginsStopped = true;
       await this.prebootPluginsSystem.stopPlugins();
     }
 


### PR DESCRIPTION
## Summary

When running `setup()` followed by `stop()`, the preboot plugins can ATM be stopped multiple times.