### PR TITLE
[Lens][Unified search] Auto expand dataview popovers based on the content 

### DIFF
--- a/packages/kbn-visualization-ui-components/components/field_picker/field_picker.tsx
+++ b/packages/kbn-visualization-ui-components/components/field_picker/field_picker.tsx
@@ -36,14 +36,14 @@ export function FieldPicker<T extends FieldOptionValue = FieldOptionValue>({
   ['data-test-subj']: dataTestSub,
   ...rest
 }: FieldPickerProps<T>) {
-  let theLongestLabel = '';
+  let maxLabelLength = 20;
   const styledOptions = options?.map(({ compatible, exists, ...otherAttr }) => {
     if (otherAttr.options) {
       return {
         ...otherAttr,
         options: otherAttr.options.map(({ exists: fieldOptionExists, ...fieldOption }) => {
-          if (fieldOption.label.length > theLongestLabel.length) {
-            theLongestLabel = fieldOption.label;
+          if (fieldOption.label.length > maxLabelLength) {
+            maxLabelLength = fieldOption.label.length;
           }
           return {
             ...fieldOption,
@@ -75,7 +75,7 @@ export function FieldPicker<T extends FieldOptionValue = FieldOptionValue>({
     };
   });
 
-  const panelMinWidth = getPanelMinWidth(theLongestLabel.length);
+  const panelMinWidth = getPanelMinWidth(maxLabelLength);
   return (
     <EuiComboBox
       fullWidth

--- a/src/plugins/presentation_util/public/components/data_view_picker/data_view_picker.tsx
+++ b/src/plugins/presentation_util/public/components/data_view_picker/data_view_picker.tsx
@@ -56,6 +56,11 @@ export function DataViewPicker({
       />
     );
   };
+  const maxLabelLength = dataViews.reduce((acc, curr) => {
+    const dataViewName = curr.name || curr.id;
+    return acc > dataViewName.length ? acc : dataViewName.length;
+  }, 0);
+  const panelMinWidth = getPanelMinWidth(maxLabelLength);
 
   return (
     <EuiInputPopover
@@ -67,6 +72,7 @@ export function DataViewPicker({
       isOpen={isPopoverOpen}
       input={createTrigger()}
       closePopover={() => setPopoverIsOpen(false)}
+      panelMinWidth={panelMinWidth}
       panelProps={{
         'data-test-subj': 'data-view-picker-popover',
       }}
@@ -113,3 +119,20 @@ export function DataViewPicker({
 // required for dynamic import using React.lazy()
 // eslint-disable-next-line import/no-default-export
 export default DataViewPicker;
+
+const MINIMUM_POPOVER_WIDTH = 300;
+const MINIMUM_POPOVER_WIDTH_CHAR_COUNT = 28;
+const AVERAGE_CHAR_WIDTH = 7;
+const MAXIMUM_POPOVER_WIDTH_CHAR_COUNT = 60;
+const MAXIMUM_POPOVER_WIDTH = 550; // fitting 60 characters
+
+function getPanelMinWidth(labelLength: number) {
+  if (labelLength > MAXIMUM_POPOVER_WIDTH_CHAR_COUNT) {
+    return MAXIMUM_POPOVER_WIDTH;
+  }
+  if (labelLength > MINIMUM_POPOVER_WIDTH_CHAR_COUNT) {
+    const overflownChars = labelLength - MINIMUM_POPOVER_WIDTH_CHAR_COUNT;
+    return MINIMUM_POPOVER_WIDTH + overflownChars * AVERAGE_CHAR_WIDTH;
+  }
+  return MINIMUM_POPOVER_WIDTH;
+}

--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.styles.ts
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.styles.ts
@@ -6,15 +6,37 @@
  * Side Public License, v 1.
  */
 
-export const DATA_VIEW_POPOVER_CONTENT_WIDTH = 280;
+const MIN_POPOVER_CONTENT_WIDTH = 280;
+const MIN_POPOVER_CHAR_COUNT = 25;
+const MAX_POPOVER_CONTENT_WIDTH = 600;
+const MAX_POPOVER_CHAR_COUNT = 60;
 
-export const changeDataViewStyles = ({ fullWidth }: { fullWidth?: boolean }) => {
+const AVERAGE_CHAR_WIDTH = 7;
+
+function getPanelMinWidth(labelLength: number) {
+  if (labelLength > MAX_POPOVER_CHAR_COUNT) {
+    return MAX_POPOVER_CONTENT_WIDTH;
+  }
+  if (labelLength > MIN_POPOVER_CHAR_COUNT) {
+    const overflownChars = labelLength - MIN_POPOVER_CHAR_COUNT;
+    return MIN_POPOVER_CONTENT_WIDTH + overflownChars * AVERAGE_CHAR_WIDTH;
+  }
+  return MIN_POPOVER_CONTENT_WIDTH;
+}
+
+export const changeDataViewStyles = ({
+  fullWidth,
+  maxLabelLength,
+}: {
+  fullWidth?: boolean;
+  maxLabelLength: number;
+}) => {
   return {
     trigger: {
-      maxWidth: fullWidth ? undefined : DATA_VIEW_POPOVER_CONTENT_WIDTH,
+      maxWidth: fullWidth ? undefined : MIN_POPOVER_CONTENT_WIDTH,
     },
     popoverContent: {
-      width: DATA_VIEW_POPOVER_CONTENT_WIDTH,
+      width: getPanelMinWidth(maxLabelLength),
     },
   };
 };

--- a/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/plugins/unified_search/public/dataview_picker/change_dataview.tsx
@@ -96,7 +96,13 @@ export function ChangeDataView({
   const { application, data, storage, dataViews, dataViewEditor, appName, usageCollection } =
     kibana.services;
   const reportUiCounter = usageCollection?.reportUiCounter.bind(usageCollection, appName);
-  const styles = changeDataViewStyles({ fullWidth: trigger.fullWidth });
+
+  const maxLabelLength = dataViewsList.reduce((acc, curr) => {
+    const dataViewName = curr.name || curr.id;
+    return acc > dataViewName.length ? acc : dataViewName.length;
+  }, 0);
+  const styles = changeDataViewStyles({ fullWidth: trigger.fullWidth, maxLabelLength });
+
   const [isTextLangTransitionModalDismissed, setIsTextLangTransitionModalDismissed] = useState(() =>
     Boolean(storage.get(TEXT_LANG_TRANSITION_MODAL_KEY))
   );

--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.scss
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.scss
@@ -14,10 +14,6 @@
   margin-bottom: $euiSizeS;
 }
 
-.lnsChangeIndexPatternPopover {
-  width: 320px;
-}
-
 .lnsChangeIndexPatternPopover__trigger {
   padding: 0 $euiSize;
 }

--- a/x-pack/plugins/lens/public/shared_components/dataview_picker/dataview_picker.tsx
+++ b/x-pack/plugins/lens/public/shared_components/dataview_picker/dataview_picker.tsx
@@ -12,6 +12,24 @@ import { DataViewsList } from '@kbn/unified-search-plugin/public';
 import { type IndexPatternRef } from '../../types';
 import { type ChangeIndexPatternTriggerProps, TriggerButton } from './trigger';
 
+const MIN_POPOVER_CONTENT_WIDTH = 280;
+const MIN_POPOVER_CHAR_COUNT = 25;
+const MAX_POPOVER_CONTENT_WIDTH = 600;
+const MAX_POPOVER_CHAR_COUNT = 60;
+
+const AVERAGE_CHAR_WIDTH = 7;
+
+function getPanelMinWidth(labelLength: number) {
+  if (labelLength > MAX_POPOVER_CHAR_COUNT) {
+    return MAX_POPOVER_CONTENT_WIDTH;
+  }
+  if (labelLength > MIN_POPOVER_CHAR_COUNT) {
+    const overflownChars = labelLength - MIN_POPOVER_CHAR_COUNT;
+    return MIN_POPOVER_CONTENT_WIDTH + overflownChars * AVERAGE_CHAR_WIDTH;
+  }
+  return MIN_POPOVER_CONTENT_WIDTH;
+}
+
 export function ChangeIndexPattern({
   indexPatternRefs,
   isMissingCurrent,
@@ -28,6 +46,11 @@ export function ChangeIndexPattern({
   selectableProps?: EuiSelectableProps;
 }) {
   const [isPopoverOpen, setPopoverIsOpen] = useState(false);
+
+  const maxLabelLength = indexPatternRefs.reduce((acc, curr) => {
+    const dataViewName = curr.name || curr.id;
+    return acc > dataViewName.length ? acc : dataViewName.length;
+  }, 20);
 
   return (
     <>
@@ -49,7 +72,11 @@ export function ChangeIndexPattern({
         panelPaddingSize="none"
         ownFocus
       >
-        <div>
+        <div
+          css={{
+            width: getPanelMinWidth(maxLabelLength),
+          }}
+        >
           <EuiPopoverTitle paddingSize="s">
             {i18n.translate('xpack.lens.indexPattern.changeDataViewTitle', {
               defaultMessage: 'Data view',

--- a/x-pack/plugins/maps/public/components/single_field_select.tsx
+++ b/x-pack/plugins/maps/public/components/single_field_select.tsx
@@ -8,16 +8,7 @@
 import _ from 'lodash';
 import React from 'react';
 
-import {
-  EuiComboBox,
-  EuiComboBoxProps,
-  EuiComboBoxOptionOption,
-  EuiHighlight,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiToolTip,
-} from '@elastic/eui';
-import { FieldIcon } from '@kbn/react-field';
+import { EuiComboBox, EuiComboBoxProps, EuiComboBoxOptionOption, EuiToolTip } from '@elastic/eui';
 import { DataViewField } from '@kbn/data-views-plugin/public';
 import { css } from '@emotion/react';
 


### PR DESCRIPTION
## Summary

Fixes partially two remaining tasks from https://github.com/elastic/kibana/issues/168753 - it stretches to maximum ~60 characters if the content needs it, but doesn't middle truncate yet (changes from eui are needed)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
