### PR TITLE
[maps] fix uncaught errors thrown during layer data fetching

### DIFF
--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
@@ -313,7 +313,7 @@ export class GeoJsonVectorLayer extends AbstractVectorLayer {
         syncContext.setJoinError
       );
     } catch (error) {
-      // Error used to stop execution flow. error already handled by data requests
+      // Error used to stop execution flow. Error state stored in data request and displayed to user in layer legend.
     }
   }
 

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
@@ -34,7 +34,6 @@ import {
   noResultsIcon,
   NO_RESULTS_ICON_AND_TOOLTIPCONTENT,
 } from '../vector_layer';
-import { DataRequestAbortError } from '../../../util/data_request';
 import { getFeatureCollectionBounds } from '../../../util/get_feature_collection_bounds';
 import { syncGeojsonSourceData } from './geojson_source_data';
 import { performInnerJoins } from './perform_inner_joins';

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/geojson_vector_layer/geojson_vector_layer.tsx
@@ -313,9 +313,7 @@ export class GeoJsonVectorLayer extends AbstractVectorLayer {
         syncContext.setJoinError
       );
     } catch (error) {
-      if (!(error instanceof DataRequestAbortError)) {
-        throw error;
-      }
+      // Error used to stop execution flow. error already handled by data requests
     }
   }
 

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx
@@ -272,7 +272,7 @@ export class MvtVectorLayer extends AbstractVectorLayer {
         await this._syncJoins(syncContext, this.getCurrentStyle());
       }
     } catch (error) {
-      // Error used to stop execution flow. error already handled by data requests
+      // Error used to stop execution flow. Error state stored in data request and displayed to user in layer legend.
     }
   }
 

--- a/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/vector_layer/mvt_vector_layer/mvt_vector_layer.tsx
@@ -228,47 +228,51 @@ export class MvtVectorLayer extends AbstractVectorLayer {
   }
 
   async syncData(syncContext: DataRequestContext) {
-    if (this.getSource().getType() === SOURCE_TYPES.ES_SEARCH) {
-      await this._syncMaxResultWindow(syncContext);
-    }
-    await this._syncSourceStyleMeta(syncContext, this.getSource(), this.getCurrentStyle());
-    await this._syncSourceFormatters(syncContext, this.getSource(), this.getCurrentStyle());
-    await this._syncSupportsFeatureEditing({ syncContext, source: this.getSource() });
-
-    let maxLineWidth = 0;
-    const lineWidth = this.getCurrentStyle()
-      .getAllStyleProperties()
-      .find((styleProperty) => {
-        return styleProperty.getStyleName() === VECTOR_STYLES.LINE_WIDTH;
-      });
-    if (lineWidth) {
-      if (!lineWidth.isDynamic() && lineWidth.isComplete()) {
-        maxLineWidth = (lineWidth as StaticSizeProperty).getOptions().size;
-      } else if (lineWidth.isDynamic() && lineWidth.isComplete()) {
-        maxLineWidth = (lineWidth as DynamicSizeProperty).getOptions().maxSize;
+    try {
+      if (this.getSource().getType() === SOURCE_TYPES.ES_SEARCH) {
+        await this._syncMaxResultWindow(syncContext);
       }
-    }
-    const buffer = Math.ceil(3.5 * maxLineWidth);
+      await this._syncSourceStyleMeta(syncContext, this.getSource(), this.getCurrentStyle());
+      await this._syncSourceFormatters(syncContext, this.getSource(), this.getCurrentStyle());
+      await this._syncSupportsFeatureEditing({ syncContext, source: this.getSource() });
 
-    await syncMvtSourceData({
-      buffer,
-      hasLabels: this.getCurrentStyle().hasLabels(),
-      layerId: this.getId(),
-      layerName: await this.getDisplayName(),
-      prevDataRequest: this.getSourceDataRequest(),
-      requestMeta: await this._getVectorSourceRequestMeta(
-        syncContext.isForceRefresh,
-        syncContext.dataFilters,
-        this.getSource(),
-        this.getCurrentStyle(),
-        syncContext.isFeatureEditorOpenForLayer
-      ),
-      source: this.getSource() as IMvtVectorSource,
-      syncContext,
-    });
+      let maxLineWidth = 0;
+      const lineWidth = this.getCurrentStyle()
+        .getAllStyleProperties()
+        .find((styleProperty) => {
+          return styleProperty.getStyleName() === VECTOR_STYLES.LINE_WIDTH;
+        });
+      if (lineWidth) {
+        if (!lineWidth.isDynamic() && lineWidth.isComplete()) {
+          maxLineWidth = (lineWidth as StaticSizeProperty).getOptions().size;
+        } else if (lineWidth.isDynamic() && lineWidth.isComplete()) {
+          maxLineWidth = (lineWidth as DynamicSizeProperty).getOptions().maxSize;
+        }
+      }
+      const buffer = Math.ceil(3.5 * maxLineWidth);
 
-    if (this.hasJoins()) {
-      await this._syncJoins(syncContext, this.getCurrentStyle());
+      await syncMvtSourceData({
+        buffer,
+        hasLabels: this.getCurrentStyle().hasLabels(),
+        layerId: this.getId(),
+        layerName: await this.getDisplayName(),
+        prevDataRequest: this.getSourceDataRequest(),
+        requestMeta: await this._getVectorSourceRequestMeta(
+          syncContext.isForceRefresh,
+          syncContext.dataFilters,
+          this.getSource(),
+          this.getCurrentStyle(),
+          syncContext.isFeatureEditorOpenForLayer
+        ),
+        source: this.getSource() as IMvtVectorSource,
+        syncContext,
+      });
+
+      if (this.hasJoins()) {
+        await this._syncJoins(syncContext, this.getCurrentStyle());
+      }
+    } catch (error) {
+      // Error used to stop execution flow. error already handled by data requests
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/172500

PR resolves the issue by not re-throwing errors in GeoJsonVectorLayer and MvtVectorLayer syncData methods. Error state is stored in data request and displayed to users. Errors are thrown to stop the flow of execution for syncData.