### PR TITLE
Use EuiIconTip instead of EuiToolTip + EuiIcon

### DIFF
--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -13,7 +13,7 @@ import {
   EuiSearchBar,
   EuiBasicTable,
   EuiButton,
-  EuiIcon,
+  EuiIconTip,
   EuiLink,
   EuiSpacer,
   EuiToolTip,
@@ -245,14 +245,13 @@ export class Table extends PureComponent<TableProps, TableState> {
         render: (type: string, object: SavedObjectWithMetadata) => {
           const typeLabel = getSavedObjectLabel(type, allowedTypes);
           return (
-            <EuiToolTip position="top" content={typeLabel}>
-              <EuiIcon
-                aria-label={typeLabel}
-                type={object.meta.icon || 'apps'}
-                size="s"
-                data-test-subj="objectType"
-              />
-            </EuiToolTip>
+            <EuiIconTip
+              aria-label={typeLabel}
+              type={object.meta.icon || 'apps'}
+              size="s"
+              content={typeLabel}
+              iconProps={{ 'data-test-subj': 'objectType' }}
+            />
           );
         },
       } as EuiTableFieldDataColumnType<SavedObjectWithMetadata<any>>,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/154421

Using the component suggested by EUI team effectively makes the icon focusable with the keyboard.
I verified that the tooltip appears automatically when focussing it:

<img width="372" alt="image" src="https://github.com/elastic/kibana/assets/25349407/c4c91a2a-f045-4f77-870d-9a1132c8dbee">
