### PR TITLE
[Lens] Fix tooltip size and partition rerendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.15.0",
     "@elastic/apm-rum-react": "^2.0.1",
-    "@elastic/charts": "60.0.0",
+    "@elastic/charts": "60.0.1",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.9.1-canary.1",
     "@elastic/ems-client": "8.5.1",

--- a/x-pack/plugins/uptime/public/legacy_uptime/components/common/charts/__snapshots__/donut_chart.test.tsx.snap
+++ b/x-pack/plugins/uptime/public/legacy_uptime/components/common/charts/__snapshots__/donut_chart.test.tsx.snap
@@ -510,7 +510,7 @@ exports[`DonutChart component passes correct props without errors for valid prop
             "tooltip": Object {
               "defaultDotColor": "black",
               "maxTableHeight": 120,
-              "maxWidth": 260,
+              "maxWidth": 500,
             },
           }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1544,10 +1544,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/charts@60.0.0":
-  version "60.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-60.0.0.tgz#088c19debf1db48aed72c84bda51e98e7c291d54"
-  integrity sha512-oGNdvKhuZ2g2i/k4Zgv5QSUcEu+DOJSlIxV/1a7JBR/uJ2AzpV4uFyrNBUnUkM+CPJvsEn5MYABAzwUwveTgHA==
+"@elastic/charts@60.0.1":
+  version "60.0.1"
+  resolved "https://registry.yarnpkg.com/@elastic/charts/-/charts-60.0.1.tgz#da8f8afd7200651d7efbf7d71b2dd60bee9299d1"
+  integrity sha512-Sl386SApHeK+IIx7R/8hAA8ribkyRi+Qi5iI7ENqywtRp1en4A75OSS9+wWy03uUvN8OcrA3Aaia2gTYHA+x0w==
   dependencies:
     "@popperjs/core" "^2.11.8"
     bezier-easing "^2.1.0"


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/171408
improves the style of tooltip by enlarging its size see https://github.com/elastic/elastic-charts/issues/2048



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->