### PR TITLE
[SecuritySolution] Disable the timeline save tour with localstorage flag

### DIFF
--- a/x-pack/plugins/fleet/cypress/tasks/common.ts
+++ b/x-pack/plugins/fleet/cypress/tasks/common.ts
@@ -49,6 +49,7 @@ export const request = <T = unknown>({
 
 const NEW_FEATURES_TOUR_STORAGE_KEYS = {
   RULE_MANAGEMENT_PAGE: 'securitySolution.rulesManagementPage.newFeaturesTour.v8.9',
+  TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTour',
 };
 
 const disableNewFeaturesTours = (window: Window) => {

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -429,6 +429,7 @@ export const RULES_TABLE_MAX_PAGE_SIZE = 100;
  */
 export const NEW_FEATURES_TOUR_STORAGE_KEYS = {
   RULE_MANAGEMENT_PAGE: 'securitySolution.rulesManagementPage.newFeaturesTour.v8.11',
+  TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTourSeen',
 };
 
 export const RULE_DETAILS_EXECUTION_LOG_TABLE_SHOW_METRIC_COLUMNS_STORAGE_KEY =

--- a/x-pack/plugins/security_solution/common/constants.ts
+++ b/x-pack/plugins/security_solution/common/constants.ts
@@ -429,7 +429,7 @@ export const RULES_TABLE_MAX_PAGE_SIZE = 100;
  */
 export const NEW_FEATURES_TOUR_STORAGE_KEYS = {
   RULE_MANAGEMENT_PAGE: 'securitySolution.rulesManagementPage.newFeaturesTour.v8.11',
-  TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTourSeen',
+  TIMELINES: 'securitySolution.security.timelineFlyoutHeader.saveTimelineTour',
 };
 
 export const RULE_DETAILS_EXECUTION_LOG_TABLE_SHOW_METRIC_COLUMNS_STORAGE_KEY =

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -108,12 +108,6 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables Protection Updates tab in the Endpoint Policy Details page
    */
   protectionUpdatesEnabled: true,
-
-  /**
-   * Disables the timeline save tour.
-   * This flag is used to disable the tour in cypress tests.
-   */
-  disableTimelineSaveTour: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/save_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/save_timeline_button.tsx
@@ -23,7 +23,7 @@ export interface SaveTimelineButtonProps {
 }
 
 const SAVE_BUTTON_ELEMENT_ID = 'SAVE_BUTTON_ELEMENT_ID';
-const LOCAL_STORAGE_KEY = 'security.timelineFlyoutHeader.saveTimelineTourSeen';
+const LOCAL_STORAGE_KEY = 'security.timelineFlyoutHeader.saveTimelineTour';
 
 export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelineId }) => {
   const [showEditTimelineOverlay, setShowEditTimelineOverlay] = useState<boolean>(false);
@@ -56,6 +56,9 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelin
   const [timelineTourStatus, setTimelineTourStatus] = useLocalStorage({
     defaultValue: { isTourActive: true },
     key: LOCAL_STORAGE_KEY,
+    isInvalidDefault: (valueFromStorage) => {
+      return !valueFromStorage;
+    },
   });
   // Why are we checking for so many flags here?
   // The tour popup should only show when timeline is fully populated and all necessary
@@ -67,7 +70,7 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelin
     isVisible &&
     !isLoading &&
     isSaveButtonMounted &&
-    timelineTourStatus.isTourActive;
+    timelineTourStatus?.isTourActive;
 
   const markTimelineSaveTourAsSeen = useCallback(() => {
     setTimelineTourStatus({ isTourActive: false });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/header/save_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/header/save_timeline_button.tsx
@@ -14,7 +14,6 @@ import { TimelineStatus } from '../../../../../common/api/timeline';
 import { useUserPrivileges } from '../../../../common/components/user_privileges';
 import { useIsElementMounted } from '../../../../detection_engine/rule_management_ui/components/rules_table/rules_table/guided_onboarding/use_is_element_mounted';
 import { useLocalStorage } from '../../../../common/components/local_storage';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 
 import { SaveTimelineModal } from './save_timeline_modal';
 import * as timelineTranslations from './translations';
@@ -27,8 +26,6 @@ const SAVE_BUTTON_ELEMENT_ID = 'SAVE_BUTTON_ELEMENT_ID';
 const LOCAL_STORAGE_KEY = 'security.timelineFlyoutHeader.saveTimelineTourSeen';
 
 export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelineId }) => {
-  const isTimelineSaveTourSaveTourDisabled =
-    useIsExperimentalFeatureEnabled('disableTimelineSaveTour');
   const [showEditTimelineOverlay, setShowEditTimelineOverlay] = useState<boolean>(false);
 
   const closeSaveTimeline = useCallback(() => {
@@ -56,8 +53,8 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelin
   } = useDeepEqualSelector((state) => getTimelineStatus(state, timelineId));
 
   const isSaveButtonMounted = useIsElementMounted(SAVE_BUTTON_ELEMENT_ID);
-  const [hasSeenTimelineSaveTour, setHasSeenTimelineSaveTour] = useLocalStorage({
-    defaultValue: false,
+  const [timelineTourStatus, setTimelineTourStatus] = useLocalStorage({
+    defaultValue: { isTourActive: true },
     key: LOCAL_STORAGE_KEY,
   });
   // Why are we checking for so many flags here?
@@ -66,17 +63,15 @@ export const SaveTimelineButton = React.memo<SaveTimelineButtonProps>(({ timelin
   // popup would show too early and in the wrong place in the DOM.
   // The last flag, checks if the tour has been dismissed before.
   const showTimelineSaveTour =
-    // The timeline save tour could be disabled on a plugin level
-    !isTimelineSaveTourSaveTourDisabled &&
     canEditTimeline &&
     isVisible &&
     !isLoading &&
     isSaveButtonMounted &&
-    !hasSeenTimelineSaveTour;
+    timelineTourStatus.isTourActive;
 
   const markTimelineSaveTourAsSeen = useCallback(() => {
-    setHasSeenTimelineSaveTour(true);
-  }, [setHasSeenTimelineSaveTour]);
+    setTimelineTourStatus({ isTourActive: false });
+  }, [setTimelineTourStatus]);
 
   const isUnsaved = timelineStatus === TimelineStatus.draft;
   const tooltipContent = canEditTimeline ? null : timelineTranslations.CALL_OUT_UNAUTHORIZED_MSG;

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -46,7 +46,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'chartEmbeddablesEnabled',
-          'disableTimelineSaveTour',
         ])}`,
         // mock cloud to enable the guided onboarding tour in e2e tests
         '--xpack.cloud.id=test',

--- a/x-pack/test/security_solution_cypress/serverless_config.ts
+++ b/x-pack/test/security_solution_cypress/serverless_config.ts
@@ -34,9 +34,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
           { product_line: 'endpoint', product_tier: 'complete' },
           { product_line: 'cloud', product_tier: 'complete' },
         ])}`,
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-          'disableTimelineSaveTour',
-        ])}`,
       ],
     },
     testRunner: SecuritySolutionConfigurableCypressTestRunner,

--- a/x-pack/test/security_solution_endpoint/config.base.ts
+++ b/x-pack/test/security_solution_endpoint/config.base.ts
@@ -90,10 +90,6 @@ export const generateConfig = async ({
         `--xpack.fleet.packages.0.version=latest`,
         // this will be removed in 8.7 when the file upload feature is released
         `--xpack.fleet.enableExperimental.0=diagnosticFileUploadEnabled`,
-        // disable a tour that prevents tests from passing
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-          'disableTimelineSaveTour',
-        ])}`,
         ...kbnServerArgs,
       ],
     },


### PR DESCRIPTION
## Summary

In this PR we're getting rid of the `enableExperimental` flag `disableTimelineSaveTour` in favor of a custom localStorage flag in the cypress tests. This will allow us to run the tests against a production version of Kibana without setting custom config flags.