### PR TITLE
[infra] Disable flaky ML job ID format test suite

### DIFF
--- a/x-pack/test/functional/apps/infra/logs/ml_job_id_formats/tests.ts
+++ b/x-pack/test/functional/apps/infra/logs/ml_job_id_formats/tests.ts
@@ -30,7 +30,8 @@ export default ({ getService, getPageObjects }: FtrProviderContext) => {
   const requestTracker = createRequestTracker(browser, pageObjects.common);
   let mlJobHelper: MlJobHelper;
 
-  describe('ML job ID formats', function () {
+  // Disabled until https://github.com/elastic/kibana/issues/171913 is addressed
+  describe.skip('ML job ID formats', function () {
     this.beforeAll(async () => {
       // Access to ml.api has to happen inside a test or test hook
       mlJobHelper = createMlJobHelper(ml.api);


### PR DESCRIPTION
These tests rely on using browser performance timings to extract URLs used when resolving ML job IDs to check if the right format is used and updated when migrating to the new format. 
Because this change is transparent to the user there isn't any way to test the behaviour through UI elements and due to the structure of the state management it's not straight forward to test it in isolation.

https://github.com/elastic/kibana/issues/171913 has been opened to refactor the state management which should allow for this tests to be updated and re-enabled.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->