### PR TITLE
[Lens] Fixes the overwriting of the description when updating a by ref chart

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/lens_top_nav.tsx
@@ -668,7 +668,7 @@ export const LensTopNavMenu = ({
                   newCopyOnSave: false,
                   isTitleDuplicateConfirmed: false,
                   returnToOrigin: true,
-                  newDescription: contextFromEmbeddable ? initialContext.description : '',
+                  ...(contextFromEmbeddable && { newDescription: initialContext.description }),
                   panelTimeRange: contextFromEmbeddable ? initialContext.panelTimeRange : undefined,
                 },
                 {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/170363

Doesn't overwrite the description of a by reference Lens chart when updating.