### PR TITLE
Add rule name to the default fields of alert table

### DIFF
--- a/x-pack/plugins/observability/public/components/alerts_table/default_columns.tsx
+++ b/x-pack/plugins/observability/public/components/alerts_table/default_columns.tsx
@@ -10,7 +10,13 @@
  * We have types and code at different imports because we don't want to import the whole package in the resulting webpack bundle for the plugin.
  * This way plugins can do targeted imports to reduce the final code bundle
  */
-import { ALERT_DURATION, ALERT_REASON, ALERT_STATUS, TIMESTAMP } from '@kbn/rule-data-utils';
+import {
+  ALERT_DURATION,
+  ALERT_REASON,
+  ALERT_RULE_NAME,
+  ALERT_STATUS,
+  TIMESTAMP,
+} from '@kbn/rule-data-utils';
 import { EuiDataGridColumn } from '@elastic/eui';
 import type { ColumnHeaderOptions } from '@kbn/timelines-plugin/common';
 import { i18n } from '@kbn/i18n';
@@ -32,6 +38,14 @@ export const columns: Array<
   },
   {
     columnHeaderType: 'not-filtered',
+    displayAsText: i18n.translate('xpack.observability.alertsTGrid.ruleNameColumnDescription', {
+      defaultMessage: 'Rule name',
+    }),
+    id: ALERT_RULE_NAME,
+    initialWidth: 150,
+  },
+  {
+    columnHeaderType: 'not-filtered',
     displayAsText: i18n.translate('xpack.observability.alertsTGrid.lastUpdatedColumnDescription', {
       defaultMessage: 'Last updated',
     }),
@@ -45,7 +59,7 @@ export const columns: Array<
       defaultMessage: 'Duration',
     }),
     id: ALERT_DURATION,
-    initialWidth: 116,
+    initialWidth: 90,
   },
   {
     columnHeaderType: 'not-filtered',


### PR DESCRIPTION
## Summary

This PR adds the rule name as a default column in the alert table on the Alerts page:

![image](https://github.com/elastic/kibana/assets/12370520/52c771c1-ec46-4bb3-a44a-38b8993430d6)

The downside is that the rule name column will also be shown on the rule details page since the alert table configuration happens at the plugin level, but I think the benefit of seeing this field on the Alerts page outweighs this downside. (Especially when there are a lot of alerts firing, rule name helps with alert group)
