### PR TITLE
[performance] Move scalability and load APM to e2e-perf cluster

### DIFF
--- a/x-pack/test/load/config.ts
+++ b/x-pack/test/load/config.ts
@@ -11,8 +11,8 @@ import { FtrConfigProviderContext } from '@kbn/test';
 import { GatlingTestRunner } from './runner';
 
 // These "secret" values are intentionally written in the source.
-const APM_SERVER_URL = 'https://142fea2d3047486e925eb8b223559cae.apm.europe-west1.gcp.cloud.es.io';
-const APM_PUBLIC_TOKEN = 'pWFFEym07AKBBhUE2i';
+const APM_SERVER_URL = 'https://kibana-ops-e2e-perf.apm.us-central1.gcp.cloud.es.io:443';
+const APM_PUBLIC_TOKEN = 'CTs9y3cvcfq13bQqsB';
 const AGGS_SHARD_DELAY = process.env.LOAD_TESTING_SHARD_DELAY;
 const DISABLE_PLUGINS = process.env.LOAD_TESTING_DISABLE_PLUGINS;
 const journeyName = process.env.GATLING_SIMULATIONS;

--- a/x-pack/test/scalability/config.ts
+++ b/x-pack/test/scalability/config.ts
@@ -18,8 +18,8 @@ import { FtrProviderContext } from './ftr_provider_context';
 import { ScalabilityJourney } from './types';
 
 // These "secret" values are intentionally written in the source.
-const APM_SERVER_URL = 'https://142fea2d3047486e925eb8b223559cae.apm.europe-west1.gcp.cloud.es.io';
-const APM_PUBLIC_TOKEN = 'pWFFEym07AKBBhUE2i';
+const APM_SERVER_URL = 'https://kibana-ops-e2e-perf.apm.us-central1.gcp.cloud.es.io:443';
+const APM_PUBLIC_TOKEN = 'CTs9y3cvcfq13bQqsB';
 
 const AGGS_SHARD_DELAY = process.env.LOAD_TESTING_SHARD_DELAY;
 const DISABLE_PLUGINS = process.env.LOAD_TESTING_DISABLE_PLUGINS;


### PR DESCRIPTION
In preparation for a cluster migration.  These metrics will remain on the e2e cluster post-migration.

<!--ONMERGE {"backportTargets":["7.17","8.11"]} ONMERGE-->