### PR TITLE
[Cases] Disabling editing ESQL visualizations

### DIFF
--- a/x-pack/plugins/cases/public/components/visualizations/attachment.test.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/attachment.test.tsx
@@ -24,7 +24,10 @@ describe('getVisualizationAttachmentType', () => {
 
   const attachmentViewProps: PersistableStateAttachmentViewProps = {
     persistableStateAttachmentTypeId: LENS_ATTACHMENT_TYPE,
-    persistableStateAttachmentState: { attributes: {}, timeRange: {} },
+    persistableStateAttachmentState: {
+      attributes: { state: { query: {} } },
+      timeRange: {},
+    },
     attachmentId: 'test',
     caseData: { title: basicCase.title, id: basicCase.id },
   };

--- a/x-pack/plugins/cases/public/components/visualizations/open_lens_button.test.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/open_lens_button.test.tsx
@@ -62,17 +62,17 @@ describe('OpenLensButton', () => {
     expect(screen.queryByText('Open visualization')).not.toBeInTheDocument();
   });
 
-  it('returns null if the visualization is an ESQL', () => {
+  it('does not show the button if the query is an ESQL', () => {
     const esqlProps = {
       attachmentId: 'test',
       ...lensVisualization,
     };
 
-    set(esqlProps, 'state.query', { type: 'esql' });
+    set(esqlProps, 'attributes.state.query', { esql: '' });
 
     // @ts-expect-error: props are correct
     appMockRender.render(<OpenLensButton {...esqlProps} />);
 
-    expect(screen.queryByText('Open visualization')).toBeInTheDocument();
+    expect(screen.queryByText('Open visualization')).not.toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/visualizations/open_lens_button.test.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/open_lens_button.test.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { set } from 'lodash';
 import React from 'react';
 import { screen } from '@testing-library/react';
 import type { AppMockRenderer } from '../../common/mock';
@@ -59,5 +60,19 @@ describe('OpenLensButton', () => {
     appMockRender.render(<OpenLensButton {...props} />);
 
     expect(screen.queryByText('Open visualization')).not.toBeInTheDocument();
+  });
+
+  it('returns null if the visualization is an ESQL', () => {
+    const esqlProps = {
+      attachmentId: 'test',
+      ...lensVisualization,
+    };
+
+    set(esqlProps, 'state.query', { type: 'esql' });
+
+    // @ts-expect-error: props are correct
+    appMockRender.render(<OpenLensButton {...esqlProps} />);
+
+    expect(screen.queryByText('Open visualization')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/visualizations/open_lens_button.tsx
+++ b/x-pack/plugins/cases/public/components/visualizations/open_lens_button.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { isOfAggregateQueryType } from '@kbn/es-query';
 import { EuiButtonEmpty } from '@elastic/eui';
 import React, { useCallback } from 'react';
 import { useKibana } from '../../common/lib/kibana';
@@ -32,8 +33,9 @@ const OpenLensButtonComponent: React.FC<Props> = ({ attachmentId, attributes, ti
   }, [attachmentId, attributes, navigateToPrefilledEditor, timeRange]);
 
   const hasLensPermissions = canUseEditor();
+  const isESQLQuery = isOfAggregateQueryType(attributes.state.query);
 
-  if (!hasLensPermissions) {
+  if (!hasLensPermissions || isESQLQuery) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

This PR disables editing an ESQL visualization from within Cases.

Fixes: https://github.com/elastic/kibana/issues/171154

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->