### PR TITLE
[7.17] [Discover/CSV Reporting] Fix support for nested field columns in CSV reports (#172240)

### DIFF
--- a/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
+++ b/src/plugins/discover/public/application/apps/main/utils/get_sharing_data.test.ts
@@ -17,7 +17,6 @@ import {
   SEARCH_FIELDS_FROM_SOURCE,
 } from '../../../../../common';
 import { indexPatternMock } from '../../../../__mocks__/index_pattern';
-import { buildDataViewMock, dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { getSharingData, showPublicUrlSwitch } from './get_sharing_data';
 
 describe('getSharingData', () => {
@@ -148,26 +147,37 @@ describe('getSharingData', () => {
     );
     expect(getSearchSource().fields).toStrictEqual([
       'cool-timefield',
+      'cool-field-1',
+      'cool-field-2',
+      'cool-field-3',
+      'cool-field-4',
+      'cool-field-5',
+      'cool-field-6',
     ]);
   });
 
   test('getSearchSource supports nested fields', async () => {
-    const index = buildDataViewMock({
-      name: 'the-data-view',
-      timeFieldName: 'cool-timefield',
-      fields: [
-        ...dataViewMock.fields,
-        {
-          name: 'cool-field-2.field',
-          type: 'keyword',
-          subType: {
-            nested: {
-              path: 'cool-field-2.field.path',
-            },
+    const fields = [
+      ...indexPatternMock.fields,
+      {
+        name: 'cool-field-2.field',
+        type: 'keyword',
+        subType: {
+          nested: {
+            path: 'cool-field-2.field.path',
           },
         },
-      ] as DataView['fields'],
-    });
+      },
+    ];
+    const index = {
+      ...indexPatternMock,
+      name: 'the-data-view',
+      timeFieldName: 'cool-timefield',
+      fields: {
+        getAll: () => fields,
+        getByName: (name: string) => fields.find((field) => field.name === name),
+      },
+    } as unknown as IndexPattern;
     const searchSourceMock = createSearchSourceMock({ index });
     const { getSearchSource } = await getSharingData(
       searchSourceMock,
@@ -176,16 +186,10 @@ describe('getSharingData', () => {
       },
       services
     );
-    expect(getSearchSource({}).fields).toStrictEqual([
-      { field: 'cool-timefield', include_unmapped: 'true' },
-      { field: 'cool-field-1', include_unmapped: 'true' },
-      { field: 'cool-field-2.*', include_unmapped: 'true' },
+    expect(getSearchSource().fields).toStrictEqual([
+      'cool-timefield',
       'cool-field-1',
-      'cool-field-2',
-      'cool-field-3',
-      'cool-field-4',
-      'cool-field-5',
-      'cool-field-6',
+      'cool-field-2.*',
     ]);
   });
 

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -17,7 +17,6 @@ import { ReportingAPIClient } from '../lib/reporting_api_client';
 import type { ReportingPublicPluginStartDendencies } from '../plugin';
 import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
-import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 
 type LicenseResults = 'valid' | 'invalid' | 'unavailable' | 'expired';
 
@@ -120,7 +119,9 @@ describe('GetCsvReportPanelAction', () => {
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
-      getField: jest.fn((name) => (name === 'index' ? dataViewMock : undefined)),
+      getField: jest.fn((name) =>
+        name === 'index' ? { fields: { getAll: () => [], getByName: () => undefined } } : undefined
+      ),
       getSerializedFields: jest.fn().mockImplementation(() => ({ testData: 'testDataValue' })),
     } as unknown as SearchSource;
     context.embeddable.getSavedSearch = () => {

--- a/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
+++ b/x-pack/plugins/reporting/public/panel_actions/get_csv_panel_action.test.ts
@@ -17,6 +17,7 @@ import { ReportingAPIClient } from '../lib/reporting_api_client';
 import type { ReportingPublicPluginStartDendencies } from '../plugin';
 import type { ActionContext } from './get_csv_panel_action';
 import { ReportingCsvPanelAction } from './get_csv_panel_action';
+import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 
 type LicenseResults = 'valid' | 'invalid' | 'unavailable' | 'expired';
 
@@ -119,7 +120,7 @@ describe('GetCsvReportPanelAction', () => {
       createCopy: () => mockSearchSource,
       removeField: jest.fn(),
       setField: jest.fn(),
-      getField: jest.fn(),
+      getField: jest.fn((name) => (name === 'index' ? dataViewMock : undefined)),
       getSerializedFields: jest.fn().mockImplementation(() => ({ testData: 'testDataValue' })),
     } as unknown as SearchSource;
     context.embeddable.getSavedSearch = () => {

--- a/x-pack/plugins/reporting/tsconfig.json
+++ b/x-pack/plugins/reporting/tsconfig.json
@@ -11,7 +11,6 @@
     "public/**/*",
     "server/**/*",
     "../../../typings/**/*"
-    "@kbn/discover-utils",
   ],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },

--- a/x-pack/plugins/reporting/tsconfig.json
+++ b/x-pack/plugins/reporting/tsconfig.json
@@ -11,6 +11,7 @@
     "public/**/*",
     "server/**/*",
     "../../../typings/**/*"
+    "@kbn/discover-utils",
   ],
   "references": [
     { "path": "../../../src/core/tsconfig.json" },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [[Discover/CSV Reporting] Fix support for nested field columns in CSV reports (#172240)](https://github.com/elastic/kibana/pull/172240)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Davis McPhee","email":"davis.mcphee@elastic.co"},"sourceCommit":{"committedDate":"2023-11-30T16:43:39Z","message":"[Discover/CSV Reporting] Fix support for nested field columns in CSV reports (#172240)\n\n## Summary\r\n\r\nWhen we generate the parameters for the report, we add all of the\r\nselected columns as entries in the search request `fields` array (or `*`\r\nif none are selected, which is why this case works), but this doesn't\r\nwork for nested fields since [the fields API doesn't support nested\r\nfield\r\nroots](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#search-fields-nested):\r\n>However, when the `fields` pattern targets the nested `user` field\r\ndirectly, no values will be returned because the pattern doesn’t match\r\nany leaf fields.\r\n\r\nInstead we can detect nested fields and add them to the `fields` array\r\nas `{nestedFieldName}.*`, ensuring that all of the leaf fields are\r\nreturned in the response.\r\n\r\nFixes #172236.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ab5ff9ca626baa90c3cc0e92813ff70cb5956e23","branchLabelMapping":{"^v8.12.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:DataDiscovery","backport:prev-minor","backport:prev-MAJOR","v8.12.0"],"number":172240,"url":"https://github.com/elastic/kibana/pull/172240","mergeCommit":{"message":"[Discover/CSV Reporting] Fix support for nested field columns in CSV reports (#172240)\n\n## Summary\r\n\r\nWhen we generate the parameters for the report, we add all of the\r\nselected columns as entries in the search request `fields` array (or `*`\r\nif none are selected, which is why this case works), but this doesn't\r\nwork for nested fields since [the fields API doesn't support nested\r\nfield\r\nroots](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#search-fields-nested):\r\n>However, when the `fields` pattern targets the nested `user` field\r\ndirectly, no values will be returned because the pattern doesn’t match\r\nany leaf fields.\r\n\r\nInstead we can detect nested fields and add them to the `fields` array\r\nas `{nestedFieldName}.*`, ensuring that all of the leaf fields are\r\nreturned in the response.\r\n\r\nFixes #172236.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ab5ff9ca626baa90c3cc0e92813ff70cb5956e23"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.12.0","labelRegex":"^v8.12.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/172240","number":172240,"mergeCommit":{"message":"[Discover/CSV Reporting] Fix support for nested field columns in CSV reports (#172240)\n\n## Summary\r\n\r\nWhen we generate the parameters for the report, we add all of the\r\nselected columns as entries in the search request `fields` array (or `*`\r\nif none are selected, which is why this case works), but this doesn't\r\nwork for nested fields since [the fields API doesn't support nested\r\nfield\r\nroots](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html#search-fields-nested):\r\n>However, when the `fields` pattern targets the nested `user` field\r\ndirectly, no values will be returned because the pattern doesn’t match\r\nany leaf fields.\r\n\r\nInstead we can detect nested fields and add them to the `fields` array\r\nas `{nestedFieldName}.*`, ensuring that all of the leaf fields are\r\nreturned in the response.\r\n\r\nFixes #172236.\r\n\r\n### Checklist\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"ab5ff9ca626baa90c3cc0e92813ff70cb5956e23"}},{"url":"https://github.com/elastic/kibana/pull/172335","number":172335,"branch":"8.11","state":"OPEN"}]}] BACKPORT-->