### PR TITLE
[Security Solution] fix broken encoding for the expandable flyout values

### DIFF
--- a/packages/kbn-url-state/index.test.ts
+++ b/packages/kbn-url-state/index.test.ts
@@ -52,7 +52,24 @@ describe('useSyncToUrl', () => {
     expect(window.history.pushState).toHaveBeenCalledWith(
       {},
       '',
-      '#should_be_there?namespace=(test:foo)'
+      '#should_be_there?namespace=(test%3Afoo)'
+    );
+  });
+
+  it('should escape values correctly', () => {
+    window.location.hash = '#should_be_there';
+
+    const { result } = renderHook(() => useUrlState('namespace', 'test'));
+
+    act(() => {
+      result.current[1]('foo#bar');
+      jest.runAllTimers();
+    });
+
+    expect(window.history.pushState).toHaveBeenCalledWith(
+      {},
+      '',
+      '#should_be_there?namespace=(test%3Afoo%23bar)'
     );
   });
 

--- a/packages/kbn-url-state/index.ts
+++ b/packages/kbn-url-state/index.ts
@@ -99,9 +99,10 @@ export const useUrlState = <T = unknown>(urlNamespace: string, key: string) => {
           if (!Object.prototype.hasOwnProperty.call(cache.namespaces, ns)) {
             continue;
           }
-          searchParams[ns] = encode(cache.namespaces[ns]);
+          searchParams[ns] = encodeURIComponent(encode(cache.namespaces[ns]));
         }
 
+        // NOTE: don't re-encode the entire url params string
         const newSearch = stringify(searchParams, { encode: false });
 
         if (window.location.search === newSearch) {


### PR DESCRIPTION
## Summary

This fixes an issue with url encoding in the flyout. Turns out that `rison` does not produce url safe strings by default.

