### PR TITLE
Skip data view serverless test suite for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/data_views/_data_view_create_delete.ts
@@ -19,6 +19,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['settings', 'common', 'header']);
 
   describe('creating and deleting default data view', function describeIndexTests() {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/171479
+    this.tags(['failsOnMKI']);
     before(async function () {
       // TODO: emptyKibanaIndex fails in Serverless with
       // "index_not_found_exception: no such index [.kibana_ingest]",


### PR DESCRIPTION
## Summary

This PR skips the `creating and deleting default data view` test suite for MKI runs.

Details about the failure in #171479
