### PR TITLE
Declare shared-ux/chrome/navigation as a browser package

### DIFF
--- a/packages/shared-ux/chrome/navigation/kibana.jsonc
+++ b/packages/shared-ux/chrome/navigation/kibana.jsonc
@@ -1,5 +1,5 @@
 {
-  "type": "shared-common",
+  "type": "shared-browser",
   "id": "@kbn/shared-ux-chrome-navigation",
   "owner": "@elastic/appex-sharedux"
 }


### PR DESCRIPTION
This corrects a `"type": "shared-common"` in one of our team's kibana.jsonc files.

Having this set to an incorrect value of `shared-common` results in the Kibana server restarting whenever changes are made to the code. When the packages are only used for the browser, cleaning this up stands to have considerable improvements to the dev experience.