### PR TITLE
observability - rules - rename uptime producer to Synthetics and Uptime

### DIFF
--- a/x-pack/plugins/synthetics/common/constants/synthetics_alerts.ts
+++ b/x-pack/plugins/synthetics/common/constants/synthetics_alerts.ts
@@ -45,3 +45,10 @@ export const SYNTHETICS_ALERT_RULE_TYPES = {
 export const SYNTHETICS_RULE_TYPES = [SYNTHETICS_STATUS_RULE, SYNTHETICS_TLS_RULE];
 
 export const SYNTHETICS_RULE_TYPES_ALERT_CONTEXT = 'observability.uptime';
+
+export const SYNTHETICS_RULE_TYPE_PRODUCER = i18n.translate(
+  'xpack.synthetics.alertRules.producer',
+  {
+    defaultMessage: 'Synthetics and Uptime',
+  }
+);

--- a/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/status_rule/monitor_status_rule.ts
@@ -23,6 +23,7 @@ import { StatusRulePramsSchema } from '../../../common/rules/status_rule';
 import {
   MONITOR_STATUS,
   SYNTHETICS_ALERT_RULE_TYPES,
+  SYNTHETICS_RULE_TYPE_PRODUCER,
 } from '../../../common/constants/synthetics_alerts';
 import {
   setRecoveredAlertsContext,
@@ -53,7 +54,7 @@ export const registerSyntheticsStatusCheckRule = (
   return createLifecycleRuleType({
     id: SYNTHETICS_ALERT_RULE_TYPES.MONITOR_STATUS,
     category: DEFAULT_APP_CATEGORIES.observability.id,
-    producer: 'uptime',
+    producer: SYNTHETICS_RULE_TYPE_PRODUCER,
     name: STATUS_RULE_NAME,
     validate: {
       params: StatusRulePramsSchema,

--- a/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
+++ b/x-pack/plugins/synthetics/server/alert_rules/tls_rule/tls_rule.ts
@@ -34,6 +34,7 @@ import { TLSRuleExecutor } from './tls_rule_executor';
 import {
   SYNTHETICS_ALERT_RULE_TYPES,
   TLS_CERTIFICATE,
+  SYNTHETICS_RULE_TYPE_PRODUCER,
 } from '../../../common/constants/synthetics_alerts';
 import { generateAlertMessage, updateState, UptimeRuleTypeAlertDefinition } from '../common';
 import { ALERT_DETAILS_URL, getActionVariables } from '../action_variables';
@@ -55,7 +56,7 @@ export const registerSyntheticsTLSCheckRule = (
   return createLifecycleRuleType({
     id: SYNTHETICS_ALERT_RULE_TYPES.TLS,
     category: DEFAULT_APP_CATEGORIES.observability.id,
-    producer: 'uptime',
+    producer: SYNTHETICS_RULE_TYPE_PRODUCER,
     name: TLS_CERTIFICATE.name,
     validate: {
       params: schema.object({

--- a/x-pack/plugins/uptime/common/constants/uptime_alerts.ts
+++ b/x-pack/plugins/uptime/common/constants/uptime_alerts.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
+import { i18n } from '@kbn/i18n';
 import { ActionGroup } from '@kbn/alerting-plugin/common';
 
 export type MonitorStatusActionGroup =
@@ -47,3 +47,10 @@ export const UPTIME_RULE_TYPES = [
   'xpack.uptime.alerts.monitorStatus',
   'xpack.uptime.alerts.durationAnomaly',
 ];
+
+export const SYNTHETICS_RULE_TYPE_PRODUCER = i18n.translate(
+  'xpack.synthetics.alertRules.producer',
+  {
+    defaultMessage: 'Synthetics and Uptime',
+  }
+);

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/duration_anomaly.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/duration_anomaly.ts
@@ -36,7 +36,11 @@ import {
   setRecoveredAlertsContext,
   UptimeRuleTypeAlertDefinition,
 } from './common';
-import { CLIENT_ALERT_TYPES, DURATION_ANOMALY } from '../../../../common/constants/uptime_alerts';
+import {
+  CLIENT_ALERT_TYPES,
+  DURATION_ANOMALY,
+  SYNTHETICS_RULE_TYPE_PRODUCER,
+} from '../../../../common/constants/uptime_alerts';
 import { commonStateTranslations, durationAnomalyTranslations } from './translations';
 import { UptimeCorePluginsSetup } from '../adapters/framework';
 import { UptimeAlertTypeFactory } from './types';
@@ -105,7 +109,7 @@ export const durationAnomalyAlertFactory: UptimeAlertTypeFactory<ActionGroupIds>
 ) => ({
   id: CLIENT_ALERT_TYPES.DURATION_ANOMALY,
   category: DEFAULT_APP_CATEGORIES.observability.id,
-  producer: 'uptime',
+  producer: SYNTHETICS_RULE_TYPE_PRODUCER,
   name: durationAnomalyTranslations.alertFactoryName,
   validate: {
     params: schema.object({

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/status_check.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/status_check.ts
@@ -32,7 +32,11 @@ import {
   Ping,
   GetMonitorAvailabilityParams,
 } from '../../../../common/runtime_types';
-import { CLIENT_ALERT_TYPES, MONITOR_STATUS } from '../../../../common/constants/uptime_alerts';
+import {
+  CLIENT_ALERT_TYPES,
+  MONITOR_STATUS,
+  SYNTHETICS_RULE_TYPE_PRODUCER,
+} from '../../../../common/constants/uptime_alerts';
 import {
   updateState,
   getViewInAppUrl,
@@ -282,7 +286,7 @@ export const statusCheckAlertFactory: UptimeAlertTypeFactory<ActionGroupIds> = (
 ) => ({
   id: CLIENT_ALERT_TYPES.MONITOR_STATUS,
   category: DEFAULT_APP_CATEGORIES.observability.id,
-  producer: 'uptime',
+  producer: SYNTHETICS_RULE_TYPE_PRODUCER,
   name: i18n.translate('xpack.uptime.alerts.monitorStatus', {
     defaultMessage: 'Uptime monitor status',
   }),

--- a/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/tls.ts
+++ b/x-pack/plugins/uptime/server/legacy_uptime/lib/alerts/tls.ts
@@ -28,7 +28,11 @@ import {
   setRecoveredAlertsContext,
   UptimeRuleTypeAlertDefinition,
 } from './common';
-import { CLIENT_ALERT_TYPES, TLS } from '../../../../common/constants/uptime_alerts';
+import {
+  CLIENT_ALERT_TYPES,
+  TLS,
+  SYNTHETICS_RULE_TYPE_PRODUCER,
+} from '../../../../common/constants/uptime_alerts';
 import { DYNAMIC_SETTINGS_DEFAULTS } from '../../../../common/constants';
 import { Cert, CertResult } from '../../../../common/runtime_types';
 import { commonStateTranslations, tlsTranslations } from './translations';
@@ -119,7 +123,7 @@ export const tlsAlertFactory: UptimeAlertTypeFactory<ActionGroupIds> = (
 ) => ({
   id: CLIENT_ALERT_TYPES.TLS,
   category: DEFAULT_APP_CATEGORIES.observability.id,
-  producer: 'uptime',
+  producer: SYNTHETICS_RULE_TYPE_PRODUCER,
   name: tlsTranslations.alertFactoryName,
   validate: {
     params: schema.object({


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/171730

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
