### PR TITLE
[Fleet] Make logs-* and metrics-* data views available across all spaces

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { SavedObjectsClientContract } from '@kbn/core-saved-objects-api-server';
+import { savedObjectsClientMock } from '@kbn/core-saved-objects-api-server-mocks';
+
+import { createAppContextStartContractMock } from '../../../../mocks';
+
+import { appContextService } from '../../../app_context';
+
+import { makeManagedIndexPatternsGlobal } from './install';
+
+describe('Fleet index patterns', () => {
+  let mockSoClient: jest.Mocked<SavedObjectsClientContract>;
+  let mockContract: ReturnType<typeof createAppContextStartContractMock>;
+
+  beforeEach(() => {
+    mockSoClient = savedObjectsClientMock.create();
+    mockContract = createAppContextStartContractMock();
+    appContextService.start(mockContract);
+  });
+
+  afterEach(() => {
+    appContextService.stop();
+  });
+
+  describe('makeManagedIndexPatternsGlobal', () => {
+    it('should call updateObjectsSpaces with the correct params', async () => {
+      const result = await makeManagedIndexPatternsGlobal(mockSoClient);
+
+      for (const pattern of ['logs-*', 'metrics-*']) {
+        expect(mockSoClient.updateObjectsSpaces).toHaveBeenCalledWith(
+          [{ id: pattern, type: 'index-pattern' }],
+          ['*'],
+          []
+        );
+      }
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('handles errors from updateObjectsSpaces', async () => {
+      mockSoClient.updateObjectsSpaces.mockRejectedValue(new Error('foo'));
+
+      const result = await makeManagedIndexPatternsGlobal(mockSoClient);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+});

--- a/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/kibana/index_pattern/install.ts
@@ -28,6 +28,30 @@ export function getIndexPatternSavedObjects() {
   }));
 }
 
+export async function makeManagedIndexPatternsGlobal(
+  savedObjectsClient: SavedObjectsClientContract
+) {
+  const logger = appContextService.getLogger();
+
+  const results = [];
+
+  for (const indexPatternType of indexPatternTypes) {
+    try {
+      const result = await savedObjectsClient.updateObjectsSpaces(
+        [{ id: `${indexPatternType}-*`, type: INDEX_PATTERN_SAVED_OBJECT_TYPE }],
+        ['*'],
+        []
+      );
+
+      results.push(result);
+    } catch (error) {
+      logger.error(`Error making managed index patterns global: ${error.message}`);
+    }
+  }
+
+  return results;
+}
+
 export async function removeUnusedIndexPatterns(savedObjectsClient: SavedObjectsClientContract) {
   const logger = appContextService.getLogger();
   // get all user installed packages

--- a/x-pack/test/fleet_api_integration/apis/epm/data_views.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/data_views.ts
@@ -51,6 +51,24 @@ export default function (providerContext: FtrProviderContext) {
       await Promise.all(testPkgs.map((pkg) => uninstallPackage(pkg.name, pkg.version)));
     });
 
+    describe('with single integration installation', async () => {
+      it('creates global data views for logs-* and metrics-*', async () => {
+        await installPackage(testPkgs[0].name, testPkgs[0].version);
+        const dataViews: any[] = await listDataViews();
+
+        expect(dataViews).to.have.length(2);
+        const logsDataView = dataViews.find(({ title }) => title === 'logs-*');
+        const metricsDataView = dataViews.find(({ title }) => title === 'metrics-*');
+
+        expect(logsDataView).to.be.ok();
+        expect(metricsDataView).to.be.ok();
+
+        // Each data view should be available in all spaces
+        expect(logsDataView.namespaces).to.contain('*');
+        expect(metricsDataView.namespaces).to.contain('*');
+      });
+    });
+
     describe('with subsequent integration installation', async () => {
       it('does not recreate managed data views', async () => {
         await installPackage(testPkgs[0].name, testPkgs[0].version);


### PR DESCRIPTION
## Summary

Closes #172009 

Adds a call to `updateObjectsSpaces` with `['*']` as the spaces list after Fleet's managed data views are created. 

Existing data views will be updated to be global whenever `installKibanaAssets` is called. 

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios