### PR TITLE
[EDR Workflows] Disabled Timeout input for saved queries preloaded queries

### DIFF
--- a/x-pack/plugins/osquery/public/saved_queries/form/index.tsx
+++ b/x-pack/plugins/osquery/public/saved_queries/form/index.tsx
@@ -93,7 +93,7 @@ const SavedQueryFormComponent: React.FC<SavedQueryFormProps> = ({
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent={'spaceBetween'}>
         <EuiFlexItem>
-          <TimeoutField />
+          <TimeoutField euiFieldProps={euiFieldProps} />
         </EuiFlexItem>
         <EuiFlexItem />
       </EuiFlexGroup>


### PR DESCRIPTION
https://github.com/elastic/kibana/issues/171906

Render timeout field on saved queries view, for preloaded queries as disabled.

![Screenshot 2023-11-24 at 12 06 17](https://github.com/elastic/kibana/assets/29123534/fe712b0b-ad39-46fe-a4c3-2e2c867ca9bc)
