### PR TITLE
[Security Solution]Fix page reload crash when preview panel is open in alerts flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/right/components/description.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/description.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { FormattedMessage, __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
 import {
   DESCRIPTION_TITLE_TEST_ID,
@@ -126,12 +126,7 @@ describe('<Description />', () => {
           indexName: panelContext.indexName,
           scopeId: panelContext.scopeId,
           banner: {
-            title: (
-              <FormattedMessage
-                id="xpack.securitySolution.flyout.right.about.description.rulePreviewTitle"
-                defaultMessage="Preview rule details"
-              />
-            ),
+            title: 'Preview rule details',
             backgroundColor: 'warning',
             textColor: 'warning',
           },

--- a/x-pack/plugins/security_solution/public/flyout/right/components/description.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/description.tsx
@@ -41,11 +41,9 @@ export const Description: FC = () => {
         indexName,
         scopeId,
         banner: {
-          title: (
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.right.about.description.rulePreviewTitle"
-              defaultMessage="Preview rule details"
-            />
+          title: i18n.translate(
+            'xpack.securitySolution.flyout.right.about.description.rulePreviewTitle',
+            { defaultMessage: 'Preview rule details' }
           ),
           backgroundColor: 'warning',
           textColor: 'warning',
@@ -66,9 +64,7 @@ export const Description: FC = () => {
           data-test-subj={RULE_SUMMARY_BUTTON_TEST_ID}
           aria-label={i18n.translate(
             'xpack.securitySolution.flyout.right.about.description.ruleSummaryButtonAriaLabel',
-            {
-              defaultMessage: 'Show rule summary',
-            }
+            { defaultMessage: 'Show rule summary' }
           )}
           disabled={isEmpty(ruleName) || isEmpty(ruleId)}
         >

--- a/x-pack/plugins/security_solution/public/flyout/right/components/reason.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/reason.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { render } from '@testing-library/react';
-import { FormattedMessage, __IntlProvider as IntlProvider } from '@kbn/i18n-react';
+import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { REASON_DETAILS_PREVIEW_BUTTON_TEST_ID, REASON_TITLE_TEST_ID } from './test_ids';
 import { Reason } from './reason';
 import { RightPanelContext } from '../context';
@@ -89,12 +89,7 @@ describe('<Reason />', () => {
         indexName: panelContextValue.indexName,
         scopeId: panelContextValue.scopeId,
         banner: {
-          title: (
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.right.about.reason.alertReasonPreviewTitle"
-              defaultMessage="Preview alert reason"
-            />
-          ),
+          title: 'Preview alert reason',
           backgroundColor: 'warning',
           textColor: 'warning',
         },

--- a/x-pack/plugins/security_solution/public/flyout/right/components/reason.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/right/components/reason.tsx
@@ -41,11 +41,9 @@ export const Reason: FC = () => {
         indexName,
         scopeId,
         banner: {
-          title: (
-            <FormattedMessage
-              id="xpack.securitySolution.flyout.right.about.reason.alertReasonPreviewTitle"
-              defaultMessage="Preview alert reason"
-            />
+          title: i18n.translate(
+            'xpack.securitySolution.flyout.right.about.reason.alertReasonPreviewTitle',
+            { defaultMessage: 'Preview alert reason' }
           ),
           backgroundColor: 'warning',
           textColor: 'warning',


### PR DESCRIPTION
## Summary

Fixes page reload crash when the preview panel is open. https://github.com/elastic/kibana/issues/172324

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
