### PR TITLE
[Security Solution] Fix flakiness in flyout cypress

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_analyzer_graph_tab.cy.ts
@@ -14,6 +14,7 @@ import { openGraphAnalyzerTab } from '../../../../tasks/expandable_flyout/alert_
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { ANALYZER_NODE } from '../../../../screens/alerts';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -27,6 +28,7 @@ describe.skip(
   { tags: ['@ess', '@brokenInServerless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_correlations_tab.cy.ts
@@ -29,87 +29,81 @@ import {
   expandFirstAlertExpandableFlyout,
 } from '../../../../tasks/expandable_flyout/common';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { ALERTS_URL } from '../../../../urls/navigation';
 
-// FLAKY: https://github.com/elastic/kibana/issues/170822
-describe.skip(
-  'Expandable flyout left panel correlations',
-  { tags: ['@ess', '@serverless'] },
-  () => {
-    beforeEach(() => {
-      login();
-      createRule(getNewRule());
-      visit(ALERTS_URL);
-      waitForAlertsToPopulate();
-      expandFirstAlertExpandableFlyout();
-      expandDocumentDetailsExpandableFlyoutLeftSection();
-      createNewCaseFromExpandableFlyout();
-      openInsightsTab();
-      openCorrelationsTab();
-    });
+describe('Expandable flyout left panel correlations', { tags: ['@ess', '@serverless'] }, () => {
+  beforeEach(() => {
+    deleteAlertsAndRules();
+    login();
+    createRule(getNewRule());
+    visit(ALERTS_URL);
+    waitForAlertsToPopulate();
+    expandFirstAlertExpandableFlyout();
+    expandDocumentDetailsExpandableFlyoutLeftSection();
+    createNewCaseFromExpandableFlyout();
+    openInsightsTab();
+    openCorrelationsTab();
+  });
 
-    it('should render correlations details correctly', () => {
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
-        .should('have.text', 'Insights')
-        .and('have.class', 'euiTab-isSelected');
+  it('should render correlations details correctly', () => {
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB)
+      .should('have.text', 'Insights')
+      .and('have.class', 'euiTab-isSelected');
 
-      cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON)
-        .should('have.text', 'Correlations')
-        .and('have.class', 'euiButtonGroupButton-isSelected');
+    cy.get(DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_CORRELATIONS_BUTTON)
+      .should('have.text', 'Correlations')
+      .and('have.class', 'euiButtonGroupButton-isSelected');
 
-      // cy.log('suppressed alerts');
+    // cy.log('suppressed alerts');
 
-      // TODO get proper data to test suppressed alerts
-      // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE).scrollIntoView();
-      // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE)
-      //   .should('be.visible')
-      //   .and('contain.text', '1 suppressed alert');
-      // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
+    // TODO get proper data to test suppressed alerts
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE).scrollIntoView();
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_TITLE)
+    //   .should('be.visible')
+    //   .and('contain.text', '1 suppressed alert');
+    // cy.get(CORRELATIONS_SUPPRESSED_ALERTS_INVESTIGATE_IN_TIMELINE_BUTTON).should('be.visible');
 
-      cy.log('related cases');
+    cy.log('related cases');
 
-      cy.get(CORRELATIONS_CASES_SECTION_TITLE).should('contain.text', '1 related case');
-      cy.get(CORRELATIONS_CASES_SECTION_TABLE)
-        .should('contain.text', 'case')
-        .and('contain.text', 'open');
+    cy.get(CORRELATIONS_CASES_SECTION_TITLE).should('contain.text', '1 related case');
+    cy.get(CORRELATIONS_CASES_SECTION_TABLE)
+      .should('contain.text', 'case')
+      .and('contain.text', 'open');
 
-      cy.log('related alerts by source event');
+    cy.log('related alerts by source event');
 
-      cy.get(CORRELATIONS_SOURCE_SECTION_TITLE).should(
-        'contain.text',
-        '1 alert related by source event'
-      );
-      cy.get(CORRELATIONS_SOURCE_SECTION_TABLE).should('exist');
-      cy.get(CORRELATIONS_SOURCE_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
-        'contain.text',
-        'Investigate in timeline'
-      );
+    cy.get(CORRELATIONS_SOURCE_SECTION_TITLE).should(
+      'contain.text',
+      '1 alert related by source event'
+    );
+    cy.get(CORRELATIONS_SOURCE_SECTION_TABLE).should('exist');
+    cy.get(CORRELATIONS_SOURCE_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
+      'contain.text',
+      'Investigate in timeline'
+    );
 
-      cy.log('related alerts by session');
+    cy.log('related alerts by session');
 
-      cy.get(CORRELATIONS_SESSION_SECTION_TITLE).should(
-        'contain.text',
-        '1 alert related by session'
-      );
-      cy.get(CORRELATIONS_SESSION_SECTION_TABLE).should('exist');
-      cy.get(CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
-        'contain.text',
-        'Investigate in timeline'
-      );
+    cy.get(CORRELATIONS_SESSION_SECTION_TITLE).should('contain.text', '1 alert related by session');
+    cy.get(CORRELATIONS_SESSION_SECTION_TABLE).should('exist');
+    cy.get(CORRELATIONS_SESSION_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
+      'contain.text',
+      'Investigate in timeline'
+    );
 
-      cy.log('related alerts by ancestry');
+    cy.log('related alerts by ancestry');
 
-      cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE).should(
-        'contain.text',
-        '1 alert related by ancestry'
-      );
-      cy.get(CORRELATIONS_ANCESTRY_SECTION_TABLE).should('exist');
-      cy.get(CORRELATIONS_ANCESTRY_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
-        'contain.text',
-        'Investigate in timeline'
-      );
-    });
-  }
-);
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TITLE).should(
+      'contain.text',
+      '1 alert related by ancestry'
+    );
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_TABLE).should('exist');
+    cy.get(CORRELATIONS_ANCESTRY_SECTION_INVESTIGATE_IN_TIMELINE_BUTTON).should(
+      'contain.text',
+      'Investigate in timeline'
+    );
+  });
+});

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_entities_tab.cy.ts
@@ -19,6 +19,7 @@ import { openEntitiesTab } from '../../../../tasks/expandable_flyout/alert_detai
 import { openInsightsTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -31,6 +32,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_investigation_tab.cy.ts
@@ -12,6 +12,7 @@ import {
 import { openInvestigationTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_investigation_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -24,6 +25,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_prevalence_tab.cy.ts
@@ -20,6 +20,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_TABLE_USER_PREVALENCE_CELL,
   DOCUMENT_DETAILS_FLYOUT_INSIGHTS_TAB_PREVALENCE_DATE_PICKER,
 } from '../../../../screens/expandable_flyout/alert_details_left_panel_prevalence_tab';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -27,12 +28,12 @@ import { getNewRule } from '../../../../objects/rule';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
 
-// FLAKY: https://github.com/elastic/kibana/issues/170751
-describe.skip(
+describe(
   'Alert details expandable flyout left panel prevalence',
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule({ ...getNewRule(), investigation_fields: { field_names: ['host.os.name'] } });
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_response_tab.cy.ts
@@ -12,6 +12,7 @@ import {
 import { openResponseTab } from '../../../../tasks/expandable_flyout/alert_details_left_panel_response_tab';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -25,6 +26,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_session_view_tab.cy.ts
@@ -9,6 +9,7 @@ import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB_SESSION_VIEW_BUTTON } from '../..
 import { DOCUMENT_DETAILS_FLYOUT_VISUALIZE_TAB } from '../../../../screens/expandable_flyout/alert_details_left_panel';
 import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../tasks/expandable_flyout/alert_details_right_panel';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -22,6 +23,7 @@ describe.skip(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_left_panel_threat_intelligence_tab.cy.ts
@@ -11,6 +11,7 @@ import { expandDocumentDetailsExpandableFlyoutLeftSection } from '../../../../ta
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { INDICATOR_MATCH_ENRICHMENT_SECTION } from '../../../../screens/alerts_details';
 import { waitForAlertsToPopulate } from '../../../../tasks/create_new_rule';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { ALERTS_URL } from '../../../../urls/navigation';
@@ -24,6 +25,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_alert_reason_preview.cy.ts
@@ -8,6 +8,7 @@
 import { DOCUMENT_DETAILS_FLYOUT_ALERT_REASON_PREVIEW_CONTAINER } from '../../../../screens/expandable_flyout/alert_details_preview_panel_alert_reason_preview';
 import { expandFirstAlertExpandableFlyout } from '../../../../tasks/expandable_flyout/common';
 import { clickAlertReasonButton } from '../../../../tasks/expandable_flyout/alert_details_right_panel_overview_tab';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -22,6 +23,7 @@ describe(
     const rule = getNewRule();
 
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(rule);
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_preview_panel_rule_preview.cy.ts
@@ -25,6 +25,7 @@ import {
   toggleRulePreviewScheduleSection,
 } from '../../../../tasks/expandable_flyout/alert_details_preview_panel_rule_preview';
 import { clickRuleSummaryButton } from '../../../../tasks/expandable_flyout/alert_details_right_panel_overview_tab';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -39,6 +40,7 @@ describe(
     const rule = getNewRule();
 
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(rule);
       visit(ALERTS_URL);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/expandable_flyout/alert_details_right_panel_json_tab.cy.ts
@@ -11,6 +11,7 @@ import {
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB_CONTENT,
   DOCUMENT_DETAILS_FLYOUT_JSON_TAB_COPY_TO_CLIPBOARD_BUTTON,
 } from '../../../../screens/expandable_flyout/alert_details_right_panel_json_tab';
+import { deleteAlertsAndRules } from '../../../../tasks/api_calls/common';
 import { login } from '../../../../tasks/login';
 import { visit } from '../../../../tasks/navigation';
 import { createRule } from '../../../../tasks/api_calls/rules';
@@ -23,6 +24,7 @@ describe(
   { tags: ['@ess', '@serverless'] },
   () => {
     beforeEach(() => {
+      deleteAlertsAndRules();
       login();
       createRule(getNewRule());
       visit(ALERTS_URL);


### PR DESCRIPTION
## Summary

Adding `deleteAlertsAndRules` to avoid previously generated alerts persist on retry


### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
