### PR TITLE
[Security Solution] Adding missing tests to explore folder

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/inspect/inspect_button.cy.ts
@@ -9,17 +9,17 @@ import {
   INSPECT_BUTTONS_IN_SECURITY,
   INSPECT_MODAL,
   INSPECT_MODAL_INDEX_PATTERN,
-} from '../../screens/inspect';
+} from '../../../screens/inspect';
 import {
   closesModal,
   openLensVisualizationsInspectModal,
   openTab,
   openTableInspectModal,
-} from '../../tasks/inspect';
-import { login } from '../../tasks/login';
-import { visitWithTimeRange } from '../../tasks/navigation';
-import { postDataView, waitForWelcomePanelToBeLoaded } from '../../tasks/common';
-import { selectDataView } from '../../tasks/sourcerer';
+} from '../../../tasks/inspect';
+import { login } from '../../../tasks/login';
+import { visitWithTimeRange } from '../../../tasks/navigation';
+import { postDataView, waitForWelcomePanelToBeLoaded } from '../../../tasks/common';
+import { selectDataView } from '../../../tasks/sourcerer';
 
 const DATA_VIEW = 'auditbeat-*';
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/ml/ml_conditional_links.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/ml/ml_conditional_links.cy.ts
@@ -5,10 +5,10 @@
  * 2.0.
  */
 
-import { KQL_INPUT } from '../../screens/security_header';
+import { KQL_INPUT } from '../../../screens/security_header';
 
-import { login } from '../../tasks/login';
-import { visit } from '../../tasks/navigation';
+import { login } from '../../../tasks/login';
+import { visit } from '../../../tasks/navigation';
 
 import {
   mlHostMultiHostKqlQuery,
@@ -24,7 +24,7 @@ import {
   mlNetworkNullKqlQuery,
   mlNetworkSingleIpKqlQuery,
   mlNetworkSingleIpNullKqlQuery,
-} from '../../urls/ml_conditional_links';
+} from '../../../urls/ml_conditional_links';
 
 describe('ml conditional links', { tags: ['@ess', '@brokenInServerless'] }, () => {
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/navigation/navigation.cy.ts
@@ -30,12 +30,12 @@ import {
   EXPLORE,
   SETTINGS,
   ENTITY_ANALYTICS,
-} from '../../screens/security_header';
-import * as ServerlessHeaders from '../../screens/serverless_security_header';
+} from '../../../screens/security_header';
+import * as ServerlessHeaders from '../../../screens/serverless_security_header';
 
-import { login } from '../../tasks/login';
-import { visit, visitGetStartedPage, visitWithTimeRange } from '../../tasks/navigation';
-import { navigateFromHeaderTo } from '../../tasks/security_header';
+import { login } from '../../../tasks/login';
+import { visit, visitGetStartedPage, visitWithTimeRange } from '../../../tasks/navigation';
+import { navigateFromHeaderTo } from '../../../tasks/security_header';
 
 import {
   ALERTS_URL,
@@ -71,12 +71,12 @@ import {
   ASSETS_URL,
   FLEET_URL,
   CLOUD_DEFEND_URL,
-} from '../../urls/navigation';
-import { RULES_MANAGEMENT_URL } from '../../urls/rules_management';
+} from '../../../urls/navigation';
+import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
 import {
   openKibanaNavigation,
   navigateFromKibanaCollapsibleTo,
-} from '../../tasks/kibana_navigation';
+} from '../../../tasks/kibana_navigation';
 import {
   CASES_PAGE,
   ALERTS_PAGE,
@@ -86,7 +86,7 @@ import {
   TIMELINES_PAGE,
   FINDINGS_PAGE,
   THREAT_INTELLIGENCE_PAGE,
-} from '../../screens/kibana_navigation';
+} from '../../../screens/kibana_navigation';
 
 describe('top-level navigation common to all pages in the Security app', { tags: '@ess' }, () => {
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/navigation/search_bar.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/navigation/search_bar.cy.ts
@@ -5,23 +5,23 @@
  * 2.0.
  */
 
-import { login } from '../../tasks/login';
-import { visitWithTimeRange } from '../../tasks/navigation';
+import { login } from '../../../tasks/login';
+import { visitWithTimeRange } from '../../../tasks/navigation';
 import {
   openAddFilterPopover,
   fillAddFilterForm,
   openKqlQueryBar,
   fillKqlQueryBar,
-} from '../../tasks/search_bar';
+} from '../../../tasks/search_bar';
 import {
   AUTO_SUGGEST_AGENT_NAME,
   AUTO_SUGGEST_HOST_NAME_VALUE,
   GLOBAL_SEARCH_BAR_FILTER_ITEM,
-} from '../../screens/search_bar';
-import { getHostIpFilter } from '../../objects/filter';
+} from '../../../screens/search_bar';
+import { getHostIpFilter } from '../../../objects/filter';
 
