### PR TITLE
Upselling tooltips for alert assignments feature within Basic license

### DIFF
--- a/x-pack/packages/security-solution/upselling/messages/index.tsx
+++ b/x-pack/packages/security-solution/upselling/messages/index.tsx
@@ -14,3 +14,11 @@ export const UPGRADE_INVESTIGATION_GUIDE = (requiredLicense: string) =>
       requiredLicense,
     },
   });
+
+export const UPGRADE_ALERT_ASSIGNMENTS = (requiredLicense: string) =>
+  i18n.translate('securitySolutionPackages.alertAssignments.upsell', {
+    defaultMessage: 'Upgrade to {requiredLicense} to make use of alert assignments',
+    values: {
+      requiredLicense,
+    },
+  });

--- a/x-pack/packages/security-solution/upselling/service/types.ts
+++ b/x-pack/packages/security-solution/upselling/service/types.ts
@@ -17,4 +17,4 @@ export type UpsellingSectionId =
   | 'osquery_automated_response_actions'
   | 'ruleDetailsEndpointExceptions';
 
-export type UpsellingMessageId = 'investigation_guide';
+export type UpsellingMessageId = 'investigation_guide' | 'alert_assignments';

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.test.tsx
@@ -16,10 +16,14 @@ import type { AssigneesIdsSelection } from '../assignees/types';
 import { useGetCurrentUserProfile } from '../user_profiles/use_get_current_user_profile';
 import { useBulkGetUserProfiles } from '../user_profiles/use_bulk_get_user_profiles';
 import { useSuggestUsers } from '../user_profiles/use_suggest_users';
+import { useLicense } from '../../hooks/use_license';
+import { useUpsellingMessage } from '../../hooks/use_upselling';
 
 jest.mock('../user_profiles/use_get_current_user_profile');
 jest.mock('../user_profiles/use_bulk_get_user_profiles');
 jest.mock('../user_profiles/use_suggest_users');
