### PR TITLE
[OAS] Add support for links and custom_details in PagerDuty connector

### DIFF
--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -303,6 +303,9 @@
                 "runJiraConnectorRequest": {
                   "$ref": "#/components/examples/run_jira_connector_request"
                 },
+                "runPagerDutyConnectorRequest": {
+                  "$ref": "#/components/examples/run_pagerduty_connector_request"
+                },
                 "runServerLogConnectorRequest": {
                   "$ref": "#/components/examples/run_server_log_connector_request"
                 },
@@ -367,6 +370,9 @@
                   },
                   "runJiraConnectorResponse": {
                     "$ref": "#/components/examples/run_jira_connector_response"
+                  },
+                  "runPagerDutyConnectorResponse": {
+                    "$ref": "#/components/examples/run_pagerduty_connector_response"
                   },
                   "runServerLogConnectorResponse": {
                     "$ref": "#/components/examples/run_server_log_connector_response"
@@ -4777,6 +4783,91 @@
           }
         }
       },
+      "run_connector_params_pagerduty": {
+        "title": "PagerDuty connector parameters",
+        "description": "Test an action that triggers, acknowledges, or resolves PagerDuty alerts.",
+        "type": "object",
+        "required": [
+          "eventAction"
+        ],
+        "properties": {
+          "class": {
+            "description": "The class or type of the event.",
+            "type": "string",
+            "example": "cpu load"
+          },
+          "component": {
+            "description": "The component of the source machine that is responsible for the event.",
+            "type": "string",
+            "example": "eth0"
+          },
+          "customDetails": {
+            "description": "Additional details to add to the event.",
+            "type": "object"
+          },
+          "dedupKey": {
+            "description": "All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.\n",
+            "type": "string",
+            "maxLength": 255
+          },
+          "eventAction": {
+            "description": "The type of event.",
+            "type": "string",
+            "enum": [
+              "acknowledge",
+              "resolve",
+              "trigger"
+            ]
+          },
+          "group": {
+            "description": "The logical grouping of components of a service.",
+            "type": "string",
+            "example": "app-stack"
+          },
+          "links": {
+            "description": "A list of links to add to the event.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "href": {
+                  "description": "The URL for the link.",
+                  "type": "string"
+                },
+                "text": {
+                  "description": "A plain text description of the purpose of the link.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "severity": {
+            "description": "The severity of the event on the affected system.",
+            "type": "string",
+            "enum": [
+              "critical",
+              "error",
+              "info",
+              "warning"
+            ],
+            "default": "info"
+          },
+          "source": {
+            "description": "The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.\n",
+            "type": "string"
+          },
+          "summary": {
+            "description": "A summery of the event.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "timestamp": {
+            "description": "An ISO-8601 timestamp that indicates when the event was detected or generated.",
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
       "run_connector_params_message_email": {
         "title": "Email connector parameters",
         "description": "Test an action that sends an email message. There must be at least one recipient in `to`, `cc`, or `bcc`.\n",
@@ -5514,6 +5605,9 @@
                 "$ref": "#/components/schemas/run_connector_params_documents"
               },
               {
+                "$ref": "#/components/schemas/run_connector_params_pagerduty"
+              },
+              {
                 "$ref": "#/components/schemas/run_connector_params_message_email"
               },
               {
@@ -5839,6 +5933,24 @@
           }
         }
       },
+      "run_pagerduty_connector_request": {
+        "summary": "Run a PagerDuty connector to trigger an alert.",
+        "value": {
+          "params": {
+            "eventAction": "trigger",
+            "summary": "A brief event summary",
+            "links": [
+              {
+                "href": "http://example.com/pagerduty",
+                "text": "An example link"
+              }
+            ],
+            "customDetails": {
+              "my_data_1": "test data"
+            }
+          }
+        }
+      },
       "run_server_log_connector_request": {
         "summary": "Run a server log connector.",
         "value": {
@@ -5972,6 +6084,18 @@
               "name": "Epic"
             }
           ],
+          "status": "ok"
+        }
+      },
+      "run_pagerduty_connector_response": {
+        "summary": "Response from running a PagerDuty connector.",
+        "value": {
+          "connector_id": "45de9f70-954f-4608-b12a-db7cf808e49d",
+          "data": {
+            "dedup_key": "5115e138b26b484a81eaea779faa6016",
+            "message": "Event processed",
+            "status": "success"
+          },
           "status": "ok"
         }
       },

