### PR TITLE
[8.12] [APM] Remove usage of internal client when fetching agent config etags metrics (#173001)

### DIFF
--- a/x-pack/plugins/apm/server/routes/fleet/merge_package_policy_with_apm.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/merge_package_policy_with_apm.ts
@@ -28,7 +28,7 @@ export async function decoratePackagePolicyWithAgentConfigAndSourceMap({
   apmIndices: APMIndices;
 }) {
   const [agentConfigurations, { artifacts }] = await Promise.all([
-    listConfigurations(internalESClient, apmIndices),
+    listConfigurations({ internalESClient, apmIndices }),
     listSourceMapArtifacts({ fleetPluginStart }),
   ]);
 

--- a/x-pack/plugins/apm/server/routes/fleet/sync_agent_configs_to_apm_package_policies.ts
+++ b/x-pack/plugins/apm/server/routes/fleet/sync_agent_configs_to_apm_package_policies.ts
@@ -39,7 +39,7 @@ export async function syncAgentConfigsToApmPackagePolicies({
   const [savedObjectsClient, agentConfigurations, packagePolicies] =
     await Promise.all([
       getInternalSavedObjectsClient(coreStart),
-      listConfigurations(internalESClient, apmIndices),
+      listConfigurations({ internalESClient, apmIndices }),
       getApmPackagePolicies({ coreStart, fleetPluginStart }),
     ]);
 

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_config_etag_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_config_etag_metrics.ts
@@ -7,23 +7,26 @@
 
 import { termQuery, rangeQuery } from '@kbn/observability-plugin/server';
 import datemath from '@kbn/datemath';
-import { APMIndices } from '@kbn/apm-data-access-plugin/server';
+import { ProcessorEvent } from '@kbn/observability-plugin/common';
+import { APMEventClient } from '../../../lib/helpers/create_es_client/create_apm_event_client';
 import { METRICSET_NAME } from '../../../../common/es_fields/apm';
-import { APMInternalESClient } from '../../../lib/helpers/create_es_client/create_internal_es_client';
 
-export async function getConfigsAppliedToAgentsThroughFleet(
-  internalESClient: APMInternalESClient,
-  apmIndices: APMIndices
+export async function getAgentConfigEtagMetrics(
+  apmEventClient: APMEventClient,
+  etag?: string
 ) {
   const params = {
-    index: apmIndices.metric,
-    track_total_hits: 0,
-    size: 0,
+    apm: {
+      events: [ProcessorEvent.metric],
+    },
     body: {
+      track_total_hits: 0,
+      size: 0,
       query: {
         bool: {
           filter: [
             ...termQuery(METRICSET_NAME, 'agent_config'),
+            ...termQuery('labels.etag', etag),
             ...rangeQuery(
               datemath.parse('now-15m')!.valueOf(),
               datemath.parse('now')!.valueOf()
@@ -42,18 +45,14 @@ export async function getConfigsAppliedToAgentsThroughFleet(
     },
   };
 
-  const response = await internalESClient.search(
+  const response = await apmEventClient.search(
     'get_config_applied_to_agent_through_fleet',
     params
   );
 
   return (
-    response.aggregations?.config_by_etag.buckets.reduce(
-      (configsAppliedToAgentsThroughFleet, bucket) => {
-        configsAppliedToAgentsThroughFleet[bucket.key as string] = true;
-        return configsAppliedToAgentsThroughFleet;
-      },
-      {} as Record<string, true>
-    ) ?? {}
+    response.aggregations?.config_by_etag.buckets.map(
+      ({ key }) => key as string
+    ) ?? []
   );
 }

--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/queries.test.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/queries.test.ts
@@ -55,7 +55,10 @@ describe('agent configuration queries', () => {
     it('fetches configurations', async () => {
       mock = await inspectSearchParams(
         ({ mockInternalESClient, mockIndices }) =>
-          listConfigurations(mockInternalESClient, mockIndices)
+          listConfigurations({
+            internalESClient: mockInternalESClient,
+            apmIndices: mockIndices,
+          })
       );
 
       expect(mock.params).toMatchSnapshot();
@@ -94,11 +97,11 @@ describe('agent configuration queries', () => {
   describe('findExactConfiguration', () => {
     it('find configuration by service.name', async () => {
       mock = await inspectSearchParams(
-        ({ mockInternalESClient, mockIndices }) =>
+        ({ mockInternalESClient, mockApmEventClient }) =>
           findExactConfiguration({
             service: { name: 'foo' },
             internalESClient: mockInternalESClient,
-            apmIndices: mockIndices,
+            apmEventClient: mockApmEventClient,
           })
       );
 
@@ -107,11 +110,11 @@ describe('agent configuration queries', () => {
 
     it('find configuration by service.environment', async () => {
       mock = await inspectSearchParams(
-        ({ mockInternalESClient, mockIndices }) =>
+        ({ mockInternalESClient, mockApmEventClient }) =>
           findExactConfiguration({
             service: { environment: 'bar' },
             internalESClient: mockInternalESClient,
-            apmIndices: mockIndices,
+            apmEventClient: mockApmEventClient,
           })
       );
 
@@ -120,11 +123,11 @@ describe('agent configuration queries', () => {
 
     it('find configuration by service.name and service.environment', async () => {
       mock = await inspectSearchParams(
-        ({ mockInternalESClient, mockIndices }) =>
+        ({ mockInternalESClient, mockApmEventClient }) =>
           findExactConfiguration({
             service: { name: 'foo', environment: 'bar' },
             internalESClient: mockInternalESClient,
-            apmIndices: mockIndices,
+            apmEventClient: mockApmEventClient,
           })
       );
 

--- a/x-pack/test/apm_api_integration/tests/settings/agent_configuration/add_agent_config_metrics.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/agent_configuration/add_agent_config_metrics.ts
@@ -4,31 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import { timerange, observer } from '@kbn/apm-synthtrace-client';
+import { observer } from '@kbn/apm-synthtrace-client';
 import type { ApmSynthtraceEsClient } from '@kbn/apm-synthtrace';
+import { Readable } from 'stream';
 
-export async function addAgentConfigMetrics({
+export function addAgentConfigEtagMetric({
   synthtraceEsClient,
-  start,
-  end,
+  timestamp,
   etag,
 }: {
   synthtraceEsClient: ApmSynthtraceEsClient;
-  start: number;
-  end: number;
-  etag?: string;
+  timestamp: number;
+  etag: string;
 }) {
-  const agentConfigEvents = [
-    timerange(start, end)
-      .interval('1m')
-      .rate(1)
-      .generator((timestamp) =>
-        observer()
-          .agentConfig()
-          .etag(etag ?? 'test-etag')
-          .timestamp(timestamp)
-      ),
-  ];
-
-  await synthtraceEsClient.index(agentConfigEvents);
+  const agentConfigMetric = observer().agentConfig().etag(etag).timestamp(timestamp);
+  return synthtraceEsClient.index(Readable.from([agentConfigMetric]));
 }

--- a/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/settings/agent_configuration/agent_configuration.spec.ts
@@ -12,9 +12,8 @@ import { omit, orderBy } from 'lodash';
 import { AgentConfigurationIntake } from '@kbn/apm-plugin/common/agent_configuration/configuration_types';
 import { AgentConfigSearchParams } from '@kbn/apm-plugin/server/routes/settings/agent_configuration/route';
 import { APIReturnType } from '@kbn/apm-plugin/public/services/rest/create_call_apm_api';
-import moment from 'moment';
 import { FtrProviderContext } from '../../../common/ftr_provider_context';
-import { addAgentConfigMetrics } from './add_agent_config_metrics';
+import { addAgentConfigEtagMetric } from './add_agent_config_metrics';
 
 export default function agentConfigurationTests({ getService }: FtrProviderContext) {
   const registry = getService('registry');
@@ -396,9 +395,7 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
       settings: { transaction_sample_rate: '0.9' },
     };
 
-    let agentConfiguration:
-      | APIReturnType<'GET /api/apm/settings/agent-configuration/view 2023-10-31'>
-      | undefined;
+    let agentConfiguration: APIReturnType<'GET /api/apm/settings/agent-configuration/view 2023-10-31'>;
 
     before(async () => {
       log.debug('creating agent configuration');
@@ -412,19 +409,15 @@ export default function agentConfigurationTests({ getService }: FtrProviderConte
     });
 
     it(`should have 'applied_by_agent=false' when there are no agent config metrics for this etag`, async () => {
-      expect(agentConfiguration?.applied_by_agent).to.be(false);
+      expect(agentConfiguration.applied_by_agent).to.be(false);
     });
 
     describe('when there are agent config metrics for this etag', () => {
       before(async () => {
-        const start = new Date().getTime();
-        const end = moment(start).add(15, 'minutes').valueOf();
-
-        await addAgentConfigMetrics({
+        await addAgentConfigEtagMetric({
           synthtraceEsClient,
-          start,
-          end,
-          etag: agentConfiguration?.etag,
+          timestamp: Date.now(),
+          etag: agentConfiguration.etag,
         });
       });
 


### PR DESCRIPTION
{defaultPrDescription}

<!--BACKPORT {commits} BACKPORT-->