### PR TITLE
[Profiling] update Linux kernel bug warning

### DIFF
--- a/x-pack/plugins/profiling/public/views/add_data_view/index.tsx
+++ b/x-pack/plugins/profiling/public/views/add_data_view/index.tsx
@@ -541,7 +541,7 @@ docker.elastic.co/observability/profiling-agent:${stackVersion} /root/pf-host-ag
             title={
               <FormattedMessage
                 id="xpack.profiling.tabs.debWarning"
-                defaultMessage="Due to a {linuxLink} which impacts stability, the profiling agent will refuse to run on kernel versions {versionFrom} to {versionTo}. Refer to {debianLink} and {fedoraLink} to learn more. If you are running such a kernel with a backported fix, please refer to {advancedLink} for instructions to override the precautionary measure."
+                defaultMessage="Due to a {linuxLink} bug which impacts stability, the Universal Profiling agent will not run on unpatched kernel versions {versionFrom} to {versionTo}. Refer to {debianLink} and {fedoraLink} to learn more. If you are running an affected kernel, the Universal Profiling agent dynamically checks for the patch. Refer to {advancedLink} for instructions on overriding this check."
                 values={{
                   versionFrom: (
                     <strong>


### PR DESCRIPTION
## Summary

New versions of Universal Profiling agent will dynamically check for a patch of the bug. Adjust the warning text accordingly.


