### PR TITLE
[Security Solution][Detection Engine] changes cypress ftrConfig to new format

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule.cy.ts
@@ -74,7 +74,11 @@ describe(
     tags: ['@ess', '@serverless'],
     env: {
       ftrConfig: {
-        enableExperimental: ['alertSuppressionForThresholdRuleEnabled'],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'alertSuppressionForThresholdRuleEnabled',
+          ])}`,
+        ],
       },
     },
   },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule_serverless_essentials.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule_serverless_essentials.cy.ts
@@ -23,7 +23,11 @@ describe(
           { product_line: 'security', product_tier: 'essentials' },
           { product_line: 'endpoint', product_tier: 'essentials' },
         ],
-        enableExperimental: ['alertSuppressionForThresholdRuleEnabled'],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'alertSuppressionForThresholdRuleEnabled',
+          ])}`,
+        ],
       },
     },
   },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
@@ -43,7 +43,11 @@ describe(
     tags: ['@ess', '@serverless'],
     env: {
       ftrConfig: {
-        enableExperimental: ['alertSuppressionForThresholdRuleEnabled'],
+        kbnServerArgs: [
+          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
+            'alertSuppressionForThresholdRuleEnabled',
+          ])}`,
+        ],
       },
     },
   },


### PR DESCRIPTION
## Summary
changes 

```
  env: {
      ftrConfig: {
        enableExperimental: ['alertSuppressionForThresholdRuleEnabled'],
      },
    },
```

to

```

    env: {
      ftrConfig: {
        kbnServerArgs: [
          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
            'alertSuppressionForThresholdRuleEnabled',
          ])}`,
        ],
      },
    },

```

to accommodate new ftr config format for Cypress tests