### PR TITLE
Do not expose host in internal API error messages

### DIFF
--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.test.ts
@@ -301,6 +301,7 @@ describe('restrictInternal post-auth handler', () => {
       name: 'my-server-name',
       restrictInternalApis: true,
     });
+
     it('returns a bad request if called without internal origin header for internal API', () => {
       const handler = createRestrictInternalRoutesPostAuthHandler(config as HttpConfig);
       const request = createForgeRequest('internal');
@@ -310,8 +311,8 @@ describe('restrictInternal post-auth handler', () => {
       const result = handler(request, responseFactory, toolkit);
 
       expect(toolkit.next).not.toHaveBeenCalled();
-      expect(responseFactory.badRequest.mock.calls[0][0]?.body).toMatch(
-        /uri \[.*\/internal\/some-path\] with method \[get\] exists but is not available with the current configuration/
+      expect(responseFactory.badRequest.mock.calls[0][0]?.body).toMatchInlineSnapshot(
+        `"uri [/internal/some-path] with method [get] exists but is not available with the current configuration"`
       );
       expect(result).toBe('badRequest');
     });

--- a/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
+++ b/packages/core/http/core-http-server-internal/src/lifecycle_handlers.ts
@@ -54,7 +54,7 @@ export const createRestrictInternalRoutesPostAuthHandler = (
     if (isRestrictionEnabled && isInternalRoute && !request.isInternalApiRequest) {
       // throw 400
       return response.badRequest({
-        body: `uri [${request.url}] with method [${request.route.method}] exists but is not available with the current configuration`,
+        body: `uri [${request.url.pathname}] with method [${request.route.method}] exists but is not available with the current configuration`,
       });
     }
     return toolkit.next();


### PR DESCRIPTION
## Summary

Only expose the `path` instead of the full `url` in the internal route handler error messages

