### PR TITLE
[ES|QL] Show policy metadata on hover

### DIFF
--- a/packages/kbn-monaco/src/esql/index.ts
+++ b/packages/kbn-monaco/src/esql/index.ts
@@ -8,4 +8,5 @@
 
 export { ESQL_LANG_ID, ESQL_THEME_ID } from './lib/constants';
 export { ESQLLang } from './language';
+export type { ESQLCallbacks } from './lib/ast/shared/types';
 export { buildESQlTheme } from './lib/monaco/esql_theme';

--- a/packages/kbn-monaco/src/esql/index.ts
+++ b/packages/kbn-monaco/src/esql/index.ts
@@ -8,5 +8,4 @@
 
 export { ESQL_LANG_ID, ESQL_THEME_ID } from './lib/constants';
 export { ESQLLang } from './language';
-export type { ESQLCallbacks } from './lib/ast/autocomplete/types';
 export { buildESQlTheme } from './lib/monaco/esql_theme';

--- a/packages/kbn-monaco/src/esql/language.ts
+++ b/packages/kbn-monaco/src/esql/language.ts
@@ -15,8 +15,8 @@ import type { ESQLWorker } from './worker/esql_worker';
 
 import { DiagnosticsAdapter } from '../common/diagnostics_adapter';
 import { WorkerProxyService } from '../common/worker_proxy';
-import type { ESQLCallbacks } from './lib/ast/autocomplete/types';
 import type { ESQLMessage } from './lib/ast/types';
+import type { ESQLCallbacks } from './lib/ast/shared/types';
 import { ESQLAstAdapter } from './lib/monaco/esql_ast_provider';
 
 const workerProxyService = new WorkerProxyService<ESQLWorker>();

--- a/packages/kbn-monaco/src/esql/lib/ast/autocomplete/types.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/autocomplete/types.ts
@@ -8,24 +8,6 @@
 
 import { monaco } from '../../../../..';
 
