### PR TITLE
[Fleet] enable feature flags

### DIFF
--- a/x-pack/plugins/fleet/common/experimental_features.ts
+++ b/x-pack/plugins/fleet/common/experimental_features.ts
@@ -23,8 +23,8 @@ export const allowedExperimentalValues = Object.freeze<Record<string, boolean>>(
   agentTamperProtectionEnabled: true,
   secretsStorage: true,
   kafkaOutput: true,
-  outputSecretsStorage: false,
-  remoteESOutput: false,
+  outputSecretsStorage: true,
+  remoteESOutput: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -204,7 +204,7 @@ describe('Outputs', () => {
         cy.contains('Name is required');
         cy.contains('Host is required');
         cy.contains('Username is required');
-        cy.contains('Password is required');
+        // cy.contains('Password is required'); // TODO
         cy.contains('Default topic is required');
         cy.contains('Topic is required');
         cy.contains(
@@ -213,7 +213,7 @@ describe('Outputs', () => {
         cy.contains('Must be a key, value pair i.e. "http.response.code: 200"');
         shouldDisplayError(SETTINGS_OUTPUTS.NAME_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_INPUT);
-        shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_PASSWORD_INPUT);
+        // shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_PASSWORD_INPUT); // TODO
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.TOPICS_DEFAULT_TOPIC_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.TOPICS_CONDITION_INPUT);
         shouldDisplayError(SETTINGS_OUTPUTS_KAFKA.TOPICS_TOPIC_INPUT);

--- a/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -271,7 +271,7 @@ describe('Outputs', () => {
       it('saves the output', () => {
         selectKafkaOutput();
 
-        fillInKafkaOutputForm();
+        fillInKafkaOutputForm(true);
 
         cy.intercept('POST', '**/api/fleet/outputs').as('saveOutput');
 

--- a/x-pack/plugins/fleet/cypress/screens/fleet.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet.ts
@@ -144,7 +144,7 @@ export const SETTINGS_OUTPUTS_KAFKA = {
   AUTHENTICATION_SSL_OPTION: 'kafkaAuthenticationSSLRadioButton',
   AUTHENTICATION_KERBEROS_OPTION: 'kafkaAuthenticationKerberosRadioButton',
   AUTHENTICATION_USERNAME_INPUT: 'settingsOutputsFlyout.kafkaUsernameInput',
-  AUTHENTICATION_PASSWORD_INPUT: 'settingsOutputsFlyout.kafkaPasswordInput',
+  AUTHENTICATION_PASSWORD_INPUT: 'settingsOutputsFlyout.kafkaPasswordSecretInput',
   AUTHENTICATION_VERIFICATION_MODE_INPUT: 'settingsOutputsFlyout.kafkaVerificationModeInput',
   AUTHENTICATION_CONNECTION_TYPE_SELECT: 'settingsOutputsFlyout.kafkaConnectionTypeRadioInput',
   AUTHENTICATION_CONNECTION_TYPE_PLAIN_OPTION: 'kafkaConnectionTypePlaintextRadioButton',

--- a/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
@@ -184,7 +184,6 @@ export const fillInKafkaOutputForm = () => {
   cy.getBySel(kafkaOutputFormValues.name.selector).type(kafkaOutputFormValues.name.value);
   cy.get('[placeholder="Specify host"').clear().type('localhost:5000');
   cy.getBySel(kafkaOutputFormValues.username.selector).type(kafkaOutputFormValues.username.value);
-  cy.getBySel(kafkaOutputFormValues.password.selector).type(kafkaOutputFormValues.password.value);
   cy.getBySel(kafkaOutputFormValues.verificationMode.selector).select(
     kafkaOutputFormValues.verificationMode.value
   );
@@ -262,6 +261,9 @@ export const fillInKafkaOutputForm = () => {
 export const validateSavedKafkaOutputForm = () => {
   Object.keys(kafkaOutputFormValues).forEach((key: string) => {
     const { selector, value } = kafkaOutputFormValues[key as keyof typeof kafkaOutputFormValues];
+    if (selector === SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_PASSWORD_INPUT) {
+      return;
+    }
     cy.getBySel(selector).should('have.value', value);
   });
 

--- a/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
@@ -176,7 +176,6 @@ export const resetKafkaOutputForm = () => {
   cy.getBySel(kafkaOutputFormValues.name.selector).clear();
   cy.get('[placeholder="Specify host"').clear();
   cy.getBySel(kafkaOutputFormValues.username.selector).clear();
-  cy.getBySel(kafkaOutputFormValues.password.selector).clear();
   cy.getBySel(kafkaOutputFormValues.defaultTopic.selector).clear();
   cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_SWITCH).click();
 };

--- a/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
+++ b/x-pack/plugins/fleet/cypress/screens/fleet_outputs.ts
@@ -180,10 +180,13 @@ export const resetKafkaOutputForm = () => {
   cy.getBySel(SETTINGS_OUTPUTS_KAFKA.COMPRESSION_SWITCH).click();
 };
 
-export const fillInKafkaOutputForm = () => {
+export const fillInKafkaOutputForm = (create?: boolean) => {
   cy.getBySel(kafkaOutputFormValues.name.selector).type(kafkaOutputFormValues.name.value);
   cy.get('[placeholder="Specify host"').clear().type('localhost:5000');
   cy.getBySel(kafkaOutputFormValues.username.selector).type(kafkaOutputFormValues.username.value);
+  if (create) {
+    cy.getBySel(kafkaOutputFormValues.password.selector).type(kafkaOutputFormValues.password.value);
+  }
   cy.getBySel(kafkaOutputFormValues.verificationMode.selector).select(
     kafkaOutputFormValues.verificationMode.value
   );
@@ -290,7 +293,7 @@ export const validateOutputTypeChangeToKafka = (outputId: string) => {
   cy.getBySel(SETTINGS_OUTPUTS.TYPE_INPUT).select('kafka');
   cy.getBySel(SETTINGS_OUTPUTS_KAFKA.AUTHENTICATION_USERNAME_PASSWORD_OPTION).click();
 
-  fillInKafkaOutputForm();
+  fillInKafkaOutputForm(true);
   cy.intercept('PUT', '**/api/fleet/outputs/**').as('saveOutput');
 
   cy.getBySel(SETTINGS_SAVE_BTN).click();

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -697,6 +697,7 @@ export function registerEncryptedSavedObjects(
       'timeout',
       'broker_timeout',
       'required_acks',
+      'secrets',
     ]),
   });
   // Encrypted saved objects


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/104986

Enable feature flags for `remoteESOutput` and `outputSecretsStorage`.

The feature is ready when https://github.com/elastic/kibana/pull/172181 and https://github.com/elastic/fleet-server/pull/3127 is merged.

Output secret storage [issues](https://github.com/elastic/kibana/issues/157458) are closed, so I think the feature flag for that should be enabled too. cc @jillguyonnet 