### PR TITLE
[Security Solution][Endpoint] Set perPage to 1000 for package policies query in Endpoint Artifacts form

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/artifact_list_page.tsx
@@ -163,6 +163,7 @@ export const ArtifactListPage = memo<ArtifactListPageProps>(
     });
 
     const policiesRequest = useGetEndpointSpecificPolicies({
+      perPage: 1000,
       onError: (err) => {
         toasts.addWarning(getLoadPoliciesError(err));
       },

--- a/x-pack/plugins/security_solution/public/management/components/artifact_list_page/integration_tests/artifact_list_page.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/artifact_list_page/integration_tests/artifact_list_page.test.tsx
@@ -13,6 +13,12 @@ import userEvent from '@testing-library/user-event';
 import type { ArtifactListPageRenderingSetup } from '../mocks';
 import { getArtifactListPageRenderingSetup } from '../mocks';
 import { getDeferred } from '../../../mocks/utils';
+import { useGetEndpointSpecificPolicies } from '../../../services/policies/hooks';
+
+jest.mock('../../../services/policies/hooks', () => ({
+  useGetEndpointSpecificPolicies: jest.fn(),
+}));
+const mockUseGetEndpointSpecificPolicies = useGetEndpointSpecificPolicies as jest.Mock;
 
 jest.mock('../../../../common/components/user_privileges');
 
@@ -29,6 +35,10 @@ describe('When using the ArtifactListPage component', () => {
     const renderSetup = getArtifactListPageRenderingSetup();
 
     ({ history, mockedApi, getFirstCard } = renderSetup);
+
+    mockUseGetEndpointSpecificPolicies.mockReturnValue({
+      data: mockedApi.responseProvider.endpointPackagePolicyList(),
+    });
 
     render = (props = {}) => (renderResult = renderSetup.renderArtifactListPage(props));
   });
@@ -132,6 +142,14 @@ describe('When using the ArtifactListPage component', () => {
       await waitFor(() => {
         expect(history.location.search).toMatch(/pageSize=20/);
       });
+    });
+
+    it('should call useGetEndpointSpecificPolicies hook with specific perPage value', () => {
+      expect(mockUseGetEndpointSpecificPolicies).toHaveBeenCalledWith(
+        expect.objectContaining({
+          perPage: 1000,
+        })
+      );
     });
 
     describe('and interacting with card actions', () => {


### PR DESCRIPTION
## Summary

It sets the `perPage` value to 1000 (overrides the default one set to `20`) in order to display more policies in Artifacts form and also in the policy filter for artifacts list.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
