### PR TITLE
[Log threshold alert] Remove technical preview from alert details page

### DIFF
--- a/x-pack/plugins/observability/public/pages/alert_details/alert_details.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/alert_details.tsx
@@ -21,7 +21,6 @@ import { PageTitle, pageTitleContent } from './components/page_title';
 import { HeaderActions } from './components/header_actions';
 import { AlertSummary, AlertSummaryField } from './components/alert_summary';
 import { CenterJustifiedSpinner } from '../../components/center_justified_spinner';
-import { FeedbackButton } from './components/feedback_button';
 import PageNotFound from '../404';
 import { getTimeZone } from '../../utils/get_time_zone';
 import { isAlertDetailsEnabledPerApp } from '../../utils/is_alert_details_enabled';
@@ -117,10 +116,6 @@ export function AlertDetails() {
   const AlertDetailsAppSection = ruleTypeModel ? ruleTypeModel.alertDetailsAppSection : null;
   const timeZone = getTimeZone(uiSettings);
 
-  const showFeedbackButton = alert?.fields[ALERT_RULE_TYPE_ID] === LOG_DOCUMENT_COUNT_RULE_TYPE_ID;
-
-  const feedbackButton = showFeedbackButton ? <FeedbackButton /> : null;
-
   return (
     <ObservabilityPageTemplate
       pageHeader={{
@@ -135,7 +130,6 @@ export function AlertDetails() {
           >
             <HeaderActions alert={alert} />
           </CasesContext>,
-          feedbackButton,
         ],
         bottomBorder: true,
       }}

--- a/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
+++ b/x-pack/plugins/observability/public/pages/alert_details/components/page_title.tsx
@@ -32,7 +32,6 @@ import { asDuration } from '../../../../common/utils/formatters';
 import { TopAlert } from '../../../typings/alerts';
 import { ExperimentalBadge } from '../../../components/experimental_badge';
 import {
-  LOG_DOCUMENT_COUNT_RULE_TYPE_ID,
   METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID,
   METRIC_THRESHOLD_ALERT_TYPE_ID,
 } from '../alert_details';
@@ -58,7 +57,6 @@ export function PageTitle({ alert, dataTestSubj }: PageTitleProps) {
   if (!alert) return <EuiLoadingSpinner />;
 
   const showExperimentalBadge =
-    alert.fields[ALERT_RULE_TYPE_ID] === LOG_DOCUMENT_COUNT_RULE_TYPE_ID ||
     alert.fields[ALERT_RULE_TYPE_ID] === METRIC_THRESHOLD_ALERT_TYPE_ID ||
     alert.fields[ALERT_RULE_TYPE_ID] === METRIC_INVENTORY_THRESHOLD_ALERT_TYPE_ID;
 


### PR DESCRIPTION
Partially resolves https://github.com/elastic/kibana/issues/172379

Removes "Technical Preview" and "Tell us what you think!" from the Log threshold alert details page.