### PR TITLE
[Dashboard] Fix flaky `sync_colors.tsx` test

### DIFF
--- a/test/functional/page_objects/time_picker.ts
+++ b/test/functional/page_objects/time_picker.ts
@@ -57,6 +57,7 @@ export class TimePickerPageObject extends FtrService {
     });
     if (isVisible) {
       await this.testSubjects.click('noDataPopoverDismissButton');
+      await this.testSubjects.waitForDeleted('noDataPopoverDismissButton');
     }
   }
 

--- a/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
@@ -35,7 +35,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return colorMapping;
   }
 
-  describe('sync colors', function () {
+  describe.only('sync colors', function () {
     before(async function () {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
+++ b/x-pack/test/functional/apps/dashboard/group2/sync_colors.ts
@@ -35,7 +35,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return colorMapping;
   }
 
-  describe.only('sync colors', function () {
+  describe('sync colors', function () {
     before(async function () {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kibanaServer.importExport.load(

--- a/x-pack/test/functional/page_objects/lens_page.ts
+++ b/x-pack/test/functional/page_objects/lens_page.ts
@@ -67,12 +67,14 @@ export function LensPageProvider({ getService, getPageObjects }: FtrProviderCont
      * a range that has data in our dataset.
      */
     async goToTimeRange(fromTime?: string, toTime?: string) {
-      await PageObjects.timePicker.ensureHiddenNoDataPopover();
-      fromTime = fromTime || PageObjects.timePicker.defaultStartTime;
-      toTime = toTime || PageObjects.timePicker.defaultEndTime;
-      await PageObjects.timePicker.setAbsoluteRange(fromTime, toTime);
-      // give some time for the update button tooltip to close
-      await PageObjects.common.sleep(500);
+      const from = fromTime || PageObjects.timePicker.defaultStartTime;
+      const to = toTime || PageObjects.timePicker.defaultEndTime;
+      await retry.try(async () => {
+        await PageObjects.timePicker.ensureHiddenNoDataPopover();
+        await PageObjects.timePicker.setAbsoluteRange(from, to);
+        // give some time for the update button tooltip to close
+        await PageObjects.common.sleep(500);
+      });
     },
 
     /**


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/148557

## Summary

It is possible for the `noDataPopover` to take more than the `100ms` timeout from `ensureHiddenNoDataPopover` (pictured below) to appear - in these cases, any tests that make use of the Lens page object's `goToTimeRange` method will fail due to clicking the wrong element (the tour step rather than the time picker).

![image](https://github.com/elastic/kibana/assets/8698078/35de1215-6f9f-4a72-a0ab-e1a60f5bb80a)


While my initial thought was to simply increase the timeout for the `noDataPopover` check, this isn't ideal - **a lot** of tests use the `goToTimeRange` method and, by doing this, we would be slowing down **every single one of them** even when the test wouldn't have failed to begin with! Instead, I've chosen to surround the important parts of the code in `goToTimeRange` with a `retry` - that way, if the `noDataPopover` never shows up or it shows up comfortably within the `100ms` timeout, the impact to the speed of a given test will be **minimal**; however, if the no data popover shows up **outside** of this timeout, the retry will save the test from outright failure.

### [Flaky Test Runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4192)

![image](https://github.com/elastic/kibana/assets/8698078/1ac033d7-6cc1-4789-9a2b-6c7b8c34f67c)


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.11","8.13"]} ONMERGE-->