### PR TITLE
[Serverless][Security Solution][Endpoint] Re-enable execute API ftr test

### DIFF
--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -16,9 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const endpointTestResources = getService('endpointTestResources');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/171667
-  // FLAKY: https://github.com/elastic/kibana/issues/171666
-  describe.skip('Endpoint `execute` response action', function () {
+  describe('Endpoint `execute` response action', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -51,15 +51,15 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
       }
     });
 
-    // loadTestFile(require.resolve('./resolver'));
-    // loadTestFile(require.resolve('./metadata'));
-    // loadTestFile(require.resolve('./policy'));
-    // loadTestFile(require.resolve('./package'));
-    // loadTestFile(require.resolve('./endpoint_authz'));
+    loadTestFile(require.resolve('./resolver'));
+    loadTestFile(require.resolve('./metadata'));
+    loadTestFile(require.resolve('./policy'));
+    loadTestFile(require.resolve('./package'));
+    loadTestFile(require.resolve('./endpoint_authz'));
     loadTestFile(require.resolve('./endpoint_response_actions/execute'));
-    // loadTestFile(require.resolve('./endpoint_artifacts/trusted_apps'));
-    // loadTestFile(require.resolve('./endpoint_artifacts/event_filters'));
-    // loadTestFile(require.resolve('./endpoint_artifacts/host_isolation_exceptions'));
-    // loadTestFile(require.resolve('./endpoint_artifacts/blocklists'));
+    loadTestFile(require.resolve('./endpoint_artifacts/trusted_apps'));
+    loadTestFile(require.resolve('./endpoint_artifacts/event_filters'));
+    loadTestFile(require.resolve('./endpoint_artifacts/host_isolation_exceptions'));
+    loadTestFile(require.resolve('./endpoint_artifacts/blocklists'));
   });
 }

--- a/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/index.ts
@@ -51,15 +51,15 @@ export default function endpointAPIIntegrationTests(providerContext: FtrProvider
       }
     });
 
-    loadTestFile(require.resolve('./resolver'));
-    loadTestFile(require.resolve('./metadata'));
-    loadTestFile(require.resolve('./policy'));
-    loadTestFile(require.resolve('./package'));
-    loadTestFile(require.resolve('./endpoint_authz'));
+    // loadTestFile(require.resolve('./resolver'));
+    // loadTestFile(require.resolve('./metadata'));
+    // loadTestFile(require.resolve('./policy'));
+    // loadTestFile(require.resolve('./package'));
+    // loadTestFile(require.resolve('./endpoint_authz'));
     loadTestFile(require.resolve('./endpoint_response_actions/execute'));
-    loadTestFile(require.resolve('./endpoint_artifacts/trusted_apps'));
-    loadTestFile(require.resolve('./endpoint_artifacts/event_filters'));
-    loadTestFile(require.resolve('./endpoint_artifacts/host_isolation_exceptions'));
-    loadTestFile(require.resolve('./endpoint_artifacts/blocklists'));
+    // loadTestFile(require.resolve('./endpoint_artifacts/trusted_apps'));
+    // loadTestFile(require.resolve('./endpoint_artifacts/event_filters'));
+    // loadTestFile(require.resolve('./endpoint_artifacts/host_isolation_exceptions'));
+    // loadTestFile(require.resolve('./endpoint_artifacts/blocklists'));
   });
 }


### PR DESCRIPTION
## Summary

Re-enable execute API ftr test

**Flakey runner**
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4090 x 100 ( all pass )

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios