### PR TITLE
universal-profiling: drop leading whitespaces

### DIFF
--- a/x-pack/plugins/profiling/public/views/add_data_view/index.tsx
+++ b/x-pack/plugins/profiling/public/views/add_data_view/index.tsx
@@ -272,15 +272,15 @@ docker.elastic.co/observability/profiling-agent:${stackVersion} /root/pf-host-ag
               <EuiCodeBlock paddingSize="s" isCopyable>
                 {`sudo rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
       cat <<EOF > /etc/yum.repos.d/elastic.repo
-      [elastic-${majorVersion}.x]
-      name=Elastic repository for ${majorVersion}.x packages
-      baseurl=https://artifacts.elastic.co/packages/${majorVersion}.x/yum
-      gpgcheck=1
-      gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
-      enabled=1
-      autorefresh=1
-      type=rpm-md
-      EOF`}
+[elastic-${majorVersion}.x]
+name=Elastic repository for ${majorVersion}.x packages
+baseurl=https://artifacts.elastic.co/packages/${majorVersion}.x/yum
+gpgcheck=1
+gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
+enabled=1
+autorefresh=1
+type=rpm-md
+EOF`}
               </EuiCodeBlock>
             ),
           },


### PR DESCRIPTION
## Summary
While testing the 8.12 RC I noticed issues with the following install instrucion:
```
sudo rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
      cat <<EOF > /etc/yum.repos.d/elastic.repo
      [elastic-8.x]
      name=Elastic repository for 8.x packages
      baseurl=https://artifacts.elastic.co/packages/8.x/yum
      gpgcheck=1
      gpgkey=https://artifacts.elastic.co/GPG-KEY-elasticsearch
      enabled=1
      autorefresh=1
      type=rpm-md
      EOF
```
Leading whitespaces result in issues when following the install instructions.


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->