### PR TITLE
[Ops] Security Solution Endpoint: don't skip the whole suite, only on serverless

### DIFF
--- a/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/artifact_entries_list.ts
@@ -52,7 +52,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       .set('kbn-xsrf', 'true');
   };
 
-  // Several flaky tests from this file
+  // Several flaky tests from this file in serverless, hence @skipInServerless
   // - https://github.com/elastic/kibana/issues?q=is%3Aissue+is%3Aopen+X-pack+endpoint+integrations++artifact+entries+list
   // https://github.com/elastic/kibana/issues/171475
   // https://github.com/elastic/kibana/issues/171476
@@ -63,8 +63,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   // https://github.com/elastic/kibana/issues/171489
   // https://github.com/elastic/kibana/issues/171491
   // https://github.com/elastic/kibana/issues/171492
-  describe.skip('For each artifact list under management', function () {
-    targetTags(this, ['@ess', '@serverless']);
+  describe('For each artifact list under management', function () {
+    targetTags(this, ['@ess', '@serverless', '@skipInServerless']);
 
     this.timeout(60_000 * 5);
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary
Correction from @gergoabraham  - these tests are only failing in serverless, so let's not skip the whole suite