### PR TITLE
[EDR Workflows] Fix failing attach to case functionality when isolating/releasing a host 

### DIFF
--- a/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
@@ -125,7 +125,7 @@ describe('Attachments', () => {
         it('is successful when a comment string of empty characters', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '   ' }))
-          ).not.toContain('The comment figeld cannot be an empty string.');
+          ).not.toContain('The comment field cannot be an empty string.');
         });
       });
     });

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
@@ -116,16 +116,16 @@ describe('Attachments', () => {
           ).toContain('The length of the comment is too long. The maximum length is 30000.');
         });
 
-        it('throws error when comment is empty', () => {
+        it('is successful when a comment with empty string', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '' }))
-          ).toContain('The comment field cannot be an empty string.');
+          ).not.toContain('The comment field cannot be an empty string.');
         });
 
-        it('throws error when comment string of empty characters', () => {
+        it('is successful when a comment string of empty characters', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '   ' }))
-          ).toContain('The comment field cannot be an empty string.');
+          ).not.toContain('The comment figeld cannot be an empty string.');
         });
       });
     });

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
@@ -119,13 +119,13 @@ describe('Attachments', () => {
         it('is successful when a comment with empty string', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '' }))
-          ).not.toContain('The comment field cannot be an empty string.');
+          ).toEqual(['No errors!']);
         });
 
         it('is successful when a comment string of empty characters', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '   ' }))
-          ).not.toContain('The comment field cannot be an empty string.');
+          ).toEqual(['No errors!']);
         });
       });
     });

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.test.ts
@@ -116,13 +116,13 @@ describe('Attachments', () => {
           ).toContain('The length of the comment is too long. The maximum length is 30000.');
         });
 
-        it('is successful when a comment with empty string', () => {
+        it('is successful when a comment is an empty string', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '' }))
           ).toEqual(['No errors!']);
         });
 
-        it('is successful when a comment string of empty characters', () => {
+        it('is successful when a comment is a string of empty characters', () => {
           expect(
             PathReporter.report(AttachmentRequestRt.decode({ ...request, comment: '   ' }))
           ).toEqual(['No errors!']);

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.ts
@@ -66,7 +66,7 @@ export const AttachmentRequestRt = rt.union([
   AlertAttachmentPayloadRt,
   rt.strict({
     type: rt.literal(AttachmentType.actions),
-    comment: limitedStringSchema({ fieldName: 'comment', min: 1, max: MAX_COMMENT_LENGTH }),
+    comment: limitedStringSchema({ fieldName: 'comment', max: MAX_COMMENT_LENGTH }),
     actions: rt.strict({
       targets: rt.array(
         rt.strict({

--- a/x-pack/plugins/cases/common/types/api/attachment/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/attachment/v1.ts
@@ -66,7 +66,7 @@ export const AttachmentRequestRt = rt.union([
   AlertAttachmentPayloadRt,
   rt.strict({
     type: rt.literal(AttachmentType.actions),
-    comment: limitedStringSchema({ fieldName: 'comment', max: MAX_COMMENT_LENGTH }),
+    comment: limitedStringSchema({ fieldName: 'comment', min: 0, max: MAX_COMMENT_LENGTH }),
     actions: rt.strict({
       targets: rt.array(
         rt.strict({


### PR DESCRIPTION
Closes: https://github.com/elastic/kibana/issues/172651

There was an issue where case attachment comment was required by cases, but optional by isolate action. 

Since we are passing an empty string `""` as comment when adding cases attachment by sending isolate/release action, we decided to make the validation in cases accept an empty string when coming from response actions (specific interface). 

Before:
<img width="886" alt="Zrzut ekranu 2023-12-8 o 10 09 10" src="https://github.com/elastic/kibana/assets/16632552/342ce901-194d-4cc8-bb28-bbadf7484c22">
After:
<img width="925" alt="Zrzut ekranu 2023-12-8 o 10 02 59" src="https://github.com/elastic/kibana/assets/16632552/99436fd7-4127-4229-9e06-19e54b436c84">
Attachments without comment:
<img width="1536" alt="Zrzut ekranu 2023-12-8 o 10 58 07" src="https://github.com/elastic/kibana/assets/16632552/dbe5129b-bb8e-4000-a83c-2003794e1f58">
