### PR TITLE
Skip failing suites related to Endpoint security tests

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -52,7 +52,18 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       .set('kbn-xsrf', 'true');
   };
 
-  describe('For each artifact list under management', function () {
+  // Several flaky tests from this file
+  // - https://github.com/elastic/kibana/issues?q=is%3Aissue+is%3Aopen+X-pack+endpoint+integrations++artifact+entries+list
+  // https://github.com/elastic/kibana/issues/171475
+  // https://github.com/elastic/kibana/issues/171476
+  // https://github.com/elastic/kibana/issues/171477
+  // https://github.com/elastic/kibana/issues/171478
+  // https://github.com/elastic/kibana/issues/171487
+  // https://github.com/elastic/kibana/issues/171488
+  // https://github.com/elastic/kibana/issues/171489
+  // https://github.com/elastic/kibana/issues/171491
+  // https://github.com/elastic/kibana/issues/171492
+  describe.skip('For each artifact list under management', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     this.timeout(60_000 * 5);
@@ -235,9 +246,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     };
 
     for (const testData of getArtifactsListTestsData()) {
-      // FLAKY: https://github.com/elastic/kibana/issues/171477
-      // FLAKY: https://github.com/elastic/kibana/issues/171478
-      describe.skip(`When on the ${testData.title} entries list`, function () {
+      describe(`When on the ${testData.title} entries list`, function () {
         beforeEach(async () => {
           policyInfo = await policyTestResources.createPolicy();
           await removeAllArtifacts();
@@ -323,8 +332,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     }
 
-    // FLAKY: https://github.com/elastic/kibana/issues/171476
-    describe.skip('Should check artifacts are correctly generated when multiple entries', function () {
+    describe('Should check artifacts are correctly generated when multiple entries', function () {
       let firstPolicy: PolicyTestResourceInfo;
       let secondPolicy: PolicyTestResourceInfo;
 

--- a/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -235,7 +235,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     };
 
     for (const testData of getArtifactsListTestsData()) {
-      describe(`When on the ${testData.title} entries list`, function () {
+      // FLAKY: https://github.com/elastic/kibana/issues/171477
+      // FLAKY: https://github.com/elastic/kibana/issues/171478
+      describe.skip(`When on the ${testData.title} entries list`, function () {
         beforeEach(async () => {
           policyInfo = await policyTestResources.createPolicy();
           await removeAllArtifacts();

--- a/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -323,7 +323,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
     }
 
-    describe('Should check artifacts are correctly generated when multiple entries', function () {
+    // FLAKY: https://github.com/elastic/kibana/issues/171476
+    describe.skip('Should check artifacts are correctly generated when multiple entries', function () {
       let firstPolicy: PolicyTestResourceInfo;
       let secondPolicy: PolicyTestResourceInfo;
 

--- a/x-pack/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/trusted_apps_list.ts
@@ -33,7 +33,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       await testSubjects.missingOrFail('header-page-title');
     });
 
-    it('should be able to add a new trusted app and remove it', async () => {
+    // FLAKY: https://github.com/elastic/kibana/issues/171481
+    it.skip('should be able to add a new trusted app and remove it', async () => {
       const SHA256 = 'A4370C0CF81686C0B696FA6261c9d3e0d810ae704ab8301839dffd5d5112f476';
 
       // Add it


### PR DESCRIPTION


## Summary
Since 2 days ago, several Endpoint Security tests seem to be failing with timeouts. Skipping the tests for now, but it seems there's some genuine issue in the background.

cc: @gergoabraham  - you're tagged on the failed test reports

See: 
 - https://github.com/elastic/kibana/issues?q=is%3Aissue+is%3Aopen+X-pack+endpoint+integrations++artifact+entries+list
 - https://ops.kibana.dev/s/ci/app/dashboards#/view/cb7380fb-67fe-5c41-873d-003d1a407dad?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4d,to:now))

For cross-linking:
  // https://github.com/elastic/kibana/issues/171475
  // https://github.com/elastic/kibana/issues/171476
  // https://github.com/elastic/kibana/issues/171477
  // https://github.com/elastic/kibana/issues/171478
  // https://github.com/elastic/kibana/issues/171487
  // https://github.com/elastic/kibana/issues/171488
  // https://github.com/elastic/kibana/issues/171489
  // https://github.com/elastic/kibana/issues/171491
  // https://github.com/elastic/kibana/issues/171492