### PR TITLE
Update design of warning status in rule details page

### DIFF
--- a/x-pack/plugins/observability/public/pages/rule_details/helpers/get_health_color.ts
+++ b/x-pack/plugins/observability/public/pages/rule_details/helpers/get_health_color.ts
@@ -17,6 +17,8 @@ export function getHealthColor(status: RuleExecutionStatuses) {
       return 'primary';
     case 'pending':
       return 'accent';
+    case 'warning':
+      return 'warning';
     default:
       return 'subdued';
   }


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/172768

### After update
<img width="492" alt="Screenshot 2023-12-11 at 23 17 26" src="https://github.com/elastic/kibana/assets/69037875/0a99a549-5dc2-4b5b-bbb9-ec310e049a75">
