### PR TITLE
[Synthetics] Fix e2e tests

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/lib/alert_types/lazy_wrapper/monitor_status.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { CoreStart } from '@kbn/core/public';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 import { RuleTypeParamsExpressionProps } from '@kbn/triggers-actions-ui-plugin/public';
@@ -26,18 +27,21 @@ interface Props {
 // eslint-disable-next-line import/no-default-export
 export default function MonitorStatusAlert({ core, plugins, params }: Props) {
   kibanaService.core = core;
+  const queryClient = new QueryClient();
   return (
     <ReduxProvider store={store}>
-      <KibanaContextProvider services={{ ...core, ...plugins }}>
-        <EuiText>
-          <FormattedMessage
-            id="xpack.synthetics.alertRule.monitorStatus.description"
-            defaultMessage="Manage synthetics monitor status rule actions."
-          />
-        </EuiText>
+      <QueryClientProvider client={queryClient}>
+        <KibanaContextProvider services={{ ...core, ...plugins }}>
+          <EuiText>
+            <FormattedMessage
+              id="xpack.synthetics.alertRule.monitorStatus.description"
+              defaultMessage="Manage synthetics monitor status rule actions."
+            />
+          </EuiText>
 
-        <EuiSpacer size="m" />
-      </KibanaContextProvider>
+          <EuiSpacer size="m" />
+        </KibanaContextProvider>
+      </QueryClientProvider>
     </ReduxProvider>
   );
 }


### PR DESCRIPTION
## Summary

Recently, https://github.com/elastic/kibana/pull/171933 introduced a notion of `QueryClientProvider` to observability. It seems like we might need to include this also in our rule wrapper, as it is perhaps rendered outside of the tree in question and doesn't play nice, perhaps as a result of lazy loading.

Strangely I cannot repro this failure locally. Here's an example build failure though: https://buildkite.com/elastic/kibana-pull-request/builds/182158#018c3f75-d7c8-42a6-ac6c-0c30f66fe54c

~This initial patch might not resolve the issue, in which case I'll ping others to assist.~

This seems to have un-broken the tests.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