-import { hostsUrl } from '../../urls/navigation';
-import { waitForAllHostsToBeLoaded } from '../../tasks/hosts/all_hosts';
+import { hostsUrl } from '../../../urls/navigation';
+import { waitForAllHostsToBeLoaded } from '../../../tasks/hosts/all_hosts';
 
 describe('SearchBar', { tags: ['@ess', '@serverless'] }, () => {
   beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/compatibility.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/compatibility.cy.ts
@@ -5,18 +5,18 @@
  * 2.0.
  */
 
-import { login } from '../../tasks/login';
-import { visit } from '../../tasks/navigation';
+import { login } from '../../../tasks/login';
+import { visit } from '../../../tasks/navigation';
 
-import { ALERTS_URL, CREATE_RULE_URL } from '../../urls/navigation';
-import { RULES_MANAGEMENT_URL } from '../../urls/rules_management';
-import { ABSOLUTE_DATE_RANGE } from '../../urls/state';
+import { ALERTS_URL, CREATE_RULE_URL } from '../../../urls/navigation';
+import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
+import { ABSOLUTE_DATE_RANGE } from '../../../urls/state';
 import {
   DATE_PICKER_START_DATE_POPOVER_BUTTON,
   GET_DATE_PICKER_END_DATE_POPOVER_BUTTON,
-} from '../../screens/date_picker';
-import { ruleDetailsUrl } from '../../urls/rule_details';
-import { editRuleUrl } from '../../urls/edit_rule';
+} from '../../../screens/date_picker';
+import { ruleDetailsUrl } from '../../../urls/rule_details';
+import { editRuleUrl } from '../../../urls/edit_rule';
 
 const LEGACY_DETECTIONS_URL_1 = '/app/siem#/detections';
 const LEGACY_DETECTIONS_URL_2 = '/app/security/detections';

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/not_found.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/not_found.cy.ts
@@ -5,8 +5,8 @@
  * 2.0.
  */
 
-import { login } from '../../tasks/login';
-import { visitWithTimeRange } from '../../tasks/navigation';
+import { login } from '../../../tasks/login';
+import { visitWithTimeRange } from '../../../tasks/navigation';
 
 import {
   ALERTS_URL,
@@ -16,12 +16,12 @@ import {
   TIMELINES_URL,
   EXCEPTIONS_URL,
   CREATE_RULE_URL,
-} from '../../urls/navigation';
-import { RULES_MANAGEMENT_URL } from '../../urls/rules_management';
+} from '../../../urls/navigation';
+import { RULES_MANAGEMENT_URL } from '../../../urls/rules_management';
 
-import { NOT_FOUND } from '../../screens/common/page';
-import { ruleDetailsUrl } from '../../urls/rule_details';
-import { editRuleUrl } from '../../urls/edit_rule';
+import { NOT_FOUND } from '../../../screens/common/page';
+import { ruleDetailsUrl } from '../../../urls/rule_details';
+import { editRuleUrl } from '../../../urls/edit_rule';
 
 const mockRuleId = '5a4a0460-d822-11eb-8962-bfd4aff0a9b3';
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/state.cy.ts
@@ -11,9 +11,9 @@ import {
   GET_LOCAL_DATE_PICKER_END_DATE_POPOVER_BUTTON,
   DATE_PICKER_START_DATE_POPOVER_BUTTON,
   GET_LOCAL_DATE_PICKER_START_DATE_POPOVER_BUTTON,
-} from '../../screens/date_picker';
-import { HOSTS_NAMES } from '../../screens/hosts/all_hosts';
-import { ANOMALIES_TAB } from '../../screens/hosts/main';
+} from '../../../screens/date_picker';
+import { HOSTS_NAMES } from '../../../screens/hosts/all_hosts';
+import { ANOMALIES_TAB } from '../../../screens/hosts/main';
 import {
   BREADCRUMBS,
   EXPLORE_PANEL_BTN,
@@ -22,38 +22,38 @@ import {
   NETWORK,
   LOADING_INDICATOR,
   openNavigationPanel,
-} from '../../screens/security_header';
-import { TIMELINE_DATE_PICKER_CONTAINER, TIMELINE_TITLE } from '../../screens/timeline';
+} from '../../../screens/security_header';
+import { TIMELINE_DATE_PICKER_CONTAINER, TIMELINE_TITLE } from '../../../screens/timeline';
 
