### PR TITLE
[POC][Logs Explorer] Explain flyout fields

### DIFF
--- a/x-pack/plugins/log_explorer/public/components/flyout_detail/sub_components/highlight_field.tsx
+++ b/x-pack/plugins/log_explorer/public/components/flyout_detail/sub_components/highlight_field.tsx
@@ -5,8 +5,16 @@
  * 2.0.
  */
 
-import { EuiFlexGroup, EuiFlexItem, EuiText, copyToClipboard, EuiTextTruncate } from '@elastic/eui';
-import React, { ReactNode, useMemo, useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiText,
+  copyToClipboard,
+  EuiTextTruncate,
+  EuiIcon,
+  EuiToolTip,
+} from '@elastic/eui';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { ValuesType } from 'utility-types';
 import {
   flyoutHoverActionFilterForText,
@@ -92,11 +100,18 @@ export function HighlightField({
     [filterForText, filterOutText, actions, field, value, columnAdded]
   );
 
+  const fieldDescription = useFieldDescription(field);
+
   return formattedValue ? (
     <EuiFlexGroup direction="column" gutterSize="none" {...props}>
       <EuiFlexItem>
         <EuiText color="subdued" size="xs">
           {label}
+          {fieldDescription && (
+            <EuiToolTip title={field} content={fieldDescription}>
+              <EuiIcon type="questionInCircle" />
+            </EuiToolTip>
+          )}
         </EuiText>
       </EuiFlexItem>
       <EuiFlexItem>
@@ -125,3 +140,16 @@ export function HighlightField({
     </EuiFlexGroup>
   ) : null;
 }
+
+// POC code just to try visualize how we can access info about a field name
+const useFieldDescription = (fieldName: string) => {
+  const [field, setField] = useState(null);
+
+  useEffect(() => {
+    fetch(`http://localhost:5000/explain?name=${encodeURIComponent(fieldName)}`)
+      .then((res) => res.json())
+      .then((data) => setField(data.description));
+  }, [fieldName]);
+
+  return field;
+};


### PR DESCRIPTION
## 📓 Summary

🛑 POC - DO NOT MERGE

As a quick experiment, this consumes a local hardcoded API to retrieve details about a field and use them inside a tooltip in the Log detail flyout

## Steps to reproduce

1. Clone the POC API from https://github.com/elastic/obs-guidance-poc/pull/11
2. Update the script to fix any CORS issue in development adding `flask-cors`
```
// requirements.txt
flask==3.0.0
flask-cors==3.0.10
pyyaml==6.0.1
requests==2.31.0
ujson==5.8.0

// src/app.py
from flask import Flask, request
from flask_cors import CORS

from . import elastic
from .models import ExplainResponse

app = Flask(__name__)
CORS(app)
```
3. Run `tox -e local` from the `poc` folder to start the local server 


https://github.com/elastic/kibana/assets/34506779/06fbda30-e962-4e81-89ed-2c8abbbabfa6

