### PR TITLE
can get fields and show docs

### DIFF
--- a/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/ese_search/ese_search_strategy.ts
@@ -205,7 +205,7 @@ export const enhancedEsSearchStrategyProvider = (
         obj.subscribe((res) => {
           console.log('RES', res.rawResponse.hits?.hits[0]);
         });
-        */
+*/
         return obj;
       }
 

--- a/src/plugins/data/server/search/strategies/esql_search/esql_search_strategy.ts
+++ b/src/plugins/data/server/search/strategies/esql_search/esql_search_strategy.ts
@@ -39,7 +39,7 @@ export const esqlSearchStrategyProvider = (
 
     // Only default index pattern type is supported here.
     // See ese for other type support.
-    if (request.indexType) {
+    if (request.indexType !== undefined && request.indexType !== 'esql') {
       throw new KbnSearchError(`Unsupported index pattern type ${request.indexType}`, 400);
     }
 

--- a/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
+++ b/src/plugins/data_view_management/public/components/index_pattern_table/index_pattern_table.tsx
@@ -374,6 +374,22 @@ export const IndexPatternTable = ({
 
   return (
     <div data-test-subj="indexPatternTable" role="region" aria-label={title}>
+      <EuiButton
+        onClick={async function () {
+          const esql = await prompt("What's your ES|QL?", 'FROM kibana*');
+          const name = await prompt("What's your title?", 'My ES|QL');
+
+          const dataView = await dataViews.createAndSave({
+            title: esql!,
+            name: name!,
+            type: 'esql',
+            timeFieldName: '@timestamp',
+          });
+          history.push(`patterns/${dataView.id}`);
+        }}
+      >
+        Create esql data view
+      </EuiButton>
       {isLoadingDataState ? (
         <div style={{ display: 'flex', justifyContent: 'center' }}>
           <EuiLoadingSpinner size="xxl" />

--- a/src/plugins/data_views/common/content_management/v1/cm_services.ts
+++ b/src/plugins/data_views/common/content_management/v1/cm_services.ts
@@ -21,7 +21,7 @@ import { serializedFieldFormatSchema, fieldSpecSchema } from '../../schemas';
 const dataViewAttributesSchema = schema.object(
   {
     title: schema.string(),
-    type: schema.maybe(schema.literal('rollup')),
+    type: schema.maybe(schema.oneOf([schema.literal('rollup'), schema.literal('esql')])),
     timeFieldName: schema.maybe(schema.string()),
     sourceFilters: schema.maybe(
       schema.arrayOf(

--- a/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
+++ b/src/plugins/data_views/server/rest_api_routes/internal/fields_for.ts
@@ -10,6 +10,7 @@ import { estypes } from '@elastic/elasticsearch';
 import { schema } from '@kbn/config-schema';
 import { IRouter, RequestHandler, StartServicesAccessor } from '@kbn/core/server';
 import { FullValidationConfig } from '@kbn/core-http-server';
+import { castEsToKbnFieldTypeName } from '@kbn/field-types';
 import { INITIAL_REST_VERSION_INTERNAL as version } from '../../constants';
 import { IndexPatternsFetcher } from '../../fetcher';
 import type {
@@ -135,7 +136,7 @@ const handler: (isRollupsEnabled: () => boolean) => RequestHandler<{}, IQuery, I
             fields: fields.columns.map((fld) => {
               return {
                 name: fld.name,
-                type: 'string',
+                type: castEsToKbnFieldTypeName(fld.type),
                 esTypes: [fld.type],
                 searchable: true,
                 aggregatable: true,

--- a/src/plugins/discover/public/application/main/utils/fetch_documents.ts
+++ b/src/plugins/discover/public/application/main/utils/fetch_documents.ts
@@ -66,7 +66,7 @@ export const fetchDocuments = (
     .pipe(
       filter((res) => !isRunningResponse(res)),
       map((res) => {
-        return buildDataTableRecordList(res.rawResponse.hits.hits as EsHitRecord[], dataView);
+        return buildDataTableRecordList(res.rawResponse?.hits?.hits as EsHitRecord[], dataView);
       })
     );
 

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -63,7 +63,6 @@ export function getInvalidFieldMessage(
   );
 
   if (isInvalid) {
-    console.log('isInvalid');
     // Missing fields have priority over wrong type
     // This has been moved as some transferable checks also perform exist checks internally and fail eventually
     // but that would make type mismatch error appear in place of missing fields scenarios

--- a/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/operations/definitions/helpers.tsx
@@ -63,6 +63,7 @@ export function getInvalidFieldMessage(
   );
 
   if (isInvalid) {
+    console.log('isInvalid');
     // Missing fields have priority over wrong type
     // This has been moved as some transferable checks also perform exist checks internally and fail eventually
     // but that would make type mismatch error appear in place of missing fields scenarios


### PR DESCRIPTION
## Summary

Data view management has a new "create esql data view button", give it a try. 

Discover will show docs. the histogram is a work in process, as is everything else.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
