### PR TITLE
[HTTP Server] support TLS config hot reload via `SIGHUP`

### DIFF
--- a/packages/core/http/core-http-server-internal/src/http_server.test.mocks.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.mocks.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const setTlsConfigMock = jest.fn();
+
+jest.doMock('@kbn/server-http-tools', () => {
+  const actual = jest.requireActual('@kbn/server-http-tools');
+  return {
+    ...actual,
+    setTlsConfig: setTlsConfigMock,
+    createServer: jest.fn(actual.createServer),
+  };
+});

--- a/packages/core/http/core-http-server-internal/src/http_server.test.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.ts
@@ -37,7 +37,7 @@ import { HttpServer } from './http_server';
 import { Readable } from 'stream';
 import { KBN_CERT_PATH, KBN_KEY_PATH } from '@kbn/dev-utils';
 import moment from 'moment';
-import { of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 
 const routerOptions: RouterOptions = {
   isDev: false,
@@ -52,8 +52,12 @@ const cookieOptions = {
 };
 
 let server: HttpServer;
+
 let config: HttpConfig;
+let config$: Observable<HttpConfig>;
+
 let configWithSSL: HttpConfig;
+let configWithSSL$: Observable<HttpConfig>;
 
 const loggingService = loggingSystemMock.create();
 const logger = loggingService.get();
@@ -85,6 +89,7 @@ beforeEach(() => {
     cdn: {},
     shutdownTimeout: moment.duration(500, 'ms'),
   } as any;
+  config$ = of(config);
 
   configWithSSL = {
     ...config,
@@ -97,6 +102,7 @@ beforeEach(() => {
       redirectHttpFromPort: config.port + 1,
     },
   } as HttpConfig;
+  configWithSSL$ = of(configWithSSL);
 
   server = new HttpServer(loggingService, 'tests', of(config.shutdownTimeout));
 });
@@ -109,7 +115,7 @@ afterEach(async () => {
 test('log listening address after started', async () => {
   expect(server.isListening()).toBe(false);
 
-  await server.setup(config);
+  await server.setup({ config$ });
   await server.start();
 
   expect(server.isListening()).toBe(true);
@@ -125,7 +131,7 @@ test('log listening address after started', async () => {
 test('log listening address after started when configured with BasePath and rewriteBasePath = false', async () => {
   expect(server.isListening()).toBe(false);
 
-  await server.setup({ ...config, basePath: '/bar', rewriteBasePath: false });
+  await server.setup({ config$: of({ ...config, basePath: '/bar', rewriteBasePath: false }) });
   await server.start();
 
   expect(server.isListening()).toBe(true);
@@ -141,7 +147,7 @@ test('log listening address after started when configured with BasePath and rewr
 test('log listening address after started when configured with BasePath and rewriteBasePath = true', async () => {
   expect(server.isListening()).toBe(false);
 
-  await server.setup({ ...config, basePath: '/bar', rewriteBasePath: true });
+  await server.setup({ config$: of({ ...config, basePath: '/bar', rewriteBasePath: true }) });
   await server.start();
 
   expect(server.isListening()).toBe(true);
@@ -157,7 +163,7 @@ test('log listening address after started when configured with BasePath and rewr
 test('does not allow router registration after server is listening', async () => {
   expect(server.isListening()).toBe(false);
 
-  const { registerRouter } = await server.setup(config);
+  const { registerRouter } = await server.setup({ config$ });
 
   const router1 = new Router('/foo', logger, enhanceWithContext, routerOptions);
   expect(() => registerRouter(router1)).not.toThrowError();
@@ -175,7 +181,7 @@ test('does not allow router registration after server is listening', async () =>
 test('allows router registration after server is listening via `registerRouterAfterListening`', async () => {
   expect(server.isListening()).toBe(false);
 
-  const { registerRouterAfterListening } = await server.setup(config);
+  const { registerRouterAfterListening } = await server.setup({ config$ });
 
   const router1 = new Router('/foo', logger, enhanceWithContext, routerOptions);
   expect(() => registerRouterAfterListening(router1)).not.toThrowError();
@@ -205,7 +211,7 @@ test('valid params', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -235,7 +241,7 @@ test('invalid params', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -270,7 +276,7 @@ test('valid query', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -300,7 +306,7 @@ test('invalid query', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -335,7 +341,7 @@ test('valid body', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -373,7 +379,7 @@ test('valid body with validate function', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -416,7 +422,7 @@ test('not inline validation - specifying params', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -459,7 +465,7 @@ test('not inline validation - specifying validation handler', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -509,7 +515,7 @@ test('not inline handler - KibanaRequest', async () => {
     handler
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -558,7 +564,7 @@ test('not inline handler - RequestHandler', async () => {
     handler
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -592,7 +598,7 @@ test('invalid body', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -627,7 +633,7 @@ test('handles putting', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -658,7 +664,7 @@ test('handles deleting', async () => {
     }
   );
 
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
   registerRouter(router);
 
   await server.start();
@@ -688,7 +694,9 @@ describe('with `basepath: /bar` and `rewriteBasePath: false`', () => {
       res.ok({ body: 'value:/foo' })
     );
 
-    const { registerRouter, server: innerServer } = await server.setup(configWithBasePath);
+    const { registerRouter, server: innerServer } = await server.setup({
+      config$: of(configWithBasePath),
+    });
     registerRouter(router);
 
     await server.start();
@@ -743,7 +751,9 @@ describe('with `basepath: /bar` and `rewriteBasePath: true`', () => {
       res.ok({ body: 'value:/foo' })
     );
 
-    const { registerRouter, server: innerServer } = await server.setup(configWithBasePath);
+    const { registerRouter, server: innerServer } = await server.setup({
+      config$: of(configWithBasePath),
+    });
     registerRouter(router);
 
     await server.start();
@@ -790,7 +800,7 @@ test('with defined `redirectHttpFromPort`', async () => {
   const router = new Router('/', logger, enhanceWithContext, routerOptions);
   router.get({ path: '/', validate: false }, (context, req, res) => res.ok({ body: 'value:/' }));
 
-  const { registerRouter } = await server.setup(configWithSSL);
+  const { registerRouter } = await server.setup({ config$: configWithSSL$ });
   registerRouter(router);
 
   await server.start();
@@ -801,7 +811,7 @@ test('returns server and connection options on start', async () => {
     ...config,
     port: 12345,
   };
-  const { server: innerServer } = await server.setup(configWithPort);
+  const { server: innerServer } = await server.setup({ config$: of(configWithPort) });
 
   expect(innerServer).toBeDefined();
   expect(innerServer).toBe((server as any).server);
@@ -815,7 +825,7 @@ test('throws an error if starts without set up', async () => {
 
 test('allows attaching metadata to attach meta-data tag strings to a route', async () => {
   const tags = ['my:tag'];
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.get({ path: '/with-tags', validate: false, options: { tags } }, (context, req, res) =>
@@ -834,7 +844,7 @@ test('allows attaching metadata to attach meta-data tag strings to a route', asy
 
 test('allows declaring route access to flag a route as public or internal', async () => {
   const access = 'internal';
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.get({ path: '/with-access', validate: false, options: { access } }, (context, req, res) =>
@@ -852,7 +862,7 @@ test('allows declaring route access to flag a route as public or internal', asyn
 });
 
 test(`sets access flag to 'internal' if not defined`, async () => {
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.get({ path: '/internal/foo', validate: false }, (context, req, res) =>
@@ -883,7 +893,7 @@ test(`sets access flag to 'internal' if not defined`, async () => {
 });
 
 test('exposes route details of incoming request to a route handler', async () => {
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.get({ path: '/', validate: false }, (context, req, res) => res.ok({ body: req.route }));
@@ -907,7 +917,9 @@ test('exposes route details of incoming request to a route handler', async () =>
 
 describe('conditional compression', () => {
   async function setupServer(innerConfig: HttpConfig) {
-    const { registerRouter, server: innerServer } = await server.setup(innerConfig);
+    const { registerRouter, server: innerServer } = await server.setup({
+      config$: of(innerConfig),
+    });
     const router = new Router('', logger, enhanceWithContext, routerOptions);
     // we need the large body here so that compression would normally be used
     const largeRequest = {
@@ -1012,8 +1024,10 @@ describe('conditional compression', () => {
 describe('response headers', () => {
   test('allows to configure "keep-alive" header', async () => {
     const { registerRouter, server: innerServer } = await server.setup({
-      ...config,
-      keepaliveTimeout: 100_000,
+      config$: of({
+        ...config,
+        keepaliveTimeout: 100_000,
+      }),
     });
 
     const router = new Router('', logger, enhanceWithContext, routerOptions);
@@ -1031,7 +1045,7 @@ describe('response headers', () => {
   });
 
   test('default headers', async () => {
-    const { registerRouter, server: innerServer } = await server.setup(config);
+    const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
     const router = new Router('', logger, enhanceWithContext, routerOptions);
     router.get({ path: '/', validate: false }, (context, req, res) => res.ok({ body: req.route }));
@@ -1053,7 +1067,7 @@ describe('response headers', () => {
 });
 
 test('exposes route details of incoming request to a route handler (POST + payload options)', async () => {
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.post(
@@ -1093,7 +1107,7 @@ test('exposes route details of incoming request to a route handler (POST + paylo
 
 describe('body options', () => {
   test('should reject the request because the Content-Type in the request is not valid', async () => {
-    const { registerRouter, server: innerServer } = await server.setup(config);
+    const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
     const router = new Router('', logger, enhanceWithContext, routerOptions);
     router.post(
@@ -1115,7 +1129,7 @@ describe('body options', () => {
   });
 
   test('should reject the request because the payload is too large', async () => {
-    const { registerRouter, server: innerServer } = await server.setup(config);
+    const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
     const router = new Router('', logger, enhanceWithContext, routerOptions);
     router.post(
@@ -1137,7 +1151,7 @@ describe('body options', () => {
   });
 
   test('should not parse the content in the request', async () => {
-    const { registerRouter, server: innerServer } = await server.setup(config);
+    const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
     const router = new Router('', logger, enhanceWithContext, routerOptions);
     router.post(
@@ -1166,7 +1180,7 @@ describe('body options', () => {
 describe('timeout options', () => {
   describe('payload timeout', () => {
     test('POST routes set the payload timeout', async () => {
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       router.post(
@@ -1200,7 +1214,7 @@ describe('timeout options', () => {
     });
 
     test('DELETE routes set the payload timeout', async () => {
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       router.delete(
@@ -1233,7 +1247,7 @@ describe('timeout options', () => {
     });
 
     test('PUT routes set the payload timeout and automatically adjusts the idle socket timeout', async () => {
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       router.put(
@@ -1266,7 +1280,7 @@ describe('timeout options', () => {
     });
 
     test('PATCH routes set the payload timeout and automatically adjusts the idle socket timeout', async () => {
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       router.patch(
@@ -1302,8 +1316,10 @@ describe('timeout options', () => {
   describe('idleSocket timeout', () => {
     test('uses server socket timeout when not specified in the route', async () => {
       const { registerRouter, server: innerServer } = await server.setup({
-        ...config,
-        socketTimeout: 11000,
+        config$: of({
+          ...config,
+          socketTimeout: 11000,
+        }),
       });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
@@ -1335,8 +1351,10 @@ describe('timeout options', () => {
 
     test('sets the socket timeout when specified in the route', async () => {
       const { registerRouter, server: innerServer } = await server.setup({
-        ...config,
-        socketTimeout: 11000,
+        config$: of({
+          ...config,
+          socketTimeout: 11000,
+        }),
       });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
@@ -1368,7 +1386,7 @@ describe('timeout options', () => {
     });
 
     test('idleSocket timeout can be smaller than the payload timeout', async () => {
-      const { registerRouter } = await server.setup(config);
+      const { registerRouter } = await server.setup({ config$ });
 
       const router = new Router('', logger, enhanceWithContext, routerOptions);
       router.post(
@@ -1395,7 +1413,7 @@ describe('timeout options', () => {
 });
 
 test('should return a stream in the body', async () => {
-  const { registerRouter, server: innerServer } = await server.setup(config);
+  const { registerRouter, server: innerServer } = await server.setup({ config$ });
 
   const router = new Router('', logger, enhanceWithContext, routerOptions);
   router.put(
@@ -1421,8 +1439,10 @@ test('should return a stream in the body', async () => {
 
 test('closes sockets on timeout', async () => {
   const { registerRouter, server: innerServer } = await server.setup({
-    ...config,
-    socketTimeout: 1000,
+    config$: of({
+      ...config,
+      socketTimeout: 1000,
+    }),
   });
   const router = new Router('', logger, enhanceWithContext, routerOptions);
 
@@ -1446,14 +1466,14 @@ test('closes sockets on timeout', async () => {
 describe('setup contract', () => {
   describe('#createSessionStorage', () => {
     test('creates session storage factory', async () => {
-      const { createCookieSessionStorageFactory } = await server.setup(config);
+      const { createCookieSessionStorageFactory } = await server.setup({ config$ });
       const sessionStorageFactory = await createCookieSessionStorageFactory(cookieOptions);
 
       expect(sessionStorageFactory.asScoped).toBeDefined();
     });
 
     test('creates session storage factory only once', async () => {
-      const { createCookieSessionStorageFactory } = await server.setup(config);
+      const { createCookieSessionStorageFactory } = await server.setup({ config$ });
       const create = async () => await createCookieSessionStorageFactory(cookieOptions);
 
       await create();
@@ -1461,7 +1481,7 @@ describe('setup contract', () => {
     });
 
     test('does not throw if called after stop', async () => {
-      const { createCookieSessionStorageFactory } = await server.setup(config);
+      const { createCookieSessionStorageFactory } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         createCookieSessionStorageFactory(cookieOptions);
@@ -1471,7 +1491,7 @@ describe('setup contract', () => {
 
   describe('#getServerInfo', () => {
     test('returns correct information', async () => {
-      let { getServerInfo } = await server.setup(config);
+      let { getServerInfo } = await server.setup({ config$ });
 
       expect(getServerInfo()).toEqual({
         hostname: '127.0.0.1',
@@ -1481,10 +1501,12 @@ describe('setup contract', () => {
       });
 
       ({ getServerInfo } = await server.setup({
-        ...config,
-        port: 12345,
-        name: 'custom-name',
-        host: 'localhost',
+        config$: of({
+          ...config,
+          port: 12345,
+          name: 'custom-name',
+          host: 'localhost',
+        }),
       }));
 
       expect(getServerInfo()).toEqual({
@@ -1496,7 +1518,7 @@ describe('setup contract', () => {
     });
 
     test('returns correct protocol when ssl is enabled', async () => {
-      const { getServerInfo } = await server.setup(configWithSSL);
+      const { getServerInfo } = await server.setup({ config$: configWithSSL$ });
 
       expect(getServerInfo().protocol).toEqual('https');
     });
@@ -1517,7 +1539,7 @@ describe('setup contract', () => {
     });
 
     test('registers routes with expected options', async () => {
-      const { registerStaticDir } = await server.setup(config);
+      const { registerStaticDir } = await server.setup({ config$ });
       expect(createServer).toHaveBeenCalledTimes(1);
       const [{ value: myServer }] = (createServer as jest.Mock).mock.results;
       jest.spyOn(myServer, 'route');
@@ -1540,7 +1562,7 @@ describe('setup contract', () => {
     });
 
     test('does not throw if called after stop', async () => {
-      const { registerStaticDir } = await server.setup(config);
+      const { registerStaticDir } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerStaticDir('/path1/{path*}', '/path/to/resource');
@@ -1548,7 +1570,7 @@ describe('setup contract', () => {
     });
 
     test('returns correct headers for static assets', async () => {
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
 
       registerStaticDir('/static/{path*}', assetFolder);
 
@@ -1562,7 +1584,7 @@ describe('setup contract', () => {
     });
 
     test('returns compressed version if present', async () => {
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
 
       registerStaticDir('/static/{path*}', assetFolder);
 
@@ -1578,7 +1600,7 @@ describe('setup contract', () => {
     });
 
     test('returns uncompressed version if compressed asset is not available', async () => {
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
 
       registerStaticDir('/static/{path*}', assetFolder);
 
@@ -1594,7 +1616,7 @@ describe('setup contract', () => {
     });
 
     test('returns a 304 if etag value matches', async () => {
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
 
       registerStaticDir('/static/{path*}', assetFolder);
 
@@ -1613,7 +1635,7 @@ describe('setup contract', () => {
     });
 
     test('serves content if etag values does not match', async () => {
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
 
       registerStaticDir('/static/{path*}', assetFolder);
 
@@ -1628,7 +1650,7 @@ describe('setup contract', () => {
     test('dynamically updates depending on the content of the file', async () => {
       const tempFile = join(tempDir, 'some_file.json');
 
-      const { registerStaticDir, server: innerServer } = await server.setup(config);
+      const { registerStaticDir, server: innerServer } = await server.setup({ config$ });
       registerStaticDir('/static/{path*}', tempDir);
 
       await server.start();
@@ -1655,7 +1677,7 @@ describe('setup contract', () => {
 
   describe('#registerOnPreRouting', () => {
     test('does not throw if called after stop', async () => {
-      const { registerOnPreRouting } = await server.setup(config);
+      const { registerOnPreRouting } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerOnPreRouting((req, res) => res.unauthorized());
@@ -1665,7 +1687,7 @@ describe('setup contract', () => {
 
   describe('#registerOnPreAuth', () => {
     test('does not throw if called after stop', async () => {
-      const { registerOnPreAuth } = await server.setup(config);
+      const { registerOnPreAuth } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerOnPreAuth((req, res) => res.unauthorized());
@@ -1675,7 +1697,7 @@ describe('setup contract', () => {
 
   describe('#registerOnPostAuth', () => {
     test('does not throw if called after stop', async () => {
-      const { registerOnPostAuth } = await server.setup(config);
+      const { registerOnPostAuth } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerOnPostAuth((req, res) => res.unauthorized());
@@ -1685,7 +1707,7 @@ describe('setup contract', () => {
 
   describe('#registerOnPreResponse', () => {
     test('does not throw if called after stop', async () => {
-      const { registerOnPreResponse } = await server.setup(config);
+      const { registerOnPreResponse } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerOnPreResponse((req, res, t) => t.next());
@@ -1695,7 +1717,7 @@ describe('setup contract', () => {
 
   describe('#registerAuth', () => {
     test('does not throw if called after stop', async () => {
-      const { registerAuth } = await server.setup(config);
+      const { registerAuth } = await server.setup({ config$ });
       await server.stop();
       expect(() => {
         registerAuth((req, res) => res.unauthorized());

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -245,13 +245,15 @@ export class HttpServer {
         .subscribe(([{ ssl: prevSslConfig }, { ssl: newSslConfig }]) => {
           if (prevSslConfig.enabled !== newSslConfig.enabled) {
             this.log.warn(
-              'Incompatible change in config - TLS cannot be toggled without a full server reboot.'
+              'Incompatible TLS config change detected - TLS cannot be toggled without a full server reboot.'
             );
+            return;
           }
 
-          const configChanged = true; // TODO: actually compare the configs
+          const sameConfig = newSslConfig.isEqualTo(prevSslConfig);
 
-          if (configChanged) {
+          if (!sameConfig) {
+            this.log.info('TLS configuration change detected - reloading TLS configuration.');
             setTlsConfig(this.server!, newSslConfig);
           }
         });

--- a/packages/core/http/core-http-server-internal/src/http_server.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.ts
@@ -14,12 +14,13 @@ import {
   createServer,
   getListenerOptions,
   getServerOptions,
+  setTlsConfig,
   getRequestId,
 } from '@kbn/server-http-tools';
 
 import type { Duration } from 'moment';
-import { firstValueFrom, Observable } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { firstValueFrom, Observable, Subscription } from 'rxjs';
+import { take, pairwise } from 'rxjs/operators';
 import apm from 'elastic-apm-node';
 // @ts-expect-error no type definition
 import Brok from 'brok';
@@ -160,9 +161,15 @@ export type LifecycleRegistrar = Pick<
   | 'registerOnPreResponse'
 >;
 
+export interface HttpServerSetupOptions {
+  config$: Observable<HttpConfig>;
+  executionContext?: InternalExecutionContextSetup;
+}
+
 export class HttpServer {
   private server?: Server;
   private config?: HttpConfig;
+  private subscriptions: Subscription[] = [];
   private registeredRouters = new Set<IRouter>();
   private authRegistered = false;
   private cookieSessionStorageCreated = false;
@@ -209,13 +216,16 @@ export class HttpServer {
     }
   }
 
-  public async setup(
-    config: HttpConfig,
-    executionContext?: InternalExecutionContextSetup
-  ): Promise<HttpServerSetup> {
+  public async setup({
+    config$,
+    executionContext,
+  }: HttpServerSetupOptions): Promise<HttpServerSetup> {
+    const config = await firstValueFrom(config$);
+    this.config = config;
+
     const serverOptions = getServerOptions(config);
     const listenerOptions = getListenerOptions(config);
-    this.config = config;
+
     this.server = createServer(serverOptions, listenerOptions);
     await this.server.register([HapiStaticFiles]);
     if (config.compression.brotli.enabled) {
@@ -225,6 +235,27 @@ export class HttpServer {
           compress: { quality: config.compression.brotli.quality },
         },
       });
+    }
+
+    // only hot-reloading TLS config - don't need to subscribe if TLS is initially disabled,
+    // given we can't hot-switch from/to enabled/disabled.
+    if (config.ssl.enabled) {
+      const configSubscription = config$
+        .pipe(pairwise())
+        .subscribe(([{ ssl: prevSslConfig }, { ssl: newSslConfig }]) => {
+          if (prevSslConfig.enabled !== newSslConfig.enabled) {
+            this.log.warn(
+              'Incompatible change in config - TLS cannot be toggled without a full server reboot.'
+            );
+          }
+
+          const configChanged = true; // TODO: actually compare the configs
+
+          if (configChanged) {
+            setTlsConfig(this.server!, newSslConfig);
+          }
+        });
+      this.subscriptions.push(configSubscription);
     }
 
     // It's important to have setupRequestStateAssignment call the very first, otherwise context passing will be broken.

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -71,7 +71,7 @@ export class HttpService
     this.env = env;
     this.log = logger.get('http');
     this.config$ = combineLatest([
-      configService.atPath<HttpConfigType>(httpConfig.path),
+      configService.atPath<HttpConfigType>(httpConfig.path, { ignoreUnchanged: false }),
       configService.atPath<CspConfigType>(cspConfig.path),
       configService.atPath<ExternalUrlConfigType>(externalUrlConfig.path),
     ]).pipe(map(([http, csp, externalUrl]) => new HttpConfig(http, csp, externalUrl)));

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -85,7 +85,9 @@ export class HttpService
     this.log.debug('setting up preboot server');
     const config = await firstValueFrom(this.config$);
 
-    const prebootSetup = await this.prebootServer.setup(config);
+    const prebootSetup = await this.prebootServer.setup({
+      config$: this.config$,
+    });
     prebootSetup.server.route({
       path: '/{p*}',
       method: '*',
@@ -157,10 +159,10 @@ export class HttpService
 
     const config = await firstValueFrom(this.config$);
 
-    const { registerRouter, ...serverContract } = await this.httpServer.setup(
-      config,
-      deps.executionContext
-    );
+    const { registerRouter, ...serverContract } = await this.httpServer.setup({
+      config$: this.config$,
+      executionContext: deps.executionContext,
+    });
 
     registerCoreHandlers(serverContract, config, this.env, this.log);
 

--- a/packages/kbn-config/src/config_service.test.ts
+++ b/packages/kbn-config/src/config_service.test.ts
@@ -131,6 +131,23 @@ test("does not push new configs when reloading if config at path hasn't changed"
   expect(valuesReceived).toEqual(['value']);
 });
 
+test("does push new configs when reloading when config at path hasn't changed if ignoreUnchanged is false", async () => {
+  const rawConfig$ = new BehaviorSubject<Record<string, any>>({ key: 'value' });
+  const rawConfigProvider = createRawConfigServiceMock({ rawConfig$ });
+
+  const configService = new ConfigService(rawConfigProvider, defaultEnv, logger);
+  await configService.setSchema('key', schema.string());
+
+  const valuesReceived: any[] = [];
+  configService.atPath('key', { ignoreUnchanged: false }).subscribe((value) => {
+    valuesReceived.push(value);
+  });
+
+  rawConfig$.next({ key: 'value' });
+
+  expect(valuesReceived).toEqual(['value', 'value']);
+});
+
 test('pushes new config when reloading and config at path has changed', async () => {
   const rawConfig$ = new BehaviorSubject<Record<string, any>>({ key: 'value' });
   const rawConfigProvider = createRawConfigServiceMock({ rawConfig$ });

--- a/packages/kbn-server-http-tools/index.ts
+++ b/packages/kbn-server-http-tools/index.ts
@@ -10,6 +10,6 @@ export type { IHttpConfig, ISslConfig, ICorsConfig } from './src/types';
 export { createServer } from './src/create_server';
 export { defaultValidationErrorHandler } from './src/default_validation_error_handler';
 export { getListenerOptions } from './src/get_listener_options';
-export { getServerOptions } from './src/get_server_options';
+export { getServerOptions, getServerTLSOptions } from './src/get_server_options';
 export { getRequestId } from './src/get_request_id';
 export { sslSchema, SslConfig } from './src/ssl';

--- a/packages/kbn-server-http-tools/index.ts
+++ b/packages/kbn-server-http-tools/index.ts
@@ -12,4 +12,5 @@ export { defaultValidationErrorHandler } from './src/default_validation_error_ha
 export { getListenerOptions } from './src/get_listener_options';
 export { getServerOptions, getServerTLSOptions } from './src/get_server_options';
 export { getRequestId } from './src/get_request_id';
+export { setTlsConfig } from './src/set_tls_config';
 export { sslSchema, SslConfig } from './src/ssl';

--- a/packages/kbn-server-http-tools/src/get_server_options.ts
+++ b/packages/kbn-server-http-tools/src/get_server_options.ts
@@ -9,7 +9,7 @@
 import { RouteOptionsCors, ServerOptions } from '@hapi/hapi';
 import { ServerOptions as TLSOptions } from 'https';
 import { defaultValidationErrorHandler } from './default_validation_error_handler';
-import { IHttpConfig } from './types';
+import { IHttpConfig, ISslConfig } from './types';
 
 const corsAllowedHeaders = ['Accept', 'Authorization', 'Content-Type', 'If-None-Match', 'kbn-xsrf'];
 
@@ -50,26 +50,31 @@ export function getServerOptions(config: IHttpConfig, { configureTLS = true } = 
     },
   };
 
-  if (configureTLS && config.ssl.enabled) {
-    const ssl = config.ssl;
-
-    // TODO: Hapi types have a typo in `tls` property type definition: `https.RequestOptions` is used instead of
-    // `https.ServerOptions`, and `honorCipherOrder` isn't presented in `https.RequestOptions`.
-    const tlsOptions: TLSOptions = {
-      ca: ssl.certificateAuthorities,
-      cert: ssl.certificate,
-      ciphers: config.ssl.cipherSuites?.join(':'),
-      // We use the server's cipher order rather than the client's to prevent the BEAST attack.
-      honorCipherOrder: true,
-      key: ssl.key,
-      passphrase: ssl.keyPassphrase,
-      secureOptions: ssl.getSecureOptions ? ssl.getSecureOptions() : undefined,
-      requestCert: ssl.requestCert,
-      rejectUnauthorized: ssl.rejectUnauthorized,
-    };
-
-    options.tls = tlsOptions;
+  if (configureTLS) {
+    options.tls = getServerTLSOptions(config.ssl);
   }
 
   return options;
+}
+
+/**
+ * Converts Kibana `SslConfig` into `TLSOptions` that are accepted by the Hapi server,
+ * and by https.Server.setSecureContext()
+ */
+export function getServerTLSOptions(ssl: ISslConfig): TLSOptions | undefined {
+  if (!ssl.enabled) {
+    return undefined;
+  }
+  return {
+    ca: ssl.certificateAuthorities,
+    cert: ssl.certificate,
+    ciphers: ssl.cipherSuites?.join(':'),
+    // We use the server's cipher order rather than the client's to prevent the BEAST attack.
+    honorCipherOrder: true,
+    key: ssl.key,
+    passphrase: ssl.keyPassphrase,
+    secureOptions: ssl.getSecureOptions ? ssl.getSecureOptions() : undefined,
+    requestCert: ssl.requestCert,
+    rejectUnauthorized: ssl.rejectUnauthorized,
+  };
 }

--- a/packages/kbn-server-http-tools/src/set_tls_config.test.mocks.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.test.mocks.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const getServerTLSOptionsMock = jest.fn();
+
+jest.doMock('./get_server_options', () => {
+  const actual = jest.requireActual('./get_server_options');
+  return {
+    ...actual,
+    getServerTLSOptions: getServerTLSOptionsMock,
+  };
+});

--- a/packages/kbn-server-http-tools/src/set_tls_config.test.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getServerTLSOptionsMock } from './set_tls_config.test.mocks';
+import { Server } from '@hapi/hapi';
+import type { ISslConfig } from './types';
+import { setTlsConfig } from './set_tls_config';
+
+describe('setTlsConfig', () => {
+  beforeEach(() => {
+    getServerTLSOptionsMock.mockReset();
+    getServerTLSOptionsMock.mockReturnValue({});
+  });
+
+  it('throws when called for a non-TLS server', () => {
+    const server = new Server({});
+    const config: ISslConfig = { enabled: true };
+    expect(() => setTlsConfig(server, config)).toThrowErrorMatchingInlineSnapshot(
+      `"tried to set TLS config on a non-TLS http server"`
+    );
+  });
+
+  it('calls `getServerTLSOptions` with the correct parameters', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    (server.listener as any).setSecureContext = jest.fn();
+    const config: ISslConfig = { enabled: true };
+
+    setTlsConfig(server, config);
+
+    expect(getServerTLSOptionsMock).toHaveBeenCalledTimes(1);
+    expect(getServerTLSOptionsMock).toHaveBeenCalledWith(config);
+  });
+
+  it('throws when called for a disabled SSL config', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    (server.listener as any).setSecureContext = jest.fn();
+    const config: ISslConfig = { enabled: false };
+
+    getServerTLSOptionsMock.mockReturnValue(undefined);
+
+    expect(() => setTlsConfig(server, config)).toThrowErrorMatchingInlineSnapshot(
+      `"tried to apply a disabled SSL config"`
+    );
+  });
+
+  it('calls `setSecureContext` on the underlying server', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    const setSecureContextMock = jest.fn();
+    (server.listener as any).setSecureContext = setSecureContextMock;
+    const config: ISslConfig = { enabled: true };
+
+    const tlsConfig = { someTlsConfig: true };
+    getServerTLSOptionsMock.mockReturnValue(tlsConfig);
+
+    setTlsConfig(server, config);
+
+    expect(setSecureContextMock).toHaveBeenCalledTimes(1);
+    expect(setSecureContextMock).toHaveBeenCalledWith(tlsConfig);
+  });
+});

--- a/packages/kbn-server-http-tools/src/set_tls_config.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Server as HapiServer } from '@hapi/hapi';
+import type { Server as HttpServer } from 'http';
+import type { Server as TlsServer } from 'https';
+import type { ISslConfig } from './types';
+import { getServerTLSOptions } from './get_server_options';
+
+function isServerTLS(server: HttpServer): server is TlsServer {
+  return 'setSecureContext' in server;
+}
+
+export const setTlsConfig = (hapiServer: HapiServer, sslConfig: ISslConfig) => {
+  const server = hapiServer.listener;
+  if (!isServerTLS(server)) {
+    throw new Error('tried to set TLS config on a non-TLS http server');
+  }
+  const tlsOptions = getServerTLSOptions(sslConfig);
+  if (!tlsOptions) {
+    throw new Error('tried to apply a disabled SSL config');
+  }
+  server.setSecureContext(tlsOptions);
+};

--- a/packages/kbn-server-http-tools/src/ssl/ssl_config.test.ts
+++ b/packages/kbn-server-http-tools/src/ssl/ssl_config.test.ts
@@ -164,6 +164,79 @@ describe('#SslConfig', () => {
       expect(configValue.certificate).toEqual('content-of-another-path');
     });
   });
+
+  describe('isEqualTo()', () => {
+    const createEnabledConfig = (obj: any) =>
+      createConfig({
+        enabled: true,
+        key: 'same-key',
+        certificate: 'same-cert',
+        ...obj,
+      });
+
+    it('compares `enabled`', () => {
+      const reference = createConfig({ enabled: true, key: 'same-key', certificate: 'same-cert' });
+      const same = createConfig({ enabled: true, key: 'same-key', certificate: 'same-cert' });
+      const different = createConfig({ enabled: false, key: 'same-key', certificate: 'same-cert' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `key`', () => {
+      const reference = createEnabledConfig({ key: 'keyA', certificate: 'same-cert' });
+      const same = createEnabledConfig({ key: 'keyA', certificate: 'same-cert' });
+      const different = createEnabledConfig({ key: 'keyB', certificate: 'same-cert' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `keyPassphrase`', () => {
+      const reference = createEnabledConfig({ keyPassphrase: 'passA' });
+      const same = createEnabledConfig({ keyPassphrase: 'passA' });
+      const different = createEnabledConfig({ keyPassphrase: 'passB' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `certificate`', () => {
+      const reference = createEnabledConfig({ key: 'same-key', certificate: 'cert-a' });
+      const same = createEnabledConfig({ key: 'same-key', certificate: 'cert-a' });
+      const different = createEnabledConfig({ key: 'same-key', certificate: 'cert-b' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `cipherSuites`', () => {
+      const reference = createEnabledConfig({ cipherSuites: ['A', 'B'] });
+      const same = createEnabledConfig({ cipherSuites: ['A', 'B'] });
+      const different = createEnabledConfig({ cipherSuites: ['A', 'C'] });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `supportedProtocols`', () => {
+      const reference = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.2'] });
+      const same = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.2'] });
+      const different = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.3'] });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `clientAuthentication`', () => {
+      const reference = createEnabledConfig({ clientAuthentication: 'none' });
+      const same = createEnabledConfig({ clientAuthentication: 'none' });
+      const different = createEnabledConfig({ clientAuthentication: 'required' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+  });
 });
 
 describe('#sslSchema', () => {

--- a/packages/kbn-server-http-tools/src/ssl/ssl_config.ts
+++ b/packages/kbn-server-http-tools/src/ssl/ssl_config.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { isEqual } from 'lodash';
 import { schema, TypeOf } from '@kbn/config-schema';
 import { readPkcs12Keystore, readPkcs12Truststore } from '@kbn/crypto';
 import { constants as cryptoConstants } from 'crypto';
@@ -160,6 +161,13 @@ export class SslConfig {
         ? secureOptions
         : secureOptions | secureOption; // eslint-disable-line no-bitwise
     }, 0);
+  }
+
+  public isEqualTo(otherConfig: SslConfig) {
+    if (this === otherConfig) {
+      return true;
+    }
+    return isEqual(this, otherConfig);
   }
 }
 

--- a/src/core/server/integration_tests/http/hapi.test.ts
+++ b/src/core/server/integration_tests/http/hapi.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import supertest from 'supertest';
+import tls from 'tls';
+import type { Server as HttpServer } from 'http';
+import type { Server as TlsServer } from 'https';
+import { KBN_CERT_PATH, KBN_KEY_PATH, ES_KEY_PATH, ES_CERT_PATH } from '@kbn/dev-utils';
+import {
+  createServer,
+  getListenerOptions,
+  getServerOptions,
+  getServerTLSOptions,
+} from '@kbn/server-http-tools';
+import {
+  HttpConfig,
+  config as httpConfig,
+  cspConfig,
+  externalUrlConfig,
+} from '@kbn/core-http-server-internal';
+
+function isServerTLS(server: HttpServer): server is TlsServer {
+  return 'setSecureContext' in server;
+}
+
+const fetchPeerCertificate = (host: string, port: number) => {
+  return new Promise<tls.DetailedPeerCertificate>((resolve, reject) => {
+    const socket = tls.connect({ host, port: Number(port), rejectUnauthorized: false });
+    socket.once('secureConnect', () => {
+      const cert = socket.getPeerCertificate(true);
+      socket.destroy();
+      resolve(cert);
+    });
+    socket.once('error', reject);
+  });
+};
+
+const flattenCertificateChain = (
+  cert: tls.DetailedPeerCertificate,
+  accumulator: tls.DetailedPeerCertificate[] = []
+) => {
+  accumulator.push(cert);
+  if (cert.issuerCertificate && cert.fingerprint256 !== cert.issuerCertificate.fingerprint256) {
+    flattenCertificateChain(cert.issuerCertificate, accumulator);
+  }
+  return accumulator;
+};
+
+describe('foo', () => {
+  const CSP_CONFIG = cspConfig.schema.validate({});
+  const EXTERNAL_URL_CONFIG = externalUrlConfig.schema.validate({});
+
+  beforeAll(() => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  });
+
+  it('bar', async () => {
+    const rawHttpConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: KBN_CERT_PATH,
+        key: KBN_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+
+    console.log(rawHttpConfig.ssl);
+
+    const config = new HttpConfig(rawHttpConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+
+    const serverOptions = getServerOptions(config);
+    const listenerOptions = getListenerOptions(config);
+    const server = createServer(serverOptions, listenerOptions);
+
+    await server.start();
+
+    const listener = server.listener;
+    // console.log('listener', listener.setSecureContext);
+
+    // const a: ServerTLS;
+    // a.setSecureContext()
+
+    const certificate = await fetchPeerCertificate(config.host, config.port);
+    const certificateChain = flattenCertificateChain(certificate);
+
+    // console.log('certificates:', certificateChain);
+
+    expect(isServerTLS(listener)).toEqual(true);
+    expect(certificateChain.length).toEqual(1);
+    expect(certificateChain[0].subject.CN).toEqual('kibana');
+
+    // force TS to understand what we're working with.
+    if (!isServerTLS(listener)) {
+      throw new Error('Server should be a TLS server');
+    }
+
+    const secondRawConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: ES_CERT_PATH,
+        key: ES_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+
+    console.log(rawHttpConfig.ssl);
+
+    const secondConfig = new HttpConfig(secondRawConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+
+    const newTlsConfig = getServerTLSOptions(secondConfig.ssl)!;
+
+    listener.setSecureContext(newTlsConfig);
+
+    const secondCertificate = await fetchPeerCertificate(config.host, config.port);
+    const secondCertificateChain = flattenCertificateChain(secondCertificate);
+
+    // console.log('certificates:', certificateChain);
+
+    expect(secondCertificateChain.length).toEqual(1);
+    expect(secondCertificateChain[0].subject.CN).toEqual('elasticsearch');
+
+    /*
+    await supertest(listener)
+      .get('/')
+      //.disableTLSCerts()
+      //.trustLocalhost(true)
+      .expect(200)
+      .then((res) => {
+        // res.
+        expect(res.text).toBe('some-string');
+      });
+    */
+
+    await server.stop();
+  });
+});

--- a/src/core/server/integration_tests/http/http_server.test.ts
+++ b/src/core/server/integration_tests/http/http_server.test.ts
@@ -52,7 +52,7 @@ describe('Http server', () => {
 
     beforeEach(async () => {
       shutdownTimeout = config.shutdownTimeout.asMilliseconds();
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$: of(config) });
       innerServerListener = innerServer.listener;
 
       const router = new Router('', logger, enhanceWithContext, {

--- a/src/core/server/integration_tests/http/tls_utils.ts
+++ b/src/core/server/integration_tests/http/tls_utils.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Server as NodeHttpServer } from 'http';
+import { Server as NodeTlsServer } from 'https';
+import tls from 'tls';
+
+export function isServerTLS(server: NodeHttpServer): server is NodeTlsServer {
+  return 'setSecureContext' in server;
+}
+
+export const fetchPeerCertificate = (host: string, port: number) => {
+  return new Promise<tls.DetailedPeerCertificate>((resolve, reject) => {
+    const socket = tls.connect({ host, port: Number(port), rejectUnauthorized: false });
+    socket.once('secureConnect', () => {
+      const cert = socket.getPeerCertificate(true);
+      socket.destroy();
+      resolve(cert);
+    });
+    socket.once('error', reject);
+  });
+};
+
+export const flattenCertificateChain = (
+  cert: tls.DetailedPeerCertificate,
+  accumulator: tls.DetailedPeerCertificate[] = []
+) => {
+  accumulator.push(cert);
+  if (cert.issuerCertificate && cert.fingerprint256 !== cert.issuerCertificate.fingerprint256) {
+    flattenCertificateChain(cert.issuerCertificate, accumulator);
+  }
+  return accumulator;
+};

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -155,6 +155,8 @@
     "@kbn/core-test-helpers-model-versions",
     "@kbn/core-plugins-contracts-browser",
     "@kbn/core-plugins-contracts-server",
+    "@kbn/dev-utils",
+    "@kbn/server-http-tools",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/54368

Add support for hot reloading the Kibana server's TLS configuration, using the same `SIGHUP`-based reload signal, as already implemented for other parts of the Kibana configuration (e.g `logging`)

**Note:**
- hot reloading is only supported for the server TLS configuration (`server.ssl`), not for the whole `server.*` config prefix
- swaping the certificate files (without modifying the kibana config itself) is supported
- it is not possible to toggle TLS (enabling or disabling) without restarting Kibana 
- hot reloading requires to force the process to reload its configuration by sending a `SIGHUP` signal 

### Example / how to test

#### Before

```yaml
server.ssl.enabled: true
server.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.crt
server.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.key
```

<img width="550" alt="Screenshot 2023-11-23 at 15 11 28" src="https://github.com/elastic/kibana/assets/1532934/1226d161-a9f2-4d62-a3de-37161829f187">

#### Changing the config

```yaml
server.ssl.enabled: true
server.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.crt
server.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.key
```

```bash
kill -SIGHUP {KIBANA_PID}
```

<img width="865" alt="Screenshot 2023-11-23 at 15 18 21" src="https://github.com/elastic/kibana/assets/1532934/c9412b2e-d70e-4cf0-8eaf-4db70a45af60">

#### After

<img width="547" alt="Screenshot 2023-11-23 at 15 18 43" src="https://github.com/elastic/kibana/assets/1532934/c839f04f-4adb-456d-a174-4f0ebd5c234c">

## Release notes

It is now possible to hot reload Kibana's TLS (`server.ssl`) configuration by updating it and then sending a `SIGHUP` signal to the Kibana process. 

Note that TLS cannot be toggled (disabled/enabled) that way, and that hot reload only works for the TLS configuration, not other properties of the `server` config prefix. 



<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->