### PR TITLE
[Ops] Don't fail if can't report to CI stats

### DIFF
--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -9,7 +9,7 @@ if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
   "$(dirname "${0}")/commit_status_complete.sh"
 fi
 
-ts-node "$(dirname "${0}")/ci_stats_complete.ts"
+ts-node "$(dirname "${0}")/ci_stats_complete.ts" || true
 
 if [[ "${GITHUB_PR_NUMBER:-}" ]]; then
   DOCS_CHANGES_URL="https://kibana_$GITHUB_PR_NUMBER}.docs-preview.app.elstc.co/diff"


### PR DESCRIPTION
## Summary
There are cases where the target is not a build that is present in main, or wasn't built properly, thus there are no CI stats available. For now, I don't know what would be the apt solution, but to unblock @benakansara (see: https://elastic.slack.com/archives/C5UDAFZQU/p1699955738527689)

chore: Prevent crashing a build if the ci-stats reporting didn't succeed.
