### PR TITLE
[SLO][8.11] Add `date_formats` to SLI ingest pipeline template

### DIFF
--- a/x-pack/plugins/observability/server/assets/ingest_templates/slo_pipeline_template.ts
+++ b/x-pack/plugins/observability/server/assets/ingest_templates/slo_pipeline_template.ts
@@ -16,6 +16,7 @@ export const getSLOPipelineTemplate = (id: string, indexNamePrefix: string) => (
         field: '@timestamp',
         index_name_prefix: indexNamePrefix,
         date_rounding: 'M',
+        date_formats: ['UNIX_MS', 'ISO8601', "yyyy-MM-dd'T'HH:mm:ss.SSSXX"],
       },
     },
   ],


### PR DESCRIPTION
## Summary

This PR fixes #172372 by adding the `date_formats` attribute to the `date_index_name` pipeline step for the SLI ingest pipeline that every SLO runs through. This PR is only for 8.11, the fix for main will be included with: https://github.com/elastic/kibana/pull/172224
