### PR TITLE
[Advanced Settings][Serverless] Temporarily skip flaky tests

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/advanced_settings.ts
@@ -88,7 +88,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       }
     });
 
-    describe('updating settings', () => {
+    describe.skip('updating settings', () => {
       it('allows to update a setting', async () => {
         const fieldTestSubj = 'management-settings-editField-' + settings.CSV_QUOTE_VALUES_ID;
         expect(await testSubjects.isEuiSwitchChecked(fieldTestSubj)).to.be(true);


### PR DESCRIPTION
Addresses https://github.com/elastic/kibana/issues/172725 and https://github.com/elastic/kibana/issues/172763


## Summary

This PR temporarily skips the serverless Advanced settings that were recently added as they appear to be flaky. A fix will be implemented in a follow-up PR.



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->