### PR TITLE
[Fleet] Fix 500 in Fleet API when request to product versions endpoint throws ECONNREFUSED

### DIFF
--- a/x-pack/plugins/fleet/server/services/agents/versions.test.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.test.ts
@@ -179,4 +179,29 @@ describe('getAvailableVersions', () => {
     expect(mockedFetch).toBeCalledTimes(1);
     expect(res2).not.toContain('300.0.0');
   });
+
+  it('should gracefully handle 400 errors when fetching from product versions API', async () => {
+    mockKibanaVersion = '300.0.0';
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+    mockedFetch.mockResolvedValue({
+      status: 400,
+      text: 'Bad request',
+    } as any);
+
+    const res = await getAvailableVersions({ ignoreCache: true });
+
+    // Should sort, uniquify and filter out versions < 7.17
+    expect(res).toEqual(['8.1.0', '8.0.0', '7.17.0']);
+  });
+
+  it('should gracefully handle network errors when fetching from product versions API', async () => {
+    mockKibanaVersion = '300.0.0';
+    mockedReadFile.mockResolvedValue(`["8.1.0", "8.0.0", "7.17.0", "7.16.0"]`);
+    mockedFetch.mockRejectedValue('ECONNREFUSED');
+
+    const res = await getAvailableVersions({ ignoreCache: true });
+
+    // Should sort, uniquify and filter out versions < 7.17
+    expect(res).toEqual(['8.1.0', '8.0.0', '7.17.0']);
+  });
 });

--- a/x-pack/plugins/fleet/server/services/agents/versions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.ts
@@ -24,6 +24,7 @@ const AGENT_VERSION_BUILD_FILE = 'x-pack/plugins/fleet/target/agent_versions_lis
 
 // Endpoint maintained by the web-team and hosted on the elastic website
 const PRODUCT_VERSIONS_URL = 'https://www.elastic.co/api/product_versions';
+const MAX_REQUEST_TIMEOUT = 60 * 1000; // Only attempt to fetch product versions for one minute total
 
 // Cache available versions in memory for 1 hour
 const CACHE_DURATION = 1000 * 60 * 60;
@@ -119,7 +120,10 @@ async function fetchAgentVersionsFromApi() {
   };
 
   try {
-    const response = await pRetry(() => fetch(PRODUCT_VERSIONS_URL, options), { retries: 1 });
+    const response = await pRetry(() => fetch(PRODUCT_VERSIONS_URL, options), {
+      retries: 1,
+      maxRetryTime: MAX_REQUEST_TIMEOUT,
+    });
     const rawBody = await response.text();
 
     // We need to handle non-200 responses gracefully here to support airgapped environments where


### PR DESCRIPTION
## Summary

Network-level errors will cause `fetch` to `throw` rather than resolving with a status code. This PR updates our logic to handle this case for airgapped environments where `ECONNREFUSED` style errors squash HTTP requests at the DNS level.



<!--ONMERGE {"backportTargets":["8.11","8.12"]} ONMERGE-->