### PR TITLE
[PoC] Multiline header rows in Discover

### DIFF
--- a/packages/kbn-unified-data-table/src/components/data_table.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table.tsx
@@ -651,6 +651,15 @@ export const UnifiedDataTable = ({
     dataGridRef,
   });
 
+  const { rowHeight, rowHeightsOptions } = useRowHeightsOptions({
+    rowHeightState,
+    onUpdateRowHeight,
+    storage,
+    configRowHeight,
+    consumer,
+    rowLineHeight: rowLineHeightOverride,
+  });
+
   const euiGridColumns = useMemo(
     () =>
       getEuiGridColumns({
@@ -673,25 +682,27 @@ export const UnifiedDataTable = ({
         visibleCellActions,
         columnTypes,
         showColumnTokens,
+        rowHeight,
       }),
     [
-      onFilter,
-      visibleColumns,
-      columnsCellActions,
-      displayedRows,
-      dataView,
-      settings,
-      defaultColumns,
-      isSortEnabled,
-      isPlainRecord,
-      uiSettings,
-      toastNotifications,
-      dataViewFieldEditor,
-      valueToStringConverter,
-      editField,
-      visibleCellActions,
       columnTypes,
+      columnsCellActions,
+      dataView,
+      dataViewFieldEditor.userPermissions,
+      defaultColumns,
+      displayedRows.length,
+      editField,
+      isPlainRecord,
+      isSortEnabled,
+      onFilter,
+      rowHeight,
+      settings,
       showColumnTokens,
+      toastNotifications,
+      uiSettings,
+      valueToStringConverter,
+      visibleCellActions,
+      visibleColumns,
     ]
   );
 
@@ -813,15 +824,6 @@ export const UnifiedDataTable = ({
           },
     [defaultColumns, isSortEnabled, additionalControls, showDisplaySelector, showFullScreenButton]
   );
-
-  const rowHeightsOptions = useRowHeightsOptions({
-    rowHeightState,
-    onUpdateRowHeight,
-    storage,
-    configRowHeight,
-    consumer,
-    rowLineHeight: rowLineHeightOverride,
-  });
 
   const isRenderComplete = loadingState !== DataLoadingState.loading;
 

--- a/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
+++ b/packages/kbn-unified-data-table/src/components/data_table_columns.tsx
@@ -85,6 +85,7 @@ function buildEuiGridColumn({
   visibleCellActions,
   columnTypes,
   showColumnTokens,
+  rowHeight,
 }: {
   columnName: string;
   columnWidth: number | undefined;
@@ -102,6 +103,7 @@ function buildEuiGridColumn({
   visibleCellActions?: number;
   columnTypes?: DataTableColumnTypes;
   showColumnTokens?: boolean;
+  rowHeight: number | undefined;
 }) {
   const dataViewField = dataView.getFieldByName(columnName);
   const editFieldButton =
@@ -137,6 +139,7 @@ function buildEuiGridColumn({
         columnName={columnName}
         columnDisplayName={columnDisplayName}
         columnTypes={columnTypes}
+        rowHeight={rowHeight}
       />
     ) : undefined,
     displayAsText: columnDisplayName,
@@ -222,6 +225,7 @@ export function getEuiGridColumns({
   visibleCellActions,
   columnTypes,
   showColumnTokens,
+  rowHeight,
 }: {
   columns: string[];
   columnsCellActions?: EuiDataGridColumnCellAction[][];
@@ -242,6 +246,7 @@ export function getEuiGridColumns({
   visibleCellActions?: number;
   columnTypes?: DataTableColumnTypes;
   showColumnTokens?: boolean;
+  rowHeight: number | undefined;
 }) {
   const getColWidth = (column: string) => settings?.columns?.[column]?.width ?? 0;
 
@@ -263,6 +268,7 @@ export function getEuiGridColumns({
       visibleCellActions,
       columnTypes,
       showColumnTokens,
+      rowHeight,
     })
   );
 }


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)