### PR TITLE
[Docs][Maps] Include details about the headers requested and served by EMS

### DIFF
--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -14,30 +14,30 @@ If you are using Kibana's out-of-the-box settings, Maps is already configured to
 
 EMS requests are made to the following domains:
 
-* tiles.maps.elastic.co
-* vector.maps.elastic.co
-
+* Tile Service: `tiles.maps.elastic.co`
+* File Service: `vector.maps.elastic.co`
 
 [float]
 === Headers
 
 Find below examples of the request and response headers from Kibana and a minimal `curl` request example showing the response headers sent by each service.
 
-WARNING: This headers may change without further notice at anytime and are shared for reference.
+WARNING: These headers may change without further notice at anytime and are shared for reference.
 
 [float]
 ==== EMS Tile Service
 
+The EMS Tile Service provides basemaps in three different styles as the default background for Maps visualizations. The basemaps use https://www.openstreetmap.org/about[OpenStreetMap] data following the https://openmaptiles.org/[OpenMapTiles] schema and can be explored at https://maps.elastic.co[maps.elastic.co].
 
-Headers for a JSON asset from the Tile Service
+Headers for the Tile Service JSON manifest describing the basemaps available.
 
 include::headers/tile-json.asciidoc[]
 
-Headers for a Vector Tile asset from the Tile Service
+Headers for a vector tile asset in _protobuffer_ format from the Tile Service.
 
 include::headers/tile-pbf.asciidoc[]
 
-Headers for an Image asset from the Tile Service
+Headers for an sprite image asset from the Tile Service
 
 include::headers/tile-png.asciidoc[]
 
@@ -45,11 +45,13 @@ include::headers/tile-png.asciidoc[]
 [float]
 ==== EMS File Service
 
-Headers for a JSON asset from the File Service
+EMS File Service provides the administrative boundaries used for <<maps-add-choropleth-layer,choropleth mapping>> as static assets in GeoJSON or TopoJSON formats and can be explored at https://maps.elastic.co[maps.elastic.co].
+
+Headers for the File Service JSON manifest that declares all the datasets available.
 
 include::headers/file-json.asciidoc[]
 
-Headers for a Dataset from the File Service
+Headers for a sample Dataset from the File Service in TopoJSON format.
 
 include::headers/file-data.asciidoc[]
 

--- a/docs/maps/connect-to-ems.asciidoc
+++ b/docs/maps/connect-to-ems.asciidoc
@@ -3,17 +3,56 @@
 
 :ems-docker-repo: docker.elastic.co/elastic-maps-service/elastic-maps-server-ubi8
 :ems-docker-image: {ems-docker-repo}:{version}
+:ems-headers-url: https://deployment-host
 
 https://www.elastic.co/elastic-maps-service[Elastic Maps Service (EMS)] is a service that hosts
 tile layers and vector shapes of administrative boundaries.
 If you are using Kibana's out-of-the-box settings, Maps is already configured to use EMS.
+
+[float]
+=== Domains
 
 EMS requests are made to the following domains:
 
 * tiles.maps.elastic.co
 * vector.maps.elastic.co
 
-Maps makes requests directly from the browser to EMS.
+
+[float]
+=== Headers
+
+Find below examples of the request and response headers from Kibana and a minimal `curl` request example showing the response headers sent by each service.
+
+WARNING: This headers may change without further notice at anytime and are shared for reference.
+
+[float]
+==== EMS Tile Service
+
+
+Headers for a JSON asset from the Tile Service
+
+include::headers/tile-json.asciidoc[]
+
+Headers for a Vector Tile asset from the Tile Service
+
+include::headers/tile-pbf.asciidoc[]
+
+Headers for an Image asset from the Tile Service
+
+include::headers/tile-png.asciidoc[]
+
+
+[float]
+==== EMS File Service
+
+Headers for a JSON asset from the File Service
+
+include::headers/file-json.asciidoc[]
+
+Headers for a Dataset from the File Service
+
+include::headers/file-data.asciidoc[]
+
 
 [float]
 === Disable Elastic Maps Service

