### PR TITLE
[Enterprise Search] Set run ML inference default setting to true

### DIFF
--- a/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/pipeline_panel.test.tsx.snap
+++ b/packages/kbn-search-connectors/components/sync_jobs/__snapshots__/pipeline_panel.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`PipelinePanel renders 1`] = `
         },
         Object {
           "setting": "Machine learning inference",
-          "value": false,
+          "value": true,
         },
       ]
     }

--- a/packages/kbn-search-connectors/components/sync_jobs/pipeline_panel.test.tsx
+++ b/packages/kbn-search-connectors/components/sync_jobs/pipeline_panel.test.tsx
@@ -17,7 +17,7 @@ describe('PipelinePanel', () => {
     extract_binary_content: true,
     name: 'name',
     reduce_whitespace: true,
-    run_ml_inference: false,
+    run_ml_inference: true,
   };
   it('renders', () => {
     const wrapper = shallow(<PipelinePanel pipeline={pipeline} />);

--- a/x-pack/plugins/enterprise_search/common/constants.ts
+++ b/x-pack/plugins/enterprise_search/common/constants.ts
@@ -197,7 +197,7 @@ export const DEFAULT_PIPELINE_VALUES: IngestPipelineParams = {
   extract_binary_content: true,
   name: DEFAULT_PIPELINE_NAME,
   reduce_whitespace: true,
-  run_ml_inference: false,
+  run_ml_inference: true,
 };
 
 export interface DefaultConnectorsPipelineMeta {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ingest_pipelines/ingest_pipelines_card.test.tsx
@@ -33,7 +33,7 @@ const DEFAULT_VALUES = {
     extract_binary_content: true,
     name: DEFAULT_PIPELINE_NAME,
     reduce_whitespace: true,
-    run_ml_inference: false,
+    run_ml_inference: true,
   },
   showModal: false,
 };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines_logic.test.ts
@@ -23,7 +23,7 @@ const DEFAULT_PIPELINE_VALUES = {
   extract_binary_content: true,
   name: 'ent-search-generic-ingestion',
   reduce_whitespace: true,
-  run_ml_inference: false,
+  run_ml_inference: true,
 };
 
 const DEFAULT_VALUES = {
@@ -104,6 +104,7 @@ describe('PipelinesLogic', () => {
       });
       expect(PipelinesLogic.values).toEqual({
         ...DEFAULT_VALUES,
+        canUseMlInferencePipeline: true,
         hasIndexIngestionPipeline: true,
         pipelineName: 'new_pipeline_name',
         pipelineState: { ...DEFAULT_PIPELINE_VALUES, name: 'new_pipeline_name' },

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
@@ -52,7 +52,7 @@ describe('addConnector lib function', () => {
             default_extract_binary_content: true,
             default_name: 'ent-search-generic-ingestion',
             default_reduce_whitespace: true,
-            default_run_ml_inference: false,
+            default_run_ml_inference: true,
           },
           version: '1',
         },
@@ -87,7 +87,7 @@ describe('addConnector lib function', () => {
         extract_binary_content: true,
         name: 'ent-search-generic-ingestion',
         reduce_whitespace: true,
-        run_ml_inference: false,
+        run_ml_inference: true,
       },
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({
@@ -205,7 +205,7 @@ describe('addConnector lib function', () => {
         extract_binary_content: true,
         name: 'ent-search-generic-ingestion',
         reduce_whitespace: true,
-        run_ml_inference: false,
+        run_ml_inference: true,
       },
     });
     expect(mockClient.asCurrentUser.indices.create).toHaveBeenCalledWith({

--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/get_index_pipeline.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/get_index_pipeline.test.ts
@@ -87,7 +87,7 @@ describe('getIndexPipelineParameters', () => {
       extract_binary_content: true,
       name: 'my-index',
       reduce_whitespace: true,
-      run_ml_inference: false,
+      run_ml_inference: true,
     });
   });
   it('returns default connector index pipeline if found in mapping', async () => {


### PR DESCRIPTION
## Summary

The ML inference pipelines setting will now default to true. Note the value comes from Elasticsearch, so this object is most likely ignored.

![Screenshot 2023-11-15 at 09 54 52](https://github.com/elastic/kibana/assets/14224983/9feccf00-b70d-40e0-b64d-dbb712e9630c)


<!--ONMERGE {"backportTargets":["8.10","8.11"]} ONMERGE-->