### PR TITLE
Cancel all requests when an alerting rule times out from running

### DIFF
--- a/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.test.ts
+++ b/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.test.ts
@@ -36,180 +36,181 @@ describe('wrapScopedClusterClient', () => {
     jest.resetAllMocks();
   });
 
-  test('searches with asInternalUser when specified', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
-
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    const asInternalUserWrappedSearchFn = childClient.search;
-
-    const wrappedSearchClient = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
-    }).client();
-    await wrappedSearchClient.asInternalUser.search(esQuery);
-
-    expect(asInternalUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {
-      signal: abortController.signal,
-    });
-    expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
-    expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+  describe('transport.request', () => {
+    // TODO
   });
 
-  test('searches with asCurrentUser when specified', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
+  describe('search', () => {
+    test('with asInternalUser when specified', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
 
-    scopedClusterClient.asCurrentUser.child.mockReturnValue(childClient as unknown as Client);
-    const asCurrentUserWrappedSearchFn = childClient.search;
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      const asInternalUserWrappedSearchFn = childClient.search;
 
-    const wrappedSearchClient = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
-    }).client();
-    await wrappedSearchClient.asCurrentUser.search(esQuery);
+      const wrappedSearchClient = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      }).client();
+      await wrappedSearchClient.asInternalUser.search(esQuery);
 
-    expect(asCurrentUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {
-      signal: abortController.signal,
-    });
-    expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
-    expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
-  });
-
-  test('uses search options when specified', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
-
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    const asInternalUserWrappedSearchFn = childClient.search;
-
-    const wrappedSearchClient = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
-    }).client();
-    await wrappedSearchClient.asInternalUser.search(esQuery, { ignore: [404] });
-
-    expect(asInternalUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {
-      ignore: [404],
-      signal: abortController.signal,
-    });
-    expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
-    expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
-  });
-
-  test('re-throws error when search throws error', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
-
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    const asInternalUserWrappedSearchFn = childClient.search;
-
-    asInternalUserWrappedSearchFn.mockRejectedValueOnce(new Error('something went wrong!'));
-    const wrappedSearchClient = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
-    }).client();
-
-    await expect(
-      wrappedSearchClient.asInternalUser.search
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong!"`);
-  });
-
-  test('handles empty search result object', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
-
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    const asInternalUserWrappedSearchFn = childClient.search;
-    // @ts-ignore incomplete return type
-    asInternalUserWrappedSearchFn.mockResolvedValue({});
-
-    const wrappedSearchClientFactory = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
+      expect(asInternalUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {});
+      expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
+      expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
     });
 
-    const wrappedSearchClient = wrappedSearchClientFactory.client();
-    await wrappedSearchClient.asInternalUser.search(esQuery);
+    test('with asCurrentUser when specified', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
 
-    expect(asInternalUserWrappedSearchFn).toHaveBeenCalledTimes(1);
-    expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
-    expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+      scopedClusterClient.asCurrentUser.child.mockReturnValue(childClient as unknown as Client);
+      const asCurrentUserWrappedSearchFn = childClient.search;
 
-    const stats = wrappedSearchClientFactory.getMetrics();
-    expect(stats.numSearches).toEqual(1);
-    expect(stats.esSearchDurationMs).toEqual(0);
-  });
+      const wrappedSearchClient = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      }).client();
+      await wrappedSearchClient.asCurrentUser.search(esQuery);
 
-  test('keeps track of number of queries', async () => {
-    const abortController = new AbortController();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
-
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    const asInternalUserWrappedSearchFn = childClient.search;
-    // @ts-ignore incomplete return type
-    asInternalUserWrappedSearchFn.mockResolvedValue({ took: 333 });
-
-    const wrappedSearchClientFactory = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
+      expect(asCurrentUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {});
+      expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
+      expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
     });
-    const wrappedSearchClient = wrappedSearchClientFactory.client();
-    await wrappedSearchClient.asInternalUser.search(esQuery);
-    await wrappedSearchClient.asInternalUser.search(esQuery);
-    await wrappedSearchClient.asInternalUser.search(esQuery);
 
