### PR TITLE
[Ops] Trim long stat blocks

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/on_complete.ts
+++ b/.buildkite/pipeline-utils/ci-stats/on_complete.ts
@@ -28,7 +28,8 @@ export async function onComplete() {
 
   const report = await ciStats.getPrReport(process.env.CI_STATS_BUILD_ID);
   if (report?.md) {
-    buildkite.setMetadata('pr_comment:ci_stats_report:body', report.md);
+    // buildkite meta-data allows for 100kb of data, so we trim the report to that size, to unblock builds
+    buildkite.setMetadata('pr_comment:ci_stats_report:body', trimToSize(report.md, 100000));
 
     const annotationType = report?.success ? 'info' : 'error';
     buildkite.setAnnotation('ci-stats-report', annotationType, report.md);
@@ -38,5 +39,24 @@ export async function onComplete() {
     console.log('+++ CI Stats Report');
     console.error('Failing build due to CI Stats report. See annotation at top of build.');
     process.exit(1);
+  }
+}
+
+function trimToSize(str: string, sizeLimit: number, totalCharsTrimmed = 0): string {
+  const trimChunkSize = 500;
+  const sizeInBytes = new Blob([str]).size;
+  if (sizeInBytes <= sizeLimit) {
+    if (totalCharsTrimmed > 0) {
+      console.log(`Trimmed ${totalCharsTrimmed} characters from report.`);
+      return `${str}... \n[trimmed ${totalCharsTrimmed} characters]`;
+    } else {
+      return str;
+    }
+  } else {
+    if (trimChunkSize > str.length) {
+      return trimToSize(str.slice(0, -trimChunkSize), sizeLimit, totalCharsTrimmed + trimChunkSize);
+    } else {
+      return `${str}... \n[trimmed ${totalCharsTrimmed} characters]`;
+    }
   }
 }


### PR DESCRIPTION
## Summary
Some post-build steps are failing because sometimes we're outgrowing the buildkite metadata limits.

This PR will prevent upload of a text block too big, instead it will try to gesture towards the build for more info.
