### PR TITLE
[Grok Debugger][Serverless] Fix functional tests

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/grok_debugger/grok_debugger.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/grok_debugger/grok_debugger.ts
@@ -10,7 +10,7 @@ import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
-  const PageObjects = getPageObjects(['common', 'grokDebugger']);
+  const PageObjects = getPageObjects(['svlCommonPage', 'common', 'grokDebugger']);
   const browser = getService('browser');
   const security = getService('security');
   const testSubjects = getService('testSubjects');
@@ -22,6 +22,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       // fold. Otherwise it can't be clicked by the browser driver.
       await browser.setWindowSize(1600, 1000);
       await security.testUser.setRoles(['global_devtools_read', 'ingest_pipelines_user']);
+      await PageObjects.svlCommonPage.login();
       await PageObjects.common.navigateToApp('dev_tools', { hash: '/grokdebugger' });
       await retry.waitFor('Grok Debugger Header to be visible', async () => {
         return testSubjects.isDisplayed('grokDebuggerContainer');
@@ -29,6 +30,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
 
     after(async () => {
+      await PageObjects.svlCommonPage.forceLogout();
       await security.testUser.restoreDefaults();
     });
 


### PR DESCRIPTION
## Summary

When running the flaky test runner on another PR ([build](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4199)), I noticed that the Grok debugger tests, which were recently added, failed in every run with the error message:

```
Error: retry.tryForTime timeout: Error: retry.try timeout: TimeoutError: Waiting for element to be located By(css selector, [data-test-subj="kibanaChrome"])
```

I think this error is caused when serverless login and logout are missing in the before/after hook, so adding them in this PR.

New flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4210



