### PR TITLE
[7.17] Add custom representation for request objects (#171155)

### DIFF
--- a/docs/development/core/server/kibana-plugin-core-server.kibanarequest.md
+++ b/docs/development/core/server/kibana-plugin-core-server.kibanarequest.md
@@ -36,3 +36,11 @@ export declare class KibanaRequest<Params = unknown, Query = unknown, Body = unk
 |  [url](./kibana-plugin-core-server.kibanarequest.url.md) | <code>readonly</code> | URL | a WHATWG URL standard object. |
 |  [uuid](./kibana-plugin-core-server.kibanarequest.uuid.md) | <code>readonly</code> | string | A UUID to identify this request. |
 
+## Methods
+
+|  Method | Modifiers | Description |
+|  --- | --- | --- |
+|  [\[inspect.custom\]()](./kibana-plugin-core-server.kibanarequest._inspect.custom_.md) |  |  |
+|  [toJSON()](./kibana-plugin-core-server.kibanarequest.tojson.md) |  |  |
+|  [toString()](./kibana-plugin-core-server.kibanarequest.tostring.md) |  |  |
+

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -24,6 +24,7 @@ import { History as History_2 } from 'history';
 import { Href } from 'history';
 import { IconType } from '@elastic/eui';
 import { IncomingHttpHeaders } from 'http';
+import { inspect } from 'util';
 import type { KibanaClient } from '@elastic/elasticsearch/api/kibana';
 import { Location as Location_2 } from 'history';
 import { LocationDescriptorObject } from 'history';
@@ -1758,7 +1759,7 @@ export interface UserProvidedValues<T = any> {
 
 // Warnings were encountered during analysis:
 //
-// bazel-kibana/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
+// bazel-kibana-2/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
 // src/core/public/core_system.ts:168:21 - (ae-forgotten-export) The symbol "InternalApplicationStart" needs to be exported by the entry point index.d.ts
 
 ```

--- a/src/core/public/public.api.md
+++ b/src/core/public/public.api.md
@@ -1759,7 +1759,7 @@ export interface UserProvidedValues<T = any> {
 
 // Warnings were encountered during analysis:
 //
-// bazel-kibana-2/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
+// bazel-kibana/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
 // src/core/public/core_system.ts:168:21 - (ae-forgotten-export) The symbol "InternalApplicationStart" needs to be exported by the entry point index.d.ts
 
 ```

--- a/src/core/server/http/integration_tests/request_representation.test.ts
+++ b/src/core/server/http/integration_tests/request_representation.test.ts
@@ -58,7 +58,7 @@ describe('request logging', () => {
 
       const response = await supertest(innerServer.listener).get('/').expect(200);
       expect(replacePorts(response.body.req)).toEqual(
-        `[CoreKibanaRequest id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" method="get" url="http://127.0.0.1:XXXX/" fake="false" system="false" api="false"]`
+        `[CoreKibanaRequest id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" method="get" url="http://127.0.0.1:XXXX/" system="false"]`
       );
     });
 
@@ -78,8 +78,6 @@ describe('request logging', () => {
       expect(JSON.parse(replacePorts(response.body.req))).toEqual({
         id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
         url: 'http://127.0.0.1:XXXX/',
-        isFakeRequest: false,
-        isInternalApiRequest: false,
         isSystemRequest: false,
         auth: {
           isAuthenticated: false,
@@ -110,9 +108,7 @@ describe('request logging', () => {
           id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
           uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
           url: 'http://127.0.0.1:XXXX/',
-          isFakeRequest: false,
           isSystemRequest: false,
-          isInternalApiRequest: false,
           auth: { isAuthenticated: false },
           route: {
             path: '/',

--- a/src/core/server/http/integration_tests/request_representation.test.ts
+++ b/src/core/server/http/integration_tests/request_representation.test.ts
@@ -18,7 +18,8 @@ import { contextServiceMock } from '../../context/context_service.mock';
 import { executionContextServiceMock } from '../../execution_context/execution_context_service.mock';
 import { loggingSystemMock } from '../../logging/logging_system.mock';
 import { createHttpServer } from '../test_utils';
-import { schema } from '@kbn/config-schema';
+import { inspect } from 'util';
+import { ensureRawRequest } from '../router/request';
 
 let server: HttpService;
 

--- a/src/core/server/http/integration_tests/request_representation.test.ts
+++ b/src/core/server/http/integration_tests/request_representation.test.ts
@@ -1,0 +1,249 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'),
+}));
+
+import supertest from 'supertest';
+
+import { HttpService } from '../http_service';
+
+import { contextServiceMock } from '../../context/context_service.mock';
+import { executionContextServiceMock } from '../../execution_context/execution_context_service.mock';
+import { loggingSystemMock } from '../../logging/logging_system.mock';
+import { createHttpServer } from '../test_utils';
+import { schema } from '@kbn/config-schema';
+
+let server: HttpService;
+
+let logger: ReturnType<typeof loggingSystemMock.create>;
+const contextSetup = contextServiceMock.createSetupContract();
+
+const setupDeps = {
+  context: contextSetup,
+  executionContext: executionContextServiceMock.createInternalSetupContract(),
+};
+
+beforeEach(async () => {
+  logger = loggingSystemMock.create();
+
+  server = createHttpServer({ logger });
+  await server.preboot({ context: contextServiceMock.createPrebootContract() });
+});
+
+afterEach(async () => {
+  await server.stop();
+});
+
+const replacePorts = (input: string): string => input.replace(/[:][0-9]+[/]/g, ':XXXX/');
+
+describe('request logging', () => {
+  describe('KibanaRequest', () => {
+    it('has expected string representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          return res.ok({ body: { req: String(req) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toEqual(
+        `[CoreKibanaRequest id="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" method="get" url="http://127.0.0.1:XXXX/" fake="false" system="false" api="false"]`
+      );
+    });
+
+    it('has expected JSON representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          return res.ok({ body: { req: JSON.stringify(req) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+
+      expect(JSON.parse(replacePorts(response.body.req))).toEqual({
+        id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+        url: 'http://127.0.0.1:XXXX/',
+        isFakeRequest: false,
+        isInternalApiRequest: false,
+        isSystemRequest: false,
+        auth: {
+          isAuthenticated: false,
+        },
+        route: {
+          method: 'get',
+          path: '/',
+          options: expect.any(Object),
+        },
+        uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+      });
+    });
+
+    it('has expected inspect representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          return res.ok({ body: { req: inspect(req) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toMatchInlineSnapshot(`
+        "{
+          id: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+          uuid: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+          url: 'http://127.0.0.1:XXXX/',
+          isFakeRequest: false,
+          isSystemRequest: false,
+          isInternalApiRequest: false,
+          auth: { isAuthenticated: false },
+          route: {
+            path: '/',
+            method: 'get',
+            options: {
+              authRequired: true,
+              xsrfRequired: false,
+              access: 'internal',
+              tags: [],
+              timeout: [Object],
+              body: undefined
+            }
+          }
+        }"
+      `);
+    });
+  });
+
+  describe('HAPI request', () => {
+    it('has expected string representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRequest = ensureRawRequest(req);
+          return res.ok({ body: { req: String(rawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toEqual(
+        `[HAPI.Request method="get" url="http://127.0.0.1:XXXX/"]`
+      );
+    });
+
+    it('has expected JSON representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRequest = ensureRawRequest(req);
+          return res.ok({ body: { req: JSON.stringify(rawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(JSON.parse(replacePorts(response.body.req))).toEqual({
+        method: 'get',
+        url: 'http://127.0.0.1:XXXX/',
+      });
+    });
+
+    it('has expected inspect representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRequest = ensureRawRequest(req);
+          return res.ok({ body: { req: inspect(rawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toMatchInlineSnapshot(
+        `"{ method: 'get', url: 'http://127.0.0.1:XXXX/' }"`
+      );
+    });
+  });
+
+  describe('http.IncomingMessage', () => {
+    it('has expected string representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRawRequest = ensureRawRequest(req).raw.req;
+          return res.ok({ body: { req: String(rawRawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toEqual(
+        `[http.IncomingMessage method="GET" url="/" complete="true" aborted="false"]`
+      );
+    });
+
+    it('has expected JSON representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRawRequest = ensureRawRequest(req).raw.req;
+          return res.ok({ body: { req: JSON.stringify(rawRawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(JSON.parse(replacePorts(response.body.req))).toEqual({
+        aborted: false,
+        complete: true,
+        method: 'GET',
+        url: '/',
+      });
+    });
+
+    it('has expected inspect representation', async () => {
+      const { server: innerServer, createRouter } = await server.setup(setupDeps);
+      const router = createRouter('/');
+      router.get(
+        { path: '/', validate: false, options: { authRequired: true } },
+        (context, req, res) => {
+          const rawRawRequest = ensureRawRequest(req).raw.req;
+          return res.ok({ body: { req: inspect(rawRawRequest) } });
+        }
+      );
+      await server.start();
+
+      const response = await supertest(innerServer.listener).get('/').expect(200);
+      expect(replacePorts(response.body.req)).toMatchInlineSnapshot(
+        `"{ method: 'GET', url: '/', complete: true, aborted: false }"`
+      );
+    });
+  });
+});

--- a/src/core/server/http/integration_tests/request_representation.test.ts
+++ b/src/core/server/http/integration_tests/request_representation.test.ts
@@ -117,7 +117,6 @@ describe('request logging', () => {
             options: {
               authRequired: true,
               xsrfRequired: false,
-              access: 'internal',
               tags: [],
               timeout: [Object],
               body: undefined

--- a/src/core/server/http/router/patch_request.ts
+++ b/src/core/server/http/router/patch_request.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+// @ts-expect-error not in the definition file
+import HapiRequest from '@hapi/hapi/lib/request.js';
+import { IncomingMessage } from 'http';
+import { inspect } from 'util';
+
+export const patchRequest = () => {
+  // HAPI request
+  HapiRequest.prototype.toString = function () {
+    return `[HAPI.Request method="${this.method}" url="${this.url}"]`;
+  };
+
+  HapiRequest.prototype.toJSON = function () {
+    return {
+      method: this.method,
+      url: String(this.url),
+    };
+  };
+
+  HapiRequest.prototype[inspect.custom] = function () {
+    return this.toJSON();
+  };
+
+  // http.IncomingMessage
+  const IncomingMessageProto = IncomingMessage.prototype;
+
+  IncomingMessageProto.toString = function () {
+    return `[http.IncomingMessage method="${this.method}" url="${this.url}" complete="${this.complete}" aborted="${this.aborted}"]`;
+  };
+
+  // @ts-expect-error missing definition
+  IncomingMessageProto.toJSON = function () {
+    return {
+      method: this.method,
+      url: this.url,
+      complete: this.complete,
+      aborted: this.aborted,
+    };
+  };
+
+  // @ts-expect-error missing definition
+  IncomingMessageProto[inspect.custom] = function () {
+    // @ts-expect-error missing definition
+    return this.toJSON();
+  };
+};

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -229,7 +229,6 @@ export class KibanaRequest<
     };
   }
 
-
   toString() {
     return `[CoreKibanaRequest id="${this.id}" method="${this.route.method}" url="${this.url}" fake="${this.isFakeRequest}" system="${this.isSystemRequest}" api="${this.isInternalApiRequest}"]`;
   }

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -8,6 +8,7 @@
 
 import { URL } from 'url';
 import uuid from 'uuid';
+import { inspect } from 'util';
 import { Request, RouteOptionsApp, RequestApplicationState, RouteOptions } from '@hapi/hapi';
 import { Observable, fromEvent, merge } from 'rxjs';
 import { shareReplay, first, takeUntil } from 'rxjs/operators';
@@ -18,6 +19,10 @@ import { Headers } from './headers';
 import { RouteMethod, RouteConfigOptions, validBodyOutput, isSafeMethod } from './route';
 import { KibanaSocket, IKibanaSocket } from './socket';
 import { RouteValidator, RouteValidatorFullConfig } from './validator';
+import { patchRequest } from './patch_requests';
+
+// patching at module load
+patchRequest();
 
 const requestSymbol = Symbol('request');
 
@@ -222,6 +227,30 @@ export class KibanaRequest<
       // missing in fakeRequests, so we cast to false
       isAuthenticated: Boolean(request.auth?.isAuthenticated),
     };
+  }
+
+
+  toString() {
+    return `[CoreKibanaRequest id="${this.id}" method="${this.route.method}" url="${this.url}" fake="${this.isFakeRequest}" system="${this.isSystemRequest}" api="${this.isInternalApiRequest}"]`;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      uuid: this.uuid,
+      url: `${this.url}`,
+      isFakeRequest: this.isFakeRequest,
+      isSystemRequest: this.isSystemRequest,
+      isInternalApiRequest: this.isInternalApiRequest,
+      auth: {
+        isAuthenticated: this.auth.isAuthenticated,
+      },
+      route: this.route,
+    };
+  }
+
+  [inspect.custom]() {
+    return this.toJSON();
   }
 
   private getEvents(request: Request): KibanaRequestEvents {

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -230,7 +230,7 @@ export class KibanaRequest<
   }
 
   toString() {
-    return `[CoreKibanaRequest id="${this.id}" method="${this.route.method}" url="${this.url}" fake="${this.isFakeRequest}" system="${this.isSystemRequest}" api="${this.isInternalApiRequest}"]`;
+    return `[CoreKibanaRequest id="${this.id}" method="${this.route.method}" url="${this.url}" system="${this.isSystemRequest}"]`;
   }
 
   toJSON() {
@@ -238,9 +238,7 @@ export class KibanaRequest<
       id: this.id,
       uuid: this.uuid,
       url: `${this.url}`,
-      isFakeRequest: this.isFakeRequest,
       isSystemRequest: this.isSystemRequest,
-      isInternalApiRequest: this.isInternalApiRequest,
       auth: {
         isAuthenticated: this.auth.isAuthenticated,
       },

--- a/src/core/server/http/router/request.ts
+++ b/src/core/server/http/router/request.ts
@@ -19,7 +19,7 @@ import { Headers } from './headers';
 import { RouteMethod, RouteConfigOptions, validBodyOutput, isSafeMethod } from './route';
 import { KibanaSocket, IKibanaSocket } from './socket';
 import { RouteValidator, RouteValidatorFullConfig } from './validator';
-import { patchRequest } from './patch_requests';
+import { patchRequest } from './patch_request';
 
 // patching at module load
 patchRequest();

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -3091,7 +3091,7 @@ export const validBodyOutput: readonly ["data", "stream"];
 
 // Warnings were encountered during analysis:
 //
-// bazel-kibana-2/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
+// bazel-kibana/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
 // src/core/server/elasticsearch/client/types.ts:94:7 - (ae-forgotten-export) The symbol "Explanation" needs to be exported by the entry point index.d.ts
 // src/core/server/http/router/response.ts:302:3 - (ae-forgotten-export) The symbol "KibanaResponse" needs to be exported by the entry point index.d.ts
 // src/core/server/plugins/types.ts:406:3 - (ae-forgotten-export) The symbol "KibanaConfigType" needs to be exported by the entry point index.d.ts

--- a/src/core/server/server.api.md
+++ b/src/core/server/server.api.md
@@ -30,6 +30,7 @@ import { EcsEventType } from '@kbn/logging';
 import { EnvironmentMode } from '@kbn/config';
 import type { estypes } from '@elastic/elasticsearch';
 import { IncomingHttpHeaders } from 'http';
+import { inspect } from 'util';
 import type { KibanaClient } from '@elastic/elasticsearch/api/kibana';
 import { Logger as Logger_2 } from '@kbn/logging';
 import { LoggerFactory } from '@kbn/logging';
@@ -1303,6 +1304,21 @@ export type KibanaExecutionContext = {
 
 // @public
 export class KibanaRequest<Params = unknown, Query = unknown, Body = unknown, Method extends RouteMethod = any> {
+    // (undocumented)
+    [inspect.custom](): {
+        id: string;
+        uuid: string;
+        url: string;
+        isSystemRequest: boolean;
+        auth: {
+            isAuthenticated: boolean;
+        };
+        route: Readonly<{
+            path: string;
+            method: RecursiveReadonly<Method>;
+            options: RecursiveReadonly<KibanaRequestRouteOptions<Method>>;
+        }>;
+    };
     // @internal (undocumented)
     protected readonly [requestSymbol]: Request_2;
     constructor(request: Request_2, params: Params, query: Query, body: Body, withoutSecretHeaders: boolean);
@@ -1328,6 +1344,23 @@ export class KibanaRequest<Params = unknown, Query = unknown, Body = unknown, Me
     readonly route: RecursiveReadonly<KibanaRequestRoute<Method>>;
     // (undocumented)
     readonly socket: IKibanaSocket;
+    // (undocumented)
+    toJSON(): {
+        id: string;
+        uuid: string;
+        url: string;
+        isSystemRequest: boolean;
+        auth: {
+            isAuthenticated: boolean;
+        };
+        route: Readonly<{
+            path: string;
+            method: RecursiveReadonly<Method>;
+            options: RecursiveReadonly<KibanaRequestRouteOptions<Method>>;
+        }>;
+    };
+    // (undocumented)
+    toString(): string;
     readonly url: URL_2;
     readonly uuid: string;
 }
@@ -3058,7 +3091,7 @@ export const validBodyOutput: readonly ["data", "stream"];
 
 // Warnings were encountered during analysis:
 //
-// bazel-kibana/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
+// bazel-kibana-2/packages/kbn-config-schema/src/byte_size_value/index.ts:1:1 - (ae-wrong-input-file-type) Incorrect file type; API Extractor expects to analyze compiler outputs with the .d.ts file extension. Troubleshooting tips: https://api-extractor.com/link/dts-error
 // src/core/server/elasticsearch/client/types.ts:94:7 - (ae-forgotten-export) The symbol "Explanation" needs to be exported by the entry point index.d.ts
 // src/core/server/http/router/response.ts:302:3 - (ae-forgotten-export) The symbol "KibanaResponse" needs to be exported by the entry point index.d.ts
 // src/core/server/plugins/types.ts:406:3 - (ae-forgotten-export) The symbol "KibanaConfigType" needs to be exported by the entry point index.d.ts

--- a/src/plugins/data/server/search/search_source/mocks.ts
+++ b/src/plugins/data/server/search/search_source/mocks.ts
@@ -7,14 +7,13 @@
  */
 
 import type { MockedKeys } from '@kbn/utility-types/jest';
-import { KibanaRequest } from 'src/core/server';
 
 import { searchSourceCommonMock } from '../../../common/search/search_source/mocks';
 import { ISearchStart } from '../types';
 
 function createStartContract(): MockedKeys<ISearchStart['searchSource']> {
   return {
-    asScoped: async (request: jest.Mocked<KibanaRequest>) => {
+    asScoped: async () => {
       return searchSourceCommonMock;
     },
   };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Add custom representation for request objects (#171155)](https://github.com/elastic/kibana/pull/171155)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2023-11-14T11:16:32Z","message":"Add custom representation for request objects (#171155)\n\n## Summary\r\n\r\nAdd custom string/json/inspect representations for `KibanaRequest`,\r\n`hapi.Request` and `http.IncomingMessage`","sha":"4aa9ed52fd01ab25fe97bbd917f873e6da273ed0","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","v8.12.0","v8.11.2"],"number":171155,"url":"https://github.com/elastic/kibana/pull/171155","mergeCommit":{"message":"Add custom representation for request objects (#171155)\n\n## Summary\r\n\r\nAdd custom string/json/inspect representations for `KibanaRequest`,\r\n`hapi.Request` and `http.IncomingMessage`","sha":"4aa9ed52fd01ab25fe97bbd917f873e6da273ed0"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/171155","number":171155,"mergeCommit":{"message":"Add custom representation for request objects (#171155)\n\n## Summary\r\n\r\nAdd custom string/json/inspect representations for `KibanaRequest`,\r\n`hapi.Request` and `http.IncomingMessage`","sha":"4aa9ed52fd01ab25fe97bbd917f873e6da273ed0"}},{"branch":"8.11","label":"v8.11.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->