### PR TITLE
chore: re-resolve transitive dependency that breaks on CI

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -25694,9 +25694,9 @@ react-remove-scroll-bar@^2.3.4:
     tslib "^2.0.0"
 
 react-remove-scroll@^2.5.6:
-  version "2.5.6"
-  resolved "https://packages.atlassian.com/api/npm/npm-remote/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
-  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.7.tgz#15a1fd038e8497f65a695bf26a4a57970cac1ccb"
+  integrity sha512-FnrTWO4L7/Bhhf3CYBNArEG/yROV0tKmTv7/3h9QCFvH6sndeFf1wPqOcbFVu5VAulS5dV1wGT3GZZ/1GawqiA==
   dependencies:
     react-remove-scroll-bar "^2.3.4"
     react-style-singleton "^2.2.1"


### PR DESCRIPTION
## Summary
Several cases of the cache population build is failing due to 401 on `https://packages.atlassian.com/api/npm/npm-remote`.

It seems it's the only one artifact with that resolved path. After a forced re-resolution, this path goes away, so let's ditch it!

It also seems to be present in `8.12` - so needs a backport

See:
 - https://buildkite.com/elastic/kibana-macos-bazel-cache/builds/29364#018c6293-9782-4b89-aa59-6344ee6fe3a8
 - https://buildkite.com/elastic/kibana-macos-bazel-cache/builds/29365#018c62a9-42c9-49b6-86ae-48f128131bbb
 - https://buildkite.com/elastic/kibana-macos-bazel-cache/builds/29366#018c62b7-776a-4239-94cf-065089a452ba

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->