### PR TITLE
[DO NOT MERGE] Use in-memory table for model selection

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/configure_pipeline.tsx
@@ -26,9 +26,10 @@ import { i18n } from '@kbn/i18n';
 import { IndexViewLogic } from '../../index_view_logic';
 
 import { EMPTY_PIPELINE_CONFIGURATION, MLInferenceLogic } from './ml_inference_logic';
-import { ModelSelect } from './model_select';
+// import { ModelSelect } from './model_select';
 import { ModelSelectLogic } from './model_select_logic';
 import { PipelineSelect } from './pipeline_select';
+import { ModelSelectTable } from './model_select_table';
 
 const CREATE_NEW_TAB_NAME = i18n.translate(
   'xpack.enterpriseSearch.content.indices.pipelines.addInferencePipelineModal.steps.configure.tabs.createNew.name',
@@ -137,7 +138,8 @@ export const ConfigurePipeline: React.FC = () => {
                 { defaultMessage: 'Select a trained ML Model' }
               )}
             >
-              <ModelSelect />
+              <ModelSelectTable />
+              {/* <ModelSelect /> */}
             </EuiFormRow>
           </EuiForm>
         </>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_option.tsx
@@ -12,7 +12,6 @@ import { useActions, useValues } from 'kea';
 import {
   EuiBadge,
   EuiButton,
-  EuiButtonEmpty,
   EuiButtonIcon,
   EuiContextMenu,
   EuiContextMenuPanelDescriptor,
@@ -86,14 +85,14 @@ export const DeployModelButton: React.FC<{ onClick: () => void; disabled: boolea
   disabled,
 }) => {
   return (
-    <EuiButtonEmpty onClick={onClick} disabled={disabled} iconType="download" size="s">
+    <EuiButton onClick={onClick} disabled={disabled} color="text" iconType="download" size="s">
       {i18n.translate(
         'xpack.enterpriseSearch.content.indices.pipelines.modelSelectOption.deployButton.label',
         {
           defaultMessage: 'Deploy',
         }
       )}
-    </EuiButtonEmpty>
+    </EuiButton>
   );
 };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_table.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useActions, useValues } from 'kea';
 
@@ -21,7 +21,6 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
-  Pagination,
 } from '@elastic/eui';
 
 import { MlModel, MlModelDeploymentState } from '../../../../../../../common/types/ml';
@@ -172,26 +171,6 @@ export const ModelSelectTable: React.FC = () => {
     },
   };
 
