### PR TITLE
[Obs AI Assistant] Abort controller when component unmounts

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_chat.test.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_chat.test.ts
@@ -233,6 +233,25 @@ describe('useChat', () => {
       });
     });
 
+    describe('after unmounting the component', () => {
+      beforeEach(() => {
+        act(() => {
+          subject.next({
+            type: StreamingChatResponseEventType.ChatCompletionChunk,
+            id: 'my-message-id',
+            message: {
+              content: 'good',
+            },
+          });
+          hookResult.unmount();
+        });
+      });
+
+      it('shows the partial message and sets chatState to aborted', () => {
+        expect(mockChatService.complete.mock.lastCall?.[0].signal.aborted).toBe(true);
+      });
+    });
+
     describe('after a response errors out', () => {
       beforeEach(() => {
         act(() => {

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_chat.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_chat.ts
@@ -225,9 +225,8 @@ export function useChat({
   );
 
   useEffect(() => {
-    const controller = abortControllerRef.current;
     return () => {
-      controller.abort();
+      abortControllerRef.current.abort();
     };
   }, []);
 


### PR DESCRIPTION
When the component unmounts (for instance when moving to a different chat or navigating to another page), the request to /complete should be aborted. This PR ensures that that is the case and adds a test for it.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->