### PR TITLE
[Fleet] Unskip upgrade integration test and fix date error

### DIFF
--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -7,6 +7,7 @@
 
 import expect from '@kbn/expect';
 import semver from 'semver';
+import moment from 'moment';
 import { AGENTS_INDEX, PACKAGE_POLICY_SAVED_OBJECT_TYPE } from '@kbn/fleet-plugin/common';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { setupFleetAndAgents } from './services';
@@ -21,8 +22,7 @@ export default function (providerContext: FtrProviderContext) {
   const kibanaServer = getService('kibanaServer');
   const supertestWithoutAuth = getService('supertestWithoutAuth');
 
-  // Failing: See https://github.com/elastic/kibana/issues/172337
-  describe.skip('fleet_upgrade_agent', () => {
+  describe('fleet_upgrade_agent', () => {
     skipIfNoDockerRegistry(providerContext);
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/fleet/agents');
@@ -1475,13 +1475,14 @@ export default function (providerContext: FtrProviderContext) {
             },
           },
         });
+        const today = new Date(Date.now());
         await supertest
           .post(`/api/fleet/agents/bulk_upgrade`)
           .set('kbn-xsrf', 'xxx')
           .send({
             version: fleetServerVersion,
             agents: ['agent1', 'agent2'],
-            start_time: new Date(Date.now()).toISOString(),
+            start_time: today.toISOString(),
           })
           .expect(200);
 
@@ -1499,10 +1500,8 @@ export default function (providerContext: FtrProviderContext) {
           'minimum_execution_duration',
           'expiration'
         );
-        // calculate 1 month from now
-        const today = new Date();
-        const nextMonthUnixTime = today.setMonth(today.getMonth() + 1);
-        const nextMonth = new Date(nextMonthUnixTime).toISOString().slice(0, 10);
+        // add 30 days from now
+        const nextMonth = moment(today).add(30, 'days').toISOString().slice(0, 10);
 
         expect(action.expiration).contain(`${nextMonth}`);
         expect(action.agents).contain('agent1');


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/172337

## Summary
Integration test unskipped, there was an error in the way the date was calculated. It should be fixed now.


