### PR TITLE
[Alerting/API Tests] Add await to objectRemover.removeAll()

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/max_queued_actions_circuit_breaker.ts
@@ -26,7 +26,7 @@ export default function createActionTests({ getService }: FtrProviderContext) {
     });
 
     afterEach(async () => {
-      objectRemover.removeAll();
+      await objectRemover.removeAll();
       await esTestIndexTool.destroy();
     });
 


### PR DESCRIPTION
## Summary

Resolves an "unhandled Promise rejection" found for a CI failure for a PR: https://buildkite.com/elastic/kibana-pull-request/builds/181932#018c3b27-e511-4678-9e18-50f90e02c934

```

2023-12-05 19:03:36 UTC | Unhandled Promise rejection detected:
-- | --
  | 2023-12-05 19:03:36 UTC |  
  | 2023-12-05 19:03:36 UTC | Error: expected 204 "No Content", got 404 "Not Found"
  | 2023-12-05 19:03:36 UTC | at map (object_remover.ts:44:12)
  | 2023-12-05 19:03:36 UTC | at Array.map (<anonymous>)
  | 2023-12-05 19:03:36 UTC | at ObjectRemover.removeAll (object_remover.ts:38:28)
  | 2023-12-05 19:03:36 UTC | at Context.apply (max_queued_actions_circuit_breaker.ts:29:21)
  | 2023-12-05 19:03:36 UTC | at Object.apply (wrap_function.js:73:30)
  | 2023-12-05 19:03:36 UTC | at processTicksAndRejections (node:internal/process/task_queues:95:5)

```



