### PR TITLE
[Fleet] Fix reinstalling bundled package during setup

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/bundled_packages.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/bundled_packages.ts
@@ -8,7 +8,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import type { BundledPackage } from '../../../types';
+import type { BundledPackage, Installation } from '../../../types';
 import { FleetError } from '../../../errors';
 import { appContextService } from '../../app_context';
 import { splitPkgKey, pkgToPkgKey } from '../registry';
@@ -57,24 +57,33 @@ export async function getBundledPackages(): Promise<BundledPackage[]> {
   }
 }
 
+export async function getBundledPackageForInstallation(
+  installation: Installation
+): Promise<BundledPackage | undefined> {
+  const bundledPackages = await getBundledPackages();
+
+  return bundledPackages.find(
+    (bundledPkg: BundledPackage) =>
+      bundledPkg.name === installation.name && bundledPkg.version === installation.version
+  );
+}
+
 export async function getBundledPackageByPkgKey(
   pkgKey: string
 ): Promise<BundledPackage | undefined> {
   const bundledPackages = await getBundledPackages();
-  const bundledPackage = bundledPackages.find((pkg) => {
+
+  return bundledPackages.find((pkg) => {
     if (pkgKey.includes('-')) {
       return pkgToPkgKey(pkg) === pkgKey;
     } else {
       return pkg.name === pkgKey;
     }
   });
-
-  return bundledPackage;
 }
 
 export async function getBundledPackageByName(name: string): Promise<BundledPackage | undefined> {
   const bundledPackages = await getBundledPackages();
-  const bundledPackage = bundledPackages.find((pkg) => pkg.name === name);
 
-  return bundledPackage;
+  return bundledPackages.find((pkg) => pkg.name === name);
 }

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
@@ -282,7 +282,7 @@ describe('install', () => {
       expect(response.error).toBeUndefined();
 
       expect(install._installPackage).toHaveBeenCalledWith(
-        expect.objectContaining({ installSource: 'upload' })
+        expect.objectContaining({ installSource: 'bundled' })
       );
     });
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -328,6 +328,7 @@ interface InstallUploadedArchiveParams {
   authorizationHeader?: HTTPAuthorizationHeader | null;
   ignoreMappingUpdateErrors?: boolean;
   skipDataStreamRollover?: boolean;
+  isBundledPackage?: boolean;
 }
 
 function getTelemetryEvent(pkgName: string, pkgVersion: string): PackageUpdateEvent {
@@ -638,10 +639,11 @@ async function installPackageByUpload({
   authorizationHeader,
   ignoreMappingUpdateErrors,
   skipDataStreamRollover,
+  isBundledPackage,
 }: InstallUploadedArchiveParams): Promise<InstallResult> {
   // if an error happens during getInstallType, report that we don't know
   let installType: InstallType = 'unknown';
-  const installSource = 'upload';
+  const installSource = isBundledPackage ? 'bundled' : 'upload';
   try {
     const { packageInfo } = await generatePackageInfoFromArchiveBuffer(archiveBuffer, contentType);
     const pkgName = packageInfo.name;
@@ -747,6 +749,7 @@ export async function installPackage(args: InstallPackageParams): Promise<Instal
         authorizationHeader,
         ignoreMappingUpdateErrors,
         skipDataStreamRollover,
+        isBundledPackage: true,
       });
 
       return { ...response, installSource: 'bundled' };

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -461,7 +461,7 @@ function getElasticSubscription(packageInfo: ArchivePackage) {
 async function installPackageCommon(options: {
   pkgName: string;
   pkgVersion: string;
-  installSource: 'registry' | 'upload' | 'custom';
+  installSource: InstallSource;
   installedPkg?: SavedObject<Installation>;
   installType: InstallType;
   savedObjectsClient: SavedObjectsClientContract;

--- a/x-pack/plugins/fleet/server/services/epm/packages/reinstall.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/reinstall.ts
@@ -11,6 +11,8 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 import type { Installation } from '../../../types';
 import { pkgToPkgKey } from '../registry';
 
+import { getBundledPackageForInstallation } from './bundled_packages';
+
 import { installPackage } from './install';
 
 export async function reinstallPackageForInstallation({
@@ -22,9 +24,18 @@ export async function reinstallPackageForInstallation({
   esClient: ElasticsearchClient;
   installation: Installation;
 }) {
-  if (installation.install_source === 'upload') {
-    throw new Error('Cannot reinstall an uploaded package');
+  if (installation.install_source === 'upload' || installation.install_source === 'bundled') {
+    // If there is a matching bundled package
+    const matchingBundledPackage = await getBundledPackageForInstallation(installation);
+    if (!matchingBundledPackage) {
+      if (installation.install_source === 'bundled') {
+        throw new Error(`Cannot reinstall: ${installation.name}, bundled package not found`);
+      } else {
+        throw new Error('Cannot reinstall an uploaded package');
+      }
+    }
   }
+
   return installPackage({
     // If the package is bundled reinstall from the registry will still use the bundled package.
     installSource: 'registry',

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -14,11 +14,7 @@ import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common/constants';
 
 import { AUTO_UPDATE_PACKAGES } from '../../common/constants';
 import type { PreconfigurationError } from '../../common/constants';
-import type {
-  DefaultPackagesInstallationError,
-  BundledPackage,
-  Installation,
-} from '../../common/types';
+import type { DefaultPackagesInstallationError } from '../../common/types';
 
 import { SO_SEARCH_LIMIT } from '../constants';
 

--- a/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.test.ts
@@ -5,8 +5,109 @@
  * 2.0.
  */
 
+import {
+  elasticsearchServiceMock,
+  loggingSystemMock,
+  savedObjectsClientMock,
+} from '@kbn/core/server/mocks';
+
+import { reinstallPackageForInstallation } from '../epm/packages';
+
+import { upgradePackageInstallVersion } from './upgrade_package_install_version';
+
+jest.mock('../epm/packages');
+
+const mockedReinstallPackageForInstallation = jest.mocked(reinstallPackageForInstallation);
+
 describe('upgradePackageInstallVersion', () => {
-  it('should work', () => {
-    // TODO
+  beforeEach(() => {
+    mockedReinstallPackageForInstallation.mockReset();
+    mockedReinstallPackageForInstallation.mockResolvedValue({} as any);
+  });
+  it('should upgrade outdated package version', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    const soClient = savedObjectsClientMock.create();
+
+    soClient.find.mockResolvedValue({
+      total: 2,
+      saved_objects: [
+        {
+          attributes: { name: 'test1' },
+        },
+        {
+          attributes: { name: 'test2' },
+        },
+      ],
+    } as any);
+
+    await upgradePackageInstallVersion({
+      esClient,
+      soClient,
+      logger,
+    });
+
+    expect(mockedReinstallPackageForInstallation).toBeCalledTimes(2);
+    expect(mockedReinstallPackageForInstallation).toBeCalledWith(
+      expect.objectContaining({
+        installation: expect.objectContaining({ name: 'test1' }),
+      })
+    );
+    expect(mockedReinstallPackageForInstallation).toBeCalledWith(
+      expect.objectContaining({
+        installation: expect.objectContaining({ name: 'test2' }),
+      })
+    );
+
+    expect(logger.warn).not.toBeCalled();
+    expect(logger.error).not.toBeCalled();
+  });
+
+  it('should log at error level when an error happens while reinstalling package', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    const soClient = savedObjectsClientMock.create();
+
+    mockedReinstallPackageForInstallation.mockRejectedValue(new Error('test error'));
+    soClient.find.mockResolvedValue({
+      total: 2,
+      saved_objects: [
+        {
+          attributes: { name: 'test1' },
+        },
+      ],
+    } as any);
+
+    await upgradePackageInstallVersion({
+      esClient,
+      soClient,
+      logger,
+    });
+
+    expect(logger.error).toBeCalled();
+  });
+
+  it('should log a warn level when an error happens while reinstalling an uploaded package', async () => {
+    const logger = loggingSystemMock.createLogger();
+    const esClient = elasticsearchServiceMock.createInternalClient();
+    const soClient = savedObjectsClientMock.create();
+
+    mockedReinstallPackageForInstallation.mockRejectedValue(new Error('test error'));
+    soClient.find.mockResolvedValue({
+      total: 2,
+      saved_objects: [
+        {
+          attributes: { name: 'test1', install_source: 'upload' },
+        },
+      ],
+    } as any);
+
+    await upgradePackageInstallVersion({
+      esClient,
+      soClient,
+      logger,
+    });
+
+    expect(logger.warn).toBeCalled();
   });
 });

--- a/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.test.ts
+++ b/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.test.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+describe('upgradePackageInstallVersion', () => {
+  it('should work', () => {
+    // TODO
+  });
+});

--- a/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.ts
+++ b/x-pack/plugins/fleet/server/services/setup/upgrade_package_install_version.ts
@@ -35,7 +35,6 @@ export async function upgradePackageInstallVersion({
   logger: Logger;
 }) {
   const res = await findOutdatedInstallations(soClient);
-
   if (res.total === 0) {
     return;
   }
@@ -44,18 +43,20 @@ export async function upgradePackageInstallVersion({
     res.saved_objects,
     ({ attributes: installation }) => {
       // Uploaded package cannot be reinstalled
-      if (installation.install_source === 'upload') {
-        logger.warn(`Uploaded package needs to be manually reinstalled ${installation.name}.`);
-        return;
-      }
       return reinstallPackageForInstallation({
         soClient,
         esClient,
         installation,
       }).catch((err: Error) => {
-        logger.error(
-          `Package needs to be manually reinstalled ${installation.name} updating install_version failed. ${err.message}`
-        );
+        if (installation.install_source === 'upload') {
+          logger.warn(
+            `Uploaded package needs to be manually reinstalled ${installation.name}. ${err.message}`
+          );
+        } else {
+          logger.error(
+            `Package needs to be manually reinstalled ${installation.name} updating install_version failed. ${err.message}`
+          );
+        }
       });
     },
     { concurrency: 10 }


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/171227

We have a mechanism to reinstall all packages when a breaking change is done in the package installation, this was broken for bundled package. That PR fix that.

The issue was dues to the `install_source` for bundled package being saved to `upload` instead of `bundled`, this is now fixed.

We also try to look for a matching bundled package when reinstalling `upload` package for bundled package installed prior that change.


## Tests

### Automated

I updated and added some unit tests to cover that change.

### Manually test 

#### Migration to 8.12.0

1. With an old version of kibana install a bundled package 
2. Then checkout that PR and bump `FLEET_INSTALL_FORMAT_VERSION` https://github.com/nchaulet/kibana/blob/44088746d74dabb13f04d9add0572e7cdc7a4176/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts#L14 
3. verify your package as been reinstalled and `install_source` is now bundled

#### Bundled package

1. install a bundled package and verify `install_source` is bundled
2. bump `FLEET_INSTALL_FORMAT_VERSION` https://github.com/nchaulet/kibana/blob/44088746d74dabb13f04d9add0572e7cdc7a4176/x-pack/plugins/fleet/server/constants/fleet_es_assets.ts#L14 
3. verify your package as been reinstalled and `install_source` is still bundled

