### PR TITLE
Add `process.uptime` to the json logger

### DIFF
--- a/packages/core/logging/core-logging-server-internal/src/__snapshots__/logging_system.test.ts.snap
+++ b/packages/core/logging/core-logging-server-internal/src/__snapshots__/logging_system.test.ts.snap
@@ -25,6 +25,7 @@ Object {
   "message": "buffered trace message",
   "process": Object {
     "pid": Any<Number>,
+    "uptime": 10,
   },
 }
 `;
@@ -42,6 +43,7 @@ Object {
   "message": "buffered info message",
   "process": Object {
     "pid": Any<Number>,
+    "uptime": 10,
   },
   "some": "value",
 }
@@ -60,6 +62,7 @@ Object {
   "message": "buffered fatal message",
   "process": Object {
     "pid": Any<Number>,
+    "uptime": 10,
   },
 }
 `;
@@ -77,6 +80,7 @@ Object {
   "message": "buffered info message",
   "process": Object {
     "pid": Any<Number>,
+    "uptime": 10,
   },
   "some": "value",
 }
@@ -95,6 +99,7 @@ Object {
   "message": "some new info message",
   "process": Object {
     "pid": Any<Number>,
+    "uptime": 10,
   },
 }
 `;

--- a/packages/core/logging/core-logging-server-internal/src/layouts/__snapshots__/json_layout.test.ts.snap
+++ b/packages/core/logging/core-logging-server-internal/src/layouts/__snapshots__/json_layout.test.ts.snap
@@ -15,6 +15,7 @@ Object {
   "message": "message-1",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -29,6 +30,7 @@ Object {
   "message": "message-2",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -43,6 +45,7 @@ Object {
   "message": "message-3",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -57,6 +60,7 @@ Object {
   "message": "message-4",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -71,6 +75,7 @@ Object {
   "message": "message-5",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -85,6 +90,7 @@ Object {
   "message": "message-6",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
 }
 `;
@@ -99,6 +105,7 @@ Object {
   "message": "message-6",
   "process": Object {
     "pid": 5355,
+    "uptime": 10,
   },
   "span": Object {
     "id": "spanId-1",

--- a/packages/core/logging/core-logging-server-internal/src/layouts/json_layout.test.ts
+++ b/packages/core/logging/core-logging-server-internal/src/layouts/json_layout.test.ts
@@ -10,6 +10,8 @@ import { EcsVersion } from '@kbn/ecs';
 import { LogLevel, LogRecord } from '@kbn/logging';
 import { JsonLayout } from './json_layout';
 
+jest.spyOn(process, 'uptime').mockReturnValue(10);
+
 const timestamp = new Date(Date.UTC(2012, 1, 1, 14, 30, 22, 11));
 const records: LogRecord[] = [
   {
@@ -121,6 +123,7 @@ test('`format()` correctly formats record with meta-data', () => {
     },
     process: {
       pid: 5355,
+      uptime: 10,
     },
   });
 });
@@ -169,6 +172,7 @@ test('`format()` correctly formats error record with meta-data', () => {
     },
     process: {
       pid: 5355,
+      uptime: 10,
     },
   });
 });
@@ -202,6 +206,7 @@ test('format() meta can merge override logs', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
   });
 });
@@ -232,6 +237,7 @@ test('format() meta can not override message', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
   });
 });
@@ -262,6 +268,7 @@ test('format() meta can not override ecs version', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
   });
 });
@@ -295,6 +302,7 @@ test('format() meta can not override logger or level', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
   });
 });
@@ -325,6 +333,7 @@ test('format() meta can not override timestamp', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
   });
 });
@@ -359,6 +368,7 @@ test('format() meta can not override tracing properties', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
     span: { id: 'span_override' },
     trace: { id: 'trace_override' },
@@ -404,6 +414,7 @@ test('format() meta.toJSON() is used if own property', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
     server: {
       address: 'localhost',
@@ -448,6 +459,7 @@ test('format() meta.toJSON() is used if present on prototype', () => {
     },
     process: {
       pid: 3,
+      uptime: 10,
     },
     foo: 'bar',
   });

--- a/packages/core/logging/core-logging-server-internal/src/layouts/json_layout.ts
+++ b/packages/core/logging/core-logging-server-internal/src/layouts/json_layout.ts
@@ -53,6 +53,7 @@ export class JsonLayout implements Layout {
       },
       process: {
         pid: record.pid,
+        uptime: process.uptime(),
       },
       span: spanId ? { id: spanId } : undefined,
       trace: traceId ? { id: traceId } : undefined,

--- a/packages/core/logging/core-logging-server-internal/src/logging_system.test.ts
+++ b/packages/core/logging/core-logging-server-internal/src/logging_system.test.ts
@@ -23,6 +23,7 @@ let system: LoggingSystem;
 beforeEach(() => {
   mockConsoleLog = jest.spyOn(global.console, 'log').mockReturnValue(undefined);
   jest.spyOn<any, any>(global, 'Date').mockImplementation(() => timestamp);
+  jest.spyOn(process, 'uptime').mockReturnValue(10);
   system = new LoggingSystem();
 });
 

--- a/src/core/server/integration_tests/elasticsearch/error_logging.test.ts
+++ b/src/core/server/integration_tests/elasticsearch/error_logging.test.ts
@@ -86,6 +86,7 @@ describe('Error logging', () => {
           name: 'ResponseError',
           process: {
             pid: expect.any(Number),
+            uptime: expect.any(Number),
           },
         });
       }


### PR DESCRIPTION
## Summary

Adding ECS-supported `process.uptime` ([docs](https://www.elastic.co/guide/en/ecs/current/ecs-process.html#field-process-uptime)) to our JSON logger.

This way we can be aware of how long the process has been running, helping us to detect restarts or potential memory leaks.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| As an ever-growing counter, it may overflow. | Very Low | High | We need thousands of years for it to overflow. |

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
