### PR TITLE
[Discover/CSV Reporting] Fix support for nested field columns in CSV reports

### DIFF
--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -18,6 +18,7 @@ import { ReportingAPIClient } from '../lib/reporting_api_client';
 import type { ReportingPublicPluginStartDependencies } from '../plugin';
 import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 
 const core = coreMock.createSetup();
 let apiClient: ReportingAPIClient;
@@ -124,7 +125,7 @@ describe('GetCsvReportPanelAction', () => {
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
-      getField: jest.fn(),
+      getField: jest.fn((name) => (name === 'index' ? dataViewMock : undefined)),
       getSerializedFields: jest.fn().mockImplementation(() => ({ testData: 'testDataValue' })),
     } as unknown as SearchSource;
     context.embeddable.getSavedSearch = () => {

--- a/x-pack/plugins/reporting/tsconfig.json
+++ b/x-pack/plugins/reporting/tsconfig.json
@@ -50,6 +50,7 @@
     "@kbn/reporting-mocks-server",
     "@kbn/core-http-request-handler-context-server",
     "@kbn/reporting-public",
+    "@kbn/discover-utils",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

When we generate the parameters for the report, we add all of the selected columns as entries in the search request `fields` array (or `*` if none are selected, which is why this case works), but this doesn't work for nested fields since [the fields API doesn't support nested field roots](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#search-fields-nested):
>However, when the `fields` pattern targets the nested `user` field directly, no values will be returned because the pattern doesn’t match any leaf fields.

Instead we can detect nested fields and add them to the `fields` array as `{nestedFieldName}.*`, ensuring that all of the leaf fields are returned in the response.

Fixes #172236.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->