### PR TITLE
[DOCS] Adds the 8.11.2 release notes.

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
 * <<release-notes-8.11.0>>
 * <<release-notes-8.10.4>>
@@ -54,6 +55,56 @@ Review important information about the {kib} 8.x releases.
 * <<release-notes-8.0.0-alpha1>>
 
 --
+[[release-notes-8.11.2]]
+== {kib} 8.11.2
+
+The 8.11.2 release includes the following bug fixes.
+
+[float]
+[[enhancement-v8.11.2]]
+=== Enhancements
+APM::
+* Added `context_propagation_only` APM agent setting ({kibana-pull}170405[#170405]).
+Elastic Security::
+For the Elastic Security 8.11.2 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Fleet::
+* Improve UX for policy secrets ({kibana-pull}171405[#171405]).
+Observability::
+* Adds `date_formats` to SLI ingest pipeline template ({kibana-pull}172377[#172377]).
+Platform::
+* It is now possible to hot reload Kibana's TLS (`server.ssl`) configuration by updating it and then sending a `SIGHUP` signal to the Kibana process ({kibana-pull}171823[#171823]).
+
+[float]
+[[fixes-v8.11.2]]
+=== Bug Fixes
+Dashboard::
+* Fixes reference extract method ({kibana-pull}171360[#171360]).
+* Adds Dashboard title to browser tab title ({kibana-pull}171255[#171255]).
+Elastic Security::
+For the Elastic Security 8.11.2 release information, refer to {security-guide}/release-notes.html[_Elastic Security Solution Release Notes_].
+Fleet::
+* Support integration secrets in a local package registry with variables `secret: true` and `required: false` ({kibana-pull}172078[#172078]).
+* Fixes agents metrics retrieval on the agent list page, previously displaying N/A for metrics for users with more than 10 agents. ({kibana-pull}172016[#172016]).
+* Only add `time_series_metric` if TSDB is enabled ({kibana-pull}171712[#171712]).
+* Fixes inability to upgrade agents from version 8.10.4 to version 8.11 ({kibana-pull}170974[#170974]).
+Lens & Visualizations::
+* Handle invalid values gracefully for static value operation in *Lens* ({kibana-pull}172198[#172198]).
+* Make the dashboard SO lighter ({kibana-pull}172130[#172130]).
+Machine Learning::
+* Fixes blocked jobs polling interval ({kibana-pull}171878[#171878]).
+Management::
+* Fixes autocomplete to show suggestions even if user types in every letter ({kibana-pull}171952[#171952]).
+* Fixes wrong autocomplete suggestions when using the slash symbol ({kibana-pull}171948[#171948]).
+* Fixes clusters and shards table expanded row not updating when request is changed ({kibana-pull}171232[#171232]).
+Maps::
+* Fixes using `max_result_window` to set up a mapbox vector tile (MVT) size request leading to all results not showing ({kibana-pull}171344[#171344]).
+Observability::
+* Fixes the custom threshold document link ({kibana-pull}171125[#171125]).
+SharedUX::
+* Fixes custom branding for users without "Saved Object Management" privilege ({kibana-pull}171308[#171308]).
+* Fixes the custom threshold document link ({kibana-pull}171125[#171125]).
+Uptime::
+* Fixes advanced fields broken for ICMP monitors ({kibana-pull}171161[#171161]).
 
 [[release-notes-8.11.1]]
 == {kib} 8.11.1


### PR DESCRIPTION
## Summary

Adds the release notes for 8.11.2

Closes: [172178](https://github.com/elastic/kibana/issues/172178)





<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->