--- a/docs/maps/headers/file-data.asciidoc
+++ b/docs/maps/headers/file-data.asciidoc
@@ -1,0 +1,135 @@
+
+
+++++
+<div class="tabs" data-tab-group="file-data-tab-group-name">
+  <div role="tablist" aria-label="Request and response to the File Service for Dataset">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="file-data-tab-group-request"
+            id="file-data-group-request">
+      Request
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="file-data-tab-group-response"
+            id="file-data-group-response"
+            tabindex="-1">
+      Response
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="file-data-tab-group-curl"
+            id="file-data-group-curl"
+            tabindex="-2">
+      Curl example
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="file-data-tab-group-request"
+       aria-labelledby="file-data-group-request">
+++++
+[%collapsible]
+====
+[source,regex,subs="attributes"]
+----------------------------------
+Host: vector.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="file-data-tab-group-response"
+       aria-labelledby="file-data-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+x-guploader-uploadid: ABPtcPqIDSg5tyavvwwtJQa8a8iycoXOCkHBp_2YJbJJnQgb5XMD7nFwRUogg00Ou27VFIs95v7L99OMnvXR1bcb9RW-xQ
+x-goog-generation: 1689593325442971
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 587241
+content-encoding: gzip
+x-goog-hash: crc32c=OcROeg==
+x-goog-hash: md5=8KKIwD6wbKa3YYXTnnFcZw==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 587241
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 12:16:01 GMT
+expires: Tue, 21 Nov 2023 13:16:01 GMT
+cache-control: public, max-age=3600,no-transform
+age: 29
+last-modified: Mon, 17 Jul 2023 11:28:45 GMT
+etag: "f0a288c03eb06ca6b76185d39e715c67"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+X-Firefox-Spdy: h2
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="file-data-tab-group-curl"
+       aria-labelledby="file-data-group-curl"
+       hidden="">
+++++
+[source,bash,subs="attributes"]
+----------------------------------
+curl -I 'https://vector.maps.elastic.co/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
+-H 'User-Agent: curl/7.81.0' \
+-H 'Accept: */*' \
+-H 'Accept-Encoding: gzip, deflate, br'
+----------------------------------
+
+Server response
+
+[source,regex]
+----------------------------------
+HTTP/2 200 
+x-guploader-uploadid: ABPtcPpmMffchVgfHIr-SSC00WORo145oV-1q0asjqRvjLV_7cIgyfLRfofXV-BG7huMYABFypblcgdgXRBARhpo2c88ow
+x-goog-generation: 1689593325442971
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 587241
+content-encoding: gzip
+x-goog-hash: crc32c=OcROeg==
+x-goog-hash: md5=8KKIwD6wbKa3YYXTnnFcZw==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 587241
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 14:22:16 GMT
+expires: Tue, 21 Nov 2023 15:22:16 GMT
+cache-control: public, max-age=3600,no-transform
+age: 2202
+last-modified: Mon, 17 Jul 2023 11:28:45 GMT
+etag: "f0a288c03eb06ca6b76185d39e715c67"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+</div>
+++++
+
+
+

--- a/docs/maps/headers/file-data.asciidoc
+++ b/docs/maps/headers/file-data.asciidoc
@@ -1,95 +1,35 @@
 
-
 ++++
 <div class="tabs" data-tab-group="file-data-tab-group-name">
   <div role="tablist" aria-label="Request and response to the File Service for Dataset">
     <button role="tab"
             aria-selected="true"
+            aria-controls="file-data-tab-group-curl"
+            id="file-data-group-curl">
+      Curl example
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="file-data-tab-group-request"
-            id="file-data-group-request">
+            id="file-data-group-request"
+            tabindex="-1">
       Request
     </button>
     <button role="tab"
             aria-selected="false"
             aria-controls="file-data-tab-group-response"
             id="file-data-group-response"
-            tabindex="-1">
-      Response
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="file-data-tab-group-curl"
-            id="file-data-group-curl"
             tabindex="-2">
-      Curl example
+      Response
     </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="file-data-tab-group-request"
-       aria-labelledby="file-data-group-request">
+       id="file-data-tab-group-curl"
+       aria-labelledby="file-data-group-curl">
 ++++
 [%collapsible]
 ====
