### PR TITLE
[8.11] [HTTP Server] support TLS config hot reload via `SIGHUP` (#171823)

### DIFF
--- a/packages/core/http/core-http-server-internal/src/http_server.test.mocks.ts
+++ b/packages/core/http/core-http-server-internal/src/http_server.test.mocks.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const setTlsConfigMock = jest.fn();
+
+jest.doMock('@kbn/server-http-tools', () => {
+  const actual = jest.requireActual('@kbn/server-http-tools');
+  return {
+    ...actual,
+    setTlsConfig: setTlsConfigMock,
+    createServer: jest.fn(actual.createServer),
+  };
+});

--- a/packages/core/http/core-http-server-internal/src/http_service.ts
+++ b/packages/core/http/core-http-server-internal/src/http_service.ts
@@ -71,7 +71,7 @@ export class HttpService
     this.env = env;
     this.log = logger.get('http');
     this.config$ = combineLatest([
-      configService.atPath<HttpConfigType>(httpConfig.path),
+      configService.atPath<HttpConfigType>(httpConfig.path, { ignoreUnchanged: false }),
       configService.atPath<CspConfigType>(cspConfig.path),
       configService.atPath<ExternalUrlConfigType>(externalUrlConfig.path),
     ]).pipe(map(([http, csp, externalUrl]) => new HttpConfig(http, csp, externalUrl)));
@@ -85,7 +85,9 @@ export class HttpService
     this.log.debug('setting up preboot server');
     const config = await firstValueFrom(this.config$);
 
-    const prebootSetup = await this.prebootServer.setup(config);
+    const prebootSetup = await this.prebootServer.setup({
+      config$: this.config$,
+    });
     prebootSetup.server.route({
       path: '/{p*}',
       method: '*',
@@ -156,10 +158,10 @@ export class HttpService
 
     const config = await firstValueFrom(this.config$);
 
-    const { registerRouter, ...serverContract } = await this.httpServer.setup(
-      config,
-      deps.executionContext
-    );
+    const { registerRouter, ...serverContract } = await this.httpServer.setup({
+      config$: this.config$,
+      executionContext: deps.executionContext,
+    });
 
     registerCoreHandlers(serverContract, config, this.env);
 

--- a/packages/kbn-config/src/config_service.test.ts
+++ b/packages/kbn-config/src/config_service.test.ts
@@ -131,6 +131,23 @@ test("does not push new configs when reloading if config at path hasn't changed"
   expect(valuesReceived).toEqual(['value']);
 });
 
+test("does push new configs when reloading when config at path hasn't changed if ignoreUnchanged is false", async () => {
+  const rawConfig$ = new BehaviorSubject<Record<string, any>>({ key: 'value' });
+  const rawConfigProvider = createRawConfigServiceMock({ rawConfig$ });
+
+  const configService = new ConfigService(rawConfigProvider, defaultEnv, logger);
+  await configService.setSchema('key', schema.string());
+
+  const valuesReceived: any[] = [];
+  configService.atPath('key', { ignoreUnchanged: false }).subscribe((value) => {
+    valuesReceived.push(value);
+  });
+
+  rawConfig$.next({ key: 'value' });
+
+  expect(valuesReceived).toEqual(['value', 'value']);
+});
+
 test('pushes new config when reloading and config at path has changed', async () => {
   const rawConfig$ = new BehaviorSubject<Record<string, any>>({ key: 'value' });
   const rawConfigProvider = createRawConfigServiceMock({ rawConfig$ });

--- a/packages/kbn-server-http-tools/index.ts
+++ b/packages/kbn-server-http-tools/index.ts
@@ -10,6 +10,7 @@ export type { IHttpConfig, ISslConfig, ICorsConfig } from './src/types';
 export { createServer } from './src/create_server';
 export { defaultValidationErrorHandler } from './src/default_validation_error_handler';
 export { getListenerOptions } from './src/get_listener_options';
-export { getServerOptions } from './src/get_server_options';
+export { getServerOptions, getServerTLSOptions } from './src/get_server_options';
 export { getRequestId } from './src/get_request_id';
+export { setTlsConfig } from './src/set_tls_config';
 export { sslSchema, SslConfig } from './src/ssl';

--- a/packages/kbn-server-http-tools/src/get_server_options.ts
+++ b/packages/kbn-server-http-tools/src/get_server_options.ts
@@ -9,7 +9,7 @@
 import { RouteOptionsCors, ServerOptions } from '@hapi/hapi';
 import { ServerOptions as TLSOptions } from 'https';
 import { defaultValidationErrorHandler } from './default_validation_error_handler';
-import { IHttpConfig } from './types';
+import { IHttpConfig, ISslConfig } from './types';
 
 const corsAllowedHeaders = ['Accept', 'Authorization', 'Content-Type', 'If-None-Match', 'kbn-xsrf'];
 
@@ -50,26 +50,31 @@ export function getServerOptions(config: IHttpConfig, { configureTLS = true } = 
     },
   };
 
-  if (configureTLS && config.ssl.enabled) {
-    const ssl = config.ssl;
-
-    // TODO: Hapi types have a typo in `tls` property type definition: `https.RequestOptions` is used instead of
-    // `https.ServerOptions`, and `honorCipherOrder` isn't presented in `https.RequestOptions`.
-    const tlsOptions: TLSOptions = {
-      ca: ssl.certificateAuthorities,
-      cert: ssl.certificate,
-      ciphers: config.ssl.cipherSuites?.join(':'),
-      // We use the server's cipher order rather than the client's to prevent the BEAST attack.
-      honorCipherOrder: true,
-      key: ssl.key,
-      passphrase: ssl.keyPassphrase,
-      secureOptions: ssl.getSecureOptions ? ssl.getSecureOptions() : undefined,
-      requestCert: ssl.requestCert,
-      rejectUnauthorized: ssl.rejectUnauthorized,
-    };
-
-    options.tls = tlsOptions;
+  if (configureTLS) {
+    options.tls = getServerTLSOptions(config.ssl);
   }
 
   return options;
+}
+
+/**
+ * Converts Kibana `SslConfig` into `TLSOptions` that are accepted by the Hapi server,
+ * and by https.Server.setSecureContext()
+ */
+export function getServerTLSOptions(ssl: ISslConfig): TLSOptions | undefined {
+  if (!ssl.enabled) {
+    return undefined;
+  }
+  return {
+    ca: ssl.certificateAuthorities,
+    cert: ssl.certificate,
+    ciphers: ssl.cipherSuites?.join(':'),
+    // We use the server's cipher order rather than the client's to prevent the BEAST attack.
+    honorCipherOrder: true,
+    key: ssl.key,
+    passphrase: ssl.keyPassphrase,
+    secureOptions: ssl.getSecureOptions ? ssl.getSecureOptions() : undefined,
+    requestCert: ssl.requestCert,
+    rejectUnauthorized: ssl.rejectUnauthorized,
+  };
 }

--- a/packages/kbn-server-http-tools/src/set_tls_config.test.mocks.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.test.mocks.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const getServerTLSOptionsMock = jest.fn();
+
+jest.doMock('./get_server_options', () => {
+  const actual = jest.requireActual('./get_server_options');
+  return {
+    ...actual,
+    getServerTLSOptions: getServerTLSOptionsMock,
+  };
+});

--- a/packages/kbn-server-http-tools/src/set_tls_config.test.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { getServerTLSOptionsMock } from './set_tls_config.test.mocks';
+import { Server } from '@hapi/hapi';
+import type { ISslConfig } from './types';
+import { setTlsConfig } from './set_tls_config';
+
+describe('setTlsConfig', () => {
+  beforeEach(() => {
+    getServerTLSOptionsMock.mockReset();
+    getServerTLSOptionsMock.mockReturnValue({});
+  });
+
+  it('throws when called for a non-TLS server', () => {
+    const server = new Server({});
+    const config: ISslConfig = { enabled: true };
+    expect(() => setTlsConfig(server, config)).toThrowErrorMatchingInlineSnapshot(
+      `"tried to set TLS config on a non-TLS http server"`
+    );
+  });
+
+  it('calls `getServerTLSOptions` with the correct parameters', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    (server.listener as any).setSecureContext = jest.fn();
+    const config: ISslConfig = { enabled: true };
+
+    setTlsConfig(server, config);
+
+    expect(getServerTLSOptionsMock).toHaveBeenCalledTimes(1);
+    expect(getServerTLSOptionsMock).toHaveBeenCalledWith(config);
+  });
+
+  it('throws when called for a disabled SSL config', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    (server.listener as any).setSecureContext = jest.fn();
+    const config: ISslConfig = { enabled: false };
+
+    getServerTLSOptionsMock.mockReturnValue(undefined);
+
+    expect(() => setTlsConfig(server, config)).toThrowErrorMatchingInlineSnapshot(
+      `"tried to apply a disabled SSL config"`
+    );
+  });
+
+  it('calls `setSecureContext` on the underlying server', () => {
+    const server = new Server({});
+    // easiest way to shim a tls.Server
+    const setSecureContextMock = jest.fn();
+    (server.listener as any).setSecureContext = setSecureContextMock;
+    const config: ISslConfig = { enabled: true };
+
+    const tlsConfig = { someTlsConfig: true };
+    getServerTLSOptionsMock.mockReturnValue(tlsConfig);
+
+    setTlsConfig(server, config);
+
+    expect(setSecureContextMock).toHaveBeenCalledTimes(1);
+    expect(setSecureContextMock).toHaveBeenCalledWith(tlsConfig);
+  });
+});

--- a/packages/kbn-server-http-tools/src/set_tls_config.ts
+++ b/packages/kbn-server-http-tools/src/set_tls_config.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { Server as HapiServer } from '@hapi/hapi';
+import type { Server as HttpServer } from 'http';
+import type { Server as TlsServer } from 'https';
+import type { ISslConfig } from './types';
+import { getServerTLSOptions } from './get_server_options';
+
+function isServerTLS(server: HttpServer): server is TlsServer {
+  return 'setSecureContext' in server;
+}
+
+export const setTlsConfig = (hapiServer: HapiServer, sslConfig: ISslConfig) => {
+  const server = hapiServer.listener;
+  if (!isServerTLS(server)) {
+    throw new Error('tried to set TLS config on a non-TLS http server');
+  }
+  const tlsOptions = getServerTLSOptions(sslConfig);
+  if (!tlsOptions) {
+    throw new Error('tried to apply a disabled SSL config');
+  }
+  server.setSecureContext(tlsOptions);
+};

--- a/packages/kbn-server-http-tools/src/ssl/ssl_config.test.ts
+++ b/packages/kbn-server-http-tools/src/ssl/ssl_config.test.ts
@@ -164,6 +164,79 @@ describe('#SslConfig', () => {
       expect(configValue.certificate).toEqual('content-of-another-path');
     });
   });