-  const [pageIndex, setPageIndex] = useState(0);
-  const [pageSize, setPageSize] = useState(3);
-
-  const onTableChange = (models: MlModel[], {
-    page = { index: 0, size: 3 },
-  }) => {
-    console.log('ontablechange', page, models)
-    const { index, size } = page;
-    setPageIndex(index);
-    setPageSize(size);
-  };
-
-  const pagination: Pagination = {
-    pageIndex,
-    pageSize,
-    totalItemCount: 10,
-    pageSizeOptions: [3],
-    showPerPageOptions: false,
-  };
-
   const getModelSelectOptionProps = (models: MlModel[]): ModelSelectOptionProps[] =>
     (models ?? []).map((model) => ({
       ...model,
@@ -218,14 +197,12 @@ export const ModelSelectTable: React.FC = () => {
         tableCaption="Demo of EuiBasicTable"
         columns={columns}
         search={search}
-        pagination={pagination}
         items={getModelSelectOptionProps(selectableModels)}
         loading={isLoading}
         hasActions
         rowProps={(model) => ({
           onClick: () => onClickRow(model),
         })}
-        onTableChange={(nextValues) => onTableChange(selectableModels, nextValues)}
       />
     </EuiPanel>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_table.tsx
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import {
+  DefaultItemAction,
+  EuiBasicTableColumn,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiPanel,
+  EuiRadio,
+  EuiSearchBarProps,
+  EuiText,
+  EuiTextColor,
+  EuiTitle,
+  Pagination,
+} from '@elastic/eui';
+
+import { MlModel, MlModelDeploymentState } from '../../../../../../../common/types/ml';
+import { IndexNameLogic } from '../../index_name_logic';
+
+import { MLInferenceLogic } from './ml_inference_logic';
+import { ModelSelectLogic } from './model_select_logic';
+import {
+  DeployModelButton,
+  LicenseBadge,
+  ModelSelectOptionProps,
+  StartModelButton,
+} from './model_select_option';
+import { normalizeModelName, TRAINED_MODELS_PATH } from './utils';
+import { TrainedModelHealth } from '../ml_model_health';
+import { KibanaLogic } from '../../../../../shared/kibana';
+
+export const ModelSelectTable: React.FC = () => {
+  const { indexName } = useValues(IndexNameLogic);
+  // const { ingestionMethod } = useValues(IndexViewLogic);
+  const {
+    addInferencePipelineModal: { configuration },
+  } = useValues(MLInferenceLogic);
+  const { areActionButtonsDisabled, isLoading, selectableModels } = useValues(ModelSelectLogic);
+  const { createModel, startModel } = useActions(ModelSelectLogic);
+  const { setInferencePipelineConfiguration } = useActions(MLInferenceLogic);
+
+  const { modelID, pipelineName, isPipelineNameUserSupplied } = configuration;
+
+  const actions: Array<DefaultItemAction<ModelSelectOptionProps>> = [
+    {
+      name: 'Tune model performance',
+      description: 'Clone this user',
+      icon: 'controlsHorizontal',
+      type: 'icon',
+      isPrimary: true,
+      onClick: () =>
+        KibanaLogic.values.navigateToUrl(TRAINED_MODELS_PATH, {
+          shouldNotCreateHref: true,
+        }),
+    },
+    {
+      name: 'Model details',
+      description: 'View model details',
+      icon: 'popout',
+      color: 'primary',
+      type: 'icon',
+      isPrimary: true,
+      href: 'model.modelDetailsPageUrl',
+      target: '_blank',
+    },
+  ];
+
+  const columns: Array<EuiBasicTableColumn<ModelSelectOptionProps>> = [
+    {
+      name: '',
+      render: (model: ModelSelectOptionProps) => {
+        return (
+          <EuiRadio
+            title="ELSER model"
+            id="ELSER model"
+            checked={model.checked === 'on'}
+            onChange={() => null}
+          />
+        );
+      },
+      width: '30px',
+    },
+    {
+      name: '',
+      truncateText: true,
+      render: (model: ModelSelectOptionProps) => (
+        <>
+          <EuiFlexGroup direction="column" gutterSize="xs">
+            <EuiFlexItem>
+              <EuiTitle size="xs">
+                <h4>{model.title}</h4>
+              </EuiTitle>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiTextColor color="subdued">{model.modelId}</EuiTextColor>
+            </EuiFlexItem>
+            {(model.licenseType || model.description) && (
+              <EuiFlexItem>
+                <EuiFlexGroup gutterSize="xs" alignItems="center">
+                  {model.licenseType && (
+                    <EuiFlexItem grow={false}>
+                      {/* Wrap in a div to prevent the badge from growing to a whole row on mobile */}
+                      <div>
+                        <LicenseBadge
+                          licenseType={model.licenseType}
+                          modelDetailsPageUrl={model.modelDetailsPageUrl}
+                        />
+                      </div>
+                    </EuiFlexItem>
+                  )}
+                  {model.description && (
+                    <EuiFlexItem style={{ overflow: 'hidden' }}>
+                      <EuiText size="xs">
+                        <div className="eui-textTruncate" title={model.description}>
+                          {model.description}
+                        </div>
+                      </EuiText>
+                    </EuiFlexItem>
+                  )}
+                </EuiFlexGroup>
+              </EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        </>
+      ),
+    },
+    {
+      name: '',
+      render: (model: ModelSelectOptionProps) => {
+        return model.isPlaceholder ? (
+          <DeployModelButton
+            onClick={() => createModel(model.modelId)}
+            disabled={areActionButtonsDisabled}
+          />
+        ) : model.deploymentState === MlModelDeploymentState.Downloaded ? (
+          <StartModelButton
+            onClick={() => startModel(model.modelId)}
+            disabled={areActionButtonsDisabled}
+          />
+        ) : (
+          <TrainedModelHealth
+            modelState={model.deploymentState}
+            modelStateReason={model.deploymentStateReason}
+          />
+        );
+      },
+      width: '150px',
+      align: 'right',
+    },
+    {
+      name: '',
+      description: '',
+      actions,
+      width: '60px',
+    },
+  ];
+
+  const search: EuiSearchBarProps = {
+    box: {
+      incremental: true,
+      schema: true,
+    },
+  };
+
+  const [pageIndex, setPageIndex] = useState(0);
+  const [pageSize, setPageSize] = useState(3);
+
+  const onTableChange = (models: MlModel[], {
+    page = { index: 0, size: 3 },
+  }) => {
+    console.log('ontablechange', page, models)
+    const { index, size } = page;
+    setPageIndex(index);
+    setPageSize(size);
+  };
+
+  const pagination: Pagination = {
+    pageIndex,
+    pageSize,
+    totalItemCount: 10,
+    pageSizeOptions: [3],
+    showPerPageOptions: false,
+  };
+
+  const getModelSelectOptionProps = (models: MlModel[]): ModelSelectOptionProps[] =>
+    (models ?? []).map((model) => ({
+      ...model,
+      label: model.modelId,
+      checked: model.modelId === modelID ? 'on' : undefined,
+    }));
+
+  const onClickRow = (selectedModel: ModelSelectOptionProps) => {
+    selectedModel.checked = 'on';
+    setInferencePipelineConfiguration({
+      ...configuration,
+      inferenceConfig: undefined,
+      modelID: selectedModel?.modelId ?? '',
+      fieldMappings: undefined,
+      pipelineName: isPipelineNameUserSupplied
+        ? pipelineName
+        : indexName + '-' + normalizeModelName(selectedModel?.modelId ?? ''),
+    });
+  };
+
+  return (
+    <EuiPanel hasBorder={true}>
+      <EuiInMemoryTable
+        tableCaption="Demo of EuiBasicTable"
+        columns={columns}
+        search={search}
+        pagination={pagination}
+        items={getModelSelectOptionProps(selectableModels)}
+        loading={isLoading}
+        hasActions
+        rowProps={(model) => ({
+          onClick: () => onClickRow(model),
+        })}
+        onTableChange={(nextValues) => onTableChange(selectableModels, nextValues)}
+      />
+    </EuiPanel>
+  );
+};


### PR DESCRIPTION
## Summary

Experimental PR for switching the model selection component to an in-memory table.

<img width="914" alt="Screenshot 2023-12-06 at 16 00 35" src="https://github.com/elastic/kibana/assets/14224983/0465dbdf-c82f-4fbc-87ad-5953ca073f8d">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

