### PR TITLE
[EBT] fix browser-side elasticsearch context schema

### DIFF
--- a/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.ts
+++ b/packages/core/analytics/core-analytics-browser-internal/src/analytics_service.ts
@@ -184,6 +184,10 @@ export class AnalyticsService {
           type: 'keyword',
           _meta: { description: 'The Cluster version', optional: true },
         },
+        cluster_build_flavor: {
+          type: 'keyword',
+          _meta: { description: 'The Cluster build flavor', optional: true },
+        },
       },
     });
   }

--- a/packages/core/injected-metadata/core-injected-metadata-common-internal/src/types.ts
+++ b/packages/core/injected-metadata/core-injected-metadata-common-internal/src/types.ts
@@ -16,6 +16,7 @@ export interface InjectedMetadataClusterInfo {
   cluster_uuid?: string;
   cluster_name?: string;
   cluster_version?: string;
+  cluster_build_flavor?: string;
 }
 
 /** @internal */


### PR DESCRIPTION
## Summary

The `cluster_build_flavor` was propagated to the browser-side and then used in the context, but without being explicitly defined in the schema. 

this PR fixes it by properly adding the field.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->