### PR TITLE
[Security Solution] Prebuilt rules diffing style adjustments

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/constants.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/constants.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const TABLE_CLASS_NAME = 'rule-update-diff-table';
+export const CODE_CLASS_NAME = 'rule-update-diff-code';
+export const GUTTER_CLASS_NAME = 'rule-update-diff-gutter';
+export const DARK_THEME_CLASS_NAME = 'rule-update-diff-dark-theme';
+
+export const COLORS = {
+  light: {
+    gutterBackground: {
+      deletion: 'rgb(255, 215, 213)',
+      insertion: 'rgb(204, 255, 216)',
+    },
+    lineBackground: {
+      deletion: 'rgb(255, 235, 233)',
+      insertion: 'rgb(230, 255, 236)',
+    },
+    characterBackground: {
+      deletion: 'rgba(255, 129, 130, 0.4)',
+      insertion: 'rgb(171, 242, 188)',
+    },
+  },
+  dark: {
+    gutterBackground: {
+      deletion: 'rgba(248, 81, 73, 0.3)',
+      insertion: 'rgba(63, 185, 80, 0.3)',
+    },
+    lineBackground: {
+      deletion: 'rgba(248, 81, 73, 0.1)',
+      insertion: 'rgba(46, 160, 67, 0.15)',
+    },
+    characterBackground: {
+      deletion: 'rgba(248, 81, 73, 0.4)',
+      insertion: 'rgba(46, 160, 67, 0.4)',
+    },
+  },
+};

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
@@ -162,7 +162,6 @@ const CustomStyles: React.FC = ({ children }) => {
 
     /* Gutter of a line with deletions */
     .${GUTTER_CLASS_NAME}.diff-gutter-delete {
-      color: ${euiTheme.colors.dangerText};
       font-weight: bold;
       background: rgb(255, 215, 213);
     }
@@ -172,7 +171,6 @@ const CustomStyles: React.FC = ({ children }) => {
 
     /* Gutter of a line with insertions */
     .${GUTTER_CLASS_NAME}.diff-gutter-insert {
-      color: ${euiTheme.colors.successText};
       font-weight: bold;
       background: rgb(204, 255, 216);
     }

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
@@ -27,6 +27,13 @@ import unidiff from 'unidiff';
 import { useEuiTheme, COLOR_MODES_STANDARD } from '@elastic/eui';
 import { Hunks } from './hunks';
 import { markEdits, DiffMethod } from './mark_edits';
+import {
+  TABLE_CLASS_NAME,
+  CODE_CLASS_NAME,
+  GUTTER_CLASS_NAME,
+  DARK_THEME_CLASS_NAME,
+  COLORS,
+} from './constants';
 
 interface UseExpandReturn {
   expandRange: (start: number, end: number) => void;
@@ -138,11 +145,6 @@ const convertToDiffFile = (oldSource: string, newSource: string) => {
   return diffFile;
 };
 
-const TABLE_CLASS_NAME = 'rule-update-diff-table';
-const CODE_CLASS_NAME = 'rule-update-diff-code';
-const GUTTER_CLASS_NAME = 'rule-update-diff-gutter';
-const DARK_THEME_CLASS_NAME = 'rule-update-diff-dark-theme';
-
 const CustomStyles: React.FC = ({ children }) => {
   const { euiTheme } = useEuiTheme();
 
@@ -163,53 +165,53 @@ const CustomStyles: React.FC = ({ children }) => {
     /* Gutter of a line with deletions */
     .${GUTTER_CLASS_NAME}.diff-gutter-delete {
       font-weight: bold;
-      background: rgb(255, 215, 213);
+      background: ${COLORS.light.gutterBackground.deletion};
     }
     .${DARK_THEME_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-delete {
-      background: rgba(248, 81, 73, 0.3);
+      background: ${COLORS.dark.gutterBackground.deletion};
     }
 
     /* Gutter of a line with insertions */
     .${GUTTER_CLASS_NAME}.diff-gutter-insert {
       font-weight: bold;
-      background: rgb(204, 255, 216);
+      background: ${COLORS.light.gutterBackground.insertion};
     }
     .${DARK_THEME_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-insert {
-      background: rgba(63, 185, 80, 0.3);
+      background: ${COLORS.dark.gutterBackground.insertion};
     }
 
     /* Background of a line with deletions */
     .${CODE_CLASS_NAME}.diff-code-delete {
-      background: rgb(255, 235, 233);
+      background: ${COLORS.light.lineBackground.deletion};
     }
     .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete {
-      background: rgba(248, 81, 73, 0.1);
+      background: ${COLORS.dark.lineBackground.deletion};
     }
 
     /* Background of a line with insertions */
     .${CODE_CLASS_NAME}.diff-code-insert {
-      background: rgb(230, 255, 236);
+      background: ${COLORS.light.lineBackground.insertion};
     }
     .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert {
-      background: rgba(46, 160, 67, 0.15);
+      background: ${COLORS.dark.lineBackground.insertion};
     }
 
     /* Accented background of removed characters / words */
     .${CODE_CLASS_NAME}.diff-code-delete .diff-code-edit {
       font-weight: 700;
-      background: rgba(255, 129, 130, 0.4);
+      background: ${COLORS.light.characterBackground.deletion};
     }
     .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete .diff-code-edit {
-      background: rgba(248, 81, 73, 0.4);
+      background: ${COLORS.dark.characterBackground.deletion};
     }
 
     /* Accented background of inserted characters / words */
     .${CODE_CLASS_NAME}.diff-code-insert .diff-code-edit {
       font-weight: 700;
-      background: rgb(171, 242, 188);
+      background: ${COLORS.light.characterBackground.insertion};
     }
     .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert .diff-code-edit {
-      background: rgba(46, 160, 67, 0.4);
+      background: ${COLORS.dark.characterBackground.insertion};
     }
   `;
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
@@ -24,7 +24,7 @@ import type {
   HunkTokens,
 } from 'react-diff-view';
 import unidiff from 'unidiff';
-import { useEuiTheme, hexToRgb, EuiRadioGroup } from '@elastic/eui';
+import { useEuiTheme, COLOR_MODES_STANDARD } from '@elastic/eui';
 import { Hunks } from './hunks';
 import { markEdits, DiffMethod } from './mark_edits';
 
@@ -143,112 +143,74 @@ const CODE_CLASS_NAME = 'rule-update-diff-code';
 const GUTTER_CLASS_NAME = 'rule-update-diff-gutter';
 const DARK_THEME_CLASS_NAME = 'rule-update-diff-dark-theme';
 
-const GITHUB_STYLES_CLASS_NAME = 'NIKITA-DONT-FORGET-TO-REMOVE-THIS-CLASS';
-
 const CustomStyles: React.FC = ({ children }) => {
   const { euiTheme } = useEuiTheme();
 
-  const insertionRgb = hexToRgb(euiTheme.colors.successText);
-  const deletionRgb = hexToRgb(euiTheme.colors.dangerText);
-
   const customCss = css`
-    .${TABLE_CLASS_NAME} .diff-gutter-col {
-      width: ${euiTheme.size.xl};
-    }
-
-    .${CODE_CLASS_NAME}.diff-code, .${GUTTER_CLASS_NAME}.diff-gutter {
-      background: transparent;
-    }
-
-    .${GUTTER_CLASS_NAME}:nth-child(3) {
-      border-left: 1px solid ${euiTheme.colors.mediumShade};
-    }
-
     .${CODE_CLASS_NAME}.diff-code {
       padding: 0 ${euiTheme.size.l} 0 ${euiTheme.size.m};
     }
 
-    //
+    .${TABLE_CLASS_NAME} .diff-gutter-col {
+      width: ${euiTheme.size.xl};
+    }
 
+    /* Vertical line separating two sides of the diff view */
+    .${GUTTER_CLASS_NAME}:nth-child(3) {
+      border-left: 1px solid ${euiTheme.colors.mediumShade};
+    }
+
+    /* Gutter of a line with deletions */
     .${GUTTER_CLASS_NAME}.diff-gutter-delete {
       color: ${euiTheme.colors.dangerText};
       font-weight: bold;
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-delete {
       background: rgb(255, 215, 213);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-delete {
+    .${DARK_THEME_CLASS_NAME}.${GUTTER_CLASS_NAME}.diff-gutter-delete {
       background: rgba(248, 81, 73, 0.3);
     }
 
+    /* Gutter of a line with insertions */
     .${GUTTER_CLASS_NAME}.diff-gutter-insert {
       color: ${euiTheme.colors.successText};
       font-weight: bold;
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-insert {
       background: rgb(204, 255, 216);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-insert {
+    .${DARK_THEME_CLASS_NAME}.${GUTTER_CLASS_NAME}.diff-gutter-insert {
       background: rgba(63, 185, 80, 0.3);
     }
 
-    //
-
+    /* Background of a line with deletions */
     .${CODE_CLASS_NAME}.diff-code-delete {
-      background: transparent;
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete {
       background: rgb(255, 235, 233);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete {
+    .${DARK_THEME_CLASS_NAME}.${CODE_CLASS_NAME}.diff-code-delete {
       background: rgba(248, 81, 73, 0.1);
     }
 
+    /* Background of a line with insertions */
     .${CODE_CLASS_NAME}.diff-code-insert {
-      background: transparent;
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert {
       background: rgb(230, 255, 236);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert {
+    .${DARK_THEME_CLASS_NAME}.${CODE_CLASS_NAME}.diff-code-insert {
       background: rgba(46, 160, 67, 0.15);
     }
 
-    //
-
+    /* Accented background of removed characters / words */
     .${CODE_CLASS_NAME}.diff-code-delete .diff-code-edit {
-      color: ${euiTheme.colors.dangerText};
-      text-decoration: line-through;
-      background: rgba(${deletionRgb.join()}, 0.05);
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete .diff-code-edit {
-      color: unset;
-      text-decoration: none;
+      font-weight: 700;
       background: rgba(255, 129, 130, 0.4);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME}
-      .${CODE_CLASS_NAME}.diff-code-delete
-      .diff-code-edit {
-      color: unset;
-      text-decoration: none;
+    .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete .diff-code-edit {
       background: rgba(248, 81, 73, 0.4);
     }
 
+    /* Accented background of inserted characters / words */
     .${CODE_CLASS_NAME}.diff-code-insert .diff-code-edit {
-      color: ${euiTheme.colors.successText};
-      text-decoration: underline;
-      background: rgba(${insertionRgb.join()}, 0.05);
-    }
-    .${GITHUB_STYLES_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert .diff-code-edit {
-      color: unset;
-      text-decoration: none;
+      font-weight: 700;
       background: rgb(171, 242, 188);
     }
-    .${DARK_THEME_CLASS_NAME}.${GITHUB_STYLES_CLASS_NAME}
-      .${CODE_CLASS_NAME}.diff-code-insert
-      .diff-code-edit {
-      color: unset;
-      text-decoration: none;
+    .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert .diff-code-edit {
       background: rgba(46, 160, 67, 0.4);
     }
   `;
@@ -297,34 +259,12 @@ export const DiffView = ({
 
   const { colorMode } = useEuiTheme();
 
-  const [selectedStyle, setSelectedStyle] = React.useState('our-styles');
-
   const tableClassName = classNames(TABLE_CLASS_NAME, {
-    [DARK_THEME_CLASS_NAME]: colorMode === 'DARK',
-    [GITHUB_STYLES_CLASS_NAME]: selectedStyle === 'github-styles',
+    [DARK_THEME_CLASS_NAME]: colorMode === COLOR_MODES_STANDARD.dark,
   });
 
   return (
     <CustomStyles>
-      <EuiRadioGroup
-        options={[
-          {
-            id: 'our-styles',
-            label: 'Our styles with added line highlighting',
-          },
-          {
-            id: 'github-styles',
-            label: 'GitHub styles',
-          },
-        ]}
-        idSelected={selectedStyle}
-        onChange={(optionId) => {
-          setSelectedStyle(optionId);
-        }}
-        legend={{
-          children: <span>{'Highlighting style (also try with dark theme)'}</span>,
-        }}
-      />
       <Diff
         /*
           "diffType": can be either 'add', 'delete', 'modify', 'rename' or 'copy'.

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/json_diff/diff_view.tsx
@@ -166,7 +166,7 @@ const CustomStyles: React.FC = ({ children }) => {
       font-weight: bold;
       background: rgb(255, 215, 213);
     }
-    .${DARK_THEME_CLASS_NAME}.${GUTTER_CLASS_NAME}.diff-gutter-delete {
+    .${DARK_THEME_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-delete {
       background: rgba(248, 81, 73, 0.3);
     }
 
@@ -176,7 +176,7 @@ const CustomStyles: React.FC = ({ children }) => {
       font-weight: bold;
       background: rgb(204, 255, 216);
     }
-    .${DARK_THEME_CLASS_NAME}.${GUTTER_CLASS_NAME}.diff-gutter-insert {
+    .${DARK_THEME_CLASS_NAME} .${GUTTER_CLASS_NAME}.diff-gutter-insert {
       background: rgba(63, 185, 80, 0.3);
     }
 
@@ -184,7 +184,7 @@ const CustomStyles: React.FC = ({ children }) => {
     .${CODE_CLASS_NAME}.diff-code-delete {
       background: rgb(255, 235, 233);
     }
-    .${DARK_THEME_CLASS_NAME}.${CODE_CLASS_NAME}.diff-code-delete {
+    .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-delete {
       background: rgba(248, 81, 73, 0.1);
     }
 
@@ -192,7 +192,7 @@ const CustomStyles: React.FC = ({ children }) => {
     .${CODE_CLASS_NAME}.diff-code-insert {
       background: rgb(230, 255, 236);
     }
-    .${DARK_THEME_CLASS_NAME}.${CODE_CLASS_NAME}.diff-code-insert {
+    .${DARK_THEME_CLASS_NAME} .${CODE_CLASS_NAME}.diff-code-insert {
       background: rgba(46, 160, 67, 0.15);
     }
 


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/173264**
**Addresses: https://github.com/elastic/kibana/issues/169160**

## Summary
Tweaks diff styling so that it's more readable in both light and dark modes.

---

#### Light mode
<img width="1178" alt="Scherm­afbeelding 2023-12-13 om 17 37 07" src="https://github.com/elastic/kibana/assets/15949146/fe8620c7-407a-4355-8863-4a5a8e1425ea">


#### Dark mode
<img width="1174" alt="Scherm­afbeelding 2023-12-13 om 17 41 03" src="https://github.com/elastic/kibana/assets/15949146/a8df3b88-a482-455f-91d3-5e08f1381b8c">



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->