### PR TITLE
Exclude Dips and Spikes from related events

### DIFF
--- a/x-pack/plugins/aiops/public/components/change_point_detection/use_change_point_agg_request.ts
+++ b/x-pack/plugins/aiops/public/components/change_point_detection/use_change_point_agg_request.ts
@@ -120,7 +120,8 @@ export function useChangePointResults(
   fieldConfig: FieldConfig,
   requestParams: ChangePointDetectionRequestParams,
   query: QueryDslQueryContainer,
-  splitFieldCardinality: number | null
+  splitFieldCardinality: number | null,
+  excludedAdditionalChangePointTypes?: Set<ChangePointType>
 ) {
   const {
     notifications: { toasts },
@@ -258,7 +259,13 @@ export function useChangePointResults(
                 : `${fieldConfig.splitField}_${v.key?.splitFieldTerm}`,
             } as ChangePointAnnotation;
           })
-          .filter((v) => !EXCLUDED_CHANGE_POINT_TYPES.has(v.type));
+          .filter(
+            (v) =>
+              !EXCLUDED_CHANGE_POINT_TYPES.has(v.type) &&
+              (excludedAdditionalChangePointTypes
+                ? !excludedAdditionalChangePointTypes.has(v.type)
+                : true)
+          );
 
         if (Array.isArray(requestParams.changePointType)) {
           groups = groups.filter((v) => requestParams.changePointType!.includes(v.type));
@@ -308,6 +315,7 @@ export function useChangePointResults(
       runRequest,
       toasts,
       usageCollection,
+      excludedAdditionalChangePointTypes,
     ]
   );
 

--- a/x-pack/plugins/aiops/public/embeddable/embeddable_change_point_chart_component.tsx
+++ b/x-pack/plugins/aiops/public/embeddable/embeddable_change_point_chart_component.tsx
@@ -19,6 +19,7 @@ import { EMBEDDABLE_CHANGE_POINT_CHART_TYPE } from '../../common/constants';
 import type { AiopsPluginStartDeps } from '../types';
 import type { EmbeddableChangePointChartInput } from './embeddable_change_point_chart';
 import type { ChangePointAnnotation } from '../components/change_point_detection/change_point_detection_context';
+import { ChangePointType } from '../components/change_point_detection/constants';
 
 export interface RelatedEventsFilter {
   term: {
@@ -48,6 +49,7 @@ export interface EmbeddableChangePointChartProps {
   lastReloadRequestTime?: number;
   relatedEventsFilter?: Array<RelatedEventsFilter | null>;
   relatedEventsStyle?: Record<string, string>;
+  excludedAdditionalChangePointTypes?: Set<ChangePointType>;
 }
 export function getEmbeddableChangePointChart(core: CoreStart, plugins: AiopsPluginStartDeps) {
   const { embeddable: embeddableStart } = plugins;

--- a/x-pack/plugins/aiops/public/embeddable/embeddable_chart_component_wrapper.tsx
+++ b/x-pack/plugins/aiops/public/embeddable/embeddable_chart_component_wrapper.tsx
@@ -103,6 +103,7 @@ export const EmbeddableInputTracker: FC<EmbeddableInputTrackerProps> = ({
               emptyState={input.emptyState}
               relatedEventsFilter={input.relatedEventsFilter}
               relatedEventsStyle={input.relatedEventsStyle}
+              excludedAdditionalChangePointTypes={input.excludedAdditionalChangePointTypes}
             />
           </FilterQueryContextProvider>
         </ChangePointDetectionControlsContextProvider>
@@ -141,6 +142,7 @@ export const ChartGridEmbeddableWrapper: FC<
   emptyState,
   relatedEventsFilter,
   relatedEventsStyle,
+  excludedAdditionalChangePointTypes,
 }) => {
   const { filters, query, timeRange } = useFilerQueryUpdates();
 
@@ -212,7 +214,8 @@ export const ChartGridEmbeddableWrapper: FC<
     fieldConfig,
     requestParams,
     combinedQuery,
-    10000
+    10000,
+    excludedAdditionalChangePointTypes
   );
 
   useEffect(() => {

--- a/x-pack/plugins/aiops/public/index.ts
+++ b/x-pack/plugins/aiops/public/index.ts
@@ -20,6 +20,8 @@ export type { LogCategorizationAppStateProps } from './components/log_categoriza
 export type { ChangePointDetectionAppStateProps } from './components/change_point_detection';
 export type { LogRateAnalysisResultsData } from './components/log_rate_analysis/log_rate_analysis_results';
 
+export type { ChangePointType } from './components/change_point_detection/constants';
+
 export {
   LogRateAnalysis,
   LogRateAnalysisContent,

--- a/x-pack/plugins/observability/public/components/custom_threshold/components/alert_details_related_events.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/alert_details_related_events.tsx
@@ -14,6 +14,7 @@ import { DataView } from '@kbn/data-views-plugin/common';
 import type { TimeRange } from '@kbn/es-query';
 import { ChangePointAnnotation } from '@kbn/aiops-plugin/public/components/change_point_detection/change_point_detection_context';
 import { ALERT_GROUP } from '@kbn/rule-data-utils';
+import { ChangePointType } from '@kbn/aiops-plugin/public';
 import { CustomThresholdExpressionMetric } from '../../../../common/custom_threshold_rule/types';
 import { useKibana } from '../../../utils/kibana_react';
 
@@ -53,6 +54,8 @@ export default function AlertDetailsRelatedEvents({
   const [metricAggType, setMetricAggType] = useState<string>();
   const [lastReloadRequestTime, setLastReloadRequestTime] = useState<number>();
   const ruleParams = rule.params as RuleTypeParams & AlertParams;
+
+  const excludedAdditionalChangePointTypes = new Set<ChangePointType>(['dip', 'spike']);
 
   const relatedEventsFilter = ruleParams.groupBy
     ? [...ruleParams.groupBy]
@@ -210,6 +213,7 @@ export default function AlertDetailsRelatedEvents({
                   relatedEventsStyle={{ 'margin-top': '10px' }}
                   lastReloadRequestTime={lastReloadRequestTime}
                   relatedEventsFilter={relatedEventsFilter}
+                  excludedAdditionalChangePointTypes={excludedAdditionalChangePointTypes}
                 />
               )
           )}


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/171603

Excludes dips and spikes from the list of related events, as detection of these change point types seem to vary between renders.