### PR TITLE
Add custom `inspect` representation for ES client's errors

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/patch_client.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-client-server-internal/src/patch_client.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { inspect } from 'util';
 import { errors } from '@elastic/elasticsearch';
 
 export const patchElasticsearchClient = () => {
@@ -16,5 +17,11 @@ export const patchElasticsearchClient = () => {
       name: this.name,
       message: this.message,
     };
+  };
+
+  // @ts-expect-error
+  baseErrorPrototype[inspect.custom] = function () {
+    // @ts-expect-error
+    return this.toJSON();
   };
 };


### PR DESCRIPTION
Follow-up of #171018

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->