### PR TITLE
[Custom threshold] Fix not showing threshold line in lens preview

### DIFF
--- a/x-pack/plugins/observability/public/components/custom_threshold/components/preview_chart/preview_chart.test.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/preview_chart/preview_chart.test.tsx
@@ -13,7 +13,7 @@ import { Comparator, Aggregators } from '../../../../../common/custom_threshold_
 import { useKibana } from '../../../../utils/kibana_react';
 import { kibanaStartMock } from '../../../../utils/kibana_react.mock';
 import { MetricExpression } from '../../types';
-import { PreviewChart } from './preview_chart';
+import { getBufferThreshold, PreviewChart } from './preview_chart';
 
 jest.mock('../../../../utils/kibana_react');
 
@@ -68,5 +68,20 @@ describe('Preview chart', () => {
     };
     const { wrapper } = await setup(expression);
     expect(wrapper.find('[data-test-subj="thresholdRuleNoChartData"]').exists()).toBeTruthy();
+  });
+});
+
+describe('getBufferThreshold', () => {
+  const testData = [
+    { threshold: undefined, buffer: '0.00' },
+    { threshold: 0.1, buffer: '0.12' },
+    { threshold: 0.01, buffer: '0.02' },
+    { threshold: 0.001, buffer: '0.01' },
+    { threshold: 0.00098, buffer: '0.01' },
+    { threshold: 130, buffer: '143.00' },
+  ];
+
+  it.each(testData)('getBufferThreshold($threshold) = $buffer', ({ threshold, buffer }) => {
+    expect(getBufferThreshold(threshold)).toBe(buffer);
   });
 });

--- a/x-pack/plugins/observability/public/components/custom_threshold/components/preview_chart/preview_chart.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/preview_chart/preview_chart.tsx
@@ -44,6 +44,9 @@ const getOperationTypeFromRuleAggType = (aggType: AggType): OperationType => {
   return aggType;
 };
 
+export const getBufferThreshold = (threshold?: number): string =>
+  (Math.ceil((threshold || 0) * 1.1 * 100) / 100).toFixed(2).toString();
+
 export function PreviewChart({
   metricExpression,
   dataView,
@@ -147,7 +150,7 @@ export function PreviewChart({
       const bufferRefLine = new XYReferenceLinesLayer({
         data: [
           {
-            value: Math.round((threshold[0] || 0) * 1.1).toString(),
+            value: getBufferThreshold(threshold[0]),
             color: 'transparent',
             fill,
             format,


### PR DESCRIPTION
Closes #171843

## Summary

This PR fixes not showing the threshold line in the following case:

<img src="https://github.com/elastic/kibana/assets/12370520/fa0af167-b7f1-499a-a703-b336d4f2414c" width=500 />