--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -4765,6 +4765,30 @@
           }
         ]
       },
+      "run_connector_params_acknowledge_resolve_pagerduty": {
+        "title": "PagerDuty connector parameters",
+        "description": "Test an action that acknowledges or resolves a PagerDuty alert.",
+        "type": "object",
+        "required": [
+          "dedupKey",
+          "eventAction"
+        ],
+        "properties": {
+          "dedupKey": {
+            "description": "The deduplication key for the PagerDuty alert.",
+            "type": "string",
+            "maxLength": 255
+          },
+          "eventAction": {
+            "description": "The type of event.",
+            "type": "string",
+            "enum": [
+              "acknowledge",
+              "resolve"
+            ]
+          }
+        }
+      },
       "run_connector_params_documents": {
         "title": "Index connector parameters",
         "description": "Test an action that indexes a document into Elasticsearch.",
@@ -4780,91 +4804,6 @@
               "type": "object",
               "additionalProperties": true
             }
-          }
-        }
-      },
-      "run_connector_params_pagerduty": {
-        "title": "PagerDuty connector parameters",
-        "description": "Test an action that triggers, acknowledges, or resolves PagerDuty alerts.",
-        "type": "object",
-        "required": [
-          "eventAction"
-        ],
-        "properties": {
-          "class": {
-            "description": "The class or type of the event.",
-            "type": "string",
-            "example": "cpu load"
-          },
-          "component": {
-            "description": "The component of the source machine that is responsible for the event.",
-            "type": "string",
-            "example": "eth0"
-          },
-          "customDetails": {
-            "description": "Additional details to add to the event.",
-            "type": "object"
-          },
-          "dedupKey": {
-            "description": "All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.\n",
-            "type": "string",
-            "maxLength": 255
-          },
-          "eventAction": {
-            "description": "The type of event.",
-            "type": "string",
-            "enum": [
-              "acknowledge",
-              "resolve",
-              "trigger"
-            ]
-          },
-          "group": {
-            "description": "The logical grouping of components of a service.",
-            "type": "string",
-            "example": "app-stack"
-          },
-          "links": {
-            "description": "A list of links to add to the event.",
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "href": {
-                  "description": "The URL for the link.",
-                  "type": "string"
-                },
-                "text": {
-                  "description": "A plain text description of the purpose of the link.",
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "severity": {
-            "description": "The severity of the event on the affected system.",
-            "type": "string",
-            "enum": [
-              "critical",
-              "error",
-              "info",
-              "warning"
-            ],
-            "default": "info"
-          },
-          "source": {
-            "description": "The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.\n",
-            "type": "string"
-          },
-          "summary": {
-            "description": "A summery of the event.",
-            "type": "string",
-            "maxLength": 1024
-          },
-          "timestamp": {
-            "description": "An ISO-8601 timestamp that indicates when the event was detected or generated.",
-            "type": "string",
-            "format": "date-time"
           }
         }
       },
@@ -4951,6 +4890,89 @@
           "message": {
             "type": "string",
             "description": "The message for server log connectors."
+          }
+        }
+      },
+      "run_connector_params_trigger_pagerduty": {
+        "title": "PagerDuty connector parameters",
+        "description": "Test an action that triggers a PagerDuty alert.",
+        "type": "object",
+        "required": [
+          "eventAction"
+        ],
+        "properties": {
+          "class": {
+            "description": "The class or type of the event.",
+            "type": "string",
+            "example": "cpu load"
+          },
+          "component": {
+            "description": "The component of the source machine that is responsible for the event.",
+            "type": "string",
+            "example": "eth0"
+          },
+          "customDetails": {
+            "description": "Additional details to add to the event.",
+            "type": "object"
+          },
+          "dedupKey": {
+            "description": "All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.\n",
+            "type": "string",
+            "maxLength": 255
+          },
+          "eventAction": {
+            "description": "The type of event.",
+            "type": "string",
+            "enum": [
+              "trigger"
+            ]
+          },
+          "group": {
+            "description": "The logical grouping of components of a service.",
+            "type": "string",
+            "example": "app-stack"
+          },
+          "links": {
+            "description": "A list of links to add to the event.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "href": {
+                  "description": "The URL for the link.",
+                  "type": "string"
+                },
+                "text": {
+                  "description": "A plain text description of the purpose of the link.",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "severity": {
+            "description": "The severity of the event on the affected system.",
+            "type": "string",
+            "enum": [
+              "critical",
+              "error",
+              "info",
+              "warning"
+            ],
+            "default": "info"
+          },
+          "source": {
+            "description": "The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.\n",
+            "type": "string"
+          },
+          "summary": {
+            "description": "A summery of the event.",
+            "type": "string",
+            "maxLength": 1024
+          },
+          "timestamp": {
+            "description": "An ISO-8601 timestamp that indicates when the event was detected or generated.",
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -5602,16 +5624,19 @@
           "params": {
             "oneOf": [
               {
-                "$ref": "#/components/schemas/run_connector_params_documents"
+                "$ref": "#/components/schemas/run_connector_params_acknowledge_resolve_pagerduty"
               },
               {
-                "$ref": "#/components/schemas/run_connector_params_pagerduty"
+                "$ref": "#/components/schemas/run_connector_params_documents"
               },
               {
                 "$ref": "#/components/schemas/run_connector_params_message_email"
               },
               {
                 "$ref": "#/components/schemas/run_connector_params_message_serverlog"
+              },
+              {
+                "$ref": "#/components/schemas/run_connector_params_trigger_pagerduty"
               },
               {
                 "title": "Subaction parameters",

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -185,6 +185,8 @@ paths:
                 $ref: '#/components/examples/run_index_connector_request'
               runJiraConnectorRequest:
                 $ref: '#/components/examples/run_jira_connector_request'
+              runPagerDutyConnectorRequest:
+                $ref: '#/components/examples/run_pagerduty_connector_request'
               runServerLogConnectorRequest:
                 $ref: '#/components/examples/run_server_log_connector_request'
               runServiceNowITOMConnectorRequest:
@@ -227,6 +229,8 @@ paths:
                   $ref: '#/components/examples/run_index_connector_response'
                 runJiraConnectorResponse:
                   $ref: '#/components/examples/run_jira_connector_response'
+                runPagerDutyConnectorResponse:
+                  $ref: '#/components/examples/run_pagerduty_connector_response'
                 runServerLogConnectorResponse:
                   $ref: '#/components/examples/run_server_log_connector_response'
                 runServiceNowITOMConnectorResponse:
@@ -3350,6 +3354,73 @@ components:
           items:
             type: object
             additionalProperties: true
+    run_connector_params_pagerduty:
+      title: PagerDuty connector parameters
+      description: Test an action that triggers, acknowledges, or resolves PagerDuty alerts.
+      type: object
+      required:
+        - eventAction
+      properties:
+        class:
+          description: The class or type of the event.
+          type: string
+          example: cpu load
+        component:
+          description: The component of the source machine that is responsible for the event.
+          type: string
+          example: eth0
+        customDetails:
+          description: Additional details to add to the event.
+          type: object
+        dedupKey:
+          description: |
+            All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.
+          type: string
+          maxLength: 255
+        eventAction:
+          description: The type of event.
+          type: string
+          enum:
+            - acknowledge
+            - resolve
+            - trigger
+        group:
+          description: The logical grouping of components of a service.
+          type: string
+          example: app-stack
+        links:
+          description: A list of links to add to the event.
+          type: array
+          items:
+            type: object
+            properties:
+              href:
+                description: The URL for the link.
+                type: string
+              text:
+                description: A plain text description of the purpose of the link.
+                type: string
+        severity:
+          description: The severity of the event on the affected system.
+          type: string
+          enum:
+            - critical
+            - error
+            - info
+            - warning
+          default: info
+        source:
+          description: |
+            The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.
+          type: string
+        summary:
+          description: A summery of the event.
+          type: string
+          maxLength: 1024
+        timestamp:
+          description: An ISO-8601 timestamp that indicates when the event was detected or generated.
+          type: string
+          format: date-time
     run_connector_params_message_email:
       title: Email connector parameters
       description: |
@@ -3879,6 +3950,7 @@ components:
         params:
           oneOf:
             - $ref: '#/components/schemas/run_connector_params_documents'
+            - $ref: '#/components/schemas/run_connector_params_pagerduty'
             - $ref: '#/components/schemas/run_connector_params_message_email'
             - $ref: '#/components/schemas/run_connector_params_message_serverlog'
             - title: Subaction parameters
@@ -4111,6 +4183,17 @@ components:
       value:
         params:
           subAction: issueTypes
+    run_pagerduty_connector_request:
+      summary: Run a PagerDuty connector to trigger an alert.
+      value:
+        params:
+          eventAction: trigger
+          summary: A brief event summary
+          links:
+            - href: http://example.com/pagerduty
+              text: An example link
+          customDetails:
+            my_data_1: test data
     run_server_log_connector_request:
       summary: Run a server log connector.
       value:
@@ -4201,6 +4284,15 @@ components:
             name: Bug
           - id: 10000
             name: Epic
+        status: ok
+    run_pagerduty_connector_response:
+      summary: Response from running a PagerDuty connector.
+      value:
+        connector_id: 45de9f70-954f-4608-b12a-db7cf808e49d
+        data:
+          dedup_key: 5115e138b26b484a81eaea779faa6016
+          message: Event processed
+          status: success
         status: ok
     run_server_log_connector_response:
       summary: Response from running a server log connector.

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -3341,6 +3341,24 @@ components:
         - $ref: '#/components/schemas/update_connector_request_torq'
         - $ref: '#/components/schemas/update_connector_request_webhook'
         - $ref: '#/components/schemas/update_connector_request_xmatters'
+    run_connector_params_acknowledge_resolve_pagerduty:
+      title: PagerDuty connector parameters
+      description: Test an action that acknowledges or resolves a PagerDuty alert.
+      type: object
+      required:
+        - dedupKey
+        - eventAction
+      properties:
+        dedupKey:
+          description: The deduplication key for the PagerDuty alert.
+          type: string
+          maxLength: 255
+        eventAction:
+          description: The type of event.
+          type: string
+          enum:
+            - acknowledge
+            - resolve
     run_connector_params_documents:
       title: Index connector parameters
       description: Test an action that indexes a document into Elasticsearch.
@@ -3354,73 +3372,6 @@ components:
           items:
             type: object
             additionalProperties: true
-    run_connector_params_pagerduty:
-      title: PagerDuty connector parameters
-      description: Test an action that triggers, acknowledges, or resolves PagerDuty alerts.
-      type: object
-      required:
-        - eventAction
-      properties:
-        class:
-          description: The class or type of the event.
-          type: string
-          example: cpu load
-        component:
-          description: The component of the source machine that is responsible for the event.
-          type: string
-          example: eth0
-        customDetails:
-          description: Additional details to add to the event.
-          type: object
-        dedupKey:
-          description: |
-            All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.
-          type: string
-          maxLength: 255
-        eventAction:
-          description: The type of event.
-          type: string
-          enum:
-            - acknowledge
-            - resolve
-            - trigger
-        group:
-          description: The logical grouping of components of a service.
-          type: string
-          example: app-stack
-        links:
-          description: A list of links to add to the event.
-          type: array
-          items:
-            type: object
-            properties:
-              href:
-                description: The URL for the link.
-                type: string
-              text:
-                description: A plain text description of the purpose of the link.
-                type: string
-        severity:
-          description: The severity of the event on the affected system.
-          type: string
-          enum:
-            - critical
-            - error
-            - info
-            - warning
-          default: info
-        source:
-          description: |
-            The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.
-          type: string
-        summary:
-          description: A summery of the event.
-          type: string
-          maxLength: 1024
-        timestamp:
-          description: An ISO-8601 timestamp that indicates when the event was detected or generated.
-          type: string
-          format: date-time
     run_connector_params_message_email:
       title: Email connector parameters
       description: |
@@ -3485,6 +3436,71 @@ components:
         message:
           type: string
           description: The message for server log connectors.
+    run_connector_params_trigger_pagerduty:
+      title: PagerDuty connector parameters
+      description: Test an action that triggers a PagerDuty alert.
+      type: object
+      required:
+        - eventAction
+      properties:
+        class:
+          description: The class or type of the event.
+          type: string
+          example: cpu load
+        component:
+          description: The component of the source machine that is responsible for the event.
+          type: string
+          example: eth0
+        customDetails:
+          description: Additional details to add to the event.
+          type: object
+        dedupKey:
+          description: |
+            All actions sharing this key will be associated with the same PagerDuty alert. This value is used to correlate trigger and resolution.
+          type: string
+          maxLength: 255
+        eventAction:
+          description: The type of event.
+          type: string
+          enum:
+            - trigger
+        group:
+          description: The logical grouping of components of a service.
+          type: string
+          example: app-stack
+        links:
+          description: A list of links to add to the event.
+          type: array
+          items:
+            type: object
+            properties:
+              href:
+                description: The URL for the link.
+                type: string
+              text:
+                description: A plain text description of the purpose of the link.
+                type: string
+        severity:
+          description: The severity of the event on the affected system.
+          type: string
+          enum:
+            - critical
+            - error
+            - info
+            - warning
+          default: info
+        source:
+          description: |
+            The affected system, such as a hostname or fully qualified domain name. Defaults to the Kibana saved object id of the action.
+          type: string
+        summary:
+          description: A summery of the event.
+          type: string
+          maxLength: 1024
+        timestamp:
+          description: An ISO-8601 timestamp that indicates when the event was detected or generated.
+          type: string
+          format: date-time
     run_connector_subaction_addevent:
       title: The addEvent subaction
       type: object
@@ -3949,10 +3965,11 @@ components:
       properties:
         params:
           oneOf:
+            - $ref: '#/components/schemas/run_connector_params_acknowledge_resolve_pagerduty'
             - $ref: '#/components/schemas/run_connector_params_documents'
-            - $ref: '#/components/schemas/run_connector_params_pagerduty'
             - $ref: '#/components/schemas/run_connector_params_message_email'
             - $ref: '#/components/schemas/run_connector_params_message_serverlog'
+            - $ref: '#/components/schemas/run_connector_params_trigger_pagerduty'
             - title: Subaction parameters
               description: Test an action that involves a subaction.
               oneOf:

--- a/x-pack/plugins/actions/docs/openapi/components/examples/run_pagerduty_connector_request.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/run_pagerduty_connector_request.yaml
@@ -1,0 +1,10 @@
+summary: Run a PagerDuty connector to trigger an alert.
+value:
+  params:
+    eventAction: trigger
+    summary: A brief event summary
+    links:
+      - href: http://example.com/pagerduty
+        text: An example link
+    customDetails:
+      my_data_1: test data

--- a/x-pack/plugins/actions/docs/openapi/components/examples/run_pagerduty_connector_response.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/examples/run_pagerduty_connector_response.yaml
@@ -1,0 +1,8 @@
+summary: Response from running a PagerDuty connector.
+value:
+  connector_id: 45de9f70-954f-4608-b12a-db7cf808e49d
+  data:
+    dedup_key: 5115e138b26b484a81eaea779faa6016
+    message: Event processed
+    status: success
+  status: ok

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_acknowledge_resolve_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_acknowledge_resolve_pagerduty.yaml
@@ -1,0 +1,17 @@
+title: PagerDuty connector parameters
+description: Test an action that acknowledges or resolves a PagerDuty alert.
+type: object
+required:
+  - dedupKey
+  - eventAction
+properties:
+  dedupKey:
+    description: The deduplication key for the PagerDuty alert.
+    type: string
+    maxLength: 255
+  eventAction:
+    description: The type of event.
+    type: string
+    enum:
+      - acknowledge
+      - resolve

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_pagerduty.yaml
@@ -1,0 +1,68 @@
+title: PagerDuty connector parameters
+description: Test an action that triggers, acknowledges, or resolves PagerDuty alerts.
+type: object
+required:
+  - eventAction
+properties:
+  class:
+    description: The class or type of the event.
+    type: string
+    example: cpu load
+  component:
+    description: The component of the source machine that is responsible for the event.
+    type: string
+    example: eth0
+  customDetails:
+    description: Additional details to add to the event.
+    type: object
+  dedupKey:
+    description: >
+      All actions sharing this key will be associated with the same PagerDuty alert.
+      This value is used to correlate trigger and resolution.
+    type: string
+    maxLength: 255
+  eventAction:
+    description: The type of event.
+    type: string
+    enum:
+      - acknowledge
+      - resolve
+      - trigger
+  group:
+    description: The logical grouping of components of a service.
+    type: string
+    example: app-stack
+  links:
+    description: A list of links to add to the event.
+    type: array
+    items:
+      type: object
+      properties:
+        href:
+          description: The URL for the link.
+          type: string
+        text:
+          description: A plain text description of the purpose of the link.
+          type: string
+  severity:
+    description: The severity of the event on the affected system.
+    type: string
+    enum:
+      - critical
+      - error
+      - info
+      - warning
+    default: info
+  source:
+    description: >
+      The affected system, such as a hostname or fully qualified domain name.
+      Defaults to the Kibana saved object id of the action.
+    type: string
+  summary:
+    description: A summery of the event.
+    type: string
+    maxLength: 1024
+  timestamp:
+    description: An ISO-8601 timestamp that indicates when the event was detected or generated.
+    type: string
+    format: date-time

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_trigger_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_params_trigger_pagerduty.yaml
@@ -1,5 +1,5 @@
 title: PagerDuty connector parameters
-description: Test an action that triggers, acknowledges, or resolves PagerDuty alerts.
+description: Test an action that triggers a PagerDuty alert.
 type: object
 required:
   - eventAction
@@ -25,8 +25,6 @@ properties:
     description: The type of event.
     type: string
     enum:
-      - acknowledge
-      - resolve
       - trigger
   group:
     description: The logical grouping of components of a service.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_request.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_request.yaml
@@ -7,6 +7,7 @@ properties:
   params:
     oneOf:
       - $ref: 'run_connector_params_documents.yaml'
+      - $ref: 'run_connector_params_pagerduty.yaml'
       - $ref: 'run_connector_params_message_email.yaml'
       - $ref: 'run_connector_params_message_serverlog.yaml'
       - title: Subaction parameters

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_request.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_request.yaml
@@ -6,10 +6,11 @@ required:
 properties:
   params:
     oneOf:
+      - $ref: 'run_connector_params_acknowledge_resolve_pagerduty.yaml'
       - $ref: 'run_connector_params_documents.yaml'
-      - $ref: 'run_connector_params_pagerduty.yaml'
       - $ref: 'run_connector_params_message_email.yaml'
       - $ref: 'run_connector_params_message_serverlog.yaml'
+      - $ref: 'run_connector_params_trigger_pagerduty.yaml'
       - title: Subaction parameters
         description: Test an action that involves a subaction.
         oneOf:

--- a/x-pack/plugins/actions/docs/openapi/paths/api@actions@connector@{connectorid}@_execute.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/api@actions@connector@{connectorid}@_execute.yaml
@@ -23,6 +23,8 @@ post:
             $ref: '../components/examples/run_index_connector_request.yaml'
           runJiraConnectorRequest:
             $ref: '../components/examples/run_jira_connector_request.yaml'
+          runPagerDutyConnectorRequest:
+            $ref: '../components/examples/run_pagerduty_connector_request.yaml'
           runServerLogConnectorRequest:
             $ref: '../components/examples/run_server_log_connector_request.yaml'
           runServiceNowITOMConnectorRequest:
@@ -65,6 +67,8 @@ post:
               $ref: '../components/examples/run_index_connector_response.yaml'
             runJiraConnectorResponse:
               $ref: '../components/examples/run_jira_connector_response.yaml'
+            runPagerDutyConnectorResponse:
+              $ref: '../components/examples/run_pagerduty_connector_response.yaml'
             runServerLogConnectorResponse:
               $ref: '../components/examples/run_server_log_connector_response.yaml'
             runServiceNowITOMConnectorResponse:


### PR DESCRIPTION
## Summary

Relates to https://github.com/elastic/kibana/issues/170044

This PR updates the openAPI specification for the run connector API to include details specific to PagerDuty connectors. The data types and descriptions are derived from https://github.com/elastic/kibana/blob/main/x-pack/plugins/stack_connectors/README.md#pagerduty