### PR TITLE
[Dashboard] Prevent overflowing dashboard title on save toast

### DIFF
--- a/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.test.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.test.ts
@@ -92,6 +92,7 @@ describe('Save dashboard state', () => {
     );
     expect(allServices.notifications.toasts.addSuccess).toHaveBeenCalledWith({
       title: `Dashboard 'BooToo' was saved`,
+      className: 'eui-textBreakWord',
       'data-test-subj': 'saveDashboardSuccess',
     });
   });

--- a/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.test.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.test.ts
@@ -68,6 +68,7 @@ describe('Save dashboard state', () => {
     );
     expect(allServices.notifications.toasts.addSuccess).toHaveBeenCalledWith({
       title: `Dashboard 'BOO' was saved`,
+      className: 'eui-textBreakWord',
       'data-test-subj': 'saveDashboardSuccess',
     });
   });

--- a/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.ts
+++ b/src/plugins/dashboard/public/services/dashboard_content_management/lib/save_dashboard_state.ts
@@ -201,6 +201,7 @@ export const saveDashboardState = async ({
     if (newId) {
       toasts.addSuccess({
         title: dashboardSaveToastStrings.getSuccessString(currentState.title),
+        className: 'eui-textBreakWord',
         'data-test-subj': 'saveDashboardSuccess',
       });
 


### PR DESCRIPTION
Fixes #153552 

## Summary

Prevent long dashboard name from overflowing toast notification on save.

<img width="450" alt="Screenshot 2023-12-05 at 2 06 49 PM" src="https://github.com/elastic/kibana/assets/1638483/6e39ddab-9949-4e8e-aaca-04e71db919f7">


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->