### PR TITLE
[Metric threshold] Fix incorrect rule params when changing nonCount agg to count in custom equation

### DIFF
--- a/x-pack/plugins/infra/public/alerting/metric_threshold/components/custom_equation/metric_row_with_agg.tsx
+++ b/x-pack/plugins/infra/public/alerting/metric_threshold/components/custom_equation/metric_row_with_agg.tsx
@@ -81,10 +81,11 @@ export const MetricRowWithAgg = ({
 
   const handleAggChange = useCallback(
     (el: React.ChangeEvent<HTMLSelectElement>) => {
+      const customMetricAggType = el.target.value as CustomMetricAggTypes;
       onChange({
         name,
-        field,
-        aggType: el.target.value as CustomMetricAggTypes,
+        field: customMetricAggType === Aggregators.COUNT ? undefined : field,
+        aggType: customMetricAggType,
       });
     },
     [name, field, onChange]


### PR DESCRIPTION
Closes #171088

## Summary

This PR fixes the incorrect params when changing aggregation from nonCount to count:

https://github.com/elastic/kibana/assets/12370520/56ae5612-e254-4815-98fa-e773cbe4ba38

I didn't find an easy way to add a test for this case, as this is a minor UI issue. It is worth mentioning that the metric threshold rule will be deprecated eventually. Let me know if you have any suggestions for it.