### PR TITLE
Add Spaces to Dashboard Listing Table

### DIFF
--- a/examples/content_management_examples/kibana.jsonc
+++ b/examples/content_management_examples/kibana.jsonc
@@ -13,6 +13,9 @@
       "kibanaReact",
       "savedObjectsTaggingOss"
     ],
+    "optionalPlugins": [
+      "spaces"
+    ],
     "requiredBundles": ["savedObjectsFinder"]
   }
 }

--- a/examples/content_management_examples/public/examples/index.tsx
+++ b/examples/content_management_examples/public/examples/index.tsx
@@ -20,7 +20,7 @@ import { FinderApp } from './finder';
 
 export const renderApp = (
   core: CoreStart,
-  { contentManagement, savedObjectsTaggingOss }: StartDeps,
+  { contentManagement, savedObjectsTaggingOss, spaces }: StartDeps,
   { element, history }: AppMountParameters
 ) => {
   ReactDOM.render(
@@ -69,6 +69,7 @@ export const renderApp = (
                   contentClient={contentManagement.client}
                   core={core}
                   savedObjectsTagging={savedObjectsTaggingOss}
+                  spaces={spaces}
                 />
               </Route>
               <Route path="/finder">

--- a/examples/content_management_examples/public/examples/msearch/msearch_app.tsx
+++ b/examples/content_management_examples/public/examples/msearch/msearch_app.tsx
@@ -6,7 +6,8 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { FC, useMemo } from 'react';
+import { SpacesContextProps, SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { ContentClientProvider, type ContentClient } from '@kbn/content-management-plugin/public';
 import { TableListViewKibanaProvider } from '@kbn/content-management-table-list-view-table';
 import type { CoreStart } from '@kbn/core/public';
@@ -15,23 +16,37 @@ import { FormattedRelative, I18nProvider } from '@kbn/i18n-react';
 import { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
 import { MSearchTable } from './msearch_table';
 
+const getEmptyFunctionComponent: FC<SpacesContextProps> = ({ children }) => <>{children}</>;
+
 export const MSearchApp = (props: {
   contentClient: ContentClient;
   core: CoreStart;
   savedObjectsTagging: SavedObjectTaggingOssPluginStart;
+  spaces?: SpacesPluginStart;
 }) => {
+  const SpacesContextWrapper = useMemo(
+    () =>
+      props.spaces
+        ? props.spaces.ui.components.getSpacesContextProvider
+        : getEmptyFunctionComponent,
+    [props.spaces]
+  );
+
   return (
-    <ContentClientProvider contentClient={props.contentClient}>
-      <I18nProvider>
-        <TableListViewKibanaProvider
-          core={props.core}
-          toMountPoint={toMountPoint}
-          FormattedRelative={FormattedRelative}
-          savedObjectsTagging={props.savedObjectsTagging.getTaggingApi()}
-        >
-          <MSearchTable />
-        </TableListViewKibanaProvider>
-      </I18nProvider>
-    </ContentClientProvider>
+    <SpacesContextWrapper>
+      <ContentClientProvider contentClient={props.contentClient}>
+        <I18nProvider>
+          <TableListViewKibanaProvider
+            core={props.core}
+            toMountPoint={toMountPoint}
+            FormattedRelative={FormattedRelative}
+            savedObjectsTagging={props.savedObjectsTagging.getTaggingApi()}
+            spacesApi={props.spaces}
+          >
+            <MSearchTable />
+          </TableListViewKibanaProvider>
+        </I18nProvider>
+      </ContentClientProvider>
+    </SpacesContextWrapper>
   );
 };

--- a/examples/content_management_examples/public/types.ts
+++ b/examples/content_management_examples/public/types.ts
@@ -10,6 +10,7 @@ import {
   ContentManagementPublicSetup,
   ContentManagementPublicStart,
 } from '@kbn/content-management-plugin/public';
+import { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import { DeveloperExamplesSetup } from '@kbn/developer-examples-plugin/public';
 import { SavedObjectTaggingOssPluginStart } from '@kbn/saved-objects-tagging-oss-plugin/public';
 
@@ -21,4 +22,5 @@ export interface SetupDeps {
 export interface StartDeps {
   contentManagement: ContentManagementPublicStart;
   savedObjectsTaggingOss: SavedObjectTaggingOssPluginStart;
+  spaces?: SpacesPluginStart;
 }

--- a/examples/content_management_examples/tsconfig.json
+++ b/examples/content_management_examples/tsconfig.json
@@ -30,5 +30,6 @@
     "@kbn/content-management-table-list-view",
     "@kbn/shared-ux-router",
     "@kbn/saved-objects-finder-plugin",
+    "@kbn/spaces-plugin",
   ]
 }

--- a/packages/content-management/table_list_view_table/src/components/spaces_list.tsx
+++ b/packages/content-management/table_list_view_table/src/components/spaces_list.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React, { FC, useState } from 'react';
+
+import type { Capabilities } from '@kbn/core/public';
+import type { SpacesPluginStart, ShareToSpaceFlyoutProps } from '@kbn/spaces-plugin/public';
+
+interface Props {
+  spacesApi: SpacesPluginStart;
+  capabilities: Capabilities | undefined;
+  spaceIds: string[];
+  type: string;
+  noun: string;
+  id: string;
+  title: string;
+  refresh(): void;
+}
+
+export const SpacesList: FC<Props> = ({
+  spacesApi,
+  capabilities,
+  type,
+  noun,
+  spaceIds,
+  id,
+  title,
+  refresh,
+}) => {
+  const [showFlyout, setShowFlyout] = useState(false);
+
+  function onClose() {
+    setShowFlyout(false);
+  }
+
+  const LazySpaceList = spacesApi.ui.components.getSpaceList;
+  const LazyShareToSpaceFlyout = spacesApi.ui.components.getShareToSpaceFlyout;
+
+  const shareToSpaceFlyoutProps: ShareToSpaceFlyoutProps = {
+    savedObjectTarget: {
+      type,
+      namespaces: spaceIds,
+      id,
+      title,
+      noun,
+    },
+    onUpdate: refresh,
+    onClose,
+  };
+
+  const canAssignSpaces = !capabilities || !!capabilities.savedObjectsManagement.shareIntoSpace;
+  const clickProperties = canAssignSpaces
+    ? { cursorStyle: 'pointer', listOnClick: () => setShowFlyout(true) }
+    : { cursorStyle: 'not-allowed' };
+  return (
+    <>
+      <LazySpaceList
+        namespaces={spaceIds}
+        displayLimit={8}
+        behaviorContext="outside-space"
+        {...clickProperties}
+      />
+      {showFlyout && <LazyShareToSpaceFlyout {...shareToSpaceFlyoutProps} />}
+    </>
+  );
+};

--- a/packages/content-management/table_list_view_table/src/components/spaces_list.tsx
+++ b/packages/content-management/table_list_view_table/src/components/spaces_list.tsx
@@ -9,10 +9,10 @@
 import React, { FC, useState } from 'react';
 
 import type { Capabilities } from '@kbn/core/public';
-import type { SpacesPluginStart, ShareToSpaceFlyoutProps } from '@kbn/spaces-plugin/public';
+import type { SpacesApi, ShareToSpaceFlyoutProps } from '@kbn/spaces-plugin/public';
 
 interface Props {
-  spacesApi: SpacesPluginStart;
+  spacesApi: SpacesApi;
   capabilities: Capabilities | undefined;
   spaceIds: string[];
   type: string;
@@ -38,6 +38,11 @@ export const SpacesList: FC<Props> = ({
     setShowFlyout(false);
   }
 
+  // TODO Check the namespaceType and disable column if not multiple
+  // See src/plugins/saved_objects_management/public/services/columns/share_saved_objects_to_space_column.tsx
+
+  // TODO Disable for Serverless
+
   const LazySpaceList = spacesApi.ui.components.getSpaceList;
   const LazyShareToSpaceFlyout = spacesApi.ui.components.getShareToSpaceFlyout;
 
@@ -49,6 +54,7 @@ export const SpacesList: FC<Props> = ({
       title,
       noun,
     },
+    behaviorContext: 'outside-space',
     onUpdate: refresh,
     onClose,
   };

--- a/packages/content-management/table_list_view_table/src/services.tsx
+++ b/packages/content-management/table_list_view_table/src/services.tsx
@@ -9,6 +9,7 @@
 import React, { FC, useContext, useMemo, useCallback } from 'react';
 import type { Observable } from 'rxjs';
 import type { FormattedRelative } from '@kbn/i18n-react';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
 import type { MountPoint, OverlayRef } from '@kbn/core-mount-utils-browser';
 import type { OverlayFlyoutOpenOptions } from '@kbn/core-overlays-browser';
 import { RedirectAppLinksKibanaProvider } from '@kbn/shared-ux-link-redirect-app';
@@ -56,6 +57,7 @@ export interface Services {
   /** Handler to retrieve the list of available tags */
   getTagList: () => Tag[];
   TagList: FC<TagListProps>;
+  spacesApi?: SpacesApi;
   /** Predicate function to indicate if some of the saved object references are tags */
   itemHasTags: (references: SavedObjectsReference[]) => boolean;
   /** Handler to return the url to navigate to the kibana tags management */
@@ -155,6 +157,7 @@ export interface TableListViewKibanaDependencies {
       getTagIdsFromReferences: (references: SavedObjectsReference[]) => string[];
     };
   };
+  spacesApi?: SpacesApi;
   /** The <FormattedRelative /> component from the @kbn/i18n-react package */
   FormattedRelative: typeof FormattedRelative;
 }
@@ -166,7 +169,7 @@ export const TableListViewKibanaProvider: FC<TableListViewKibanaDependencies> = 
   children,
   ...services
 }) => {
-  const { core, toMountPoint, savedObjectsTagging, FormattedRelative } = services;
+  const { core, toMountPoint, savedObjectsTagging, spacesApi, FormattedRelative } = services;
 
   const searchQueryParser = useMemo(() => {
     if (savedObjectsTagging) {
@@ -245,6 +248,7 @@ export const TableListViewKibanaProvider: FC<TableListViewKibanaDependencies> = 
           itemHasTags={itemHasTags}
           getTagIdsFromReferences={getTagIdsFromReferences}
           getTagManagementUrl={() => core.http.basePath.prepend(TAG_MANAGEMENT_APP_URL)}
+          spacesApi={spacesApi}
         >
           {children}
         </TableListViewProvider>

--- a/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
+++ b/packages/content-management/table_list_view_table/src/table_list_view.test.tsx
@@ -141,6 +141,7 @@ describe('TableListView', () => {
       const hits: UserContentCommonSchema[] = [
         {
           id: 'item-1',
+          namespaces: ['default'],
           type: 'dashboard',
           updatedAt: '2020-01-01T00:00:00Z',
           attributes: {
@@ -188,6 +189,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: twoDaysAgo.toISOString(),
         type: 'dashboard',
         attributes: {
@@ -198,6 +200,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         // This is the latest updated and should come first in the table
         updatedAt: yesterday.toISOString(),
         type: 'dashboard',
@@ -330,6 +333,7 @@ describe('TableListView', () => {
 
     const hits: UserContentCommonSchema[] = [...Array(totalItems)].map((_, i) => ({
       id: `item${i}`,
+      namespaces: ['default'],
       type: 'dashboard',
       updatedAt,
       attributes: {
@@ -438,6 +442,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: twoDaysAgo.toISOString(), // first asc, last desc
         type: 'dashboard',
         attributes: {
@@ -447,6 +452,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         updatedAt: yesterday.toISOString(), // first desc, last asc
         type: 'dashboard',
         attributes: {
@@ -639,6 +645,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: new Date(new Date().setDate(new Date().getDate() - 1)).toISOString(),
         attributes: {
           title: 'Item 1',
@@ -649,6 +656,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         updatedAt: new Date(new Date().setDate(new Date().getDate() - 2)).toISOString(),
         attributes: {
           title: 'Item 2',
@@ -697,6 +705,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: new Date(new Date().setDate(new Date().getDate() - 1)).toISOString(),
         type: 'dashboard',
         attributes: {
@@ -710,6 +719,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         updatedAt: new Date(new Date().setDate(new Date().getDate() - 2)).toISOString(),
         type: 'dashboard',
         attributes: {
@@ -890,6 +900,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: 'item-1',
+        namespaces: ['default'],
         type: 'dashboard',
         updatedAt,
         attributes: {
@@ -899,6 +910,7 @@ describe('TableListView', () => {
       },
       {
         id: 'item-2',
+        namespaces: ['default'],
         type: 'dashboard',
         updatedAt,
         attributes: {
@@ -1075,6 +1087,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: yesterday.toISOString(),
         type: 'dashboard',
         attributes: {
@@ -1085,6 +1098,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         updatedAt: twoDaysAgo.toISOString(),
         type: 'dashboard',
         attributes: {
@@ -1344,6 +1358,7 @@ describe('TableListView', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: '123',
+        namespaces: ['default'],
         updatedAt: twoDaysAgo.toISOString(),
         type: 'dashboard',
         attributes: {
@@ -1354,6 +1369,7 @@ describe('TableListView', () => {
       },
       {
         id: '456',
+        namespaces: ['default'],
         updatedAt: yesterday.toISOString(),
         type: 'dashboard',
         attributes: {
@@ -1467,6 +1483,7 @@ describe('TableList', () => {
     const originalHits: UserContentCommonSchema[] = [
       {
         id: `item`,
+        namespaces: ['default'],
         type: 'dashboard',
         updatedAt: 'original timestamp',
         attributes: {
@@ -1491,6 +1508,7 @@ describe('TableList', () => {
     const hits: UserContentCommonSchema[] = [
       {
         id: `item`,
+        namespaces: ['default'],
         type: 'dashboard',
         updatedAt: 'updated timestamp',
         attributes: {

--- a/packages/content-management/table_list_view_table/src/table_list_view_table.tsx
+++ b/packages/content-management/table_list_view_table/src/table_list_view_table.tsx
@@ -534,7 +534,7 @@ function TableListViewTableComp<T extends UserContentCommonSchema>({
       columns.push(customTableColumn);
     }
 
-    if (spacesApi) {
+    if (spacesApi && !spacesApi.hasOnlyDefaultSpace) {
       columns.push({
         field: tableColumnMetadata.spaces.field,
         name: i18n.translate('contentManagement.tableList.spacesColumnTitle', {

--- a/packages/content-management/table_list_view_table/tsconfig.json
+++ b/packages/content-management/table_list_view_table/tsconfig.json
@@ -25,6 +25,8 @@
     "@kbn/shared-ux-page-kibana-template",
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/test-jest-helpers",
+    "@kbn/core",
+    "@kbn/spaces-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/dashboard/public/dashboard_app/hooks/use_dashboard_outcome_validation.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/hooks/use_dashboard_outcome_validation.tsx
@@ -25,7 +25,10 @@ export const useDashboardOutcomeValidation = () => {
   /**
    * Unpack dashboard services
    */
-  const { screenshotMode, spaces } = pluginServices.getServices();
+  const {
+    screenshotMode,
+    spaces: { spacesApi },
+  } = pluginServices.getServices();
 
   const validateOutcome: DashboardCreationOptions['validateLoadedSavedObject'] = useCallback(
     ({ dashboardFound, resolveMeta, dashboardId }: LoadDashboardReturn) => {
@@ -43,7 +46,7 @@ export const useDashboardOutcomeValidation = () => {
           if (screenshotMode.isScreenshotMode()) {
             scopedHistory.replace(path); // redirect without the toast when in screenshot mode.
           } else {
-            spaces.redirectLegacyUrl?.({ path, aliasPurpose });
+            spacesApi?.ui.redirectLegacyUrl?.({ path, aliasPurpose });
           }
           return 'redirected'; // redirected. Stop loading dashboard.
         }
@@ -53,20 +56,20 @@ export const useDashboardOutcomeValidation = () => {
       }
       return 'valid';
     },
-    [scopedHistory, screenshotMode, spaces]
+    [scopedHistory, screenshotMode, spacesApi]
   );
 
   const getLegacyConflictWarning = useMemo(() => {
     if (savedObjectId && outcome === 'conflict' && aliasId) {
       return () =>
-        spaces.getLegacyUrlConflict?.({
+        spacesApi?.ui.components?.getLegacyUrlConflict?.({
           currentObjectId: savedObjectId,
           otherObjectId: aliasId,
           otherObjectPath: `#${createDashboardEditUrl(aliasId)}${scopedHistory.location.search}`,
         });
     }
     return null;
-  }, [aliasId, outcome, savedObjectId, scopedHistory, spaces]);
+  }, [aliasId, outcome, savedObjectId, scopedHistory, spacesApi]);
 
   return { validateOutcome, getLegacyConflictWarning };
 };

--- a/src/plugins/dashboard/public/dashboard_listing/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/dashboard_listing/dashboard_listing.tsx
@@ -42,6 +42,7 @@ export const DashboardListing = ({
     chrome: { theme },
     savedObjectsTagging,
     coreContext: { executionContext },
+    spaces: { spacesApi },
   } = pluginServices.getServices();
 
   useExecutionContext(executionContext, {
@@ -78,6 +79,7 @@ export const DashboardListing = ({
           },
           toMountPoint,
           savedObjectsTagging: savedObjectsTaggingFakePlugin,
+          spacesApi,
           FormattedRelative,
         }}
       >

--- a/src/plugins/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
+++ b/src/plugins/dashboard/public/dashboard_listing/hooks/use_dashboard_listing_table.tsx
@@ -44,6 +44,7 @@ const toTableListViewSavedObject = (hit: DashboardItem): DashboardSavedObjectUse
     updatedAt: hit.updatedAt!,
     references: hit.references,
     managed: hit.managed,
+    namespaces: hit.namespaces!,
     attributes: {
       title,
       description,

--- a/src/plugins/dashboard/public/services/spaces/spaces.stub.ts
+++ b/src/plugins/dashboard/public/services/spaces/spaces.stub.ts
@@ -16,8 +16,6 @@ export const spacesServiceFactory: SpacesServiceFactory = () => {
   const pluginMock = spacesPluginMock.createStartContract();
 
   return {
-    getActiveSpace$: pluginMock.getActiveSpace$,
-    getLegacyUrlConflict: pluginMock.ui.components.getLegacyUrlConflict,
-    redirectLegacyUrl: pluginMock.ui.redirectLegacyUrl,
+    spacesApi: pluginMock,
   };
 };

--- a/src/plugins/dashboard/public/services/spaces/spaces_service.ts
+++ b/src/plugins/dashboard/public/services/spaces/spaces_service.ts
@@ -16,21 +16,9 @@ export type SpacesServiceFactory = KibanaPluginServiceFactory<
 >;
 export const spacesServiceFactory: SpacesServiceFactory = ({ startPlugins }) => {
   const { spaces } = startPlugins;
-  if (!spaces || !spaces.ui) return {};
+  if (!spaces) return {};
 
-  const {
-    getActiveSpace$,
-    ui: {
-      components: { getLegacyUrlConflict, getSpacesContextProvider },
-      redirectLegacyUrl,
-      useSpaces,
-    },
-  } = spaces;
   return {
-    getActiveSpace$,
-    getLegacyUrlConflict,
-    getSpacesContextProvider,
-    redirectLegacyUrl,
-    useSpaces,
+    spacesApi: spaces,
   };
 };

--- a/src/plugins/dashboard/public/services/spaces/types.ts
+++ b/src/plugins/dashboard/public/services/spaces/types.ts
@@ -6,12 +6,8 @@
  * Side Public License, v 1.
  */
 
-import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
+import type { SpacesApi } from '@kbn/spaces-plugin/public';
 
 export interface DashboardSpacesService {
-  getActiveSpace$?: SpacesPluginStart['getActiveSpace$'];
-  getLegacyUrlConflict?: SpacesPluginStart['ui']['components']['getLegacyUrlConflict'];
-  getSpacesContextProvider?: SpacesPluginStart['ui']['components']['getSpacesContextProvider'];
-  redirectLegacyUrl?: SpacesPluginStart['ui']['redirectLegacyUrl'];
-  useSpaces?: SpacesPluginStart['ui']['useSpaces'];
+  spacesApi?: SpacesApi;
 }


### PR DESCRIPTION
## Summary

Related #171461.

Adds the Spaces column to the Dashboard listing page to allow users to easily see and share their dashboards with other Spaces.

I made updates the TableListViewTable shared component to conditionally show the Spaces column. This will allow other applications such as Lens and Maps to also show the Spaces column on their listing pages. The content management mSearch developer example has also been updated to show how other applications could add the Spaces column.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
