### PR TITLE
[ES|QL] Fix functions highlight with ES grammar

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/monaco/esql_theme.ts
+++ b/packages/kbn-monaco/src/esql/lib/monaco/esql_theme.ts
@@ -77,12 +77,9 @@ export const buildESQlTheme = (): monaco.editor.IStandaloneThemeData => ({
         'row',
         'show',
         'limit',
-        'cidr_match',
         'nulls_ordering_direction',
         'nulls_ordering',
         'null',
-        'boolean_value',
-        'comparison_operator',
         'enrich',
         'on',
         'with',
@@ -90,12 +87,8 @@ export const buildESQlTheme = (): monaco.editor.IStandaloneThemeData => ({
       euiThemeVars.euiColorPrimaryText
     ),
 
-    // aggregation functions
-    ...buildRuleGroup(['unary_function'], euiThemeVars.euiColorPrimaryText),
-    // is null functions
-    ...buildRuleGroup(['where_functions'], euiThemeVars.euiColorPrimaryText),
-    // math functions
-    ...buildRuleGroup(['math_function'], euiThemeVars.euiColorPrimaryText),
+    // functions
+    ...buildRuleGroup(['functions'], euiThemeVars.euiColorPrimaryText),
 
     // operators
     ...buildRuleGroup(

--- a/packages/kbn-monaco/src/esql/lib/monaco/esql_token_helpers.ts
+++ b/packages/kbn-monaco/src/esql/lib/monaco/esql_token_helpers.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { monaco } from '../../../monaco_imports';
+import { nonNullable } from '../ast/ast_helpers';
+import { ESQL_TOKEN_POSTFIX } from '../constants';
+
+export function enrichTokensWithFunctionsMetadata(
+  tokens: monaco.languages.IToken[]
+): monaco.languages.IToken[] {
+  // need to trim spaces as "abs (arg)" is still valid as function
+  const myTokensWithoutSpaces = tokens.filter(
+    ({ scopes }) => scopes !== 'expr_ws' + ESQL_TOKEN_POSTFIX
+  );
+  // find out all unquoted_identifiers index
+  const possiblyFunctions = myTokensWithoutSpaces
+    .map((t, i) => (t.scopes === 'unquoted_identifier' + ESQL_TOKEN_POSTFIX ? i : undefined))
+    .filter(nonNullable);
+
+  // then check if the token next is an opening bracket
+  for (const index of possiblyFunctions) {
+    if (myTokensWithoutSpaces[index + 1]?.scopes === 'lp' + ESQL_TOKEN_POSTFIX) {
+      // set the custom "functions" token (only used in theming)
+      myTokensWithoutSpaces[index].scopes = 'functions' + ESQL_TOKEN_POSTFIX;
+    }
+  }
+  return [...tokens];
+}

--- a/packages/kbn-monaco/src/esql/lib/monaco/esql_tokens_provider.ts
+++ b/packages/kbn-monaco/src/esql/lib/monaco/esql_tokens_provider.ts
@@ -16,6 +16,7 @@ import { ESQLState } from './esql_state';
 
 import { getLexer } from '../antlr_facade';
 import { ESQL_TOKEN_POSTFIX } from '../constants';
+import { enrichTokensWithFunctionsMetadata } from './esql_token_helpers';
 
 const EOF = -1;
 
@@ -69,6 +70,11 @@ export class ESQLTokensProvider implements monaco.languages.TokensProvider {
 
     myTokens.sort((a, b) => a.startIndex - b.startIndex);
 
-    return new ESQLLineTokens(myTokens, prevState.getLineNumber() + 1);
+    // special tratement for functions
+    // the previous custom Kibana grammar baked functions directly as tokens, so highlight was easier
+    // The ES grammar doesn't have the token concept of "function"
+    const tokensWithFunctions = enrichTokensWithFunctionsMetadata(myTokens);
+
+    return new ESQLLineTokens(tokensWithFunctions, prevState.getLineNumber() + 1);
   }
 }


### PR DESCRIPTION
## Summary

Fix ESQL function highlight as with the previous grammar.
<img width="859" alt="Screenshot 2023-11-30 at 14 52 42" src="https://github.com/elastic/kibana/assets/924948/652b1944-fa31-4e63-9936-f0e063eb50c6">


