### PR TITLE
[Security Solution] Adding missing test to detection engine

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/overview/cti_link_panel.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/overview/cti_link_panel.cy.ts
@@ -10,11 +10,11 @@ import {
   OVERVIEW_CTI_LINKS,
   OVERVIEW_CTI_LINKS_ERROR_INNER_PANEL,
   OVERVIEW_CTI_TOTAL_EVENT_COUNT,
-} from '../../screens/overview';
+} from '../../../../screens/overview';
 
-import { login } from '../../tasks/login';
-import { visit } from '../../tasks/navigation';
-import { OVERVIEW_URL } from '../../urls/navigation';
+import { login } from '../../../../tasks/login';
+import { visit } from '../../../../tasks/navigation';
+import { OVERVIEW_URL } from '../../../../urls/navigation';
 
 // TODO: https://github.com/elastic/kibana/issues/161539
 // FLAKY: https://github.com/elastic/kibana/issues/165709


### PR DESCRIPTION
## Summary

When we created the specific Cypress execution for the Detection Engine team, we missed a test to be added under the ownership of the team.

In this PR we are fixing that.