### PR TITLE
[ES|QL] Displays the number of suggestions when accordion is closed

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -549,35 +549,37 @@ export function SuggestionPanel({
       forceState={hideSuggestions ? 'closed' : 'open'}
       onToggle={toggleSuggestions}
       extraAction={
-        !hideSuggestions && (
-          <>
-            {existsStagedPreview && (
-              <EuiToolTip
-                content={i18n.translate('xpack.lens.suggestion.refreshSuggestionTooltip', {
-                  defaultMessage: 'Refresh the suggestions based on the selected visualization.',
-                })}
-              >
-                <EuiButtonEmpty
-                  data-test-subj="lensSubmitSuggestion"
-                  size="xs"
-                  iconType="refresh"
-                  onClick={() => {
-                    dispatchLens(submitSuggestion());
-                  }}
-                >
-                  {i18n.translate('xpack.lens.sugegstion.refreshSuggestionLabel', {
-                    defaultMessage: 'Refresh',
+        <>
+          {!hideSuggestions && (
+            <>
+              {existsStagedPreview && (
+                <EuiToolTip
+                  content={i18n.translate('xpack.lens.suggestion.refreshSuggestionTooltip', {
+                    defaultMessage: 'Refresh the suggestions based on the selected visualization.',
                   })}
-                </EuiButtonEmpty>
-              </EuiToolTip>
-            )}
-            {wrapSuggestions && (
-              <EuiNotificationBadge size="m" color="subdued">
-                {suggestions.length + 1}
-              </EuiNotificationBadge>
-            )}
-          </>
-        )
+                >
+                  <EuiButtonEmpty
+                    data-test-subj="lensSubmitSuggestion"
+                    size="xs"
+                    iconType="refresh"
+                    onClick={() => {
+                      dispatchLens(submitSuggestion());
+                    }}
+                  >
+                    {i18n.translate('xpack.lens.sugegstion.refreshSuggestionLabel', {
+                      defaultMessage: 'Refresh',
+                    })}
+                  </EuiButtonEmpty>
+                </EuiToolTip>
+              )}
+            </>
+          )}
+          {wrapSuggestions && (
+            <EuiNotificationBadge size="m" color="subdued">
+              {suggestions.length + 1}
+            </EuiNotificationBadge>
+          )}
+        </>
       }
     >
       <div


### PR DESCRIPTION
## Summary

We want the suggestion number on the ES|QL suggestions accordion to appear also when the accordion is closed. 

**Closed**
<img width="503" alt="image" src="https://github.com/elastic/kibana/assets/17003240/3c180442-7eaf-4152-acb9-ff8037fca930">


**Open**
<img width="495" alt="image" src="https://github.com/elastic/kibana/assets/17003240/69dbf97f-cdca-4bec-8e24-e5d81400f2f7">
