### PR TITLE
[DOCS] Removes tech preview badge from log rate analysis docs

### DIFF
--- a/docs/user/ml/index.asciidoc
+++ b/docs/user/ml/index.asciidoc
@@ -148,8 +148,6 @@ advanced statistical methods to help you interpret your data and its behavior.
 [[log-rate-analysis]]
 === Log rate analysis
 
-preview::[]
-
 Log rate analysis is a feature that uses advanced statistical methods to 
 identify reasons for increases or decreases in log rates. It makes it easy to 
 find and investigate causes of unusual spikes or drops by using the analysis 


### PR DESCRIPTION
## Summary

This PR removes the `Technical Preview` badge from the documentation page of Log Rate Analysis.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->