### PR TITLE
Fix KME pipeline being triggered by comments

### DIFF
--- a/.buildkite/pull_requests.json
+++ b/.buildkite/pull_requests.json
@@ -65,7 +65,6 @@
       "build_on_commit": true,
       "build_on_comment": false,
       "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
-      "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))",
       "skip_ci_labels": [],
       "labels": ["kme-test"],
       "skip_target_branches": ["6.8", "7.11", "7.12"],


### PR DESCRIPTION
## Summary

`always_trigger_comment_regex` will override other settings like `build_on_comment = false` and is triggering the KME pipeline from comments.