### PR TITLE
[Enterprise Search] Add navigation to license if URL is configured

### DIFF
--- a/x-pack/plugins/enterprise_search/common/types/ml.ts
+++ b/x-pack/plugins/enterprise_search/common/types/ml.ts
@@ -29,7 +29,8 @@ export interface MlModel {
   type: string;
   title: string;
   description?: string;
-  license?: string;
+  licenseType?: string;
+  licensePageUrl?: string;
   modelDetailsPageUrl?: string;
   deploymentState: MlModelDeploymentState;
   deploymentStateReason?: string;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiBadge, EuiLink, EuiText } from '@elastic/eui';
+import { EuiLink, EuiText } from '@elastic/eui';
 
 import { MlModelDeploymentState } from '../../../../../../../common/types/ml';
 import { TrainedModelHealth } from '../ml_model_health';
@@ -99,7 +99,12 @@ describe('ModelSelectOption', () => {
 
 describe('LicenseBadge', () => {
   it('renders with link if URL is present', () => {
-    const wrapper = shallow(<LicenseBadge licenseType={DEFAULT_PROPS.licenseType!} licensePageUrl={DEFAULT_PROPS.licensePageUrl} />);
+    const wrapper = shallow(
+      <LicenseBadge
+        licenseType={DEFAULT_PROPS.licenseType!}
+        licensePageUrl={DEFAULT_PROPS.licensePageUrl}
+      />
+    );
     expect(wrapper.find(EuiLink)).toHaveLength(1);
   });
   it('renders without link if URL is not present', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.test.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 
 import { shallow } from 'enzyme';
 
-import { EuiBadge, EuiText } from '@elastic/eui';
+import { EuiBadge, EuiLink, EuiText } from '@elastic/eui';
 
 import { MlModelDeploymentState } from '../../../../../../../common/types/ml';
 import { TrainedModelHealth } from '../ml_model_health';
@@ -19,6 +19,7 @@ import { TrainedModelHealth } from '../ml_model_health';
 import {
   DeployModelButton,
   getContextMenuPanel,
+  LicenseBadge,
   ModelSelectOption,
   ModelSelectOptionProps,
   StartModelButton,
@@ -30,7 +31,8 @@ const DEFAULT_PROPS: ModelSelectOptionProps = {
   label: 'Model 1',
   title: 'Model 1',
   description: 'Model 1 description',
-  license: 'elastic',
+  licenseType: 'elastic',
+  licensePageUrl: 'https://licen.se',
   deploymentState: MlModelDeploymentState.NotDeployed,
   startTime: 0,
   targetAllocationCount: 0,
@@ -47,16 +49,16 @@ describe('ModelSelectOption', () => {
   });
   it('renders with license badge if present', () => {
     const wrapper = shallow(<ModelSelectOption {...DEFAULT_PROPS} />);
-    expect(wrapper.find(EuiBadge)).toHaveLength(1);
+    expect(wrapper.find(LicenseBadge)).toHaveLength(1);
   });
   it('renders without license badge if not present', () => {
     const props = {
       ...DEFAULT_PROPS,
-      license: undefined,
+      licenseType: undefined,
     };
 
     const wrapper = shallow(<ModelSelectOption {...props} />);
-    expect(wrapper.find(EuiBadge)).toHaveLength(0);
+    expect(wrapper.find(LicenseBadge)).toHaveLength(0);
   });
   it('renders with description if present', () => {
     const wrapper = shallow(<ModelSelectOption {...DEFAULT_PROPS} />);
@@ -93,11 +95,22 @@ describe('ModelSelectOption', () => {
     const wrapper = shallow(<ModelSelectOption {...DEFAULT_PROPS} />);
     expect(wrapper.find(TrainedModelHealth)).toHaveLength(1);
   });
+});
 
-  describe('getContextMenuPanel', () => {
-    it('gets model details link if URL is present', () => {
-      const panels = getContextMenuPanel('https://model.ai');
-      expect(panels[0].items).toHaveLength(2);
-    });
+describe('LicenseBadge', () => {
+  it('renders with link if URL is present', () => {
+    const wrapper = shallow(<LicenseBadge licenseType={DEFAULT_PROPS.licenseType!} licensePageUrl={DEFAULT_PROPS.licensePageUrl} />);
+    expect(wrapper.find(EuiLink)).toHaveLength(1);
+  });
+  it('renders without link if URL is not present', () => {
+    const wrapper = shallow(<LicenseBadge licenseType={DEFAULT_PROPS.licenseType!} />);
+    expect(wrapper.find(EuiLink)).toHaveLength(0);
+  });
+});
+
+describe('getContextMenuPanel', () => {
+  it('gets model details link if URL is present', () => {
+    const panels = getContextMenuPanel('https://model.ai');
+    expect(panels[0].items).toHaveLength(2);
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -18,6 +18,7 @@ import {
   EuiContextMenuPanelDescriptor,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiLink,
   EuiPopover,
   EuiRadio,
   EuiText,
@@ -142,11 +143,41 @@ export const ModelMenuPopover: React.FC<{
   );
 };
 
+export interface LicenseBadgeProps {
+  licenseType: string;
+  licensePageUrl?: string;
+}
+
+export const LicenseBadge: React.FC<LicenseBadgeProps> = ({ licenseType, licensePageUrl }) => {
+  const licenseLabel = i18n.translate(
+    'xpack.enterpriseSearch.content.indices.pipelines.modelSelectOption.licenseBadge.label',
+    {
+      defaultMessage: 'License: {licenseType}',
+      values: {
+        licenseType,
+      },
+    }
+  );
+
+  return (
+    <EuiBadge color="hollow">
+      {licensePageUrl ? (
+        <EuiLink target="_blank" href={licensePageUrl}>
+          {licenseLabel}
+        </EuiLink>
+      ) : (
+        <p>{licenseLabel}</p>
+      )}
+    </EuiBadge>
+  );
+};
+
 export const ModelSelectOption: React.FC<ModelSelectOptionProps> = ({
   modelId,
   title,
   description,
-  license,
+  licenseType,
+  licensePageUrl,
   deploymentState,
   deploymentStateReason,
   modelDetailsPageUrl,
@@ -184,24 +215,14 @@ export const ModelSelectOption: React.FC<ModelSelectOptionProps> = ({
           <EuiFlexItem>
             <EuiTextColor color="subdued">{modelId}</EuiTextColor>
           </EuiFlexItem>
-          {(license || description) && (
+          {(licenseType || description) && (
             <EuiFlexItem>
               <EuiFlexGroup gutterSize="xs" alignItems="center">
-                {license && (
+                {licenseType && (
                   <EuiFlexItem grow={false}>
                     {/* Wrap in a div to prevent the badge from growing to a whole row on mobile */}
                     <div>
-                      <EuiBadge color="hollow">
-                        {i18n.translate(
-                          'xpack.enterpriseSearch.content.indices.pipelines.modelSelectOption.licenseBadge.label',
-                          {
-                            defaultMessage: 'License: {license}',
-                            values: {
-                              license,
-                            },
-                          }
-                        )}
-                      </EuiBadge>
+                      <LicenseBadge licenseType={licenseType} licensePageUrl={licensePageUrl} />
                     </div>
                   </EuiFlexItem>
                 )}

--- a/x-pack/plugins/enterprise_search/server/lib/ml/utils.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/utils.ts
@@ -81,7 +81,8 @@ export const E5_MODEL_PLACEHOLDER: MlModel = {
     defaultMessage:
       'E5 is an NLP model that enables you to perform multi-lingual semantic search by using dense vector representations. This model performs best for non-English language documents and queries.',
   }),
-  license: 'MIT',
+  licenseType: 'mit',
+  licensePageUrl: 'https://huggingface.co/elastic/multilingual-e5-small-optimized',
   modelDetailsPageUrl: 'https://huggingface.co/intfloat/multilingual-e5-small',
   isPlaceholder: true,
 };


### PR DESCRIPTION
## Summary

If a license page URL is configured for a (curated) model, the badge renders as clickable and navigates to the page in a new tab.
We are also adding the license link to the E5 model card.

<img width="1414" alt="Screenshot 2023-12-01 at 17 24 36" src="https://github.com/elastic/kibana/assets/14224983/caf8d4f8-dd15-46c9-bfa3-2f97d06c0132">


### Checklist
- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