-import { login } from '../../tasks/login';
-import { visit, visitWithTimeRange } from '../../tasks/navigation';
+import { login } from '../../../tasks/login';
+import { visit, visitWithTimeRange } from '../../../tasks/navigation';
 import {
   updateDates,
   setStartDate,
   setEndDate,
   updateTimelineDates,
-} from '../../tasks/date_picker';
-import { openFirstHostDetails, waitForAllHostsToBeLoaded } from '../../tasks/hosts/all_hosts';
-import { openAllHosts } from '../../tasks/hosts/main';
+} from '../../../tasks/date_picker';
+import { openFirstHostDetails, waitForAllHostsToBeLoaded } from '../../../tasks/hosts/all_hosts';
+import { openAllHosts } from '../../../tasks/hosts/main';
 
-import { waitForIpsTableToBeLoaded } from '../../tasks/network/flows';
+import { waitForIpsTableToBeLoaded } from '../../../tasks/network/flows';
 import {
   clearSearchBar,
   kqlSearch,
   navigateFromHeaderTo,
   saveQuery,
-} from '../../tasks/security_header';
-import { openTimelineUsingToggle } from '../../tasks/security_main';
-import { addNameToTimelineAndSave, closeTimeline, populateTimeline } from '../../tasks/timeline';
+} from '../../../tasks/security_header';
+import { openTimelineUsingToggle } from '../../../tasks/security_main';
+import { addNameToTimelineAndSave, closeTimeline, populateTimeline } from '../../../tasks/timeline';
 
-import { hostsUrl } from '../../urls/navigation';
-import { ABSOLUTE_DATE_RANGE } from '../../urls/state';
+import { hostsUrl } from '../../../urls/navigation';
+import { ABSOLUTE_DATE_RANGE } from '../../../urls/state';
 
-import { getTimeline } from '../../objects/timeline';
+import { getTimeline } from '../../../objects/timeline';
 import {
   GLOBAL_SEARCH_BAR_FILTER_ITEM_AT,
   GLOBAL_SEARCH_BAR_PINNED_FILTER,
-} from '../../screens/search_bar';
+} from '../../../screens/search_bar';
 
 const ABSOLUTE_DATE = {
   endTime: 'Aug 1, 2019 @ 20:33:29.186',


### PR DESCRIPTION
## Summary

This PR is part of the effort we are doing to have our tests ready for the second quality gate.

All the tests should have a clear owner so teams can take action when a serverless release is blocked due to a failing test.

In this PR we are moving some Cypress tests under the `Explore` team folder