-[source,regex,subs="attributes"]
-----------------------------------
-Host: vector.maps.elastic.co
-User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
-Accept: */*
-Accept-Language: en-US,en;q=0.5
-Accept-Encoding: gzip, deflate, br
-Referer: {ems-headers-url}/app/maps/map
-Origin: {ems-headers-url}
-Connection: keep-alive
-Sec-Fetch-Dest: empty
-Sec-Fetch-Mode: cors
-Sec-Fetch-Site: cross-site
-Pragma: no-cache
-Cache-Control: no-cache
-----------------------------------
-====
-++++
-  </div>
-  <div tabindex="1"
-       role="tabpanel"
-       id="file-data-tab-group-response"
-       aria-labelledby="file-data-group-response"
-       hidden="">
-++++
-[source,regex]
-----------------------------------
-x-guploader-uploadid: ABPtcPqIDSg5tyavvwwtJQa8a8iycoXOCkHBp_2YJbJJnQgb5XMD7nFwRUogg00Ou27VFIs95v7L99OMnvXR1bcb9RW-xQ
-x-goog-generation: 1689593325442971
-x-goog-metageneration: 1
-x-goog-stored-content-encoding: gzip
-x-goog-stored-content-length: 587241
-content-encoding: gzip
-x-goog-hash: crc32c=OcROeg==
-x-goog-hash: md5=8KKIwD6wbKa3YYXTnnFcZw==
-x-goog-storage-class: MULTI_REGIONAL
-accept-ranges: bytes
-content-length: 587241
-access-control-allow-origin: *
-access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
-server: UploadServer
-date: Tue, 21 Nov 2023 12:16:01 GMT
-expires: Tue, 21 Nov 2023 13:16:01 GMT
-cache-control: public, max-age=3600,no-transform
-age: 29
-last-modified: Mon, 17 Jul 2023 11:28:45 GMT
-etag: "f0a288c03eb06ca6b76185d39e715c67"
-content-type: application/json
-alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-X-Firefox-Spdy: h2
-----------------------------------
-++++
-  </div>
-  <div tabindex="2"
-       role="tabpanel"
-       id="file-data-tab-group-curl"
-       aria-labelledby="file-data-group-curl"
-       hidden="">
-++++
 [source,bash,subs="attributes"]
 ----------------------------------
 curl -I 'https://vector.maps.elastic.co/files/world_countries_v7.topo.json?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
@@ -126,10 +66,66 @@ etag: "f0a288c03eb06ca6b76185d39e715c67"
 content-type: application/json
 alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 ----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="file-data-tab-group-request"
+       aria-labelledby="file-data-group-request"
+       hidden="">
+++++
+[source,regex,subs="attributes"]
+----------------------------------
+Host: vector.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="file-data-tab-group-response"
+       aria-labelledby="file-data-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+x-guploader-uploadid: ABPtcPqIDSg5tyavvwwtJQa8a8iycoXOCkHBp_2YJbJJnQgb5XMD7nFwRUogg00Ou27VFIs95v7L99OMnvXR1bcb9RW-xQ
+x-goog-generation: 1689593325442971
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 587241
+content-encoding: gzip
+x-goog-hash: crc32c=OcROeg==
+x-goog-hash: md5=8KKIwD6wbKa3YYXTnnFcZw==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 587241
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 12:16:01 GMT
+expires: Tue, 21 Nov 2023 13:16:01 GMT
+cache-control: public, max-age=3600,no-transform
+age: 29
+last-modified: Mon, 17 Jul 2023 11:28:45 GMT
+etag: "f0a288c03eb06ca6b76185d39e715c67"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+X-Firefox-Spdy: h2
+----------------------------------
 ++++
   </div>
 </div>
 ++++
-
-
-

--- a/docs/maps/headers/file-json.asciidoc
+++ b/docs/maps/headers/file-json.asciidoc
@@ -1,0 +1,134 @@
+
+++++
+<div class="tabs" data-tab-group="file-json-tab-group-name">
+  <div role="tablist" aria-label="Request and response to the File Service for a JSON Asset">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="file-json-tab-group-request"
+            id="file-json-group-request">
+      Request
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="file-json-tab-group-response"
+            id="file-json-group-response"
+            tabindex="-1">
+      Response
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="file-json-tab-group-curl"
+            id="file-json-group-curl"
+            tabindex="-2">
+      Curl example
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="file-json-tab-group-request"
+       aria-labelledby="file-json-group-request">
+++++
+[%collapsible]
+====
+[source,regex,subs="attributes"]
+----------------------------------
+Host: vector.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="file-json-tab-group-response"
+       aria-labelledby="file-json-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+x-guploader-uploadid: ABPtcPoUFrCmjBeebnfRxSZp44ZHsZ-_iQg7794RU1Z7Lb2cNNxXsMRkIDa5s7VBEfyehvo-_9rcm1A3HfYW8geguUxKrw
+x-goog-generation: 1689593295246576
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 108029
+content-encoding: gzip
+x-goog-hash: crc32c=T5gVpw==
+x-goog-hash: md5=6F8KWV8VTdx8FsN2iFehow==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 108029
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 11:24:45 GMT
+expires: Tue, 21 Nov 2023 12:24:45 GMT
+cache-control: public, max-age=3600,no-transform
+age: 3101
+last-modified: Mon, 17 Jul 2023 11:28:15 GMT
+etag: "e85f0a595f154ddc7c16c3768857a1a3"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+X-Firefox-Spdy: h2
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="file-json-tab-group-curl"
+       aria-labelledby="file-json-group-curl"
+       hidden="">
+++++
+[source,bash,subs="attributes"]
+----------------------------------
+curl -I 'https://vector.maps.elastic.co/v{minor-version}/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
+-H 'User-Agent: curl/7.81.0' \
+-H 'Accept: */*' \
+-H 'Accept-Encoding: gzip, deflate, br'
+----------------------------------
+
+Server response
+
+[source,regex]
+----------------------------------
+HTTP/2 200 
+x-guploader-uploadid: ABPtcPp_BvMdBDO5jVlutETVHmvpOachwjilw4AkIKwMrOQJ4exR9Eln4g0LkW3V_LLSEpvjYLtUtFmO0Uwr61XXUhoP_A
+x-goog-generation: 1689593295246576
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 108029
+content-encoding: gzip
+x-goog-hash: crc32c=T5gVpw==
+x-goog-hash: md5=6F8KWV8VTdx8FsN2iFehow==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 108029
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 14:25:07 GMT
+expires: Tue, 21 Nov 2023 15:25:07 GMT
+cache-control: public, max-age=3600,no-transform
+age: 2170
+last-modified: Mon, 17 Jul 2023 11:28:15 GMT
+etag: "e85f0a595f154ddc7c16c3768857a1a3"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+</div>
+++++
+
+
+

--- a/docs/maps/headers/file-json.asciidoc
+++ b/docs/maps/headers/file-json.asciidoc
@@ -4,91 +4,33 @@
   <div role="tablist" aria-label="Request and response to the File Service for a JSON Asset">
     <button role="tab"
             aria-selected="true"
