### PR TITLE
[Search] Update Connector ACL name pattern

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -26,7 +26,6 @@ import {
   ENTERPRISE_SEARCH_DOCUMENTS_DEFAULT_DOC_COUNT,
 } from '../../../../../common/constants';
 import { Status } from '../../../../../common/types/api';
-import { stripSearchPrefix } from '../../../../../common/utils/strip_search_prefix';
 
 import { DEFAULT_META } from '../../../shared/constants';
 import { KibanaLogic } from '../../../shared/kibana';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/documents.tsx
@@ -69,7 +69,7 @@ export const SearchIndexDocuments: React.FC = () => {
   const indexToShow =
     selectedIndexType === 'content-index'
       ? indexName
-      : stripSearchPrefix(indexName, CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX);
+      : `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexName}`;
   const mappingLogic = mappingsWithPropsApiLogic(indexToShow);
   const documentLogic = searchDocumentsApiLogic(indexToShow);
 

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.test.ts
@@ -345,7 +345,7 @@ describe('startSync lib function', () => {
           },
           filtering: null,
           id: 'connectorId',
-          index_name: `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}index_name`,
+          index_name: `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}search-index_name`,
           language: null,
           pipeline: null,
           service_type: null,

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/start_sync.ts
@@ -23,7 +23,6 @@ import {
 } from '../../../common/constants';
 
 import { ErrorCode } from '../../../common/types/error_codes';
-import { stripSearchPrefix } from '../../../common/utils/strip_search_prefix';
 
 export const startSync = async (
   client: IScopedClusterClient,
@@ -70,10 +69,9 @@ export const startSync = async (
       });
     }
 
-    const indexNameWithoutSearchPrefix = index_name ? stripSearchPrefix(index_name) : '';
     const targetIndexName =
       jobType === SyncJobType.ACCESS_CONTROL
-        ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexNameWithoutSearchPrefix}`
+        ? `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${index_name}`
         : index_name ?? undefined;
 
     return await startConnectorSync(client.asCurrentUser, {

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.test.ts
@@ -32,7 +32,7 @@ describe('deleteAccessControlIndex lib function', () => {
         deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
       ).resolves.toEqual(true);
       expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
-        index: 'indexName',
+        index: '.search-acl-filter-indexName',
       });
     });
   });
@@ -58,7 +58,7 @@ describe('deleteAccessControlIndex lib function', () => {
         deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
       ).resolves.not.toThrowError();
       expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
-        index: 'indexName',
+        index: '.search-acl-filter-indexName',
       });
     });
   });
@@ -84,7 +84,7 @@ describe('deleteAccessControlIndex lib function', () => {
         deleteAccessControlIndex(mockClient as unknown as IScopedClusterClient, 'indexName')
       ).rejects.toEqual(mockErrorRejection);
       expect(mockClient.asCurrentUser.indices.delete).toHaveBeenCalledWith({
-        index: 'indexName',
+        index: '.search-acl-filter-indexName',
       });
     });
   });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/delete_access_control_index.ts
@@ -8,14 +8,15 @@
 import { IScopedClusterClient } from '@kbn/core/server';
 
 import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../common/constants';
-import { stripSearchPrefix } from '../../../common/utils/strip_search_prefix';
 
 import { isIndexNotFoundException } from '../../utils/identify_exceptions';
 
-export const deleteAccessControlIndex = async (client: IScopedClusterClient, index: string) => {
+export const deleteAccessControlIndex = async (client: IScopedClusterClient, indexName: string) => {
+  const aclIndexName = `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexName}`;
+
   try {
     return await client.asCurrentUser.indices.delete({
-      index: stripSearchPrefix(index, CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX),
+      index: aclIndexName,
     });
   } catch (e) {
     // Gracefully exit if index not found. This is a valid case.

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
@@ -94,7 +94,7 @@ describe('generateApiKey lib function', () => {
           cluster: ['monitor'],
           index: [
             {
-              names: ['search-test', '.search-acl-filter-test', `${CONNECTORS_INDEX}*`],
+              names: ['search-test', '.search-acl-filter-search-test', `${CONNECTORS_INDEX}*`],
               privileges: ['all'],
             },
           ],

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
@@ -7,13 +7,16 @@
 
 import { IScopedClusterClient } from '@kbn/core/server';
 
-import { ConnectorDocument, CONNECTORS_INDEX } from '@kbn/search-connectors';
+import {
+  ConnectorDocument,
+  CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX,
+  CONNECTORS_INDEX,
+} from '@kbn/search-connectors';
 
 import { toAlphanumeric } from '../../../common/utils/to_alphanumeric';
 
 export const generateApiKey = async (client: IScopedClusterClient, indexName: string) => {
-  // removes the "search-" prefix if present, and applies the new prefix
-  const aclIndexName = indexName.replace(/^(?:search-)?(.*)$/, '.search-acl-filter-$1');
+  const aclIndexName = `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexName}`;
 
   const apiKeyResult = await client.asCurrentUser.security.createApiKey({
     name: `${indexName}-connector`,


### PR DESCRIPTION
## Summary

This PR changes the ACL index pattern logic.
Previously an index named `search-foo` would create an ACL index named `.search-acl-filter-foo`. If a user wants to also use an index named just `foo`, the ACL index generated would be identical.
These changes simplify the index name creation. Now, indices will look like:

- `search-foo` -> `.search-acl-filter-search-foo`
- `foo` -> `.search-acl-filter-foo`

Migrations for this have been added already to Enterprise Search.
