### PR TITLE
[ES|QL] Improves the warning / error hover titles

### DIFF
--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -713,6 +713,14 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                         iconType="error"
                         iconSide="left"
                         data-test-subj="TextBasedLangEditor-inline-errors-badge"
+                        title={i18n.translate(
+                          'textBasedEditor.query.textBasedLanguagesEditor.errorCountTitle',
+                          {
+                            defaultMessage:
+                              '{count} {count, plural, one {error} other {errors}} found',
+                            values: { count: editorMessages.errors.length },
+                          }
+                        )}
                       >
                         {editorMessages.errors.length}
                       </EuiBadge>
@@ -726,6 +734,14 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                           iconType="warning"
                           iconSide="left"
                           data-test-subj="TextBasedLangEditor-inline-warning-badge"
+                          title={i18n.translate(
+                            'textBasedEditor.query.textBasedLanguagesEditor.warningCountTitle',
+                            {
+                              defaultMessage:
+                                '{count} {count, plural, one {warning} other {warnings}} found',
+                              values: { count: editorMessages.warnings.length },
+                            }
+                          )}
                         >
                           {editorMessages.warnings.length}
                         </EuiBadge>


### PR DESCRIPTION
## Summary

Improves the hover message on the warning / error badges.

![image (17)](https://github.com/elastic/kibana/assets/17003240/788c4dc7-aef1-4230-b6d7-71554a27ff18)


It used to be only the number of errors/warnings and it was causing confusion

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->