### PR TITLE
[ES|QL] Unskip remaining tests that no longer fail after #172220

### DIFF
--- a/test/functional/apps/discover/group3/_view_mode_toggle.ts
+++ b/test/functional/apps/discover/group3/_view_mode_toggle.ts
@@ -28,8 +28,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     defaultIndex: 'logstash-*',
   };
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/172247
-  describe.skip('discover view mode toggle', function () {
+  describe('discover view mode toggle', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');

--- a/x-pack/test/functional/apps/discover/value_suggestions.ts
+++ b/x-pack/test/functional/apps/discover/value_suggestions.ts
@@ -25,8 +25,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     );
   }
 
-  // FAILING ES PROMOTION: https://github.com/elastic/kibana/issues/172248
-  describe.skip('value suggestions', function describeIndexTests() {
+  describe('value suggestions', function describeIndexTests() {
     before(async function () {
       await kibanaServer.savedObjects.cleanStandardList();
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
@@ -55,8 +54,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.common.navigateToApp('discover');
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/172246
-      describe.skip('discover', () => {
+      describe('discover', () => {
         afterEach(async () => {
           await queryBar.clearQuery();
         });


### PR DESCRIPTION
## Summary

This PR unskips the remaining skipped tests that no longer fail after the fix to ES|QL `time_zone` param in #172220.

Resolves #172247.
Resolves #172246.
Resolves #172248.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)