+            aria-controls="file-json-tab-group-curl"
+            id="file-json-group-curl"
+            >
+      Curl example
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="file-json-tab-group-request"
-            id="file-json-group-request">
+            id="file-json-group-request"
+            tabindex="-1">
       Request
     </button>
     <button role="tab"
             aria-selected="false"
             aria-controls="file-json-tab-group-response"
             id="file-json-group-response"
-            tabindex="-1">
-      Response
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="file-json-tab-group-curl"
-            id="file-json-group-curl"
             tabindex="-2">
-      Curl example
+      Response
     </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="file-json-tab-group-request"
-       aria-labelledby="file-json-group-request">
+       id="file-json-tab-group-curl"
+       aria-labelledby="file-json-group-curl">
 ++++
 [%collapsible]
 ====
-[source,regex,subs="attributes"]
-----------------------------------
-Host: vector.maps.elastic.co
-User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
-Accept: */*
-Accept-Language: en-US,en;q=0.5
-Accept-Encoding: gzip, deflate, br
-Referer: {ems-headers-url}/app/maps/map
-Origin: {ems-headers-url}
-Connection: keep-alive
-Sec-Fetch-Dest: empty
-Sec-Fetch-Mode: cors
-Sec-Fetch-Site: cross-site
-Pragma: no-cache
-Cache-Control: no-cache
-----------------------------------
-====
-++++
-  </div>
-  <div tabindex="1"
-       role="tabpanel"
-       id="file-json-tab-group-response"
-       aria-labelledby="file-json-group-response"
-       hidden="">
-++++
-[source,regex]
-----------------------------------
-x-guploader-uploadid: ABPtcPoUFrCmjBeebnfRxSZp44ZHsZ-_iQg7794RU1Z7Lb2cNNxXsMRkIDa5s7VBEfyehvo-_9rcm1A3HfYW8geguUxKrw
-x-goog-generation: 1689593295246576
-x-goog-metageneration: 1
-x-goog-stored-content-encoding: gzip
-x-goog-stored-content-length: 108029
-content-encoding: gzip
-x-goog-hash: crc32c=T5gVpw==
-x-goog-hash: md5=6F8KWV8VTdx8FsN2iFehow==
-x-goog-storage-class: MULTI_REGIONAL
-accept-ranges: bytes
-content-length: 108029
-access-control-allow-origin: *
-access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
-server: UploadServer
-date: Tue, 21 Nov 2023 11:24:45 GMT
-expires: Tue, 21 Nov 2023 12:24:45 GMT
-cache-control: public, max-age=3600,no-transform
-age: 3101
-last-modified: Mon, 17 Jul 2023 11:28:15 GMT
-etag: "e85f0a595f154ddc7c16c3768857a1a3"
-content-type: application/json
-alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-X-Firefox-Spdy: h2
-----------------------------------
-++++
-  </div>
-  <div tabindex="2"
-       role="tabpanel"
-       id="file-json-tab-group-curl"
-       aria-labelledby="file-json-group-curl"
-       hidden="">
-++++
 [source,bash,subs="attributes"]
 ----------------------------------
 curl -I 'https://vector.maps.elastic.co/v{minor-version}/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
@@ -125,10 +67,66 @@ etag: "e85f0a595f154ddc7c16c3768857a1a3"
 content-type: application/json
 alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 ----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="file-json-tab-group-request"
+       aria-labelledby="file-json-group-request"
+       hidden="">
+++++
+[source,regex,subs="attributes"]
+----------------------------------
+Host: vector.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="file-json-tab-group-response"
+       aria-labelledby="file-json-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+x-guploader-uploadid: ABPtcPoUFrCmjBeebnfRxSZp44ZHsZ-_iQg7794RU1Z7Lb2cNNxXsMRkIDa5s7VBEfyehvo-_9rcm1A3HfYW8geguUxKrw
+x-goog-generation: 1689593295246576
+x-goog-metageneration: 1
+x-goog-stored-content-encoding: gzip
+x-goog-stored-content-length: 108029
+content-encoding: gzip
+x-goog-hash: crc32c=T5gVpw==
+x-goog-hash: md5=6F8KWV8VTdx8FsN2iFehow==
+x-goog-storage-class: MULTI_REGIONAL
+accept-ranges: bytes
+content-length: 108029
+access-control-allow-origin: *
+access-control-expose-headers: Authorization, Content-Length, Content-Type, Date, Server, Transfer-Encoding, X-GUploader-UploadID, X-Google-Trace, accept, elastic-api-version, kbn-name, kbn-version, origin
+server: UploadServer
+date: Tue, 21 Nov 2023 11:24:45 GMT
+expires: Tue, 21 Nov 2023 12:24:45 GMT
+cache-control: public, max-age=3600,no-transform
+age: 3101
+last-modified: Mon, 17 Jul 2023 11:28:15 GMT
+etag: "e85f0a595f154ddc7c16c3768857a1a3"
+content-type: application/json
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+X-Firefox-Spdy: h2
+----------------------------------
 ++++
   </div>
 </div>
 ++++
-
-
-

--- a/docs/maps/headers/tile-json.asciidoc
+++ b/docs/maps/headers/tile-json.asciidoc
@@ -1,0 +1,124 @@
+
+++++
+<div class="tabs" data-tab-group="tiles-json-tab-group-name">
+  <div role="tablist" aria-label="Request and response to the Tile Service for a JSON asset">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="tiles-json-tab-group-request"
+            id="tiles-json-group-request">
+      Request
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-json-tab-group-response"
+            id="tiles-json-group-response"
+            tabindex="-1">
+      Response
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-json-tab-group-curl"
+            id="tiles-json-group-curl"
+            tabindex="-2">
+      Curl Example
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="tiles-json-tab-group-request"
+       aria-labelledby="tiles-json-group-request">
+++++
+[%collapsible]
+====
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+TE: trailers
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-json-tab-group-response"
+       aria-labelledby="tiles-json-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+server: BaseHTTP/0.6 Python/3.11.4
+date: Mon, 20 Nov 2023 17:53:10 GMT
+content-type: application/json; charset=utf-8
+elastic-api-version: 2023-10-31
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+content-encoding: gzip
+vary: Accept-Encoding
+x-varnish: 8848609 1142291
+accept-ranges: bytes
+varnish-age: 65725
+cache-control: private, max-age=86400
+content-length: 341
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-json-tab-group-curl"
+       aria-labelledby="tiles-json-group-curl"
+       hidden="">
+++++
+[source,bash,subs="attributes"]
+----------------------------------
+curl -I 'https://tiles.maps.elastic.co/v{minor-version}/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
+-H 'User-Agent: curl/7.81.0' \
+-H 'Accept: */*' \
+-H 'Accept-Encoding: gzip, deflate, br'
+----------------------------------
+
+Server response
+
+[source,regex]
+----------------------------------
+HTTP/2 200 
+server: BaseHTTP/0.6 Python/3.11.4
+date: Mon, 20 Nov 2023 15:08:46 GMT
+content-type: application/json; charset=utf-8
+elastic-api-version: 2023-10-31
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+content-encoding: gzip
+vary: Accept-Encoding
+x-varnish: 844076 5416505
+accept-ranges: bytes
+varnish-age: 85285
+cache-control: private, max-age=86400
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+</div>
+++++
+
+
+
+

