### PR TITLE
[Search Relevance] Remove v2 from ELSER callout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/deploy_model.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/deploy_model.tsx
@@ -55,7 +55,7 @@ export const DeployModel = ({
                 <h3>
                   {i18n.translate(
                     'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.title',
-                    { defaultMessage: 'Improve your results with ELSER v2' }
+                    { defaultMessage: 'Improve your results with ELSER' }
                   )}
                 </h3>
               </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployed.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployed.tsx
@@ -51,7 +51,7 @@ export const ModelDeployed = ({
                 <h3>
                   {i18n.translate(
                     'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.deployedTitle',
-                    { defaultMessage: 'Your ELSER v2 model has deployed but not started.' }
+                    { defaultMessage: 'Your ELSER model has deployed but not started.' }
                   )}
                 </h3>
               </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployment_in_progress.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_deployment_in_progress.tsx
@@ -28,7 +28,7 @@ export const ModelDeploymentInProgress = ({
               <h3>
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.deployingTitle',
-                  { defaultMessage: 'Your ELSER v2 model is deploying.' }
+                  { defaultMessage: 'Your ELSER model is deploying.' }
                 )}
               </h3>
             </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_started.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/model_started.tsx
@@ -50,20 +50,20 @@ export const ModelStarted = ({
                   ? isCompact
                     ? i18n.translate(
                         'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.startedSingleThreadedTitleCompact',
-                        { defaultMessage: 'Your ELSER v2 model is running single-threaded.' }
+                        { defaultMessage: 'Your ELSER model is running single-threaded.' }
                       )
                     : i18n.translate(
                         'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.startedSingleThreadedTitle',
-                        { defaultMessage: 'Your ELSER v2 model has started single-threaded.' }
+                        { defaultMessage: 'Your ELSER model has started single-threaded.' }
                       )
                   : isCompact
                   ? i18n.translate(
                       'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.startedTitleCompact',
-                      { defaultMessage: 'Your ELSER v2 model is running.' }
+                      { defaultMessage: 'Your ELSER model is running.' }
                     )
                   : i18n.translate(
                       'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.startedTitle',
-                      { defaultMessage: 'Your ELSER v2 model has started.' }
+                      { defaultMessage: 'Your ELSER model has started.' }
                     )}
               </h3>
             </EuiText>
@@ -92,7 +92,7 @@ export const ModelStarted = ({
                       'xpack.enterpriseSearch.content.index.pipelines.textExpansionCallOut.startedBody',
                       {
                         defaultMessage:
-                          'Enjoy the power of ELSER v2 in your custom Inference pipeline.',
+                          'Enjoy the power of ELSER in your custom Inference pipeline.',
                       }
                     )}
               </p>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/text_expansion_callout_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/text_expansion_callout_logic.test.ts
@@ -80,19 +80,19 @@ describe('TextExpansionCalloutLogic', () => {
     });
     it('uses the correct title and message from a create error', () => {
       expect(getTextExpansionError(error, undefined, undefined)).toEqual({
-        title: 'Error with ELSER v2 deployment',
+        title: 'Error with ELSER deployment',
         message: error.body?.message,
       });
     });
     it('uses the correct title and message from a fetch error', () => {
       expect(getTextExpansionError(undefined, error, undefined)).toEqual({
-        title: 'Error fetching ELSER v2 model',
+        title: 'Error fetching ELSER model',
         message: error.body?.message,
       });
     });
     it('uses the correct title and message from a start error', () => {
       expect(getTextExpansionError(undefined, undefined, error)).toEqual({
-        title: 'Error starting ELSER v2 deployment',
+        title: 'Error starting ELSER deployment',
         message: error.body?.message,
       });
     });
@@ -303,7 +303,7 @@ describe('TextExpansionCalloutLogic', () => {
     describe('textExpansionError', () => {
       const error = {
         body: {
-          error: 'Error with ELSER v2 deployment',
+          error: 'Error with ELSER deployment',
           message: 'Mocked error message',
           statusCode: 500,
         },
@@ -318,21 +318,21 @@ describe('TextExpansionCalloutLogic', () => {
       it('returns extracted error for create', () => {
         CreateTextExpansionModelApiLogic.actions.apiError(error);
         expect(TextExpansionCalloutLogic.values.textExpansionError).toStrictEqual({
-          title: 'Error with ELSER v2 deployment',
+          title: 'Error with ELSER deployment',
           message: 'Mocked error message',
         });
       });
       it('returns extracted error for fetch', () => {
         FetchTextExpansionModelApiLogic.actions.apiError(error);
         expect(TextExpansionCalloutLogic.values.textExpansionError).toStrictEqual({
-          title: 'Error fetching ELSER v2 model',
+          title: 'Error fetching ELSER model',
           message: 'Mocked error message',
         });
       });
       it('returns extracted error for start', () => {
         StartTextExpansionModelApiLogic.actions.apiError(error);
         expect(TextExpansionCalloutLogic.values.textExpansionError).toStrictEqual({
-          title: 'Error starting ELSER v2 deployment',
+          title: 'Error starting ELSER deployment',
           message: 'Mocked error message',
         });
       });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/text_expansion_callout_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/text_expansion_callout/text_expansion_callout_logic.ts
@@ -97,7 +97,7 @@ export const getTextExpansionError = (
         title: i18n.translate(
           'xpack.enterpriseSearch.content.indices.pipelines.textExpansionCreateError.title',
           {
-            defaultMessage: 'Error with ELSER v2 deployment',
+            defaultMessage: 'Error with ELSER deployment',
           }
         ),
         message: getErrorsFromHttpResponse(createError)[0],
@@ -107,7 +107,7 @@ export const getTextExpansionError = (
         title: i18n.translate(
           'xpack.enterpriseSearch.content.indices.pipelines.textExpansionStartError.title',
           {
-            defaultMessage: 'Error starting ELSER v2 deployment',
+            defaultMessage: 'Error starting ELSER deployment',
           }
         ),
         message: getErrorsFromHttpResponse(startError)[0],
@@ -117,7 +117,7 @@ export const getTextExpansionError = (
         title: i18n.translate(
           'xpack.enterpriseSearch.content.indices.pipelines.textExpansionFetchError.title',
           {
-            defaultMessage: 'Error fetching ELSER v2 model',
+            defaultMessage: 'Error fetching ELSER model',
           }
         ),
         message: getErrorsFromHttpResponse(fetchError)[0],


### PR DESCRIPTION
In this PR, we removed the **v2** from the text-expansion-callout. 
<img width="918" alt="Screenshot 2023-11-23 at 9 33 11 AM" src="https://github.com/elastic/kibana/assets/132922331/ea303544-9dda-4b17-8798-0716609bddef">


