### PR TITLE
Load and initialize all plugins concurrently

### DIFF
--- a/packages/core/plugins/core-plugins-server-internal/src/plugins_system.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugins_system.ts
@@ -104,6 +104,9 @@ export class PluginsSystem<T extends PluginType> {
       `Setting up [${sortedPlugins.size}] plugins: [${[...sortedPlugins.keys()].join(',')}]`
     );
 
+    // Load all the plugins' code asynchronously and concurrently
+    await Promise.all([...sortedPlugins.values()].map((plugin) => plugin.init()));
+
     for (const [pluginName, plugin] of sortedPlugins) {
       this.log.debug(`Setting up plugin "${pluginName}"...`);
       const pluginDeps = new Set([...plugin.requiredPlugins, ...plugin.optionalPlugins]);
@@ -131,7 +134,6 @@ export class PluginsSystem<T extends PluginType> {
         });
       }
 
-      await plugin.init();
       let contract: unknown;
       const contractOrPromise = plugin.setup(pluginSetupContext, pluginDepContracts);
       if (isPromise(contractOrPromise)) {


### PR DESCRIPTION
## Summary

After #170856, we may want to parallelize the load of the plugin's code in an attempt to speed up Kibana's startup.

We are only parallelizing the part where we load the plugin and call the constructor but we still maintain the expected order of calling the plugins' `setup` and `start` methods.

### Risk Matrix

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Concurrently performing this action may cause unexpected spikes in CPU (and Memory?), leading to momentarily high Event Loop Delays. | Low | Low | Memory-wise, it shouldn't be a problem because we already hold all the plugins in memory. I wouldn't expect this approach to use much more. Regarding CPU, it might require higher processing power since it's performing parallel processing, while earlier, it was sequential. We need to test it, but I doubt this will cause any issues. |

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