--- a/docs/maps/headers/tile-json.asciidoc
+++ b/docs/maps/headers/tile-json.asciidoc
@@ -4,86 +4,32 @@
   <div role="tablist" aria-label="Request and response to the Tile Service for a JSON asset">
     <button role="tab"
             aria-selected="true"
+            aria-controls="tiles-json-tab-group-curl"
+            id="tiles-json-group-curl">
+      Curl Example
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="tiles-json-tab-group-request"
-            id="tiles-json-group-request">
+            id="tiles-json-group-request"
+            tabindex="-1">
       Request
     </button>
     <button role="tab"
             aria-selected="false"
             aria-controls="tiles-json-tab-group-response"
             id="tiles-json-group-response"
-            tabindex="-1">
-      Response
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="tiles-json-tab-group-curl"
-            id="tiles-json-group-curl"
             tabindex="-2">
-      Curl Example
+      Response
     </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="tiles-json-tab-group-request"
-       aria-labelledby="tiles-json-group-request">
+       id="tiles-json-tab-group-curl"
+       aria-labelledby="tiles-json-group-curl">
 ++++
 [%collapsible]
 ====
-[source,regex,subs="attributes"]
-----------------------------------
-Host: tiles.maps.elastic.co
-User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
-Accept: */*
-Accept-Language: en-US,en;q=0.5
-Accept-Encoding: gzip, deflate, br
-Referer: {ems-headers-url}/app/maps/map
-Origin: {ems-headers-url}
-Connection: keep-alive
-Sec-Fetch-Dest: empty
-Sec-Fetch-Mode: cors
-Sec-Fetch-Site: cross-site
-Pragma: no-cache
-Cache-Control: no-cache
-TE: trailers
-----------------------------------
-====
-++++
-  </div>
-  <div tabindex="1"
-       role="tabpanel"
-       id="tiles-json-tab-group-response"
-       aria-labelledby="tiles-json-group-response"
-       hidden="">
-++++
-[source,regex]
-----------------------------------
-server: BaseHTTP/0.6 Python/3.11.4
-date: Mon, 20 Nov 2023 17:53:10 GMT
-content-type: application/json; charset=utf-8
-elastic-api-version: 2023-10-31
-access-control-allow-origin: *
-access-control-allow-methods: GET, OPTIONS, HEAD
-access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
-access-control-expose-headers: etag
-content-encoding: gzip
-vary: Accept-Encoding
-x-varnish: 8848609 1142291
-accept-ranges: bytes
-varnish-age: 65725
-cache-control: private, max-age=86400
-content-length: 341
-via: 1.1 varnish (Varnish/7.0), 1.1 google
-alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-----------------------------------
-++++
-  </div>
-  <div tabindex="2"
-       role="tabpanel"
-       id="tiles-json-tab-group-curl"
-       aria-labelledby="tiles-json-group-curl"
-       hidden="">
-++++
 [source,bash,subs="attributes"]
 ----------------------------------
 curl -I 'https://tiles.maps.elastic.co/v{minor-version}/manifest?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
@@ -114,11 +60,61 @@ cache-control: private, max-age=86400
 via: 1.1 varnish (Varnish/7.0), 1.1 google
 alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 ----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-json-tab-group-request"
+       aria-labelledby="tiles-json-group-request"
+       hidden="">
+++++
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+TE: trailers
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-json-tab-group-response"
+       aria-labelledby="tiles-json-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+server: BaseHTTP/0.6 Python/3.11.4
+date: Mon, 20 Nov 2023 17:53:10 GMT
+content-type: application/json; charset=utf-8
+elastic-api-version: 2023-10-31
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+content-encoding: gzip
+vary: Accept-Encoding
+x-varnish: 8848609 1142291
+accept-ranges: bytes
+varnish-age: 65725
+cache-control: private, max-age=86400
+content-length: 341
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
 ++++
   </div>
 </div>
 ++++
-
-
-
-

--- a/docs/maps/headers/tile-pbf.asciidoc
+++ b/docs/maps/headers/tile-pbf.asciidoc
@@ -4,85 +4,32 @@
   <div role="tablist" aria-label="Request and response to the Tile Service for a Vector Tile Asset">
     <button role="tab"
             aria-selected="true"
+            aria-controls="tiles-pbf-tab-group-curl"
+            id="tiles-pbf-group-curl">
+      Curl Example
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="tiles-pbf-tab-group-request"
-            id="tiles-pbf-group-request">
+            id="tiles-pbf-group-request"
+            tabindex="-1">
       Request
     </button>
     <button role="tab"
             aria-selected="false"
             aria-controls="tiles-pbf-tab-group-response"
             id="tiles-pbf-group-response"
-            tabindex="-1">
-      Response
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="tiles-pbf-tab-group-curl"
-            id="tiles-pbf-group-curl"
             tabindex="-2">
-      Curl Example
+      Response
     </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="tiles-pbf-tab-group-request"
-       aria-labelledby="tiles-pbf-group-request">
+       id="tiles-pbf-tab-group-curl"
+       aria-labelledby="tiles-pbf-group-curl">
 ++++
 [%collapsible]
 ====
-[source,regex,subs="attributes"]
-----------------------------------
-Host: tiles.maps.elastic.co
-User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
-Accept: */*
-Accept-Language: en-US,en;q=0.5
-Accept-Encoding: gzip, deflate, br
-Referer: {ems-headers-url}/app/maps/map
-Origin: {ems-headers-url}
-Connection: keep-alive
-Sec-Fetch-Dest: empty
-Sec-Fetch-Mode: cors
-Sec-Fetch-Site: cross-site
-TE: trailers
-----------------------------------
-====
-++++
-  </div>
-  <div tabindex="1"
-       role="tabpanel"
-       id="tiles-pbf-tab-group-response"
-       aria-labelledby="tiles-pbf-group-response"
-       hidden="">
-++++
-[source,regex]
-----------------------------------
-content-encoding: gzip
-content-length: 101691
-access-control-allow-origin: *
-access-control-allow-methods: GET, OPTIONS, HEAD
-access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
-access-control-expose-headers: etag
-x-varnish: 4698676 3660338
-accept-ranges: bytes
-varnish-age: 9206
-via: 1.1 varnish (Varnish/7.0), 1.1 google
-date: Mon, 20 Nov 2023 15:05:29 GMT
-age: 75788
-last-modified: Thu, 16 Sep 2021 17:14:41 GMT
-etag: W/"18d3b-ot9ckSsdpH7n+yJz4BXXQp6Zs08"
-content-type: application/x-protobuf
-vary: Accept-Encoding
-cache-control: public,max-age=3600
-alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-----------------------------------
-++++
-  </div>
-  <div tabindex="2"
-       role="tabpanel"
-       id="tiles-pbf-tab-group-curl"
-       aria-labelledby="tiles-pbf-group-curl"
-       hidden="">
-++++
 [source,bash,subs="attributes"]
 ----------------------------------
 $ curl -I 'https://tiles.maps.elastic.co/data/v3/1/1/0.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
