### PR TITLE
[Observability] Remove redundant contexts from pages

### DIFF
--- a/x-pack/plugins/observability/public/application/index.tsx
+++ b/x-pack/plugins/observability/public/application/index.tsx
@@ -20,7 +20,6 @@ import { RedirectAppLinks } from '@kbn/shared-ux-link-redirect-app';
 import { Storage } from '@kbn/kibana-utils-plugin/public';
 import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import { ObservabilityAIAssistantProvider } from '@kbn/observability-ai-assistant-plugin/public';
-import { HasDataContextProvider } from '../context/has_data_context/has_data_context';
 import { PluginContext } from '../context/plugin_context/plugin_context';
 import { ConfigSchema, ObservabilityPublicPluginsStart } from '../plugin';
 import { routes } from '../routes/routes';
@@ -119,9 +118,7 @@ export const renderApp = ({
                           data-test-subj="observabilityMainContainer"
                         >
                           <QueryClientProvider client={queryClient}>
-                            <HasDataContextProvider>
-                              <App />
-                            </HasDataContextProvider>
+                            <App />
                             <HideableReactQueryDevTools />
                           </QueryClientProvider>
                         </RedirectAppLinks>

--- a/x-pack/plugins/observability/public/context/has_data_context/has_data_context.tsx
+++ b/x-pack/plugins/observability/public/context/has_data_context/has_data_context.tsx
@@ -7,7 +7,6 @@
 
 import { isEmpty, uniqueId } from 'lodash';
 import React, { createContext, useEffect, useState } from 'react';
-import { useRouteMatch } from 'react-router-dom';
 import { asyncForEach } from '@kbn/std';
 import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 import { useKibana } from '../../utils/kibana_react';
@@ -65,84 +64,81 @@ export function HasDataContextProvider({ children }: { children: React.ReactNode
 
   const [hasDataMap, setHasDataMap] = useState<HasDataContextValue['hasDataMap']>({});
 
-  const isExploratoryView = useRouteMatch('/exploratory-view');
-
   useEffect(
     () => {
-      if (!isExploratoryView)
-        asyncForEach(apps, async (app) => {
-          try {
-            const updateState = ({
-              hasData,
-              indices,
-              serviceName,
-            }: {
-              hasData?: boolean;
-              serviceName?: string;
-              indices?: string | ApmIndicesConfig;
-            }) => {
-              setHasDataMap((prevState) => ({
-                ...prevState,
-                [app]: {
-                  hasData,
-                  ...(serviceName ? { serviceName } : {}),
-                  ...(indices ? { indices } : {}),
-                  status: FETCH_STATUS.SUCCESS,
-                },
-              }));
-            };
-            switch (app) {
-              case UX_APP:
-                const params = { absoluteTime: { start: absoluteStart!, end: absoluteEnd! } };
-                const resultUx = await getDataHandler(app)?.hasData(params);
-                updateState({
-                  hasData: resultUx?.hasData,
-                  indices: resultUx?.indices,
-                  serviceName: resultUx?.serviceName as string,
-                });
-                break;
-              case UPTIME_APP:
-                const resultSy = await getDataHandler(app)?.hasData();
-                updateState({ hasData: resultSy?.hasData, indices: resultSy?.indices });
-
-                break;
-              case APM_APP:
-                const resultApm = await getDataHandler(app)?.hasData();
-                updateState({ hasData: resultApm?.hasData, indices: resultApm?.indices });
-
-                break;
-              case INFRA_LOGS_APP:
-                const resultInfraLogs = await getDataHandler(app)?.hasData();
-                updateState({
-                  hasData: resultInfraLogs?.hasData,
-                  indices: resultInfraLogs?.indices,
-                });
-                break;
-              case INFRA_METRICS_APP:
-                const resultInfraMetrics = await getDataHandler(app)?.hasData();
-                updateState({
-                  hasData: resultInfraMetrics?.hasData,
-                  indices: resultInfraMetrics?.indices,
-                });
-                break;
-              case UNIVERSAL_PROFILING_APP:
-                // Profiling only shows the empty section for now
-                updateState({ hasData: false });
-                break;
-            }
-          } catch (e) {
+      asyncForEach(apps, async (app) => {
+        try {
+          const updateState = ({
+            hasData,
+            indices,
+            serviceName,
+          }: {
+            hasData?: boolean;
+            serviceName?: string;
+            indices?: string | ApmIndicesConfig;
+          }) => {
             setHasDataMap((prevState) => ({
               ...prevState,
               [app]: {
-                hasData: undefined,
-                status: FETCH_STATUS.FAILURE,
+                hasData,
+                ...(serviceName ? { serviceName } : {}),
+                ...(indices ? { indices } : {}),
+                status: FETCH_STATUS.SUCCESS,
               },
             }));
+          };
+          switch (app) {
+            case UX_APP:
+              const params = { absoluteTime: { start: absoluteStart!, end: absoluteEnd! } };
+              const resultUx = await getDataHandler(app)?.hasData(params);
+              updateState({
+                hasData: resultUx?.hasData,
+                indices: resultUx?.indices,
+                serviceName: resultUx?.serviceName as string,
+              });
+              break;
+            case UPTIME_APP:
+              const resultSy = await getDataHandler(app)?.hasData();
+              updateState({ hasData: resultSy?.hasData, indices: resultSy?.indices });
+
+              break;
+            case APM_APP:
+              const resultApm = await getDataHandler(app)?.hasData();
+              updateState({ hasData: resultApm?.hasData, indices: resultApm?.indices });
+
+              break;
+            case INFRA_LOGS_APP:
+              const resultInfraLogs = await getDataHandler(app)?.hasData();
+              updateState({
+                hasData: resultInfraLogs?.hasData,
+                indices: resultInfraLogs?.indices,
+              });
+              break;
+            case INFRA_METRICS_APP:
+              const resultInfraMetrics = await getDataHandler(app)?.hasData();
+              updateState({
+                hasData: resultInfraMetrics?.hasData,
+                indices: resultInfraMetrics?.indices,
+              });
+              break;
+            case UNIVERSAL_PROFILING_APP:
+              // Profiling only shows the empty section for now
+              updateState({ hasData: false });
+              break;
           }
-        });
+        } catch (e) {
+          setHasDataMap((prevState) => ({
+            ...prevState,
+            [app]: {
+              hasData: undefined,
+              status: FETCH_STATUS.FAILURE,
+            },
+          }));
+        }
+      });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isExploratoryView]
+    []
   );
 
   useEffect(() => {

--- a/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
+++ b/x-pack/plugins/observability/public/pages/alerts/alerts.tsx
@@ -19,12 +19,10 @@ import { DEFAULT_APP_CATEGORIES } from '@kbn/core-application-common';
 import { rulesLocatorID } from '../../../common';
 import { RulesParams } from '../../locators/rules';
 import { useKibana } from '../../utils/kibana_react';
-import { useHasData } from '../../hooks/use_has_data';
 import { usePluginContext } from '../../hooks/use_plugin_context';
 import { useTimeBuckets } from '../../hooks/use_time_buckets';
 import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
 import { useToasts } from '../../hooks/use_toast';
-import { LoadingObservability } from '../../components/loading_observability';
 import { renderRuleStats, RuleStatsState } from './components/rule_stats';
 import { ObservabilityAlertSearchBar } from '../../components/alert_search_bar/alert_search_bar';
 import {
@@ -94,7 +92,6 @@ function InternalAlertsPage() {
     error: 0,
     snoozed: 0,
   });
-  const { hasAnyData, isAllRequestsComplete } = useHasData();
   const [esQuery, setEsQuery] = useState<{ bool: BoolQuery }>();
   const timeBuckets = useTimeBuckets();
   const bucketSize = useMemo(
@@ -172,10 +169,6 @@ function InternalAlertsPage() {
   }, []);
 
   const manageRulesHref = http.basePath.prepend('/app/observability/alerts/rules');
-
-  if (!hasAnyData && !isAllRequestsComplete) {
-    return <LoadingObservability />;
-  }
 
   return (
     <Provider value={alertSearchBarStateContainer}>

--- a/x-pack/plugins/observability/public/pages/cases/cases.tsx
+++ b/x-pack/plugins/observability/public/pages/cases/cases.tsx
@@ -9,21 +9,13 @@ import React from 'react';
 
 import { useGetUserCasesPermissions } from '../../hooks/use_get_user_cases_permissions';
 import { usePluginContext } from '../../hooks/use_plugin_context';
-import { useHasData } from '../../hooks/use_has_data';
 import { Cases } from './components/cases';
-import { LoadingObservability } from '../../components/loading_observability';
 import { CaseFeatureNoPermissions } from './components/feature_no_permissions';
 import { HeaderMenu } from '../overview/components/header_menu/header_menu';
 
 export function CasesPage() {
   const userCasesPermissions = useGetUserCasesPermissions();
   const { ObservabilityPageTemplate } = usePluginContext();
-
-  const { hasAnyData, isAllRequestsComplete } = useHasData();
-
-  if (!hasAnyData && !isAllRequestsComplete) {
-    return <LoadingObservability />;
-  }
 
   return userCasesPermissions.read ? (
     <ObservabilityPageTemplate isPageDataLoaded data-test-subj="o11yCasesPage">

--- a/x-pack/plugins/observability/public/pages/slos/slos.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/slos.tsx
@@ -32,7 +32,7 @@ export function SlosPage() {
   const { hasWriteCapabilities } = useCapabilities();
   const { hasAtLeast } = useLicense();
 
-  const { isInitialLoading, isLoading, isError, data: sloList } = useFetchSloList();
+  const { isLoading, isError, data: sloList } = useFetchSloList();
   const { total } = sloList ?? { total: 0 };
 
   const { storeAutoRefreshState, getAutoRefreshState } = useAutoRefreshStorage();
@@ -62,10 +62,6 @@ export function SlosPage() {
     setIsAutoRefreshing(!isAutoRefreshing);
     storeAutoRefreshState(!isAutoRefreshing);
   };
-
-  if (isInitialLoading) {
-    return null;
-  }
 
   return (
     <ObservabilityPageTemplate

--- a/x-pack/plugins/observability/public/routes/routes.tsx
+++ b/x-pack/plugins/observability/public/routes/routes.tsx
@@ -37,6 +37,7 @@ import {
   SLO_DETAIL_PATH,
   SLO_EDIT_PATH,
 } from '../../common/locators/paths';
+import { HasDataContextProvider } from '../context/has_data_context/has_data_context';
 
 // Note: React Router DOM <Redirect> component was not working here
 // so I've recreated this simple version for this purpose.
@@ -65,7 +66,11 @@ export const routes = {
   },
   [LANDING_PATH]: {
     handler: () => {
-      return <LandingPage />;
+      return (
+        <HasDataContextProvider>
+          <LandingPage />
+        </HasDataContextProvider>
+      );
     },
     params: {},
     exact: true,
@@ -73,9 +78,11 @@ export const routes = {
   [OVERVIEW_PATH]: {
     handler: () => {
       return (
-        <DatePickerContextProvider>
-          <OverviewPage />
-        </DatePickerContextProvider>
+        <HasDataContextProvider>
+          <DatePickerContextProvider>
+            <OverviewPage />
+          </DatePickerContextProvider>
+        </HasDataContextProvider>
       );
     },
     params: {},


### PR DESCRIPTION
## Summary

Include HasDataContext only where it's needed and used. 


### Testing
Just browser around different pages in Observability and nothing should be suspicious 