### PR TITLE
ES|QL in-product help: DATE_TRUNC arg order

### DIFF
--- a/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
+++ b/packages/kbn-text-based-editor/src/esql_documentation_sections.tsx
@@ -1180,7 +1180,7 @@ Rounds down a date to the closest interval.
 
 \`\`\`
 FROM employees
-| EVAL year_hired = DATE_TRUNC(hire_date, 1 year)
+| EVAL year_hired = DATE_TRUNC(1 year, hire_date)
 | STATS count(emp_no) BY year_hired
 | SORT year_hired
 \`\`\`


### PR DESCRIPTION
A small fix: the arguments for ES|QL's DATE_TRUNC function were swapped a while ago, but that was never reflected in the in-product help. This PR fixes that.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->