### PR TITLE
[OAS] Adds examples for find rules API parameters

### DIFF
--- a/x-pack/plugins/alerting/docs/openapi/bundled.json
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.json
@@ -500,7 +500,7 @@
               "type": "string",
               "default": "OR",
               "examples": [
-                "OR"
+                "AND"
               ]
             }
           },
@@ -568,7 +568,10 @@
             "in": "query",
             "description": "An Elasticsearch simple_query_string query that filters the objects in the response.",
             "schema": {
-              "type": "string"
+              "type": "string",
+              "examples": [
+                "threshold +-test*"
+              ]
             }
           },
           {
@@ -578,7 +581,10 @@
             "schema": {
               "oneOf": [
                 {
-                  "type": "string"
+                  "type": "string",
+                  "examples": [
+                    "name"
+                  ]
                 },
                 {
                   "type": "array",

--- a/x-pack/plugins/alerting/docs/openapi/bundled.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/bundled.yaml
@@ -305,7 +305,7 @@ paths:
             type: string
             default: OR
             examples:
-              - OR
+              - AND
         - name: fields
           in: query
           description: The fields to return in the `attributes` key of the response.
@@ -350,12 +350,16 @@ paths:
           description: An Elasticsearch simple_query_string query that filters the objects in the response.
           schema:
             type: string
+            examples:
+              - threshold +-test*
         - name: search_fields
           in: query
           description: The fields to perform the simple_query_string parsed query against.
           schema:
             oneOf:
               - type: string
+                examples:
+                  - name
               - type: array
                 items:
                   type: string

--- a/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rules@_find.yaml
+++ b/x-pack/plugins/alerting/docs/openapi/paths/s@{spaceid}@api@alerting@rules@_find.yaml
@@ -20,7 +20,7 @@ get:
         type: string
         default: OR
         examples:
-          - OR
+          - AND
     - name: fields
       in: query
       description: The fields to return in the `attributes` key of the response.
@@ -69,12 +69,16 @@ get:
       description: An Elasticsearch simple_query_string query that filters the objects in the response.
       schema:
         type: string
+        examples:
+          - threshold +-test*
     - name: search_fields
       in: query
       description: The fields to perform the simple_query_string parsed query against.
       schema:
         oneOf:
           - type: string
+            examples:
+              - name
           - type: array
             items:
               type: string


### PR DESCRIPTION
## Summary

This PR adds some examples for the `search_fields` and `search` query parameters in the find rules API.
These parameters support simpley query string syntax per https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax