### PR TITLE
[Security Solution][Endpoint] Re-enable authz API tests

### DIFF
--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_authz.ts
@@ -10,10 +10,11 @@ import {
   ACTION_DETAILS_ROUTE,
   ACTION_STATUS_ROUTE,
   AGENT_POLICY_SUMMARY_ROUTE,
-  BASE_POLICY_RESPONSE_ROUTE,
   BASE_ENDPOINT_ACTION_ROUTE,
-  GET_PROCESSES_ROUTE,
+  BASE_POLICY_RESPONSE_ROUTE,
+  EXECUTE_ROUTE,
   GET_FILE_ROUTE,
+  GET_PROCESSES_ROUTE,
   HOST_METADATA_GET_ROUTE,
   HOST_METADATA_LIST_ROUTE,
   ISOLATE_HOST_ROUTE_V2,
@@ -21,7 +22,6 @@ import {
   METADATA_TRANSFORMS_STATUS_ROUTE,
   SUSPEND_PROCESS_ROUTE,
   UNISOLATE_HOST_ROUTE_V2,
-  EXECUTE_ROUTE,
 } from '@kbn/security-solution-plugin/common/endpoint/constants';
 import { IndexedHostsAndAlertsResponse } from '@kbn/security-solution-plugin/common/endpoint/index_data';
 import { targetTags } from '../../security_solution_endpoint/target_tags';
@@ -40,12 +40,7 @@ export default function ({ getService }: FtrProviderContext) {
     body: Record<string, unknown> | undefined;
   }
 
-  // Flaky:
-  // https://github.com/elastic/kibana/issues/171655
-  // https://github.com/elastic/kibana/issues/171656
-  // https://github.com/elastic/kibana/issues/171647
-  // https://github.com/elastic/kibana/issues/171648
-  describe.skip('When attempting to call an endpoint api', function () {
+  describe('When attempting to call an endpoint api', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary

Re-enable endpoint autz api test suite

**Flaky runner**
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4108 x 100 ( all pass )

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios