### PR TITLE
[Discover] Unskip field tokens tests

### DIFF
--- a/test/functional/apps/discover/group2/_data_grid_field_tokens.ts
+++ b/test/functional/apps/discover/group2/_data_grid_field_tokens.ts
@@ -60,8 +60,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     return firstFieldIcons;
   }
 
-  // FAILING VERSION BUMP: https://github.com/elastic/kibana/issues/172756
-  describe.skip('discover data grid field tokens', function () {
+  describe('discover data grid field tokens', function () {
     before(async () => {
       await security.testUser.setRoles(['kibana_admin', 'test_logstash_reader']);
       await esArchiver.loadIfNeeded('test/functional/fixtures/es_archiver/logstash_functional');
@@ -131,7 +130,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.unifiedFieldList.clickFieldListItemAdd('ip');
       await PageObjects.unifiedFieldList.clickFieldListItemAdd('geo.coordinates');
 
-      expect(await findFirstColumnTokens()).to.eql(['Number', 'String', 'String']);
+      expect(await findFirstColumnTokens()).to.eql(['Number', 'String', 'String', 'String']);
 
       expect(await findFirstDocViewerTokens()).to.eql([
         'String',
@@ -141,7 +140,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'Number',
         'String',
         'String',
-        'Unknown field',
+        'String',
         'String',
         'String',
       ]);


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/172756

## Summary

Looks like ES|QL now supports geo fields.

100x https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4240



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->