### PR TITLE
[tests] skip advanced_settings for MKI run

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import { ALL_COMMON_SETTINGS } from '@kbn/serverless-common-settings';
 import * as settings from '@kbn/management-settings-ids';
+import { ALL_COMMON_SETTINGS } from '@kbn/serverless-common-settings';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 const editorSettings = new Set<string>([
@@ -38,6 +38,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   let INITIAL_CSV_QUOTE_VALUES_SETTING_VALUE: any;
 
   describe('Common advanced settings', function () {
+    // the suite is flaky on MKI
+    this.tags(['failsOnMKI']);
     before(async () => {
       // We need kibana_admin role in order to update settings
       await security.testUser.setRoles(['kibana_admin']);

--- a/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
@@ -6,8 +6,8 @@
  */
 
 import expect from '@kbn/expect';
-import * as settings from '@kbn/management-settings-ids';
 import { ALL_COMMON_SETTINGS } from '@kbn/serverless-common-settings';
+import * as settings from '@kbn/management-settings-ids';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 const editorSettings = new Set<string>([


### PR DESCRIPTION
## Summary

Skipping advanced settings tests for MKI pipeline as we see many random failures:

https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/599
https://buildkite.com/elastic/appex-qa-serverless-kibana-ftr-tests/builds/600

I was trying to make a quick fix but I don't see a clear reason for this failure in
```
      it('allows resetting a setting to its default value', async () => {
        const fieldTestSubj = 'management-settings-editField-' + settings.CSV_QUOTE_VALUES_ID;
        const resetLinkTestSubj = 'management-settings-resetField-' + settings.CSV_QUOTE_VALUES_ID;
        expect(await testSubjects.exists(resetLinkTestSubj)).to.be(true);
        await testSubjects.click(resetLinkTestSubj);

        // Save changes
        await testSubjects.click(SAVE_BUTTON_TEST_SUBJ);

        await browser.refresh();
        await pageObjects.common.sleep(1000);

        // Check if field is now enabled
        expect(await testSubjects.isEuiSwitchChecked(fieldTestSubj)).to.be(true);
      });
```

and we don't see it failing in Kibana CI with local Kibana build