### PR TITLE
Update IronBank BASE_IMAGE with ironbank prefix

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/ironbank/Dockerfile
@@ -3,7 +3,7 @@
 # Extract Kibana and make various file manipulations.
 ################################################################################
 ARG BASE_REGISTRY=registry1.dso.mil
-ARG BASE_IMAGE=redhat/ubi/ubi9
+ARG BASE_IMAGE=ironbank/redhat/ubi/ubi9
 ARG BASE_TAG=9.3
 
 FROM ${BASE_REGISTRY}/${BASE_IMAGE}:${BASE_TAG} as prep_files


### PR DESCRIPTION
This supports local testing.  It should not be included in hardening_manifest.yml, which injects the scope at runtime.

Prompted by https://repo1.dso.mil/dsop/elastic/elasticsearch/elasticsearch/-/merge_requests/140#note_1690926
Documentation https://docs-ironbank.dso.mil/hardening/choosing-base-image/

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->