### PR TITLE
[TSVB][AggBased] Carry filters/query when navigating from dashboard -> editor -> lens

### DIFF
--- a/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
+++ b/src/plugins/visualizations/public/visualize_app/utils/get_top_nav_config.tsx
@@ -309,6 +309,8 @@ export const getTopNavConfig = (
                 vis,
                 data.query.timefilter.timefilter
               );
+              const searchFilters = data.query.filterManager.getAppFilters();
+              const searchQuery = data.query.queryString.getQuery();
               const updatedWithMeta = {
                 ...navigateToLensConfig,
                 embeddableId,
@@ -319,6 +321,8 @@ export const getTopNavConfig = (
                 description: visInstance?.panelDescription || vis.description,
                 panelTimeRange: visInstance?.panelTimeRange,
                 isEmbeddable: Boolean(originatingApp),
+                ...(searchFilters && { searchFilters }),
+                ...(searchQuery && { searchQuery }),
               };
               if (navigateToLensConfig) {
                 hideLensBadge();


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/170076

![tsvb](https://github.com/elastic/kibana/assets/17003240/5da192c6-2de4-4e02-a1c0-fa2a8fc72d44)

This bug happens when navigating from dashboard to legacy editor to lens. From legacy editor to Lens works as expected

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios