### PR TITLE
[BUG][OBS-UX-MNGMT] Alert details page search bar doesn't consider QueryConfig in the Kibana Advanced setting

### DIFF
--- a/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
+++ b/x-pack/plugins/observability/public/components/alert_search_bar/alert_search_bar.tsx
@@ -10,12 +10,14 @@ import React, { useCallback, useEffect } from 'react';
 
 import { i18n } from '@kbn/i18n';
 import { Query } from '@kbn/es-query';
+import { getEsQueryConfig } from '@kbn/data-plugin/common';
 import { AlertsStatusFilter } from './components';
 import { observabilityAlertFeatureIds } from '../../../common/constants';
 import { ALERT_STATUS_QUERY, DEFAULT_QUERIES, DEFAULT_QUERY_STRING } from './constants';
 import { ObservabilityAlertSearchBarProps } from './types';
 import { buildEsQuery } from '../../utils/build_es_query';
 import { AlertStatus } from '../../../common/typings';
+import { useKibana } from '../../utils/kibana_react';
 
 const getAlertStatusQuery = (status: string): Query[] => {
   return ALERT_STATUS_QUERY[status]
@@ -41,6 +43,7 @@ export function ObservabilityAlertSearchBar({
   status,
 }: ObservabilityAlertSearchBarProps) {
   const toasts = useToasts();
+  const { uiSettings } = useKibana().services;
 
   const onAlertStatusChange = useCallback(
     (alertStatus: AlertStatus) => {
@@ -52,7 +55,8 @@ export function ObservabilityAlertSearchBar({
               from: rangeFrom,
             },
             kuery,
-            [...getAlertStatusQuery(alertStatus), ...defaultSearchQueries]
+            [...getAlertStatusQuery(alertStatus), ...defaultSearchQueries],
+            getEsQueryConfig(uiSettings)
           )
         );
       } catch (error) {
@@ -62,7 +66,16 @@ export function ObservabilityAlertSearchBar({
         onKueryChange(DEFAULT_QUERY_STRING);
       }
     },
-    [onEsQueryChange, rangeTo, rangeFrom, kuery, defaultSearchQueries, toasts, onKueryChange]
+    [
+      onEsQueryChange,
+      rangeTo,
+      rangeFrom,
+      kuery,
+      defaultSearchQueries,
+      uiSettings,
+      toasts,
+      onKueryChange,
+    ]
   );
 
   useEffect(() => {
@@ -84,7 +97,8 @@ export function ObservabilityAlertSearchBar({
             from: dateRange.from,
           },
           query,
-          [...getAlertStatusQuery(status), ...defaultSearchQueries]
+          [...getAlertStatusQuery(status), ...defaultSearchQueries],
+          getEsQueryConfig(uiSettings)
         );
         if (query) onKueryChange(query);
         timeFilterService.setTime(dateRange);
@@ -99,13 +113,14 @@ export function ObservabilityAlertSearchBar({
       }
     },
     [
+      status,
       defaultSearchQueries,
+      uiSettings,
+      onKueryChange,
       timeFilterService,
       onRangeFromChange,
       onRangeToChange,
-      onKueryChange,
       onEsQueryChange,
-      status,
       toasts,
     ]
   );

--- a/x-pack/plugins/observability/public/utils/build_es_query/build_es_query.ts
+++ b/x-pack/plugins/observability/public/utils/build_es_query/build_es_query.ts
@@ -5,11 +5,16 @@
  * 2.0.
  */
 
-import { buildEsQuery as kbnBuildEsQuery, TimeRange, Query } from '@kbn/es-query';
+import { buildEsQuery as kbnBuildEsQuery, TimeRange, Query, EsQueryConfig } from '@kbn/es-query';
 import { ALERT_TIME_RANGE } from '@kbn/rule-data-utils';
 import { getTime } from '@kbn/data-plugin/common';
 
-export function buildEsQuery(timeRange: TimeRange, kuery?: string, queries: Query[] = []) {
+export function buildEsQuery(
+  timeRange: TimeRange,
+  kuery?: string,
+  queries: Query[] = [],
+  config: EsQueryConfig = {}
+) {
   const timeFilter =
     timeRange &&
     getTime(undefined, timeRange, {
@@ -18,6 +23,5 @@ export function buildEsQuery(timeRange: TimeRange, kuery?: string, queries: Quer
   const filtersToUse = timeFilter ? [timeFilter] : [];
   const kueryFilter = kuery ? [{ query: kuery, language: 'kuery' }] : [];
   const queryToUse = [...kueryFilter, ...queries];
-
-  return kbnBuildEsQuery(undefined, queryToUse, filtersToUse);
+  return kbnBuildEsQuery(undefined, queryToUse, filtersToUse, config);
 }


### PR DESCRIPTION
## Summary

It fixes #172495 by considering the Query related config in the Kbiana advanced settings.


### Before
 
<img width="975" alt="Screenshot 2023-12-04 at 13 33 07" src="https://github.com/elastic/kibana/assets/6838659/c61f728c-c1c2-4265-ba34-0ad324887f3d">


### After
<img width="999" alt="Screenshot 2023-12-04 at 17 50 56" src="https://github.com/elastic/kibana/assets/6838659/4da6a4c2-f317-4e1f-b14f-d2e2dfedad00">

