### PR TITLE
[Fleet] Cleanup some noisier logs

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
+++ b/x-pack/plugins/fleet/server/services/epm/agent/agent.ts
@@ -21,7 +21,6 @@ export function compileTemplate(variables: PackagePolicyConfigRecord, templateSt
   const { vars, yamlValues } = buildTemplateVariables(logger, variables);
   let compiledTemplate: string;
   try {
-    logger.debug(`Compiling agent template: ${templateStr}`);
     const template = handlebars.compile(templateStr, { noEscape: true });
     compiledTemplate = template(vars);
   } catch (err) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/_install_package.ts
@@ -381,7 +381,7 @@ export async function _installPackage({
         await packagePolicyService.upgrade(savedObjectsClient, esClient, policyIdsToUpgrade.items);
       });
     }
-    logger.debug(`Package install - Installation complete}`);
+    logger.debug(`Package install - Installation complete`);
     return [...installedKibanaAssetsRefs, ...esReferences];
   } catch (err) {
     if (SavedObjectsErrorHelpers.isConflictError(err)) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -516,9 +516,7 @@ async function installPackageCommon(options: {
   } = options;
   let { telemetryEvent } = options;
   const logger = appContextService.getLogger();
-  logger.info(
-    `Install - Starting installation of ${pkgName}@${pkgVersion} from ${installSource}, paths: ${paths}`
-  );
+  logger.info(`Install - Starting installation of ${pkgName}@${pkgVersion} from ${installSource} `);
 
   // Workaround apm issue with async spans: https://github.com/elastic/apm-agent-nodejs/issues/2611
   await Promise.resolve();


### PR DESCRIPTION
## Summary

Cleans up a few logging calls added in https://github.com/elastic/kibana/pull/172657 that are just a bit noisy, like logging package archive paths and full handlebars template contents.

e.g. 

![image](https://github.com/elastic/kibana/assets/6766512/90ca4a2d-e640-4899-9316-e0e786db7f8c)

![image](https://github.com/elastic/kibana/assets/6766512/af079c3a-71f1-4cdb-82ac-84fd0402bd75)

