### PR TITLE
Set explicit resource requests in the QG

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
@@ -10,7 +10,7 @@
 #
 # Docs: https://docs.elastic.dev/serverless/qualitygates
 
-agent:
+agents:
   cpu: 2
   ephemeralStorage: "20G"
   memory: "8G"

--- a/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.kibana-tests.yaml
@@ -10,6 +10,11 @@
 #
 # Docs: https://docs.elastic.dev/serverless/qualitygates
 
+agent:
+  cpu: 2
+  ephemeralStorage: "20G"
+  memory: "8G"
+
 env:
   TEAM_CHANNEL: "#kibana-mission-control"
   ENVIRONMENT: ${ENVIRONMENT?}


### PR DESCRIPTION
Kibana is fairly large, we should explicitly set in the gate what we are expecting in terms of resource for each individual step.
