### PR TITLE
Fix: kibana-keystore requires kibana.yml starting 8.11.2

### DIFF
--- a/packages/kbn-utils/src/path/index.ts
+++ b/packages/kbn-utils/src/path/index.ts
@@ -44,7 +44,13 @@ function findFile(paths: string[]) {
 }
 
 export const buildDataPaths = (): string[] => {
-  const configDataPath = getConfigFromFiles([getConfigPath()]).path?.data;
+  let configDataPath: string | undefined;
+  try {
+    configDataPath = getConfigFromFiles([getConfigPath()])?.path?.data;
+  } catch (e) {
+    // Config not available, skip
+  }
+
   const argv = process.argv.slice(2);
   const options = getopts(argv, {
     string: ['pathData'],

--- a/packages/kbn-utils/src/path/index.ts
+++ b/packages/kbn-utils/src/path/index.ts
@@ -48,7 +48,7 @@ export const buildDataPaths = (): string[] => {
   try {
     configDataPath = getConfigFromFiles([getConfigPath()])?.path?.data;
   } catch (e) {
-    // Config not available, skip
+    // Config not available, skip - undefined will allow for fall-through to defaults
   }
 
   const argv = process.argv.slice(2);


### PR DESCRIPTION
## Summary
Closes #172919

In a specific use case, the Keystore would be used in a context where one of the default configs is not present, causing an error from opening a non-existent file. That's because `findFile` will default to the first file path, if no file is found. This path would later be read, causing an error.

The fix wraps the config path acquisition with a try-catch, defaulting to `undefined`. This `undefined` will then be skipped when enumerating the data path options.

fix: Fixes an issue where the keystore would crash if used with no available config
