### PR TITLE
[Lens] unify expression search context type

### DIFF
--- a/packages/kbn-es-query/index.ts
+++ b/packages/kbn-es-query/index.ts
@@ -128,3 +128,5 @@ export {
   isDataViewFieldSubtypeMulti,
   isDataViewFieldSubtypeNested,
 } from './src/utils';
+
+export type { ExecutionContextSearch } from './src/expressions/types';

--- a/packages/kbn-es-query/src/expressions/types.ts
+++ b/packages/kbn-es-query/src/expressions/types.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Filter, Query, TimeRange } from '../filters';
+
+export interface ExecutionContextSearch {
+  filters?: Filter[];
+  query?: Query | Query[];
+  timeRange?: TimeRange;
+  disableWarningToasts?: boolean;
+}

--- a/src/plugins/chart_expressions/expression_metric/common/expression_functions/metric_trendline_function.test.ts
+++ b/src/plugins/chart_expressions/expression_metric/common/expression_functions/metric_trendline_function.test.ts
@@ -8,11 +8,10 @@
 
 import { Datatable, ExecutionContext } from '@kbn/expressions-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common';
-import { SerializableRecord } from '@kbn/utility-types';
 import { TrendlineArguments } from '../types';
 import { metricTrendlineFunction } from './metric_trendline_function';
 
-const fakeContext = {} as ExecutionContext<Adapters, SerializableRecord>;
+const fakeContext = {} as ExecutionContext<Adapters>;
 const fakeInput = {} as Datatable;
 const metricTrendline = (args: TrendlineArguments) =>
   metricTrendlineFunction().fn(fakeInput, args, fakeContext);

