### PR TITLE
[Fleet] Fix agent policy timeout to accept only integer

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -7092,10 +7092,10 @@
             "nullable": true
           },
           "unenroll_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "inactivity_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "package_policies": {
             "description": "This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter",
@@ -7195,10 +7195,10 @@
             "nullable": true
           },
           "unenroll_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "inactivity_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "agent_features": {
             "type": "array",
@@ -7267,10 +7267,10 @@
             "nullable": true
           },
           "unenroll_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "inactivity_timeout": {
-            "type": "number"
+            "type": "integer"
           },
           "agent_features": {
             "type": "array",

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -4535,9 +4535,9 @@ components:
           type: string
           nullable: true
         unenroll_timeout:
-          type: number
+          type: integer
         inactivity_timeout:
-          type: number
+          type: integer
         package_policies:
           description: >-
             This field is present only when retrieving a single agent policy, or
@@ -4616,9 +4616,9 @@ components:
           type: string
           nullable: true
         unenroll_timeout:
-          type: number
+          type: integer
         inactivity_timeout:
-          type: number
+          type: integer
         agent_features:
           type: array
           items:
@@ -4666,9 +4666,9 @@ components:
           type: string
           nullable: true
         unenroll_timeout:
-          type: number
+          type: integer
         inactivity_timeout:
-          type: number
+          type: integer
         agent_features:
           type: array
           items:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
@@ -33,9 +33,9 @@ properties:
     type: string
     nullable: true
   unenroll_timeout:
-    type: number
+    type: integer
   inactivity_timeout:
-    type: number
+    type: integer
   package_policies:
     description: This field is present only when retrieving a single agent policy, or when retrieving a list of agent policies with the ?full=true parameter
     type: array

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_create_request.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_create_request.yaml
@@ -29,9 +29,9 @@ properties:
     type: string
     nullable: true
   unenroll_timeout:
-    type: number
+    type: integer
   inactivity_timeout:
-    type: number
+    type: integer
   agent_features:
     type: array
     items:

--- a/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
+++ b/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
@@ -27,9 +27,9 @@ properties:
     type: string
     nullable: true
   unenroll_timeout:
-    type: number
+    type: integer
   inactivity_timeout:
-    type: number
+    type: integer
   agent_features:
     type: array
     items:

--- a/x-pack/plugins/fleet/server/types/models/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/types/models/agent_policy.ts
@@ -19,6 +19,12 @@ function validateNonEmptyString(val: string) {
 
 const TWO_WEEKS_SECONDS = 1209600;
 
+function isInteger(n: number) {
+  if (!Number.isInteger(n)) {
+    return `${n} is not a valid integer`;
+  }
+}
+
 export const AgentPolicyBaseSchema = {
   id: schema.maybe(schema.string()),
   name: schema.string({ minLength: 1, validate: validateNonEmptyString }),
@@ -28,8 +34,12 @@ export const AgentPolicyBaseSchema = {
   has_fleet_server: schema.maybe(schema.boolean()),
   is_default: schema.maybe(schema.boolean()),
   is_default_fleet_server: schema.maybe(schema.boolean()),
-  unenroll_timeout: schema.maybe(schema.number({ min: 0 })),
-  inactivity_timeout: schema.number({ min: 0, defaultValue: TWO_WEEKS_SECONDS }),
+  unenroll_timeout: schema.maybe(schema.number({ min: 0, validate: isInteger })),
+  inactivity_timeout: schema.number({
+    min: 0,
+    defaultValue: TWO_WEEKS_SECONDS,
+    validate: isInteger,
+  }),
   monitoring_enabled: schema.maybe(
     schema.arrayOf(
       schema.oneOf([schema.literal(dataTypes.Logs), schema.literal(dataTypes.Metrics)])


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/172100

Validate that `unenroll_timeout` and `inactivity_timeout` are proper integer and not a float, updated the openAPI doc too.

<img width="715" alt="Screenshot 2023-11-29 at 3 37 59 PM" src="https://github.com/elastic/kibana/assets/1336873/650de148-2bc3-4467-a570-1e1cc600b6d8">


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->