### PR TITLE
[System Actions] Complete API audit and update APIs to comply with System Actions

### DIFF
--- a/x-pack/plugins/alerting/common/rule.ts
+++ b/x-pack/plugins/alerting/common/rule.ts
@@ -141,6 +141,7 @@ export interface RuleSystemAction {
   actionTypeId: string;
   params: RuleActionParams;
   type: typeof RuleActionTypes.SYSTEM;
+  useAlertDataForTemplate?: boolean;
 }
 
 export type RuleAction = RuleDefaultAction | RuleSystemAction;

--- a/x-pack/plugins/alerting/server/routes/clone_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/clone_rule.ts
@@ -8,18 +8,14 @@
 import { schema } from '@kbn/config-schema';
 import { IRouter } from '@kbn/core/server';
 import { ILicenseState, RuleTypeDisabledError } from '../lib';
-import {
-  verifyAccessAndContext,
-  handleDisabledApiKeysError,
-  rewriteRuleLastRun,
-  rewriteActionsRes,
-} from './lib';
+import { verifyAccessAndContext, handleDisabledApiKeysError, rewriteRuleLastRun } from './lib';
 import {
   RuleTypeParams,
   AlertingRequestHandlerContext,
   INTERNAL_BASE_ALERTING_API_PATH,
   PartialRule,
 } from '../types';