@@ -110,6 +57,59 @@ date: Mon, 20 Nov 2023 15:08:19 GMT
 age: 78827
 last-modified: Thu, 16 Sep 2021 17:14:41 GMT
 etag: W/"232cb-zYEfNgd8rzHusLotRFzgRDSDDGA"
+content-type: application/x-protobuf
+vary: Accept-Encoding
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-pbf-tab-group-request"
+       aria-labelledby="tiles-pbf-group-request"
+       hidden="">
+++++
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+TE: trailers
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-pbf-tab-group-response"
+       aria-labelledby="tiles-pbf-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+content-encoding: gzip
+content-length: 101691
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 4698676 3660338
+accept-ranges: bytes
+varnish-age: 9206
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Mon, 20 Nov 2023 15:05:29 GMT
+age: 75788
+last-modified: Thu, 16 Sep 2021 17:14:41 GMT
+etag: W/"18d3b-ot9ckSsdpH7n+yJz4BXXQp6Zs08"
 content-type: application/x-protobuf
 vary: Accept-Encoding
 cache-control: public,max-age=3600

--- a/docs/maps/headers/tile-pbf.asciidoc
+++ b/docs/maps/headers/tile-pbf.asciidoc
@@ -1,0 +1,121 @@
+
+++++
+<div class="tabs" data-tab-group="tiles-pbf-tab-group-name">
+  <div role="tablist" aria-label="Request and response to the Tile Service for a Vector Tile Asset">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="tiles-pbf-tab-group-request"
+            id="tiles-pbf-group-request">
+      Request
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-pbf-tab-group-response"
+            id="tiles-pbf-group-response"
+            tabindex="-1">
+      Response
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-pbf-tab-group-curl"
+            id="tiles-pbf-group-curl"
+            tabindex="-2">
+      Curl Example
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="tiles-pbf-tab-group-request"
+       aria-labelledby="tiles-pbf-group-request">
+++++
+[%collapsible]
+====
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: */*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+TE: trailers
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-pbf-tab-group-response"
+       aria-labelledby="tiles-pbf-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+content-encoding: gzip
+content-length: 101691
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 4698676 3660338
+accept-ranges: bytes
+varnish-age: 9206
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Mon, 20 Nov 2023 15:05:29 GMT
+age: 75788
+last-modified: Thu, 16 Sep 2021 17:14:41 GMT
+etag: W/"18d3b-ot9ckSsdpH7n+yJz4BXXQp6Zs08"
+content-type: application/x-protobuf
+vary: Accept-Encoding
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-pbf-tab-group-curl"
+       aria-labelledby="tiles-pbf-group-curl"
+       hidden="">
+++++
+[source,bash,subs="attributes"]
+----------------------------------
+$ curl -I 'https://tiles.maps.elastic.co/data/v3/1/1/0.pbf?elastic_tile_service_tos=agree&my_app_name=kibana&my_app_version={version}' \
+-H 'User-Agent: curl/7.81.0' \
+-H 'Accept: */*' \
+-H 'Accept-Encoding: gzip, deflate, br'
+----------------------------------
+
+Server response
+
+[source,regex]
+----------------------------------
+HTTP/2 200 
+content-encoding: gzip
+content-length: 144075
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 3269455 5976667
+accept-ranges: bytes
+varnish-age: 9045
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Mon, 20 Nov 2023 15:08:19 GMT
+age: 78827
+last-modified: Thu, 16 Sep 2021 17:14:41 GMT
+etag: W/"232cb-zYEfNgd8rzHusLotRFzgRDSDDGA"
+content-type: application/x-protobuf
+vary: Accept-Encoding
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+</div>
+++++

