### PR TITLE
fix Failing test: X-Pack Saved Object Tagging Functional Tests.x-pack/test/saved_object_tagging/functional/tests/dashboard_integration·ts

### DIFF
--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -556,7 +556,6 @@ export class DashboardPageObject extends FtrService {
   }
 
   public async selectDashboardTags(tagNames: string[]) {
-    await this.testSubjects.click('savedObjectTagSelector');
     const tagsComboBox = await this.testSubjects.find('savedObjectTagSelector');
     for (const tagName of tagNames) {
       await this.comboBox.setElement(tagsComboBox, tagName);

--- a/test/functional/page_objects/dashboard_page.ts
+++ b/test/functional/page_objects/dashboard_page.ts
@@ -27,6 +27,7 @@ interface SaveDashboardOptions {
 }
 
 export class DashboardPageObject extends FtrService {
+  private readonly comboBox = this.ctx.getService('comboBox');
   private readonly config = this.ctx.getService('config');
   private readonly log = this.ctx.getService('log');
   private readonly find = this.ctx.getService('find');
@@ -556,8 +557,9 @@ export class DashboardPageObject extends FtrService {
 
   public async selectDashboardTags(tagNames: string[]) {
     await this.testSubjects.click('savedObjectTagSelector');
+    const tagsComboBox = await this.testSubjects.find('savedObjectTagSelector');
     for (const tagName of tagNames) {
-      await this.testSubjects.click(`tagSelectorOption-${tagName.replace(' ', '_')}`);
+      await this.comboBox.setElement(tagsComboBox, tagName);
     }
     await this.testSubjects.click('savedObjectTitle');
   }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/160583

Test failed because combobox trying to select already selected tag. PR fixes test by using combobox service to set element. Combobox service includes logic to only select value when not selected.

![image](https://github.com/elastic/kibana/assets/373691/e4d04854-b147-4d88-a7e5-5a7bc5fa3f38)

```
[00:07:27]           â”‚ debg Find.clickByCssSelector('[data-test-subj="savedObjectTagSelector"]') with timeout=10000
[00:07:27]           â”‚ debg Find.findByCssSelector('[data-test-subj="savedObjectTagSelector"]') with timeout=10000
[00:07:27]           â”‚ debg TestSubjects.click(tagSelectorOption-tag-1)
[00:07:27]           â”‚ debg Find.clickByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:07:27]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:07:37]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:07:37]           â”‚      Wait timed out after 10003ms
[00:07:38]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:07:48]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:07:48]           â”‚      Wait timed out after 10038ms
[00:07:48]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:07:58]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:07:58]           â”‚      Wait timed out after 10054ms
[00:07:59]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:08:09]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:08:09]           â”‚      Wait timed out after 10013ms
[00:08:09]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:08:19]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:08:19]           â”‚      Wait timed out after 10038ms
[00:08:20]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:08:30]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:08:30]           â”‚      Wait timed out after 10005ms
[00:08:30]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:08:40]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:08:40]           â”‚      Wait timed out after 10034ms
[00:08:41]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:08:51]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:08:51]           â”‚      Wait timed out after 10037ms
[00:08:51]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:09:01]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:01]           â”‚      Wait timed out after 10007ms
[00:09:02]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:09:12]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:12]           â”‚      Wait timed out after 10054ms
[00:09:13]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:09:23]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:23]           â”‚      Wait timed out after 10037ms
[00:09:23]           â”‚ debg Find.findByCssSelector('[data-test-subj="tagSelectorOption-tag-1"]') with timeout=10000
[00:09:33]           â”‚ debg --- retry.try error: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:33]           â”‚      Wait timed out after 10042ms
[00:09:34]           â”‚ debg --- retry.try error: retry.try timeout: TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:34]           â”‚      Wait timed out after 10042ms
[00:09:34]           â”‚          at /var/lib/buildkite-agent/builds/kb-n2-4-spot-ee2d6153f1c6deeb/elastic/kibana-on-merge/kibana/node_modules/selenium-webdriver/lib/webdriver.js:929:17
[00:09:34]           â”‚          at processTicksAndRejections (node:internal/process/task_queues:95:5)
[00:09:34]           â”‚ info Taking window screenshot "/var/lib/buildkite-agent/builds/kb-n2-4-spot-ee2d6153f1c6deeb/elastic/kibana-on-merge/kibana/x-pack/test/saved_object_tagging/functional/screenshots/failure/saved objects tagging - functional tests dashboard integration creating allows t-29814279444f4d298f24b012c2e451886d9c481ab2ec65240025329c4f56ba13.png"
[00:09:34]           â”‚ info Current URL is: http://localhost:5620/app/dashboards#/create?_g=(filters:!(),refreshInterval:(pause:!t,value:60000),time:(from:now-15m,to:now))
[00:09:34]           â”‚ info Saving page source to: /var/lib/buildkite-agent/builds/kb-n2-4-spot-ee2d6153f1c6deeb/elastic/kibana-on-merge/kibana/x-pack/test/saved_object_tagging/functional/failure_debug/html/saved objects tagging - functional tests dashboard integration creating allows t-29814279444f4d298f24b012c2e451886d9c481ab2ec65240025329c4f56ba13.html
[00:09:34]           â””- âœ– fail: saved objects tagging - functional tests dashboard integration creating allows to select tags for a new dashboard
[00:09:34]           â”‚      Error: retry.try timeout: Error: retry.try timeout: TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="tagSelectorOption-tag-1"])
[00:09:34]           â”‚ Wait timed out after 10042ms
[00:09:34]           â”‚     at /var/lib/buildkite-agent/builds/kb-n2-4-spot-ee2d6153f1c6deeb/elastic/kibana-on-merge/kibana/node_modules/selenium-webdriver/lib/webdriver.js:929:17
[00:09:34]           â”‚     at processTicksAndRejections (node:internal/process/task_queues:95:5)
[00:09:34]           â”‚     at onFailure (retry_for_success.ts:17:9)
[00:09:34]           â”‚     at retryForSuccess (retry_for_success.ts:59:13)
[00:09:34]           â”‚     at RetryService.try (retry.ts:31:12)
[00:09:34]           â”‚     at Proxy.clickByCssSelector (find.ts:417:5)
[00:09:34]           â”‚     at TestSubjects.click (test_subjects.ts:164:5)
[00:09:34]           â”‚     at DashboardPageObject.selectDashboardTags (dashboard_page.ts:560:7)
[00:09:34]           â”‚     at DashboardPageObject.enterDashboardTitleAndClickSave (dashboard_page.ts:544:7)
[00:09:34]           â”‚     at dashboard_page.ts:481:7
[00:09:34]           â”‚     at runAttempt (retry_for_success.ts:29:15)
[00:09:34]           â”‚     at retryForSuccess (retry_for_success.ts:68:21)
[00:09:34]           â”‚     at RetryService.try (retry.ts:31:12)
[00:09:34]           â”‚     at DashboardPageObject.saveDashboard (dashboard_page.ts:480:5)
[00:09:34]           â”‚     at Context.<anonymous> (dashboard_integration.ts:87:9)
[00:09:34]           â”‚     at Object.apply (wrap_function.js:73:16)
[00:09:34]           â”‚       at onFailure (retry_for_success.ts:17:9)
[00:09:34]           â”‚       at retryForSuccess (retry_for_success.ts:59:13)
[00:09:34]           â”‚       at RetryService.try (retry.ts:31:12)
[00:09:34]           â”‚       at DashboardPageObject.saveDashboard (dashboard_page.ts:480:5)
[00:09:34]           â”‚       at Context.<anonymous> (dashboard_integration.ts:87:9)
[00:09:34]           â”‚       at Object.apply (wrap_function.js:73:16)
[00:09:34]           â”‚ 
[00:09:34]           â”‚ 
```


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->