### PR TITLE
[Logs Explorer] Disable the too-slow url check in functional test

### DIFF
--- a/x-pack/test/functional/page_objects/observability_log_explorer.ts
+++ b/x-pack/test/functional/page_objects/observability_log_explorer.ts
@@ -226,7 +226,12 @@ export function ObservabilityLogExplorerPageObject({
       return await PageObjects.common.navigateToUrlWithBrowserHistory(
         'observabilityLogExplorer',
         '/',
-        queryStringParams
+        queryStringParams,
+        {
+          // the check sometimes is too slow for the page so it misses the point
+          // in time before the app rewrites the URL
+          ensureCurrentUrl: false,
+        }
       );
     },
 
@@ -246,7 +251,12 @@ export function ObservabilityLogExplorerPageObject({
       return await PageObjects.common.navigateToUrlWithBrowserHistory(
         'observabilityLogExplorer',
         '/',
-        queryStringParams
+        queryStringParams,
+        {
+          // the check sometimes is too slow for the page so it misses the point
+          // in time before the app rewrites the URL
+          ensureCurrentUrl: false,
+        }
       );
     },
 


### PR DESCRIPTION
## :memo: Summary

This sets `ensureCurrentUrl` to `false` in the Observability Logs Explorer page object, because it seems to be too slow sometimes. Therefore it misses the right moment before the URL is rewritten by the app and fails unnecessarily.

closes https://github.com/elastic/kibana/issues/167515