### PR TITLE
[ProfilingxAPM] Passing selected time range to links

### DIFF
--- a/x-pack/plugins/apm/public/components/app/profiling_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/profiling_overview/index.tsx
@@ -78,6 +78,8 @@ export function ProfilingOverview() {
               environment={environment}
               dataSource={preferred?.source}
               kuery={kuery}
+              rangeFrom={rangeFrom}
+              rangeTo={rangeTo}
             />
           </>
         ),
@@ -99,12 +101,23 @@ export function ProfilingOverview() {
               endIndex={10}
               dataSource={preferred?.source}
               kuery={kuery}
+              rangeFrom={rangeFrom}
+              rangeTo={rangeTo}
             />
           </>
         ),
       },
     ];
-  }, [end, environment, kuery, preferred?.source, serviceName, start]);
+  }, [
+    end,
+    environment,
+    kuery,
+    preferred?.source,
+    rangeFrom,
+    rangeTo,
+    serviceName,
+    start,
+  ]);
 
   if (isLoading) {
     return (

--- a/x-pack/plugins/apm/public/components/app/profiling_overview/profiling_flamegraph.tsx
+++ b/x-pack/plugins/apm/public/components/app/profiling_overview/profiling_flamegraph.tsx
@@ -40,6 +40,8 @@ interface Props {
     ApmDocumentType.TransactionMetric | ApmDocumentType.TransactionEvent
   >;
   kuery: string;
+  rangeFrom: string;
+  rangeTo: string;
 }
 
 export function ProfilingFlamegraph({
@@ -49,6 +51,8 @@ export function ProfilingFlamegraph({
   environment,
   dataSource,
   kuery,
+  rangeFrom,
+  rangeTo,
 }: Props) {
   const { profilingLocators } = useProfilingPlugin();
 
@@ -93,6 +97,8 @@ export function ProfilingFlamegraph({
               data-test-subj="apmProfilingFlamegraphGoToFlamegraphLink"
               href={profilingLocators?.flamegraphLocator.getRedirectUrl({
                 kuery: mergeKueries([`(${hostNamesKueryFormat})`, kuery]),
+                rangeFrom,
+                rangeTo,
               })}
             >
               {i18n.translate('xpack.apm.profiling.flamegraph.link', {

--- a/x-pack/plugins/apm/public/components/app/profiling_overview/profiling_top_functions.tsx
+++ b/x-pack/plugins/apm/public/components/app/profiling_overview/profiling_top_functions.tsx
@@ -31,6 +31,8 @@ interface Props {
     ApmDocumentType.TransactionMetric | ApmDocumentType.TransactionEvent
   >;
   kuery: string;
+  rangeFrom: string;
+  rangeTo: string;
 }
 
 export function ProfilingTopNFunctions({
@@ -42,6 +44,8 @@ export function ProfilingTopNFunctions({
   endIndex,
   dataSource,
   kuery,
+  rangeFrom,
+  rangeTo,
 }: Props) {
   const { profilingLocators } = useProfilingPlugin();
 
@@ -97,6 +101,8 @@ export function ProfilingTopNFunctions({
               data-test-subj="apmProfilingTopNFunctionsGoToUniversalProfilingFlamegraphLink"
               href={profilingLocators?.topNFunctionsLocator.getRedirectUrl({
                 kuery: mergeKueries([`(${hostNamesKueryFormat})`, kuery]),
+                rangeFrom,
+                rangeTo,
               })}
             >
               {i18n.translate('xpack.apm.profiling.topnFunctions.link', {


### PR DESCRIPTION
I forgot to pass the selected time range to the Profiling links in the APM UI. 

Fixing it here.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->