### PR TITLE
[8.11] fix/142865/path.data config unused (#158426)

### DIFF
--- a/docs/setup/settings.asciidoc
+++ b/docs/setup/settings.asciidoc
@@ -326,8 +326,9 @@ or `*` to select all roles. *Default: `*`*
  Choose the default email connector for user notifications. As of `8.6.0`, {kib} is shipping with a new notification mechanism that will send email notifications for various user actions, e.g. assigning a _Case_ to a user. To enable notifications, an email connector must be <<pre-configured-connectors,preconfigured>> in the system via `kibana.yml`, and the notifications plugin must be configured to point to the ID of that connector.
 
 [[path-data]] `path.data`::
-The path where {kib} stores persistent data
-not saved in {es}. *Default: `data`*
+The path where {kib} stores persistent data not saved in {es}.
+Can be a relative or absolute path.
+Relative paths are resolved starting from the installation directory. *Default: `data`*
 
 `pid.file`::
 Specifies the path where {kib} creates the process ID file.

--- a/packages/kbn-utils/src/path/index.ts
+++ b/packages/kbn-utils/src/path/index.ts
@@ -6,26 +6,28 @@
  * Side Public License, v 1.
  */
 
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { accessSync, constants } from 'fs';
 import { TypeOf, schema } from '@kbn/config-schema';
 import { REPO_ROOT } from '@kbn/repo-info';
+import { getConfigFromFiles } from '@kbn/config';
+import getopts from 'getopts';
 
 const isString = (v: any): v is string => typeof v === 'string';
 
-const CONFIG_PATHS = [
-  process.env.KBN_PATH_CONF && join(process.env.KBN_PATH_CONF, 'kibana.yml'),
-  join(REPO_ROOT, 'config/kibana.yml'),
-  '/etc/kibana/kibana.yml',
-].filter(isString);
+const buildConfigPaths = () => {
+  return [
+    process.env.KBN_PATH_CONF && resolve(process.env.KBN_PATH_CONF, 'kibana.yml'),
+    join(REPO_ROOT, 'config/kibana.yml'),
+    '/etc/kibana/kibana.yml',
+  ].filter(isString);
+};
 
 const CONFIG_DIRECTORIES = [
   process.env.KBN_PATH_CONF,
   join(REPO_ROOT, 'config'),
   '/etc/kibana',
 ].filter(isString);
-
-const DATA_PATHS = [join(REPO_ROOT, 'data'), '/var/lib/kibana'].filter(isString);
 
 const LOGS_PATHS = [join(REPO_ROOT, 'logs'), '/var/log/kibana'].filter(isString);
 
@@ -41,11 +43,29 @@ function findFile(paths: string[]) {
   return availablePath || paths[0];
 }
 
+export const buildDataPaths = (): string[] => {
+  const configDataPath = getConfigFromFiles([getConfigPath()]).path?.data;
+  const argv = process.argv.slice(2);
+  const options = getopts(argv, {
+    string: ['pathData'],
+    alias: {
+      pathData: 'path.data',
+    },
+  });
+
+  return [
+    !!options.pathData && resolve(REPO_ROOT, options.pathData),
+    configDataPath && resolve(REPO_ROOT, configDataPath),
+    join(REPO_ROOT, 'data'),
+    '/var/lib/kibana',
+  ].filter(isString);
+};
+
 /**
  * Get the path of kibana.yml
  * @internal
  */
-export const getConfigPath = () => findFile(CONFIG_PATHS);
+export const getConfigPath = () => findFile(buildConfigPaths());
 
 /**
  * Get the directory containing configuration files
@@ -57,7 +77,7 @@ export const getConfigDirectory = () => findFile(CONFIG_DIRECTORIES);
  * Get the directory containing runtime data
  * @internal
  */
-export const getDataPath = () => findFile(DATA_PATHS);
+export const getDataPath = () => findFile(buildDataPaths());
 
 /**
  * Get the directory containing logs

--- a/packages/kbn-utils/tsconfig.json
+++ b/packages/kbn-utils/tsconfig.json
@@ -13,6 +13,7 @@
   "kbn_references": [
     "@kbn/config-schema",
     "@kbn/repo-info",
+    "@kbn/config",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [fix/142865/path.data config unused (#158426)](https://github.com/elastic/kibana/pull/158426)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Brad White","email":"Ikuni17@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-11-29T00:16:47Z","message":"fix/142865/path.data config unused (#158426)","sha":"86d2f58c09b3bfedd12576f9fc5fe68649028f9c","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Operations","release_note:skip","backport:skip","ci:cloud-deploy","ci:project-deploy-security","v8.12.0"],"number":158426,"url":"https://github.com/elastic/kibana/pull/158426","mergeCommit":{"message":"fix/142865/path.data config unused (#158426)","sha":"86d2f58c09b3bfedd12576f9fc5fe68649028f9c"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/158426","number":158426,"mergeCommit":{"message":"fix/142865/path.data config unused (#158426)","sha":"86d2f58c09b3bfedd12576f9fc5fe68649028f9c"}}]}] BACKPORT-->