-    expect(asInternalUserWrappedSearchFn).toHaveBeenCalledTimes(3);
-    expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
-    expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+    test('uses search options when specified', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
 
-    const stats = wrappedSearchClientFactory.getMetrics();
-    expect(stats.numSearches).toEqual(3);
-    expect(stats.esSearchDurationMs).toEqual(999);
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      const asInternalUserWrappedSearchFn = childClient.search;
 
-    expect(logger.debug).toHaveBeenCalledWith(
-      `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
-    );
-  });
+      const wrappedSearchClient = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      }).client();
+      await wrappedSearchClient.asInternalUser.search(esQuery, { ignore: [404] });
 
-  test('throws error when search throws abort error', async () => {
-    const abortController = new AbortController();
-    abortController.abort();
-    const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
-    const childClient = elasticsearchServiceMock.createElasticsearchClient();
+      expect(asInternalUserWrappedSearchFn).toHaveBeenCalledWith(esQuery, {
+        ignore: [404],
+      });
+      expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
+      expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+    });
 
-    scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
-    childClient.search.mockRejectedValueOnce(new Error('Request has been aborted by the user'));
+    test('re-throws error when search throws error', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
 
-    const abortableSearchClient = createWrappedScopedClusterClientFactory({
-      scopedClusterClient,
-      rule,
-      logger,
-      abortController,
-    }).client();
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      const asInternalUserWrappedSearchFn = childClient.search;
 
-    await expect(
-      abortableSearchClient.asInternalUser.search
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Search has been aborted due to cancelled execution"`
-    );
+      asInternalUserWrappedSearchFn.mockRejectedValueOnce(new Error('something went wrong!'));
+      const wrappedSearchClient = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      }).client();
+
+      await expect(
+        wrappedSearchClient.asInternalUser.search
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong!"`);
+    });
+
+    test('handles empty search result object', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
+
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      const asInternalUserWrappedSearchFn = childClient.search;
+      // @ts-ignore incomplete return type
+      asInternalUserWrappedSearchFn.mockResolvedValue({});
+
+      const wrappedSearchClientFactory = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      });
+
+      const wrappedSearchClient = wrappedSearchClientFactory.client();
+      await wrappedSearchClient.asInternalUser.search(esQuery);
+
+      expect(asInternalUserWrappedSearchFn).toHaveBeenCalledTimes(1);
+      expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
+      expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+
+      const stats = wrappedSearchClientFactory.getMetrics();
+      expect(stats.numSearches).toEqual(1);
+      expect(stats.esSearchDurationMs).toEqual(0);
+    });
+
+    test('keeps track of number of queries', async () => {
+      const abortController = new AbortController();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
+
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      const asInternalUserWrappedSearchFn = childClient.search;
+      // @ts-ignore incomplete return type
+      asInternalUserWrappedSearchFn.mockResolvedValue({ took: 333 });
+
+      const wrappedSearchClientFactory = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      });
+      const wrappedSearchClient = wrappedSearchClientFactory.client();
+      await wrappedSearchClient.asInternalUser.search(esQuery);
+      await wrappedSearchClient.asInternalUser.search(esQuery);
+      await wrappedSearchClient.asInternalUser.search(esQuery);
+
+      expect(asInternalUserWrappedSearchFn).toHaveBeenCalledTimes(3);
+      expect(scopedClusterClient.asInternalUser.search).not.toHaveBeenCalled();
+      expect(scopedClusterClient.asCurrentUser.search).not.toHaveBeenCalled();
+
+      const stats = wrappedSearchClientFactory.getMetrics();
+      expect(stats.numSearches).toEqual(3);
+      expect(stats.esSearchDurationMs).toEqual(999);
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        `executing query for rule .test-rule-type:abcdefg in space my-space - {\"body\":{\"query\":{\"bool\":{\"filter\":{\"range\":{\"@timestamp\":{\"gte\":0}}}}}}} - with options {}`
+      );
+    });
+
+    test('throws error when search throws abort error', async () => {
+      const abortController = new AbortController();
+      abortController.abort();
+      const scopedClusterClient = elasticsearchServiceMock.createScopedClusterClient();
+      const childClient = elasticsearchServiceMock.createElasticsearchClient();
+
+      scopedClusterClient.asInternalUser.child.mockReturnValue(childClient as unknown as Client);
+      childClient.search.mockRejectedValueOnce(new Error('Request has been aborted by the user'));
+
+      const abortableSearchClient = createWrappedScopedClusterClientFactory({
+        scopedClusterClient,
+        rule,
+        logger,
+        abortController,
+      }).client();
+
+      await expect(
+        abortableSearchClient.asInternalUser.search
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Search has been aborted due to cancelled execution"`
+      );
+    });
   });
 });

--- a/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
+++ b/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
@@ -12,6 +12,15 @@ import {
   TransportRequestOptionsWithOutMeta,
   TransportRequestParams,
 } from '@elastic/elasticsearch';
