### PR TITLE
[Console] Fix wrong autocomplete suggestions on typing in slash

### DIFF
--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -981,8 +981,8 @@ export default function ({
     context.token = ret.token;
     context.otherTokenValues = ret.otherTokenValues;
     context.urlTokenPath = ret.urlTokenPath;
-    const components = getTopLevelUrlCompleteComponents(context.method);
 
+    const components = getTopLevelUrlCompleteComponents(context.method);
     let urlTokenPath = context.urlTokenPath;
     let predicate: (term: ReturnType<typeof addMetaToTermsList>[0]) => boolean = () => true;
 

--- a/src/plugins/console/public/lib/autocomplete/autocomplete.ts
+++ b/src/plugins/console/public/lib/autocomplete/autocomplete.ts
@@ -978,6 +978,7 @@ export default function ({
   function addPathAutoCompleteSetToContext(context: AutoCompleteContext, pos: Position) {
     const ret = getCurrentMethodAndTokenPaths(editor, pos, parser);
     context.method = ret.method?.toUpperCase();
+    context.token = ret.token;
     context.otherTokenValues = ret.otherTokenValues;
     context.urlTokenPath = ret.urlTokenPath;
     const components = getTopLevelUrlCompleteComponents(context.method);


### PR DESCRIPTION
Closes #171947

## Summary

This PR fixes wrong autocomplete suggestions on typing in slash in some specific cases.
![fix-suggestion-on-slash](https://github.com/elastic/kibana/assets/721858/f3cab482-63ca-4ee7-99b7-0e3fc37e8940)

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fixes wrong autocomplete suggestions on typing in slash

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->