### PR TITLE
Upgrade tests to support the 1st event being the "available"

### DIFF
--- a/test/analytics/tests/instrumented_events/from_the_server/core_overall_status_changed.ts
+++ b/test/analytics/tests/instrumented_events/from_the_server/core_overall_status_changed.ts
@@ -13,41 +13,36 @@ import { FtrProviderContext } from '../../../services';
 export default function ({ getService }: FtrProviderContext) {
   const ebtServerHelper = getService('kibana_ebt_server');
 
-  // Failing: See https://github.com/elastic/kibana/issues/171164
-  describe.skip('core-overall_status_changed', () => {
-    let initialEvent: Event<Record<string, unknown>>;
-    let secondEvent: Event<Record<string, unknown>>;
+  describe('core-overall_status_changed', () => {
+    let currentEvent: Event<Record<string, unknown>>;
 
     before(async () => {
-      [initialEvent, secondEvent] = await ebtServerHelper.getEvents(2, {
+      [currentEvent] = await ebtServerHelper.getEvents(1, {
         eventTypes: ['core-overall_status_changed'],
       });
     });
 
-    it('should emit the initial "degraded" event with the context set to `initializing`', () => {
+    it('should emit an initial event with the context set to `initializing`', async () => {
+      const initialEvent = currentEvent;
       expect(initialEvent.event_type).to.eql('core-overall_status_changed');
-      expect(initialEvent.context).to.have.property('overall_status_level', 'initializing');
-      expect(initialEvent.context).to.have.property(
-        'overall_status_summary',
-        'Kibana is starting up'
-      );
-      expect(initialEvent.properties).to.have.property('overall_status_level', 'degraded');
-      expect(initialEvent.properties).to.have.property('overall_status_summary');
-      expect(initialEvent.properties.overall_status_summary).to.be.a('string');
+      expect(initialEvent.context.overall_status_level).to.eql('initializing');
+      expect(initialEvent.context.overall_status_summary).to.eql('Kibana is starting up');
     });
 
-    it('should emit the 2nd event as `available` with the context set to the previous values', () => {
-      expect(secondEvent.event_type).to.eql('core-overall_status_changed');
-      expect(secondEvent.context).to.have.property(
-        'overall_status_level',
-        initialEvent.properties.overall_status_level
-      );
-      expect(secondEvent.context).to.have.property(
-        'overall_status_summary',
-        initialEvent.properties.overall_status_summary
-      );
-      expect(secondEvent.properties.overall_status_level).to.be.a('string'); // Ideally we would test it as `available`, but we can't do that as it may result flaky for many side effects in the CI.
-      expect(secondEvent.properties.overall_status_summary).to.be.a('string');
+    it('should emit an event with status `available` eventually', async () => {
+      const isAvailable = (ev: Event<Record<string, unknown>>) =>
+        ev.properties.overall_status_level === 'available';
+
+      for (let i = 2; i <= 10 && !isAvailable(currentEvent); ++i) {
+        currentEvent = (
+          await ebtServerHelper.getEvents(i, {
+            eventTypes: ['core-overall_status_changed'],
+          })
+        ).pop()!;
+      }
+
+      // at this point, Kibana is NOT available after 10 emissions!
+      expect(isAvailable(currentEvent)).to.eql(true);
     });
   });
 }


### PR DESCRIPTION
## Summary

Address https://github.com/elastic/kibana/issues/171164

The tests were assuming that the first event emitted is always `"degraded"`.
After merging https://github.com/elastic/kibana/pull/171012 this might no longer be the case, aka the first event might already have an `"available"` status and we might have no more events in that case. 

This PR takes this enhancement into account and makes the test more robust:
* Checking that an `"initializing"` event comes through first.
* Checking that we eventually get an `"available"` event.

---

Flaky Test Runner Pipeline - 100x 🟢 
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/3981