+import type {
+  SearchRequest,
+  SearchResponse,
+  AggregateName,
+} from '@elastic/elasticsearch/lib/api/types';
+import type {
+  SearchRequest as SearchRequestWithBody,
+  AggregationsAggregate,
+} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { IScopedClusterClient, ElasticsearchClient, Logger } from '@kbn/core/server';
 import { SearchMetrics, RuleInfo } from './types';
 
@@ -80,11 +89,14 @@ function wrapEsClient(opts: WrapEsClientOpts): ElasticsearchClient {
 
   const wrappedClient = esClient.child({});
 
-  // Mutating the functions we want to wrap
+  // Mutating the request function so we can cancel all ongoing requests
   wrappedClient.transport.request = getWrappedTransportRequestFn({
     esClient: wrappedClient,
     ...rest,
   });
+
+  // Mutating the functions we want to wrap
+  wrappedClient.search = getWrappedSearchFn({ esClient: wrappedClient, ...rest });
 
   return wrappedClient;
 }
@@ -113,4 +125,78 @@ function getWrappedTransportRequestFn(opts: WrapEsClientOpts) {
   }
 
   return request;
+}
+
+function getWrappedSearchFn(opts: WrapEsClientOpts) {
+  const originalSearch = opts.esClient.search;
+
+  // A bunch of overloads to make TypeScript happy
+  async function search<
+    TDocument = unknown,
+    TAggregations = Record<AggregateName, AggregationsAggregate>
+  >(
+    params?: SearchRequest | SearchRequestWithBody,
+    options?: TransportRequestOptionsWithOutMeta
+  ): Promise<SearchResponse<TDocument, TAggregations>>;
+  async function search<
+    TDocument = unknown,
+    TAggregations = Record<AggregateName, AggregationsAggregate>
+  >(
+    params?: SearchRequest | SearchRequestWithBody,
+    options?: TransportRequestOptionsWithMeta
+  ): Promise<TransportResult<SearchResponse<TDocument, TAggregations>, unknown>>;
+  async function search<
+    TDocument = unknown,
+    TAggregations = Record<AggregateName, AggregationsAggregate>
+  >(
+    params?: SearchRequest | SearchRequestWithBody,
+    options?: TransportRequestOptions
+  ): Promise<SearchResponse<TDocument, TAggregations>>;
+  async function search<
+    TDocument = unknown,
+    TAggregations = Record<AggregateName, AggregationsAggregate>
+  >(
+    params?: SearchRequest | SearchRequestWithBody,
+    options?: TransportRequestOptions
+  ): Promise<
+    | TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
+    | SearchResponse<TDocument, TAggregations>
+  > {
+    try {
+      const searchOptions = options ?? {};
+      const start = Date.now();
+      opts.logger.debug(
+        `executing query for rule ${opts.rule.alertTypeId}:${opts.rule.id} in space ${
+          opts.rule.spaceId
+        } - ${JSON.stringify(params)} - with options ${JSON.stringify(searchOptions)}`
+      );
+      // No need to pass "signal" because the lower level request function is already wrapped to do so
+      const result = (await originalSearch.call(opts.esClient, params, searchOptions)) as
+        | TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
+        | SearchResponse<TDocument, TAggregations>;
+
+      const end = Date.now();
+      const durationMs = end - start;
+
+      let took = 0;
+      if (searchOptions.meta) {
+        // when meta: true, response is TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
+        took = (result as TransportResult<SearchResponse<TDocument, TAggregations>, unknown>).body
+          .took;
+      } else {
+        // when meta: false, response is SearchResponse<TDocument, TAggregations>
+        took = (result as SearchResponse<TDocument, TAggregations>).took;
+      }
+
+      opts.logMetricsFn({ esSearchDuration: took ?? 0, totalSearchDuration: durationMs });
+      return result;
+    } catch (e) {
+      if (opts.abortController.signal.aborted) {
+        throw new Error('Search has been aborted due to cancelled execution');
+      }
+      throw e;
+    }
+  }
+
+  return search;
 }

--- a/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
+++ b/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
@@ -10,16 +10,8 @@ import {
   TransportResult,
   TransportRequestOptionsWithMeta,
   TransportRequestOptionsWithOutMeta,
+  TransportRequestParams,
 } from '@elastic/elasticsearch';
-import type {
-  SearchRequest,
-  SearchResponse,
-  AggregateName,
-} from '@elastic/elasticsearch/lib/api/types';
-import type {
-  SearchRequest as SearchRequestWithBody,
-  AggregationsAggregate,
-} from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import type { IScopedClusterClient, ElasticsearchClient, Logger } from '@kbn/core/server';
 import { SearchMetrics, RuleInfo } from './types';
 
