### PR TITLE
[ML] Fixes data drift numeric fields not showing correctly

### DIFF
--- a/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
@@ -459,12 +459,12 @@ const fetchComparisonDriftedData = async ({
   );
 
   const fieldsWithNoOverlap = new Set<string>();
-  const rangesAggs = rangesResp.aggregations.sample
+  const rangesAggs = rangesResp?.aggregations?.sample
     ? rangesResp.aggregations.sample
-    : rangesResp.aggregations;
+    : rangesResp?.aggregations;
   for (const { field } of fields) {
-    if (rangesAggs[`${field}_ranges`]) {
-      const buckets = rangesAggs[`${field}_ranges`].buckets as AggregationsRangeBucketKeys[];
+    if (isPopulatedObject(rangesAggs, [`${field}_ranges`])) {
+      const buckets = rangesAggs[`${field}_ranges`];
 
       if (buckets) {
         const totalSumOfAllBuckets = buckets.reduce((acc, bucket) => acc + bucket.doc_count, 0);
@@ -781,7 +781,7 @@ export const useFetchDataComparisonResult = (
 
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadingReference', {
-              defaultMessage: `Loading reference data for { fieldsCount } fields.`,
+              defaultMessage: `Loading reference data for {fieldsCount} fields.`,
               values: { fieldsCount },
             })
           );
@@ -843,7 +843,7 @@ export const useFetchDataComparisonResult = (
 
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadingComparison', {
-              defaultMessage: `Loading comparison data for { fieldsCount } fields.`,
+              defaultMessage: `Loading comparison data for {fieldsCount} fields.`,
               values: { fieldsCount },
             })
           );
@@ -886,7 +886,7 @@ export const useFetchDataComparisonResult = (
           setLoaded(0.5);
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadedComparison', {
-              defaultMessage: `Loaded comparison data.Now loading histogram data.`,
+              defaultMessage: `Loaded comparison data. Now loading histogram data.`,
             })
           );
 

--- a/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
@@ -29,7 +29,7 @@ import { isDefined } from '@kbn/ml-is-defined';
 import { computeChi2PValue, type Histogram } from '@kbn/ml-chi2test';
 import { mapAndFlattenFilters } from '@kbn/data-plugin/public';
 
-import type { AggregationsRangeBucketKeys } from '@elastic/elasticsearch/lib/api/types';
+import type { AggregationsMultiTermsBucketKeys } from '@elastic/elasticsearch/lib/api/types';
 import { createMergedEsQuery } from '../index_data_visualizer/utils/saved_search_utils';
 import { useDataVisualizerKibana } from '../kibana_context';
 
@@ -463,10 +463,15 @@ const fetchComparisonDriftedData = async ({
     ? rangesResp.aggregations.sample
     : rangesResp?.aggregations;
   for (const { field } of fields) {
-    if (isPopulatedObject(rangesAggs, [`${field}_ranges`])) {
-      const buckets = rangesAggs[`${field}_ranges`];
+    if (
+      isPopulatedObject<
+        string,
+        estypes.AggregationsMultiBucketAggregateBase<AggregationsMultiTermsBucketKeys>
+      >(rangesAggs, [`${field}_ranges`])
+    ) {
+      const buckets = rangesAggs[`${field}_ranges`].buckets;
 
-      if (buckets) {
+      if (Array.isArray(buckets)) {
         const totalSumOfAllBuckets = buckets.reduce((acc, bucket) => acc + bucket.doc_count, 0);
 
         const fractions = buckets.map((bucket) => ({

--- a/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
+++ b/x-pack/plugins/data_visualizer/public/application/data_drift/use_data_drift_result.ts
@@ -459,10 +459,12 @@ const fetchComparisonDriftedData = async ({
   );
 
   const fieldsWithNoOverlap = new Set<string>();
+  const rangesAggs = rangesResp.aggregations.sample
+    ? rangesResp.aggregations.sample
+    : rangesResp.aggregations;
   for (const { field } of fields) {
-    if (rangesResp.aggregations[`${field}_ranges`]) {
-      const buckets = rangesResp.aggregations[`${field}_ranges`]
-        .buckets as AggregationsRangeBucketKeys[];
+    if (rangesAggs[`${field}_ranges`]) {
+      const buckets = rangesAggs[`${field}_ranges`].buckets as AggregationsRangeBucketKeys[];
 
       if (buckets) {
         const totalSumOfAllBuckets = buckets.reduce((acc, bucket) => acc + bucket.doc_count, 0);
@@ -475,7 +477,7 @@ const fetchComparisonDriftedData = async ({
         if (totalSumOfAllBuckets > 0) {
           driftedRequestAggs[`${field}_ks_test`] = {
             bucket_count_ks_test: {
-              buckets_path: `${field}_ranges>_count`,
+              buckets_path: `${field}_ranges > _count`,
               alternative: ['two_sided'],
               ...(totalSumOfAllBuckets > 0
                 ? { fractions: fractions.map((bucket) => Number(bucket.fraction.toFixed(3))) }
@@ -779,7 +781,7 @@ export const useFetchDataComparisonResult = (
 
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadingReference', {
-              defaultMessage: `Loading reference data for {fieldsCount} fields.`,
+              defaultMessage: `Loading reference data for { fieldsCount } fields.`,
               values: { fieldsCount },
             })
           );
@@ -841,7 +843,7 @@ export const useFetchDataComparisonResult = (
 
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadingComparison', {
-              defaultMessage: `Loading comparison data for {fieldsCount} fields.`,
+              defaultMessage: `Loading comparison data for { fieldsCount } fields.`,
               values: { fieldsCount },
             })
           );
@@ -870,6 +872,7 @@ export const useFetchDataComparisonResult = (
                 signal,
               }),
           });
+
           if (isReturnedError(driftedRespAggs)) {
             setResult({
               data: undefined,
@@ -883,7 +886,7 @@ export const useFetchDataComparisonResult = (
           setLoaded(0.5);
           setProgressMessage(
             i18n.translate('xpack.dataVisualizer.dataDrift.progress.loadedComparison', {
-              defaultMessage: `Loaded comparison data. Now loading histogram data.`,
+              defaultMessage: `Loaded comparison data.Now loading histogram data.`,
             })
           );
 


### PR DESCRIPTION
## Summary

This PR fixes an issue with data drift not showing numeric fields correctly for datasets that automatically uses random sampling. 

<img width="1720" alt="image" src="https://github.com/elastic/kibana/assets/43350163/65e5efce-e428-40fc-8b53-c373c5771dd0">








<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->