### PR TITLE
Retry ES calls when receiving `504 Gateway Timeout`

### DIFF
--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/retryable_es_client_errors.test.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/retryable_es_client_errors.test.ts
@@ -59,15 +59,18 @@ describe('isRetryableEsClientError', () => {
       expect(isRetryableEsClientError(error)).toEqual(true);
     });
 
-    it.each([503, 401, 403, 408, 410, 429])('ResponseError with %p status code', (statusCode) => {
-      const error = new esErrors.ResponseError(
-        elasticsearchClientMock.createApiResponse({
-          statusCode,
-          body: { error: { type: 'reason' } },
-        })
-      );
+    it.each([503, 504, 401, 403, 408, 410, 429])(
+      'ResponseError with %p status code',
+      (statusCode) => {
+        const error = new esErrors.ResponseError(
+          elasticsearchClientMock.createApiResponse({
+            statusCode,
+            body: { error: { type: 'reason' } },
+          })
+        );
 
-      expect(isRetryableEsClientError(error)).toEqual(true);
-    });
+        expect(isRetryableEsClientError(error)).toEqual(true);
+      }
+    );
   });
 });

--- a/packages/core/elasticsearch/core-elasticsearch-server-internal/src/retryable_es_client_errors.ts
+++ b/packages/core/elasticsearch/core-elasticsearch-server-internal/src/retryable_es_client_errors.ts
@@ -9,12 +9,13 @@
 import { errors as EsErrors } from '@elastic/elasticsearch';
 
 const retryResponseStatuses = [
-  503, // ServiceUnavailable
   401, // AuthorizationException
   403, // AuthenticationException
   408, // RequestTimeout
   410, // Gone
   429, // TooManyRequests -> ES circuit breaker
+  503, // ServiceUnavailable
+  504, // GatewayTimeout
 ];
 
 /**


### PR DESCRIPTION
## Summary

Address https://github.com/elastic/kibana/issues/172352