+jest.mock('../../hooks/use_license');
+jest.mock('../../hooks/use_upselling');
 
 const mockUserProfiles = [
   {
@@ -70,6 +74,8 @@ describe('<FilterByAssigneesPopover />', () => {
       isLoading: false,
       data: mockUserProfiles,
     });
+    (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
+    (useUpsellingMessage as jest.Mock).mockReturnValue('Go for Platinum!');
   });
 
   it('should render closed popover component', () => {

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
@@ -59,11 +59,9 @@ export const FilterByAssigneesPopover: FC<FilterByAssigneesPopoverProps> = memo(
             <EuiToolTip
               position="bottom"
               content={
-                !isPlatinumPlus && upsellingMessage
-                  ? upsellingMessage
-                  : i18n.translate('xpack.securitySolution.filtersGroup.assignees.popoverTooltip', {
-                      defaultMessage: 'Filter by assignee',
-                    })
+                upsellingMessage ?? i18n.translate('xpack.securitySolution.filtersGroup.assignees.popoverTooltip', {
+                  defaultMessage: 'Filter by assignee',
+                })
               }
             >
               <EuiFilterButton

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
@@ -59,7 +59,8 @@ export const FilterByAssigneesPopover: FC<FilterByAssigneesPopoverProps> = memo(
             <EuiToolTip
               position="bottom"
               content={
-                upsellingMessage ?? i18n.translate('xpack.securitySolution.filtersGroup.assignees.popoverTooltip', {
+                upsellingMessage ??
+                i18n.translate('xpack.securitySolution.filtersGroup.assignees.popoverTooltip', {
                   defaultMessage: 'Filter by assignee',
                 })
               }

--- a/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/filter_group/filter_by_assignees.tsx
@@ -9,11 +9,13 @@ import type { FC } from 'react';
 import React, { memo, useCallback, useState } from 'react';
 
 import { i18n } from '@kbn/i18n';
-import { EuiFilterButton, EuiFilterGroup } from '@elastic/eui';
+import { EuiFilterButton, EuiFilterGroup, EuiToolTip } from '@elastic/eui';
 
 import { TEST_IDS } from './constants';
 import { AssigneesPopover } from '../assignees/assignees_popover';
 import type { AssigneesIdsSelection } from '../assignees/types';
+import { useLicense } from '../../hooks/use_license';
+import { useUpsellingMessage } from '../../hooks/use_upselling';
 
 export interface FilterByAssigneesPopoverProps {
   /**
@@ -32,6 +34,9 @@ export interface FilterByAssigneesPopoverProps {
  */
 export const FilterByAssigneesPopover: FC<FilterByAssigneesPopoverProps> = memo(
   ({ assignedUserIds, onSelectionChange }) => {
+    const isPlatinumPlus = useLicense().isPlatinumPlus();
+    const upsellingMessage = useUpsellingMessage('alert_assignments');
+
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
     const togglePopover = useCallback(() => setIsPopoverOpen((value) => !value), []);
 
@@ -51,19 +56,31 @@ export const FilterByAssigneesPopover: FC<FilterByAssigneesPopoverProps> = memo(
           assignedUserIds={assignedUserIds}
           showUnassignedOption={true}
           button={
-            <EuiFilterButton
-              data-test-subj={TEST_IDS.FILTER_BY_ASSIGNEES_BUTTON}
-              iconType="arrowDown"
-              badgeColor="subdued"
-              onClick={togglePopover}
-              isSelected={isPopoverOpen}
-              hasActiveFilters={selectedAssignees.length > 0}
-              numActiveFilters={selectedAssignees.length}
+            <EuiToolTip
+              position="bottom"
+              content={
+                !isPlatinumPlus && upsellingMessage
+                  ? upsellingMessage
+                  : i18n.translate('xpack.securitySolution.filtersGroup.assignees.popoverTooltip', {
+                      defaultMessage: 'Filter by assignee',
+                    })
+              }
             >
-              {i18n.translate('xpack.securitySolution.filtersGroup.assignees.buttonTitle', {
-                defaultMessage: 'Assignees',
-              })}
-            </EuiFilterButton>
+              <EuiFilterButton
+                data-test-subj={TEST_IDS.FILTER_BY_ASSIGNEES_BUTTON}
+                iconType="arrowDown"
+                badgeColor="subdued"
+                disabled={!isPlatinumPlus}
+                onClick={togglePopover}
+                isSelected={isPopoverOpen}
+                hasActiveFilters={selectedAssignees.length > 0}
+                numActiveFilters={selectedAssignees.length}
+              >
+                {i18n.translate('xpack.securitySolution.filtersGroup.assignees.buttonTitle', {
+                  defaultMessage: 'Assignees',
+                })}
+              </EuiFilterButton>
+            </EuiToolTip>
           }
           isPopoverOpen={isPopoverOpen}
           closePopover={togglePopover}

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.test.tsx
@@ -33,6 +33,7 @@ import { FilterGroup } from '../../../common/components/filter_group';
 import type { AlertsTableComponentProps } from '../../components/alerts_table/alerts_grouping';
 import { getMockedFilterGroupWithCustomFilters } from '../../../common/components/filter_group/mocks';
 import { TableId } from '@kbn/securitysolution-data-table';
+import { useUpsellingMessage } from '../../../common/hooks/use_upselling';
 
 // Test will fail because we will to need to mock some core services to make the test work
 // For now let's forget about SiemSearchBar and QueryBar
@@ -219,6 +220,7 @@ jest.mock('../../components/alerts_table/timeline_actions/use_add_bulk_to_timeli
 
 jest.mock('../../../common/components/visualization_actions/lens_embeddable');
 jest.mock('../../../common/components/page/use_refetch_by_session');
+jest.mock('../../../common/hooks/use_upselling');
 
 describe('DetectionEnginePageComponent', () => {
   beforeAll(() => {
@@ -239,6 +241,7 @@ describe('DetectionEnginePageComponent', () => {
     (FilterGroup as jest.Mock).mockImplementation(() => {
       return <span />;
     });
+    (useUpsellingMessage as jest.Mock).mockReturnValue('Go for Platinum!');
   });
   beforeEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/detection_engine/detection_engine.tsx
@@ -32,7 +32,6 @@ import {
   TableId,
 } from '@kbn/securitysolution-data-table';
 import { isEqual } from 'lodash';
-import { useLicense } from '../../../common/hooks/use_license';
 import { FilterByAssigneesPopover } from '../../../common/components/filter_group/filter_by_assignees';
 import type { AssigneesIdsSelection } from '../../../common/components/assignees/types';
 import { ALERTS_TABLE_REGISTRY_CONFIG_IDS } from '../../../../common/constants';
@@ -139,8 +138,6 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
   ] = useUserData();
   const { loading: listsConfigLoading, needsConfiguration: needsListsConfiguration } =
     useListsConfig();
-
-  const isPlatinumPlus = useLicense().isPlatinumPlus();
 
   const [assignees, setAssignees] = useState<AssigneesIdsSelection[]>([]);
   const handleSelectedAssignees = useCallback(
@@ -468,14 +465,12 @@ const DetectionEnginePageComponent: React.FC<DetectionEngineComponentProps> = ({
             <Display show={!globalFullScreen}>
               <HeaderPage title={i18n.PAGE_TITLE}>
                 <EuiFlexGroup gutterSize="m">
-                  {isPlatinumPlus && (
-                    <EuiFlexItem>
-                      <FilterByAssigneesPopover
-                        assignedUserIds={assignees}
-                        onSelectionChange={handleSelectedAssignees}
-                      />
-                    </EuiFlexItem>
-                  )}
+                  <EuiFlexItem>
+                    <FilterByAssigneesPopover
+                      assignedUserIds={assignees}
+                      onSelectionChange={handleSelectedAssignees}
+                    />
+                  </EuiFlexItem>
                   <EuiFlexItem>
                     <SecuritySolutionLinkButton
                       onClick={goToRules}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.test.tsx
@@ -19,6 +19,7 @@ import { useSetAlertAssignees } from '../../../../common/components/toolbar/bulk
 import { TestProviders } from '../../../../common/mock';
 import { ASSIGNEES_APPLY_BUTTON_TEST_ID } from '../../../../common/components/assignees/test_ids';
 import { useLicense } from '../../../../common/hooks/use_license';
+import { useUpsellingMessage } from '../../../../common/hooks/use_upselling';
 import {
   USERS_AVATARS_COUNT_BADGE_TEST_ID,
   USERS_AVATARS_PANEL_TEST_ID,
@@ -31,6 +32,7 @@ jest.mock('../../../../common/components/user_profiles/use_bulk_get_user_profile
 jest.mock('../../../../common/components/user_profiles/use_suggest_users');
 jest.mock('../../../../common/components/toolbar/bulk_actions/use_set_alert_assignees');
 jest.mock('../../../../common/hooks/use_license');
+jest.mock('../../../../common/hooks/use_upselling');
 jest.mock('../../../../detections/containers/detection_engine/alerts/use_alerts_privileges');
 
 const mockUserProfiles = [
@@ -75,6 +77,7 @@ describe('<Assignees />', () => {
     });
     (useAlertsPrivileges as jest.Mock).mockReturnValue({ hasIndexWrite: true });
     (useLicense as jest.Mock).mockReturnValue({ isPlatinumPlus: () => true });
+    (useUpsellingMessage as jest.Mock).mockReturnValue('Go for Platinum!');
 
     setAlertAssigneesMock = jest.fn().mockReturnValue(Promise.resolve());
     (useSetAlertAssignees as jest.Mock).mockReturnValue(setAlertAssigneesMock);

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
@@ -136,14 +136,13 @@ export const Assignees: FC<AssigneesProps> = memo(
                 togglePopover={togglePopover}
                 isDisabled={!hasIndexWrite || !isPlatinumPlus}
                 toolTipMessage={
-                  !isPlatinumPlus && upsellingMessage
-                    ? upsellingMessage
-                    : i18n.translate(
-                        'xpack.securitySolution.flyout.right.visualizations.assignees.popoverTooltip',
-                        {
-                          defaultMessage: 'Assign alert',
-                        }
-                      )
+                  upsellingMessage ??
+                  i18n.translate(
+                    'xpack.securitySolution.flyout.right.visualizations.assignees.popoverTooltip',
+                    {
+                      defaultMessage: 'Assign alert',
+                    }
+                  )
                 }
               />
             }

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/assignees.tsx
@@ -13,6 +13,7 @@ import { EuiButtonIcon, EuiFlexGroup, EuiFlexItem, EuiTitle, EuiToolTip } from '
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { useUpsellingMessage } from '../../../../common/hooks/use_upselling';
 import { useLicense } from '../../../../common/hooks/use_license';
 import { useAlertsPrivileges } from '../../../../detections/containers/detection_engine/alerts/use_alerts_privileges';
 import { useBulkGetUserProfiles } from '../../../../common/components/user_profiles/use_bulk_get_user_profiles';
@@ -27,27 +28,21 @@ import {
   ASSIGNEES_TITLE_TEST_ID,
 } from './test_ids';
 
-const UpdateAssigneesButton: FC<{ togglePopover: () => void; isDisabled: boolean }> = memo(
-  ({ togglePopover, isDisabled }) => (
-    <EuiToolTip
-      position="bottom"
-      content={i18n.translate(
-        'xpack.securitySolution.flyout.right.visualizations.assignees.popoverTooltip',
-        {
-          defaultMessage: 'Assign alert',
-        }
-      )}
-    >
-      <EuiButtonIcon
-        aria-label="Update assignees"
-        data-test-subj={ASSIGNEES_ADD_BUTTON_TEST_ID}
-        iconType={'plusInCircle'}
-        onClick={togglePopover}
-        isDisabled={isDisabled}
-      />
-    </EuiToolTip>
-  )
-);
+const UpdateAssigneesButton: FC<{
+  isDisabled: boolean;
+  toolTipMessage: string;
+  togglePopover: () => void;
+}> = memo(({ togglePopover, isDisabled, toolTipMessage }) => (
+  <EuiToolTip position="bottom" content={toolTipMessage}>
+    <EuiButtonIcon
+      aria-label="Update assignees"
+      data-test-subj={ASSIGNEES_ADD_BUTTON_TEST_ID}
+      iconType={'plusInCircle'}
+      onClick={togglePopover}
+      isDisabled={isDisabled}
+    />
+  </EuiToolTip>
+));
 UpdateAssigneesButton.displayName = 'UpdateAssigneesButton';
 
 export interface AssigneesProps {
@@ -73,6 +68,7 @@ export interface AssigneesProps {
 export const Assignees: FC<AssigneesProps> = memo(
   ({ eventId, assignedUserIds, onAssigneesUpdated }) => {
     const isPlatinumPlus = useLicense().isPlatinumPlus();
+    const upsellingMessage = useUpsellingMessage('alert_assignments');
 
     const { hasIndexWrite } = useAlertsPrivileges();
     const setAlertAssignees = useSetAlertAssignees();
@@ -139,6 +135,16 @@ export const Assignees: FC<AssigneesProps> = memo(
               <UpdateAssigneesButton
                 togglePopover={togglePopover}
                 isDisabled={!hasIndexWrite || !isPlatinumPlus}
+                toolTipMessage={
+                  !isPlatinumPlus && upsellingMessage
+                    ? upsellingMessage
+                    : i18n.translate(
+                        'xpack.securitySolution.flyout.right.visualizations.assignees.popoverTooltip',
+                        {
+                          defaultMessage: 'Assign alert',
+                        }
+                      )
+                }
               />
             }
             isPopoverOpen={isPopoverOpen}

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/index.test.tsx
@@ -26,6 +26,7 @@ import {
   DEFAULT_PREVIEW_INDEX,
   ASSISTANT_FEATURE_ID,
 } from '../../../../../common/constants';
+import { useUpsellingMessage } from '../../../../common/hooks/use_upselling';
 
 const ecsData: Ecs = {
   _id: '1',
@@ -128,6 +129,7 @@ jest.mock('../../../../explore/containers/risk_score', () => {
     }),
   };
 });
+jest.mock('../../../../common/hooks/use_upselling');
 
 const defaultProps = {
   scopeId: TimelineId.test,
@@ -181,6 +183,7 @@ describe('event details panel component', () => {
       },
     });
     (useGetUserCasesPermissions as jest.Mock).mockReturnValue(allCasesPermissions());
+    (useUpsellingMessage as jest.Mock).mockReturnValue('Go for Platinum!');
   });
   afterEach(() => {
     jest.clearAllMocks();

--- a/x-pack/plugins/security_solution_ess/public/upselling/register_upsellings.tsx
+++ b/x-pack/plugins/security_solution_ess/public/upselling/register_upsellings.tsx
@@ -16,7 +16,10 @@ import type {
 } from '@kbn/security-solution-upselling/service';
 import type { ILicense, LicenseType } from '@kbn/licensing-plugin/public';
 import React, { lazy } from 'react';
-import { UPGRADE_INVESTIGATION_GUIDE } from '@kbn/security-solution-upselling/messages';
+import {
+  UPGRADE_ALERT_ASSIGNMENTS,
+  UPGRADE_INVESTIGATION_GUIDE,
+} from '@kbn/security-solution-upselling/messages';
 import type { Services } from '../common/services';
 import { withServicesProvider } from '../common/services';
 const EntityAnalyticsUpsellingLazy = lazy(
@@ -106,5 +109,10 @@ export const upsellingMessages: UpsellingMessages = [
     id: 'investigation_guide',
     minimumLicenseRequired: 'platinum',
     message: UPGRADE_INVESTIGATION_GUIDE('Platinum'),
+  },
+  {
+    id: 'alert_assignments',
+    minimumLicenseRequired: 'platinum',
+    message: UPGRADE_ALERT_ASSIGNMENTS('Platinum'),
   },
 ];

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/assignments/assignments_ess_basic.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_alerts/assignments/assignments_ess_basic.cy.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { login } from '../../../../tasks/login';
 import { getNewRule } from '../../../../objects/rule';
 import { expandFirstAlert } from '../../../../tasks/alerts';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -20,6 +21,21 @@ import {
 describe('Alert user assignment - Basic License', { tags: ['@ess'] }, () => {
   before(() => {
     cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
+    login();
+    cy.request({
+      method: 'POST',
+      url: '/api/license/start_basic?acknowledge=true',
+      headers: {
+        'kbn-xsrf': 'cypress-creds',
+        'x-elastic-internal-origin': 'security-solution',
+      },
+    }).then(({ body }) => {
+      cy.log(`body: ${JSON.stringify(body)}`);
+      expect(body).contains({
+        acknowledged: true,
+        basic_was_started: true,
+      });
+    });
   });
 
   after(() => {
@@ -31,15 +47,6 @@ describe('Alert user assignment - Basic License', { tags: ['@ess'] }, () => {
     deleteAlertsAndRules();
     createRule(getNewRule({ rule_id: 'new custom rule' }));
     waitForAlertsToPopulate();
-
-    cy.request({
-      method: 'POST',
-      url: '/api/license/start_basic?acknowledge=true',
-      headers: {
-        'kbn-xsrf': 'cypress-creds',
-        'x-elastic-internal-origin': 'security-solution',
-      },
-    });
   });
 
   it('user with Basic license should not be able to update assignees', () => {


### PR DESCRIPTION
## Summary

These changes add upselling for "Alert assignments" feature within Basic license:

<img width="619" alt="Screenshot 2023-11-27 at 19 51 36" src="https://github.com/elastic/kibana/assets/2700761/b5d9cf36-d2c7-4387-a3f0-83dbf5c616e8">

**NOTE**: exact upselling message is still under design team review.