--- a/docs/maps/headers/tile-png.asciidoc
+++ b/docs/maps/headers/tile-png.asciidoc
@@ -1,0 +1,120 @@
+
+++++
+<div class="tabs" data-tab-group="tiles-png-tab-group-name">
+  <div role="tablist" aria-label="Request and response to the Tile Service for an Image Asset">
+    <button role="tab"
+            aria-selected="true"
+            aria-controls="tiles-png-tab-group-request"
+            id="tiles-png-group-request">
+      Request
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-png-tab-group-response"
+            id="tiles-png-group-response"
+            tabindex="-1">
+      Response
+    </button>
+    <button role="tab"
+            aria-selected="false"
+            aria-controls="tiles-png-tab-group-curl"
+            id="tiles-png-group-curl"
+            tabindex="-2">
+      Curl Example
+    </button>
+  </div>
+  <div tabindex="0"
+       role="tabpanel"
+       id="tiles-png-tab-group-request"
+       aria-labelledby="tiles-png-group-request">
+++++
+[%collapsible]
+====
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: image/avif,image/webp,*/*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: image
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+TE: trailers
+----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-png-tab-group-response"
+       aria-labelledby="tiles-png-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+content-length: 17181
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 3530683 3764574
+accept-ranges: bytes
+varnish-age: 833
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Mon, 20 Nov 2023 14:44:29 GMT
+age: 77048
+etag: W/"431d-/dqE/W5Q3FqkHikyDQtCuQqAdlY"
+content-type: image/png
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-png-tab-group-curl"
+       aria-labelledby="tiles-png-group-curl"
+       hidden="">
+++++
+[source,bash]
+----------------------------------
+curl -I 'https://tiles.maps.elastic.co/styles/osm-bright-desaturated/sprite.png' \
+-H 'User-Agent: curl/7.81.0' \
+-H 'Accept: image/avif,image/webp,*/*' \
+-H 'Accept-Encoding: gzip, deflate, br'
+----------------------------------
+
+Server response
+
+[source,regex]
+----------------------------------
+HTTP/2 200 
+content-length: 17181
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 8769943 4865354
+accept-ranges: bytes
+varnish-age: 250
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Tue, 21 Nov 2023 14:44:36 GMT
+age: 592
+etag: W/"431d-/dqE/W5Q3FqkHikyDQtCuQqAdlY"
+content-type: image/png
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
+++++
+  </div>
+</div>
+++++
+
+
+

--- a/docs/maps/headers/tile-png.asciidoc
+++ b/docs/maps/headers/tile-png.asciidoc
@@ -4,84 +4,32 @@
   <div role="tablist" aria-label="Request and response to the Tile Service for an Image Asset">
     <button role="tab"
             aria-selected="true"
