### PR TITLE
[Security Solution][Timeline] skipping failing test in main

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/url_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/url_state.cy.ts
@@ -22,7 +22,7 @@ import { visit, visitWithTimeRange } from '../../../tasks/navigation';
 
 import { TIMELINES_URL } from '../../../urls/navigation';
 
-describe('Open timeline', { tags: ['@serverless', '@ess'] }, () => {
+describe.skip('Open timeline', { tags: ['@serverless', '@ess'] }, () => {
   let timelineSavedObjectId: string | null = null;
   before(function () {
     login();


### PR DESCRIPTION
## Summary

This PR skips a failing test in `main` (see failure [here](https://github.com/elastic/kibana/issues/172503#issuecomment-1843102833)).
The failure seems to be happening in the `before` method.

https://github.com/elastic/kibana/issues/172503

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->