### PR TITLE
[Defend Workflows][8.11] Unblock fleet setup when cannot decrypt uninstall tokens

### DIFF
--- a/x-pack/plugins/fleet/server/mocks/index.ts
+++ b/x-pack/plugins/fleet/server/mocks/index.ts
@@ -200,5 +200,7 @@ export function createUninstallTokenServiceMock(): UninstallTokenServiceInterfac
     generateTokensForPolicyIds: jest.fn(),
     generateTokensForAllPolicies: jest.fn(),
     encryptTokens: jest.fn(),
+    checkTokenValidityForAllPolicies: jest.fn(),
+    checkTokenValidityForPolicy: jest.fn(),
   };
 }

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -512,6 +512,7 @@ class AgentPolicyService {
     }
 
     this.checkTamperProtectionLicense(agentPolicy);
+    await this.checkForValidUninstallToken(agentPolicy, id);
 
     const logger = appContextService.getLogger();
 
@@ -1210,6 +1211,20 @@ class AgentPolicyService {
   private checkTamperProtectionLicense(agentPolicy: { is_protected?: boolean }): void {
     if (agentPolicy?.is_protected && !licenseService.isPlatinum()) {
       throw new FleetUnauthorizedError('Tamper protection requires Platinum license');
+    }
+  }
+  private async checkForValidUninstallToken(
+    agentPolicy: { is_protected?: boolean },
+    policyId: string
+  ): Promise<void> {
+    if (agentPolicy?.is_protected) {
+      const uninstallTokenService = appContextService.getUninstallTokenService();
+
+      try {
+        await uninstallTokenService?.checkTokenValidityForPolicy(policyId);
+      } catch (e) {
+        throw new Error(`Cannot enable Agent Tamper Protection: ${e.message}`);
+      }
     }
   }
 }

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -499,5 +499,54 @@ describe('UninstallTokenService', () => {
         });
       });
     });
+
+    describe('check validity of tokens', () => {
+      let okayTokensPolicyId: string;
+      let missingTokensPolicyId: string;
+
+      beforeEach(() => {
+        const so = getDefaultSO(canEncrypt);
+        so.attributes.token = undefined;
+        so.attributes.token_plain = undefined;
+        missingTokensPolicyId = so.attributes.policy_id;
+
+        const so2 = getDefaultSO2(canEncrypt);
+        okayTokensPolicyId = so2.attributes.policy_id;
+
+        mockCreatePointInTimeFinderAsInternalUser([so, so2]);
+      });
+
+      describe('checkTokenValidityForAllPolicies', () => {
+        it('resolves if all of the tokens are available', async () => {
+          mockCreatePointInTimeFinderAsInternalUser();
+
+          await expect(
+            uninstallTokenService.checkTokenValidityForAllPolicies()
+          ).resolves.not.toThrowError();
+        });
+
+        it('rejects if any of the tokens is missing', async () => {
+          await expect(
+            uninstallTokenService.checkTokenValidityForAllPolicies()
+          ).rejects.toThrowError('Uninstall Token is missing the token.');
+        });
+      });
+
+      describe('checkTokenValidityForPolicy', () => {
+        it('resolves if token is available', async () => {
+          mockCreatePointInTimeFinderAsInternalUser();
+
+          await expect(
+            uninstallTokenService.checkTokenValidityForPolicy(okayTokensPolicyId)
+          ).resolves.not.toThrowError();
+        });
+
+        it('rejects if token is missing', async () => {
+          await expect(
+            uninstallTokenService.checkTokenValidityForPolicy(missingTokensPolicyId)
+          ).rejects.toThrowError('Uninstall Token is missing the token.');
+        });
+      });
+    });
   });
 });

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -528,7 +528,9 @@ describe('UninstallTokenService', () => {
         it('rejects if any of the tokens is missing', async () => {
           await expect(
             uninstallTokenService.checkTokenValidityForAllPolicies()
-          ).rejects.toThrowError('Uninstall Token is missing the token.');
+          ).rejects.toThrowError(
+            'Invalid uninstall token: Saved object is missing the `token` attribute.'
+          );
         });
       });
 
