### PR TITLE
fleet: upgrade universal profiling integrations

### DIFF
--- a/fleet_packages.json
+++ b/fleet_packages.json
@@ -42,12 +42,12 @@
   },
   {
     "name": "profiler_symbolizer",
-    "version": "8.10.0",
+    "version": "8.12.0",
     "forceAlignStackVersion": true
   },
   {
     "name": "profiler_collector",
-    "version": "8.11.0",
+    "version": "8.12.0",
     "forceAlignStackVersion": true
   },
   {


### PR DESCRIPTION
## Summary

With https://github.com/elastic/integrations/pull/8582 the integration packages for Universal Profiling got upgraded. With Kibana bundle these new integration packages.