### PR TITLE
[Convert2Lens] Correctly assign the panel timerange during conversion

### DIFF
--- a/src/plugins/visualizations/public/actions/edit_in_lens_action.tsx
+++ b/src/plugins/visualizations/public/actions/edit_in_lens_action.tsx
@@ -94,7 +94,7 @@ export class EditInLensAction implements Action<EditInLensContext> {
         searchQuery,
         isEmbeddable: true,
         description: vis.description || embeddable.getOutput().description,
-        panelTimeRange: embeddable.getInput()?.timeRange,
+        panelTimeRange: embeddable.getExplicitInput()?.timeRange,
       };
       if (navigateToLensConfig) {
         if (this.currentAppId) {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/170077

Correctly assigns the dashboard panel timerange during conversion to Lens. 

Note: The bug exists only if you click the convert to Lens panel action.

![convert2lens](https://github.com/elastic/kibana/assets/17003240/a954853a-6303-4d08-bd62-9ddeddadb4a2)



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->