### PR TITLE
[Ops] Tighten kibana-tests pipeline permissions

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -54,19 +54,9 @@ spec:
       provider_settings:
         trigger_mode: none
       teams:
-        kibana-release-operators:
-          access_level: MANAGE_BUILD_AND_READ
         kibana-operations:
           access_level: MANAGE_BUILD_AND_READ
-        appex-qa:
-          access_level: BUILD_AND_READ
-        security-engineering-productivity:
-          access_level: BUILD_AND_READ
-        fleet:
-          access_level: BUILD_AND_READ
-        kibana-tech-leads:
-          access_level: BUILD_AND_READ
-        kibana-core:
+        kibana-release-operators:
           access_level: BUILD_AND_READ
         cloud-tooling:
           access_level: BUILD_AND_READ


### PR DESCRIPTION
Changes permissions around who can start new builds on the [kibana-tests](https://buildkite.com/elastic/kibana-tests) pipeline + who has access to edit the pipeline.

I changed my mind on a recent decision and decided to only allow `kibana-release-operators` to start new builds, but not to edit pipeline settings. This permission should be maintained by `kibana-operations` only.

Likewise, I removed the ability to start new builds from the following teams:
- `kibana-tech-leads`: These users are also part of `kibana-release-operators`, so there's no need to set separate permissions for `kibana-tech-leads` as well.
- `appex-qa`: Permissions not required at this time. Individuals who need it from this team has already been added to `kibana-release-operators`.
- `security-engineering-productivity`: Permissions not required at this time.
- `fleet`: Permissions not required at this time.
- `kibana-core`: Permissions not required at this time.
