### PR TITLE
[Search] Remove indices callout and rename Home nav item

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.test.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiCallOut, EuiButton } from '@elastic/eui';
+import { EuiCallOut } from '@elastic/eui';
 
 import { AddContentEmptyPrompt } from '../../../shared/add_content_empty_prompt';
 import { ElasticsearchResources } from '../../../shared/elasticsearch_resources';
@@ -76,19 +76,6 @@ describe('SearchIndices', () => {
 
     expect(mockActions.fetchIndices).toHaveBeenCalled();
     expect(wrapper.find(EuiCallOut)).toHaveLength(1);
-  });
-
-  it('dismisses callout on click to button', () => {
-    setMockValues(mockValues);
-    setMockActions(mockActions);
-
-    const wrapper = shallow(<SearchIndices />);
-    const dismissButton = wrapper.find(EuiCallOut).find(EuiButton);
-    expect(global.localStorage.getItem('enterprise-search-indices-callout-dismissed')).toBe(
-      'false'
-    );
-    dismissButton.simulate('click');
-    expect(global.localStorage.getItem('enterprise-search-indices-callout-dismissed')).toBe('true');
   });
 
   // Move this test to the indices table when writing tests there

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.test.tsx
@@ -14,8 +14,6 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiCallOut } from '@elastic/eui';
-
 import { AddContentEmptyPrompt } from '../../../shared/add_content_empty_prompt';
 import { ElasticsearchResources } from '../../../shared/elasticsearch_resources';
 import { GettingStartedSteps } from '../../../shared/getting_started_steps';
@@ -75,7 +73,6 @@ describe('SearchIndices', () => {
     expect(wrapper.find(ElasticsearchResources)).toHaveLength(0);
 
     expect(mockActions.fetchIndices).toHaveBeenCalled();
-    expect(wrapper.find(EuiCallOut)).toHaveLength(1);
   });
 
   // Move this test to the indices table when writing tests there

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -18,7 +18,6 @@ import {
   EuiTitle,
   EuiSwitch,
   EuiSearchBar,
-  EuiLink,
   EuiToolTip,
   EuiCode,
 } from '@elastic/eui';
@@ -27,14 +26,12 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
 import { AddContentEmptyPrompt } from '../../../shared/add_content_empty_prompt';
-import { docLinks } from '../../../shared/doc_links';
 import { ElasticsearchResources } from '../../../shared/elasticsearch_resources';
 import { GettingStartedSteps } from '../../../shared/getting_started_steps';
 import { HttpLogic } from '../../../shared/http/http_logic';
 import { KibanaLogic } from '../../../shared/kibana';
 import { EuiButtonTo, EuiLinkTo } from '../../../shared/react_router_helpers';
 import { handlePageChange } from '../../../shared/table_pagination';
-import { useLocalStorage } from '../../../shared/use_local_storage';
 import { NEW_INDEX_PATH } from '../../routes';
 import { EnterpriseSearchContentPageTemplate } from '../layout/page_template';
 
