### PR TITLE
[Enterprise Search] Remove E5 callout

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference_pipeline_processors_card.tsx
@@ -18,7 +18,6 @@ import { IndexNameLogic } from '../index_name_logic';
 
 import { InferencePipelineCard } from './inference_pipeline_card';
 import { AddMLInferencePipelineButton } from './ml_inference/add_ml_inference_button';
-import { E5MultilingualCallOut } from './ml_inference/e5_multilingual_callout/e5_multilingual_callout';
 import { TextExpansionCallOut } from './ml_inference/text_expansion_callout/text_expansion_callout';
 import { PipelinesLogic } from './pipelines_logic';
 
@@ -39,7 +38,6 @@ export const MlInferencePipelineProcessorsCard: React.FC = () => {
   return (
     <EuiFlexGroup direction="column" gutterSize="s">
       {hasMLPermissions && !isGated && <TextExpansionCallOut isDismissable />}
-      {hasMLPermissions && !isGated && <E5MultilingualCallOut isDismissable />}
       <EuiFlexItem>
         <AddMLInferencePipelineButton onClick={() => openAddMlInferencePipelineModal()} />
       </EuiFlexItem>


### PR DESCRIPTION
## Summary

We are removing the E5 model deployment callout from the Pipelines tab in favor of the model selector list with action buttons (#171436). The orphan code cleanup will happen in a separate PR.

<img width="636" alt="Screenshot 2023-12-04 at 14 18 43" src="https://github.com/elastic/kibana/assets/14224983/1b0fbce1-34aa-44d4-a9b9-f783761ea2bd">