+            aria-controls="tiles-png-tab-group-curl"
+            id="tiles-png-group-curl">
+      Curl Example
+    </button>
+    <button role="tab"
+            aria-selected="false"
             aria-controls="tiles-png-tab-group-request"
-            id="tiles-png-group-request">
+            id="tiles-png-group-request"
+            tabindex="-1">
       Request
     </button>
     <button role="tab"
             aria-selected="false"
             aria-controls="tiles-png-tab-group-response"
             id="tiles-png-group-response"
-            tabindex="-1">
-      Response
-    </button>
-    <button role="tab"
-            aria-selected="false"
-            aria-controls="tiles-png-tab-group-curl"
-            id="tiles-png-group-curl"
             tabindex="-2">
-      Curl Example
+      Response
     </button>
   </div>
   <div tabindex="0"
        role="tabpanel"
-       id="tiles-png-tab-group-request"
-       aria-labelledby="tiles-png-group-request">
+       id="tiles-png-tab-group-curl"
+       aria-labelledby="tiles-png-group-curl">
 ++++
 [%collapsible]
 ====
-[source,regex,subs="attributes"]
-----------------------------------
-Host: tiles.maps.elastic.co
-User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
-Accept: image/avif,image/webp,*/*
-Accept-Language: en-US,en;q=0.5
-Accept-Encoding: gzip, deflate, br
-Referer: {ems-headers-url}/app/maps/map
-Origin: {ems-headers-url}
-Connection: keep-alive
-Sec-Fetch-Dest: image
-Sec-Fetch-Mode: cors
-Sec-Fetch-Site: cross-site
-Pragma: no-cache
-Cache-Control: no-cache
-TE: trailers
-----------------------------------
-====
-++++
-  </div>
-  <div tabindex="1"
-       role="tabpanel"
-       id="tiles-png-tab-group-response"
-       aria-labelledby="tiles-png-group-response"
-       hidden="">
-++++
-[source,regex]
-----------------------------------
-content-length: 17181
-access-control-allow-origin: *
-access-control-allow-methods: GET, OPTIONS, HEAD
-access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
-access-control-expose-headers: etag
-x-varnish: 3530683 3764574
-accept-ranges: bytes
-varnish-age: 833
-via: 1.1 varnish (Varnish/7.0), 1.1 google
-date: Mon, 20 Nov 2023 14:44:29 GMT
-age: 77048
-etag: W/"431d-/dqE/W5Q3FqkHikyDQtCuQqAdlY"
-content-type: image/png
-cache-control: public,max-age=3600
-alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-----------------------------------
-++++
-  </div>
-  <div tabindex="2"
-       role="tabpanel"
-       id="tiles-png-tab-group-curl"
-       aria-labelledby="tiles-png-group-curl"
-       hidden="">
-++++
 [source,bash]
 ----------------------------------
 curl -I 'https://tiles.maps.elastic.co/styles/osm-bright-desaturated/sprite.png' \
@@ -111,10 +59,59 @@ content-type: image/png
 cache-control: public,max-age=3600
 alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
 ----------------------------------
+====
+++++
+  </div>
+  <div tabindex="1"
+       role="tabpanel"
+       id="tiles-png-tab-group-request"
+       aria-labelledby="tiles-png-group-request"
+       hidden="">
+++++
+[source,regex,subs="attributes"]
+----------------------------------
+Host: tiles.maps.elastic.co
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/119.0
+Accept: image/avif,image/webp,*/*
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate, br
+Referer: {ems-headers-url}/app/maps/map
+Origin: {ems-headers-url}
+Connection: keep-alive
+Sec-Fetch-Dest: image
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Pragma: no-cache
+Cache-Control: no-cache
+TE: trailers
+----------------------------------
+++++
+  </div>
+  <div tabindex="2"
+       role="tabpanel"
+       id="tiles-png-tab-group-response"
+       aria-labelledby="tiles-png-group-response"
+       hidden="">
+++++
+[source,regex]
+----------------------------------
+content-length: 17181
+access-control-allow-origin: *
+access-control-allow-methods: GET, OPTIONS, HEAD
+access-control-allow-headers: Origin, Accept, Content-Type, kbn-version, elastic-api-version
+access-control-expose-headers: etag
+x-varnish: 3530683 3764574
+accept-ranges: bytes
+varnish-age: 833
+via: 1.1 varnish (Varnish/7.0), 1.1 google
+date: Mon, 20 Nov 2023 14:44:29 GMT
+age: 77048
+etag: W/"431d-/dqE/W5Q3FqkHikyDQtCuQqAdlY"
+content-type: image/png
+cache-control: public,max-age=3600
+alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+----------------------------------
 ++++
   </div>
 </div>
 ++++
-
-
-


### PR DESCRIPTION
Fixes #129751

## Summary

Extends the EMS documentation to detail request and response headers the browser sends to EMS resources and includes also a minimal `curl` command to request the response headers for same resource as well.

I tried to edit this in a way it does not take the whole page but happy to hear feedback or ideas on how to make this easier to digest.

https://github.com/elastic/kibana/assets/188264/27e83a5f-4d01-47a8-af2c-3739576bf56e


Also, I am not sure if this is something worth adding to our release notes :thinking: 

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->