### PR TITLE
[Logs Explorer] Add optional data-test-subj param for the AI Assistant button context

### DIFF
--- a/x-pack/plugins/logs_shared/public/components/log_ai_assistant/log_ai_assistant.tsx
+++ b/x-pack/plugins/logs_shared/public/components/log_ai_assistant/log_ai_assistant.tsx
@@ -77,12 +77,20 @@ export const LogAIAssistant = withProviders(({ doc }: LogAIAssistantProps) => {
     <EuiFlexGroup direction="column" gutterSize="m">
       {aiAssistant.isEnabled() && explainLogMessageMessages ? (
         <EuiFlexItem grow={false}>
-          <ContextualInsight title={explainLogMessageTitle} messages={explainLogMessageMessages} />
+          <ContextualInsight
+            title={explainLogMessageTitle}
+            messages={explainLogMessageMessages}
+            dataTestSubj="obsAiAssistantInsightButtonExplainLogMessage"
+          />
         </EuiFlexItem>
       ) : null}
       {aiAssistant.isEnabled() && similarLogMessageMessages ? (
         <EuiFlexItem grow={false}>
-          <ContextualInsight title={similarLogMessagesTitle} messages={similarLogMessageMessages} />
+          <ContextualInsight
+            title={similarLogMessagesTitle}
+            messages={similarLogMessageMessages}
+            dataTestSubj="obsAiAssistantInsightButtonSimilarLogMessage"
+          />
         </EuiFlexItem>
       ) : null}
     </EuiFlexGroup>

--- a/x-pack/plugins/observability_ai_assistant/public/components/insight/insight.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/insight/insight.tsx
@@ -280,7 +280,15 @@ function ChatContent({
   );
 }
 
-export function Insight({ messages, title }: { messages: Message[]; title: string }) {
+export function Insight({
+  messages,
+  title,
+  dataTestSubj,
+}: {
+  messages: Message[];
+  title: string;
+  dataTestSubj?: string;
+}) {
   const [hasOpened, setHasOpened] = useState(false);
 
   const connectors = useGenAIConnectors();
@@ -322,6 +330,7 @@ export function Insight({ messages, title }: { messages: Message[]; title: strin
       }}
       controls={<ConnectorSelectorBase {...connectors} />}
       loading={connectors.loading || chatService.loading}
+      dataTestSubj={dataTestSubj}
     >
       {chatService.value ? (
         <ObservabilityAIAssistantChatServiceProvider value={chatService.value}>

--- a/x-pack/plugins/observability_ai_assistant/public/components/insight/insight_base.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/insight/insight_base.tsx
@@ -32,6 +32,7 @@ export interface InsightBaseProps {
   onToggle: (isOpen: boolean) => void;
   children: React.ReactNode;
   loading?: boolean;
+  dataTestSubj?: string;
 }
 
 export function InsightBase({
@@ -44,6 +45,7 @@ export function InsightBase({
   actions,
   onToggle,
   loading,
+  dataTestSubj = 'obsAiAssistantInsightButton',
 }: InsightBaseProps) {
   const { euiTheme } = useEuiTheme();
 
@@ -59,7 +61,7 @@ export function InsightBase({
         id="obsAiAssistantInsight"
         arrowProps={{ css: { alignSelf: 'flex-start' } }}
         buttonContent={
-          <EuiFlexGroup wrap responsive={false} gutterSize="m">
+          <EuiFlexGroup wrap responsive={false} gutterSize="m" data-test-subj={dataTestSubj}>
             <EuiFlexItem grow={false}>
               <EuiSpacer size="xs" />
               <AssistantAvatar size="xs" />


### PR DESCRIPTION
## Summary

In order to capture Telemetry on which of the AI assistant the users are clicking, we need an identifier so that we can use it to create a funnel in Full Story.

What better than having an option to pass dataTestSubj from the client