### PR TITLE
[ftr] fix supertest service to avoid caching cookie

### DIFF
--- a/x-pack/test_serverless/shared/services/supertest.ts
+++ b/x-pack/test_serverless/shared/services/supertest.ts
@@ -6,15 +6,46 @@
  */
 
 import { format as formatUrl } from 'url';
-import supertest from 'supertest';
+import supertest, { SuperTest, Test } from 'supertest';
 import { FtrProviderContext } from '../../functional/ftr_provider_context';
+
+/**
+ * Return a new SuperAgentTest instance for every API call to avoid cookie caching.
+ * If you want to verify cookies are empty use the following code:
+ * import { CookieAccessInfo } from 'cookiejar';
+ * console.log(JSON.stringify(agent.jar.getCookies(CookieAccessInfo.All)));
+ */
+const initSuperAgentTest = (kbnUrl: string, ca?: string[]) => {
+  return {
+    get(url: string) {
+      const agent = supertest.agent(kbnUrl, { ca });
+      return agent.get(url);
+    },
+    delete(url: string) {
+      const agent = supertest.agent(kbnUrl, { ca });
+      return agent.delete(url);
+    },
+    post(url: string) {
+      const agent = supertest.agent(kbnUrl, { ca });
+      return agent.post(url);
+    },
+    patch(url: string) {
+      const agent = supertest.agent(kbnUrl, { ca });
+      return agent.patch(url);
+    },
+    put(url: string) {
+      const agent = supertest.agent(kbnUrl, { ca });
+      return agent.put(url);
+    },
+  } as Partial<SuperTest<Test>>;
+};
 
 export function SupertestProvider({ getService }: FtrProviderContext) {
   const config = getService('config');
   const kbnUrl = formatUrl(config.get('servers.kibana'));
-  const ca = config.get('servers.kibana').certificateAuthorities;
+  const ca = config.get('servers.kibana').certificateAuthorities as string[];
 
-  return supertest.agent(kbnUrl, { ca });
+  return initSuperAgentTest(kbnUrl, ca);
 }
 
 export function SupertestWithoutAuthProvider({ getService }: FtrProviderContext) {
@@ -23,7 +54,7 @@ export function SupertestWithoutAuthProvider({ getService }: FtrProviderContext)
     ...config.get('servers.kibana'),
     auth: false,
   });
-  const ca = config.get('servers.kibana').certificateAuthorities;
+  const ca = config.get('servers.kibana').certificateAuthorities as string[];
 
-  return supertest.agent(kbnUrl, { ca });
+  return initSuperAgentTest(kbnUrl, ca);
 }

--- a/x-pack/test_serverless/shared/services/supertest.ts
+++ b/x-pack/test_serverless/shared/services/supertest.ts
@@ -6,7 +6,7 @@
  */
 
 import { format as formatUrl } from 'url';
-import supertest, { SuperTest, Test } from 'supertest';
+import supertest, { SuperAgentTest } from 'supertest';
 import { FtrProviderContext } from '../../functional/ftr_provider_context';
 
 /**
@@ -37,7 +37,7 @@ const initSuperAgentTest = (kbnUrl: string, ca?: string[]) => {
       const agent = supertest.agent(kbnUrl, { ca });
       return agent.put(url);
     },
-  } as Partial<SuperTest<Test>>;
+  } as Partial<Pick<SuperAgentTest, 'get' | 'delete' | 'post' | 'patch' | 'put'>>;
 };
 
 export function SupertestProvider({ getService }: FtrProviderContext) {


### PR DESCRIPTION
## Summary

While working on #170417 we discovered that supertest FTR service caches cookie so the next test will already have it in place. This PR makes a change to create a new agent for each API call and guarantee all the tests using supertest are completely independent. 