### PR TITLE
[Console] Fix autocomplete on typing in every letter

### DIFF
--- a/src/plugins/console/public/lib/autocomplete/looks_like_typing_in.test.ts
+++ b/src/plugins/console/public/lib/autocomplete/looks_like_typing_in.test.ts
@@ -103,6 +103,10 @@ describe('looksLikeTypingIn', () => {
       { preamble: 'GET _cat/indices?s=index&exp', autocomplete: 'and_wildcards', input: '=' },
       { preamble: 'GET _cat/indices?v&', autocomplete: 'expand_wildcards', input: '=' },
       { preamble: 'GET _cat/indices?v&exp', autocomplete: 'and_wildcards', input: '=' },
+      // autocomplete skips one iteration of token evaluation if user types in every letter
+      { preamble: 'GET .kibana', autocomplete: '/', input: '_' }, // token '/' may not be evaluated
+      { preamble: 'GET .kibana', autocomplete: ',', input: '.' }, // token ',' may not be evaluated
+      { preamble: 'GET .kibana', autocomplete: '?', input: 'k' }, // token '?' may not be evaluated
     ];
     for (const c of cases) {
       const name =


### PR DESCRIPTION
Closes #171951

## Summary

This PR fixes autocomplete to show suggestions even if user types in every letter.
![autocomplete-typing-in](https://github.com/elastic/kibana/assets/721858/c2d2dfb9-bc81-4285-b5c1-444d634f9af2)

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

## Release note

Fixes autocomplete to show suggestions even if user types in every letter

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->