### PR TITLE
[Fleet] Fix package overview details title wrap

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -327,7 +327,7 @@ export const OverviewPage: React.FC<Props> = memo(
                 />
               </EuiFlexItem>
             ) : null}
-            <EuiFlexItem>
+            <EuiFlexItem className="eui-textBreakWord">
               <Details packageInfo={packageInfo} />
             </EuiFlexItem>
           </EuiFlexGroup>


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/171224

Fix how we wrap package details title

## UI Changes

### Before

<img width="600" alt="Screenshot 2023-11-16 at 9 55 34 AM" src="https://github.com/elastic/kibana/assets/1336873/9ded2d2b-1661-4fe7-8093-bfa95612225c">



### After

<img width="600" alt="Screenshot 2023-11-16 at 9 54 37 AM" src="https://github.com/elastic/kibana/assets/1336873/6af71b40-8a95-46db-8443-56dca7e030f9">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->