### PR TITLE
[ML] Rename index pattern references to data view.

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/create_step/create_step.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/create_step/create_step.tsx
@@ -163,7 +163,7 @@ export const CreateStep: FC<Props> = ({ actions, state, step }) => {
                   >
                     <EuiCheckbox
                       disabled={isJobCreated || canCreateDataView === false}
-                      name="mlDataFrameAnalyticsCreateIndexPattern"
+                      name="mlDataFrameAnalyticsCreateDataView"
                       id={'dataframe-create-data-view-checkbox'}
                       label={i18n.translate(
                         'xpack.ml.dataframe.analytics.create.createDataViewLabel',
@@ -173,7 +173,7 @@ export const CreateStep: FC<Props> = ({ actions, state, step }) => {
                       )}
                       checked={createIndexPattern === true}
                       onChange={() => setFormState({ createIndexPattern: !createIndexPattern })}
-                      data-test-subj="mlAnalyticsCreateJobWizardCreateIndexPatternCheckbox"
+                      data-test-subj="mlAnalyticsCreateJobWizardCreateDataViewCheckbox"
                     />
                   </EuiFormRow>
                 </EuiFlexItem>

--- a/x-pack/test/accessibility/apps/ml.ts
+++ b/x-pack/test/accessibility/apps/ml.ts
@@ -50,10 +50,10 @@ export default function ({ getService }: FtrProviderContext) {
 
       describe('with data loaded', function () {
         const dfaOutlierResultsJobId = 'iph_outlier_a11y';
-        const ecIndexPattern = 'ft_module_sample_ecommerce';
-        const ihpIndexPattern = 'ft_ihp_outlier';
-        const egsIndexPattern = 'ft_egs_regression';
-        const bmIndexPattern = 'ft_bank_marketing';
+        const ecIndexName = 'ft_module_sample_ecommerce';
+        const ihpIndexName = 'ft_ihp_outlier';
+        const egsIndexName = 'ft_egs_regression';
+        const bmIndexName = 'ft_bank_marketing';
         const ecExpectedTotalCount = '287';
 
         const dfaOutlierJobType = 'outlier_detection';
@@ -78,10 +78,10 @@ export default function ({ getService }: FtrProviderContext) {
           await esArchiver.loadIfNeeded(
             'x-pack/test/functional/es_archives/ml/module_sample_ecommerce'
           );
-          await ml.testResources.createIndexPatternIfNeeded(ihpIndexPattern);
-          await ml.testResources.createIndexPatternIfNeeded(egsIndexPattern);
-          await ml.testResources.createIndexPatternIfNeeded(bmIndexPattern);
-          await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+          await ml.testResources.createDataViewIfNeeded(ihpIndexName);
+          await ml.testResources.createDataViewIfNeeded(egsIndexName);
+          await ml.testResources.createDataViewIfNeeded(bmIndexName);
+          await ml.testResources.createDataViewIfNeeded(ecIndexName, 'order_date');
           await ml.testResources.setKibanaTimeZoneToUTC();
 
           await ml.api.createAndRunDFAJob(
@@ -93,10 +93,10 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.api.cleanMlIndices();
           await ml.api.deleteIndices(`user-${dfaOutlierResultsJobId}`);
 
-          await ml.testResources.deleteIndexPatternByTitle(ihpIndexPattern);
-          await ml.testResources.deleteIndexPatternByTitle(egsIndexPattern);
-          await ml.testResources.deleteIndexPatternByTitle(bmIndexPattern);
-          await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
+          await ml.testResources.deleteDataViewByTitle(ihpIndexName);
+          await ml.testResources.deleteDataViewByTitle(egsIndexName);
+          await ml.testResources.deleteDataViewByTitle(bmIndexName);
+          await ml.testResources.deleteDataViewByTitle(ecIndexName);
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/egs_regression');
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/bm_classification');
@@ -134,7 +134,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.testExecution.logTestStep(
             'job creation selects the source data and loads the DFA job wizard page'
           );
-          await ml.jobSourceSelection.selectSourceForAnalyticsJob(ihpIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnalyticsJob(ihpIndexName);
           await ml.dataFrameAnalyticsCreation.assertConfigurationStepActive();
           await a11y.testAppSnapshot();
         });
@@ -180,7 +180,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.navigation.navigateToMl();
           await ml.navigation.navigateToDataFrameAnalytics();
           await ml.dataFrameAnalytics.startAnalyticsCreation();
-          await ml.jobSourceSelection.selectSourceForAnalyticsJob(egsIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnalyticsJob(egsIndexName);
           await ml.dataFrameAnalyticsCreation.assertConfigurationStepActive();
           await ml.testExecution.logTestStep('selects the regression job type');
           await ml.dataFrameAnalyticsCreation.assertJobTypeSelectExists();
@@ -227,7 +227,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.navigation.navigateToMl();
           await ml.navigation.navigateToDataFrameAnalytics();
           await ml.dataFrameAnalytics.startAnalyticsCreation();
-          await ml.jobSourceSelection.selectSourceForAnalyticsJob(bmIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnalyticsJob(bmIndexName);
           await ml.dataFrameAnalyticsCreation.assertConfigurationStepActive();
           await ml.testExecution.logTestStep('selects the classification job type');
           await ml.dataFrameAnalyticsCreation.assertJobTypeSelectExists();
@@ -275,12 +275,12 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         it('index data visualizer select index pattern page', async () => {
-          await ml.dataVisualizer.navigateToIndexPatternSelection();
+          await ml.dataVisualizer.navigateToDataViewSelection();
           await a11y.testAppSnapshot();
         });
 
         it('index data visualizer page for selected index', async () => {
-          await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexPattern);
+          await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexName);
 
           await ml.testExecution.logTestStep('should display the time range step');
           await ml.dataVisualizerIndexBased.assertTimeRangeSelectorSectionExists();

--- a/x-pack/test/accessibility/apps/ml_anomaly_detection.ts
+++ b/x-pack/test/accessibility/apps/ml_anomaly_detection.ts
@@ -65,10 +65,10 @@ export default function ({ getService }: FtrProviderContext) {
         const eventDescription = 'calendar_event_a11y';
         const filterId = 'filter_a11y';
         const filterItems = ['filter_item_a11y'];
-        const fqIndexPattern = 'ft_farequote';
-        const ecIndexPattern = 'ft_module_sample_ecommerce';
+        const fqIndexName = 'ft_farequote';
+        const ecIndexName = 'ft_module_sample_ecommerce';
 
-        const categorizationIndexPattern = 'ft_categorization_small';
+        const categorizationIndexName = 'ft_categorization_small';
 
         const adJobAggAndFieldIdentifier = 'Mean(responsetime)';
         const adJobBucketSpan = '30m';
@@ -87,12 +87,12 @@ export default function ({ getService }: FtrProviderContext) {
 
         const advancedJobTestData = {
           suiteTitle: 'with multiple metric detectors and custom datafeed settings',
-          jobSource: ecIndexPattern,
+          jobSource: ecIndexName,
           jobId: `ec_advanced_1_${Date.now()}`,
           get jobIdClone(): string {
             return `${this.jobId}_clone`;
           },
-          jobDescription: `Create advanced job from ${ecIndexPattern} dataset with multiple metric detectors and custom datafeed settings`,
+          jobDescription: `Create advanced job from ${ecIndexName} dataset with multiple metric detectors and custom datafeed settings`,
           jobGroups: ['automated', 'ecommerce', 'advanced'],
           get jobGroupsClone(): string[] {
             return [...this.jobGroups, 'clone'];
@@ -149,7 +149,7 @@ export default function ({ getService }: FtrProviderContext) {
         };
         const populationJobTestData = {
           suiteTitle: 'population job',
-          jobSource: ecIndexPattern,
+          jobSource: ecIndexName,
           jobId: `ec_population_1_${Date.now()}`,
           get jobIdClone(): string {
             return `${this.jobId}_clone`;
@@ -201,12 +201,9 @@ export default function ({ getService }: FtrProviderContext) {
           await esArchiver.loadIfNeeded(
             'x-pack/test/functional/es_archives/ml/categorization_small'
           );
-          await ml.testResources.createIndexPatternIfNeeded(fqIndexPattern, '@timestamp');
-          await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
-          await ml.testResources.createIndexPatternIfNeeded(
-            'ft_categorization_small',
-            '@timestamp'
-          );
+          await ml.testResources.createDataViewIfNeeded(fqIndexName, '@timestamp');
+          await ml.testResources.createDataViewIfNeeded(ecIndexName, 'order_date');
+          await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
           await ml.testResources.setKibanaTimeZoneToUTC();
 
           await ml.api.createAndRunAnomalyDetectionLookbackJob(
@@ -238,9 +235,9 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.api.deleteCalendar(calendarId);
           await ml.api.deleteFilter(filterId);
 
-          await ml.testResources.deleteIndexPatternByTitle(fqIndexPattern);
-          await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
-          await ml.testResources.deleteIndexPatternByTitle(categorizationIndexPattern);
+          await ml.testResources.deleteDataViewByTitle(fqIndexName);
+          await ml.testResources.deleteDataViewByTitle(ecIndexName);
+          await ml.testResources.deleteDataViewByTitle(categorizationIndexName);
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/categorization_small');
@@ -259,7 +256,7 @@ export default function ({ getService }: FtrProviderContext) {
         });
 
         it('anomaly detection create job select type page', async () => {
-          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(fqIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(fqIndexName);
           await a11y.testAppSnapshot();
         });
 
@@ -308,7 +305,7 @@ export default function ({ getService }: FtrProviderContext) {
           // as the other steps have already been tested for the single metric job
           await ml.navigation.navigateToAnomalyDetection();
           await ml.jobManagement.navigateToNewJobSourceSelection();
-          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(fqIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(fqIndexName);
           await ml.jobTypeSelection.selectMultiMetricJob();
           await ml.testExecution.logTestStep('job creation set the time range');
           await ml.jobWizardCommon.clickUseFullDataButton(
@@ -442,7 +439,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.navigation.navigateToJobManagement();
           await ml.jobManagement.navigateToNewJobSourceSelection();
 
-          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(ecIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(ecIndexName);
 
           await ml.testExecution.logTestStep('job creation loads the population job wizard page');
           await ml.jobTypeSelection.selectPopulationJob();
@@ -509,9 +506,7 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.navigation.navigateToJobManagement();
           await ml.jobManagement.navigateToNewJobSourceSelection();
 
-          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(
-            categorizationIndexPattern
-          );
+          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(categorizationIndexName);
 
           await ml.testExecution.logTestStep(
             'job creation loads the categorization job wizard page'
@@ -566,7 +561,7 @@ export default function ({ getService }: FtrProviderContext) {
         it('anomaly detection create job from data recognizer module open wizard', async () => {
           await ml.navigation.navigateToJobManagement();
           await ml.jobManagement.navigateToNewJobSourceSelection();
-          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(ecIndexPattern);
+          await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(ecIndexName);
           await ml.testExecution.logTestStep(
             `job creation loads the data recognizer job wizard page for the ${adRecognizerJobModuleId} module`
           );

--- a/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts
+++ b/x-pack/test/accessibility/apps/ml_embeddables_in_dashboard.ts
@@ -66,7 +66,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await ml.securityCommon.createMlUsers();
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });

--- a/x-pack/test/accessibility/apps/transform.ts
+++ b/x-pack/test/accessibility/apps/transform.ts
@@ -42,7 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       describe('with data loaded', function () {
-        const ecIndexPattern = 'ft_ecommerce';
+        const ecDataView = 'ft_ecommerce';
 
         const pivotGroupByEntries = [
           {
@@ -85,7 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         before(async () => {
           await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-          await transform.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+          await transform.testResources.createDataViewIfNeeded(ecDataView, 'order_date');
           await transform.testResources.setKibanaTimeZoneToUTC();
         });
 
@@ -93,9 +93,9 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.api.cleanTransformIndices();
           await transform.api.deleteIndices(pivotTransformDestinationIndex);
           await transform.api.deleteIndices(latestTransformDestinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(pivotTransformDestinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(latestTransformDestinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(ecIndexPattern);
+          await transform.testResources.deleteDataViewByTitle(pivotTransformDestinationIndex);
+          await transform.testResources.deleteDataViewByTitle(latestTransformDestinationIndex);
+          await transform.testResources.deleteDataViewByTitle(ecDataView);
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
           await transform.testResources.resetKibanaTimeZone();
         });
@@ -110,7 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.testExecution.logTestStep(
             'transform creation selects the source data and loads the Transform wizard page'
           );
-          await transform.sourceSelection.selectSource(ecIndexPattern);
+          await transform.sourceSelection.selectSource(ecDataView);
 
           await transform.testExecution.logTestStep(
             `sets the date picker to the default '15 minutes ago'`
@@ -201,7 +201,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.testExecution.logTestStep(
             'selects the source data and loads the Transform wizard page'
           );
-          await transform.sourceSelection.selectSource(ecIndexPattern);
+          await transform.sourceSelection.selectSource(ecDataView);
 
           await transform.testExecution.logTestStep(
             `sets the date picker to the default '15 minutes ago'`

--- a/x-pack/test/accessibility/apps/transform.ts
+++ b/x-pack/test/accessibility/apps/transform.ts
@@ -42,7 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       describe('with data loaded', function () {
-        const ecDataView = 'ft_ecommerce';
+        const ecIndexName = 'ft_ecommerce';
 
         const pivotGroupByEntries = [
           {
@@ -85,7 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         before(async () => {
           await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-          await transform.testResources.createDataViewIfNeeded(ecDataView, 'order_date');
+          await transform.testResources.createDataViewIfNeeded(ecIndexName, 'order_date');
           await transform.testResources.setKibanaTimeZoneToUTC();
         });
 
@@ -95,7 +95,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.api.deleteIndices(latestTransformDestinationIndex);
           await transform.testResources.deleteDataViewByTitle(pivotTransformDestinationIndex);
           await transform.testResources.deleteDataViewByTitle(latestTransformDestinationIndex);
-          await transform.testResources.deleteDataViewByTitle(ecDataView);
+          await transform.testResources.deleteDataViewByTitle(ecIndexName);
           await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
           await transform.testResources.resetKibanaTimeZone();
         });
@@ -110,7 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.testExecution.logTestStep(
             'transform creation selects the source data and loads the Transform wizard page'
           );
-          await transform.sourceSelection.selectSource(ecDataView);
+          await transform.sourceSelection.selectSource(ecIndexName);
 
           await transform.testExecution.logTestStep(
             `sets the date picker to the default '15 minutes ago'`
@@ -201,7 +201,7 @@ export default function ({ getService }: FtrProviderContext) {
           await transform.testExecution.logTestStep(
             'selects the source data and loads the Transform wizard page'
           );
-          await transform.sourceSelection.selectSource(ecDataView);
+          await transform.sourceSelection.selectSource(ecIndexName);
 
           await transform.testExecution.logTestStep(
             `sets the date picker to the default '15 minutes ago'`

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
@@ -42,8 +42,8 @@ export default ({ getService }: FtrProviderContext) => {
   const testJobConfigs: Array<DeepPartial<DataFrameAnalyticsConfig>> = [
     'Test delete job only',
     'Test delete job and target index',
-    'Test delete job and index pattern',
-    'Test delete job, target index, and index pattern',
+    'Test delete job and data view',
+    'Test delete job, target index, and data view',
   ].map((description, idx) => {
     const analyticsId = `${jobId}_${idx + 1}`;
     return {
@@ -159,7 +159,7 @@ export default ({ getService }: FtrProviderContext) => {
         const destinationIndex = generateDestinationIndex(analyticsId);
 
         before(async () => {
-          // Mimic real job by creating index pattern after job is created
+          // Mimic real job by creating data view after job is created
           await ml.testResources.createIndexPatternIfNeeded(destinationIndex);
         });
 
@@ -167,7 +167,7 @@ export default ({ getService }: FtrProviderContext) => {
           await ml.testResources.deleteIndexPatternByTitle(destinationIndex);
         });
 
-        it('should delete job and index pattern by id', async () => {
+        it('should delete job and data view by id', async () => {
           const { body, status } = await supertest
             .delete(`/internal/ml/data_frame/analytics/${analyticsId}`)
             .query({ deleteDestIndexPattern: true })
@@ -188,7 +188,7 @@ export default ({ getService }: FtrProviderContext) => {
         const destinationIndex = generateDestinationIndex(analyticsId);
 
         before(async () => {
-          // Mimic real job by creating target index & index pattern after DFA job is created
+          // Mimic real job by creating target index & data view after DFA job is created
           await ml.api.createIndex(destinationIndex);
           await ml.api.assertIndicesExist(destinationIndex);
           await ml.testResources.createIndexPatternIfNeeded(destinationIndex);
@@ -199,7 +199,7 @@ export default ({ getService }: FtrProviderContext) => {
           await ml.testResources.deleteIndexPatternByTitle(destinationIndex);
         });
 
-        it('should delete job, target index, and index pattern by id', async () => {
+        it('should delete job, target index, and data view by id', async () => {
           const { body, status } = await supertest
             .delete(`/internal/ml/data_frame/analytics/${analyticsId}`)
             .query({ deleteDestIndex: true, deleteDestIndexPattern: true })

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
@@ -179,7 +179,7 @@ export default ({ getService }: FtrProviderContext) => {
           expect(body.destIndexDeleted.success).to.eql(false);
           expect(body.destIndexPatternDeleted.success).to.eql(true);
           await ml.api.waitForDataFrameAnalyticsJobNotToExist(analyticsId);
-          await ml.testResources.assertIndexPatternNotExist(destinationIndex);
+          await ml.testResources.assertDataViewNotExist(destinationIndex);
         });
       });
 
@@ -212,7 +212,7 @@ export default ({ getService }: FtrProviderContext) => {
           expect(body.destIndexPatternDeleted.success).to.eql(true);
           await ml.api.waitForDataFrameAnalyticsJobNotToExist(analyticsId);
           await ml.api.assertIndicesNotToExist(destinationIndex);
-          await ml.testResources.assertIndexPatternNotExist(destinationIndex);
+          await ml.testResources.assertDataViewNotExist(destinationIndex);
         });
       });
     });

--- a/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
+++ b/x-pack/test/api_integration/apis/ml/data_frame_analytics/delete.ts
@@ -160,11 +160,11 @@ export default ({ getService }: FtrProviderContext) => {
 
         before(async () => {
           // Mimic real job by creating data view after job is created
-          await ml.testResources.createIndexPatternIfNeeded(destinationIndex);
+          await ml.testResources.createDataViewIfNeeded(destinationIndex);
         });
 
         after(async () => {
-          await ml.testResources.deleteIndexPatternByTitle(destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(destinationIndex);
         });
 
         it('should delete job and data view by id', async () => {
@@ -191,12 +191,12 @@ export default ({ getService }: FtrProviderContext) => {
           // Mimic real job by creating target index & data view after DFA job is created
           await ml.api.createIndex(destinationIndex);
           await ml.api.assertIndicesExist(destinationIndex);
-          await ml.testResources.createIndexPatternIfNeeded(destinationIndex);
+          await ml.testResources.createDataViewIfNeeded(destinationIndex);
         });
 
         after(async () => {
           await ml.api.deleteIndices(destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(destinationIndex);
         });
 
         it('should delete job, target index, and data view by id', async () => {

--- a/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/close_jobs.ts
@@ -46,12 +46,12 @@ export default ({ getService }: FtrProviderContext) => {
   describe('close_jobs', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     beforeEach(async () => {

--- a/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/jobs_exist.ts
@@ -83,13 +83,13 @@ export default ({ getService }: FtrProviderContext) => {
   describe('jobs_exist', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
     });
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('sets up jobs', async () => {

--- a/x-pack/test/api_integration/apis/ml/jobs/reset.ts
+++ b/x-pack/test/api_integration/apis/ml/jobs/reset.ts
@@ -55,12 +55,12 @@ export default ({ getService }: FtrProviderContext) => {
   describe('reset_jobs', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     beforeEach(async () => {

--- a/x-pack/test/api_integration/apis/ml/modules/jobs_exist.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/jobs_exist.ts
@@ -39,12 +39,12 @@ export default ({ getService }: FtrProviderContext) => {
       await ml.testResources.setKibanaTimeZoneToUTC();
       await esArchiver.loadIfNeeded(sourceDataArchive);
       // create data view in default space
-      await ml.testResources.createIndexPatternIfNeeded(
+      await ml.testResources.createDataViewIfNeeded(
         moduleInfo.dataView.name,
         moduleInfo.dataView.timeField
       );
       // create data view in idSpace1
-      await ml.testResources.createIndexPatternIfNeeded(
+      await ml.testResources.createDataViewIfNeeded(
         moduleInfo.dataView.name,
         moduleInfo.dataView.timeField,
         idSpace1
@@ -57,8 +57,8 @@ export default ({ getService }: FtrProviderContext) => {
 
     after(async () => {
       // delete all data views in all spaces
-      await ml.testResources.deleteIndexPatternByTitle(moduleInfo.dataView.name);
-      await ml.testResources.deleteIndexPatternByTitle(moduleInfo.dataView.name, idSpace1);
+      await ml.testResources.deleteDataViewByTitle(moduleInfo.dataView.name);
+      await ml.testResources.deleteDataViewByTitle(moduleInfo.dataView.name, idSpace1);
     });
 
     it('should find jobs installed by module without prefix', async () => {

--- a/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
+++ b/x-pack/test/api_integration/apis/ml/modules/setup_module.ts
@@ -710,7 +710,7 @@ export default ({ getService }: FtrProviderContext) => {
       describe('sets up module data', function () {
         before(async () => {
           await esArchiver.loadIfNeeded(testData.sourceDataArchive);
-          await ml.testResources.createIndexPatternIfNeeded(
+          await ml.testResources.createDataViewIfNeeded(
             testData.indexPattern.name,
             testData.indexPattern.timeField
           );
@@ -730,7 +730,7 @@ export default ({ getService }: FtrProviderContext) => {
             await ml.api.deleteAnomalyDetectionJobES(job.jobId);
           }
           await ml.api.cleanMlIndices();
-          await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
+          await ml.testResources.deleteDataViewByTitle(testData.indexPattern.name);
         });
 
         it(testData.testTitleSuffix, async () => {
@@ -864,7 +864,7 @@ export default ({ getService }: FtrProviderContext) => {
             await esArchiver.loadIfNeeded(testData.sourceDataArchive!);
           }
           if (testData.hasOwnProperty('indexPattern')) {
-            await ml.testResources.createIndexPatternIfNeeded(
+            await ml.testResources.createDataViewIfNeeded(
               testData.indexPattern!.name as string,
               testData.indexPattern!.timeField as string
             );
@@ -874,7 +874,7 @@ export default ({ getService }: FtrProviderContext) => {
         after(async () => {
           await ml.api.cleanMlIndices();
           if (testData.hasOwnProperty('indexPattern')) {
-            await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern!.name);
+            await ml.testResources.deleteDataViewByTitle(testData.indexPattern!.name);
           }
         });
 

--- a/x-pack/test/api_integration/apis/ml/results/get_categorizer_stats.ts
+++ b/x-pack/test/api_integration/apis/ml/results/get_categorizer_stats.ts
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_logs');
       await ml.api.cleanMlIndices();
     });
 

--- a/x-pack/test/api_integration/apis/ml/results/get_stopped_partitions.ts
+++ b/x-pack/test/api_integration/apis/ml/results/get_stopped_partitions.ts
@@ -96,7 +96,7 @@ export default ({ getService }: FtrProviderContext) => {
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_logs');
       await ml.api.cleanMlIndices();
     });
 

--- a/x-pack/test/api_integration/apis/transform/delete_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/delete_transforms.ts
@@ -232,12 +232,12 @@ export default ({ getService }: FtrProviderContext) => {
       before(async () => {
         await createTransform(transformId);
         await transform.api.createIndices(destinationIndex);
-        await transform.testResources.createIndexPatternIfNeeded(destinationIndex);
+        await transform.testResources.createDataViewIfNeeded(destinationIndex);
       });
 
       after(async () => {
         await transform.api.deleteIndices(destinationIndex);
-        await transform.testResources.deleteIndexPatternByTitle(destinationIndex);
+        await transform.testResources.deleteDataViewByTitle(destinationIndex);
       });
 
       it('should delete transform and destination index pattern', async () => {
@@ -272,12 +272,12 @@ export default ({ getService }: FtrProviderContext) => {
       before(async () => {
         await createTransform(transformId);
         await transform.api.createIndices(destinationIndex);
-        await transform.testResources.createIndexPatternIfNeeded(destinationIndex);
+        await transform.testResources.createDataViewIfNeeded(destinationIndex);
       });
 
       after(async () => {
         await transform.api.deleteIndices(destinationIndex);
-        await transform.testResources.deleteIndexPatternByTitle(destinationIndex);
+        await transform.testResources.deleteDataViewByTitle(destinationIndex);
       });
 
       it('should delete transform, destination index, & destination index pattern', async () => {

--- a/x-pack/test/api_integration/apis/transform/delete_transforms.ts
+++ b/x-pack/test/api_integration/apis/transform/delete_transforms.ts
@@ -261,7 +261,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(body[transformId].destDataViewDeleted.success).to.eql(true);
         await transform.api.waitForTransformNotToExist(transformId);
         await transform.api.waitForIndicesToExist(destinationIndex);
-        await transform.testResources.assertIndexPatternNotExist(destinationIndex);
+        await transform.testResources.assertDataViewNotExist(destinationIndex);
       });
     });
 
@@ -301,7 +301,7 @@ export default ({ getService }: FtrProviderContext) => {
         expect(body[transformId].destDataViewDeleted.success).to.eql(true);
         await transform.api.waitForTransformNotToExist(transformId);
         await transform.api.waitForIndicesNotToExist(destinationIndex);
-        await transform.testResources.assertIndexPatternNotExist(destinationIndex);
+        await transform.testResources.assertDataViewNotExist(destinationIndex);
       });
     });
   });

--- a/x-pack/test/api_integration/apis/transform/transforms_create.ts
+++ b/x-pack/test/api_integration/apis/transform/transforms_create.ts
@@ -84,7 +84,7 @@ export default ({ getService }: FtrProviderContext) => {
         },
       ]);
 
-      await transform.testResources.deleteIndexPatternByTitle(destinationIndex);
+      await transform.testResources.deleteDataViewByTitle(destinationIndex);
     });
 
     it('should create a transform with data view and time field', async () => {
@@ -118,7 +118,7 @@ export default ({ getService }: FtrProviderContext) => {
         },
       ]);
 
-      await transform.testResources.deleteIndexPatternByTitle(destinationIndex);
+      await transform.testResources.deleteDataViewByTitle(destinationIndex);
     });
 
     it('should not allow pivot and latest configs in same transform', async () => {

--- a/x-pack/test/api_integration/apis/watcher/watcher.ts
+++ b/x-pack/test/api_integration/apis/watcher/watcher.ts
@@ -17,7 +17,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('watcher', () => {
     before(async () => {
       try {
-        await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+        await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       } catch (error) {
         log.debug('[Setup error] Error creating index pattern');
         throw error;
@@ -26,7 +26,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       try {
-        await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+        await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
       } catch (error) {
         log.debug('[Cleanup error] Error deleting index pattern');
         throw error;

--- a/x-pack/test/functional/apps/aiops/change_point_detection.ts
+++ b/x-pack/test/functional/apps/aiops/change_point_detection.ts
@@ -32,7 +32,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // Start navigation from the base of the ML app.
       await ml.navigation.navigateToMl();
       await elasticChart.setNewChartUiDebugFlag(true);
-      await aiops.changePointDetectionPage.navigateToIndexPatternSelection();
+      await aiops.changePointDetectionPage.navigateToDataViewSelection();
       await ml.jobSourceSelection.selectSourceForChangePointDetection('ft_ecommerce');
       await aiops.changePointDetectionPage.assertChangePointDetectionPageExists();
     });

--- a/x-pack/test/functional/apps/aiops/change_point_detection.ts
+++ b/x-pack/test/functional/apps/aiops/change_point_detection.ts
@@ -19,13 +19,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('change point detection', async function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     it(`loads the change point detection page`, async () => {

--- a/x-pack/test/functional/apps/aiops/log_pattern_analysis.ts
+++ b/x-pack/test/functional/apps/aiops/log_pattern_analysis.ts
@@ -36,13 +36,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
-      await ml.testResources.createIndexPatternIfNeeded('logstash-*', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('logstash-*', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('logstash-*');
+      await ml.testResources.deleteDataViewByTitle('logstash-*');
     });
 
     it(`loads the log pattern analysis page and filters in patterns in discover`, async () => {

--- a/x-pack/test/functional/apps/aiops/log_pattern_analysis.ts
+++ b/x-pack/test/functional/apps/aiops/log_pattern_analysis.ts
@@ -49,7 +49,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // Start navigation from the base of the ML app.
       await ml.navigation.navigateToMl();
       await elasticChart.setNewChartUiDebugFlag(true);
-      await aiops.logPatternAnalysisPage.navigateToIndexPatternSelection();
+      await aiops.logPatternAnalysisPage.navigateToDataViewSelection();
       await ml.jobSourceSelection.selectSourceForLogPatternAnalysisDetection('logstash-*');
       await aiops.logPatternAnalysisPage.assertLogPatternAnalysisPageExists();
 
@@ -76,7 +76,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       // Start navigation from the base of the ML app.
       await ml.navigation.navigateToMl();
       await elasticChart.setNewChartUiDebugFlag(true);
-      await aiops.logPatternAnalysisPage.navigateToIndexPatternSelection();
+      await aiops.logPatternAnalysisPage.navigateToDataViewSelection();
       await ml.jobSourceSelection.selectSourceForLogPatternAnalysisDetection('logstash-*');
       await aiops.logPatternAnalysisPage.assertLogPatternAnalysisPageExists();
 

--- a/x-pack/test/functional/apps/aiops/log_pattern_analysis_in_discover.ts
+++ b/x-pack/test/functional/apps/aiops/log_pattern_analysis_in_discover.ts
@@ -36,13 +36,13 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
-      await ml.testResources.createIndexPatternIfNeeded('logstash-*', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('logstash-*', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle('logstash-*');
+      await ml.testResources.deleteDataViewByTitle('logstash-*');
     });
 
     it(`loads the log pattern analysis flyout and shows patterns in discover`, async () => {

--- a/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
+++ b/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
@@ -234,7 +234,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         before(async () => {
           await aiops.logRateAnalysisDataGenerator.generateData(testData.dataGenerator);
 
-          await ml.testResources.createIndexPatternIfNeeded(
+          await ml.testResources.createDataViewIfNeeded(
             testData.sourceIndexOrSavedSearch,
             '@timestamp'
           );
@@ -260,7 +260,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         after(async () => {
           await elasticChart.setNewChartUiDebugFlag(false);
           if (testData.dataGenerator !== 'kibana_sample_data_logs') {
-            await ml.testResources.deleteIndexPatternByTitle(testData.sourceIndexOrSavedSearch);
+            await ml.testResources.deleteDataViewByTitle(testData.sourceIndexOrSavedSearch);
           }
           await aiops.logRateAnalysisDataGenerator.removeGeneratedData(testData.dataGenerator);
         });

--- a/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
+++ b/x-pack/test/functional/apps/aiops/log_rate_analysis.ts
@@ -28,7 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the saved search selection page`
       );
-      await aiops.logRateAnalysisPage.navigateToIndexPatternSelection();
+      await aiops.logRateAnalysisPage.navigateToDataViewSelection();
 
       await ml.testExecution.logTestStep(`${testData.suiteTitle} loads the log rate analysis page`);
       await ml.jobSourceSelection.selectSourceForLogRateAnalysis(testData.sourceIndexOrSavedSearch);

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/anomaly_charts_dashboard_embeddables.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/anomaly_charts_dashboard_embeddables.ts
@@ -40,7 +40,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
       await PageObjects.common.setTime({ from, to });
@@ -48,7 +48,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
       await PageObjects.common.unsetTime();
     });
 

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/anomaly_embeddables_migration.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/anomaly_embeddables_migration.ts
@@ -70,7 +70,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
 
@@ -85,7 +85,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_integrations/map_to_ml.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_integrations/map_to_ml.ts
@@ -36,7 +36,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await ml.securityUI.loginAsMlPowerUser();
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await kibanaServer.importExport.load(dashboardArchive);
       await browser.setWindowSize(1920, 1080);
     });

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/advanced_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/advanced_job.ts
@@ -199,8 +199,8 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/categorization_small');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
-      await ml.testResources.createIndexPatternIfNeeded('ft_categorization_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -209,8 +209,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
-      await ml.testResources.deleteIndexPatternByTitle('ft_categorization_small');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_categorization_small');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/categorization_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/categorization_job.ts
@@ -86,7 +86,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/categorization_small');
-      await ml.testResources.createIndexPatternIfNeeded('ft_categorization_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -95,7 +95,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_categorization_small');
+      await ml.testResources.deleteDataViewByTitle('ft_categorization_small');
     });
 
     it('job creation loads the categorization wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_jobs_to_advanced_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_jobs_to_advanced_job.ts
@@ -209,8 +209,8 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/categorization_small');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
-      await ml.testResources.createIndexPatternIfNeeded('ft_categorization_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_categorization_small', '@timestamp');
 
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -220,8 +220,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
-      await ml.testResources.deleteIndexPatternByTitle('ft_categorization_small');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_categorization_small');
     });
 
     describe('from multi-metric job creation wizard', function () {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_single_metric_job_to_multi_metric.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_single_metric_job_to_multi_metric.ts
@@ -25,7 +25,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -34,7 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(indexPatternString);
     });
 
     const jobId = `fq_single_to_multi_${Date.now()}`;

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_single_metric_job_to_multi_metric.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/convert_single_metric_job_to_multi_metric.ts
@@ -16,16 +16,16 @@ export default function ({ getService }: FtrProviderContext) {
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
   const remoteName = 'ftr-remote:';
-  const indexPatternName = 'ft_farequote';
-  const indexPatternString = config.get('esTestCluster.ccs')
-    ? remoteName + indexPatternName
-    : indexPatternName;
+  const esIndexPatternName = 'ft_farequote';
+  const esIndexPatternString = config.get('esTestCluster.ccs')
+    ? remoteName + esIndexPatternName
+    : esIndexPatternName;
 
   describe('single metric job conversion to multi-metric job', function () {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(esIndexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -34,7 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteDataViewByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(esIndexPatternString);
     });
 
     const jobId = `fq_single_to_multi_${Date.now()}`;
@@ -59,7 +59,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.jobManagement.navigateToNewJobSourceSelection();
 
       await ml.testExecution.logTestStep('loads the job type selection page');
-      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(indexPatternString);
+      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(esIndexPatternString);
 
       await ml.testExecution.logTestStep('loads the single metric job wizard page');
       await ml.jobTypeSelection.selectSingleMetricJob();

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/custom_urls.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/custom_urls.ts
@@ -69,7 +69,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       testDashboardId = await ml.testResources.createMLTestDashboardIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -80,7 +80,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.testResources.deleteMLTestDashboard();
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('opens the custom URLs tab in the edit job flyout', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/date_nanos_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/date_nanos_job.ts
@@ -94,17 +94,14 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/event_rate_nanos');
-      await ml.testResources.createIndexPatternIfNeeded(
-        'ft_event_rate_gen_trend_nanos',
-        '@timestamp'
-      );
+      await ml.testResources.createDataViewIfNeeded('ft_event_rate_gen_trend_nanos', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_event_rate_gen_trend_nanos');
+      await ml.testResources.deleteDataViewByTitle('ft_event_rate_gen_trend_nanos');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/delete_job_and_delete_annotations.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/delete_job_and_delete_annotations.ts
@@ -64,7 +64,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();
@@ -72,7 +72,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(indexPatternString);
     });
 
     for (const { suiteTitle, jobId, deleteAnnotations, expectedAnnotations } of testConfigs) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/delete_job_and_delete_annotations.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/delete_job_and_delete_annotations.ts
@@ -20,10 +20,10 @@ export default function ({ getService }: FtrProviderContext) {
   const ml = getService('ml');
 
   const remoteName = 'ftr-remote:';
-  const indexPatternName = 'ft_farequote';
-  const indexPatternString = config.get('esTestCluster.ccs')
-    ? remoteName + indexPatternName
-    : indexPatternName;
+  const esIndexPatternName = 'ft_farequote';
+  const esIndexPatternString = config.get('esTestCluster.ccs')
+    ? remoteName + esIndexPatternName
+    : esIndexPatternName;
 
   const testSetupJobConfigs = [SINGLE_METRIC_JOB_CONFIG, MULTI_METRIC_JOB_CONFIG];
 
@@ -64,7 +64,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(esIndexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();
@@ -72,7 +72,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteDataViewByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(esIndexPatternString);
     });
 
     for (const { suiteTitle, jobId, deleteAnnotations, expectedAnnotations } of testConfigs) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/geo_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/geo_job.ts
@@ -84,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -93,7 +93,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     it('job creation loads the geo wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/multi_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/multi_metric_job.ts
@@ -84,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -93,7 +93,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('job creation loads the multi metric wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/population_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/population_job.ts
@@ -98,7 +98,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -107,7 +107,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     it('job creation loads the population wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/saved_search_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/saved_search_job.ts
@@ -269,7 +269,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteFilterIfNeeded();
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded();
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
@@ -283,7 +283,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job.ts
@@ -75,10 +75,10 @@ export default function ({ getService }: FtrProviderContext) {
 
   const calendarId = `wizard-test-calendar_${Date.now()}`;
   const remoteName = 'ftr-remote:';
-  const indexPatternName = 'ft_farequote';
-  const indexPatternString = config.get('esTestCluster.ccs')
-    ? remoteName + indexPatternName
-    : indexPatternName;
+  const esIndexPatternName = 'ft_farequote';
+  const esIndexPatternString = config.get('esTestCluster.ccs')
+    ? remoteName + esIndexPatternName
+    : esIndexPatternName;
 
   const fieldStatsEntries = [
     {
@@ -92,7 +92,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(esIndexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -101,7 +101,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteDataViewByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(esIndexPatternString);
     });
 
     it('job creation loads the single metric wizard for the source data', async () => {
@@ -113,7 +113,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.jobManagement.navigateToNewJobSourceSelection();
 
       await ml.testExecution.logTestStep('job creation loads the job type selection page');
-      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(indexPatternString);
+      await ml.jobSourceSelection.selectSourceForAnomalyDetectionJob(esIndexPatternString);
 
       await ml.testExecution.logTestStep('job creation loads the single metric job wizard page');
       await ml.jobTypeSelection.selectSingleMetricJob();
@@ -230,7 +230,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('job cloning creates a temporary data view and opens the single metric wizard if a matching data view does not exist', async () => {
       await ml.testExecution.logTestStep('delete data view used by job');
-      await ml.testResources.deleteDataViewByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(esIndexPatternString);
 
       // Refresh page to ensure page has correct cache of data views
       await browser.refresh();
@@ -244,7 +244,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('job cloning opens the existing job in the single metric wizard', async () => {
       await ml.testExecution.logTestStep('recreate data view used by job');
-      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(esIndexPatternString, '@timestamp');
 
       await ml.navigation.navigateToMl();
       await ml.navigation.navigateToJobManagement();

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job.ts
@@ -92,7 +92,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esNode.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.api.createCalendar(calendarId);
@@ -101,7 +101,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(indexPatternString);
     });
 
     it('job creation loads the single metric wizard for the source data', async () => {
@@ -230,7 +230,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('job cloning creates a temporary data view and opens the single metric wizard if a matching data view does not exist', async () => {
       await ml.testExecution.logTestStep('delete data view used by job');
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternString);
+      await ml.testResources.deleteDataViewByTitle(indexPatternString);
 
       // Refresh page to ensure page has correct cache of data views
       await browser.refresh();
@@ -244,7 +244,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('job cloning opens the existing job in the single metric wizard', async () => {
       await ml.testExecution.logTestStep('recreate data view used by job');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternString, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternString, '@timestamp');
 
       await ml.navigation.navigateToMl();
       await ml.navigation.navigateToJobManagement();

--- a/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job_without_datafeed_start.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_jobs/single_metric_job_without_datafeed_start.ts
@@ -60,7 +60,7 @@ export default function ({ getService }: FtrProviderContext) {
     this.tags(['ml']);
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();
@@ -68,7 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('job creation loads the single metric wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/aggregated_scripted_job.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/aggregated_scripted_job.ts
@@ -364,16 +364,16 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
     });
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
     for (const testData of supportedTestSuites) {
       describe(testData.suiteTitle, function () {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/annotations.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/annotations.ts
@@ -32,7 +32,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       const JOB_CONFIG = ml.commonConfig.getADFqSingleMetricJobConfig(jobId);
@@ -47,7 +47,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     describe('creating', function () {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/anomaly_explorer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/anomaly_explorer.ts
@@ -76,7 +76,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.createMLTestDashboardIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -85,7 +85,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteMLTestDashboard();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/forecasts.ts
@@ -45,7 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('with single metric job', function () {
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-        await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
         await ml.testResources.setKibanaTimeZoneToUTC();
 
         await ml.api.createAndRunAnomalyDetectionLookbackJob(JOB_CONFIG, DATAFEED_CONFIG);
@@ -54,7 +54,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+        await ml.testResources.deleteDataViewByTitle('ft_farequote');
       });
 
       it('opens a job from job list link', async () => {

--- a/x-pack/test/functional/apps/ml/anomaly_detection_result_views/single_metric_viewer.ts
+++ b/x-pack/test/functional/apps/ml/anomaly_detection_result_views/single_metric_viewer.ts
@@ -46,7 +46,7 @@ export default function ({ getService }: FtrProviderContext) {
     describe('with single metric job', function () {
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-        await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
         await ml.testResources.setKibanaTimeZoneToUTC();
 
         await ml.api.createAndRunAnomalyDetectionLookbackJob(JOB_CONFIG, DATAFEED_CONFIG);
@@ -55,7 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+        await ml.testResources.deleteDataViewByTitle('ft_farequote');
       });
 
       it('opens a job from job list link', async () => {
@@ -134,7 +134,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-        await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+        await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
         await ml.testResources.setKibanaTimeZoneToUTC();
         await ml.api.createAndRunAnomalyDetectionLookbackJob(jobConfig, datafeedConfig);
         await ml.securityUI.loginAsMlPowerUser();
@@ -142,7 +142,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       after(async () => {
         await ml.api.cleanMlIndices();
-        await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+        await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
       });
 
       it('opens a job from job list link', async () => {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation.ts
@@ -43,7 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
     let testDashboardId: string | null = null;
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/bm_classification');
-      await ml.testResources.createIndexPatternIfNeeded('ft_bank_marketing');
+      await ml.testResources.createDataViewIfNeeded('ft_bank_marketing');
       await ml.testResources.setKibanaTimeZoneToUTC();
       testDashboardId = await ml.testResources.createMLTestDashboardIfNeeded();
 
@@ -52,7 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
+      await ml.testResources.deleteDataViewByTitle('ft_bank_marketing');
     });
 
     const jobId = `bm_1_${Date.now()}`;
@@ -201,7 +201,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -338,8 +338,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(
             testData.createIndexPattern
           );
         });

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation_saved_search.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/classification_creation_saved_search.ts
@@ -18,7 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe.skip('classification saved search creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote_small');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote_small', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded('ft_farequote_small');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded('ft_farequote_small');
       // Need to use the saved searches with filters that match multiple airlines
@@ -36,7 +36,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote_small');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote_small');
     });
 
     const dateNow = Date.now();
@@ -93,7 +93,7 @@ export default function ({ getService }: FtrProviderContext) {
         dependentVariable: 'airline',
         trainingPercent: 20,
         modelMemory: '20mb',
-        createIndexPattern: true,
+        createDataView: true,
         expected: {
           fieldStatsValues: { airline: ['AAL', 'AWE', 'ASA', 'ACA', 'AMX'] } as Record<
             string,
@@ -193,7 +193,7 @@ export default function ({ getService }: FtrProviderContext) {
         dependentVariable: 'airline',
         trainingPercent: 20,
         modelMemory: '20mb',
-        createIndexPattern: true,
+        createDataView: true,
         expected: {
           fieldStatsValues: { airline: ['AAL', 'AWE', 'ASA', 'ACA', 'AMX'] } as Record<
             string,
@@ -293,7 +293,7 @@ export default function ({ getService }: FtrProviderContext) {
         dependentVariable: 'airline',
         trainingPercent: 20,
         modelMemory: '20mb',
-        createIndexPattern: true,
+        createDataView: true,
         expected: {
           fieldStatsValues: {
             airline: ['AAL', 'ASA'],
@@ -385,7 +385,7 @@ export default function ({ getService }: FtrProviderContext) {
         dependentVariable: 'airline',
         trainingPercent: 20,
         modelMemory: '20mb',
-        createIndexPattern: true,
+        createDataView: true,
         expected: {
           fieldStatsValues: { airline: ['ASA', 'FFT'] } as Record<string, string[]>,
           source: 'ft_farequote_small',
@@ -463,7 +463,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -592,10 +592,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
-            testData.createIndexPattern
-          );
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(testData.createDataView);
         });
 
         it('runs the analytics job and displays it correctly in the job list', async () => {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/cloning.ts
@@ -141,7 +141,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         before(async () => {
           await esArchiver.loadIfNeeded(testData.archive);
-          await ml.testResources.createIndexPatternIfNeeded(
+          await ml.testResources.createDataViewIfNeeded(
             testData.indexPattern.name,
             testData.indexPattern.timeField
           );
@@ -157,9 +157,9 @@ export default function ({ getService }: FtrProviderContext) {
         after(async () => {
           await ml.api.deleteIndices(cloneDestIndex);
           await ml.api.deleteIndices(testData.job.dest!.index as string);
-          await ml.testResources.deleteIndexPatternByTitle(testData.job.dest!.index as string);
-          await ml.testResources.deleteIndexPatternByTitle(cloneDestIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
+          await ml.testResources.deleteDataViewByTitle(testData.job.dest!.index as string);
+          await ml.testResources.deleteDataViewByTitle(cloneDestIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.indexPattern.name);
         });
 
         it('opens the existing job in the data frame analytics job wizard', async () => {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/custom_urls.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/custom_urls.ts
@@ -70,7 +70,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
       await ml.api.createAndRunDFAJob(dfaJobConfig);
@@ -79,7 +79,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       await ml.api.deleteIndices('user-farequote_small');
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     describe('run custom urls', function () {

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
@@ -36,13 +36,13 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     loadTestFile(require.resolve('./outlier_detection_creation'));
-    loadTestFile(require.resolve('./regression_creation'));
-    loadTestFile(require.resolve('./classification_creation'));
-    loadTestFile(require.resolve('./cloning'));
-    loadTestFile(require.resolve('./results_view_content'));
-    loadTestFile(require.resolve('./regression_creation_saved_search'));
-    loadTestFile(require.resolve('./classification_creation_saved_search'));
-    loadTestFile(require.resolve('./outlier_detection_creation_saved_search'));
-    loadTestFile(require.resolve('./custom_urls'));
+    // loadTestFile(require.resolve('./regression_creation'));
+    // loadTestFile(require.resolve('./classification_creation'));
+    // loadTestFile(require.resolve('./cloning'));
+    // loadTestFile(require.resolve('./results_view_content'));
+    // loadTestFile(require.resolve('./regression_creation_saved_search'));
+    // loadTestFile(require.resolve('./classification_creation_saved_search'));
+    // loadTestFile(require.resolve('./outlier_detection_creation_saved_search'));
+    // loadTestFile(require.resolve('./custom_urls'));
   });
 }

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/index.ts
@@ -36,13 +36,13 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
     });
 
     loadTestFile(require.resolve('./outlier_detection_creation'));
-    // loadTestFile(require.resolve('./regression_creation'));
-    // loadTestFile(require.resolve('./classification_creation'));
-    // loadTestFile(require.resolve('./cloning'));
-    // loadTestFile(require.resolve('./results_view_content'));
-    // loadTestFile(require.resolve('./regression_creation_saved_search'));
-    // loadTestFile(require.resolve('./classification_creation_saved_search'));
-    // loadTestFile(require.resolve('./outlier_detection_creation_saved_search'));
-    // loadTestFile(require.resolve('./custom_urls'));
+    loadTestFile(require.resolve('./regression_creation'));
+    loadTestFile(require.resolve('./classification_creation'));
+    loadTestFile(require.resolve('./cloning'));
+    loadTestFile(require.resolve('./results_view_content'));
+    loadTestFile(require.resolve('./regression_creation_saved_search'));
+    loadTestFile(require.resolve('./classification_creation_saved_search'));
+    loadTestFile(require.resolve('./outlier_detection_creation_saved_search'));
+    loadTestFile(require.resolve('./custom_urls'));
   });
 }

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation.ts
@@ -44,7 +44,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier');
+      await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier');
       testDashboardId = await ml.testResources.createMLTestDashboardIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -53,7 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
+      await ml.testResources.deleteDataViewByTitle('ft_ihp_outlier');
     });
 
     const jobId = `ihp_1_${Date.now()}`;
@@ -192,7 +192,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -324,8 +324,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(
             testData.createIndexPattern
           );
         });

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation_saved_search.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/outlier_detection_creation_saved_search.ts
@@ -16,7 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('outlier detection saved search creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote_small');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote_small', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded('ft_farequote_small');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded('ft_farequote_small');
       await ml.testResources.createSavedSearchFarequoteFilterAndLuceneIfNeeded(
@@ -31,7 +31,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote_small');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote_small');
     });
 
     const dateNow = Date.now();
@@ -362,7 +362,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -463,8 +463,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(
             testData.createIndexPattern
           );
         });

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation.ts
@@ -57,7 +57,7 @@ export default function ({ getService }: FtrProviderContext) {
     let testDashboardId: string | null = null;
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/egs_regression');
-      await ml.testResources.createIndexPatternIfNeeded('ft_egs_regression');
+      await ml.testResources.createDataViewIfNeeded('ft_egs_regression');
       await ml.testResources.setKibanaTimeZoneToUTC();
       testDashboardId = await ml.testResources.createMLTestDashboardIfNeeded();
 
@@ -66,7 +66,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
+      await ml.testResources.deleteDataViewByTitle('ft_egs_regression');
     });
 
     const jobId = `egs_1_${Date.now()}`;
@@ -197,7 +197,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -339,8 +339,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(
             testData.createIndexPattern
           );
         });

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation_saved_search.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/regression_creation_saved_search.ts
@@ -16,7 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('regression saved search creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote_small');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote_small', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote_small', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded('ft_farequote_small');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded('ft_farequote_small');
       await ml.testResources.createSavedSearchFarequoteFilterAndLuceneIfNeeded(
@@ -31,7 +31,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote_small');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote_small');
     });
 
     const dateNow = Date.now();
@@ -401,7 +401,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await ml.api.deleteIndices(testData.destinationIndex);
-          await ml.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await ml.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the data frame analytics wizard', async () => {
@@ -498,8 +498,8 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.dataFrameAnalyticsCreation.continueToCreateStep();
 
           await ml.testExecution.logTestStep('sets the create data view switch');
-          await ml.dataFrameAnalyticsCreation.assertCreateIndexPatternSwitchExists();
-          await ml.dataFrameAnalyticsCreation.setCreateIndexPatternSwitchState(
+          await ml.dataFrameAnalyticsCreation.assertCreateDataViewSwitchExists();
+          await ml.dataFrameAnalyticsCreation.setCreateDataViewSwitchState(
             testData.createIndexPattern
           );
         });

--- a/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
+++ b/x-pack/test/functional/apps/ml/data_frame_analytics/results_view_content.ts
@@ -252,7 +252,7 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.securityUI.loginAsMlPowerUser();
       for (const testData of testDataList) {
         await esArchiver.loadIfNeeded(testData.archive);
-        await ml.testResources.createIndexPatternIfNeeded(
+        await ml.testResources.createDataViewIfNeeded(
           testData.indexPattern.name,
           testData.indexPattern.timeField
         );
@@ -263,7 +263,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await ml.api.cleanMlIndices();
       for (const testData of testDataList) {
-        await ml.testResources.deleteIndexPatternByTitle(testData.indexPattern.name);
+        await ml.testResources.deleteDataViewByTitle(testData.indexPattern.name);
       }
     });
 
@@ -273,13 +273,13 @@ export default function ({ getService }: FtrProviderContext) {
           await ml.navigation.navigateToMl();
           await ml.navigation.navigateToDataFrameAnalytics();
           await ml.dataFrameAnalyticsTable.waitForAnalyticsToLoad();
-          await ml.testResources.createIndexPatternIfNeeded(testData.job.dest!.index as string);
+          await ml.testResources.createDataViewIfNeeded(testData.job.dest!.index as string);
           await ml.dataFrameAnalyticsTable.openResultsView(testData.job.id as string);
         });
 
         after(async () => {
           await ml.api.deleteIndices(testData.job.dest!.index as string);
-          await ml.testResources.deleteIndexPatternByTitle(testData.job.dest!.index as string);
+          await ml.testResources.deleteDataViewByTitle(testData.job.dest!.index as string);
         });
 
         it('should display the total feature importance in the results view', async () => {

--- a/x-pack/test/functional/apps/ml/data_visualizer/data_drift.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/data_drift.ts
@@ -84,10 +84,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('data drift', async function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier');
+      await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier');
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteFilterAndKueryIfNeeded();
 
       await ml.testResources.setKibanaTimeZoneToUTC();
@@ -97,10 +97,10 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ihp_outlier');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await Promise.all([
-        ml.testResources.deleteIndexPatternByTitle('ft_fare*'),
-        ml.testResources.deleteIndexPatternByTitle('ft_fare*,ft_fareq*'),
-        ml.testResources.deleteIndexPatternByTitle('ft_farequote'),
-        ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier'),
+        ml.testResources.deleteDataViewByTitle('ft_fare*'),
+        ml.testResources.deleteDataViewByTitle('ft_fare*,ft_fareq*'),
+        ml.testResources.deleteDataViewByTitle('ft_farequote'),
+        ml.testResources.deleteDataViewByTitle('ft_ihp_outlier'),
       ]);
     });
 

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -147,8 +147,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/module_sample_logs');
 
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_module_sample_logs', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_module_sample_logs', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded();
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
       await ml.testResources.createSavedSearchFarequoteFilterAndKueryIfNeeded();
@@ -159,8 +159,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_logs');
     });
 
     describe('with farequote', function () {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer.ts
@@ -26,7 +26,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the saved search selection page`
       );
-      await ml.dataVisualizer.navigateToIndexPatternSelection();
+      await ml.dataVisualizer.navigateToDataViewSelection();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the index data visualizer page`
@@ -223,7 +223,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
         await ml.testExecution.logTestStep(
           `${testData.suiteTitle} loads the saved search selection page`
         );
-        await ml.dataVisualizer.navigateToIndexPatternSelection();
+        await ml.dataVisualizer.navigateToDataViewSelection();
 
         await ml.testExecution.logTestStep(
           `${testData.suiteTitle} loads the index data visualizer page`

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
@@ -14,7 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('index based actions panel on trial license', function () {
     this.tags(['ml']);
 
-    const indexPatternName = 'ft_farequote';
+    const esIndexName = 'ft_farequote';
 
     const advancedJobWizardDatafeedQuery = JSON.stringify(
       {
@@ -33,7 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createDataViewIfNeeded(indexPatternName, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(esIndexName, '@timestamp');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -42,7 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteDataViewByTitle(indexPatternName);
+      await ml.testResources.deleteDataViewByTitle(esIndexName);
     });
 
     describe('create advanced job action', function () {
@@ -55,7 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.dataVisualizer.navigateToIndexPatternSelection();
 
         await ml.testExecution.logTestStep('loads the index data visualizer page');
-        await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(indexPatternName);
+        await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(esIndexName);
       });
 
       it('opens the advanced job wizard', async () => {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
@@ -33,7 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternName, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternName, '@timestamp');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -42,7 +42,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternName);
+      await ml.testResources.deleteDataViewByTitle(indexPatternName);
     });
 
     describe('create advanced job action', function () {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_actions_panel.ts
@@ -52,7 +52,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.navigation.navigateToDataVisualizer();
 
         await ml.testExecution.logTestStep('loads the saved search selection page');
-        await ml.dataVisualizer.navigateToIndexPatternSelection();
+        await ml.dataVisualizer.navigateToDataViewSelection();
 
         await ml.testExecution.logTestStep('loads the index data visualizer page');
         await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(esIndexName);
@@ -84,7 +84,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.navigation.navigateToDataVisualizer();
 
         await ml.testExecution.logTestStep('loads the saved search selection page');
-        await ml.dataVisualizer.navigateToIndexPatternSelection();
+        await ml.dataVisualizer.navigateToDataViewSelection();
 
         await ml.testExecution.logTestStep('loads the index data visualizer page');
         await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(savedSearch);

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_data_view_management.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_data_view_management.ts
@@ -182,12 +182,12 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     beforeEach(async () => {
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternTitle, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternTitle, '@timestamp');
       await navigateToIndexDataVisualizer(originalTestData);
     });
 
     afterEach(async () => {
-      await ml.testResources.deleteIndexPatternByTitle(indexPatternTitle);
+      await ml.testResources.deleteDataViewByTitle(indexPatternTitle);
     });
 
     it(`adds new field`, async () => {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_data_view_management.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_data_view_management.ts
@@ -118,7 +118,7 @@ export default function ({ getService }: FtrProviderContext) {
     await ml.testExecution.logTestStep(
       `${testData.suiteTitle} loads the saved search selection page`
     );
-    await ml.dataVisualizer.navigateToIndexPatternSelection();
+    await ml.dataVisualizer.navigateToDataViewSelection();
 
     await ml.testExecution.logTestStep(
       `${testData.suiteTitle} loads the index data visualizer page`

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_filters.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_filters.ts
@@ -124,7 +124,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('data visualizer with pinned global filters', function () {
     before(async function () {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteFilterAndLuceneIfNeeded();
       await ml.testResources.createSavedSearchFarequoteFilterAndKueryIfNeeded();
 
@@ -133,7 +133,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async function () {
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     describe(`with ${farequoteDataViewTestData.suiteTitle}`, function () {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_filters.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_filters.ts
@@ -54,7 +54,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the saved search selection page`
       );
-      await ml.dataVisualizer.navigateToIndexPatternSelection();
+      await ml.dataVisualizer.navigateToDataViewSelection();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the index data visualizer page`
@@ -91,7 +91,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the saved search selection page`
       );
-      await ml.dataVisualizer.navigateToIndexPatternSelection();
+      await ml.dataVisualizer.navigateToDataViewSelection();
 
       await ml.testExecution.logTestStep(
         `${testData.suiteTitle} loads the index data visualizer page`

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_dashboard.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_dashboard.ts
@@ -115,7 +115,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('field statistics in Dashboard', function () {
     before(async function () {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteFilterAndLuceneIfNeeded();
       await ml.securityUI.loginAsMlPowerUser();
     });
@@ -123,7 +123,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async function () {
       await ml.testResources.clearAdvancedSettingProperty(SHOW_FIELD_STATISTICS);
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     runTests(farequoteLuceneFiltersSearchTestData);

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_discover.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_grid_in_discover.ts
@@ -96,8 +96,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     before(async function () {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/module_sample_logs');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_module_sample_logs', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_module_sample_logs', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded();
       await ml.testResources.createSavedSearchFarequoteFilterAndLuceneIfNeeded();
@@ -109,8 +109,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     after(async function () {
       await ml.testResources.clearAdvancedSettingProperty(SHOW_FIELD_STATISTICS);
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_logs');
     });
 
     describe('when enabled', function () {

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_random_sampler.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_random_sampler.ts
@@ -17,7 +17,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
     await ml.navigation.navigateToDataVisualizer();
 
     await ml.testExecution.logTestStep(`loads the saved search selection page`);
-    await ml.dataVisualizer.navigateToIndexPatternSelection();
+    await ml.dataVisualizer.navigateToDataViewSelection();
 
     await ml.testExecution.logTestStep(`loads the index data visualizer page`);
     await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(sourceIndexOrSavedSearch);

--- a/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_random_sampler.ts
+++ b/x-pack/test/functional/apps/ml/data_visualizer/index_data_visualizer_random_sampler.ts
@@ -28,8 +28,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/module_sample_logs');
 
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_module_sample_logs', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_module_sample_logs', '@timestamp');
       await ml.testResources.createSavedSearchFarequoteLuceneIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -40,8 +40,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.testResources.deleteSavedSearches();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_logs');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_logs');
       await browser.removeLocalStorageItem('dataVisualizer.randomSamplerPreference');
     });
 

--- a/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
@@ -132,9 +132,9 @@ export default function ({ getService }: FtrProviderContext) {
         await esArchiver.loadIfNeeded(
           'x-pack/test/functional/es_archives/ml/module_sample_ecommerce'
         );
-        await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-        await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier', '@timestamp');
-        await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+        await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded(ecIndexPattern, 'order_date');
         await ml.testResources.setKibanaTimeZoneToUTC();
 
         await ml.api.createAndRunAnomalyDetectionLookbackJob(
@@ -170,9 +170,9 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.api.deleteCalendar(calendarId);
         await ml.api.deleteFilter(filterId);
         await ml.api.cleanMlIndices();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
-        await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
+        await ml.testResources.deleteDataViewByTitle('ft_farequote');
+        await ml.testResources.deleteDataViewByTitle('ft_ihp_outlier');
+        await ml.testResources.deleteDataViewByTitle(ecIndexPattern);
       });
 
       for (const testUser of testUsers) {

--- a/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/full_ml_access.ts
@@ -387,7 +387,7 @@ export default function ({ getService }: FtrProviderContext) {
             await ml.testExecution.logTestStep(
               'should load an index into the data visualizer page'
             );
-            await ml.dataVisualizer.navigateToIndexPatternSelection();
+            await ml.dataVisualizer.navigateToDataViewSelection();
             await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexPattern);
 
             await ml.testExecution.logTestStep('should display the time range step');

--- a/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
@@ -138,9 +138,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await esArchiver.loadIfNeeded(
           'x-pack/test/functional/es_archives/ml/module_sample_ecommerce'
         );
-        await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-        await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier', '@timestamp');
-        await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+        await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier', '@timestamp');
+        await ml.testResources.createDataViewIfNeeded(ecIndexPattern, 'order_date');
         await ml.testResources.setKibanaTimeZoneToUTC();
 
         await ml.api.createAndRunAnomalyDetectionLookbackJob(
@@ -176,9 +176,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await ml.api.deleteCalendar(calendarId);
         await ml.api.deleteFilter(filterId);
         await ml.api.cleanMlIndices();
-        await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-        await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
-        await ml.testResources.deleteIndexPatternByTitle(ecIndexPattern);
+        await ml.testResources.deleteDataViewByTitle('ft_farequote');
+        await ml.testResources.deleteDataViewByTitle('ft_ihp_outlier');
+        await ml.testResources.deleteDataViewByTitle(ecIndexPattern);
       });
 
       for (const testUser of testUsers) {

--- a/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional/apps/ml/permissions/read_ml_access.ts
@@ -378,7 +378,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             await ml.testExecution.logTestStep(
               'should load an index into the data visualizer page'
             );
-            await ml.dataVisualizer.navigateToIndexPatternSelection();
+            await ml.dataVisualizer.navigateToDataViewSelection();
             await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexPattern);
 
             await ml.testExecution.logTestStep('should display the time range step');

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -120,7 +120,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       // Need to delete index before ingest pipeline, else it will give error
       await ml.api.deleteIngestPipeline(modelWithPipelineAndDestIndex.modelId);
-      await ml.testResources.deleteIndexPatternByTitle(
+      await ml.testResources.deleteDataViewByTitle(
         modelWithPipelineAndDestIndexExpectedValues.dataViewTitle
       );
     });

--- a/x-pack/test/functional/apps/ml/short_tests/notifications/notification_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/notifications/notification_list.ts
@@ -29,7 +29,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('Notifications list', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
 
@@ -54,7 +54,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await spacesService.delete(idSpace1);
       await ml.api.cleanMlIndices();
       await ml.testResources.cleanMLSavedObjects();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('displays a generic notification indicator', async () => {

--- a/x-pack/test/functional/apps/ml/short_tests/settings/calendar_creation.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/settings/calendar_creation.ts
@@ -18,7 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('calendar creation', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
 
       await asyncForEach(jobConfigs, async (jobConfig) => {
         // @ts-expect-error not full interface
@@ -30,7 +30,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     afterEach(async () => {

--- a/x-pack/test/functional/apps/ml/short_tests/settings/calendar_edit.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/settings/calendar_edit.ts
@@ -24,7 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('calendar edit', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
 
       await asyncForEach(jobConfigs, async (jobConfig) => {
         // @ts-expect-error not full interface
@@ -43,7 +43,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     afterEach(async () => {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/export_jobs.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/export_jobs.ts
@@ -257,16 +257,16 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await ml.api.cleanMlIndices();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/bm_classification');
-      await ml.testResources.createIndexPatternIfNeeded('ft_bank_marketing', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_bank_marketing', '@timestamp');
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier', '@timestamp');
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/egs_regression');
-      await ml.testResources.createIndexPatternIfNeeded('ft_egs_regression', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_egs_regression', '@timestamp');
 
       await ml.testResources.setKibanaTimeZoneToUTC();
 
@@ -289,10 +289,10 @@ export default function ({ getService }: FtrProviderContext) {
         'anomaly_detection_jobs',
         'data_frame_analytics_jobs',
       ]);
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
-      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
-      await ml.testResources.deleteIndexPatternByTitle('ft_egs_regression');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_bank_marketing');
+      await ml.testResources.deleteDataViewByTitle('ft_ihp_outlier');
+      await ml.testResources.deleteDataViewByTitle('ft_egs_regression');
     });
 
     it('opens export flyout and exports anomaly detector jobs', async () => {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/import_jobs.ts
@@ -36,8 +36,8 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.api.cleanMlIndices();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/bm_classification');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_bank_marketing', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_bank_marketing', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();
@@ -47,8 +47,8 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await ml.api.cleanMlIndices();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_bank_marketing');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_bank_marketing');
     });
 
     for (const testData of testDataListPositive) {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/manage_spaces.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/manage_spaces.ts
@@ -111,8 +111,8 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier', '@timestamp');
 
       await ml.testResources.setKibanaTimeZoneToUTC();
       await ml.securityUI.loginAsMlPowerUser();
@@ -137,8 +137,8 @@ export default function ({ getService }: FtrProviderContext) {
       }
       await ml.api.cleanMlIndices();
       await ml.testResources.cleanMLSavedObjects([spaceIds.idSpace1]);
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_ihp_outlier');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_ihp_outlier');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/ml/stack_management_jobs/synchronize.ts
+++ b/x-pack/test/functional/apps/ml/stack_management_jobs/synchronize.ts
@@ -24,7 +24,7 @@ export default function ({ getService }: FtrProviderContext) {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();
@@ -40,7 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.api.deleteDataFrameAnalyticsJobES(dfaJobId);
       }
       await ml.testResources.cleanMLSavedObjects();
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     it('should have nothing to sync initially', async () => {

--- a/x-pack/test/functional/apps/transform/actions/deleting.ts
+++ b/x-pack/test/functional/apps/transform/actions/deleting.ts
@@ -65,7 +65,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {
         await transform.api.createAndRunTransform(
@@ -80,11 +80,11 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       for (const testData of testDataList) {
-        await transform.testResources.deleteIndexPatternByTitle(testData.originalConfig.dest.index);
+        await transform.testResources.deleteDataViewByTitle(testData.originalConfig.dest.index);
         await transform.api.deleteIndices(testData.originalConfig.dest.index);
       }
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/transform/actions/reauthorizing.ts
+++ b/x-pack/test/functional/apps/transform/actions/reauthorizing.ts
@@ -138,7 +138,7 @@ export default function ({ getService }: FtrProviderContext) {
       );
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {
         await transform.api.createTransform(testData.originalConfig.id, testData.originalConfig, {
@@ -157,12 +157,12 @@ export default function ({ getService }: FtrProviderContext) {
       await transform.securityCommon.clearAllTransformApiKeys();
 
       for (const testData of testDataList) {
-        await transform.testResources.deleteIndexPatternByTitle(testData.originalConfig.dest.index);
+        await transform.testResources.deleteDataViewByTitle(testData.originalConfig.dest.index);
         await transform.api.deleteIndices(testData.originalConfig.dest.index);
       }
 
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/transform/actions/resetting.ts
+++ b/x-pack/test/functional/apps/transform/actions/resetting.ts
@@ -67,7 +67,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {
         await transform.api.createAndRunTransform(
@@ -82,11 +82,11 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       for (const testData of testDataList) {
-        await transform.testResources.deleteIndexPatternByTitle(testData.originalConfig.dest.index);
+        await transform.testResources.deleteDataViewByTitle(testData.originalConfig.dest.index);
         await transform.api.deleteIndices(testData.originalConfig.dest.index);
       }
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/transform/actions/starting.ts
+++ b/x-pack/test/functional/apps/transform/actions/starting.ts
@@ -110,7 +110,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       for (const testData of testDataList) {
         if (
@@ -135,12 +135,12 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       for (const testData of testDataList) {
-        await transform.testResources.deleteIndexPatternByTitle(testData.originalConfig.dest.index);
+        await transform.testResources.deleteDataViewByTitle(testData.originalConfig.dest.index);
         await transform.api.deleteIndices(testData.originalConfig.dest.index);
       }
 
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     for (const testData of testDataList) {

--- a/x-pack/test/functional/apps/transform/creation/index_pattern/continuous_transform.ts
+++ b/x-pack/test/functional/apps/transform/creation/index_pattern/continuous_transform.ts
@@ -36,7 +36,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     const DEFAULT_NUM_FAILURE_RETRIES = '5';
@@ -326,7 +326,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         });
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await transform.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
+++ b/x-pack/test/functional/apps/transform/creation/index_pattern/creation_index_pattern.ts
@@ -25,7 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
   describe('creation_index_pattern', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await transform.testResources.setKibanaTimeZoneToUTC();
 
       await transform.securityUI.loginAsTransformPowerUser();
@@ -33,7 +33,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
       await transform.securityUI.logout();
     });
 
@@ -509,7 +509,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await transform.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_runtime_mappings.ts
+++ b/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_runtime_mappings.ts
@@ -37,7 +37,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('creation with runtime mappings', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await transform.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await transform.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await transform.testResources.setKibanaTimeZoneToUTC();
 
       await transform.securityUI.loginAsTransformPowerUser();
@@ -45,7 +45,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     after(async () => {
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await transform.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     const histogramCharts: HistogramCharts = [
@@ -254,7 +254,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await transform.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
+++ b/x-pack/test/functional/apps/transform/creation/runtime_mappings_saved_search/creation_saved_search.ts
@@ -23,7 +23,7 @@ export default function ({ getService }: FtrProviderContext) {
   describe('creation_saved_search', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await transform.testResources.createIndexPatternIfNeeded('ft_farequote', '@timestamp');
+      await transform.testResources.createDataViewIfNeeded('ft_farequote', '@timestamp');
       await transform.testResources.createSavedSearchFarequoteFilterIfNeeded();
       await transform.testResources.setKibanaTimeZoneToUTC();
 
@@ -33,7 +33,7 @@ export default function ({ getService }: FtrProviderContext) {
     after(async () => {
       await transform.api.cleanTransformIndices();
       await transform.testResources.deleteSavedSearches();
-      await transform.testResources.deleteIndexPatternByTitle('ft_farequote');
+      await transform.testResources.deleteDataViewByTitle('ft_farequote');
     });
 
     const testDataList: Array<PivotTransformTestData | LatestTransformTestData> = [
@@ -121,7 +121,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await transform.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('loads the wizard for the source data', async () => {

--- a/x-pack/test/functional/apps/transform/edit_clone/cloning.ts
+++ b/x-pack/test/functional/apps/transform/edit_clone/cloning.ts
@@ -199,7 +199,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await transform.api.createAndRunTransform(
         transformConfigWithPivot.id,
         transformConfigWithPivot
@@ -223,17 +223,17 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await transform.testResources.deleteIndexPatternByTitle(transformConfigWithPivot.dest.index);
-      await transform.testResources.deleteIndexPatternByTitle(
+      await transform.testResources.deleteDataViewByTitle(transformConfigWithPivot.dest.index);
+      await transform.testResources.deleteDataViewByTitle(
         transformConfigWithRuntimeMapping.dest.index
       );
 
-      await transform.testResources.deleteIndexPatternByTitle(transformConfigWithLatest.dest.index);
+      await transform.testResources.deleteDataViewByTitle(transformConfigWithLatest.dest.index);
       await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
       await transform.api.deleteIndices(transformConfigWithRuntimeMapping.dest.index);
       await transform.api.deleteIndices(transformConfigWithLatest.dest.index);
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     const testDataList: TestData[] = [
@@ -397,7 +397,7 @@ export default function ({ getService }: FtrProviderContext) {
       describe(`${testData.suiteTitle}`, function () {
         after(async () => {
           await transform.api.deleteIndices(testData.destinationIndex);
-          await transform.testResources.deleteIndexPatternByTitle(testData.destinationIndex);
+          await transform.testResources.deleteDataViewByTitle(testData.destinationIndex);
         });
 
         it('opens the existing transform in the wizard', async () => {

--- a/x-pack/test/functional/apps/transform/edit_clone/editing.ts
+++ b/x-pack/test/functional/apps/transform/edit_clone/editing.ts
@@ -27,7 +27,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       await transform.api.createAndRunTransform(
         transformConfigWithPivot.id,
@@ -43,12 +43,12 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     after(async () => {
-      await transform.testResources.deleteIndexPatternByTitle(transformConfigWithPivot.dest.index);
+      await transform.testResources.deleteDataViewByTitle(transformConfigWithPivot.dest.index);
       await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
-      await transform.testResources.deleteIndexPatternByTitle(transformConfigWithLatest.dest.index);
+      await transform.testResources.deleteDataViewByTitle(transformConfigWithLatest.dest.index);
       await transform.api.deleteIndices(transformConfigWithLatest.dest.index);
       await transform.api.cleanTransformIndices();
-      await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
     });
 
     const testDataList = [

--- a/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/full_transform_access.ts
@@ -55,7 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-        await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+        await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
         await transform.api.createAndRunTransform(
           transformConfigWithPivot.id,
@@ -67,12 +67,10 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await transform.testResources.deleteIndexPatternByTitle(
-          transformConfigWithPivot.dest.index
-        );
+        await transform.testResources.deleteDataViewByTitle(transformConfigWithPivot.dest.index);
         await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
         await transform.api.cleanTransformIndices();
-        await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+        await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
       });
 
       it('should display elements in the Transform list page correctly', async () => {

--- a/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
+++ b/x-pack/test/functional/apps/transform/permissions/read_transform_access.ts
@@ -55,7 +55,7 @@ export default function ({ getService }: FtrProviderContext) {
 
       before(async () => {
         await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-        await transform.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+        await transform.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
         await transform.api.createAndRunTransform(
           transformConfigWithPivot.id,
@@ -67,12 +67,10 @@ export default function ({ getService }: FtrProviderContext) {
       });
 
       after(async () => {
-        await transform.testResources.deleteIndexPatternByTitle(
-          transformConfigWithPivot.dest.index
-        );
+        await transform.testResources.deleteDataViewByTitle(transformConfigWithPivot.dest.index);
         await transform.api.deleteIndices(transformConfigWithPivot.dest.index);
         await transform.api.cleanTransformIndices();
-        await transform.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+        await transform.testResources.deleteDataViewByTitle('ft_ecommerce');
       });
 
       it('should display elements in the Transform list page correctly', async () => {

--- a/x-pack/test/functional/services/aiops/change_point_detection_page.ts
+++ b/x-pack/test/functional/services/aiops/change_point_detection_page.ts
@@ -26,7 +26,7 @@ export function ChangePointDetectionPageProvider(
   const dashboardPage = getPageObject('dashboard');
 
   return {
-    async navigateToIndexPatternSelection() {
+    async navigateToDataViewSelection() {
       await testSubjects.click('mlMainTab changePointDetection');
       await testSubjects.existOrFail('mlPageSourceSelection');
     },

--- a/x-pack/test/functional/services/aiops/log_pattern_analysis_page.ts
+++ b/x-pack/test/functional/services/aiops/log_pattern_analysis_page.ts
@@ -21,7 +21,7 @@ export function LogPatternAnalysisPageProvider({ getService, getPageObject }: Ft
       });
     },
 
-    async navigateToIndexPatternSelection() {
+    async navigateToDataViewSelection() {
       await testSubjects.click('mlMainTab logCategorization');
       await testSubjects.existOrFail('mlPageSourceSelection');
     },

--- a/x-pack/test/functional/services/aiops/log_rate_analysis_page.ts
+++ b/x-pack/test/functional/services/aiops/log_rate_analysis_page.ts
@@ -255,7 +255,7 @@ export function LogRateAnalysisPageProvider({ getService, getPageObject }: FtrPr
       });
     },
 
-    async navigateToIndexPatternSelection() {
+    async navigateToDataViewSelection() {
       await testSubjects.click('mlMainTab logRateAnalysis');
       await testSubjects.existOrFail('mlPageSourceSelection');
     },

--- a/x-pack/test/functional/services/ml/common_ui.ts
+++ b/x-pack/test/functional/services/ml/common_ui.ts
@@ -287,12 +287,12 @@ export function MachineLearningCommonUIProvider({
           valueTolerance
         );
 
-        expect(actualColorStatsWithTolerance.every((d) => d.withinTolerance)).to.eql(
-          true,
-          `Color stats for '${dataTestSubj}' should be within tolerance. Expected: '${JSON.stringify(
-            expectedColorStats
-          )}' (got '${JSON.stringify(actualColorStatsWithTolerance)}')`
-        );
+        // expect(actualColorStatsWithTolerance.every((d) => d.withinTolerance)).to.eql(
+        //   true,
+        //   `Color stats for '${dataTestSubj}' should be within tolerance. Expected: '${JSON.stringify(
+        //     expectedColorStats
+        //   )}' (got '${JSON.stringify(actualColorStatsWithTolerance)}')`
+        // );
       });
     },
 

--- a/x-pack/test/functional/services/ml/common_ui.ts
+++ b/x-pack/test/functional/services/ml/common_ui.ts
@@ -287,12 +287,12 @@ export function MachineLearningCommonUIProvider({
           valueTolerance
         );
 
-        // expect(actualColorStatsWithTolerance.every((d) => d.withinTolerance)).to.eql(
-        //   true,
-        //   `Color stats for '${dataTestSubj}' should be within tolerance. Expected: '${JSON.stringify(
-        //     expectedColorStats
-        //   )}' (got '${JSON.stringify(actualColorStatsWithTolerance)}')`
-        // );
+        expect(actualColorStatsWithTolerance.every((d) => d.withinTolerance)).to.eql(
+          true,
+          `Color stats for '${dataTestSubj}' should be within tolerance. Expected: '${JSON.stringify(
+            expectedColorStats
+          )}' (got '${JSON.stringify(actualColorStatsWithTolerance)}')`
+        );
       });
     },
 

--- a/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
+++ b/x-pack/test/functional/services/ml/data_frame_analytics_creation.ts
@@ -623,22 +623,22 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
       });
     },
 
-    async assertCreateIndexPatternSwitchExists() {
-      await testSubjects.existOrFail(`mlAnalyticsCreateJobWizardCreateIndexPatternCheckbox`, {
+    async assertCreateDataViewSwitchExists() {
+      await testSubjects.existOrFail(`mlAnalyticsCreateJobWizardCreateDataViewCheckbox`, {
         allowHidden: true,
       });
     },
 
-    async getCreateIndexPatternSwitchCheckState(): Promise<boolean> {
+    async getCreateDataViewSwitchCheckState(): Promise<boolean> {
       const state = await testSubjects.getAttribute(
-        'mlAnalyticsCreateJobWizardCreateIndexPatternCheckbox',
+        'mlAnalyticsCreateJobWizardCreateDataViewCheckbox',
         'checked'
       );
       return state === 'true';
     },
 
-    async assertCreateIndexPatternSwitchCheckState(expectedCheckState: boolean) {
-      const actualCheckState = await this.getCreateIndexPatternSwitchCheckState();
+    async assertCreateDataViewSwitchCheckState(expectedCheckState: boolean) {
+      const actualCheckState = await this.getCreateDataViewSwitchCheckState();
       expect(actualCheckState).to.eql(
         expectedCheckState,
         `Create data view switch check state should be '${expectedCheckState}' (got '${actualCheckState}')`
@@ -674,11 +674,11 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
       await this.assertDestIndexSameAsIdCheckState(checkState);
     },
 
-    async setCreateIndexPatternSwitchState(checkState: boolean) {
-      if ((await this.getCreateIndexPatternSwitchCheckState()) !== checkState) {
-        await testSubjects.click('mlAnalyticsCreateJobWizardCreateIndexPatternCheckbox');
+    async setCreateDataViewSwitchState(checkState: boolean) {
+      if ((await this.getCreateDataViewSwitchCheckState()) !== checkState) {
+        await testSubjects.click('mlAnalyticsCreateJobWizardCreateDataViewCheckbox');
       }
-      await this.assertCreateIndexPatternSwitchCheckState(checkState);
+      await this.assertCreateDataViewSwitchCheckState(checkState);
     },
 
     async assertStartJobCheckboxExists() {
@@ -755,7 +755,6 @@ export function MachineLearningDataFrameAnalyticsCreationProvider(
     async assertCreationCalloutMessagesExist() {
       await testSubjects.existOrFail('analyticsWizardCreationCallout_0');
       await testSubjects.existOrFail('analyticsWizardCreationCallout_1');
-      await testSubjects.existOrFail('analyticsWizardCreationCallout_2');
     },
 
     async navigateToJobManagementPage() {

--- a/x-pack/test/functional/services/ml/data_visualizer.ts
+++ b/x-pack/test/functional/services/ml/data_visualizer.ts
@@ -55,7 +55,7 @@ export function MachineLearningDataVisualizerProvider({ getService }: FtrProvide
       );
     },
 
-    async navigateToIndexPatternSelection() {
+    async navigateToDataViewSelection() {
       await testSubjects.click('mlDataVisualizerSelectIndexButton');
       await testSubjects.existOrFail('mlPageSourceSelection');
     },

--- a/x-pack/test/functional/services/ml/test_resources.ts
+++ b/x-pack/test/functional/services/ml/test_resources.ts
@@ -120,7 +120,7 @@ export function MachineLearningTestResourcesProvider(
       return savedObjectIds;
     },
 
-    async getIndexPatternId(title: string, space?: string): Promise<string | undefined> {
+    async getDataViewId(title: string, space?: string): Promise<string | undefined> {
       return this.getSavedObjectIdByTitle(title, SavedObjectType.INDEX_PATTERN, space);
     },
 
@@ -136,11 +136,7 @@ export function MachineLearningTestResourcesProvider(
       return this.getSavedObjectIdByTitle(title, SavedObjectType.DASHBOARD);
     },
 
-    async createIndexPattern(
-      title: string,
-      timeFieldName?: string,
-      space?: string
-    ): Promise<string> {
+    async createDataView(title: string, timeFieldName?: string, space?: string): Promise<string> {
       log.debug(
         `Creating index pattern with title '${title}'${
           timeFieldName !== undefined ? ` and time field '${timeFieldName}'` : ''
@@ -153,7 +149,7 @@ export function MachineLearningTestResourcesProvider(
         .send({ attributes: { title, timeFieldName } });
       mlApi.assertResponseStatusCode(200, status, createResponse);
 
-      await this.assertIndexPatternExistByTitle(title, space);
+      await this.assertDataViewExistByTitle(title, space);
 
       log.debug(` > Created with id '${createResponse.id}'`);
       return createResponse.id;
@@ -172,21 +168,21 @@ export function MachineLearningTestResourcesProvider(
       return createResponse;
     },
 
-    async createIndexPatternIfNeeded(
+    async createDataViewIfNeeded(
       title: string,
       timeFieldName?: string,
       space?: string
     ): Promise<string> {
-      const indexPatternId = await this.getIndexPatternId(title, space);
-      if (indexPatternId !== undefined) {
+      const dataViewId = await this.getDataViewId(title, space);
+      if (dataViewId !== undefined) {
         log.debug(`Index pattern with title '${title}' already exists. Nothing to create.`);
-        return indexPatternId;
+        return dataViewId;
       } else {
-        return await this.createIndexPattern(title, timeFieldName, space);
+        return await this.createDataView(title, timeFieldName, space);
       }
     },
 
-    async assertIndexPatternNotExist(title: string) {
+    async assertDataViewNotExist(title: string) {
       await this.assertSavedObjectNotExistsByTitle(title, SavedObjectType.INDEX_PATTERN);
     },
 
@@ -218,7 +214,7 @@ export function MachineLearningTestResourcesProvider(
       return createResponse.id;
     },
 
-    async createSavedSearchIfNeeded(savedSearch: any, indexPatternTitle: string): Promise<string> {
+    async createSavedSearchIfNeeded(savedSearch: any, dataViewTitle: string): Promise<string> {
       const title = savedSearch.requestBody.attributes.title;
       const savedSearchId = await this.getSavedSearchId(title);
       if (savedSearchId !== undefined) {
@@ -227,24 +223,24 @@ export function MachineLearningTestResourcesProvider(
       } else {
         const body = await this.updateSavedSearchRequestBody(
           savedSearch.requestBody,
-          indexPatternTitle
+          dataViewTitle
         );
         return await this.createSavedSearch(title, body);
       }
     },
 
-    async updateSavedSearchRequestBody(body: object, indexPatternTitle: string): Promise<object> {
-      const indexPatternId = await this.getIndexPatternId(indexPatternTitle);
-      if (indexPatternId === undefined) {
+    async updateSavedSearchRequestBody(body: object, dataViewTitle: string): Promise<object> {
+      const dataViewId = await this.getDataViewId(dataViewTitle);
+      if (dataViewId === undefined) {
         throw new Error(
-          `Index pattern '${indexPatternTitle}' to base saved search on does not exist. `
+          `Index pattern '${dataViewTitle}' to base saved search on does not exist. `
         );
       }
 
       // inject index pattern id
       const updatedBody = JSON.parse(JSON.stringify(body), (_key, value) => {
         if (value === 'INDEX_PATTERN_ID_PLACEHOLDER') {
-          return indexPatternId;
+          return dataViewId;
         } else {
           return value;
         }
@@ -258,8 +254,8 @@ export function MachineLearningTestResourcesProvider(
       return updatedBody;
     },
 
-    async createSavedSearchFarequoteFilterIfNeeded(indexPatternTitle: string = 'ft_farequote') {
-      await this.createSavedSearchIfNeeded(savedSearches.farequoteFilter, indexPatternTitle);
+    async createSavedSearchFarequoteFilterIfNeeded(dataViewTitle: string = 'ft_farequote') {
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteFilter, dataViewTitle);
     },
 
     async createMLTestDashboardIfNeeded(): Promise<string> {
@@ -281,48 +277,37 @@ export function MachineLearningTestResourcesProvider(
       }
     },
 
-    async createSavedSearchFarequoteLuceneIfNeeded(indexPatternTitle: string = 'ft_farequote') {
-      await this.createSavedSearchIfNeeded(savedSearches.farequoteLucene, indexPatternTitle);
+    async createSavedSearchFarequoteLuceneIfNeeded(dataViewTitle: string = 'ft_farequote') {
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteLucene, dataViewTitle);
     },
 
-    async createSavedSearchFarequoteKueryIfNeeded(indexPatternTitle: string = 'ft_farequote') {
-      await this.createSavedSearchIfNeeded(savedSearches.farequoteKuery, indexPatternTitle);
+    async createSavedSearchFarequoteKueryIfNeeded(dataViewTitle: string = 'ft_farequote') {
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteKuery, dataViewTitle);
     },
 
     async createSavedSearchFarequoteFilterAndLuceneIfNeeded(
-      indexPatternTitle: string = 'ft_farequote'
+      dataViewTitle: string = 'ft_farequote'
     ) {
-      await this.createSavedSearchIfNeeded(
-        savedSearches.farequoteFilterAndLucene,
-        indexPatternTitle
-      );
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteFilterAndLucene, dataViewTitle);
     },
 
-    async createSavedSearchFarequoteFilterAndKueryIfNeeded(
-      indexPatternTitle: string = 'ft_farequote'
-    ) {
-      await this.createSavedSearchIfNeeded(
-        savedSearches.farequoteFilterAndKuery,
-        indexPatternTitle
-      );
+    async createSavedSearchFarequoteFilterAndKueryIfNeeded(dataViewTitle: string = 'ft_farequote') {
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteFilterAndKuery, dataViewTitle);
     },
 
     async createSavedSearchFarequoteFilterTwoAndLuceneIfNeeded(
-      indexPatternTitle: string = 'ft_farequote'
+      dataViewTitle: string = 'ft_farequote'
     ) {
       await this.createSavedSearchIfNeeded(
         savedSearches.farequoteFilterTwoAndLucene,
-        indexPatternTitle
+        dataViewTitle
       );
     },
 
     async createSavedSearchFarequoteFilterTwoAndKueryIfNeeded(
-      indexPatternTitle: string = 'ft_farequote'
+      dataViewTitle: string = 'ft_farequote'
     ) {
-      await this.createSavedSearchIfNeeded(
-        savedSearches.farequoteFilterTwoAndKuery,
-        indexPatternTitle
-      );
+      await this.createSavedSearchIfNeeded(savedSearches.farequoteFilterTwoAndKuery, dataViewTitle);
     },
 
     async deleteSavedObjectById(
@@ -349,19 +334,19 @@ export function MachineLearningTestResourcesProvider(
       }
     },
 
-    async deleteIndexPatternByTitle(title: string, space?: string) {
+    async deleteDataViewByTitle(title: string, space?: string) {
       log.debug(`Deleting index pattern with title '${title}'...`);
 
-      const indexPatternId = await this.getIndexPatternId(title, space);
-      if (indexPatternId === undefined) {
+      const dataViewId = await this.getDataViewId(title, space);
+      if (dataViewId === undefined) {
         log.debug(`Index pattern with title '${title}' does not exists. Nothing to delete.`);
         return;
       } else {
-        await this.deleteIndexPatternById(indexPatternId, space);
+        await this.deleteDataViewById(dataViewId, space);
       }
     },
 
-    async deleteIndexPatternById(id: string, space?: string) {
+    async deleteDataViewById(id: string, space?: string) {
       await this.deleteSavedObjectById(id, SavedObjectType.INDEX_PATTERN, false, space);
     },
 
@@ -485,11 +470,11 @@ export function MachineLearningTestResourcesProvider(
       );
     },
 
-    async assertIndexPatternExistByTitle(title: string, space?: string) {
+    async assertDataViewExistByTitle(title: string, space?: string) {
       await this.assertSavedObjectExistsByTitle(title, SavedObjectType.INDEX_PATTERN, space);
     },
 
-    async assertIndexPatternExistById(id: string) {
+    async assertDataViewExistById(id: string) {
       await this.assertSavedObjectExistsById(id, SavedObjectType.INDEX_PATTERN);
     },
 

--- a/x-pack/test/functional_basic/apps/ml/data_visualizer/group1/index.ts
+++ b/x-pack/test/functional_basic/apps/ml/data_visualizer/group1/index.ts
@@ -25,8 +25,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       await ml.testResources.deleteSavedSearches();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_ecommerce');
 
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');

--- a/x-pack/test/functional_basic/apps/ml/data_visualizer/group2/index.ts
+++ b/x-pack/test/functional_basic/apps/ml/data_visualizer/group2/index.ts
@@ -25,8 +25,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       await ml.testResources.deleteSavedSearches();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_ecommerce');
 
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');

--- a/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index.ts
+++ b/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index.ts
@@ -25,8 +25,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       await ml.testResources.deleteSavedSearches();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_ecommerce');
 
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');

--- a/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index_data_visualizer_actions_panel.ts
@@ -34,7 +34,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.navigation.navigateToDataVisualizer();
 
         await ml.testExecution.logTestStep('loads the saved search selection page');
-        await ml.dataVisualizer.navigateToIndexPatternSelection();
+        await ml.dataVisualizer.navigateToDataViewSelection();
 
         await ml.testExecution.logTestStep('loads the index data visualizer page');
         await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(savedSearch);

--- a/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index_data_visualizer_actions_panel.ts
+++ b/x-pack/test/functional_basic/apps/ml/data_visualizer/group3/index_data_visualizer_actions_panel.ts
@@ -20,7 +20,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/farequote');
-      await ml.testResources.createIndexPatternIfNeeded(indexPatternName, '@timestamp');
+      await ml.testResources.createDataViewIfNeeded(indexPatternName, '@timestamp');
       await ml.testResources.createSavedSearchFarequoteKueryIfNeeded();
       await ml.testResources.setKibanaTimeZoneToUTC();
 

--- a/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
@@ -105,7 +105,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         it('should display elements on Index Data Visualizer page correctly', async () => {
           await ml.testExecution.logTestStep('should load an index into the data visualizer page');
-          await ml.dataVisualizer.navigateToIndexPatternSelection();
+          await ml.dataVisualizer.navigateToDataViewSelection();
           await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexPattern);
 
           await ml.testExecution.logTestStep('should display the time range step');

--- a/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/full_ml_access.ts
@@ -36,7 +36,7 @@ export default function ({ getService }: FtrProviderContext) {
           await esArchiver.loadIfNeeded(
             'x-pack/test/functional/es_archives/ml/module_sample_ecommerce'
           );
-          await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+          await ml.testResources.createDataViewIfNeeded(ecIndexPattern, 'order_date');
 
           await ml.securityUI.loginAs(testUser.user);
         });

--- a/x-pack/test/functional_basic/apps/ml/permissions/index.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/index.ts
@@ -25,8 +25,8 @@ export default function ({ getService, loadTestFile }: FtrProviderContext) {
 
       await ml.testResources.deleteSavedSearches();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_farequote');
-      await ml.testResources.deleteIndexPatternByTitle('ft_module_sample_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_farequote');
+      await ml.testResources.deleteDataViewByTitle('ft_module_sample_ecommerce');
 
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/farequote');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/module_sample_ecommerce');

--- a/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
@@ -105,7 +105,7 @@ export default function ({ getService }: FtrProviderContext) {
 
         it('should display elements on Index Data Visualizer page correctly', async () => {
           await ml.testExecution.logTestStep('should load an index into the data visualizer page');
-          await ml.dataVisualizer.navigateToIndexPatternSelection();
+          await ml.dataVisualizer.navigateToDataViewSelection();
           await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(ecIndexPattern);
 
           await ml.testExecution.logTestStep('should display the time range step');

--- a/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
+++ b/x-pack/test/functional_basic/apps/ml/permissions/read_ml_access.ts
@@ -36,7 +36,7 @@ export default function ({ getService }: FtrProviderContext) {
           await esArchiver.loadIfNeeded(
             'x-pack/test/functional/es_archives/ml/module_sample_ecommerce'
           );
-          await ml.testResources.createIndexPatternIfNeeded(ecIndexPattern, 'order_date');
+          await ml.testResources.createDataViewIfNeeded(ecIndexPattern, 'order_date');
 
           await ml.securityUI.loginAs(testUser.user);
         });

--- a/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/alert_flyout.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/alert_flyout.ts
@@ -70,7 +70,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   describe('anomaly detection alert', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
       await ml.testResources.setKibanaTimeZoneToUTC();
 
       await ml.securityUI.loginAsMlPowerUser();

--- a/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/index.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/discover_ml_uptime/ml/index.ts
@@ -23,7 +23,7 @@ export default ({ loadTestFile, getService }: FtrProviderContext) => {
       // NOTE: Logout needs to happen before anything else to avoid flaky behavior
       await ml.securityUI.logout();
 
-      await ml.testResources.deleteIndexPatternByTitle('ft_ecommerce');
+      await ml.testResources.deleteDataViewByTitle('ft_ecommerce');
       await esArchiver.unload('x-pack/test/functional/es_archives/ml/ecommerce');
       await ml.securityCommon.cleanMlUsers();
       await ml.securityCommon.cleanMlRoles();

--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/generate_anomaly_alerts.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/generate_anomaly_alerts.ts
@@ -78,7 +78,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   describe('anomaly detection alert', function () {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ecommerce');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ecommerce', 'order_date');
+      await ml.testResources.createDataViewIfNeeded('ft_ecommerce', 'order_date');
 
       const { job, datafeed } = createTestJobAndDatafeed();
 

--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/geographic_data.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/geographic_data.ts
@@ -101,7 +101,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('open index in data visualizer');
       await ml.navigation.navigateToMl();
       await ml.navigation.navigateToDataVisualizer();
-      await ml.dataVisualizer.navigateToIndexPatternSelection();
+      await ml.dataVisualizer.navigateToDataViewSelection();
       await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(LOGS_INDEX_PATTERN);
 
       await ml.testExecution.logTestStep('set data visualizer options');

--- a/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/mapping_anomalies.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/anomaly_detection/mapping_anomalies.ts
@@ -60,7 +60,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await ml.testExecution.logTestStep('open index in data visualizer');
       await ml.navigation.navigateToMl();
       await ml.navigation.navigateToDataVisualizer();
-      await ml.dataVisualizer.navigateToIndexPatternSelection();
+      await ml.dataVisualizer.navigateToDataViewSelection();
       await ml.jobSourceSelection.selectSourceForIndexBasedDataVisualizer(LOGS_INDEX_PATTERN);
 
       await ml.testExecution.logTestStep('set data visualizer options');

--- a/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/classification.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/classification.ts
@@ -40,12 +40,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('classification job', function () {
     before(async () => {
       await ml.api.createAndRunDFAJob(classificationJobConfig as DataFrameAnalyticsConfig);
-      await ml.testResources.createIndexPatternIfNeeded(classificationJobConfig.dest!.index!);
+      await ml.testResources.createDataViewIfNeeded(classificationJobConfig.dest!.index!);
     });
 
     after(async () => {
       await ml.api.deleteDataFrameAnalyticsJobES(classificationJobConfig.id as string);
-      await ml.testResources.deleteIndexPatternByTitle(classificationJobConfig.dest!.index!);
+      await ml.testResources.deleteDataViewByTitle(classificationJobConfig.dest!.index!);
       await ml.api.deleteIndices(classificationJobConfig.dest!.index!);
       await ml.api.cleanMlIndices();
     });

--- a/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/outlier_detection.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/outlier_detection.ts
@@ -49,19 +49,19 @@ export default function ({ getService }: FtrProviderContext) {
   describe('outlier detection job', function () {
     before(async () => {
       await transform.api.createAndRunTransform(transformConfig.id, transformConfig);
-      await ml.testResources.createIndexPatternIfNeeded(transformConfig.dest.index);
+      await ml.testResources.createDataViewIfNeeded(transformConfig.dest.index);
 
       await ml.api.createAndRunDFAJob(outlierJobConfig as DataFrameAnalyticsConfig);
-      await ml.testResources.createIndexPatternIfNeeded(outlierJobConfig.dest!.index!);
+      await ml.testResources.createDataViewIfNeeded(outlierJobConfig.dest!.index!);
     });
 
     after(async () => {
-      await ml.testResources.deleteIndexPatternByTitle(transformConfig.dest.index);
+      await ml.testResources.deleteDataViewByTitle(transformConfig.dest.index);
       await transform.api.deleteIndices(transformConfig.dest.index);
       await transform.api.cleanTransformIndices();
 
       await ml.api.deleteDataFrameAnalyticsJobES(outlierJobConfig.id as string);
-      await ml.testResources.deleteIndexPatternByTitle(outlierJobConfig.dest!.index!);
+      await ml.testResources.deleteDataViewByTitle(outlierJobConfig.dest!.index!);
       await ml.api.deleteIndices(outlierJobConfig.dest!.index!);
       await ml.api.cleanMlIndices();
     });

--- a/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/regression.ts
+++ b/x-pack/test/screenshot_creation/apps/ml_docs/data_frame_analytics/regression.ts
@@ -41,12 +41,12 @@ export default function ({ getService }: FtrProviderContext) {
   describe('regression job', function () {
     before(async () => {
       await ml.api.createAndRunDFAJob(regressionJobConfig as DataFrameAnalyticsConfig);
-      await ml.testResources.createIndexPatternIfNeeded(regressionJobConfig.dest!.index!);
+      await ml.testResources.createDataViewIfNeeded(regressionJobConfig.dest!.index!);
     });
 
     after(async () => {
       await ml.api.deleteDataFrameAnalyticsJobES(regressionJobConfig.id as string);
-      await ml.testResources.deleteIndexPatternByTitle(regressionJobConfig.dest!.index!);
+      await ml.testResources.deleteDataViewByTitle(regressionJobConfig.dest!.index!);
       await ml.api.deleteIndices(regressionJobConfig.dest!.index!);
       await ml.api.cleanMlIndices();
     });

--- a/x-pack/test_serverless/functional/test_suites/security/ml/data_frame_analytics_jobs_list.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ml/data_frame_analytics_jobs_list.ts
@@ -20,7 +20,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.svlCommonPage.login();
 
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/ml/ihp_outlier');
-      await ml.testResources.createIndexPatternIfNeeded('ft_ihp_outlier', '@timestamp');
+      await ml.testResources.createDataViewIfNeeded('ft_ihp_outlier', '@timestamp');
 
       await ml.api.createDataFrameAnalyticsJob(
         ml.commonConfig.getDFAIhpOutlierDetectionJobConfig(dfaJobId)


### PR DESCRIPTION
## Summary

Renames references to index pattern to data views.

- Updates references in `data-test-subj` attributes for data frame analytics.
- Renames methods in the ` ml.testResources` service used in tests.
- `IndexPattern` references in testing code referring to single indices were renamed to use `IndexName`. For variable names still using `IndexPattern` they were prefixed with e.g. `esIndexPattern` to avoid ambiguity with the legacy data view name.

Note there are still references in the state management code of the data frame analytics creation wizard, this wasn't picked up in this PR since it focuses mostly on test related code.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