@@ -89,83 +81,36 @@ function wrapEsClient(opts: WrapEsClientOpts): ElasticsearchClient {
   const wrappedClient = esClient.child({});
 
   // Mutating the functions we want to wrap
-  wrappedClient.search = getWrappedSearchFn({ esClient: wrappedClient, ...rest });
+  wrappedClient.transport.request = getWrappedTransportRequestFn({
+    esClient: wrappedClient,
+    ...rest,
+  });
 
   return wrappedClient;
 }
 
-function getWrappedSearchFn(opts: WrapEsClientOpts) {
-  const originalSearch = opts.esClient.search;
+function getWrappedTransportRequestFn(opts: WrapEsClientOpts) {
+  const originalRequestFn = opts.esClient.transport.request;
 
   // A bunch of overloads to make TypeScript happy
-  async function search<
-    TDocument = unknown,
-    TAggregations = Record<AggregateName, AggregationsAggregate>
-  >(
-    params?: SearchRequest | SearchRequestWithBody,
+  async function request<TResponse = unknown>(
+    params: TransportRequestParams,
     options?: TransportRequestOptionsWithOutMeta
-  ): Promise<SearchResponse<TDocument, TAggregations>>;
-  async function search<
-    TDocument = unknown,
-    TAggregations = Record<AggregateName, AggregationsAggregate>
-  >(
-    params?: SearchRequest | SearchRequestWithBody,
+  ): Promise<TResponse>;
+  async function request<TResponse = unknown, TContext = unknown>(
+    params: TransportRequestParams,
     options?: TransportRequestOptionsWithMeta
-  ): Promise<TransportResult<SearchResponse<TDocument, TAggregations>, unknown>>;
-  async function search<
-    TDocument = unknown,
-    TAggregations = Record<AggregateName, AggregationsAggregate>
-  >(
-    params?: SearchRequest | SearchRequestWithBody,
+  ): Promise<TransportResult<TResponse, TContext>>;
+  async function request<TResponse = unknown>(
+    params: TransportRequestParams,
     options?: TransportRequestOptions
-  ): Promise<SearchResponse<TDocument, TAggregations>>;
-  async function search<
-    TDocument = unknown,
-    TAggregations = Record<AggregateName, AggregationsAggregate>
-  >(
-    params?: SearchRequest | SearchRequestWithBody,
-    options?: TransportRequestOptions
-  ): Promise<
-    | TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
-    | SearchResponse<TDocument, TAggregations>
-  > {
-    try {
-      const searchOptions = options ?? {};
-      const start = Date.now();
-      opts.logger.debug(
-        `executing query for rule ${opts.rule.alertTypeId}:${opts.rule.id} in space ${
-          opts.rule.spaceId
-        } - ${JSON.stringify(params)} - with options ${JSON.stringify(searchOptions)}`
-      );
-      const result = (await originalSearch.call(opts.esClient, params, {
-        ...searchOptions,
-        signal: opts.abortController.signal,
-      })) as
-        | TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
-        | SearchResponse<TDocument, TAggregations>;
-
-      const end = Date.now();
-      const durationMs = end - start;
-
-      let took = 0;
-      if (searchOptions.meta) {
-        // when meta: true, response is TransportResult<SearchResponse<TDocument, TAggregations>, unknown>
-        took = (result as TransportResult<SearchResponse<TDocument, TAggregations>, unknown>).body
-          .took;
-      } else {
-        // when meta: false, response is SearchResponse<TDocument, TAggregations>
-        took = (result as SearchResponse<TDocument, TAggregations>).took;
-      }
-
-      opts.logMetricsFn({ esSearchDuration: took ?? 0, totalSearchDuration: durationMs });
-      return result;
-    } catch (e) {
-      if (opts.abortController.signal.aborted) {
-        throw new Error('Search has been aborted due to cancelled execution');
-      }
-      throw e;
-    }
+  ): Promise<TResponse> {
+    const requestOptions = options ?? {};
+    return (await originalRequestFn.call(opts.esClient.transport, params, {
+      ...requestOptions,
+      signal: opts.abortController.signal,
+    })) as Promise<TResponse>;
   }
 
-  return search;
+  return request;
 }


### PR DESCRIPTION
WIP

This PR cancels all requests made with the esClient by an alerting rule type executor when an alerting rule times out.

- [ ] Add back search metrics and logic