### PR TITLE
[Security Solution][Detections] Sometimes alerts table and details flyout do not show latest data after updating alert assignments

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/toolbar/bulk_actions/use_bulk_alert_assignees_items.tsx
@@ -125,14 +125,17 @@ export const useBulkAlertAssigneesItems = ({
     }: RenderContentPanelProps) => (
       <BulkAlertAssigneesPanel
         alertItems={alertItems}
-        refresh={refresh}
+        refresh={() => {
+          onSuccess();
+          refresh?.();
+        }}
         setIsLoading={setIsBulkActionsLoading}
         clearSelection={clearSelection}
         closePopoverMenu={closePopoverMenu}
         onSubmit={handleOnAlertAssigneesSubmit}
       />
     ),
-    [handleOnAlertAssigneesSubmit]
+    [handleOnAlertAssigneesSubmit, onSuccess]
   );
 
   const alertAssigneesPanels: UseBulkAlertAssigneesPanel[] = useMemo(

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/set_alert_assignees_route.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/routes/signals/set_alert_assignees_route.ts
@@ -100,7 +100,7 @@ export const setAlertAssigneesRoute = (router: SecuritySolutionPluginRouter) => 
         try {
           const body = await esClient.updateByQuery({
             index: `${DEFAULT_ALERTS_INDEX}-${spaceId}`,
-            refresh: false,
+            refresh: true,
             body: {
               script: painlessScript,
               query: {


### PR DESCRIPTION
## Summary

These changes fixes the issue when we show stale data after the assignees update for the alerts in a table or details flyout.

Address:
- https://github.com/elastic/security-team/issues/8025
- https://github.com/elastic/security-team/issues/8006

cc @PhilippeOberti 