-/** @public **/
-export interface ESQLCallbacks {
-  getSources?: CallbackFn;
-  getFieldsFor?: CallbackFn<
-    { sourcesOnly?: boolean } | { customQuery?: string },
-    { name: string; type: string }
-  >;
-  getPolicies?: CallbackFn<
-    {},
-    { name: string; sourceIndices: string[]; matchField: string; enrichFields: string[] }
-  >;
-  getPolicyFields?: CallbackFn;
-  getPolicyMatchingField?: CallbackFn;
-}
-
-/** @internal **/
-type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
-
 /** @internal **/
 export interface UserDefinedVariables {
   userDefined: string[];

--- a/packages/kbn-monaco/src/esql/lib/ast/hover/index.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/hover/index.ts
@@ -6,38 +6,76 @@
  * Side Public License, v 1.
  */
 
+import { i18n } from '@kbn/i18n';
 import type { monaco } from '../../../../monaco_imports';
 import { getFunctionSignatures } from '../definitions/helpers';
 import { getAstContext } from '../shared/context';
-import { monacoPositionToOffset, getFunctionDefinition } from '../shared/helpers';
+import { monacoPositionToOffset, getFunctionDefinition, isSourceItem } from '../shared/helpers';
+import { getPolicyHelper } from '../shared/resources_helpers';
+import { ESQLCallbacks } from '../shared/types';
 import type { AstProviderFn } from '../types';
 
 export async function getHoverItem(
   model: monaco.editor.ITextModel,
   position: monaco.Position,
   token: monaco.CancellationToken,
-  astProvider: AstProviderFn
+  astProvider: AstProviderFn,
+  resourceRetriever?: ESQLCallbacks
 ) {
   const innerText = model.getValue();
   const offset = monacoPositionToOffset(innerText, position);
 
   const { ast } = await astProvider(innerText);
   const astContext = getAstContext(innerText, ast, offset);
+  const { getPolicyMetadata } = getPolicyHelper(resourceRetriever);
 
-  if (astContext.type !== 'function') {
+  if (['newCommand', 'list'].includes(astContext.type)) {
     return { contents: [] };
   }
 
-  const fnDefinition = getFunctionDefinition(astContext.node.name);
+  if (astContext.type === 'function') {
+    const fnDefinition = getFunctionDefinition(astContext.node.name);
 
-  if (!fnDefinition) {
-    return { contents: [] };
+    if (fnDefinition) {
+      return {
+        contents: [
+          { value: getFunctionSignatures(fnDefinition)[0].declaration },
+          { value: fnDefinition.description },
+        ],
+      };
+    }
   }
 
-  return {
-    contents: [
-      { value: getFunctionSignatures(fnDefinition)[0].declaration },
-      { value: fnDefinition.description },
-    ],
-  };
+  if (astContext.type === 'expression') {
+    if (
+      astContext.node &&
+      isSourceItem(astContext.node) &&
+      astContext.node.sourceType === 'policy'
+    ) {
+      const policyMetadata = await getPolicyMetadata(astContext.node.name);
+      if (policyMetadata) {
+        return {
+          contents: [
+            {
+              value: `${i18n.translate('monaco.esql.hover.policyIndexes', {
+                defaultMessage: '**Indexes**',
+              })}: ${policyMetadata.sourceIndices}`,
+            },
+            {
+              value: `${i18n.translate('monaco.esql.hover.policyMatchingField', {
+                defaultMessage: '**Matching field**',
+              })}: ${policyMetadata.matchField}`,
+            },
+            {
+              value: `${i18n.translate('monaco.esql.hover.policyEnrichedFields', {
+                defaultMessage: '**Fields**',
+              })}: ${policyMetadata.enrichFields}`,
+            },
+          ],
+        };
+      }
+    }
+  }
+
+  return { contents: [] };
 }

--- a/packages/kbn-monaco/src/esql/lib/ast/shared/resources_helpers.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/shared/resources_helpers.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { ESQLCallbacks } from './types';
+import type { ESQLRealField } from '../validation/types';
+
+// These are method useful for any non-validation use cases that can be re-used.
+// Validation has its own logic so DO NOT USE THESE there.
+
+export function getFieldsByTypeHelper(resourceRetriever?: ESQLCallbacks) {
+  const cacheFields = new Map<string, ESQLRealField>();
+  const getFields = async () => {
+    if (!cacheFields.size) {
+      const fieldsOfType = await resourceRetriever?.getFieldsFor?.();
+      for (const field of fieldsOfType || []) {
+        cacheFields.set(field.name, field);
+      }
+    }
+  };
+  return {
+    getFieldsByType: async (expectedType: string | string[] = 'any', ignored: string[] = []) => {
+      const types = Array.isArray(expectedType) ? expectedType : [expectedType];
+      await getFields();
+      return (
+        Array.from(cacheFields.values())
+          ?.filter(({ name, type }) => {
+            const ts = Array.isArray(type) ? type : [type];
+            return (
+              !ignored.includes(name) && ts.some((t) => types[0] === 'any' || types.includes(t))
+            );
+          })
+          .map(({ name }) => name) || []
+      );
+    },
+    getFieldsMap: async () => {
+      await getFields();
+      const cacheCopy = new Map<string, ESQLRealField>();
+      cacheFields.forEach((value, key) => cacheCopy.set(key, value));
+      return cacheCopy;
+    },
+  };
+}
+
+export function getPolicyHelper(resourceRetriever?: ESQLCallbacks) {
+  const getPolicies = async () => {
+    return (await resourceRetriever?.getPolicies?.()) || [];
+  };
+  return {
+    getPolicies: async () => {
+      const policies = await getPolicies();
+      return policies;
+    },
+    getPolicyMetadata: async (policyName: string) => {
+      const policies = await getPolicies();
+      return policies.find(({ name }) => name === policyName);
+    },
+  };
+}
+
+export function getSourcesHelper(resourceRetriever?: ESQLCallbacks) {
+  return async () => {
+    return (await resourceRetriever?.getSources?.()) || [];
+  };
+}

--- a/packages/kbn-monaco/src/esql/lib/ast/shared/types.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/shared/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/** @internal **/
+type CallbackFn<Options = {}, Result = string> = (ctx?: Options) => Result[] | Promise<Result[]>;
+
+/** @public **/
+export interface ESQLCallbacks {
+  getSources?: CallbackFn;
+  getFieldsFor?: CallbackFn<
+    { sourcesOnly?: boolean } | { customQuery?: string },
+    { name: string; type: string }
+  >;
+  getPolicies?: CallbackFn<
+    {},
+    { name: string; sourceIndices: string[]; matchField: string; enrichFields: string[] }
+  >;
+  getPolicyFields?: CallbackFn;
+  getPolicyMatchingField?: CallbackFn;
+}

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/validation.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/validation.ts
@@ -9,7 +9,6 @@
 import uniqBy from 'lodash/uniqBy';
 import capitalize from 'lodash/capitalize';
 import { nonNullable } from '../ast_helpers';
-import type { ESQLCallbacks } from '../autocomplete/types';
 import { CommandOptionsDefinition, SignatureArgType } from '../definitions/types';
 import {
   areFieldAndVariableTypesCompatible,
@@ -56,6 +55,7 @@ import type {
   ReferenceMaps,
   ValidationResult,
 } from './types';
+import type { ESQLCallbacks } from '../shared/types';
 
 function validateFunctionLiteralArg(
   astFunction: ESQLFunction,

--- a/packages/kbn-monaco/src/esql/lib/monaco/esql_ast_provider.ts
+++ b/packages/kbn-monaco/src/esql/lib/monaco/esql_ast_provider.ts
@@ -50,7 +50,7 @@ export class ESQLAstAdapter {
     token: monaco.CancellationToken
   ) {
     const getAstFn = await this.getAstWorker(model);
-    return getHoverItem(model, position, token, getAstFn);
+    return getHoverItem(model, position, token, getAstFn, this.callbacks);
   }
 
   async autocomplete(

--- a/packages/kbn-monaco/src/types.ts
+++ b/packages/kbn-monaco/src/types.ts
@@ -31,7 +31,7 @@ export interface LanguageProvidersModule<Deps = unknown> {
   ) => Promise<{ errors: monaco.editor.IMarkerData[]; warnings: monaco.editor.IMarkerData[] }>;
   getSuggestionProvider: (callbacks?: Deps) => monaco.languages.CompletionItemProvider;
   getSignatureProvider?: (callbacks?: Deps) => monaco.languages.SignatureHelpProvider;
-  getHoverProvider?: () => monaco.languages.HoverProvider;
+  getHoverProvider?: (callbacks?: Deps) => monaco.languages.HoverProvider;
 }
 
 export interface CustomLangModuleType<Deps = unknown>

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -338,7 +338,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
         }
         return [];
       },
-      getPolicies: async (ctx) => {
+      getPolicies: async () => {
         const { data: policies, error } =
           (await indexManagementApiService?.getAllEnrichPolicies()) || {};
         if (error || !policies) {
@@ -413,8 +413,8 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
   );
 
   const hoverProvider = useMemo(
-    () => (language === 'esql' ? ESQLLang.getHoverProvider?.() : undefined),
-    [language]
+    () => (language === 'esql' ? ESQLLang.getHoverProvider?.(esqlCallbacks) : undefined),
+    [language, esqlCallbacks]
   );
 
   const onErrorClick = useCallback(({ startLineNumber, startColumn }: MonacoMessage) => {


### PR DESCRIPTION
## Summary

This PR adds some more hover feature on policies hovering, showing some useful details:

<img width="531" alt="Screenshot 2023-11-24 at 18 02 18" src="https://github.com/elastic/kibana/assets/924948/b47e957e-a9eb-4c20-bd85-05f69fb350b1">

Initially I thought about adding also the signature for `command` and `option` on hover, but there's enough space there for examples, which are kind of important together with the signature.
I'd wait for https://github.com/elastic/kibana/pull/171720 to be merged, and then leverage the `HTML` support in markdown together with some additional nice features in the editor with the newer version.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
