### PR TITLE
[Cloud Security] reduce the size of the CIS logo to match the benchmark logo size

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/findings_flyout/findings_flyout.tsx
@@ -100,7 +100,7 @@ export const CisKubernetesIcons = ({
   <EuiFlexGroup gutterSize="s" alignItems="center">
     <EuiFlexItem grow={false}>
       <EuiToolTip content="Center for Internet Security">
-        <EuiIcon type={cisLogoIcon} size="xxl" />
+        <EuiIcon type={cisLogoIcon} size="xl" />
       </EuiToolTip>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>


### PR DESCRIPTION
## Summary

A follow up of the Quick Wins day, see more [in this discussion](https://elastic.slack.com/archives/C03E5KGNWT1/p1693994546394189)

**Before**
<img width="194" alt="Screenshot 2023-12-04 at 11 04 42" src="https://github.com/elastic/kibana/assets/478762/cd259338-1600-44d7-8fbf-93a2b2a229f8">

**After**
<img width="189" alt="Screenshot 2023-12-04 at 11 05 03" src="https://github.com/elastic/kibana/assets/478762/ab3db895-f36a-4e41-820a-e3ebbe1ad083">

