### PR TITLE
[Unified Search] Improve accessibility of flex width comboboxes

### DIFF
--- a/src/plugins/unified_search/public/filter_bar/filter_editor/phrase_value_input.tsx
+++ b/src/plugins/unified_search/public/filter_bar/filter_editor/phrase_value_input.tsx
@@ -82,8 +82,10 @@ class PhraseValueInputUI extends PhraseSuggestorUI<PhraseValueInputProps> {
           onChange={([newValue = '']) => {
             onChange(newValue);
             setTimeout(() => {
-              // Note: requires a tick skip to correctly blur element focus
-              this.inputRef?.blur();
+              // Note: requires a tick skip to correctly move focus from the input to the combobox toggle
+              this.comboBoxWrapperRef.current
+                ?.querySelector<HTMLButtonElement>('[data-test-subj="comboBoxToggleListButton"]')
+                ?.focus();
             });
           }}
           onSearchChange={this.onSearchChange}

--- a/src/plugins/unified_search/public/filters_builder/filter_item/field_input.tsx
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/field_input.tsx
@@ -81,11 +81,6 @@ export function FieldInput({ field, dataView, onHandleField }: FieldInputProps) 
     });
   };
 
-  const handleFocus: React.FocusEventHandler<HTMLDivElement> = () => {
-    // Force focus on input due to https://github.com/elastic/eui/issues/7170
-    inputRef?.current?.focus();
-  };
-
   return (
     <div ref={comboBoxWrapperRef}>
       <EuiComboBox
@@ -103,7 +98,6 @@ export function FieldInput({ field, dataView, onHandleField }: FieldInputProps) 
         isClearable={false}
         compressed
         fullWidth
-        onFocus={handleFocus}
         data-test-subj="filterFieldSuggestionList"
         singleSelection={SINGLE_SELECTION_AS_TEXT_PROPS}
         truncationProps={MIDDLE_TRUNCATION_PROPS}

--- a/src/plugins/unified_search/public/filters_builder/filter_item/field_input.tsx
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/field_input.tsx
@@ -74,8 +74,10 @@ export function FieldInput({ field, dataView, onHandleField }: FieldInputProps) 
     onFieldChange(newValues);
 
     setTimeout(() => {
-      // Note: requires a tick skip to correctly blur element focus
-      inputRef?.current?.blur();
+      // Note: requires a tick skip to correctly move focus from the input to the combobox toggle
+      comboBoxWrapperRef.current
+        ?.querySelector<HTMLButtonElement>('[data-test-subj="comboBoxToggleListButton"]')
+        ?.focus();
     });
   };
 

--- a/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
@@ -26,7 +26,8 @@ export const fieldAndParamCss = (euiTheme: EuiThemeComputed) => css`
   .euiFormRow {
     max-width: 800px;
   }
-  &:focus-within {
+  // Expand the combobox if the dropdown is open or the input has focus
+  &:has(input[aria-expanded='true'], input:focus) {
     flex-grow: 4;
   }
 `;

--- a/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
@@ -48,7 +48,7 @@ export const actionButtonCss = (euiTheme: EuiThemeComputed) => css`
 `;
 
 export const disabledDraggableCss = css`
-  &.euiDraggable .euiDraggable__item.euiDraggable__item--isDisabled {
+  &.euiDraggable .euiDraggable__item-isDisabled {
     cursor: unset;
   }
 `;

--- a/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
+++ b/src/plugins/unified_search/public/filters_builder/filter_item/filter_item.styles.ts
@@ -30,6 +30,9 @@ export const fieldAndParamCss = (euiTheme: EuiThemeComputed) => css`
   &:has(input[aria-expanded='true'], input:focus) {
     flex-grow: 4;
   }
+  input {
+    width: 100% !important; // TODO: Remove this once latest EUI upgrade merges
+  }
 `;
 
 export const operationCss = (euiTheme: EuiThemeComputed) => css`


### PR DESCRIPTION
## Summary

`.blur()`ing focus from the combobox was done for the custom flex/width behavior, but is an accessibility issue as it strands focus for keyboard and screen reader users (see https://github.com/elastic/eui/pull/7279).

I've worked around this by focusing the dropdown arrow toggle button instead of blurring focus, and modifying the CSS selectors from `:focus-within` to `:has` to only expand the combobox width on input focus. This has the added bonus of removing an unnecessary extra `onFocus` workaround (see https://github.com/elastic/eui/issues/7170).

![sr](https://github.com/elastic/kibana/assets/549407/0c97a726-5a18-4d98-ab78-89d18f60b55a)

While here, I also noticed a bug with a disabled cursor appearing that I fixed.

### Checklist

- ~[ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios~ None found
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)