### PR TITLE
Fleet: add support for subobjects: false

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/epm.ts
+++ b/x-pack/plugins/fleet/common/types/models/epm.ts
@@ -618,6 +618,7 @@ export interface IndexTemplateMappings {
   properties: any;
   dynamic_templates?: any;
   runtime?: any;
+  subobjects?: boolean;
 }
 
 // This is an index template v2, see https://github.com/elastic/elasticsearch/issues/53101

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -768,8 +768,8 @@ describe('EPM template', () => {
             labels: {
               type: 'object',
               subobjects: false,
-            }
-          }
+            },
+          },
         },
       },
     };

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -755,30 +755,6 @@ describe('EPM template', () => {
     expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
   });
 
-  it('tests processing object field with subobjects set to false (case A)', () => {
-    const objectFieldWithPropertyReversedLiteralYml = `
-- name: a.labels
-  type: object
-  subobjects: false
-  `;
-    const objectFieldWithPropertyReversedMapping = {
-      properties: {
-        a: {
-          properties: {
-            labels: {
-              type: 'object',
-              subobjects: false,
-            },
-          },
-        },
-      },
-    };
-    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
-    const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
-    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
-  });
-
   it('tests processing object field with subobjects set to false (case B)', () => {
     const objectFieldWithPropertyReversedLiteralYml = `
 - name: b.labels.*

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -779,6 +779,80 @@ describe('EPM template', () => {
     expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
   });
 
+  it('tests processing object field with subobjects set to false (case B)', () => {
+    const objectFieldWithPropertyReversedLiteralYml = `
+- name: b.labels.*
+  type: object
+  object_type: keyword
+  subobjects: false
+  `;
+    const objectFieldWithPropertyReversedMapping = {
+      dynamic_templates: [{
+        "b.labels.*": {
+          path_match: "b.labels.*",
+          match_mapping_type: "string",
+          mapping: {
+            type: "keyword"
+          }
+        }
+      }],
+      properties: {
+        b: {
+          type: 'object',
+          dynamic: true,
+          properties: {
+            labels: {
+              dynamic: true,
+              type: 'object',
+              subobjects: false,
+            }
+          }
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
+  });
+
+  it('tests processing object field with subobjects set to false (case D)', () => {
+    const objectFieldWithPropertyReversedLiteralYml = `
+- name: d.labels
+  type: object
+  object_type: keyword
+  subobjects: false
+  `;
+    const objectFieldWithPropertyReversedMapping = {
+      dynamic_templates: [{
+        "d.labels": {
+          path_match: "d.labels.*",
+          match_mapping_type: "string",
+          mapping: {
+            type: "keyword"
+          }
+        }
+      }],
+      properties: {
+        d: {
+          type: 'object',
+          dynamic: true,
+          properties: {
+            labels: {
+              dynamic: true,
+              type: 'object',
+              subobjects: false,
+            }
+          }
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
+  });
+
   it('tests processing nested field with property', () => {
     const nestedYaml = `
   - name: a.b

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -755,6 +755,30 @@ describe('EPM template', () => {
     expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
   });
 
+  it('tests processing object field with subobjects set to false (case A)', () => {
+    const objectFieldWithPropertyReversedLiteralYml = `
+- name: a.labels
+  type: object
+  subobjects: false
+  `;
+    const objectFieldWithPropertyReversedMapping = {
+      properties: {
+        a: {
+          properties: {
+            labels: {
+              type: 'object',
+              subobjects: false,
+            }
+          }
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
+  });
+
   it('tests processing nested field with property', () => {
     const nestedYaml = `
   - name: a.b

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -833,6 +833,31 @@ describe('EPM template', () => {
     expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
   });
 
+  it('tests processing object field with subobjects without dynamic mappings', () => {
+    const objectFieldWithPropertyReversedLiteralYml = `
+- name: a
+  type: object
+  subobjects: false
+  fields:
+  - name: b.c
+    type: keyword
+  - name: x.y
+    type: keyword
+  `;
+    const objectFieldWithPropertyReversedMapping = {
+      properties: {
+        a: {
+          type: 'object',
+          subobjects: false,
+        },
+      },
+    };
+    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
+    const processedFields = processFields(fields);
+    const mappings = generateMappings(processedFields);
+    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
+  });
+
   it('tests processing nested field with property', () => {
     const nestedYaml = `
   - name: a.b

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -787,15 +787,17 @@ describe('EPM template', () => {
   subobjects: false
   `;
     const objectFieldWithPropertyReversedMapping = {
-      dynamic_templates: [{
-        "b.labels.*": {
-          path_match: "b.labels.*",
-          match_mapping_type: "string",
-          mapping: {
-            type: "keyword"
-          }
-        }
-      }],
+      dynamic_templates: [
+        {
+          'b.labels.*': {
+            path_match: 'b.labels.*',
+            match_mapping_type: 'string',
+            mapping: {
+              type: 'keyword',
+            },
+          },
+        },
+      ],
       properties: {
         b: {
           type: 'object',
@@ -805,8 +807,8 @@ describe('EPM template', () => {
               dynamic: true,
               type: 'object',
               subobjects: false,
-            }
-          }
+            },
+          },
         },
       },
     };
@@ -824,15 +826,17 @@ describe('EPM template', () => {
   subobjects: false
   `;
     const objectFieldWithPropertyReversedMapping = {
-      dynamic_templates: [{
-        "d.labels": {
-          path_match: "d.labels.*",
-          match_mapping_type: "string",
-          mapping: {
-            type: "keyword"
-          }
-        }
-      }],
+      dynamic_templates: [
+        {
+          'd.labels': {
+            path_match: 'd.labels.*',
+            match_mapping_type: 'string',
+            mapping: {
+              type: 'keyword',
+            },
+          },
+        },
+      ],
       properties: {
         d: {
           type: 'object',
@@ -842,8 +846,8 @@ describe('EPM template', () => {
               dynamic: true,
               type: 'object',
               subobjects: false,
-            }
-          }
+            },
+          },
         },
       },
     };

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -833,31 +833,6 @@ describe('EPM template', () => {
     expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
   });
 
-  it('tests processing object field with subobjects without dynamic mappings', () => {
-    const objectFieldWithPropertyReversedLiteralYml = `
-- name: a
-  type: object
-  subobjects: false
-  fields:
-  - name: b.c
-    type: keyword
-  - name: x.y
-    type: keyword
-  `;
-    const objectFieldWithPropertyReversedMapping = {
-      properties: {
-        a: {
-          type: 'object',
-          subobjects: false,
-        },
-      },
-    };
-    const fields: Field[] = safeLoad(objectFieldWithPropertyReversedLiteralYml);
-    const processedFields = processFields(fields);
-    const mappings = generateMappings(processedFields);
-    expect(mappings).toEqual(objectFieldWithPropertyReversedMapping);
-  });
-
   it('tests processing nested field with property', () => {
     const nestedYaml = `
   - name: a.b

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -438,11 +438,15 @@ function _generateMappings(
             );
         }
 
-        // Flag that the mapping of this field subobjects property is set.
-        if (field.subobjects !== undefined) {
-          if (path.includes('*')) {
-            subobjects = field.subobjects;
-          }
+        // When a wildcard field specifies the subobjects setting,
+        // the parent intermediate object should set the subobjects
+        // setting.
+        //
+        // For example, if a wildcard field `foo.*` has subobjects,
+        // we should set subobjects on the intermediate object `foo`.
+        //
+        if (field.subobjects !== undefined && path.includes('*')) {
+          subobjects = field.subobjects;
         }
 
         if (dynProperties && matchingType) {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -239,7 +239,7 @@ function _generateMappings(
     const fieldProps = {
       type: 'object',
       dynamic: true,
-      ...(field.subobjects !== undefined && { subobjects: field.subobjects })
+      ...(field.subobjects !== undefined && { subobjects: field.subobjects }),
     };
 
     props[field.name] = fieldProps;
@@ -442,7 +442,7 @@ function _generateMappings(
         if (field.subobjects !== undefined) {
           if (path.includes('*')) {
             subobjects = field.subobjects;
-          } 
+          }
         }
 
         if (dynProperties && matchingType) {
@@ -452,7 +452,6 @@ function _generateMappings(
           // index templates not using `"dynamic": true`.
           addParentObjectAsStaticProperty(field);
         }
-
       } else {
         let fieldProps = getDefaultProperties(field);
 
@@ -619,7 +618,12 @@ function _generateMappings(
     });
   }
 
-  return { properties: props, hasNonDynamicTemplateMappings, hasDynamicTemplateMappings, subobjects };
+  return {
+    properties: props,
+    hasNonDynamicTemplateMappings,
+    hasDynamicTemplateMappings,
+    subobjects,
+  };
 }
 
 function generateDynamicAndEnabled(field: Field) {

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -444,16 +444,15 @@ function _generateMappings(
         }
 
         if (field.subobjects !== undefined) {
-          let fieldProps: Properties = {
+          const fieldProps: Properties = {
             subobjects: field.subobjects,
             type: 'object',
           };
-          
+
           // props['what?'] = fieldProps;
 
           hasNonDynamicTemplateMappings = true;
         }
-
       } else {
         let fieldProps = getDefaultProperties(field);
 

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -442,6 +442,18 @@ function _generateMappings(
           // index templates not using `"dynamic": true`.
           addParentObjectAsStaticProperty(field);
         }
+
+        if (field.subobjects !== undefined) {
+          let fieldProps: Properties = {
+            subobjects: field.subobjects,
+            type: 'object',
+          };
+          
+          // props['what?'] = fieldProps;
+
+          hasNonDynamicTemplateMappings = true;
+        }
+
       } else {
         let fieldProps = getDefaultProperties(field);
 
@@ -581,6 +593,10 @@ function _generateMappings(
         }
         if (field.dimension && isIndexModeTimeSeries) {
           fieldProps.time_series_dimension = field.dimension;
+        }
+
+        if (field.subobjects !== undefined) {
+          fieldProps.subobjects = field.subobjects;
         }
 
         // Even if we don't add the property because it has a wildcard, notify

--- a/x-pack/plugins/fleet/server/services/epm/fields/field.ts
+++ b/x-pack/plugins/fleet/server/services/epm/fields/field.ts
@@ -40,6 +40,7 @@ export interface Field {
   dimension?: boolean;
   default_field?: boolean;
   runtime?: boolean | string;
+  subobjects?: boolean;
 
   // Fields specific of the aggregate_metric_double type
   metrics?: string[];


### PR DESCRIPTION
## Summary

Update the Fleet plugin to support the [subobjects](https://www.elastic.co/guide/en/elasticsearch/reference/current/subobjects.html) setting on the `object` type mapping.

This PR supports the `subobjects` setting on a per-field basis. We will add support for `subobjects` setting at the data stream level when Elasticsearch will automatically flatten the mappings in elastic/elasticsearch#99860.

The PR add deals with the following [user cases](https://github.com/elastic/package-spec/issues/349#issuecomment-1820439710) found in the integration packages and add support for a few of them.

### ~~Case A~~

```yaml
- name: a.labels
  type: object
  subobjects: false
```

The use case A is invalid on package-spec v3 and it's not supported.


### Case B

```yaml
- name: b.labels.*
  type: object
  object_type: keyword
  subobjects: false
```

that `_generateMappings()` should map to:

```js
{
  dynamic_templates: [{
    "b.labels.*": {
      path_match: "b.labels.*",
      match_mapping_type: "string",
      mapping: {
        type: "keyword"
      }
    }
  }],
  properties: {
    b: {
      type: 'object',
      dynamic: true,
      properties: {
        labels: {
          dynamic: true,
          type: 'object',
          subobjects: false,
        }
      }
    },
  },
}
```

### ~~Case C~~

```yaml
- name: prometheus.c.labels.*
  type: object
  subobjects: false
```

The use case C is considered invalid and it's not supported.

### Case D

```yaml
- name: d.labels
  type: object
  object_type: keyword
  subobjects: false
```

that `_generateMappings()` should map to:

```js
{
  dynamic_templates: [{
    "d.labels": {
      path_match: "d.labels.*",
      match_mapping_type: "string",
      mapping: {
        type: "keyword"
      }
    }
  }],
  properties: {
    d: {
      type: 'object',
      dynamic: true,
      properties: {
        labels: {
          dynamic: true,
          type: 'object',
          subobjects: false,
        }
      }
    },
  },
}
```

### Checklist

Delete any items that are not applicable to this PR.

- ~~[ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)~~
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- ~~[ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))~~
- ~~[ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))~~
- ~~[ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)~~
- ~~[ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))~~
- ~~[ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)~~


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