--- a/src/plugins/data/common/search/expressions/kibana.ts
+++ b/src/plugins/data/common/search/expressions/kibana.ts
@@ -9,7 +9,7 @@
 import { i18n } from '@kbn/i18n';
 import { ExecutionContext, ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common';
-import { ExpressionValueSearchContext, ExecutionContextSearch } from './kibana_context_type';
+import { ExpressionValueSearchContext } from './kibana_context_type';
 
 const toArray = <T>(query: undefined | T | T[]): T[] =>
   !query ? [] : Array.isArray(query) ? query : [query];
@@ -20,7 +20,7 @@ export type ExpressionFunctionKibana = ExpressionFunctionDefinition<
   ExpressionValueSearchContext | null,
   object,
   ExpressionValueSearchContext,
-  ExecutionContext<Adapters, ExecutionContextSearch>
+  ExecutionContext<Adapters>
 >;
 
 export const kibana: ExpressionFunctionKibana = {

--- a/src/plugins/data/common/search/expressions/kibana_context.ts
+++ b/src/plugins/data/common/search/expressions/kibana_context.ts
@@ -8,13 +8,7 @@
 
 import { ExpressionFunctionDefinition, ExecutionContext } from '@kbn/expressions-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common';
-import {
-  KibanaTimerangeOutput,
-  ExecutionContextSearch,
-  KibanaContext,
-  KibanaFilter,
-  KibanaQueryOutput,
-} from '../..';
+import { KibanaTimerangeOutput, KibanaContext, KibanaFilter, KibanaQueryOutput } from '../..';
 
 interface Arguments {
   q?: KibanaQueryOutput[] | null;
@@ -28,5 +22,5 @@ export type ExpressionFunctionKibanaContext = ExpressionFunctionDefinition<
   KibanaContext | null,
   Arguments,
   Promise<KibanaContext>,
-  ExecutionContext<Adapters, ExecutionContextSearch>
+  ExecutionContext<Adapters>
 >;

--- a/src/plugins/data/common/search/expressions/kibana_context_type.ts
+++ b/src/plugins/data/common/search/expressions/kibana_context_type.ts
@@ -5,18 +5,10 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import { Filter } from '@kbn/es-query';
+import { Filter, ExecutionContextSearch } from '@kbn/es-query';
 import { ExpressionValueBoxed } from '@kbn/expressions-plugin/common';
-import { Query, TimeRange } from '../../query';
+import { Query } from '../../query';
 import { DataViewField } from '../..';
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type ExecutionContextSearch = {
-  filters?: Filter[];
-  query?: Query | Query[];
-  timeRange?: TimeRange;
-  disableWarningToasts?: boolean;
-};
 
 export type ExpressionValueSearchContext = ExpressionValueBoxed<
   'kibana_context',

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -138,7 +138,6 @@ export type {
   OptionedValueProp,
   ParsedInterval,
   // expressions
-  ExecutionContextSearch,
   ExpressionFunctionKql,
   ExpressionFunctionLucene,
   ExpressionFunctionKibana,

--- a/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
+++ b/src/plugins/event_annotation/common/fetch_event_annotations/request_event_annotations.ts
@@ -21,7 +21,6 @@ import { ExecutionContext } from '@kbn/expressions-plugin/common';
 import moment from 'moment';
 import { ESCalendarInterval, ESFixedInterval, roundDateToESInterval } from '@elastic/charts';
 import { Adapters } from '@kbn/inspector-plugin/common';
-import { SerializableRecord } from '@kbn/utility-types';
 import { IUiSettingsClient } from '@kbn/core-ui-settings-browser';
 import { i18n } from '@kbn/i18n';
 import { handleRequest } from './handle_request';
@@ -71,7 +70,7 @@ export const requestEventAnnotations = (
     abortSignal,
     getSearchSessionId,
     getExecutionContext,
-  }: ExecutionContext<Adapters, SerializableRecord>,
+  }: ExecutionContext<Adapters>,
   getStartDependencies: () => Promise<FetchEventAnnotationsStartDependencies>
 ) => {
   return defer(async () => {

--- a/src/plugins/event_annotation/tsconfig.json
+++ b/src/plugins/event_annotation/tsconfig.json
@@ -12,7 +12,6 @@
     "@kbn/core",
     "@kbn/expressions-plugin",
     "@kbn/data-plugin",
-    "@kbn/utility-types",
     "@kbn/i18n",
     "@kbn/data-views-plugin",
     "@kbn/inspector-plugin",

--- a/src/plugins/expressions/common/execution/types.ts
+++ b/src/plugins/expressions/common/execution/types.ts
@@ -6,11 +6,11 @@
  * Side Public License, v 1.
  */
 
-import type { SerializableRecord } from '@kbn/utility-types';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 
 import { Adapters, RequestAdapter } from '@kbn/inspector-plugin/common';
+import { ExecutionContextSearch } from '@kbn/es-query';
 import { Datatable, ExpressionType } from '../expression_types';
 import { TablesAdapter } from '../util/tables_adapter';
 import { ExpressionsInspectorAdapter } from '../util';
@@ -19,10 +19,7 @@ import { ExpressionsInspectorAdapter } from '../util';
  * `ExecutionContext` is an object available to all functions during a single execution;
  * it provides various methods to perform side-effects.
  */
-export interface ExecutionContext<
-  InspectorAdapters extends Adapters = Adapters,
-  ExecutionContextSearch extends SerializableRecord = SerializableRecord
-> {
+export interface ExecutionContext<InspectorAdapters extends Adapters = Adapters> {
   /**
    * Get search context of the expression.
    */

--- a/src/plugins/expressions/common/service/expressions_services.ts
+++ b/src/plugins/expressions/common/service/expressions_services.ts
@@ -8,7 +8,6 @@
 
 import { Observable } from 'rxjs';
 import type { Logger } from '@kbn/logging';
-import type { SerializableRecord } from '@kbn/utility-types';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 
@@ -19,6 +18,7 @@ import {
   VersionedState,
 } from '@kbn/kibana-utils-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common/adapters';
+import { ExecutionContextSearch } from '@kbn/es-query';
 import { Executor } from '../executor';
 import { AnyExpressionRenderDefinition, ExpressionRendererRegistry } from '../expression_renderers';
 import { ExpressionAstExpression } from '../ast';
@@ -130,7 +130,7 @@ export interface ExpressionsServiceSetup {
 }
 
 export interface ExpressionExecutionParams {
-  searchContext?: SerializableRecord;
+  searchContext?: ExecutionContextSearch;
 
   variables?: Record<string, unknown>;
 

--- a/src/plugins/expressions/public/react_expression_renderer/react_expression_renderer.test.tsx
+++ b/src/plugins/expressions/public/react_expression_renderer/react_expression_renderer.test.tsx
@@ -185,7 +185,7 @@ describe('ExpressionRenderer', () => {
         reload$={refreshSubject}
         expression=""
         debounce={1000}
-        searchContext={{ from: 'now-15m', to: 'now' }}
+        searchContext={{ timeRange: { from: 'now-15m', to: 'now' } }}
       />
     );
 

--- a/src/plugins/expressions/public/types/index.ts
+++ b/src/plugins/expressions/public/types/index.ts
@@ -6,9 +6,9 @@
  * Side Public License, v 1.
  */
 
-import type { SerializableRecord } from '@kbn/utility-types';
 import type { KibanaExecutionContext } from '@kbn/core/public';
 import { Adapters } from '@kbn/inspector-plugin/public';
+import { ExecutionContextSearch } from '@kbn/es-query';
 import {
   IInterpreterRenderHandlers,
   ExpressionValue,
@@ -35,7 +35,7 @@ export interface ExpressionInterpreter {
 }
 
 export interface IExpressionLoaderParams {
-  searchContext?: SerializableRecord;
+  searchContext?: ExecutionContextSearch;
   context?: ExpressionValue;
   variables?: Record<string, unknown>;
   // Enables debug tracking on each expression in the AST

--- a/src/plugins/expressions/tsconfig.json
+++ b/src/plugins/expressions/tsconfig.json
@@ -17,6 +17,7 @@
     "@kbn/core-execution-context-common",
     "@kbn/tinymath",
     "@kbn/panel-loader",
+    "@kbn/es-query",
   ],
   "exclude": [
     "target/**/*",

--- a/src/plugins/vis_types/vega/public/vega_fn.ts
+++ b/src/plugins/vis_types/vega/public/vega_fn.ts
@@ -8,7 +8,6 @@
 
 import { get } from 'lodash';
 import { i18n } from '@kbn/i18n';
-import { ExecutionContextSearch } from '@kbn/data-plugin/public';
 import {
   ExecutionContext,
   ExpressionFunctionDefinition,
@@ -40,7 +39,7 @@ export type VegaExpressionFunctionDefinition = ExpressionFunctionDefinition<
   Input,
   Arguments,
   Output,
-  ExecutionContext<VegaInspectorAdapters, ExecutionContextSearch>
+  ExecutionContext<VegaInspectorAdapters>
 >;
 
 export const createVegaFn = (

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/csv.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/csv.test.ts
@@ -5,7 +5,6 @@
  * 2.0.
  */
 
-import { SerializableRecord } from '@kbn/utility-types';
 import { functionWrapper } from '@kbn/presentation-util-plugin/test_helpers';
 import { getFunctionErrors } from '../../../i18n';
 import { csv } from './csv';
@@ -40,7 +39,7 @@ one,1
 two,2
 fourty two,42`,
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expected);
   });
@@ -56,7 +55,7 @@ two\t2
 fourty two\t42`,
           delimiter: '\t',
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expected);
 
@@ -70,7 +69,7 @@ two%SPLIT%2
 fourty two%SPLIT%42`,
           delimiter: '%SPLIT%',
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expected);
   });
@@ -83,7 +82,7 @@ fourty two%SPLIT%42`,
           data: `name,number\rone,1\rtwo,2\rfourty two,42`,
           newline: '\r',
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expected);
   });
@@ -107,7 +106,7 @@ fourty two%SPLIT%42`,
           data: `foo," bar  ", baz, " buz "
 1,2,3,4`,
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expectedResult);
   });
@@ -135,7 +134,7 @@ fourty two%SPLIT%42`,
 1,"  best  ",3, "  ok"
 "  good", bad, better   , " worst    " `,
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       )
     ).toEqual(expectedResult);
   });
@@ -150,7 +149,7 @@ one|1
 two.2
 fourty two,42`,
         },
-        {} as ExecutionContext<Adapters, SerializableRecord>
+        {} as ExecutionContext<Adapters>
       );
     }).toThrow(new RegExp(errors.invalidInputCSV().message));
   });

--- a/x-pack/plugins/canvas/canvas_plugin_src/functions/common/dropdown_control.test.ts
+++ b/x-pack/plugins/canvas/canvas_plugin_src/functions/common/dropdown_control.test.ts
@@ -10,25 +10,16 @@ import { testTable, relationalTable } from './__fixtures__/test_tables';
 import { dropdownControl } from './dropdownControl';
 import { ExecutionContext } from '@kbn/expressions-plugin/common';
 import { Adapters } from '@kbn/inspector-plugin/common';
-import { SerializableRecord } from '@kbn/utility-types';
 
 describe('dropdownControl', () => {
   const fn = functionWrapper(dropdownControl);
 
   it('returns a render as dropdown_filter', () => {
     expect(
-      fn(
-        testTable,
-        { filterColumn: 'name', valueColumn: 'name' },
-        {} as ExecutionContext<Adapters, SerializableRecord>
-      )
+      fn(testTable, { filterColumn: 'name', valueColumn: 'name' }, {} as ExecutionContext<Adapters>)
     ).toHaveProperty('type', 'render');
     expect(
-      fn(
-        testTable,
-        { filterColumn: 'name', valueColumn: 'name' },
-        {} as ExecutionContext<Adapters, SerializableRecord>
-      )
+      fn(testTable, { filterColumn: 'name', valueColumn: 'name' }, {} as ExecutionContext<Adapters>)
     ).toHaveProperty('as', 'dropdown_filter');
   });
 
@@ -41,25 +32,16 @@ describe('dropdownControl', () => {
           []
         );
         expect(
-          fn(
-            testTable,
-            { valueColumn: 'name' },
-            {} as ExecutionContext<Adapters, SerializableRecord>
-          )?.value?.choices
+          fn(testTable, { valueColumn: 'name' }, {} as ExecutionContext<Adapters>)?.value?.choices
         ).toEqual(uniqueNames);
       });
 
       it('returns an empty array when provided an invalid column', () => {
         expect(
-          fn(
-            testTable,
-            { valueColumn: 'foo' },
-            {} as ExecutionContext<Adapters, SerializableRecord>
-          )?.value?.choices
+          fn(testTable, { valueColumn: 'foo' }, {} as ExecutionContext<Adapters>)?.value?.choices
         ).toEqual([]);
         expect(
-          fn(testTable, { valueColumn: '' }, {} as ExecutionContext<Adapters, SerializableRecord>)
-            ?.value?.choices
+          fn(testTable, { valueColumn: '' }, {} as ExecutionContext<Adapters>)?.value?.choices
         ).toEqual([]);
       });
     });
@@ -71,7 +53,7 @@ describe('dropdownControl', () => {
           fn(
             relationalTable,
             { valueColumn: 'id', labelColumn: 'name' },
-            {} as ExecutionContext<Adapters, SerializableRecord>
+            {} as ExecutionContext<Adapters>
           )?.value?.choices
         ).toEqual(expectedChoices);
       });
@@ -81,28 +63,20 @@ describe('dropdownControl', () => {
   describe('filterColumn', () => {
     it('sets which column the filter is applied to', () => {
       expect(
-        fn(
-          testTable,
-          { filterColumn: 'name' },
-          {} as ExecutionContext<Adapters, SerializableRecord>
-        )?.value
+        fn(testTable, { filterColumn: 'name' }, {} as ExecutionContext<Adapters>)?.value
       ).toHaveProperty('column', 'name');
       expect(
         fn(
           testTable,
           { filterColumn: 'name', valueColumn: 'price' },
-          {} as ExecutionContext<Adapters, SerializableRecord>
+          {} as ExecutionContext<Adapters>
         )?.value
       ).toHaveProperty('column', 'name');
     });
 
     it('defaults to valueColumn if not provided', () => {
       expect(
-        fn(
-          testTable,
-          { valueColumn: 'price' },
-          {} as ExecutionContext<Adapters, SerializableRecord>
-        )?.value
+        fn(testTable, { valueColumn: 'price' }, {} as ExecutionContext<Adapters>)?.value
       ).toHaveProperty('column', 'price');
     });
   });

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -28,7 +28,8 @@ import { IconType } from '@elastic/eui/src/components/icon/icon';
 import { Ast, fromExpression, toExpression } from '@kbn/interpreter';
 import { i18n } from '@kbn/i18n';
 import classNames from 'classnames';
-import { DataPublicPluginStart, ExecutionContextSearch } from '@kbn/data-plugin/public';
+import { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ExecutionContextSearch } from '@kbn/es-query';
 import {
   ReactExpressionRendererProps,
   ReactExpressionRendererType,

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/workspace_panel.tsx
@@ -23,7 +23,8 @@ import {
   EuiSpacer,
 } from '@elastic/eui';
 import type { CoreStart } from '@kbn/core/public';
-import type { DataPublicPluginStart, ExecutionContextSearch } from '@kbn/data-plugin/public';
+import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { ExecutionContextSearch } from '@kbn/es-query';
 import type {
   ExpressionRendererEvent,
   ExpressionRenderError,

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -20,11 +20,11 @@ import {
   TimeRange,
   isOfQueryType,
   getAggregateQueryMode,
+  ExecutionContextSearch,
 } from '@kbn/es-query';
 import type { PaletteOutput } from '@kbn/coloring';
 import {
   DataPublicPluginStart,
-  ExecutionContextSearch,
   TimefilterContract,
   FilterManager,
   getEsQueryConfig,

--- a/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
@@ -13,7 +13,7 @@ import {
   ReactExpressionRendererType,
 } from '@kbn/expressions-plugin/public';
 import type { CoreStart, KibanaExecutionContext } from '@kbn/core/public';
-import { ExecutionContextSearch } from '@kbn/data-plugin/public';
+import type { ExecutionContextSearch } from '@kbn/es-query';
 import { DefaultInspectorAdapters, RenderMode } from '@kbn/expressions-plugin/common';
 import classNames from 'classnames';
 import { getOriginalRequestErrorMessages } from '../editor_frame_service/error_helper';


### PR DESCRIPTION
## Summary

While working on https://github.com/elastic/kibana/pull/172710 I noticed how loose our search context types were. This leeway seems like overkill given how we actually use the expressions framework.
