### PR TITLE
[ES|QL] Make the dashboard SO lighter

### DIFF
--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -401,6 +401,7 @@ describe('Textbased Data Source', () => {
       );
       expect(suggestions[0].state).toEqual({
         ...state,
+        initialContext: undefined,
         fieldList: textBasedQueryColumns,
         indexPatternRefs: [
           {
@@ -552,6 +553,7 @@ describe('Textbased Data Source', () => {
       );
       expect(suggestions[0].state).toEqual({
         ...state,
+        initialContext: undefined,
         fieldList: textBasedQueryColumns,
         indexPatternRefs: [
           {

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -169,7 +169,6 @@ export function getTextBasedDatasource({
           },
         },
       };
-      console.dir(updatedState);
 
       return [
         {

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.tsx
@@ -145,6 +145,7 @@ export function getTextBasedDatasource({
       const query = context.query;
       const updatedState = {
         ...state,
+        initialContext: undefined,
         fieldList: textBasedQueryColumns,
         ...(context.dataViewSpec.id
           ? {
@@ -168,6 +169,7 @@ export function getTextBasedDatasource({
           },
         },
       };
+      console.dir(updatedState);
 
       return [
         {


### PR DESCRIPTION
## Summary

This PR makes the dashboard SO lighter by removing the initialContext from the state. It is not needed after the navigation from Discover to Dashboard and can create SO size problems as it contains a lot of information for the transition.

<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->