### PR TITLE
[Serverless] Improve stability of prod quality gate SLO check

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -11,6 +11,8 @@ steps:
         TARGET_ENV: production
         CHECK_SLO: true
         CHECK_SLO_TAG: kibana
+        CHECK_SLO_WAITING_PERIOD: 15m
+        CHECK_SLO_BURN_RATE_THRESHOLD: 0.1
     soft_fail: true
 
   - label: ":rocket: control-plane e2e tests"


### PR DESCRIPTION
Based on a recent discussion with @kobelb I'm changing the SLO check that's currently running during a serverless promotion in `Production-Canary` and `Production-NonCanary`.

Before this change we relied on the default values of these settings, which are quite "aggressive":
- `CHECK_SLO_WAITING_PERIOD` - Due to the relatively low amount of deployments in these environments, we suspect it would be a good idea to increase this value from the default `5m` to `15m`.
- `CHECK_SLO_BURN_RATE_THRESHOLD` - The default value is `0`, which leaves absolutely no room for even the smallest hiccup. Setting to `0.1` to avoid this.

We can always update this in the future once we start to get more deployments in these environments.