### PR TITLE
[Serverless][Security Solution][Endpoint] Re-enable serverless endpoint list test

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -70,7 +70,8 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        specPattern:
+          'public/management/cypress/e2e/**/endpoint_list_with_security_essentials.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -70,8 +70,7 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern:
-          'public/management/cypress/e2e/**/endpoint_list_with_security_essentials.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/endpoint_list_with_security_essentials.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/serverless/endpoint_list_with_security_essentials.cy.ts
@@ -15,8 +15,7 @@ import {
   visitEndpointList,
 } from '../../screens';
 
-// FLAKY: https://github.com/elastic/kibana/issues/171643
-describe.skip(
+describe(
   'When on the Endpoint List in Security Essentials PLI',
   {
     tags: ['@serverless'],

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/fleet_server/fleet_server_services.ts
@@ -325,7 +325,7 @@ const startFleetServerWithDocker = async ({
       if (isServerless) {
         log.info(`Waiting for server [${hostname}] to register with Elasticsearch`);
 
-        await waitForFleetServerToRegisterWithElasticsearch(kbnClient, hostname, 120000);
+        await waitForFleetServerToRegisterWithElasticsearch(kbnClient, hostname, 180000);
       } else {
         await waitForHostToEnroll(kbnClient, log, hostname, 120000);
       }
@@ -743,7 +743,7 @@ const waitForFleetServerToRegisterWithElasticsearch = async (
 
   if (!found) {
     throw new Error(
-      `Timed out waiting for fleet server [${fleetServerHostname}] to register with Elasticsarch`
+      `Timed out waiting for fleet server [${fleetServerHostname}] to register with Elasticsearch`
     );
   }
 };


### PR DESCRIPTION
## Summary

Re-enable serverless tests for endpoint list
Closes elastic/kibana/issues/171643

**flaky runner**
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4137 x 100 ( 1 failure ) - Timed out waiting for fleet server [dev-fleet-server.8289.1a2h] to register with Elasticsarch
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4139 x 100 ( all pass )
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4142 x 100 ( all pass )

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios