### PR TITLE
[chore] Adjust Renovate settings for Storybook

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -458,12 +458,37 @@
       "matchPackagePatterns": [
         "^@storybook"
       ],
+      "excludePackageNames": [
+        "@storybook/testing-react"
+      ],
       "labels": [
         "Team:Operations",
-        "release_note:skip"
+        "release_note:skip",
+        "ci:build-storybooks",
+        "backport:skip"
       ],
       "enabled": true,
       "allowedVersions": "<7.0"
+    },
+    {
+      "groupName": "@storybook/testing-react",
+      "reviewers": [
+        "team:kibana-operations"
+      ],
+      "matchBaseBranches": [
+        "main"
+      ],
+      "matchPackageNames": [
+        "@storybook/testing-react"
+      ],
+      "labels": [
+        "Team:Operations",
+        "release_note:skip",
+        "ci:build-storybooks",
+        "backport:skip"
+      ],
+      "enabled": true,
+      "allowedVersions": "<2.0"
     },
     {
       "groupName": "react-query",


### PR DESCRIPTION
## Summary

This is a continuation of #171453 to stop package updates in #169655 due to Storybook V7 breaking changes. `@storybook/testing-react` uses different versioning than other `@storybook/*` packages, so requires a new rule. Also adjusts the default labelling for Storybook PRs.
