### PR TITLE
[Fleet] Remove agent upgrade fix from 8.11.1 release notes

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -65,7 +65,6 @@ The 8.11.1 release includes the following bug fixes.
 === Bug Fixes
 
 Fleet::
-* Fixes inability to upgrade agents from version 8.10.4 to version 8.11 ({kibana-pull}170974[#170974]).
 * Append space ID to security solution tag ({kibana-pull}170789[#170789]).
 * Modify bulk unenroll to include inactive agents ({kibana-pull}170249[#170249]).
 Lens & Visualizations::


### PR DESCRIPTION
## Summary

The 8.11.1 release notes included #170974 which didn't actually land in 8.11.1. We shipped BC2 of 8.11.1 which was built from this Kibana commit: https://github.com/elastic/kibana/commits/09feaf416f986b239b8e8ad95ecdda0f9d56ebec. The PR was not merged until after this commit, so the bug is still present (though [mitigated slightly](https://github.com/elastic/kibana/issues/169825#issuecomment-1808453016)) in 8.11.1. 

This PR removes the erroneous release note from the 8.11.1 release notes. How can we make sure the fix _does_ get included in the eventual 8.11.2 release notes?

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->