### PR TITLE
[DOCS] Fix authentication types for alerting rule enable API

### DIFF
--- a/docs/api/alerting/enable_rule.asciidoc
+++ b/docs/api/alerting/enable_rule.asciidoc
@@ -6,8 +6,6 @@
 
 Enable a rule.
 
-WARNING: This API supports <<token-api-authentication>> only.
-
 [NOTE]
 ====
 For the most up-to-date API details, refer to the


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/171761

The openAPI specification does not need to be updated, since it already has the `security` options set at the root level and they're not overridden at the operation level: https://github.com/elastic/kibana/blob/92bc2a0d7c863153beba9529258bafe91d25e9f3/x-pack/plugins/alerting/docs/openapi/entrypoint.yaml#L73

<!--ONMERGE {"backportTargets":["8.10","8.11","8.8","8.9"]} ONMERGE-->