### PR TITLE
[ML][AIOps] Removes Technical preview badge from AIOps log rate analysis

### DIFF
--- a/x-pack/plugins/ml/public/application/aiops/log_rate_analysis.tsx
+++ b/x-pack/plugins/ml/public/application/aiops/log_rate_analysis.tsx
@@ -8,13 +8,11 @@
 import React, { FC } from 'react';
 import { pick } from 'lodash';
 
-import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { LogRateAnalysis } from '@kbn/aiops-plugin/public';
 import { useDataSource } from '../contexts/ml/data_source_context';
 import { useMlKibana } from '../contexts/kibana';
 import { HelpMenu } from '../components/help_menu';
-import { TechnicalPreviewBadge } from '../components/technical_preview_badge';
 import { MlPageHeader } from '../components/page_header';
 import { useEnabledFeatures } from '../contexts/ml';
 
@@ -27,17 +25,10 @@ export const LogRateAnalysisPage: FC = () => {
   return (
     <>
       <MlPageHeader>
-        <EuiFlexGroup responsive={false} wrap={false} alignItems={'center'} gutterSize={'m'}>
-          <EuiFlexItem grow={false}>
-            <FormattedMessage
-              id="xpack.ml.logRateAnalysis.pageHeader"
-              defaultMessage="Log rate analysis"
-            />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <TechnicalPreviewBadge />
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        <FormattedMessage
+          id="xpack.ml.logRateAnalysis.pageHeader"
+          defaultMessage="Log rate analysis"
+        />
       </MlPageHeader>
       {dataView && (
         <LogRateAnalysis


### PR DESCRIPTION
## Summary

This PR removes the 'Technical Preview' badge from Log Rate Analysis in ML AIOps labs.

<img width="1225" alt="image" src="https://github.com/elastic/kibana/assets/6446462/4403e912-23a3-4fa6-b8c4-9d2440a90f1f">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->