### PR TITLE
Fix existing pipeline list keyboard accessibility

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select.tsx
@@ -45,19 +45,10 @@ export const PipelineSelect: React.FC = () => {
     }
   };
 
-  const getActiveOptionIndex = (): number | undefined => {
-    const index = existingInferencePipelines.findIndex(
-      (pipelineOption) => pipelineOption.pipelineName === pipelineName
-    );
-
-    return index >= 0 ? index : undefined;
-  };
-
   return (
     <EuiSelectable
       options={getPipelineOptions(existingInferencePipelines)}
       listProps={{
-        activeOptionIndex: getActiveOptionIndex(),
         bordered: true,
         rowHeight: useIsWithinMaxBreakpoint('s') ? 120 : 90,
         showIcons: true,


### PR DESCRIPTION
## Summary

Fix keyboard accessibility for the existing pipeline selection list:

![Screenshot 2023-12-06 at 8 42 56 AM](https://github.com/elastic/kibana/assets/26927948/f87d380e-ebb1-49c0-80ec-d7d7b24a5002)

### Checklist

- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->