+
+  describe('isEqualTo()', () => {
+    const createEnabledConfig = (obj: any) =>
+      createConfig({
+        enabled: true,
+        key: 'same-key',
+        certificate: 'same-cert',
+        ...obj,
+      });
+
+    it('compares `enabled`', () => {
+      const reference = createConfig({ enabled: true, key: 'same-key', certificate: 'same-cert' });
+      const same = createConfig({ enabled: true, key: 'same-key', certificate: 'same-cert' });
+      const different = createConfig({ enabled: false, key: 'same-key', certificate: 'same-cert' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `key`', () => {
+      const reference = createEnabledConfig({ key: 'keyA', certificate: 'same-cert' });
+      const same = createEnabledConfig({ key: 'keyA', certificate: 'same-cert' });
+      const different = createEnabledConfig({ key: 'keyB', certificate: 'same-cert' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `keyPassphrase`', () => {
+      const reference = createEnabledConfig({ keyPassphrase: 'passA' });
+      const same = createEnabledConfig({ keyPassphrase: 'passA' });
+      const different = createEnabledConfig({ keyPassphrase: 'passB' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `certificate`', () => {
+      const reference = createEnabledConfig({ key: 'same-key', certificate: 'cert-a' });
+      const same = createEnabledConfig({ key: 'same-key', certificate: 'cert-a' });
+      const different = createEnabledConfig({ key: 'same-key', certificate: 'cert-b' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `cipherSuites`', () => {
+      const reference = createEnabledConfig({ cipherSuites: ['A', 'B'] });
+      const same = createEnabledConfig({ cipherSuites: ['A', 'B'] });
+      const different = createEnabledConfig({ cipherSuites: ['A', 'C'] });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `supportedProtocols`', () => {
+      const reference = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.2'] });
+      const same = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.2'] });
+      const different = createEnabledConfig({ supportedProtocols: ['TLSv1.1', 'TLSv1.3'] });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+
+    it('compares `clientAuthentication`', () => {
+      const reference = createEnabledConfig({ clientAuthentication: 'none' });
+      const same = createEnabledConfig({ clientAuthentication: 'none' });
+      const different = createEnabledConfig({ clientAuthentication: 'required' });
+
+      expect(reference.isEqualTo(same)).toBe(true);
+      expect(reference.isEqualTo(different)).toBe(false);
+    });
+  });
 });
 
 describe('#sslSchema', () => {

--- a/packages/kbn-server-http-tools/src/ssl/ssl_config.ts
+++ b/packages/kbn-server-http-tools/src/ssl/ssl_config.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { isEqual } from 'lodash';
 import { schema, TypeOf } from '@kbn/config-schema';
 import { readPkcs12Keystore, readPkcs12Truststore } from '@kbn/crypto';
 import { constants as cryptoConstants } from 'crypto';
@@ -160,6 +161,13 @@ export class SslConfig {
         ? secureOptions
         : secureOptions | secureOption; // eslint-disable-line no-bitwise
     }, 0);
+  }
+
+  public isEqualTo(otherConfig: SslConfig) {
+    if (this === otherConfig) {
+      return true;
+    }
+    return isEqual(this, otherConfig);
   }
 }
 

--- a/src/core/server/integration_tests/http/http_server.test.ts
+++ b/src/core/server/integration_tests/http/http_server.test.ts
@@ -51,7 +51,7 @@ describe('Http server', () => {
 
     beforeEach(async () => {
       shutdownTimeout = config.shutdownTimeout.asMilliseconds();
-      const { registerRouter, server: innerServer } = await server.setup(config);
+      const { registerRouter, server: innerServer } = await server.setup({ config$: of(config) });
       innerServerListener = innerServer.listener;
 
       const router = new Router('', logger, enhanceWithContext, {

--- a/src/core/server/integration_tests/http/set_tls_config.test.ts
+++ b/src/core/server/integration_tests/http/set_tls_config.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import supertest from 'supertest';
+import { KBN_CERT_PATH, KBN_KEY_PATH, ES_KEY_PATH, ES_CERT_PATH } from '@kbn/dev-utils';
+import {
+  createServer,
+  getListenerOptions,
+  getServerOptions,
+  setTlsConfig,
+} from '@kbn/server-http-tools';
+import {
+  HttpConfig,
+  config as httpConfig,
+  cspConfig,
+  externalUrlConfig,
+} from '@kbn/core-http-server-internal';
+import { flattenCertificateChain, fetchPeerCertificate, isServerTLS } from './tls_utils';
+
+describe('setTlsConfig', () => {
+  const CSP_CONFIG = cspConfig.schema.validate({});
+  const EXTERNAL_URL_CONFIG = externalUrlConfig.schema.validate({});
+
+  beforeAll(() => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  });
+
+  it('replaces the TLS configuration on the HAPI server', async () => {
+    const rawHttpConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: KBN_CERT_PATH,
+        key: KBN_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+    const firstConfig = new HttpConfig(rawHttpConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+
+    const serverOptions = getServerOptions(firstConfig);
+    const listenerOptions = getListenerOptions(firstConfig);
+    const server = createServer(serverOptions, listenerOptions);
+
+    server.route({
+      method: 'GET',
+      path: '/',
+      handler: (request, toolkit) => {
+        return toolkit.response('ok');
+      },
+    });
+
+    await server.start();
+
+    const listener = server.listener;
+
+    // force TS to understand what we're working with.
+    if (!isServerTLS(listener)) {
+      throw new Error('Server should be a TLS server');
+    }
+
+    const certificate = await fetchPeerCertificate(firstConfig.host, firstConfig.port);
+    const certificateChain = flattenCertificateChain(certificate);
+
+    expect(isServerTLS(listener)).toEqual(true);
+    expect(certificateChain.length).toEqual(1);
+    expect(certificateChain[0].subject.CN).toEqual('kibana');
+
+    await supertest(listener).get('/').expect(200);
+
+    const secondRawConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: ES_CERT_PATH,
+        key: ES_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+
+    const secondConfig = new HttpConfig(secondRawConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+
+    setTlsConfig(server, secondConfig.ssl);
+
+    const secondCertificate = await fetchPeerCertificate(firstConfig.host, firstConfig.port);
+    const secondCertificateChain = flattenCertificateChain(secondCertificate);
+
+    expect(secondCertificateChain.length).toEqual(1);
+    expect(secondCertificateChain[0].subject.CN).toEqual('elasticsearch');
+
+    await supertest(listener).get('/').expect(200);
+
+    await server.stop();
+  });
+});

--- a/src/core/server/integration_tests/http/tls_config_reload.test.ts
+++ b/src/core/server/integration_tests/http/tls_config_reload.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import supertest from 'supertest';
+import { duration } from 'moment';
+import { BehaviorSubject, of } from 'rxjs';
+import { KBN_CERT_PATH, KBN_KEY_PATH, ES_KEY_PATH, ES_CERT_PATH } from '@kbn/dev-utils';
+import { loggingSystemMock } from '@kbn/core-logging-server-mocks';
+import { Router } from '@kbn/core-http-router-server-internal';
+import {
+  HttpServer,
+  HttpConfig,
+  config as httpConfig,
+  cspConfig,
+  externalUrlConfig,
+} from '@kbn/core-http-server-internal';
+import { isServerTLS, flattenCertificateChain, fetchPeerCertificate } from './tls_utils';
+
+const CSP_CONFIG = cspConfig.schema.validate({});
+const EXTERNAL_URL_CONFIG = externalUrlConfig.schema.validate({});
+const enhanceWithContext = (fn: (...args: any[]) => any) => fn.bind(null, {});
+
+describe('HttpServer - TLS config', () => {
+  let server: HttpServer;
+  let logger: ReturnType<typeof loggingSystemMock.createLogger>;
+
+  beforeAll(() => {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+  });
+
+  beforeEach(() => {
+    const loggingService = loggingSystemMock.create();
+    logger = loggingSystemMock.createLogger();
+    server = new HttpServer(loggingService, 'tests', of(duration('1s')));
+  });
+
+  it('supports dynamic reloading of the TLS configuration', async () => {
+    const rawHttpConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: KBN_CERT_PATH,
+        key: KBN_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+    const firstConfig = new HttpConfig(rawHttpConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+
+    const config$ = new BehaviorSubject(firstConfig);
+
+    const { server: innerServer, registerRouter } = await server.setup({ config$ });
+    const listener = innerServer.listener;
+
+    const router = new Router('', logger, enhanceWithContext, {
+      isDev: false,
+      versionedRouteResolution: 'oldest',
+    });
+    router.get(
+      {
+        path: '/',
+        validate: false,
+      },
+      async (ctx, req, res) => {
+        return res.ok({
+          body: 'ok',
+        });
+      }
+    );
+    registerRouter(router);
+
+    await server.start();
+
+    // force TS to understand what we're working with.
+    if (!isServerTLS(listener)) {
+      throw new Error('Server should be a TLS server');
+    }
+
+    const certificate = await fetchPeerCertificate(firstConfig.host, firstConfig.port);
+    const certificateChain = flattenCertificateChain(certificate);
+
+    expect(certificateChain.length).toEqual(1);
+    expect(certificateChain[0].subject.CN).toEqual('kibana');
+
+    await supertest(listener).get('/').expect(200);
+
+    const secondRawConfig = httpConfig.schema.validate({
+      name: 'kibana',
+      host: '127.0.0.1',
+      port: 10002,
+      ssl: {
+        enabled: true,
+        certificate: ES_CERT_PATH,
+        key: ES_KEY_PATH,
+        cipherSuites: ['TLS_AES_256_GCM_SHA384'],
+        redirectHttpFromPort: 10003,
+      },
+      shutdownTimeout: '1s',
+    });
+
+    const secondConfig = new HttpConfig(secondRawConfig, CSP_CONFIG, EXTERNAL_URL_CONFIG);
+    config$.next(secondConfig);
+
+    const secondCertificate = await fetchPeerCertificate(firstConfig.host, firstConfig.port);
+    const secondCertificateChain = flattenCertificateChain(secondCertificate);
+
+    expect(secondCertificateChain.length).toEqual(1);
+    expect(secondCertificateChain[0].subject.CN).toEqual('elasticsearch');
+
+    await supertest(listener).get('/').expect(200);
+
+    await server.stop();
+  });
+});

--- a/src/core/server/integration_tests/http/tls_utils.ts
+++ b/src/core/server/integration_tests/http/tls_utils.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Server as NodeHttpServer } from 'http';
+import { Server as NodeTlsServer } from 'https';
+import tls from 'tls';
+
+export function isServerTLS(server: NodeHttpServer): server is NodeTlsServer {
+  return 'setSecureContext' in server;
+}
+
+export const fetchPeerCertificate = (host: string, port: number) => {
+  return new Promise<tls.DetailedPeerCertificate>((resolve, reject) => {
+    const socket = tls.connect({ host, port: Number(port), rejectUnauthorized: false });
+    socket.once('secureConnect', () => {
+      const cert = socket.getPeerCertificate(true);
+      socket.destroy();
+      resolve(cert);
+    });
+    socket.once('error', reject);
+  });
+};
+
+export const flattenCertificateChain = (
+  cert: tls.DetailedPeerCertificate,
+  accumulator: tls.DetailedPeerCertificate[] = []
+) => {
+  accumulator.push(cert);
+  if (cert.issuerCertificate && cert.fingerprint256 !== cert.issuerCertificate.fingerprint256) {
+    flattenCertificateChain(cert.issuerCertificate, accumulator);
+  }
+  return accumulator;
+};

--- a/src/core/tsconfig.json
+++ b/src/core/tsconfig.json
@@ -153,6 +153,8 @@
     "@kbn/stdio-dev-helpers",
     "@kbn/safer-lodash-set",
     "@kbn/core-test-helpers-model-versions",
+    "@kbn/dev-utils",
+    "@kbn/server-http-tools"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[HTTP Server] support TLS config hot reload via `SIGHUP` (#171823)](https://github.com/elastic/kibana/pull/171823)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pierre Gayvallet","email":"pierre.gayvallet@elastic.co"},"sourceCommit":{"committedDate":"2023-11-24T09:05:27Z","message":"[HTTP Server] support TLS config hot reload via `SIGHUP` (#171823)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/54368\r\n\r\nAdd support for hot reloading the Kibana server's TLS configuration,\r\nusing the same `SIGHUP`-based reload signal, as already implemented for\r\nother parts of the Kibana configuration (e.g `logging`)\r\n\r\n**Note:**\r\n- hot reloading is only supported for the server TLS configuration\r\n(`server.ssl`), not for the whole `server.*` config prefix\r\n- swaping the certificate files (without modifying the kibana config\r\nitself) is supported\r\n- it is not possible to toggle TLS (enabling or disabling) without\r\nrestarting Kibana\r\n- hot reloading requires to force the process to reload its\r\nconfiguration by sending a `SIGHUP` signal\r\n\r\n### Example / how to test\r\n\r\n#### Before\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.key\r\n```\r\n\r\n<img width=\"550\" alt=\"Screenshot 2023-11-23 at 15 11 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/1226d161-a9f2-4d62-a3de-37161829f187\">\r\n\r\n#### Changing the config\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.key\r\n```\r\n\r\n```bash\r\nkill -SIGHUP {KIBANA_PID}\r\n```\r\n\r\n<img width=\"865\" alt=\"Screenshot 2023-11-23 at 15 18 21\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c9412b2e-d70e-4cf0-8eaf-4db70a45af60\">\r\n\r\n#### After\r\n\r\n<img width=\"547\" alt=\"Screenshot 2023-11-23 at 15 18 43\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c839f04f-4adb-456d-a174-4f0ebd5c234c\">\r\n\r\n## Release notes\r\n\r\nIt is now possible to hot reload Kibana's TLS (`server.ssl`)\r\nconfiguration by updating it and then sending a `SIGHUP` signal to the\r\nKibana process.\r\n\r\nNote that TLS cannot be toggled (disabled/enabled) that way, and that\r\nhot reload only works for the TLS configuration, not other properties of\r\nthe `server` config prefix.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"87213e7efe4420b0edf72d471056fe78cbd9df60","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:enhancement","Feature:http","Team:Core","backport:prev-minor","v8.12.0"],"number":171823,"url":"https://github.com/elastic/kibana/pull/171823","mergeCommit":{"message":"[HTTP Server] support TLS config hot reload via `SIGHUP` (#171823)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/54368\r\n\r\nAdd support for hot reloading the Kibana server's TLS configuration,\r\nusing the same `SIGHUP`-based reload signal, as already implemented for\r\nother parts of the Kibana configuration (e.g `logging`)\r\n\r\n**Note:**\r\n- hot reloading is only supported for the server TLS configuration\r\n(`server.ssl`), not for the whole `server.*` config prefix\r\n- swaping the certificate files (without modifying the kibana config\r\nitself) is supported\r\n- it is not possible to toggle TLS (enabling or disabling) without\r\nrestarting Kibana\r\n- hot reloading requires to force the process to reload its\r\nconfiguration by sending a `SIGHUP` signal\r\n\r\n### Example / how to test\r\n\r\n#### Before\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.key\r\n```\r\n\r\n<img width=\"550\" alt=\"Screenshot 2023-11-23 at 15 11 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/1226d161-a9f2-4d62-a3de-37161829f187\">\r\n\r\n#### Changing the config\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.key\r\n```\r\n\r\n```bash\r\nkill -SIGHUP {KIBANA_PID}\r\n```\r\n\r\n<img width=\"865\" alt=\"Screenshot 2023-11-23 at 15 18 21\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c9412b2e-d70e-4cf0-8eaf-4db70a45af60\">\r\n\r\n#### After\r\n\r\n<img width=\"547\" alt=\"Screenshot 2023-11-23 at 15 18 43\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c839f04f-4adb-456d-a174-4f0ebd5c234c\">\r\n\r\n## Release notes\r\n\r\nIt is now possible to hot reload Kibana's TLS (`server.ssl`)\r\nconfiguration by updating it and then sending a `SIGHUP` signal to the\r\nKibana process.\r\n\r\nNote that TLS cannot be toggled (disabled/enabled) that way, and that\r\nhot reload only works for the TLS configuration, not other properties of\r\nthe `server` config prefix.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"87213e7efe4420b0edf72d471056fe78cbd9df60"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/171823","number":171823,"mergeCommit":{"message":"[HTTP Server] support TLS config hot reload via `SIGHUP` (#171823)\n\n## Summary\r\n\r\nFix https://github.com/elastic/kibana/issues/54368\r\n\r\nAdd support for hot reloading the Kibana server's TLS configuration,\r\nusing the same `SIGHUP`-based reload signal, as already implemented for\r\nother parts of the Kibana configuration (e.g `logging`)\r\n\r\n**Note:**\r\n- hot reloading is only supported for the server TLS configuration\r\n(`server.ssl`), not for the whole `server.*` config prefix\r\n- swaping the certificate files (without modifying the kibana config\r\nitself) is supported\r\n- it is not possible to toggle TLS (enabling or disabling) without\r\nrestarting Kibana\r\n- hot reloading requires to force the process to reload its\r\nconfiguration by sending a `SIGHUP` signal\r\n\r\n### Example / how to test\r\n\r\n#### Before\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/kibana.key\r\n```\r\n\r\n<img width=\"550\" alt=\"Screenshot 2023-11-23 at 15 11 28\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/1226d161-a9f2-4d62-a3de-37161829f187\">\r\n\r\n#### Changing the config\r\n\r\n```yaml\r\nserver.ssl.enabled: true\r\nserver.ssl.certificate: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.crt\r\nserver.ssl.key: /path-to-kibana/packages/kbn-dev-utils/certs/elasticsearch.key\r\n```\r\n\r\n```bash\r\nkill -SIGHUP {KIBANA_PID}\r\n```\r\n\r\n<img width=\"865\" alt=\"Screenshot 2023-11-23 at 15 18 21\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c9412b2e-d70e-4cf0-8eaf-4db70a45af60\">\r\n\r\n#### After\r\n\r\n<img width=\"547\" alt=\"Screenshot 2023-11-23 at 15 18 43\"\r\nsrc=\"https://github.com/elastic/kibana/assets/1532934/c839f04f-4adb-456d-a174-4f0ebd5c234c\">\r\n\r\n## Release notes\r\n\r\nIt is now possible to hot reload Kibana's TLS (`server.ssl`)\r\nconfiguration by updating it and then sending a `SIGHUP` signal to the\r\nKibana process.\r\n\r\nNote that TLS cannot be toggled (disabled/enabled) that way, and that\r\nhot reload only works for the TLS configuration, not other properties of\r\nthe `server` config prefix.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"87213e7efe4420b0edf72d471056fe78cbd9df60"}}]}] BACKPORT-->