@@ -544,7 +546,9 @@ describe('UninstallTokenService', () => {
         it('rejects if token is missing', async () => {
           await expect(
             uninstallTokenService.checkTokenValidityForPolicy(missingTokensPolicyId)
-          ).rejects.toThrowError('Uninstall Token is missing the token.');
+          ).rejects.toThrowError(
+            'Invalid uninstall token: Saved object is missing the `token` attribute.'
+          );
         });
       });
     });

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -134,6 +134,20 @@ export interface UninstallTokenServiceInterface {
    * If encryption is available, checks for any plain text uninstall tokens and encrypts them
    */
   encryptTokens(): Promise<void>;
+
+  /**
+   * Check whether the selected policy has a valid uninstall token. Rejects returning promise if not.
+   *
+   * @param policyId policy Id to check
+   */
+  checkTokenValidityForPolicy(policyId: string): Promise<void>;
+
+  /**
+   * Check whether all policies have a valid uninstall token. Rejects returning promise if not.
+   *
+   * @param policyId policy Id to check
+   */
+  checkTokenValidityForAllPolicies(): Promise<void>;
 }
 
 export class UninstallTokenService implements UninstallTokenServiceInterface {
@@ -473,6 +487,15 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     });
 
     return this._soClient;
+  }
+
+  public async checkTokenValidityForPolicy(policyId: string): Promise<void> {
+    await this.getDecryptedTokensForPolicyIds([policyId]);
+  }
+
+  public async checkTokenValidityForAllPolicies(): Promise<void> {
+    const policyIds = await this.getAllPolicyIds();
+    await this.getDecryptedTokensForPolicyIds(policyIds);
   }
 
   private get isEncryptionAvailable(): boolean {

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -224,7 +224,11 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     tokensFinder.close();
 
     const uninstallTokens: UninstallToken[] = tokenObject.map(
-      ({ id: _id, attributes, created_at: createdAt }) => {
+      ({ id: _id, attributes, created_at: createdAt, error }) => {
+        if (error) {
+          throw new UninstallTokenError(`Error when reading Uninstall Token: ${error.message}`);
+        }
+
         this.assertPolicyId(attributes);
         this.assertToken(attributes);
         this.assertCreatedAt(createdAt);

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -109,7 +109,7 @@ export interface UninstallTokenServiceInterface {
    * @param force generate a new token even if one already exists
    * @returns hashedToken
    */
-  generateTokenForPolicyId(policyId: string, force?: boolean): Promise<string>;
+  generateTokenForPolicyId(policyId: string, force?: boolean): Promise<void>;
 
   /**
    * Generate uninstall tokens for given policy ids
@@ -119,7 +119,7 @@ export interface UninstallTokenServiceInterface {
    * @param force generate a new token even if one already exists
    * @returns Record<policyId, hashedToken>
    */
-  generateTokensForPolicyIds(policyIds: string[], force?: boolean): Promise<Record<string, string>>;
+  generateTokensForPolicyIds(policyIds: string[], force?: boolean): Promise<void>;
 
   /**
    * Generate uninstall tokens all policies
@@ -128,7 +128,7 @@ export interface UninstallTokenServiceInterface {
    * @param force generate a new token even if one already exists
    * @returns Record<policyId, hashedToken>
    */
-  generateTokensForAllPolicies(force?: boolean): Promise<Record<string, string>>;
+  generateTokensForAllPolicies(force?: boolean): Promise<void>;
 
   /**
    * If encryption is available, checks for any plain text uninstall tokens and encrypts them
@@ -214,6 +214,10 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
         this.assertPolicyId(attributes);
         this.assertToken(attributes);
         this.assertCreatedAt(createdAt);
+
+        // todo: can we give warnings while setup?
+        // todo: give error when enabling stuff
+        // todo: maybe this is a function: check tokens!
 
         return {
           id: _id,
@@ -304,32 +308,30 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     return this.getHashedTokensForPolicyIds(policyIds);
   }
 
-  public async generateTokenForPolicyId(policyId: string, force: boolean = false): Promise<string> {
-    return (await this.generateTokensForPolicyIds([policyId], force))[policyId];
+  public generateTokenForPolicyId(policyId: string, force: boolean = false): Promise<void> {
+    return this.generateTokensForPolicyIds([policyId], force);
   }
 
   public async generateTokensForPolicyIds(
     policyIds: string[],
     force: boolean = false
-  ): Promise<Record<string, string>> {
+  ): Promise<void> {
     const { agentTamperProtectionEnabled } = appContextService.getExperimentalFeatures();
 
     if (!agentTamperProtectionEnabled || !policyIds.length) {
-      return {};
+      return;
     }
 
-    const existingTokens = force
-      ? {}
-      : (await this.getDecryptedTokensForPolicyIds(policyIds)).reduce(
-          (acc, { policy_id: policyId, token }) => {
-            acc[policyId] = token;
-            return acc;
-          },
-          {} as Record<string, string>
-        );
+    const existingTokens = new Set();
+
+    if (!force) {
+      (await this.getTokenObjectsByIncludeFilter(policyIds)).forEach((tokenObject) => {
+        existingTokens.add(tokenObject._source[UNINSTALL_TOKENS_SAVED_OBJECT_TYPE].policy_id);
+      });
+    }
     const missingTokenPolicyIds = force
       ? policyIds
-      : policyIds.filter((policyId) => !existingTokens[policyId]);
+      : policyIds.filter((policyId) => !existingTokens.has(policyId));
 
     const newTokensMap = missingTokenPolicyIds.reduce((acc, policyId) => {
       const token = this.generateToken();
@@ -338,7 +340,6 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
         [policyId]: token,
       };
     }, {} as Record<string, string>);
-
     await this.persistTokens(missingTokenPolicyIds, newTokensMap);
     if (force) {
       const config = appContextService.getConfig();
@@ -349,21 +350,9 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
           await agentPolicyService.deployPolicies(this.soClient, policyIdsBatch)
       );
     }
-
-    const tokensMap = {
-      ...existingTokens,
-      ...newTokensMap,
-    };
-
-    return Object.entries(tokensMap).reduce((acc, [policyId, token]) => {
-      acc[policyId] = this.hashToken(token);
-      return acc;
-    }, {} as Record<string, string>);
   }
 
-  public async generateTokensForAllPolicies(
-    force: boolean = false
-  ): Promise<Record<string, string>> {
+  public async generateTokensForAllPolicies(force: boolean = false): Promise<void> {
     const policyIds = await this.getAllPolicyIds();
     return this.generateTokensForPolicyIds(policyIds, force);
   }

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -229,10 +229,6 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
         this.assertToken(attributes);
         this.assertCreatedAt(createdAt);
 
-        // todo: can we give warnings while setup?
-        // todo: give error when enabling stuff
-        // todo: maybe this is a function: check tokens!
-
         return {
           id: _id,
           policy_id: attributes.policy_id,

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -510,7 +510,9 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
 
   private assertToken(attributes: UninstallTokenSOAttributes | undefined) {
     if (!attributes?.token && !attributes?.token_plain) {
-      throw new UninstallTokenError('Uninstall Token is missing the token.');
+      throw new UninstallTokenError(
+        'Invalid uninstall token: Saved object is missing the `token` attribute.'
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

This PR should help in case of an improper encryption key rotation. Prior to this PR, the user was blocked on Fleet setup:
![image](https://github.com/elastic/security-team/assets/39014407/f9a90754-a57f-43be-a196-48f55b27da35)

This PR does the following:
- don't decrypt tokens when trying to generate missing tokens on Fleet setup -> hence no error is thrown
- but, checks if existing tokens can be decrypted, and returns with a non-fatal error during Fleet setup if not
![image](https://github.com/elastic/kibana/assets/39014407/ed72ddb1-e5c1-4002-80f3-e91181efc822)
<img width="607" alt="image" src="https://github.com/elastic/kibana/assets/39014407/3e19d359-7ae7-4e4d-94a4-c662b42104e1">
<img width="1102" alt="image" src="https://github.com/elastic/kibana/assets/39014407/779bada0-ee5b-48a6-ae62-f19d9cdf8d51">

- prohibits user to enable tamper protection when the given policy's uninstall token cannot be decrypted
![image](https://github.com/elastic/kibana/assets/39014407/3f2fe821-0fa8-4daf-8a00-9cc4fe386cae)

- no change: still throws error when trying to decrypt
![image](https://github.com/elastic/kibana/assets/39014407/0896ee69-667e-4b55-bd32-9ff6442305df)
<img width="1268" alt="image" src="https://github.com/elastic/kibana/assets/39014407/9c51c8dd-f373-4007-abd6-1494af106352">


## Reproducing the encryption key issue
- setup a Kibana, add at least one policy (probably Fleet policy is enough)
- modify (or add a new) encryption key in your `kibana.dev.yml`:
```yml
xpack.encryptedSavedObjects.encryptionKey: "some-random-encryption-key-min-32-bytes"
```


### Checklist

Delete any items that are not applicable to this PR.


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

