### PR TITLE
[ResponseOps] Fix for flaky test - Actions migrations "before all" hook for "7.10.0 migrates the casesConfiguration to be the incidentConfiguration in config, then 7.11.0 removes incidentConfiguration"

### DIFF
--- a/x-pack/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/actions/migrations.ts
@@ -15,8 +15,7 @@ export default function createGetTests({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const esArchiver = getService('esArchiver');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/169159
-  describe.skip('migrations', () => {
+  describe('migrations', () => {
     before(async () => {
       await esArchiver.load('x-pack/test/functional/es_archives/actions');
     });


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/169159

## Summary

I only removed the skip bc the flaky test runner passed after 500+ runs.

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4231 x 50
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4232 x 250
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4234 x 250



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->