### PR TITLE
[Es Archiver] Only Higher Water Mark for Load Action

### DIFF
--- a/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
+++ b/packages/kbn-es-archiver/src/lib/docs/index_doc_records_stream.ts
@@ -68,7 +68,8 @@ export function createIndexDocRecordsStream(
   }
 
   return new Writable({
-    highWaterMark: 300,
+    // highWaterMark: 300,
+    highWaterMark: parseInt((process.env.HIGH_WATER_MARK as string) ?? 5000, 10),
     objectMode: true,
 
     async write(record, enc, callback) {


### PR DESCRIPTION
With only increasing the High Water Mark:

- We want to know if [less tests fail](https://github.com/elastic/kibana/pull/167993)?  _Due to concurrency_
  - w/o benchmark tool
- What are the performance numbers on [serverless](https://ci.ml-qa.com/blue/organizations/jenkins/dev%2Fes-archiver-benchmark/detail/es-archiver-benchmark/145/pipeline)?
  - w/ benchmark tool



