### PR TITLE
[8.11] [OAS] Migrate connector APIs to v3.1.0 (#171464)

### DIFF
--- a/x-pack/plugins/actions/docs/openapi/bundled.json
+++ b/x-pack/plugins/actions/docs/openapi/bundled.json
@@ -1,9 +1,9 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "title": "Connectors",
     "description": "OpenAPI schema for Connectors endpoints",
-    "version": "0.1",
+    "version": "0.2",
     "contact": {
       "name": "Connectors Team"
     },
@@ -266,7 +266,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "example": "ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74"
+              "examples": [
+                "ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74"
+              ]
             }
           }
         ],
@@ -489,28 +491,7 @@
             }
           },
           "400": {
-            "description": "Indicates a bad request.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                      "example": "Bad Request"
-                    },
-                    "message": {
-                      "type": "string",
-                      "example": "error validating action type config: [index]: expected value of type [string] but got [undefined]"
-                    },
-                    "statusCode": {
-                      "type": "integer",
-                      "example": 400
-                    }
-                  }
-                }
-              }
-            }
+            "$ref": "#/components/responses/400"
           },
           "401": {
             "$ref": "#/components/responses/401"
@@ -542,56 +523,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "title": "Get connectors response body properties",
-                    "description": "The properties vary for each connector type.",
-                    "type": "object",
-                    "required": [
-                      "connector_type_id",
-                      "id",
-                      "is_deprecated",
-                      "is_preconfigured",
-                      "name",
-                      "referenced_by_count"
-                    ],
-                    "properties": {
-                      "connector_type_id": {
-                        "$ref": "#/components/schemas/connector_types"
-                      },
-                      "config": {
-                        "type": "object",
-                        "description": "The configuration for the connector. Configuration properties vary depending on the connector type.",
-                        "additionalProperties": true,
-                        "nullable": true
-                      },
-                      "id": {
-                        "type": "string",
-                        "description": "The identifier for the connector.",
-                        "example": "b0766e10-d190-11ec-b04c-776c77d14fca"
-                      },
-                      "is_deprecated": {
-                        "$ref": "#/components/schemas/is_deprecated"
-                      },
-                      "is_missing_secrets": {
-                        "$ref": "#/components/schemas/is_missing_secrets"
-                      },
-                      "is_preconfigured": {
-                        "$ref": "#/components/schemas/is_preconfigured"
-                      },
-                      "is_system_action": {
-                        "$ref": "#/components/schemas/is_system_action"
-                      },
-                      "name": {
-                        "type": "string",
-                        "description": "The display name for the connector.",
-                        "example": "my-connector"
-                      },
-                      "referenced_by_count": {
-                        "type": "integer",
-                        "description": "Indicates the number of saved objects that reference the connector. If `is_preconfigured` is true, this value is not calculated.",
-                        "example": 2,
-                        "default": 0
-                      }
-                    }
+                    "$ref": "#/components/schemas/connector_response_properties"
                   }
                 },
                 "examples": {
@@ -644,17 +576,23 @@
                       "enabled": {
                         "type": "boolean",
                         "description": "Indicates whether the connector type is enabled in Kibana.",
-                        "example": true
+                        "examples": [
+                          true
+                        ]
                       },
                       "enabled_in_config": {
                         "type": "boolean",
                         "description": "Indicates whether the connector type is enabled in the Kibana `.yml` file.",
-                        "example": true
+                        "examples": [
+                          true
+                        ]
                       },
                       "enabled_in_license": {
                         "type": "boolean",
                         "description": "Indicates whether the connector is enabled in the license.",
-                        "example": true
+                        "examples": [
+                          true
+                        ]
                       },
                       "id": {
                         "$ref": "#/components/schemas/connector_types"
@@ -662,12 +600,16 @@
                       "minimum_license_required": {
                         "type": "string",
                         "description": "The license that is required to use the connector type.",
-                        "example": "basic"
+                        "examples": [
+                          "basic"
+                        ]
                       },
                       "name": {
                         "type": "string",
                         "description": "The name of the connector type.",
-                        "example": "Index"
+                        "examples": [
+                          "Index"
+                        ]
                       },
                       "supported_feature_ids": {
                         "type": "array",
@@ -675,10 +617,12 @@
                         "items": {
                           "$ref": "#/components/schemas/features"
                         },
-                        "example": [
-                          "alerting",
-                          "uptime",
-                          "siem"
+                        "examples": [
+                          [
+                            "alerting",
+                            "uptime",
+                            "siem"
+                          ]
                         ]
                       }
                     }
@@ -1105,7 +1049,9 @@
                       "enabledInLicense": {
                         "type": "boolean",
                         "description": "Indicates whether the connector is enabled in the license.",
-                        "example": true
+                        "examples": [
+                          true
+                        ]
                       },
                       "id": {
                         "type": "string",
@@ -1244,7 +1190,9 @@
         "required": true,
         "schema": {
           "type": "string",
-          "example": "default"
+          "examples": [
+            "default"
+          ]
         }
       },
       "connector_id": {
@@ -1254,7 +1202,9 @@
         "required": true,
         "schema": {
           "type": "string",
-          "example": "df770e30-8b8b-11ed-a780-3b746c987a81"
+          "examples": [
+            "df770e30-8b8b-11ed-a780-3b746c987a81"
+          ]
         }
       },
       "action_id": {
@@ -1264,7 +1214,9 @@
         "required": true,
         "schema": {
           "type": "string",
-          "example": "c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad"
+          "examples": [
+            "c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad"
+          ]
         }
       }
     },
@@ -1327,12 +1279,16 @@
             "enum": [
               ".bedrock"
             ],
-            "example": ".bedrock"
+            "examples": [
+              ".bedrock"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_bedrock"
@@ -1357,11 +1313,13 @@
           "createCommentJson": {
             "type": "string",
             "description": "A JSON payload sent to the create comment URL to create a case comment. You can use variables to add Kibana Cases data to the payload. The required variable is `case.comment`. Due to Mustache template variables (the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated once the Mustache variables have been placed when the REST method runs. Manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass.\n",
-            "example": {
-              "body": {
-                "[object Object]": null
+            "examples": [
+              {
+                "body": {
+                  "[object Object]": null
+                }
               }
-            }
+            ]
           },
           "createCommentMethod": {
             "type": "string",
@@ -1376,24 +1334,28 @@
           "createCommentUrl": {
             "type": "string",
             "description": "The REST API URL to create a case comment by ID in the third-party system. You can use a variable to add the external system ID to the URL. If you are using the `xpack.actions.allowedHosts setting`, add the hostname to the allowed hosts.\n",
-            "example": "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment"
+            "examples": [
+              "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment"
+            ]
           },
           "createIncidentJson": {
             "type": "string",
             "description": "A JSON payload sent to the create case URL to create a case. You can use variables to add case data to the payload. Required variables are `case.title` and `case.description`. Due to Mustache template variables (which is the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid to avoid future validation errors; disregard Mustache variables during your review.\n",
-            "example": {
-              "fields": {
-                "summary": {
-                  "[object Object]": null
-                },
-                "description": {
-                  "[object Object]": null
-                },
-                "labels": {
-                  "[object Object]": null
+            "examples": [
+              {
+                "fields": {
+                  "summary": {
+                    "[object Object]": null
+                  },
+                  "description": {
+                    "[object Object]": null
+                  },
+                  "labels": {
+                    "[object Object]": null
+                  }
                 }
               }
-            }
+            ]
           },
           "createIncidentMethod": {
             "type": "string",
@@ -1420,7 +1382,9 @@
           "getIncidentUrl": {
             "type": "string",
             "description": "The REST API URL to get the case by ID from the third-party system. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts. You can use a variable to add the external system ID to the URL. Due to Mustache template variables (the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass.\n",
-            "example": "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}"
+            "examples": [
+              "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}"
+            ]
           },
           "hasAuth": {
             "type": "boolean",
@@ -1434,19 +1398,21 @@
           "updateIncidentJson": {
             "type": "string",
             "description": "The JSON payload sent to the update case URL to update the case. You can use variables to add Kibana Cases data to the payload. Required variables are `case.title` and `case.description`. Due to Mustache template variables (which is the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid to avoid future validation errors; disregard Mustache variables during your review.\n",
-            "example": {
-              "fields": {
-                "summary": {
-                  "[object Object]": null
-                },
-                "description": {
-                  "[object Object]": null
-                },
-                "labels": {
-                  "[object Object]": null
+            "examples": [
+              {
+                "fields": {
+                  "summary": {
+                    "[object Object]": null
+                  },
+                  "description": {
+                    "[object Object]": null
+                  },
+                  "labels": {
+                    "[object Object]": null
+                  }
                 }
               }
-            }
+            ]
           },
           "updateIncidentMethod": {
             "type": "string",
@@ -1461,12 +1427,16 @@
           "updateIncidentUrl": {
             "type": "string",
             "description": "The REST API URL to update the case by ID in the third-party system. You can use a variable to add the external system ID to the URL. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.\n",
-            "example": "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}"
+            "examples": [
+              "https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}"
+            ]
           },
           "viewIncidentUrl": {
             "type": "string",
             "description": "The URL to view the case in the external system. You can use variables to add the external system ID or external system title to the URL.\n",
-            "example": "https://testing-jira.atlassian.net/browse/{{{external.system.title}}}"
+            "examples": [
+              "https://testing-jira.atlassian.net/browse/{{{external.system.title}}}"
+            ]
           }
         }
       },
@@ -1503,12 +1473,16 @@
             "enum": [
               ".cases-webhook"
             ],
-            "example": ".cases-webhook"
+            "examples": [
+              ".cases-webhook"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_cases_webhook"
@@ -1563,12 +1537,16 @@
             "enum": [
               ".d3security"
             ],
-            "example": ".d3security"
+            "examples": [
+              ".d3security"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_d3security"
@@ -1585,8 +1563,10 @@
         "properties": {
           "clientId": {
             "description": "The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.\n",
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "from": {
             "description": "The from address for all emails sent by the connector. It must be specified in `user@host-name` format.\n",
@@ -1602,8 +1582,10 @@
             "type": "string"
           },
           "oauthTokenUrl": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "port": {
             "description": "The port to connect to on the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. \n",
@@ -1627,8 +1609,10 @@
           },
           "tenantId": {
             "description": "The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.\n",
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       },
@@ -1671,12 +1655,16 @@
             "enum": [
               ".email"
             ],
-            "example": ".email"
+            "examples": [
+              ".email"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_email"
@@ -1767,12 +1755,16 @@
             "enum": [
               ".gen-ai"
             ],
-            "example": ".gen-ai"
+            "examples": [
+              ".gen-ai"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_genai"
@@ -1790,8 +1782,10 @@
           "executionTimeField": {
             "description": "A field that indicates when the document was indexed.",
             "default": null,
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "index": {
             "description": "The Elasticsearch index to be written to.",
@@ -1823,12 +1817,16 @@
             "enum": [
               ".index"
             ],
-            "example": ".index"
+            "examples": [
+              ".index"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           }
         }
       },
@@ -1890,12 +1888,16 @@
             "enum": [
               ".jira"
             ],
-            "example": ".jira"
+            "examples": [
+              ".jira"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_jira"
@@ -1950,12 +1952,16 @@
             "enum": [
               ".opsgenie"
             ],
-            "example": ".opsgenie"
+            "examples": [
+              ".opsgenie"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_opsgenie"
@@ -1969,9 +1975,13 @@
         "properties": {
           "apiUrl": {
             "description": "The PagerDuty event URL.",
-            "type": "string",
-            "nullable": true,
-            "example": "https://events.pagerduty.com/v2/enqueue"
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://events.pagerduty.com/v2/enqueue"
+            ]
           }
         }
       },
@@ -2009,12 +2019,16 @@
             "enum": [
               ".pagerduty"
             ],
-            "example": ".pagerduty"
+            "examples": [
+              ".pagerduty"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_pagerduty"
@@ -2076,7 +2090,9 @@
           "connector_type_id": {
             "description": "The type of connector.",
             "type": "string",
-            "example": ".resilient",
+            "examples": [
+              ".resilient"
+            ],
             "enum": [
               ".resilient"
             ]
@@ -2084,7 +2100,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_resilient"
@@ -2106,12 +2124,16 @@
             "enum": [
               ".server-log"
             ],
-            "example": ".server-log"
+            "examples": [
+              ".server-log"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           }
         }
       },
@@ -2198,12 +2220,16 @@
             "enum": [
               ".servicenow"
             ],
-            "example": ".servicenow"
+            "examples": [
+              ".servicenow"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_servicenow"
@@ -2261,12 +2287,16 @@
             "enum": [
               ".servicenow-itom"
             ],
-            "example": ".servicenow-itom"
+            "examples": [
+              ".servicenow-itom"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_servicenow"
@@ -2293,12 +2323,16 @@
             "enum": [
               ".servicenow-sir"
             ],
-            "example": ".servicenow-sir"
+            "examples": [
+              ".servicenow-sir"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_servicenow"
@@ -2335,12 +2369,16 @@
             "enum": [
               ".slack_api"
             ],
-            "example": ".slack_api"
+            "examples": [
+              ".slack_api"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_slack_api"
@@ -2377,12 +2415,16 @@
             "enum": [
               ".slack"
             ],
-            "example": ".slack"
+            "examples": [
+              ".slack"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_slack_webhook"
@@ -2659,12 +2701,16 @@
             "enum": [
               ".swimlane"
             ],
-            "example": ".swimlane"
+            "examples": [
+              ".swimlane"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_swimlane"
@@ -2701,12 +2747,16 @@
             "enum": [
               ".teams"
             ],
-            "example": ".teams"
+            "examples": [
+              ".teams"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_teams"
@@ -2766,12 +2816,16 @@
             "enum": [
               ".tines"
             ],
-            "example": ".tines"
+            "examples": [
+              ".tines"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_tines"
@@ -2826,12 +2880,16 @@
             "enum": [
               ".torq"
             ],
-            "example": ".torq"
+            "examples": [
+              ".torq"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_torq"
@@ -2869,8 +2927,10 @@
             "description": "If `true`, a user name and password must be provided for login type authentication.\n"
           },
           "headers": {
-            "type": "object",
-            "nullable": true,
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "A set of key-value pairs sent as headers with the request."
           },
           "method": {
@@ -2945,12 +3005,16 @@
             "enum": [
               ".webhook"
             ],
-            "example": ".webhook"
+            "examples": [
+              ".webhook"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_webhook"
@@ -2964,8 +3028,10 @@
         "properties": {
           "configUrl": {
             "description": "The request URL for the Elastic Alerts trigger in xMatters. It is applicable only when `usesBasic` is `true`.\n",
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "usesBasic": {
             "description": "Specifies whether the connector uses HTTP basic authentication (`true`) or URL authentication (`false`).",
@@ -3013,12 +3079,16 @@
             "enum": [
               ".xmatters"
             ],
-            "example": ".xmatters"
+            "examples": [
+              ".xmatters"
+            ]
           },
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_xmatters"
@@ -3028,22 +3098,38 @@
       "is_deprecated": {
         "type": "boolean",
         "description": "Indicates whether the connector type is deprecated.",
-        "example": false
+        "examples": [
+          false
+        ]
       },
       "is_missing_secrets": {
         "type": "boolean",
         "description": "Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type.",
-        "example": false
+        "examples": [
+          false
+        ]
       },
       "is_preconfigured": {
         "type": "boolean",
-        "description": "Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response.",
-        "example": false
+        "description": "Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response. \n",
+        "examples": [
+          false
+        ]
       },
       "is_system_action": {
         "type": "boolean",
         "description": "Indicates whether the connector is used for system actions.",
-        "example": false
+        "examples": [
+          false
+        ]
+      },
+      "referenced_by_count": {
+        "type": "integer",
+        "description": "Indicates the number of saved objects that reference the connector. If `is_preconfigured` is true, this value is not calculated. This property is returned only by the get all connectors API.\n",
+        "examples": [
+          2
+        ],
+        "default": 0
       },
       "connector_response_properties_cases_webhook": {
         "title": "Connector request properties for a Webhook - Case Management connector",
@@ -3086,6 +3172,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3130,6 +3219,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3137,7 +3229,6 @@
         "title": "Connector response properties for an email connector",
         "type": "object",
         "required": [
-          "config",
           "connector_type_id",
           "id",
           "is_deprecated",
@@ -3174,6 +3265,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3218,6 +3312,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3262,6 +3359,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3306,6 +3406,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3350,6 +3453,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3394,6 +3500,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3410,8 +3519,10 @@
         ],
         "properties": {
           "config": {
-            "type": "object",
-            "nullable": true
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "connector_type_id": {
             "type": "string",
@@ -3439,6 +3550,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3483,6 +3597,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3527,6 +3644,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3571,6 +3691,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3611,6 +3734,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3651,6 +3777,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3695,6 +3824,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3738,6 +3870,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3782,6 +3917,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3826,6 +3964,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3870,6 +4011,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -3914,6 +4058,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector."
+          },
+          "referenced_by_count": {
+            "$ref": "#/components/schemas/referenced_by_count"
           }
         }
       },
@@ -4000,7 +4147,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_cases_webhook"
@@ -4253,7 +4402,9 @@
           "name": {
             "type": "string",
             "description": "The display name for the connector.",
-            "example": "my-connector"
+            "examples": [
+              "my-connector"
+            ]
           },
           "secrets": {
             "$ref": "#/components/schemas/secrets_properties_swimlane"
@@ -4361,6 +4512,16 @@
           }
         }
       },
+      "features": {
+        "type": "string",
+        "description": "The feature that uses the connector. Valid values are `alerting`, `cases`, `uptime`, and `siem`.\n",
+        "enum": [
+          "alerting",
+          "cases",
+          "uptime",
+          "siem"
+        ]
+      },
       "connector_types": {
         "title": "Connector types",
         "type": "string",
@@ -4389,16 +4550,8 @@
           ".webhook",
           ".xmatters"
         ],
-        "example": ".server-log"
-      },
-      "features": {
-        "type": "string",
-        "description": "The feature that uses the connector. Valid values are `alerting`, `cases`, `uptime`, and `siem`.\n",
-        "enum": [
-          "alerting",
-          "cases",
-          "uptime",
-          "siem"
+        "examples": [
+          ".server-log"
         ]
       },
       "run_connector_params_documents": {
@@ -4596,10 +4749,12 @@
                 "type": "object",
                 "description": "The custom properties of the alert.",
                 "additionalProperties": true,
-                "example": {
-                  "key1": "value1",
-                  "key2": "value2"
-                }
+                "examples": [
+                  {
+                    "key1": "value1",
+                    "key2": "value2"
+                  }
+                ]
               },
               "entity": {
                 "type": "string",
@@ -4731,7 +4886,9 @@
               "id": {
                 "type": "string",
                 "description": "The Jira issue type identifier.",
-                "example": 10024
+                "examples": [
+                  10024
+                ]
               }
             }
           }
@@ -4813,7 +4970,9 @@
               "externalId": {
                 "type": "string",
                 "description": "The Jira, ServiceNow ITSM, or ServiceNow SecOps issue identifier.",
-                "example": 71778
+                "examples": [
+                  71778
+                ]
               }
             }
           }
@@ -4843,7 +5002,9 @@
               "id": {
                 "type": "string",
                 "description": "The Jira issue identifier.",
-                "example": 71778
+                "examples": [
+                  71778
+                ]
               }
             }
           }
@@ -5566,6 +5727,36 @@
       }
     },
     "responses": {
+      "400": {
+        "description": "Indicates a bad request.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string",
+                  "examples": [
+                    "Bad Request"
+                  ]
+                },
+                "message": {
+                  "type": "string",
+                  "examples": [
+                    "error validating action type config: [index]: expected value of type [string] but got [undefined]"
+                  ]
+                },
+                "statusCode": {
+                  "type": "integer",
+                  "examples": [
+                    400
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
       "401": {
         "description": "Authorization information is missing or invalid.",
         "content": {
@@ -5576,7 +5767,9 @@
               "properties": {
                 "error": {
                   "type": "string",
-                  "example": "Unauthorized",
+                  "examples": [
+                    "Unauthorized"
+                  ],
                   "enum": [
                     "Unauthorized"
                   ]
@@ -5586,7 +5779,9 @@
                 },
                 "statusCode": {
                   "type": "integer",
-                  "example": 401,
+                  "examples": [
+                    401
+                  ],
                   "enum": [
                     401
                   ]
@@ -5606,18 +5801,24 @@
               "properties": {
                 "error": {
                   "type": "string",
-                  "example": "Not Found",
+                  "examples": [
+                    "Not Found"
+                  ],
                   "enum": [
                     "Not Found"
                   ]
                 },
                 "message": {
                   "type": "string",
-                  "example": "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
+                  "examples": [
+                    "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
+                  ]
                 },
                 "statusCode": {
                   "type": "integer",
-                  "example": 404,
+                  "examples": [
+                    404
+                  ],
                   "enum": [
                     404
                   ]

--- a/x-pack/plugins/actions/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/actions/docs/openapi/bundled.yaml
@@ -1,8 +1,8 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Connectors
   description: OpenAPI schema for Connectors endpoints
-  version: '0.1'
+  version: '0.2'
   contact:
     name: Connectors Team
   license:
@@ -146,7 +146,8 @@ paths:
           required: true
           schema:
             type: string
-            example: ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74
+            examples:
+              - ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74
       requestBody:
         required: true
         content:
@@ -245,21 +246,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/connector_response_properties'
         '400':
-          description: Indicates a bad request.
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                    example: Bad Request
-                  message:
-                    type: string
-                    example: 'error validating action type config: [index]: expected value of type [string] but got [undefined]'
-                  statusCode:
-                    type: integer
-                    example: 400
+          $ref: '#/components/responses/400'
         '401':
           $ref: '#/components/responses/401'
         '404':
@@ -282,45 +269,7 @@ paths:
               schema:
                 type: array
                 items:
-                  title: Get connectors response body properties
-                  description: The properties vary for each connector type.
-                  type: object
-                  required:
-                    - connector_type_id
-                    - id
-                    - is_deprecated
-                    - is_preconfigured
-                    - name
-                    - referenced_by_count
-                  properties:
-                    connector_type_id:
-                      $ref: '#/components/schemas/connector_types'
-                    config:
-                      type: object
-                      description: The configuration for the connector. Configuration properties vary depending on the connector type.
-                      additionalProperties: true
-                      nullable: true
-                    id:
-                      type: string
-                      description: The identifier for the connector.
-                      example: b0766e10-d190-11ec-b04c-776c77d14fca
-                    is_deprecated:
-                      $ref: '#/components/schemas/is_deprecated'
-                    is_missing_secrets:
-                      $ref: '#/components/schemas/is_missing_secrets'
-                    is_preconfigured:
-                      $ref: '#/components/schemas/is_preconfigured'
-                    is_system_action:
-                      $ref: '#/components/schemas/is_system_action'
-                    name:
-                      type: string
-                      description: The display name for the connector.
-                      example: my-connector
-                    referenced_by_count:
-                      type: integer
-                      description: Indicates the number of saved objects that reference the connector. If `is_preconfigured` is true, this value is not calculated.
-                      example: 2
-                      default: 0
+                  $ref: '#/components/schemas/connector_response_properties'
               examples:
                 getConnectorsResponse:
                   $ref: '#/components/examples/get_connectors_response'
@@ -356,34 +305,39 @@ paths:
                     enabled:
                       type: boolean
                       description: Indicates whether the connector type is enabled in Kibana.
-                      example: true
+                      examples:
+                        - true
                     enabled_in_config:
                       type: boolean
                       description: Indicates whether the connector type is enabled in the Kibana `.yml` file.
-                      example: true
+                      examples:
+                        - true
                     enabled_in_license:
                       type: boolean
                       description: Indicates whether the connector is enabled in the license.
-                      example: true
+                      examples:
+                        - true
                     id:
                       $ref: '#/components/schemas/connector_types'
                     minimum_license_required:
                       type: string
                       description: The license that is required to use the connector type.
-                      example: basic
+                      examples:
+                        - basic
                     name:
                       type: string
                       description: The name of the connector type.
-                      example: Index
+                      examples:
+                        - Index
                     supported_feature_ids:
                       type: array
                       description: The Kibana features that are supported by the connector type.
                       items:
                         $ref: '#/components/schemas/features'
-                      example:
-                        - alerting
-                        - uptime
-                        - siem
+                      examples:
+                        - - alerting
+                          - uptime
+                          - siem
               examples:
                 getConnectorTypesResponse:
                   $ref: '#/components/examples/get_connector_types_response'
@@ -640,7 +594,8 @@ paths:
                     enabledInLicense:
                       type: boolean
                       description: Indicates whether the connector is enabled in the license.
-                      example: true
+                      examples:
+                        - true
                     id:
                       type: string
                       description: The unique identifier for the connector type.
@@ -726,7 +681,8 @@ components:
       required: true
       schema:
         type: string
-        example: default
+        examples:
+          - default
     connector_id:
       in: path
       name: connectorId
@@ -734,7 +690,8 @@ components:
       required: true
       schema:
         type: string
-        example: df770e30-8b8b-11ed-a780-3b746c987a81
+        examples:
+          - df770e30-8b8b-11ed-a780-3b746c987a81
     action_id:
       in: path
       name: actionId
@@ -742,7 +699,8 @@ components:
       required: true
       schema:
         type: string
-        example: c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad
+        examples:
+          - c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad
   schemas:
     config_properties_bedrock:
       title: Connector request properties for an Amazon Bedrock connector
@@ -790,11 +748,13 @@ components:
           description: The type of connector.
           enum:
             - .bedrock
-          example: .bedrock
+          examples:
+            - .bedrock
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_bedrock'
     config_properties_cases_webhook:
@@ -815,9 +775,9 @@ components:
           type: string
           description: |
             A JSON payload sent to the create comment URL to create a case comment. You can use variables to add Kibana Cases data to the payload. The required variable is `case.comment`. Due to Mustache template variables (the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated once the Mustache variables have been placed when the REST method runs. Manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass.
-          example:
-            body:
-              '[object Object]': null
+          examples:
+            - body:
+                '[object Object]': null
         createCommentMethod:
           type: string
           description: |
@@ -831,19 +791,20 @@ components:
           type: string
           description: |
             The REST API URL to create a case comment by ID in the third-party system. You can use a variable to add the external system ID to the URL. If you are using the `xpack.actions.allowedHosts setting`, add the hostname to the allowed hosts.
-          example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment
+          examples:
+            - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment
         createIncidentJson:
           type: string
           description: |
             A JSON payload sent to the create case URL to create a case. You can use variables to add case data to the payload. Required variables are `case.title` and `case.description`. Due to Mustache template variables (which is the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid to avoid future validation errors; disregard Mustache variables during your review.
-          example:
-            fields:
-              summary:
-                '[object Object]': null
-              description:
-                '[object Object]': null
-              labels:
-                '[object Object]': null
+          examples:
+            - fields:
+                summary:
+                  '[object Object]': null
+                description:
+                  '[object Object]': null
+                labels:
+                  '[object Object]': null
         createIncidentMethod:
           type: string
           description: |
@@ -867,7 +828,8 @@ components:
           type: string
           description: |
             The REST API URL to get the case by ID from the third-party system. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts. You can use a variable to add the external system ID to the URL. Due to Mustache template variables (the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid, disregarding the Mustache variables, so the later validation will pass.
-          example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}
+          examples:
+            - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}
         hasAuth:
           type: boolean
           description: If true, a username and password for login type authentication must be provided.
@@ -880,14 +842,14 @@ components:
           type: string
           description: |
             The JSON payload sent to the update case URL to update the case. You can use variables to add Kibana Cases data to the payload. Required variables are `case.title` and `case.description`. Due to Mustache template variables (which is the text enclosed in triple braces, for example, `{{{case.title}}}`), the JSON is not validated when you create the connector. The JSON is validated after the Mustache variables have been placed when REST method runs. Manually ensure that the JSON is valid to avoid future validation errors; disregard Mustache variables during your review.
-          example:
-            fields:
-              summary:
-                '[object Object]': null
-              description:
-                '[object Object]': null
-              labels:
-                '[object Object]': null
+          examples:
+            - fields:
+                summary:
+                  '[object Object]': null
+                description:
+                  '[object Object]': null
+                labels:
+                  '[object Object]': null
         updateIncidentMethod:
           type: string
           description: |
@@ -901,12 +863,14 @@ components:
           type: string
           description: |
             The REST API URL to update the case by ID in the third-party system. You can use a variable to add the external system ID to the URL. If you are using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.
-          example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}
+          examples:
+            - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}
         viewIncidentUrl:
           type: string
           description: |
             The URL to view the case in the external system. You can use variables to add the external system ID or external system title to the URL.
-          example: https://testing-jira.atlassian.net/browse/{{{external.system.title}}}
+          examples:
+            - https://testing-jira.atlassian.net/browse/{{{external.system.title}}}
     secrets_properties_cases_webhook:
       title: Connector secrets properties for Webhook - Case Management connector
       type: object
@@ -934,11 +898,13 @@ components:
           description: The type of connector.
           enum:
             - .cases-webhook
-          example: .cases-webhook
+          examples:
+            - .cases-webhook
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_cases_webhook'
     config_properties_d3security:
@@ -980,11 +946,13 @@ components:
           description: The type of connector.
           enum:
             - .d3security
-          example: .d3security
+          examples:
+            - .d3security
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_d3security'
     config_properties_email:
@@ -997,8 +965,9 @@ components:
         clientId:
           description: |
             The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         from:
           description: |
             The from address for all emails sent by the connector. It must be specified in `user@host-name` format.
@@ -1013,8 +982,9 @@ components:
             The host name of the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. 
           type: string
         oauthTokenUrl:
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         port:
           description: |
             The port to connect to on the service provider. If the `service` is `elastic_cloud` (for Elastic Cloud notifications) or one of Nodemailer's well-known email service providers, this property is ignored. If `service` is `other`, this property must be defined. 
@@ -1037,8 +1007,9 @@ components:
         tenantId:
           description: |
             The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format. If `service` is `exchange_server`, this property is required.
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
     secrets_properties_email:
       title: Connector secrets properties for an email connector
       description: Defines secrets for connectors when type is `.email`.
@@ -1074,11 +1045,13 @@ components:
           description: The type of connector.
           enum:
             - .email
-          example: .email
+          examples:
+            - .email
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_email'
     config_properties_genai:
@@ -1142,11 +1115,13 @@ components:
           description: The type of connector.
           enum:
             - .gen-ai
-          example: .gen-ai
+          examples:
+            - .gen-ai
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_genai'
     config_properties_index:
@@ -1159,8 +1134,9 @@ components:
         executionTimeField:
           description: A field that indicates when the document was indexed.
           default: null
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         index:
           description: The Elasticsearch index to be written to.
           type: string
@@ -1185,11 +1161,13 @@ components:
           description: The type of connector.
           enum:
             - .index
-          example: .index
+          examples:
+            - .index
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
     config_properties_jira:
       title: Connector request properties for a Jira connector
       required:
@@ -1235,11 +1213,13 @@ components:
           description: The type of connector.
           enum:
             - .jira
-          example: .jira
+          examples:
+            - .jira
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_jira'
     config_properties_opsgenie:
@@ -1280,11 +1260,13 @@ components:
           description: The type of connector.
           enum:
             - .opsgenie
-          example: .opsgenie
+          examples:
+            - .opsgenie
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_opsgenie'
     config_properties_pagerduty:
@@ -1294,9 +1276,11 @@ components:
       properties:
         apiUrl:
           description: The PagerDuty event URL.
-          type: string
-          nullable: true
-          example: https://events.pagerduty.com/v2/enqueue
+          type:
+            - string
+            - 'null'
+          examples:
+            - https://events.pagerduty.com/v2/enqueue
     secrets_properties_pagerduty:
       title: Connector secrets properties for a PagerDuty connector
       description: Defines secrets for connectors when type is `.pagerduty`.
@@ -1326,11 +1310,13 @@ components:
           description: The type of connector.
           enum:
             - .pagerduty
-          example: .pagerduty
+          examples:
+            - .pagerduty
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_pagerduty'
     config_properties_resilient:
@@ -1376,13 +1362,15 @@ components:
         connector_type_id:
           description: The type of connector.
           type: string
-          example: .resilient
+          examples:
+            - .resilient
           enum:
             - .resilient
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_resilient'
     create_connector_request_serverlog:
@@ -1398,11 +1386,13 @@ components:
           description: The type of connector.
           enum:
             - .server-log
-          example: .server-log
+          examples:
+            - .server-log
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
     config_properties_servicenow:
       title: Connector request properties for a ServiceNow ITSM connector
       required:
@@ -1473,11 +1463,13 @@ components:
           description: The type of connector.
           enum:
             - .servicenow
-          example: .servicenow
+          examples:
+            - .servicenow
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_servicenow'
     config_properties_servicenow_itom:
@@ -1525,11 +1517,13 @@ components:
           description: The type of connector.
           enum:
             - .servicenow-itom
-          example: .servicenow-itom
+          examples:
+            - .servicenow-itom
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_servicenow'
     create_connector_request_servicenow_sir:
@@ -1550,11 +1544,13 @@ components:
           description: The type of connector.
           enum:
             - .servicenow-sir
-          example: .servicenow-sir
+          examples:
+            - .servicenow-sir
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_servicenow'
     secrets_properties_slack_api:
@@ -1581,11 +1577,13 @@ components:
           description: The type of connector.
           enum:
             - .slack_api
-          example: .slack_api
+          examples:
+            - .slack_api
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_slack_api'
     secrets_properties_slack_webhook:
@@ -1612,11 +1610,13 @@ components:
           description: The type of connector.
           enum:
             - .slack
-          example: .slack
+          examples:
+            - .slack
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_slack_webhook'
     config_properties_swimlane:
@@ -1825,11 +1825,13 @@ components:
           description: The type of connector.
           enum:
             - .swimlane
-          example: .swimlane
+          examples:
+            - .swimlane
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_swimlane'
     secrets_properties_teams:
@@ -1857,11 +1859,13 @@ components:
           description: The type of connector.
           enum:
             - .teams
-          example: .teams
+          examples:
+            - .teams
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_teams'
     config_properties_tines:
@@ -1907,11 +1911,13 @@ components:
           description: The type of connector.
           enum:
             - .tines
-          example: .tines
+          examples:
+            - .tines
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_tines'
     config_properties_torq:
@@ -1952,11 +1958,13 @@ components:
           description: The type of connector.
           enum:
             - .torq
-          example: .torq
+          examples:
+            - .torq
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_torq'
     config_properties_webhook:
@@ -1988,8 +1996,9 @@ components:
           description: |
             If `true`, a user name and password must be provided for login type authentication.
         headers:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
           description: A set of key-value pairs sent as headers with the request.
         method:
           type: string
@@ -2052,11 +2061,13 @@ components:
           description: The type of connector.
           enum:
             - .webhook
-          example: .webhook
+          examples:
+            - .webhook
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_webhook'
     config_properties_xmatters:
@@ -2067,8 +2078,9 @@ components:
         configUrl:
           description: |
             The request URL for the Elastic Alerts trigger in xMatters. It is applicable only when `usesBasic` is `true`.
-          type: string
-          nullable: true
+          type:
+            - string
+            - 'null'
         usesBasic:
           description: Specifies whether the connector uses HTTP basic authentication (`true`) or URL authentication (`false`).
           type: boolean
@@ -2108,29 +2120,43 @@ components:
           description: The type of connector.
           enum:
             - .xmatters
-          example: .xmatters
+          examples:
+            - .xmatters
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_xmatters'
     is_deprecated:
       type: boolean
       description: Indicates whether the connector type is deprecated.
-      example: false
+      examples:
+        - false
     is_missing_secrets:
       type: boolean
       description: Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type.
-      example: false
+      examples:
+        - false
     is_preconfigured:
       type: boolean
-      description: Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response.
-      example: false
+      description: |
+        Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response. 
+      examples:
+        - false
     is_system_action:
       type: boolean
       description: Indicates whether the connector is used for system actions.
-      example: false
+      examples:
+        - false
+    referenced_by_count:
+      type: integer
+      description: |
+        Indicates the number of saved objects that reference the connector. If `is_preconfigured` is true, this value is not calculated. This property is returned only by the get all connectors API.
+      examples:
+        - 2
+      default: 0
     connector_response_properties_cases_webhook:
       title: Connector request properties for a Webhook - Case Management connector
       type: object
@@ -2163,6 +2189,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_d3security:
       title: Connector response properties for a D3 Security connector
       type: object
@@ -2195,11 +2223,12 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_email:
       title: Connector response properties for an email connector
       type: object
       required:
-        - config
         - connector_type_id
         - id
         - is_deprecated
@@ -2227,6 +2256,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_index:
       title: Connector response properties for an index connector
       type: object
@@ -2259,6 +2290,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_jira:
       title: Connector response properties for a Jira connector
       type: object
@@ -2291,6 +2324,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_opsgenie:
       title: Connector response properties for an Opsgenie connector
       type: object
@@ -2323,6 +2358,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_pagerduty:
       title: Connector response properties for a PagerDuty connector
       type: object
@@ -2355,6 +2392,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_resilient:
       title: Connector response properties for a IBM Resilient connector
       type: object
@@ -2387,6 +2426,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_serverlog:
       title: Connector response properties for a server log connector
       type: object
@@ -2399,8 +2440,9 @@ components:
         - name
       properties:
         config:
-          type: object
-          nullable: true
+          type:
+            - object
+            - 'null'
         connector_type_id:
           type: string
           description: The type of connector.
@@ -2420,6 +2462,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_servicenow:
       title: Connector response properties for a ServiceNow ITSM connector
       type: object
@@ -2452,6 +2496,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_servicenow_itom:
       title: Connector response properties for a ServiceNow ITOM connector
       type: object
@@ -2484,6 +2530,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_servicenow_sir:
       title: Connector response properties for a ServiceNow SecOps connector
       type: object
@@ -2516,6 +2564,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_slack_api:
       title: Connector response properties for a Slack connector
       type: object
@@ -2545,6 +2595,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_slack_webhook:
       title: Connector response properties for a Slack connector
       type: object
@@ -2574,6 +2626,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_swimlane:
       title: Connector response properties for a Swimlane connector
       type: object
@@ -2606,6 +2660,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_teams:
       title: Connector response properties for a Microsoft Teams connector
       type: object
@@ -2637,6 +2693,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_tines:
       title: Connector response properties for a Tines connector
       type: object
@@ -2669,6 +2727,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_torq:
       title: Connector response properties for a Torq connector
       type: object
@@ -2701,6 +2761,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_webhook:
       title: Connector response properties for a Webhook connector
       type: object
@@ -2733,6 +2795,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties_xmatters:
       title: Connector response properties for an xMatters connector
       type: object
@@ -2765,6 +2829,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
+        referenced_by_count:
+          $ref: '#/components/schemas/referenced_by_count'
     connector_response_properties:
       title: Connector response properties
       description: The properties vary depending on the connector type.
@@ -2803,7 +2869,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_cases_webhook'
     update_connector_request_d3security:
@@ -2983,7 +3050,8 @@ components:
         name:
           type: string
           description: The display name for the connector.
-          example: my-connector
+          examples:
+            - my-connector
         secrets:
           $ref: '#/components/schemas/secrets_properties_swimlane'
     update_connector_request_teams:
@@ -3058,6 +3126,15 @@ components:
           description: The display name for the connector.
         secrets:
           $ref: '#/components/schemas/secrets_properties_xmatters'
+    features:
+      type: string
+      description: |
+        The feature that uses the connector. Valid values are `alerting`, `cases`, `uptime`, and `siem`.
+      enum:
+        - alerting
+        - cases
+        - uptime
+        - siem
     connector_types:
       title: Connector types
       type: string
@@ -3085,16 +3162,8 @@ components:
         - .torq
         - .webhook
         - .xmatters
-      example: .server-log
-    features:
-      type: string
-      description: |
-        The feature that uses the connector. Valid values are `alerting`, `cases`, `uptime`, and `siem`.
-      enum:
-        - alerting
-        - cases
-        - uptime
-        - siem
+      examples:
+        - .server-log
     run_connector_params_documents:
       title: Index connector parameters
       description: Test an action that indexes a document into Elasticsearch.
@@ -3241,9 +3310,9 @@ components:
               type: object
               description: The custom properties of the alert.
               additionalProperties: true
-              example:
-                key1: value1
-                key2: value2
+              examples:
+                - key1: value1
+                  key2: value2
             entity:
               type: string
               description: The domain of the alert. For example, the application or server name.
@@ -3341,7 +3410,8 @@ components:
             id:
               type: string
               description: The Jira issue type identifier.
-              example: 10024
+              examples:
+                - 10024
     run_connector_subaction_getchoices:
       title: The getChoices subaction
       type: object
@@ -3399,7 +3469,8 @@ components:
             externalId:
               type: string
               description: The Jira, ServiceNow ITSM, or ServiceNow SecOps issue identifier.
-              example: 71778
+              examples:
+                - 71778
     run_connector_subaction_issue:
       title: The issue subaction
       type: object
@@ -3420,7 +3491,8 @@ components:
             id:
               type: string
               description: The Jira issue identifier.
-              example: 71778
+              examples:
+                - 71778
     run_connector_subaction_issues:
       title: The issues subaction
       type: object
@@ -3929,6 +4001,25 @@ components:
               pushedDate: '2022-09-08T16:52:27.865Z'
         status: ok
   responses:
+    '400':
+      description: Indicates a bad request.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                examples:
+                  - Bad Request
+              message:
+                type: string
+                examples:
+                  - 'error validating action type config: [index]: expected value of type [string] but got [undefined]'
+              statusCode:
+                type: integer
+                examples:
+                  - 400
     '401':
       description: Authorization information is missing or invalid.
       content:
@@ -3939,14 +4030,16 @@ components:
             properties:
               error:
                 type: string
-                example: Unauthorized
+                examples:
+                  - Unauthorized
                 enum:
                   - Unauthorized
               message:
                 type: string
               statusCode:
                 type: integer
-                example: 401
+                examples:
+                  - 401
                 enum:
                   - 401
     '404':
@@ -3959,15 +4052,18 @@ components:
             properties:
               error:
                 type: string
-                example: Not Found
+                examples:
+                  - Not Found
                 enum:
                   - Not Found
               message:
                 type: string
-                example: Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found
+                examples:
+                  - Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found
               statusCode:
                 type: integer
-                example: 404
+                examples:
+                  - 404
                 enum:
                   - 404
     200_actions:

--- a/x-pack/plugins/actions/docs/openapi/components/parameters/action_id.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/parameters/action_id.yaml
@@ -4,4 +4,5 @@ description: An identifier for the action.
 required: true
 schema:
   type: string
-  example: c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad
+  examples:
+    - c55b6eb0-6bad-11eb-9f3b-611eebc6c3ad

--- a/x-pack/plugins/actions/docs/openapi/components/parameters/connector_id.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/parameters/connector_id.yaml
@@ -4,4 +4,5 @@ description: An identifier for the connector.
 required: true
 schema:
   type: string
-  example: df770e30-8b8b-11ed-a780-3b746c987a81
+  examples:
+    - df770e30-8b8b-11ed-a780-3b746c987a81

--- a/x-pack/plugins/actions/docs/openapi/components/parameters/space_id.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/parameters/space_id.yaml
@@ -4,4 +4,5 @@ description: An identifier for the space. If `/s/` and the identifier are omitte
 required: true
 schema:
   type: string
-  example: default
+  examples:
+    - default

--- a/x-pack/plugins/actions/docs/openapi/components/responses/400.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/responses/400.yaml
@@ -1,0 +1,18 @@
+description: Indicates a bad request.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        error: 
+          type: string
+          examples:
+            - Bad Request
+        message:
+          type: string
+          examples:
+            - "error validating action type config: [index]: expected value of type [string] but got [undefined]"
+        statusCode:
+          type: integer
+          examples:
+            - 400

--- a/x-pack/plugins/actions/docs/openapi/components/responses/401.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/responses/401.yaml
@@ -7,13 +7,15 @@ content:
       properties:
         error:
           type: string
-          example: Unauthorized
+          examples:
+            - Unauthorized
           enum:
             - Unauthorized
         message:
           type: string 
         statusCode:
           type: integer
-          example: 401
+          examples:
+            - 401
           enum:
             - 401

--- a/x-pack/plugins/actions/docs/openapi/components/responses/404.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/responses/404.yaml
@@ -7,14 +7,17 @@ content:
       properties:
         error:
           type: string
-          example: Not Found
+          examples:
+            - Not Found
           enum:
             - Not Found
         message:
           type: string
-          example: "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
+          examples:
+            - "Saved object [action/baf33fc0-920c-11ed-b36a-874bd1548a00] not found"
         statusCode:
           type: integer
-          example: 404
+          examples:
+            - 404
           enum:
             - 404

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_cases_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_cases_webhook.yaml
@@ -22,7 +22,8 @@ properties:
       connector. The JSON is validated once the Mustache variables have been
       placed when the REST method runs. Manually ensure that the JSON is valid,
       disregarding the Mustache variables, so the later validation will pass.
-    example: {"body": {{{case.comment}}}}
+    examples:
+      - {"body": {{{case.comment}}}}
   createCommentMethod:
     type: string
     description: >
@@ -40,7 +41,8 @@ properties:
       You can use a variable to add the external system ID to the URL. If you
       are using the `xpack.actions.allowedHosts setting`, add the hostname to
       the allowed hosts.
-    example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment
+    examples:
+      - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}/comment
   createIncidentJson:
     type: string
     description: >
@@ -52,7 +54,8 @@ properties:
       connector. The JSON is validated after the Mustache variables have been
       placed when REST method runs. Manually ensure that the JSON is valid to
       avoid future validation errors; disregard Mustache variables during your review.
-    example: {"fields": {"summary": {{{case.title}}},"description": {{{case.description}}},"labels": {{{case.tags}}}}}
+    examples:
+      - {"fields": {"summary": {{{case.title}}},"description": {{{case.description}}},"labels": {{{case.tags}}}}}
   createIncidentMethod:
     type: string
     description: >
@@ -86,7 +89,8 @@ properties:
       variables have been placed when REST method runs. Manually ensure that the
       JSON is valid, disregarding the Mustache variables, so the later
       validation will pass.
-    example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}
+    examples:
+      - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.id}}}
   hasAuth:
     type: boolean
     description: If true, a username and password for login type authentication must be provided.
@@ -107,7 +111,8 @@ properties:
       connector. The JSON is validated after the Mustache variables have been
       placed when REST method runs. Manually ensure that the JSON is valid to
       avoid future validation errors; disregard Mustache variables during your review.
-    example: {"fields": {"summary": {{{case.title}}},"description": {{{case.description}}},"labels": {{{case.tags}}}}}
+    examples:
+      - {"fields": {"summary": {{{case.title}}},"description": {{{case.description}}},"labels": {{{case.tags}}}}}
   updateIncidentMethod:
     type: string
     description: >
@@ -124,12 +129,14 @@ properties:
       The REST API URL to update the case by ID in the third-party system. You
       can use a variable to add the external system ID to the URL. If you are
       using the `xpack.actions.allowedHosts` setting, add the hostname to the allowed hosts.
-    example: https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}
+    examples:
+      - https://testing-jira.atlassian.net/rest/api/2/issue/{{{external.system.ID}}}
   viewIncidentUrl:
     type: string
     description: >
       The URL to view the case in the external system. You can use variables to
       add the external system ID or external system title to the URL.
-    example: https://testing-jira.atlassian.net/browse/{{{external.system.title}}}
+    examples:
+      - https://testing-jira.atlassian.net/browse/{{{external.system.title}}}
 
 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_email.yaml
@@ -8,8 +8,9 @@ properties:
     description: >
       The client identifier, which is a part of OAuth 2.0 client credentials authentication, in GUID format.
       If `service` is `exchange_server`, this property is required.
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
   from:
     description: >
       The from address for all emails sent by the connector. It must be specified in `user@host-name` format.
@@ -27,8 +28,9 @@ properties:
     type: string
   oauthTokenUrl:
     # description: TBD
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
   port:
     description: >
       The port to connect to on the service provider.
@@ -55,5 +57,6 @@ properties:
     description: >
       The tenant identifier, which is part of OAuth 2.0 client credentials authentication, in GUID format.
       If `service` is `exchange_server`, this property is required.
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_index.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_index.yaml
@@ -7,8 +7,9 @@ properties:
   executionTimeField:
     description: A field that indicates when the document was indexed.
     default: null
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
   index:
     description: The Elasticsearch index to be written to.
     type: string

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_pagerduty.yaml
@@ -4,6 +4,8 @@ type: object
 properties:
   apiUrl:
     description: The PagerDuty event URL.
-    type: string
-    nullable: true
-    example: https://events.pagerduty.com/v2/enqueue
+    type:
+      - "string"
+      - "null"
+    examples:
+      - https://events.pagerduty.com/v2/enqueue

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_webhook.yaml
@@ -27,8 +27,9 @@ properties:
     description: >
       If `true`, a user name and password must be provided for login type authentication.
   headers:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
     description: A set of key-value pairs sent as headers with the request.
   method:
     type: string

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_xmatters.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/config_properties_xmatters.yaml
@@ -6,8 +6,9 @@ properties:
     description: >
       The request URL for the Elastic Alerts trigger in xMatters.
       It is applicable only when `usesBasic` is `true`.
-    type: string
-    nullable: true
+    type:
+      - "string"
+      - "null"
   usesBasic:
     description: Specifies whether the connector uses HTTP basic authentication (`true`) or URL authentication (`false`).
     type: boolean

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_bedrock.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_bedrock.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_cases_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_cases_webhook.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_d3security.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_d3security.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_email.yaml
@@ -1,7 +1,6 @@
 title: Connector response properties for an email connector
 type: object
 required:
-  - config
   - connector_type_id
   - id
   - is_deprecated
@@ -29,3 +28,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_genai.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_genai.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_index.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_index.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_jira.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_jira.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_opsgenie.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_opsgenie.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_pagerduty.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_resilient.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_resilient.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_serverlog.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_serverlog.yaml
@@ -9,8 +9,9 @@ required:
   - name
 properties:
   config:
-    type: object
-    nullable: true
+    type:
+      - "object"
+      - "null"
   connector_type_id:
     type: string
     description: The type of connector.
@@ -30,3 +31,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_itom.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_itom.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_sir.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_servicenow_sir.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_api.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_api.yaml
@@ -26,3 +26,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_slack_webhook.yaml
@@ -26,3 +26,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_swimlane.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_swimlane.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_teams.yaml
@@ -28,3 +28,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_tines.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_tines.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_torq.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_torq.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_webhook.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_xmatters.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_response_properties_xmatters.yaml
@@ -29,3 +29,5 @@ properties:
   name:
     type: string
     description: The display name for the connector.
+  referenced_by_count:
+    $ref: 'referenced_by_count.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/connector_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/connector_types.yaml
@@ -24,4 +24,5 @@ enum:
   - .torq
   - .webhook
   - .xmatters
-example: .server-log
+examples:
+  - .server-log

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_bedrock.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_bedrock.yaml
@@ -14,10 +14,12 @@ properties:
     description: The type of connector.
     enum:
       - .bedrock
-    example: .bedrock
+    examples:
+      - .bedrock
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_bedrock.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_cases_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_cases_webhook.yaml
@@ -15,10 +15,12 @@ properties:
     description: The type of connector.
     enum:
       - .cases-webhook
-    example: .cases-webhook
+    examples:
+      - .cases-webhook
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_cases_webhook.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_d3security.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_d3security.yaml
@@ -15,10 +15,12 @@ properties:
     description: The type of connector.
     enum:
       - .d3security
-    example: .d3security
+    examples:
+      - .d3security
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_d3security.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_email.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_email.yaml
@@ -18,10 +18,12 @@ properties:
     description: The type of connector.
     enum:
       - .email
-    example: .email
+    examples:
+      - .email
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_email.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_genai.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_genai.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .gen-ai
-    example: .gen-ai
+    examples:
+      - .gen-ai
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_genai.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_index.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_index.yaml
@@ -13,8 +13,10 @@ properties:
     description: The type of connector.
     enum:
       - .index
-    example: .index
+    examples:
+      - .index
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_jira.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_jira.yaml
@@ -14,10 +14,12 @@ properties:
     description: The type of connector.
     enum:
       - .jira
-    example: .jira
+    examples:
+      - .jira
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_jira.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_opsgenie.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_opsgenie.yaml
@@ -14,10 +14,12 @@ properties:
     description: The type of connector.
     enum:
       - .opsgenie
-    example: .opsgenie
+    examples:
+      - .opsgenie
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
      $ref: 'secrets_properties_opsgenie.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_pagerduty.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_pagerduty.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .pagerduty
-    example: .pagerduty
+    examples:
+      - .pagerduty
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_pagerduty.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_resilient.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_resilient.yaml
@@ -12,12 +12,14 @@ properties:
   connector_type_id:
     description: The type of connector.
     type: string
-    example: .resilient
+    examples:
+      - .resilient
     enum:
       - .resilient
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_resilient.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_serverlog.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_serverlog.yaml
@@ -10,8 +10,10 @@ properties:
     description: The type of connector.
     enum:
       - .server-log
-    example: .server-log
+    examples:
+      - .server-log
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .servicenow
-    example: .servicenow
+    examples:
+      - .servicenow
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_servicenow.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow_itom.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow_itom.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .servicenow-itom
-    example: .servicenow-itom
+    examples:
+      - .servicenow-itom
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_servicenow.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow_sir.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_servicenow_sir.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .servicenow-sir
-    example: .servicenow-sir
+    examples:
+      - .servicenow-sir
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_servicenow.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_slack_api.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_slack_api.yaml
@@ -11,10 +11,12 @@ properties:
     description: The type of connector.
     enum:
       - .slack_api
-    example: .slack_api
+    examples:
+      - .slack_api
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_slack_api.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_slack_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_slack_webhook.yaml
@@ -11,10 +11,12 @@ properties:
     description: The type of connector.
     enum:
       - .slack
-    example: .slack
+    examples:
+      - .slack
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_slack_webhook.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_swimlane.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_swimlane.yaml
@@ -14,10 +14,12 @@ properties:
     description: The type of connector.
     enum:
       - .swimlane
-    example: .swimlane
+    examples:
+      - .swimlane
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_swimlane.yaml'

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_teams.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_teams.yaml
@@ -11,10 +11,12 @@ properties:
     description: The type of connector.
     enum:
       - .teams
-    example: .teams
+    examples:
+      - .teams
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_teams.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_tines.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_tines.yaml
@@ -15,10 +15,12 @@ properties:
     description: The type of connector.
     enum:
       - .tines
-    example: .tines
+    examples:
+      - .tines
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_tines.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_torq.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_torq.yaml
@@ -15,10 +15,12 @@ properties:
     description: The type of connector.
     enum:
       - .torq
-    example: .torq
+    examples:
+      - .torq
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_torq.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_webhook.yaml
@@ -15,10 +15,12 @@ properties:
     description: The type of connector.
     enum:
       - .webhook
-    example: .webhook
+    examples:
+      - .webhook
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_webhook.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_xmatters.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/create_connector_request_xmatters.yaml
@@ -16,10 +16,12 @@ properties:
     description: The type of connector.
     enum:
       - .xmatters
-    example: .xmatters
+    examples:
+      - .xmatters
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_xmatters.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/is_deprecated.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/is_deprecated.yaml
@@ -1,3 +1,4 @@
 type: boolean
 description: Indicates whether the connector type is deprecated.
-example: false
+examples:
+  - false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/is_missing_secrets.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/is_missing_secrets.yaml
@@ -1,3 +1,4 @@
 type: boolean
 description: Indicates whether secrets are missing for the connector. Secrets configuration properties vary depending on the connector type.
-example: false
+examples:
+  - false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/is_preconfigured.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/is_preconfigured.yaml
@@ -1,3 +1,6 @@
 type: boolean
-description: Indicates whether it is a preconfigured connector. If true, the `config` and `is_missing_secrets` properties are omitted from the response. 
-example: false
+description: >
+  Indicates whether it is a preconfigured connector.
+  If true, the `config` and `is_missing_secrets` properties are omitted from the response. 
+examples:
+  - false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/is_system_action.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/is_system_action.yaml
@@ -1,3 +1,4 @@
 type: boolean
 description: Indicates whether the connector is used for system actions.
-example: false
+examples:
+  - false

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/referenced_by_count.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/referenced_by_count.yaml
@@ -1,0 +1,8 @@
+type: integer
+description: >
+  Indicates the number of saved objects that reference the connector.
+  If `is_preconfigured` is true, this value is not calculated.
+  This property is returned only by the get all connectors API.
+examples:
+  - 2
+default: 0

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_createalert.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_createalert.yaml
@@ -30,7 +30,8 @@ properties:
         type: object
         description: The custom properties of the alert.
         additionalProperties: true
-        example: {"key1":"value1","key2":"value2"}
+        examples:
+          - {"key1":"value1","key2":"value2"}
       entity:
         type: string
         description: The domain of the alert. For example, the application or server name.

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_fieldsbyissuetype.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_fieldsbyissuetype.yaml
@@ -18,5 +18,6 @@ properties:
       id:
         type: string
         description: The Jira issue type identifier.
-        example: 10024
+        examples:
+          - 10024
   

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_getincident.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_getincident.yaml
@@ -18,4 +18,5 @@ properties:
       externalId:
         type: string
         description: The Jira, ServiceNow ITSM, or ServiceNow SecOps issue identifier.
-        example: 71778
+        examples:
+          - 71778

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_issue.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/run_connector_subaction_issue.yaml
@@ -17,4 +17,5 @@ properties:
       id:
         type: string
         description: The Jira issue identifier.
-        example: 71778
+        examples:
+          - 71778

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_cases_webhook.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_cases_webhook.yaml
@@ -9,6 +9,7 @@ properties:
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_cases_webhook.yaml' 

--- a/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_swimlane.yaml
+++ b/x-pack/plugins/actions/docs/openapi/components/schemas/update_connector_request_swimlane.yaml
@@ -10,6 +10,7 @@ properties:
   name:
     type: string
     description: The display name for the connector.
-    example: my-connector
+    examples:
+      - my-connector
   secrets:
     $ref: 'secrets_properties_swimlane.yaml'

--- a/x-pack/plugins/actions/docs/openapi/entrypoint.yaml
+++ b/x-pack/plugins/actions/docs/openapi/entrypoint.yaml
@@ -1,8 +1,8 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   title: Connectors
   description: OpenAPI schema for Connectors endpoints
-  version: '0.1'
+  version: '0.2'
   contact:
     name: Connectors Team
   license:

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector@{connectorid}.yaml
@@ -59,7 +59,8 @@ post:
       required: true
       schema:
         type: string
-        example: ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74
+        examples:
+          - ac4e6b90-6be7-11eb-ba0d-9b1c1f912d74
   requestBody:
     required: true
     content:
@@ -159,21 +160,7 @@ put:
           schema:
             $ref: '../components/schemas/connector_response_properties.yaml'
     '400':
-      description: Indicates a bad request.
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              error: 
-                type: string
-                example: Bad Request
-              message:
-                type: string
-                example: "error validating action type config: [index]: expected value of type [string] but got [undefined]"
-              statusCode:
-                type: integer
-                example: 400
+      $ref: '../components/responses/400.yaml'
     '401':
       $ref: '../components/responses/401.yaml'
     '404':

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connector_types.yaml
@@ -27,34 +27,37 @@ get:
                 enabled:
                   type: boolean
                   description: Indicates whether the connector type is enabled in Kibana.
-                  example: true
+                  examples:
+                    - true
                 enabled_in_config:
                   type: boolean
                   description: Indicates whether the connector type is enabled in the Kibana `.yml` file.
-                  example: true
+                  examples:
+                    - true
                 enabled_in_license:
                   type: boolean
                   description: Indicates whether the connector is enabled in the license.
-                  example: true
+                  examples:
+                    - true
                 id:
                   $ref: '../components/schemas/connector_types.yaml'
                 minimum_license_required:
                   type: string
                   description: The license that is required to use the connector type.
-                  example: basic
+                  examples:
+                    - basic
                 name:
                   type: string
                   description: The name of the connector type.
-                  example: Index
+                  examples:
+                    - Index
                 supported_feature_ids:
                   type: array
                   description: The Kibana features that are supported by the connector type.
                   items:
                     $ref: '../components/schemas/features.yaml'
-                  example:
-                    - alerting
-                    - uptime
-                    - siem
+                  examples:
+                    - [alerting, uptime, siem]
           examples:
             getConnectorTypesResponse:
               $ref: '../components/examples/get_connector_types_response.yaml'

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@connectors.yaml
@@ -15,45 +15,7 @@ get:
           schema:
             type: array
             items:
-              title: Get connectors response body properties
-              description: The properties vary for each connector type.
-              type: object
-              required:
-                - connector_type_id
-                - id
-                - is_deprecated
-                - is_preconfigured
-                - name
-                - referenced_by_count
-              properties:
-                connector_type_id:
-                  $ref: '../components/schemas/connector_types.yaml'
-                config:
-                  type: object
-                  description: The configuration for the connector. Configuration properties vary depending on the connector type.
-                  additionalProperties: true
-                  nullable: true
-                id:
-                  type: string
-                  description: The identifier for the connector.
-                  example: b0766e10-d190-11ec-b04c-776c77d14fca
-                is_deprecated:
-                  $ref: '../components/schemas/is_deprecated.yaml'
-                is_missing_secrets:
-                  $ref: '../components/schemas/is_missing_secrets.yaml'  
-                is_preconfigured:
-                  $ref: '../components/schemas/is_preconfigured.yaml'
-                is_system_action:
-                  $ref: '../components/schemas/is_system_action.yaml'
-                name:
-                  type: string
-                  description: The display name for the connector.
-                  example: my-connector
-                referenced_by_count:
-                  type: integer
-                  description: Indicates the number of saved objects that reference the connector. If `is_preconfigured` is true, this value is not calculated.
-                  example: 2
-                  default: 0
+              $ref: '../components/schemas/connector_response_properties.yaml'
           examples:
             getConnectorsResponse:
               $ref: '../components/examples/get_connectors_response.yaml'

--- a/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@list_action_types.yaml
+++ b/x-pack/plugins/actions/docs/openapi/paths/s@{spaceid}@api@actions@list_action_types.yaml
@@ -28,7 +28,8 @@ get:
                 enabledInLicense:
                   type: boolean
                   description: Indicates whether the connector is enabled in the license.
-                  example: true
+                  examples:
+                    - true
                 id:
                   type: string
                   description: The unique identifier for the connector type.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[OAS] Migrate connector APIs to v3.1.0 (#171464)](https://github.com/elastic/kibana/pull/171464)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2023-11-24T20:51:14Z","message":"[OAS] Migrate connector APIs to v3.1.0 (#171464)","sha":"14886bf8b8a1629535e9b3ce0d6a6485b98299e5","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","docs","Feature:Actions/ConnectorsManagement","backport:prev-minor","v8.12.0"],"number":171464,"url":"https://github.com/elastic/kibana/pull/171464","mergeCommit":{"message":"[OAS] Migrate connector APIs to v3.1.0 (#171464)","sha":"14886bf8b8a1629535e9b3ce0d6a6485b98299e5"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/171464","number":171464,"mergeCommit":{"message":"[OAS] Migrate connector APIs to v3.1.0 (#171464)","sha":"14886bf8b8a1629535e9b3ce0d6a6485b98299e5"}}]}] BACKPORT-->