### PR TITLE
[ci] Increase parallelism for Defend Workflow CY tests for 8.11

### DIFF
--- a/.buildkite/pipelines/pull_request/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/defend_workflows.yml
@@ -5,7 +5,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 6
+    parallelism: 10
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
## Summary

Looks like Defend Workflow Cypress tests can fail because of timeout. On `main`, their parallelism has already been increased to `10`, see:
- #169902

This should help with:
- #171230 
- #171421