### PR TITLE
[APM] Unskip apm api test suite

### DIFF
--- a/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_config_etag_metrics.ts
+++ b/x-pack/plugins/apm/server/routes/settings/agent_configuration/get_agent_config_etag_metrics.ts
@@ -46,7 +46,7 @@ export async function getAgentConfigEtagMetrics(
   };
 
   const response = await apmEventClient.search(
-    'get_config_applied_to_agent_through_fleet',
+    'get_agent_config_etag_metrics',
     params
   );
 

--- a/x-pack/test/apm_api_integration/tests/error_rate/service_maps.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/error_rate/service_maps.spec.ts
@@ -140,7 +140,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       after(() => synthtraceEsClient.clean());
 
-      describe('compare latency value between service inventory and service maps', () => {
+      // FLAKY: https://github.com/elastic/kibana/issues/172772
+      describe.skip('compare latency value between service inventory and service maps', () => {
         before(async () => {
           [errorTransactionValues, errorRateMetricValues] = await Promise.all([
             getErrorRateValues('transaction'),

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -26,6 +26,9 @@ function getGlobPattern() {
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {
   const registry = getService('registry');
 
+  // DO NOT SKIP
+  // Skipping here will skip the entire apm api test suite
+  // Instead skip (flaky) tests individually
   describe('APM API tests', function () {
     const filePattern = getGlobPattern();
     const tests = globby.sync(filePattern, { cwd });

--- a/x-pack/test/apm_api_integration/tests/index.ts
+++ b/x-pack/test/apm_api_integration/tests/index.ts
@@ -26,8 +26,7 @@ function getGlobPattern() {
 export default function apmApiIntegrationTests({ getService, loadTestFile }: FtrProviderContext) {
   const registry = getService('registry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/172772
-  describe.skip('APM API tests', function () {
+  describe('APM API tests', function () {
     const filePattern = getGlobPattern();
     const tests = globby.sync(filePattern, { cwd });
 

--- a/x-pack/test/apm_api_integration/tests/inspect/inspect.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/inspect/inspect.spec.ts
@@ -10,7 +10,7 @@ import { FtrProviderContext } from '../../common/ftr_provider_context';
 
 import archives_metadata from '../../common/fixtures/es_archiver/archives_metadata';
 
-export default function customLinksTests({ getService }: FtrProviderContext) {
+export default function inspectFlagTests({ getService }: FtrProviderContext) {
   const registry = getService('registry');
   const apmApiClient = getService('apmApiClient');
 
@@ -64,7 +64,7 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
         });
       });
 
-      describe('elasticsearch calls made with internal user are not return', () => {
+      describe('elasticsearch calls made with internal user should not leak internal queries', () => {
         it('for custom links', async () => {
           const { status, body } = await apmApiClient.readUser({
             endpoint: 'GET /internal/apm/settings/custom_links',
@@ -92,7 +92,9 @@ export default function customLinksTests({ getService }: FtrProviderContext) {
           });
 
           expect(status).to.be(200);
-          expect(body._inspect).to.eql([]);
+          expect(body._inspect?.map((res) => res.stats?.indexPattern.value)).to.eql([
+            ['metrics-apm*', 'apm-*'],
+          ]);
         });
       });
     });


### PR DESCRIPTION
APM api test suite was accidentally skipped in https://github.com/elastic/kibana/issues/172772.
This unskips the suite and instead skips just the flaky tests

Blocking: https://github.com/elastic/kibana/pull/173038

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->