### PR TITLE
[Entity Analytics] Update Entity Risk Scoring doc link to point to new page

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -462,7 +462,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
         riskScorePrerequisites: `${SECURITY_SOLUTION_DOCS}ers-requirements.html`,
         hostRiskScore: `${SECURITY_SOLUTION_DOCS}host-risk-score.html`,
         userRiskScore: `${SECURITY_SOLUTION_DOCS}user-risk-score.html`,
-        entityRiskScoring: `${SECURITY_SOLUTION_DOCS}advanced-entity-analytics-overview.html#entity-risk-scoring`,
+        entityRiskScoring: `${SECURITY_SOLUTION_DOCS}entity-risk-scoring.html`,
       },
     },
     query: {

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -462,7 +462,7 @@ export const getDocLinks = ({ kibanaBranch }: GetDocLinkOptions): DocLinks => {
         riskScorePrerequisites: `${SECURITY_SOLUTION_DOCS}ers-requirements.html`,
         hostRiskScore: `${SECURITY_SOLUTION_DOCS}host-risk-score.html`,
         userRiskScore: `${SECURITY_SOLUTION_DOCS}user-risk-score.html`,
-        entityRiskScoring: `${SECURITY_SOLUTION_DOCS}entity-risk-scoring.html`,
+        entityRiskScoring: `${SECURITY_SOLUTION_DOCS}advanced-entity-analytics-overview.html`,
       },
     },
     query: {


### PR DESCRIPTION
Update: We are now setting the link to a temporary link to get https://github.com/elastic/security-docs/pull/4296 merged and will then update to the new page

As requested by @natasha-moore-elastic [here](https://github.com/elastic/security-docs/pull/4296#issuecomment-1840370134)

The entity risk scorign documentation is moving to a new page and we need to update this link to fix the build in https://github.com/elastic/security-docs/pull/4296. 