### PR TITLE
Add model name to default pipeline name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -62,7 +62,7 @@ export const ConfigurePipeline: React.FC = () => {
   const { ingestionMethod } = useValues(IndexViewLogic);
   const { indexName } = useValues(IndexNameLogic);
 
-  const { existingPipeline, modelID, pipelineName } = configuration;
+  const { existingPipeline, modelID, pipelineName, pipelineNameUserSupplied } = configuration;
 
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
 
@@ -149,6 +149,7 @@ export const ConfigurePipeline: React.FC = () => {
                   setInferencePipelineConfiguration({
                     ...configuration,
                     pipelineName: e.target.value,
+                    pipelineNameUserSupplied: true,
                   })
                 }
               />
@@ -166,15 +167,23 @@ export const ConfigurePipeline: React.FC = () => {
                 hasDividers
                 disabled={inputsDisabled}
                 itemLayoutAlign="top"
-                onChange={(value) =>
-                  setInferencePipelineConfiguration({
+                onChange={(value) => {
+                  const newConfiguration = {
                     ...configuration,
                     inferenceConfig: undefined,
                     modelID: value,
                     fieldMappings: undefined,
-                    pipelineName: pipelineName || indexName + '-' + normalizeModelName(value),
-                  })
-                }
+                    pipelineName: indexName + '-' + normalizeModelName(value),
+                    pipelineNameUserSupplied: false,
+                  };
+
+                  if (pipelineName && pipelineNameUserSupplied) {
+                    newConfiguration.pipelineName = pipelineName;
+                    newConfiguration.pipelineNameUserSupplied = true;
+                  }
+
+                  setInferencePipelineConfiguration(newConfiguration);
+                }}
                 options={modelOptions}
                 valueOfSelected={modelID === '' ? MODEL_SELECT_PLACEHOLDER_VALUE : modelID}
               />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -62,7 +62,7 @@ export const ConfigurePipeline: React.FC = () => {
   const { ingestionMethod } = useValues(IndexViewLogic);
   const { indexName } = useValues(IndexNameLogic);
 
-  const { existingPipeline, modelID, pipelineName, pipelineNameUserSupplied } = configuration;
+  const { existingPipeline, modelID, pipelineName, isPipelineNameUserSupplied } = configuration;
 
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
 
@@ -148,8 +148,8 @@ export const ConfigurePipeline: React.FC = () => {
                 onChange={(e) =>
                   setInferencePipelineConfiguration({
                     ...configuration,
+                    isPipelineNameUserSupplied: true,
                     pipelineName: e.target.value,
-                    pipelineNameUserSupplied: true,
                   })
                 }
               />
@@ -171,15 +171,15 @@ export const ConfigurePipeline: React.FC = () => {
                   const newConfiguration = {
                     ...configuration,
                     inferenceConfig: undefined,
+                    isPipelineNameUserSupplied: false,
                     modelID: value,
                     fieldMappings: undefined,
                     pipelineName: indexName + '-' + normalizeModelName(value),
-                    pipelineNameUserSupplied: false,
                   };
 
-                  if (pipelineName && pipelineNameUserSupplied) {
+                  if (pipelineName && isPipelineNameUserSupplied) {
                     newConfiguration.pipelineName = pipelineName;
-                    newConfiguration.pipelineNameUserSupplied = true;
+                    newConfiguration.isPipelineNameUserSupplied = true;
                   }
 
                   setInferencePipelineConfiguration(newConfiguration);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { useValues, useActions } from 'kea';
 
@@ -30,7 +30,7 @@ import { IndexViewLogic } from '../../index_view_logic';
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
 import { MlModelSelectOption } from './model_select_option';
 import { PipelineSelectOption } from './pipeline_select_option';
-import { MODEL_REDACTED_VALUE, MODEL_SELECT_PLACEHOLDER } from './utils';
+import { MODEL_REDACTED_VALUE, MODEL_SELECT_PLACEHOLDER, normalizeModelName } from './utils';
 
 const MODEL_SELECT_PLACEHOLDER_VALUE = 'model_placeholder$$';
 const PIPELINE_SELECT_PLACEHOLDER_VALUE = 'pipeline_placeholder$$';
@@ -63,13 +63,6 @@ export const ConfigurePipeline: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
 
   const { existingPipeline, modelID, pipelineName } = configuration;
-
-  useEffect(() => {
-    setInferencePipelineConfiguration({
-      ...configuration,
-      pipelineName: pipelineName || indexName,
-    });
-  }, []);
 
   const nameError = formErrors.pipelineName !== undefined && pipelineName.length > 0;
 
@@ -179,6 +172,7 @@ export const ConfigurePipeline: React.FC = () => {
                     inferenceConfig: undefined,
                     modelID: value,
                     fieldMappings: undefined,
+                    pipelineName: pipelineName || indexName + '-' + normalizeModelName(value),
                   })
                 }
                 options={modelOptions}
@@ -253,13 +247,10 @@ export const ConfigurePipeline: React.FC = () => {
         onTabClick={(tab) => {
           const isExistingPipeline = tab.id === ConfigurePipelineTabId.USE_EXISTING;
           if (isExistingPipeline !== configuration.existingPipeline) {
-            const pipelineConfig = EMPTY_PIPELINE_CONFIGURATION;
-            pipelineConfig.existingPipeline = isExistingPipeline;
-            if (!isExistingPipeline) {
-              pipelineConfig.pipelineName = indexName;
-            }
-
-            setInferencePipelineConfiguration(pipelineConfig);
+            setInferencePipelineConfiguration({
+              ...EMPTY_PIPELINE_CONFIGURATION,
+              existingPipeline: isExistingPipeline,
+            });
           }
         }}
       />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -148,7 +148,7 @@ export const ConfigurePipeline: React.FC = () => {
                 onChange={(e) =>
                   setInferencePipelineConfiguration({
                     ...configuration,
-                    isPipelineNameUserSupplied: true,
+                    isPipelineNameUserSupplied: e.target.value.length > 0,
                     pipelineName: e.target.value,
                   })
                 }
@@ -167,23 +167,17 @@ export const ConfigurePipeline: React.FC = () => {
                 hasDividers
                 disabled={inputsDisabled}
                 itemLayoutAlign="top"
-                onChange={(value) => {
-                  const newConfiguration = {
+                onChange={(value) =>
+                  setInferencePipelineConfiguration({
                     ...configuration,
                     inferenceConfig: undefined,
-                    isPipelineNameUserSupplied: false,
                     modelID: value,
                     fieldMappings: undefined,
-                    pipelineName: indexName + '-' + normalizeModelName(value),
-                  };
-
-                  if (pipelineName && isPipelineNameUserSupplied) {
-                    newConfiguration.pipelineName = pipelineName;
-                    newConfiguration.isPipelineNameUserSupplied = true;
-                  }
-
-                  setInferencePipelineConfiguration(newConfiguration);
-                }}
+                    pipelineName: isPipelineNameUserSupplied
+                      ? pipelineName
+                      : indexName + '-' + normalizeModelName(value),
+                  })
+                }
                 options={modelOptions}
                 valueOfSelected={modelID === '' ? MODEL_SELECT_PLACEHOLDER_VALUE : modelID}
               />

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/types.ts
@@ -14,6 +14,7 @@ export interface InferencePipelineConfiguration {
   inferenceConfig?: InferencePipelineInferenceConfig;
   modelID: string;
   pipelineName: string;
+  pipelineNameUserSupplied?: boolean;
   fieldMappings?: FieldMapping[];
   targetField: string;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/types.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/types.ts
@@ -12,9 +12,9 @@ import { InferencePipelineInferenceConfig } from '../../../../../../../common/ty
 export interface InferencePipelineConfiguration {
   existingPipeline?: boolean;
   inferenceConfig?: InferencePipelineInferenceConfig;
+  isPipelineNameUserSupplied?: boolean;
   modelID: string;
   pipelineName: string;
-  pipelineNameUserSupplied?: boolean;
   fieldMappings?: FieldMapping[];
   targetField: string;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { isValidPipelineName } from './utils';
+import { isValidPipelineName, normalizeModelName } from './utils';
 
 describe('ml inference utils', () => {
   describe('isValidPipelineName', () => {
@@ -22,6 +22,18 @@ describe('ml inference utils', () => {
       expect(isValidPipelineName('a_pipeline_name_1%')).toEqual(false);
       expect(isValidPipelineName('a_pipeline_name_1^')).toEqual(false);
       expect(isValidPipelineName('a_pipeline_name_1"')).toEqual(false);
+    });
+  });
+  describe('normalizeModelName', () => {
+    it('no normalization', () => {
+      expect(normalizeModelName('valid_model_name_123')).toEqual('valid_model_name_123');
+      expect(normalizeModelName('valid-model-name-123')).toEqual('valid-model-name-123');
+    });
+    it('normalize model name', () => {
+      expect(normalizeModelName('.elser_model_2')).toEqual('_elser_model_2');
+      expect(normalizeModelName('model!@with#$special%^chars&*123')).toEqual(
+        'model__with__special__chars__123'
+      );
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
@@ -12,6 +12,7 @@ import { FetchPipelineResponse } from '../../../../api/pipelines/fetch_pipeline'
 import { AddInferencePipelineFormErrors, InferencePipelineConfiguration } from './types';
 
 const VALID_PIPELINE_NAME_REGEX = /^[\w\-]+$/;
+const INVALID_PIPELINE_NAME_CHAR_REGEX = /[^\w\-]/g;
 export const TRAINED_MODELS_PATH = '/app/ml/trained_models';
 
 export const isValidPipelineName = (input: string): boolean => {
@@ -77,6 +78,10 @@ export const validateInferencePipelineFields = (
     errors.fieldMappings = FIELD_REQUIRED_ERROR;
   }
   return errors;
+};
+
+export const normalizeModelName = (modelName: string): string => {
+  return modelName.replace(INVALID_PIPELINE_NAME_CHAR_REGEX, '_');
 };
 
 export const EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS = (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/utils.ts
@@ -12,7 +12,7 @@ import { FetchPipelineResponse } from '../../../../api/pipelines/fetch_pipeline'
 import { AddInferencePipelineFormErrors, InferencePipelineConfiguration } from './types';
 
 const VALID_PIPELINE_NAME_REGEX = /^[\w\-]+$/;
-const INVALID_PIPELINE_NAME_CHAR_REGEX = /[^\w\-]/g;
+const NORMALIZABLE_PIPELINE_CHARS_REGEX = /[^\w\-]/g;
 export const TRAINED_MODELS_PATH = '/app/ml/trained_models';
 
 export const isValidPipelineName = (input: string): boolean => {
@@ -81,7 +81,7 @@ export const validateInferencePipelineFields = (
 };
 
 export const normalizeModelName = (modelName: string): string => {
-  return modelName.replace(INVALID_PIPELINE_NAME_CHAR_REGEX, '_');
+  return modelName.replace(NORMALIZABLE_PIPELINE_CHARS_REGEX, '_');
 };
 
 export const EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS = (


### PR DESCRIPTION
## Summary

Update the default pipeline name to include the model name, like so:

`ml-inference-<index name>-<model name>`

 Unsupported characters in the model name are mapped to `_`.

Also added logic to detect & differentiate between user-supplied and auto-generated pipeline names to handle edge cases, such as when the user selects a model (and thus generates a pipeline name) and then selects a different model. The edge cases are demonstrated in the attached video:

https://github.com/elastic/kibana/assets/26927948/89b35925-0205-48b9-806a-2171bf295932

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

