### PR TITLE
Start the initial status timeout when the service is "started"

### DIFF
--- a/packages/core/status/core-status-server-internal/src/plugins_status.test.ts
+++ b/packages/core/status/core-status-server-internal/src/plugins_status.test.ts
@@ -41,7 +41,7 @@ describe('PluginStatusService', () => {
         pluginDependencies,
       });
 
-      service.blockNewRegistrations();
+      service.start();
       expect(() => {
         service.set(
           'a',
@@ -365,6 +365,8 @@ describe('PluginStatusService', () => {
 
       const pluginA$ = new ReplaySubject<ServiceStatus>(1);
       service.set('a', pluginA$);
+      service.start(); // the plugin emission timeout starts counting when we call pluginsStatus.start()
+
       // the first emission happens right after core$ services emit
       const firstEmission = firstValueFrom(service.getAll$().pipe(skip(1)));
 

--- a/packages/core/status/core-status-server-internal/src/status_service.ts
+++ b/packages/core/status/core-status-server-internal/src/status_service.ts
@@ -179,7 +179,7 @@ export class StatusService implements CoreService<InternalStatusServiceSetup> {
     if (!this.pluginsStatus || !this.overall$) {
       throw new Error(`StatusService#setup must be called before #start`);
     }
-    this.pluginsStatus.blockNewRegistrations();
+    this.pluginsStatus.start();
     this.logStatusChanges();
   }
 


### PR DESCRIPTION
## Summary

The _plugins status service_ listens to some of the plugins' statuses through Observables.
If these plugins don't emit an initial status after some time, it injects a first "timed out" value, with an `unavailable` state.

We're currently starting this 30s timeout at service creation time.
This is not accurate, as other services starting before plugins (e.g. saved objects + migrations) are time consuming and can leave short to no time for plugins to `start()` before hitting the 30s timeout.

This PR aims at fixing this, by starting to count when the plugins `start()` methods are called.
This way, we're actually giving plugins 30s to emit a status.
