### PR TITLE
[Fleet] Support integration secrets with `required: false`

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/components/steps/components/package_policy_input_var_field.tsx
@@ -338,8 +338,8 @@ const SecretFieldWrapper = ({ children }: { children: React.ReactNode }) => {
 const SecretFieldLabel = ({ fieldLabel }: { fieldLabel: string }) => {
   return (
     <>
-      <EuiFlexGroup alignItems="center" gutterSize="xs">
-        <EuiFlexItem grow={true} aria-label={fieldLabel}>
+      <EuiFlexGroup alignItems="flexEnd" gutterSize="xs">
+        <EuiFlexItem grow={false} aria-label={fieldLabel}>
           {fieldLabel}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
@@ -376,12 +376,37 @@ function SecretInputField({
   setIsDirty,
   isDirty,
 }: InputComponentProps) {
-  const [editMode, setEditMode] = useState(isEditPage && !value);
+  const [isReplacing, setIsReplacing] = useState(isEditPage && !value);
   const valueOnFirstRender = useRef(value);
 
+  const hasExistingValue = !!valueOnFirstRender.current;
   const lowercaseTitle = varDef.title?.toLowerCase();
+  const showInactiveReplaceUi = isEditPage && !isReplacing && hasExistingValue;
+  const valueIsSecretRef = value && value?.isSecretRef;
 
-  if (isEditPage && !editMode) {
+  const inputComponent = getInputComponent({
+    varDef,
+    value: isReplacing && valueIsSecretRef ? '' : value,
+    onChange,
+    frozen,
+    packageName,
+    packageType,
+    datastreams,
+    isEditPage,
+    isInvalid,
+    fieldLabel,
+    fieldTestSelector,
+    isDirty,
+    setIsDirty,
+  });
+
+  // If there's no value for this secret, display the input as its "brand new" creation state
+  // instead of the "replace" state
+  if (!hasExistingValue) {
+    return inputComponent;
+  }
+
+  if (showInactiveReplaceUi) {
     return (
       <>
         <EuiText size="s" color="subdued">
@@ -395,7 +420,7 @@ function SecretInputField({
         </EuiText>
         <EuiSpacer size="s" />
         <EuiButtonEmpty
-          onClick={() => setEditMode(true)}
+          onClick={() => setIsReplacing(true)}
           color="primary"
           iconType="refresh"
           iconSide="left"
@@ -413,28 +438,11 @@ function SecretInputField({
     );
   }
 
-  const valueIsSecretRef = value && value?.isSecretRef;
-  const field = getInputComponent({
-    varDef,
-    value: editMode && valueIsSecretRef ? '' : value,
-    onChange,
-    frozen,
-    packageName,
-    packageType,
-    datastreams,
-    isEditPage,
-    isInvalid,
-    fieldLabel,
-    fieldTestSelector,
-    isDirty,
-    setIsDirty,
-  });
-
-  if (editMode) {
+  if (isReplacing) {
     const cancelButton = (
       <EuiButtonEmpty
         onClick={() => {
-          setEditMode(false);
+          setIsReplacing(false);
           setIsDirty(false);
           onChange(valueOnFirstRender.current);
         }}
@@ -455,12 +463,12 @@ function SecretInputField({
     return (
       <EuiFlexGroup direction="column" gutterSize="s" alignItems="flexStart">
         <EuiFlexItem grow={false} style={{ width: '100%' }}>
-          {field}
+          {inputComponent}
         </EuiFlexItem>
         <EuiFlexItem grow={false}>{cancelButton}</EuiFlexItem>
       </EuiFlexGroup>
     );
   }
 
-  return field;
+  return inputComponent;
 }

--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -12,679 +12,635 @@
  * 2[0].
  */
 
+import { v4 as uuidv4 } from 'uuid';
+
+import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
+
+import { createAppContextStartContractMock } from '../mocks';
+
 import type { NewPackagePolicy, PackageInfo } from '../types';
 
-import { getPolicySecretPaths, diffSecretPaths } from './secrets';
+import { appContextService } from './app_context';
 
-describe('getPolicySecretPaths', () => {
-  describe('integration package with one policy template', () => {
-    const mockIntegrationPackage = {
-      name: 'mock-package',
-      title: 'Mock package',
-      version: '0[0].0',
-      description: 'description',
-      type: 'integration',
-      status: 'not_installed',
-      vars: [
-        { name: 'pkg-secret-1', type: 'text', secret: true },
-        { name: 'pkg-secret-2', type: 'text', secret: true },
-      ],
-      data_streams: [
-        {
-          dataset: 'somedataset',
-          streams: [
-            {
-              input: 'foo',
-              title: 'Foo',
-              vars: [
-                { name: 'stream-secret-1', type: 'text', secret: true },
-                { name: 'stream-secret-2', type: 'text', secret: true },
-              ],
+import { getPolicySecretPaths, diffSecretPaths, extractAndWriteSecrets } from './secrets';
+
+describe('secrets', () => {
+  let mockContract: ReturnType<typeof createAppContextStartContractMock>;
+
+  beforeEach(async () => {
+    // prevents `Logger not set.` and other appContext errors
+    mockContract = createAppContextStartContractMock();
+    appContextService.start(mockContract);
+  });
+
+  describe('getPolicySecretPaths', () => {
+    describe('integration package with one policy template', () => {
+      const mockIntegrationPackage = {
+        name: 'mock-package',
+        title: 'Mock package',
+        version: '0[0].0',
+        description: 'description',
+        type: 'integration',
+        status: 'not_installed',
+        vars: [
+          { name: 'pkg-secret-1', type: 'text', secret: true },
+          { name: 'pkg-secret-2', type: 'text', secret: true },
+        ],
+        data_streams: [
+          {
+            dataset: 'somedataset',
+            streams: [
+              {
+                input: 'foo',
+                title: 'Foo',
+                vars: [
+                  { name: 'stream-secret-1', type: 'text', secret: true },
+                  { name: 'stream-secret-2', type: 'text', secret: true },
+                ],
+              },
+            ],
+          },
+        ],
+        policy_templates: [
+          {
+            name: 'pkgPolicy1',
+            title: 'Package policy 1',
+            description: 'test package policy',
+            inputs: [
+              {
+                type: 'foo',
+                title: 'Foo',
+                vars: [
+                  { default: 'foo-input-var-value', name: 'foo-input-var-name', type: 'text' },
+                  {
+                    name: 'input-secret-1',
+                    type: 'text',
+                    secret: true,
+                  },
+                  {
+                    name: 'input-secret-2',
+                    type: 'text',
+                    secret: true,
+                  },
+                  { name: 'foo-input3-var-name', type: 'text', multi: true },
+                ],
+              },
+            ],
+          },
+        ],
+      } as unknown as PackageInfo;
+      it('policy with package level secret vars', () => {
+        const packagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
             },
-          ],
-        },
-      ],
-      policy_templates: [
-        {
-          name: 'pkgPolicy1',
-          title: 'Package policy 1',
-          description: 'test package policy',
+            'pkg-secret-2': {
+              value: 'pkg-secret-2-val',
+            },
+          },
+          inputs: [],
+        } as unknown as NewPackagePolicy;
+
+        expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
+          {
+            path: 'vars.pkg-secret-1',
+            value: {
+              value: 'pkg-secret-1-val',
+            },
+          },
+          {
+            path: 'vars.pkg-secret-2',
+            value: {
+              value: 'pkg-secret-2-val',
+            },
+          },
+        ]);
+      });
+      it('policy with package level secret vars and only one set', () => {
+        const packagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
+            },
+          },
+          inputs: [],
+        } as unknown as NewPackagePolicy;
+
+        expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
+          {
+            path: 'vars.pkg-secret-1',
+            value: {
+              value: 'pkg-secret-1-val',
+            },
+          },
+        ]);
+      });
+      it('policy with input level secret vars', () => {
+        const packagePolicy = {
           inputs: [
             {
               type: 'foo',
-              title: 'Foo',
-              vars: [
-                { default: 'foo-input-var-value', name: 'foo-input-var-name', type: 'text' },
-                {
-                  name: 'input-secret-1',
-                  type: 'text',
-                  secret: true,
+              policy_template: 'pkgPolicy1',
+              vars: {
+                'input-secret-1': {
+                  value: 'input-secret-1-val',
                 },
-                {
-                  name: 'input-secret-2',
-                  type: 'text',
-                  secret: true,
+                'input-secret-2': {
+                  value: 'input-secret-2-val',
                 },
-                { name: 'foo-input3-var-name', type: 'text', multi: true },
+              },
+              streams: [],
+            },
+          ],
+        } as unknown as NewPackagePolicy;
+
+        expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
+          {
+            path: 'inputs[0].vars.input-secret-1',
+            value: { value: 'input-secret-1-val' },
+          },
+          {
+            path: 'inputs[0].vars.input-secret-2',
+            value: { value: 'input-secret-2-val' },
+          },
+        ]);
+      });
+      it('stream level secret vars', () => {
+        const packagePolicy = {
+          inputs: [
+            {
+              type: 'foo',
+              policy_template: 'pkgPolicy1',
+              streams: [
+                {
+                  data_stream: {
+                    dataset: 'somedataset',
+                    type: 'logs',
+                  },
+                  vars: {
+                    'stream-secret-1': {
+                      value: 'stream-secret-1-value',
+                    },
+                    'stream-secret-2': {
+                      value: 'stream-secret-2-value',
+                    },
+                  },
+                },
               ],
             },
           ],
-        },
-      ],
-    } as unknown as PackageInfo;
-    it('policy with package level secret vars', () => {
-      const packagePolicy = {
-        vars: {
-          'pkg-secret-1': {
-            value: 'pkg-secret-1-val',
-          },
-          'pkg-secret-2': {
-            value: 'pkg-secret-2-val',
-          },
-        },
-        inputs: [],
-      } as unknown as NewPackagePolicy;
+        } as unknown as NewPackagePolicy;
 
-      expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
-        {
-          path: 'vars.pkg-secret-1',
-          value: {
-            value: 'pkg-secret-1-val',
-          },
-        },
-        {
-          path: 'vars.pkg-secret-2',
-          value: {
-            value: 'pkg-secret-2-val',
-          },
-        },
-      ]);
-    });
-    it('policy with package level secret vars and only one set', () => {
-      const packagePolicy = {
-        vars: {
-          'pkg-secret-1': {
-            value: 'pkg-secret-1-val',
-          },
-        },
-        inputs: [],
-      } as unknown as NewPackagePolicy;
-
-      expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
-        {
-          path: 'vars.pkg-secret-1',
-          value: {
-            value: 'pkg-secret-1-val',
-          },
-        },
-      ]);
-    });
-    it('policy with input level secret vars', () => {
-      const packagePolicy = {
-        inputs: [
+        expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
           {
-            type: 'foo',
-            policy_template: 'pkgPolicy1',
-            vars: {
-              'input-secret-1': {
-                value: 'input-secret-1-val',
-              },
-              'input-secret-2': {
-                value: 'input-secret-2-val',
-              },
-            },
-            streams: [],
+            path: 'inputs[0].streams[0].vars.stream-secret-1',
+            value: { value: 'stream-secret-1-value' },
           },
-        ],
-      } as unknown as NewPackagePolicy;
-
-      expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
-        {
-          path: 'inputs[0].vars.input-secret-1',
-          value: { value: 'input-secret-1-val' },
-        },
-        {
-          path: 'inputs[0].vars.input-secret-2',
-          value: { value: 'input-secret-2-val' },
-        },
-      ]);
-    });
-    it('stream level secret vars', () => {
-      const packagePolicy = {
-        inputs: [
           {
-            type: 'foo',
-            policy_template: 'pkgPolicy1',
-            streams: [
+            path: 'inputs[0].streams[0].vars.stream-secret-2',
+            value: { value: 'stream-secret-2-value' },
+          },
+        ]);
+      });
+    });
+
+    describe('integration package with multiple policy templates (e.g AWS)', () => {
+      const miniAWsPackage = {
+        name: 'aws',
+        title: 'AWS',
+        version: '0.5.3',
+        release: 'beta',
+        description: 'AWS Integration',
+        type: 'integration',
+        policy_templates: [
+          {
+            name: 'billing',
+            title: 'AWS Billing',
+            description: 'Collect AWS billing metrics',
+            data_streams: ['billing'],
+            inputs: [
               {
-                data_stream: {
-                  dataset: 'somedataset',
-                  type: 'logs',
-                },
-                vars: {
-                  'stream-secret-1': {
-                    value: 'stream-secret-1-value',
+                type: 'aws/metrics',
+                title: 'Collect billing metrics',
+                description: 'Collect billing metrics',
+                input_group: 'metrics',
+                vars: [
+                  {
+                    name: 'password',
+                    type: 'text',
+                    secret: true,
                   },
-                  'stream-secret-2': {
-                    value: 'stream-secret-2-value',
+                ],
+              },
+            ],
+          },
+          {
+            name: 'cloudtrail',
+            title: 'AWS Cloudtrail',
+            description: 'Collect logs from AWS Cloudtrail',
+            data_streams: ['cloudtrail'],
+            inputs: [
+              {
+                type: 's3',
+                title: 'Collect logs from Cloudtrail service',
+                description: 'Collecting Cloudtrail logs using S3 input',
+                input_group: 'logs',
+                vars: [
+                  {
+                    name: 'password',
+                    type: 'text',
+                    secret: true,
                   },
-                },
+                ],
+              },
+              {
+                type: 'httpjson',
+                title: 'Collect logs from third-party REST API (experimental)',
+                description: 'Collect logs from third-party REST API (experimental)',
+                input_group: 'logs',
+                vars: [
+                  {
+                    name: 'password',
+                    type: 'text',
+                    secret: true,
+                  },
+                ],
               },
             ],
           },
         ],
-      } as unknown as NewPackagePolicy;
-
-      expect(getPolicySecretPaths(packagePolicy, mockIntegrationPackage)).toEqual([
-        {
-          path: 'inputs[0].streams[0].vars.stream-secret-1',
-          value: { value: 'stream-secret-1-value' },
-        },
-        {
-          path: 'inputs[0].streams[0].vars.stream-secret-2',
-          value: { value: 'stream-secret-2-value' },
-        },
-      ]);
-    });
-  });
-
-  describe('integration package with multiple policy templates (e.g AWS)', () => {
-    const miniAWsPackage = {
-      name: 'aws',
-      title: 'AWS',
-      version: '0.5.3',
-      release: 'beta',
-      description: 'AWS Integration',
-      type: 'integration',
-      policy_templates: [
-        {
-          name: 'billing',
-          title: 'AWS Billing',
-          description: 'Collect AWS billing metrics',
-          data_streams: ['billing'],
+        vars: [
+          {
+            name: 'secret_access_key',
+            type: 'text',
+            title: 'Secret Access Key',
+            multi: false,
+            required: false,
+            show_user: false,
+            secret: true,
+          },
+        ],
+        data_streams: [
+          {
+            type: 'metrics',
+            dataset: 'aws.billing',
+            title: 'AWS billing metrics',
+            release: 'beta',
+            streams: [
+              {
+                input: 'aws/metrics',
+                vars: [
+                  {
+                    name: 'password',
+                    type: 'text',
+                    secret: true,
+                  },
+                ],
+                template_path: 'stream.yml.hbs',
+                title: 'AWS Billing metrics',
+                description: 'Collect AWS billing metrics',
+                enabled: true,
+              },
+            ],
+            package: 'aws',
+            path: 'billing',
+          },
+          {
+            type: 'logs',
+            dataset: 'aws.cloudtrail',
+            title: 'AWS CloudTrail logs',
+            release: 'beta',
+            ingest_pipeline: 'default',
+            streams: [
+              {
+                input: 's3',
+                vars: [
+                  {
+                    name: 'password',
+                    type: 'text',
+                    secret: true,
+                  },
+                ],
+                template_path: 's3.yml.hbs',
+              },
+              {
+                input: 'httpjson',
+                vars: [
+                  {
+                    name: 'username',
+                    type: 'text',
+                    title: 'Splunk REST API Username',
+                    multi: false,
+                    required: true,
+                    show_user: true,
+                  },
+                  {
+                    name: 'password',
+                    type: 'password',
+                    title: 'Splunk REST API Password',
+                    multi: false,
+                    required: true,
+                    show_user: true,
+                    secret: true,
+                  },
+                ],
+                template_path: 'httpjson.yml.hbs',
+              },
+            ],
+            package: 'aws',
+            path: 'cloudtrail',
+          },
+        ],
+      } as PackageInfo;
+      it('single policy with package + input + stream level secret var', () => {
+        const policy = {
+          vars: {
+            secret_access_key: {
+              value: 'my_secret_access_key',
+            },
+          },
           inputs: [
             {
               type: 'aws/metrics',
-              title: 'Collect billing metrics',
-              description: 'Collect billing metrics',
-              input_group: 'metrics',
-              vars: [
+              policy_template: 'billing',
+              enabled: true,
+              vars: {
+                password: { value: 'billing_input_password', type: 'text' },
+              },
+              streams: [
                 {
-                  name: 'password',
-                  type: 'text',
-                  secret: true,
+                  enabled: true,
+                  data_stream: { type: 'metrics', dataset: 'aws.billing' },
+                  vars: {
+                    password: { value: 'billing_stream_password', type: 'text' },
+                  },
                 },
               ],
             },
           ],
-        },
-        {
-          name: 'cloudtrail',
-          title: 'AWS Cloudtrail',
-          description: 'Collect logs from AWS Cloudtrail',
-          data_streams: ['cloudtrail'],
+        };
+        expect(
+          getPolicySecretPaths(
+            policy as unknown as NewPackagePolicy,
+            miniAWsPackage as unknown as PackageInfo
+          )
+        ).toEqual([
+          {
+            path: 'vars.secret_access_key',
+            value: {
+              value: 'my_secret_access_key',
+            },
+          },
+          {
+            path: 'inputs[0].vars.password',
+            value: {
+              type: 'text',
+              value: 'billing_input_password',
+            },
+          },
+          {
+            path: 'inputs[0].streams[0].vars.password',
+            value: {
+              type: 'text',
+              value: 'billing_stream_password',
+            },
+          },
+        ]);
+      });
+      it('double policy with package + input + stream level secret var', () => {
+        const policy = {
+          vars: {
+            secret_access_key: {
+              value: 'my_secret_access_key',
+            },
+          },
           inputs: [
             {
-              type: 's3',
-              title: 'Collect logs from Cloudtrail service',
-              description: 'Collecting Cloudtrail logs using S3 input',
-              input_group: 'logs',
-              vars: [
-                {
-                  name: 'password',
-                  type: 'text',
-                  secret: true,
-                },
-              ],
-            },
-            {
               type: 'httpjson',
-              title: 'Collect logs from third-party REST API (experimental)',
-              description: 'Collect logs from third-party REST API (experimental)',
-              input_group: 'logs',
-              vars: [
+              policy_template: 'cloudtrail',
+              enabled: false,
+              vars: {
+                password: { value: 'cloudtrail_httpjson_input_password' },
+              },
+              streams: [
                 {
-                  name: 'password',
-                  type: 'text',
-                  secret: true,
+                  data_stream: { type: 'logs', dataset: 'aws.cloudtrail' },
+                  vars: {
+                    username: { value: 'hop_dev' },
+                    password: { value: 'cloudtrail_httpjson_stream_password' },
+                  },
                 },
               ],
             },
-          ],
-        },
-      ],
-      vars: [
-        {
-          name: 'secret_access_key',
-          type: 'text',
-          title: 'Secret Access Key',
-          multi: false,
-          required: false,
-          show_user: false,
-          secret: true,
-        },
-      ],
-      data_streams: [
-        {
-          type: 'metrics',
-          dataset: 'aws.billing',
-          title: 'AWS billing metrics',
-          release: 'beta',
-          streams: [
             {
-              input: 'aws/metrics',
-              vars: [
-                {
-                  name: 'password',
-                  type: 'text',
-                  secret: true,
-                },
-              ],
-              template_path: 'stream.yml.hbs',
-              title: 'AWS Billing metrics',
-              description: 'Collect AWS billing metrics',
+              type: 's3',
+              policy_template: 'cloudtrail',
               enabled: true,
-            },
-          ],
-          package: 'aws',
-          path: 'billing',
-        },
-        {
-          type: 'logs',
-          dataset: 'aws.cloudtrail',
-          title: 'AWS CloudTrail logs',
-          release: 'beta',
-          ingest_pipeline: 'default',
-          streams: [
-            {
-              input: 's3',
-              vars: [
+              vars: {
+                password: { value: 'cloudtrail_s3_input_password' },
+              },
+              streams: [
                 {
-                  name: 'password',
-                  type: 'text',
-                  secret: true,
+                  enabled: true,
+                  data_stream: { type: 'logs', dataset: 'aws.cloudtrail' },
+                  vars: {
+                    password: { value: 'cloudtrail_s3_stream_password' },
+                  },
                 },
               ],
-              template_path: 's3.yml.hbs',
             },
+          ],
+        };
+
+        expect(
+          getPolicySecretPaths(
+            policy as unknown as NewPackagePolicy,
+            miniAWsPackage as unknown as PackageInfo
+          )
+        ).toEqual([
+          {
+            path: 'vars.secret_access_key',
+            value: {
+              value: 'my_secret_access_key',
+            },
+          },
+          {
+            path: 'inputs[0].vars.password',
+            value: {
+              value: 'cloudtrail_httpjson_input_password',
+            },
+          },
+          {
+            path: 'inputs[0].streams[0].vars.password',
+            value: {
+              value: 'cloudtrail_httpjson_stream_password',
+            },
+          },
+          {
+            path: 'inputs[1].vars.password',
+            value: {
+              value: 'cloudtrail_s3_input_password',
+            },
+          },
+          {
+            path: 'inputs[1].streams[0].vars.password',
+            value: {
+              value: 'cloudtrail_s3_stream_password',
+            },
+          },
+        ]);
+      });
+    });
+
+    describe('input package', () => {
+      const mockInputPackage = {
+        name: 'log',
+        version: '2.0.0',
+        description: 'Collect custom logs with Elastic Agent.',
+        title: 'Custom Logs',
+        format_version: '2.6.0',
+        owner: {
+          github: 'elastic/elastic-agent-data-plane',
+        },
+        type: 'input',
+        categories: ['custom', 'custom_logs'],
+        conditions: {},
+        icons: [],
+        policy_templates: [
+          {
+            name: 'logs',
+            title: 'Custom log file',
+            description: 'Collect your custom log files.',
+            multiple: true,
+            input: 'logfile',
+            type: 'logs',
+            template_path: 'input.yml.hbs',
+            vars: [
+              {
+                name: 'paths',
+                required: true,
+                title: 'Log file path',
+                description: 'Path to log files to be collected',
+                type: 'text',
+                multi: true,
+              },
+              {
+                name: 'data_stream.dataset',
+                required: true,
+                title: 'Dataset name',
+                description:
+                  "Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).\n",
+                type: 'text',
+              },
+              {
+                name: 'secret-1',
+                type: 'text',
+                secret: true,
+              },
+              {
+                name: 'secret-2',
+                type: 'text',
+                secret: true,
+              },
+            ],
+          },
+        ],
+      };
+      it('template level vars', () => {
+        const policy = {
+          inputs: [
             {
-              input: 'httpjson',
-              vars: [
+              type: 'logfile',
+              policy_template: 'logs',
+              enabled: true,
+              streams: [
                 {
-                  name: 'username',
-                  type: 'text',
-                  title: 'Splunk REST API Username',
-                  multi: false,
-                  required: true,
-                  show_user: true,
-                },
-                {
-                  name: 'password',
-                  type: 'password',
-                  title: 'Splunk REST API Password',
-                  multi: false,
-                  required: true,
-                  show_user: true,
-                  secret: true,
+                  enabled: true,
+                  data_stream: {
+                    type: 'logs',
+                    dataset: 'log.logs',
+                  },
+                  vars: {
+                    paths: {
+                      value: ['/tmp/test.log'],
+                    },
+                    'data_stream.dataset': {
+                      value: 'hello',
+                    },
+                    'secret-1': {
+                      value: 'secret-1-value',
+                    },
+                    'secret-2': {
+                      value: 'secret-2-value',
+                    },
+                  },
                 },
               ],
-              template_path: 'httpjson.yml.hbs',
             },
           ],
-          package: 'aws',
-          path: 'cloudtrail',
-        },
-      ],
-    } as PackageInfo;
-    it('single policy with package + input + stream level secret var', () => {
-      const policy = {
-        vars: {
-          secret_access_key: {
-            value: 'my_secret_access_key',
-          },
-        },
-        inputs: [
+        };
+
+        expect(
+          getPolicySecretPaths(
+            policy as unknown as NewPackagePolicy,
+            mockInputPackage as unknown as PackageInfo
+          )
+        ).toEqual([
           {
-            type: 'aws/metrics',
-            policy_template: 'billing',
-            enabled: true,
-            vars: {
-              password: { value: 'billing_input_password', type: 'text' },
+            path: 'inputs[0].streams[0].vars.secret-1',
+            value: {
+              value: 'secret-1-value',
             },
-            streams: [
-              {
-                enabled: true,
-                data_stream: { type: 'metrics', dataset: 'aws.billing' },
-                vars: {
-                  password: { value: 'billing_stream_password', type: 'text' },
-                },
-              },
-            ],
-          },
-        ],
-      };
-      expect(
-        getPolicySecretPaths(
-          policy as unknown as NewPackagePolicy,
-          miniAWsPackage as unknown as PackageInfo
-        )
-      ).toEqual([
-        {
-          path: 'vars.secret_access_key',
-          value: {
-            value: 'my_secret_access_key',
-          },
-        },
-        {
-          path: 'inputs[0].vars.password',
-          value: {
-            type: 'text',
-            value: 'billing_input_password',
-          },
-        },
-        {
-          path: 'inputs[0].streams[0].vars.password',
-          value: {
-            type: 'text',
-            value: 'billing_stream_password',
-          },
-        },
-      ]);
-    });
-    it('double policy with package + input + stream level secret var', () => {
-      const policy = {
-        vars: {
-          secret_access_key: {
-            value: 'my_secret_access_key',
-          },
-        },
-        inputs: [
-          {
-            type: 'httpjson',
-            policy_template: 'cloudtrail',
-            enabled: false,
-            vars: {
-              password: { value: 'cloudtrail_httpjson_input_password' },
-            },
-            streams: [
-              {
-                data_stream: { type: 'logs', dataset: 'aws.cloudtrail' },
-                vars: {
-                  username: { value: 'hop_dev' },
-                  password: { value: 'cloudtrail_httpjson_stream_password' },
-                },
-              },
-            ],
           },
           {
-            type: 's3',
-            policy_template: 'cloudtrail',
-            enabled: true,
-            vars: {
-              password: { value: 'cloudtrail_s3_input_password' },
+            path: 'inputs[0].streams[0].vars.secret-2',
+            value: {
+              value: 'secret-2-value',
             },
-            streams: [
-              {
-                enabled: true,
-                data_stream: { type: 'logs', dataset: 'aws.cloudtrail' },
-                vars: {
-                  password: { value: 'cloudtrail_s3_stream_password' },
-                },
-              },
-            ],
           },
-        ],
-      };
-
-      expect(
-        getPolicySecretPaths(
-          policy as unknown as NewPackagePolicy,
-          miniAWsPackage as unknown as PackageInfo
-        )
-      ).toEqual([
-        {
-          path: 'vars.secret_access_key',
-          value: {
-            value: 'my_secret_access_key',
-          },
-        },
-        {
-          path: 'inputs[0].vars.password',
-          value: {
-            value: 'cloudtrail_httpjson_input_password',
-          },
-        },
-        {
-          path: 'inputs[0].streams[0].vars.password',
-          value: {
-            value: 'cloudtrail_httpjson_stream_password',
-          },
-        },
-        {
-          path: 'inputs[1].vars.password',
-          value: {
-            value: 'cloudtrail_s3_input_password',
-          },
-        },
-        {
-          path: 'inputs[1].streams[0].vars.password',
-          value: {
-            value: 'cloudtrail_s3_stream_password',
-          },
-        },
-      ]);
+        ]);
+      });
     });
   });
 
-  describe('input package', () => {
-    const mockInputPackage = {
-      name: 'log',
-      version: '2.0.0',
-      description: 'Collect custom logs with Elastic Agent.',
-      title: 'Custom Logs',
-      format_version: '2.6.0',
-      owner: {
-        github: 'elastic/elastic-agent-data-plane',
-      },
-      type: 'input',
-      categories: ['custom', 'custom_logs'],
-      conditions: {},
-      icons: [],
-      policy_templates: [
-        {
-          name: 'logs',
-          title: 'Custom log file',
-          description: 'Collect your custom log files.',
-          multiple: true,
-          input: 'logfile',
-          type: 'logs',
-          template_path: 'input.yml.hbs',
-          vars: [
-            {
-              name: 'paths',
-              required: true,
-              title: 'Log file path',
-              description: 'Path to log files to be collected',
-              type: 'text',
-              multi: true,
-            },
-            {
-              name: 'data_stream.dataset',
-              required: true,
-              title: 'Dataset name',
-              description:
-                "Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).\n",
-              type: 'text',
-            },
-            {
-              name: 'secret-1',
-              type: 'text',
-              secret: true,
-            },
-            {
-              name: 'secret-2',
-              type: 'text',
-              secret: true,
-            },
-          ],
-        },
-      ],
-    };
-    it('template level vars', () => {
-      const policy = {
-        inputs: [
-          {
-            type: 'logfile',
-            policy_template: 'logs',
-            enabled: true,
-            streams: [
-              {
-                enabled: true,
-                data_stream: {
-                  type: 'logs',
-                  dataset: 'log.logs',
-                },
-                vars: {
-                  paths: {
-                    value: ['/tmp/test.log'],
-                  },
-                  'data_stream.dataset': {
-                    value: 'hello',
-                  },
-                  'secret-1': {
-                    value: 'secret-1-value',
-                  },
-                  'secret-2': {
-                    value: 'secret-2-value',
-                  },
-                },
-              },
-            ],
-          },
-        ],
-      };
-
-      expect(
-        getPolicySecretPaths(
-          policy as unknown as NewPackagePolicy,
-          mockInputPackage as unknown as PackageInfo
-        )
-      ).toEqual([
-        {
-          path: 'inputs[0].streams[0].vars.secret-1',
-          value: {
-            value: 'secret-1-value',
-          },
-        },
-        {
-          path: 'inputs[0].streams[0].vars.secret-2',
-          value: {
-            value: 'secret-2-value',
-          },
-        },
-      ]);
+  describe('diffSecretPaths', () => {
+    it('should return empty array if no secrets', () => {
+      expect(diffSecretPaths([], [])).toEqual({
+        toCreate: [],
+        toDelete: [],
+        noChange: [],
+      });
     });
-  });
-});
-
-describe('diffSecretPaths', () => {
-  it('should return empty array if no secrets', () => {
-    expect(diffSecretPaths([], [])).toEqual({
-      toCreate: [],
-      toDelete: [],
-      noChange: [],
-    });
-  });
-  it('should return empty array if single secret not changed', () => {
-    const paths = [
-      {
-        path: 'somepath',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-1',
-          },
-        },
-      },
-    ];
-    expect(diffSecretPaths(paths, paths)).toEqual({
-      toCreate: [],
-      toDelete: [],
-      noChange: paths,
-    });
-  });
-  it('should return empty array if multiple secrets not changed', () => {
-    const paths = [
-      {
-        path: 'somepath',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-1',
-          },
-        },
-      },
-      {
-        path: 'somepath2',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-2',
-          },
-        },
-      },
-      {
-        path: 'somepath3',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-3',
-          },
-        },
-      },
-    ];
-
-    expect(diffSecretPaths(paths, paths.slice().reverse())).toEqual({
-      toCreate: [],
-      toDelete: [],
-      noChange: paths,
-    });
-  });
-  it('single secret modified', () => {
-    const paths1 = [
-      {
-        path: 'somepath1',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-1',
-          },
-        },
-      },
-      {
-        path: 'somepath2',
-        value: {
-          value: { isSecretRef: true, id: 'secret-2' },
-        },
-      },
-    ];
-
-    const paths2 = [
-      paths1[0],
-      {
-        path: 'somepath2',
-        value: { value: 'newvalue' },
-      },
-    ];
-
-    expect(diffSecretPaths(paths1, paths2)).toEqual({
-      toCreate: [
+    it('should return empty array if single secret not changed', () => {
+      const paths = [
         {
-          path: 'somepath2',
-          value: { value: 'newvalue' },
+          path: 'somepath',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-1',
+            },
+          },
         },
-      ],
-      toDelete: [
+      ];
+      expect(diffSecretPaths(paths, paths)).toEqual({
+        toCreate: [],
+        toDelete: [],
+        noChange: paths,
+      });
+    });
+    it('should return empty array if multiple secrets not changed', () => {
+      const paths = [
+        {
+          path: 'somepath',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-1',
+            },
+          },
+        },
         {
           path: 'somepath2',
           value: {
@@ -694,55 +650,73 @@ describe('diffSecretPaths', () => {
             },
           },
         },
-      ],
-      noChange: [paths1[0]],
+        {
+          path: 'somepath3',
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-3',
+            },
+          },
+        },
+      ];
+
+      expect(diffSecretPaths(paths, paths.slice().reverse())).toEqual({
+        toCreate: [],
+        toDelete: [],
+        noChange: paths,
+      });
     });
-  });
-  it('double secret modified', () => {
-    const paths1 = [
-      {
-        path: 'somepath1',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-1',
-          },
-        },
-      },
-      {
-        path: 'somepath2',
-        value: {
-          value: {
-            isSecretRef: true,
-            id: 'secret-2',
-          },
-        },
-      },
-    ];
-
-    const paths2 = [
-      {
-        path: 'somepath1',
-        value: { value: 'newvalue1' },
-      },
-      {
-        path: 'somepath2',
-        value: { value: 'newvalue2' },
-      },
-    ];
-
-    expect(diffSecretPaths(paths1, paths2)).toEqual({
-      toCreate: [
+    it('single secret modified', () => {
+      const paths1 = [
         {
           path: 'somepath1',
-          value: { value: 'newvalue1' },
+          value: {
+            value: {
+              isSecretRef: true,
+              id: 'secret-1',
+            },
+          },
         },
         {
           path: 'somepath2',
-          value: { value: 'newvalue2' },
+          value: {
+            value: { isSecretRef: true, id: 'secret-2' },
+          },
         },
-      ],
-      toDelete: [
+      ];
+
+      const paths2 = [
+        paths1[0],
+        {
+          path: 'somepath2',
+          value: { value: 'newvalue' },
+        },
+      ];
+
+      expect(diffSecretPaths(paths1, paths2)).toEqual({
+        toCreate: [
+          {
+            path: 'somepath2',
+            value: { value: 'newvalue' },
+          },
+        ],
+        toDelete: [
+          {
+            path: 'somepath2',
+            value: {
+              value: {
+                isSecretRef: true,
+                id: 'secret-2',
+              },
+            },
+          },
+        ],
+        noChange: [paths1[0]],
+      });
+    });
+    it('double secret modified', () => {
+      const paths1 = [
         {
           path: 'somepath1',
           value: {
@@ -761,41 +735,184 @@ describe('diffSecretPaths', () => {
             },
           },
         },
-      ],
-      noChange: [],
-    });
-  });
+      ];
 
-  it('single secret added', () => {
-    const paths1 = [
-      {
-        path: 'somepath1',
-        value: {
+      const paths2 = [
+        {
+          path: 'somepath1',
+          value: { value: 'newvalue1' },
+        },
+        {
+          path: 'somepath2',
+          value: { value: 'newvalue2' },
+        },
+      ];
+
+      expect(diffSecretPaths(paths1, paths2)).toEqual({
+        toCreate: [
+          {
+            path: 'somepath1',
+            value: { value: 'newvalue1' },
+          },
+          {
+            path: 'somepath2',
+            value: { value: 'newvalue2' },
+          },
+        ],
+        toDelete: [
+          {
+            path: 'somepath1',
+            value: {
+              value: {
+                isSecretRef: true,
+                id: 'secret-1',
+              },
+            },
+          },
+          {
+            path: 'somepath2',
+            value: {
+              value: {
+                isSecretRef: true,
+                id: 'secret-2',
+              },
+            },
+          },
+        ],
+        noChange: [],
+      });
+    });
+
+    it('single secret added', () => {
+      const paths1 = [
+        {
+          path: 'somepath1',
           value: {
-            isSecretRef: true,
-            id: 'secret-1',
+            value: {
+              isSecretRef: true,
+              id: 'secret-1',
+            },
           },
         },
-      },
-    ];
+      ];
 
-    const paths2 = [
-      paths1[0],
-      {
-        path: 'somepath2',
-        value: { value: 'newvalue' },
-      },
-    ];
-
-    expect(diffSecretPaths(paths1, paths2)).toEqual({
-      toCreate: [
+      const paths2 = [
+        paths1[0],
         {
           path: 'somepath2',
           value: { value: 'newvalue' },
         },
+      ];
+
+      expect(diffSecretPaths(paths1, paths2)).toEqual({
+        toCreate: [
+          {
+            path: 'somepath2',
+            value: { value: 'newvalue' },
+          },
+        ],
+        toDelete: [],
+        noChange: [paths1[0]],
+      });
+    });
+  });
+
+  describe('extractAndWriteSecrets', () => {
+    const esClientMock = elasticsearchServiceMock.createInternalClient();
+
+    esClientMock.transport.request.mockImplementation(async (req) => {
+      return {
+        id: uuidv4(),
+      };
+    });
+
+    beforeEach(() => {
+      esClientMock.transport.request.mockClear();
+    });
+
+    const mockIntegrationPackage = {
+      name: 'mock-package',
+      title: 'Mock package',
+      version: '0.0.0',
+      description: 'description',
+      type: 'integration',
+      status: 'not_installed',
+      vars: [
+        { name: 'pkg-secret-1', type: 'text', secret: true, required: true },
+        { name: 'pkg-secret-2', type: 'text', secret: true, required: false },
       ],
-      toDelete: [],
-      noChange: [paths1[0]],
+      data_streams: [
+        {
+          dataset: 'somedataset',
+          streams: [
+            {
+              input: 'foo',
+              title: 'Foo',
+            },
+          ],
+        },
+      ],
+      policy_templates: [
+        {
+          name: 'pkgPolicy1',
+          title: 'Package policy 1',
+          description: 'test package policy',
+          inputs: [
+            {
+              type: 'foo',
+              title: 'Foo',
+              vars: [],
+            },
+          ],
+        },
+      ],
+    } as unknown as PackageInfo;
+
+    describe('when only required secret value is provided', () => {
+      it('returns single secret reference for required secret', async () => {
+        const mockPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
+            },
+          },
+          inputs: [],
+        } as unknown as NewPackagePolicy;
+
+        const result = await extractAndWriteSecrets({
+          packagePolicy: mockPackagePolicy,
+          packageInfo: mockIntegrationPackage,
+          esClient: esClientMock,
+        });
+
+        expect(esClientMock.transport.request).toHaveBeenCalledTimes(1);
+        expect(result.secretReferences).toHaveLength(1);
+      });
+    });
+
+    describe('when both required and optional secret values are provided', () => {
+      it('returns secret reference for both required and optional secret', async () => {
+        const mockPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
+            },
+            'pkg-secret-2': {
+              value: 'pkg-secret-2-val',
+            },
+          },
+          inputs: [],
+        } as unknown as NewPackagePolicy;
+
+        const result = await extractAndWriteSecrets({
+          packagePolicy: mockPackagePolicy,
+          packageInfo: mockIntegrationPackage,
+          esClient: esClientMock,
+        });
+
+        expect(esClientMock.transport.request).toHaveBeenCalledTimes(2);
+        expect(result.secretReferences).toHaveLength(2);
+      });
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -228,13 +228,15 @@ export async function extractAndWriteSecrets(opts: {
     return { packagePolicy, secretReferences: [] };
   }
 
+  const secretsToCreate = secretPaths.filter((secretPath) => !!secretPath.value.value);
+
   const secrets = await createSecrets({
     esClient,
-    values: secretPaths.map((secretPath) => secretPath.value.value),
+    values: secretsToCreate.map((secretPath) => secretPath.value.value),
   });
 
   const policyWithSecretRefs = JSON.parse(JSON.stringify(packagePolicy));
-  secretPaths.forEach((secretPath, i) => {
+  secretsToCreate.forEach((secretPath, i) => {
     set(policyWithSecretRefs, secretPath.path + '.value', toVarSecretRef(secrets[i].id));
   });
 
@@ -384,7 +386,7 @@ export async function extractAndUpdateSecrets(opts: {
     // check if the previous secret is actually a secret refrerence
     // it may be that secrets were not enabled at the time of creation
     // in which case they are just stored as plain text
-    if (secretPath.value.value.isSecretRef) {
+    if (secretPath.value.value?.isSecretRef) {
       secretsToDelete.push({ id: secretPath.value.value.id });
     }
   });


### PR DESCRIPTION
## Summary

Support secrets with `required: false` in package manifests.

Closes #172061

## To test

1. Set up an integration in a local package registry with a variable that has `secret: true` and `required: false`, e.g.

```yml
- name: secret_token
  type: password
  title: (Test) Secret Token
  description: |
    Test non-required secret
  show_user: true
  secret: true
  required: false
```

2. Create a package policy for your test package and note the optional secret is rendered properly
3. Submit the policy editor form without filling out a value for the optional secret
4. Observe the request is successful
5. Edit the package policy and set a value for the optional secret
6. Observe that the secret creation logic works as expected

## Screen recording

https://github.com/elastic/kibana/assets/6766512/36e271c5-29d0-49f8-91e8-abc6a7871b20




<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->