### PR TITLE
Add fieldsForAAD to observability plugin rule types

### DIFF
--- a/x-pack/plugins/observability/common/field_names/slo.ts
+++ b/x-pack/plugins/observability/common/field_names/slo.ts
@@ -8,3 +8,5 @@
 export const SLO_ID_FIELD = 'slo.id';
 export const SLO_REVISION_FIELD = 'slo.revision';
 export const SLO_INSTANCE_ID_FIELD = 'slo.instanceId';
+
+export const SLO_BURN_RATE_AAD_FIELDS = [SLO_ID_FIELD, SLO_REVISION_FIELD, SLO_INSTANCE_ID_FIELD];

--- a/x-pack/plugins/observability/server/lib/rules/custom_threshold/constants.ts
+++ b/x-pack/plugins/observability/server/lib/rules/custom_threshold/constants.ts
@@ -28,3 +28,12 @@ export const NO_DATA_ACTION = {
     }
   ),
 };
+
+export const CUSTOM_THRESHOLD_AAD_FIELDS = [
+  'cloud.*',
+  'host.*',
+  'orchestrator.*',
+  'container.*',
+  'labels.*',
+  'tags',
+];

--- a/x-pack/plugins/observability/server/lib/rules/custom_threshold/register_custom_threshold_rule_type.ts
+++ b/x-pack/plugins/observability/server/lib/rules/custom_threshold/register_custom_threshold_rule_type.ts
@@ -40,7 +40,7 @@ import {
   createCustomThresholdExecutor,
   CustomThresholdLocators,
 } from './custom_threshold_executor';
-import { FIRED_ACTION, NO_DATA_ACTION } from './constants';
+import { CUSTOM_THRESHOLD_AAD_FIELDS, FIRED_ACTION, NO_DATA_ACTION } from './constants';
 import { ObservabilityConfig } from '../../..';
 
 export const MetricsRulesTypeAlertDefinition: IRuleTypeAlerts = {
@@ -110,6 +110,7 @@ export function thresholdRuleType(
     name: i18n.translate('xpack.observability.threshold.ruleName', {
       defaultMessage: 'Custom threshold (Beta)',
     }),
+    fieldsForAAD: CUSTOM_THRESHOLD_AAD_FIELDS,
     validate: {
       params: schema.object(
         {

--- a/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/register.ts
+++ b/x-pack/plugins/observability/server/lib/rules/slo_burn_rate/register.ts
@@ -14,6 +14,7 @@ import { createLifecycleExecutor } from '@kbn/rule-registry-plugin/server';
 import { legacyExperimentalFieldMap } from '@kbn/alerts-as-data-utils';
 import { IBasePath } from '@kbn/core/server';
 import { LocatorPublic } from '@kbn/share-plugin/common';
+import { SLO_BURN_RATE_AAD_FIELDS } from '../../../../common/field_names/slo';
 import { AlertsLocatorParams, observabilityPaths, sloFeatureId } from '../../../../common';
 import { SLO_RULE_REGISTRATION_CONTEXT } from '../../../common/constants';
 
@@ -54,6 +55,7 @@ export function sloBurnRateRuleType(
     name: i18n.translate('xpack.observability.slo.rules.burnRate.name', {
       defaultMessage: 'SLO burn rate',
     }),
+    fieldsForAAD: SLO_BURN_RATE_AAD_FIELDS,
     validate: {
       params: schema.object({
         sloId: schema.string(),


### PR DESCRIPTION
Related to #158324

## Summary

This PR adds `fieldsForAAD` to the SLO burn rate and Custom threshold rules to ensure conditional actions can use fields related to these rules.

<img src="https://github.com/elastic/kibana/assets/12370520/7cb31448-58cc-4bf6-b0da-cdc5e746ae60" width=500 />


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->