+import { transformRuleActions } from './rule/transforms';
 
 const paramSchema = schema.object({
   id: schema.string(),
@@ -70,7 +66,7 @@ const rewriteBodyRes = ({
     : {}),
   ...(actions
     ? {
-        actions: rewriteActionsRes(actions),
+        actions: transformRuleActions(actions),
       }
     : {}),
   ...(lastRun ? { last_run: rewriteRuleLastRun(lastRun) } : {}),

--- a/x-pack/plugins/alerting/server/routes/clone_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/clone_rule.ts
@@ -94,11 +94,12 @@ export const cloneRuleRoute = (
       router.handleLegacyErrors(
         verifyAccessAndContext(licenseState, async function (context, req, res) {
           const rulesClient = (await context.alerting).getRulesClient();
+          const { isSystemAction } = (await context.actions).getActionsClient();
           const { id, newId } = req.params;
           try {
             const cloneRule = await rulesClient.clone(id, { newId });
             return res.ok({
-              body: rewriteBodyRes(cloneRule),
+              body: rewriteBodyRes(cloneRule, isSystemAction),
             });
           } catch (e) {
             if (e instanceof RuleTypeDisabledError) {

--- a/x-pack/plugins/alerting/server/routes/clone_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/clone_rule.ts
@@ -10,7 +10,6 @@ import { IRouter } from '@kbn/core/server';
 import { ILicenseState, RuleTypeDisabledError } from '../lib';
 import {
   verifyAccessAndContext,
-  RewriteResponseCase,
   handleDisabledApiKeysError,
   rewriteRuleLastRun,
   rewriteActionsRes,
@@ -20,6 +19,7 @@ import {
   AlertingRequestHandlerContext,
   INTERNAL_BASE_ALERTING_API_PATH,
   PartialRule,
+  IsSystemAction,
 } from '../types';
 
 const paramSchema = schema.object({
@@ -27,26 +27,29 @@ const paramSchema = schema.object({
   newId: schema.maybe(schema.string()),
 });
 
-const rewriteBodyRes: RewriteResponseCase<PartialRule<RuleTypeParams>> = ({
-  actions,
-  alertTypeId,
-  scheduledTaskId,
-  createdBy,
-  updatedBy,
-  createdAt,
-  updatedAt,
-  apiKeyOwner,
-  apiKeyCreatedByUser,
-  notifyWhen,
-  muteAll,
-  mutedInstanceIds,
-  executionStatus,
-  snoozeSchedule,
-  isSnoozedUntil,
-  lastRun,
-  nextRun,
-  ...rest
-}) => ({
+const rewriteBodyRes = (
+  {
+    actions,
+    alertTypeId,
+    scheduledTaskId,
+    createdBy,
+    updatedBy,
+    createdAt,
+    updatedAt,
+    apiKeyOwner,
+    apiKeyCreatedByUser,
+    notifyWhen,
+    muteAll,
+    mutedInstanceIds,
+    executionStatus,
+    snoozeSchedule,
+    isSnoozedUntil,
+    lastRun,
+    nextRun,
+    ...rest
+  }: PartialRule<RuleTypeParams>,
+  isSystemAction: IsSystemAction
+) => ({
   ...rest,
   api_key_owner: apiKeyOwner,
   created_by: createdBy,
@@ -71,7 +74,7 @@ const rewriteBodyRes: RewriteResponseCase<PartialRule<RuleTypeParams>> = ({
     : {}),
   ...(actions
     ? {
-        actions: rewriteActionsRes(actions),
+        actions: rewriteActionsRes(actions, isSystemAction),
       }
     : {}),
   ...(lastRun ? { last_run: rewriteRuleLastRun(lastRun) } : {}),

--- a/x-pack/plugins/alerting/server/routes/find_rules.ts
+++ b/x-pack/plugins/alerting/server/routes/find_rules.ts
@@ -10,12 +10,7 @@ import { UsageCounter } from '@kbn/usage-collection-plugin/server';
 import { schema } from '@kbn/config-schema';
 import { ILicenseState } from '../lib';
 import { FindOptions, FindResult } from '../rules_client';
-import {
-  RewriteRequestCase,
-  RewriteResponseCase,
-  verifyAccessAndContext,
-  rewriteRule,
-} from './lib';
+import { RewriteRequestCase, verifyAccessAndContext, rewriteRule } from './lib';
 import {
   RuleTypeParams,
   AlertingRequestHandlerContext,
@@ -69,11 +64,7 @@ const rewriteQueryReq: RewriteRequestCase<FindOptions> = ({
   ...(hasReference ? { hasReference } : {}),
   ...(searchFields ? { searchFields } : {}),
 });
-const rewriteBodyRes: RewriteResponseCase<FindResult<RuleTypeParams>> = ({
-  perPage,
-  data,
-  ...restOfResult
-}) => {
+const rewriteBodyRes = ({ perPage, data, ...restOfResult }: FindResult<RuleTypeParams>) => {
   return {
     ...restOfResult,
     per_page: perPage,

--- a/x-pack/plugins/alerting/server/routes/get_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/get_rule.ts
@@ -9,12 +9,7 @@ import { omit } from 'lodash';
 import { schema } from '@kbn/config-schema';
 import { IRouter } from '@kbn/core/server';
 import { ILicenseState } from '../lib';
-import {
-  verifyAccessAndContext,
-  RewriteResponseCase,
-  rewriteRuleLastRun,
-  rewriteActionsRes,
-} from './lib';
+import { verifyAccessAndContext, rewriteRuleLastRun } from './lib';
 import {
   RuleTypeParams,
   AlertingRequestHandlerContext,
@@ -22,12 +17,13 @@ import {
   INTERNAL_BASE_ALERTING_API_PATH,
   SanitizedRule,
 } from '../types';
+import { transformRuleActions } from './rule/transforms';
 
 const paramSchema = schema.object({
   id: schema.string(),
 });
 
-const rewriteBodyRes: RewriteResponseCase<SanitizedRule<RuleTypeParams>> = ({
+const rewriteBodyRes = ({
   alertTypeId,
   createdBy,
   updatedBy,
@@ -47,7 +43,7 @@ const rewriteBodyRes: RewriteResponseCase<SanitizedRule<RuleTypeParams>> = ({
   nextRun,
   viewInAppRelativeUrl,
   ...rest
-}) => ({
+}: SanitizedRule<RuleTypeParams>) => ({
   ...rest,
   rule_type_id: alertTypeId,
   created_by: createdBy,
@@ -66,7 +62,7 @@ const rewriteBodyRes: RewriteResponseCase<SanitizedRule<RuleTypeParams>> = ({
     last_execution_date: executionStatus.lastExecutionDate,
     last_duration: executionStatus.lastDuration,
   },
-  actions: rewriteActionsRes(actions),
+  actions: transformRuleActions(actions),
   ...(lastRun ? { last_run: rewriteRuleLastRun(lastRun) } : {}),
   ...(nextRun ? { next_run: nextRun } : {}),
   ...(viewInAppRelativeUrl ? { view_in_app_relative_url: viewInAppRelativeUrl } : {}),

--- a/x-pack/plugins/alerting/server/routes/lib/index.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/index.ts
@@ -18,11 +18,7 @@ export type {
 } from './rewrite_request_case';
 export { verifyAccessAndContext } from './verify_access_and_context';
 export { countUsageOfPredefinedIds } from './count_usage_of_predefined_ids';
-export {
-  rewriteActionsReq,
-  rewriteActionsRes,
-  rewriteActionsReqWithSystemActions,
-} from './rewrite_actions';
+export { rewriteActionsReq, rewriteActionsRes } from './rewrite_actions';
 export { actionsSchema } from './actions_schema';
 export { rewriteRule, rewriteRuleLastRun } from './rewrite_rule';
 export { rewriteNamespaces } from './rewrite_namespaces';

--- a/x-pack/plugins/alerting/server/routes/lib/index.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/index.ts
@@ -18,7 +18,7 @@ export type {
 } from './rewrite_request_case';
 export { verifyAccessAndContext } from './verify_access_and_context';
 export { countUsageOfPredefinedIds } from './count_usage_of_predefined_ids';
-export { rewriteActionsReq, rewriteActionsRes } from './rewrite_actions';
+export { rewriteActionsReq } from './rewrite_actions';
 export { actionsSchema } from './actions_schema';
 export { rewriteRule, rewriteRuleLastRun } from './rewrite_rule';
 export { rewriteNamespaces } from './rewrite_namespaces';

--- a/x-pack/plugins/alerting/server/routes/lib/rewrite_actions.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/rewrite_actions.ts
@@ -57,10 +57,7 @@ export const rewriteActionsReq = (
   );
 };
 
-export const rewriteActionsRes = (
-  actions: RuleAction[] | undefined,
-  isSystemAction: IsSystemAction
-) => {
+export const rewriteActionsRes = (actions?: RuleAction[]) => {
   const rewriteFrequency = ({
     notifyWhen,
     ...rest
@@ -70,7 +67,7 @@ export const rewriteActionsRes = (
   });
   if (!actions) return [];
   return actions.map(({ actionTypeId, useAlertDataForTemplate, ...action }) => {
-    if (isSystemAction(action.id)) {
+    if (action.type === RuleActionTypes.SYSTEM) {
       return {
         ...action,
         connector_type_id: actionTypeId,

--- a/x-pack/plugins/alerting/server/routes/lib/rewrite_actions.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/rewrite_actions.ts
@@ -7,13 +7,13 @@
 import { TypeOf } from '@kbn/config-schema/src/types/object_type';
 import { omit } from 'lodash';
 import { NormalizedAlertAction } from '../../rules_client';
-import { RuleAction } from '../../types';
+import { IsSystemAction, RuleAction } from '../../types';
 import { actionsSchema } from './actions_schema';
 import { RuleActionTypes, RuleDefaultAction } from '../../../common';
 
 export const rewriteActionsReq = (
   actions: TypeOf<typeof actionsSchema>,
-  isSystemAction: (connectorId: string) => boolean
+  isSystemAction: IsSystemAction
 ): NormalizedAlertAction[] => {
   if (!actions) return [];
 
@@ -59,7 +59,7 @@ export const rewriteActionsReq = (
 
 export const rewriteActionsRes = (
   actions: RuleAction[] | undefined,
-  isSystemAction: (connectorId: string) => boolean
+  isSystemAction: IsSystemAction
 ) => {
   const rewriteFrequency = ({
     notifyWhen,

--- a/x-pack/plugins/alerting/server/routes/lib/rewrite_rule.test.ts
+++ b/x-pack/plugins/alerting/server/routes/lib/rewrite_rule.test.ts
@@ -38,12 +38,20 @@ const sampleRule: SanitizedRule<RuleTypeParams> & { activeSnoozes?: string[] } =
       id: 'aaa',
       actionTypeId: 'bbb',
       params: {},
+      type: 'default',
       frequency: {
         summary: false,
         notifyWhen: 'onThrottleInterval',
         throttle: '1m',
       },
       alertsFilter: { query: { kql: 'test:1', dsl: '{}', filters: [] } },
+    },
+    {
+      id: 'ccc',
+      actionTypeId: 'ddd',
+      params: {},
+      type: 'system',
+      useAlertDataForTemplate: true,
     },
   ],
   scheduledTaskId: 'xyz456',
@@ -78,13 +86,15 @@ describe('rewriteRule', () => {
   });
   it('should rewrite actions correctly', () => {
     const rewritten = rewriteRule(sampleRule);
-    for (const action of rewritten.actions) {
-      expect(Object.keys(action)).toEqual(
-        expect.arrayContaining(['group', 'id', 'connector_type_id', 'params', 'frequency'])
-      );
-      expect(Object.keys(action.frequency!)).toEqual(
-        expect.arrayContaining(['summary', 'notify_when', 'throttle'])
-      );
-    }
+    const [rewrittenDefaultAction, rewrittenSystemAction] = rewritten.actions;
+    expect(Object.keys(rewrittenDefaultAction)).toEqual(
+      expect.arrayContaining(['group', 'id', 'connector_type_id', 'params', 'frequency'])
+    );
+    expect(Object.keys(rewrittenDefaultAction.frequency!)).toEqual(
+      expect.arrayContaining(['summary', 'notify_when', 'throttle'])
+    );
+    expect(Object.keys(rewrittenSystemAction)).toEqual(
+      expect.arrayContaining(['use_alert_data_for_template', 'connector_type_id'])
+    );
   });
 });

--- a/x-pack/plugins/alerting/server/routes/update_rule.ts
+++ b/x-pack/plugins/alerting/server/routes/update_rule.ts
@@ -16,7 +16,7 @@ import {
   handleDisabledApiKeysError,
   actionsSchema,
   rewriteRuleLastRun,
-  rewriteActionsReqWithSystemActions,
+  rewriteActionsReq,
 } from './lib';
 import {
   RuleTypeParams,
@@ -70,7 +70,7 @@ const rewriteBodyReq = (
     data: {
       ...rest,
       notifyWhen,
-      actions: rewriteActionsReqWithSystemActions(actions, isSystemAction),
+      actions: rewriteActionsReq(actions, isSystemAction),
     },
   };
 };
@@ -146,15 +146,13 @@ export const updateRuleRoute = (
       router.handleLegacyErrors(
         verifyAccessAndContext(licenseState, async function (context, req, res) {
           const rulesClient = (await context.alerting).getRulesClient();
-          const actionsClient = (await context.actions).getActionsClient();
+          const { isSystemAction } = (await context.actions).getActionsClient();
 
           const { id } = req.params;
           const rule = req.body;
           try {
             const alertRes = await rulesClient.update(
-              rewriteBodyReq({ id, data: rule }, (connectorId: string) =>
-                actionsClient.isSystemAction(connectorId)
-              )
+              rewriteBodyReq({ id, data: rule }, isSystemAction)
             );
             return res.ok({
               body: rewriteBodyRes(alertRes),

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -484,3 +484,5 @@ export interface RawRule {
 }
 
 export type { DataStreamAdapter } from './alerts_service/lib/data_stream_adapter';
+
+export type IsSystemAction = (connectorId: string) => boolean;

--- a/x-pack/plugins/alerting/server/types.ts
+++ b/x-pack/plugins/alerting/server/types.ts
@@ -484,5 +484,3 @@ export interface RawRule {
 }
 
 export type { DataStreamAdapter } from './alerts_service/lib/data_stream_adapter';
-
-export type IsSystemAction = (connectorId: string) => boolean;


### PR DESCRIPTION
## Summary

Closes #172168

This updates the legacy `rewriteActionsReq` and `rewriteRule` transforms to be compatible with System Actions, and replaces all uses of legacy `rewriteActionsRes` with `transformRuleActions`, which is already System Actions-compliant.

Affected APIs are:

- `_clone`
- `_find`
- `_get`
- `_update`