@@ -61,11 +58,6 @@ export const SearchIndices: React.FC = () => {
   const [searchQuery, setSearchValue] = useState('');
   const { config } = useValues(KibanaLogic);
   const { errorConnectingMessage } = useValues(HttpLogic);
-
-  const [calloutDismissed, setCalloutDismissed] = useLocalStorage<boolean>(
-    'enterprise-search-indices-callout-dismissed',
-    false
-  );
 
   useEffect(() => {
     // We don't want to trigger loading for each search query change, so we need this
@@ -162,46 +154,6 @@ export const SearchIndices: React.FC = () => {
         )}
         {!hasNoIndices ? (
           <EuiFlexGroup direction="column">
-            {!calloutDismissed && (
-              <EuiFlexItem>
-                <EuiSpacer size="l" />
-                <EuiCallOut
-                  size="m"
-                  title={i18n.translate('xpack.enterpriseSearch.content.callout.title', {
-                    defaultMessage: 'Introducing Elasticsearch indices in Search',
-                  })}
-                  iconType="iInCircle"
-                >
-                  <p>
-                    <FormattedMessage
-                      id="xpack.enterpriseSearch.content.indices.callout.text"
-                      defaultMessage="Your Elasticsearch indices are now front and center in Search. You can create new indices and build search experiences with them directly. To learn more about how to use Elasticsearch indices in Search {docLink}"
-                      values={{
-                        docLink: (
-                          <EuiLink
-                            data-test-subj="search-index-link"
-                            href={docLinks.appSearchElasticsearchIndexedEngines}
-                            target="_blank"
-                          >
-                            {i18n.translate(
-                              'xpack.enterpriseSearch.content.indices.callout.docLink',
-                              {
-                                defaultMessage: 'read the documentation',
-                              }
-                            )}
-                          </EuiLink>
-                        ),
-                      }}
-                    />
-                  </p>
-                  <EuiButton fill onClick={() => setCalloutDismissed(true)}>
-                    {i18n.translate('xpack.enterpriseSearch.content.callout.dismissButton', {
-                      defaultMessage: 'Dismiss',
-                    })}
-                  </EuiButton>
-                </EuiCallOut>
-              </EuiFlexItem>
-            )}
             <EuiFlexItem>
               <IndicesStats />
             </EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.test.tsx
@@ -27,12 +27,11 @@ const DEFAULT_PRODUCT_ACCESS: ProductAccess = {
   hasWorkplaceSearchAccess: true,
 };
 const baseNavItems = [
-  {
+  expect.objectContaining({
     href: '/app/enterprise_search/overview',
-    id: 'overview',
+    id: 'home',
     items: undefined,
-    name: 'Overview',
-  },
+  }),
   {
     id: 'content',
     items: [
@@ -225,8 +224,8 @@ describe('useEnterpriseSearchApplicationNav', () => {
   it('returns selected engine sub nav items', () => {
     const engineName = 'my-test-engine';
     const navItems = useEnterpriseSearchApplicationNav(engineName);
-    expect(navItems?.map((ni) => ni.name)).toEqual([
-      'Overview',
+    expect(navItems![0].id).toEqual('home');
+    expect(navItems?.slice(1).map((ni) => ni.name)).toEqual([
       'Content',
       'Applications',
       'Getting started',
@@ -282,8 +281,8 @@ describe('useEnterpriseSearchApplicationNav', () => {
   it('returns selected engine without tabs when isEmpty', () => {
     const engineName = 'my-test-engine';
     const navItems = useEnterpriseSearchApplicationNav(engineName, true);
-    expect(navItems?.map((ni) => ni.name)).toEqual([
-      'Overview',
+    expect(navItems![0].id).toEqual('home');
+    expect(navItems?.slice(1).map((ni) => ni.name)).toEqual([
       'Content',
       'Applications',
       'Getting started',
@@ -355,7 +354,12 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
     expect(navItems).toEqual(
       baseNavItems.map((item) =>
         item.id === 'content'
-          ? { ...item, items: item.items?.filter((contentItem) => contentItem.id !== 'settings') }
+          ? {
+              ...item,
+              items: item.items?.filter(
+                (contentItem: { id: string }) => contentItem.id !== 'settings'
+              ),
+            }
           : item
       )
     );
@@ -367,7 +371,12 @@ describe('useEnterpriseSearchAnalyticsNav', () => {
     expect(navItems).toEqual(
       baseNavItems.map((item) =>
         item.id === 'content'
-          ? { ...item, items: item.items?.filter((contentItem) => contentItem.id !== 'settings') }
+          ? {
+              ...item,
+              items: item.items?.filter(
+                (contentItem: { id: string }) => contentItem.id !== 'settings'
+              ),
+            }
           : item
       )
     );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/nav.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 import { useValues } from 'kea';
 
-import { EuiFlexGroup, EuiIcon, EuiSideNavItemType } from '@elastic/eui';
+import { EuiFlexGroup, EuiIcon, EuiSideNavItemType, EuiText } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 
 import {
@@ -35,10 +35,14 @@ export const useEnterpriseSearchNav = () => {
 
   const navItems: Array<EuiSideNavItemType<unknown>> = [
     {
-      id: 'overview',
-      name: i18n.translate('xpack.enterpriseSearch.nav.overviewTitle', {
-        defaultMessage: 'Overview',
-      }),
+      id: 'home',
+      name: (
+        <EuiText size="s">
+          {i18n.translate('xpack.enterpriseSearch.nav.homeTitle', {
+            defaultMessage: 'Home',
+          })}
+        </EuiText>
+      ),
       ...generateNavLink({
         shouldNotCreateHref: true,
         shouldShowActiveForSubroutes: true,


### PR DESCRIPTION
## Summary

Removes the indices callout that's been here for over a year, and renames the Overview nav item to Home.