### PR TITLE
[Docs] Remove kibana-keystore show

### DIFF
--- a/docs/setup/secure-settings.asciidoc
+++ b/docs/setup/secure-settings.asciidoc
@@ -82,13 +82,3 @@ To remove a setting from the keystore, use the `remove` command:
 bin/kibana-keystore remove the.setting.name.to.remove
 ----------------------------------------------------------------
 
-[float]
-[[read-settings]]
-=== Read settings
-
-To display the configured setting values, use the `show` command:
-
-[source, sh]
-----------------------------------------------------------------
-bin/kibana-keystore show setting.key
-----------------------------------------------------------------


### PR DESCRIPTION


## Summary
Doc update.

`bin/kibana-keystore` show seems to not be available (no longer). We need to remove this portion in the documentation as it's misleading users.

```bash
➜  bin ./kibana-keystore show

 ERROR  unknown command show

  Usage: bin/kibana-keystore [command] [options]

  A tool for managing settings stored in the Kibana keystore

  Commands:
    create  [options]       Creates a new Kibana keystore
    list  [options]         List entries in the keystore
    add  [options] <key>    Add a string setting to the keystore
    remove  [options] <key> Remove a setting from the keystore
    help  <command>         get the help for a specific command

➜  bin
```
<img width="560" alt="Screenshot 2023-11-20 at 14 26 03" src="https://github.com/elastic/kibana/assets/8897253/5f028128-6054-4705-a07a-f7cc696a7e69">

