### PR TITLE
[Fleet] fix for update optional secrets

### DIFF
--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -18,7 +18,7 @@ import { elasticsearchServiceMock } from '@kbn/core-elasticsearch-server-mocks';
 
 import { createAppContextStartContractMock } from '../mocks';
 
-import type { NewPackagePolicy, PackageInfo } from '../types';
+import type { NewPackagePolicy, PackageInfo, PackagePolicy, UpdatePackagePolicy } from '../types';
 
 import { appContextService } from './app_context';
 import {
@@ -26,6 +26,7 @@ import {
   diffSecretPaths,
   diffOutputSecretPaths,
   extractAndWriteSecrets,
+  extractAndUpdateSecrets,
 } from './secrets';
 
 describe('secrets', () => {
@@ -910,6 +911,128 @@ describe('secrets', () => {
 
         const result = await extractAndWriteSecrets({
           packagePolicy: mockPackagePolicy,
+          packageInfo: mockIntegrationPackage,
+          esClient: esClientMock,
+        });
+
+        expect(esClientMock.transport.request).toHaveBeenCalledTimes(2);
+        expect(result.secretReferences).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('extractAndUpdateSecrets', () => {
+    const esClientMock = elasticsearchServiceMock.createInternalClient();
+
+    esClientMock.transport.request.mockImplementation(async (req) => {
+      return {
+        id: uuidv4(),
+      };
+    });
+
+    beforeEach(() => {
+      esClientMock.transport.request.mockClear();
+    });
+
+    const mockIntegrationPackage = {
+      name: 'mock-package',
+      title: 'Mock package',
+      version: '0.0.0',
+      description: 'description',
+      type: 'integration',
+      status: 'not_installed',
+      vars: [
+        { name: 'pkg-secret-1', type: 'text', secret: true, required: true },
+        { name: 'pkg-secret-2', type: 'text', secret: true, required: false },
+      ],
+      data_streams: [
+        {
+          dataset: 'somedataset',
+          streams: [
+            {
+              input: 'foo',
+              title: 'Foo',
+            },
+          ],
+        },
+      ],
+      policy_templates: [
+        {
+          name: 'pkgPolicy1',
+          title: 'Package policy 1',
+          description: 'test package policy',
+          inputs: [
+            {
+              type: 'foo',
+              title: 'Foo',
+              vars: [],
+            },
+          ],
+        },
+      ],
+    } as unknown as PackageInfo;
+
+    describe('when only required secret value is provided', () => {
+      it('returns single secret reference for required secret', async () => {
+        const oldPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
+            },
+          },
+          inputs: [],
+        } as unknown as PackagePolicy;
+
+        const mockPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val-update',
+            },
+          },
+          inputs: [],
+        } as unknown as UpdatePackagePolicy;
+
+        const result = await extractAndUpdateSecrets({
+          oldPackagePolicy,
+          packagePolicyUpdate: mockPackagePolicy,
+          packageInfo: mockIntegrationPackage,
+          esClient: esClientMock,
+        });
+
+        expect(esClientMock.transport.request).toHaveBeenCalledTimes(1);
+        expect(result.secretReferences).toHaveLength(1);
+      });
+    });
+
+    describe('when both required and optional secret values are provided', () => {
+      it('returns secret reference for both required and optional secret', async () => {
+        const oldPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val',
+            },
+            'pkg-secret-2': {
+              value: 'pkg-secret-2-val',
+            },
+          },
+          inputs: [],
+        } as unknown as PackagePolicy;
+
+        const mockPackagePolicy = {
+          vars: {
+            'pkg-secret-1': {
+              value: 'pkg-secret-1-val-update',
+            },
+            'pkg-secret-2': {
+              value: 'pkg-secret-2-val-update',
+            },
+          },
+          inputs: [],
+        } as unknown as UpdatePackagePolicy;
+
+        const result = await extractAndUpdateSecrets({
+          oldPackagePolicy,
+          packagePolicyUpdate: mockPackagePolicy,
           packageInfo: mockIntegrationPackage,
           esClient: esClientMock,
         });

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -405,9 +405,10 @@ export async function extractAndUpdateSecrets(opts: {
 
   const { toCreate, toDelete, noChange } = diffSecretPaths(oldSecretPaths, updatedSecretPaths);
 
+  const secretsToCreate = toCreate.filter((secretPath) => !!secretPath.value.value);
   const createdSecrets = await createSecrets({
     esClient,
-    values: toCreate.map((secretPath) => secretPath.value.value),
+    values: secretsToCreate.map((secretPath) => secretPath.value.value),
   });
 
   const policyWithSecretRefs = JSON.parse(JSON.stringify(packagePolicyUpdate));


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/172061

Fix for update agent policy with optional secret.

Steps to verify:
- change a secret variable in a package to optional, used `universal_profiling_agent` package
```
          - name: profiler.secret_token
            title: Authorization
            description: Token used to authenticate the agent.
            required: false
            show_user: true
            type: text
            secret: true
```
- build a new package version and upload zip to fleet api locally
- add integration policy by keeping the secret_token empty
- edit the integration policy, and verify that the edit works
- there is no secret value saved in `.fleet-secrets`

<img width="1190" alt="image" src="https://github.com/elastic/kibana/assets/90178898/fd8e7a0d-199d-4dd3-bf2b-b887f48848a3">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.11"]} ONMERGE-->