### PR TITLE
[APM] Make `useDataViewId` optional and remove default values

### DIFF
--- a/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/simple_trace.ts
@@ -25,7 +25,7 @@ const scenario: Scenario<ApmFields> = async (runOptions) => {
 
       const instances = [...Array(numServices).keys()].map((index) =>
         apm
-          .service({ name: `synth-go-${index}`, environment: ENVIRONMENT, agentName: 'go' })
+          .service({ name: `synth-node-${index}`, environment: ENVIRONMENT, agentName: 'nodejs' })
           .instance('instance')
       );
       const instanceSpans = (instance: Instance) => {

--- a/x-pack/plugins/apm/public/components/app/metrics/static_dashboard/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/metrics/static_dashboard/index.tsx
@@ -62,6 +62,10 @@ export function JsonMetricsDashboard(dashboardProps: MetricsDashboardProps) {
     });
   }, [dataView, serviceName, environment, dashboard]);
 
+  if (!dataViewId) {
+    return null;
+  }
+
   return (
     <DashboardRenderer
       getCreationOptions={() =>

--- a/x-pack/plugins/apm/public/components/app/mobile/service_overview/geo_map/embedded_map.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/mobile/service_overview/geo_map/embedded_map.test.tsx
@@ -31,6 +31,12 @@ describe('Embedded Map', () => {
       }),
     }));
 
+    const mockSpaces = {
+      getActiveSpace: jest
+        .fn()
+        .mockImplementation(() => ({ id: 'mockSpaceId' })),
+    };
+
     const { findByTestId } = render(
       <MemoryRouter
         initialEntries={[
@@ -38,7 +44,9 @@ describe('Embedded Map', () => {
         ]}
       >
         <MockApmPluginContextWrapper>
-          <KibanaContextProvider services={{ embeddable: mockEmbeddable }}>
+          <KibanaContextProvider
+            services={{ embeddable: mockEmbeddable, spaces: mockSpaces }}
+          >
             <EmbeddedMap
               selectedMap={MapTypes.Http}
               filters={[]}

--- a/x-pack/plugins/apm/public/components/app/mobile/service_overview/geo_map/embedded_map.tsx
+++ b/x-pack/plugins/apm/public/components/app/mobile/service_overview/geo_map/embedded_map.tsx
@@ -129,7 +129,7 @@ function EmbeddedMapComponent({
 
   useEffect(() => {
     const setLayerList = async () => {
-      if (embeddable && !isErrorEmbeddable(embeddable)) {
+      if (embeddable && !isErrorEmbeddable(embeddable) && dataViewId) {
         const layerList = await getLayerList({ selectedMap, maps, dataViewId });
         await Promise.all([
           embeddable.setLayerList(layerList),

--- a/x-pack/plugins/apm/public/components/shared/links/discover_links/discover_link.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/discover_links/discover_link.tsx
@@ -66,6 +66,10 @@ export function DiscoverLink({ query = {}, ...rest }: Props) {
   const location = useLocation();
   const dataViewId = useDataViewId();
 
+  if (!dataViewId) {
+    return null;
+  }
+
   const href = getDiscoverHref({
     basePath: core.http.basePath,
     query,

--- a/x-pack/plugins/apm/public/components/shared/links/discover_links/discover_links.integration.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/links/discover_links/discover_links.integration.test.tsx
@@ -35,7 +35,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_default,interval:auto,query:(language:kuery,query:'processor.event:\\"transaction\\" AND transaction.id:\\"8b60bd32ecc6e150\\" AND trace.id:\\"8b60bd32ecc6e1506735a8b6cfcf175c\\"'))"`
+      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_mockSpaceId,interval:auto,query:(language:kuery,query:'processor.event:\\"transaction\\" AND transaction.id:\\"8b60bd32ecc6e150\\" AND trace.id:\\"8b60bd32ecc6e1506735a8b6cfcf175c\\"'))"`
     );
   });
 
@@ -55,7 +55,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_default,interval:auto,query:(language:kuery,query:'span.id:\\"test-span-id\\"'))"`
+      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_mockSpaceId,interval:auto,query:(language:kuery,query:'span.id:\\"test-span-id\\"'))"`
     );
   });
 
@@ -77,7 +77,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_default,interval:auto,query:(language:kuery,query:'service.name:\\"service-name\\" AND error.grouping_key:\\"grouping-key\\"'),sort:('@timestamp':desc))"`
+      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_mockSpaceId,interval:auto,query:(language:kuery,query:'service.name:\\"service-name\\" AND error.grouping_key:\\"grouping-key\\"'),sort:('@timestamp':desc))"`
     );
   });
 
@@ -100,7 +100,7 @@ describe('DiscoverLinks', () => {
     );
 
     expect(href).toMatchInlineSnapshot(
-      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_default,interval:auto,query:(language:kuery,query:'service.name:\\"service-name\\" AND error.grouping_key:\\"grouping-key\\" AND some:kuery-string'),sort:('@timestamp':desc))"`
+      `"/basepath/app/discover#/?_g=(refreshInterval:(pause:!t,value:0),time:(from:now/w,to:now))&_a=(index:apm_static_data_view_id_mockSpaceId,interval:auto,query:(language:kuery,query:'service.name:\\"service-name\\" AND error.grouping_key:\\"grouping-key\\" AND some:kuery-string'),sort:('@timestamp':desc))"`
     );
   });
 });

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections.ts
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/sections.ts
@@ -69,9 +69,9 @@ export const getSections = ({
   allDatasetsLocator: LocatorPublic<AllDatasetsLocatorParams>;
   logsLocator: LocatorPublic<LogsLocatorParams>;
   nodeLogsLocator: LocatorPublic<NodeLogsLocatorParams>;
-  dataViewId: string;
+  dataViewId?: string;
 }) => {
-  if (!transaction) return [];
+  if (!transaction || !dataViewId) return [];
 
   const hostName = transaction.host?.hostname;
   const podId = transaction.kubernetes?.pod?.uid;

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
@@ -30,6 +30,7 @@ import {
 } from '../../../utils/test_helpers';
 import { TransactionActionMenu } from './transaction_action_menu';
 import * as Transactions from './__fixtures__/mock_data';
+import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
 
 const apmContextMock = {
   ...mockApmPluginContextValue,
@@ -60,10 +61,16 @@ history.replace(
 );
 
 function Wrapper({ children }: { children?: React.ReactNode }) {
+  const mockSpaces = {
+    getActiveSpace: jest.fn().mockImplementation(() => ({ id: 'mockSpaceId' })),
+  };
+
   return (
     <MemoryRouter>
       <MockApmPluginContextWrapper value={apmContextMock} history={history}>
-        {children}
+        <KibanaContextProvider services={{ spaces: mockSpaces }}>
+          {children}
+        </KibanaContextProvider>
       </MockApmPluginContextWrapper>
     </MemoryRouter>
   );

--- a/x-pack/plugins/apm/public/hooks/use_data_view_id.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_data_view_id.tsx
@@ -11,15 +11,15 @@ import { getDataViewId } from '../../common/data_view_constants';
 import { ApmPluginStartDeps } from '../plugin';
 
 export function useDataViewId() {
-  const [dataViewId, setDataViewId] = useState<string>(
-    getDataViewId('default')
-  );
+  const [dataViewId, setDataViewId] = useState<string | undefined>();
   const { spaces } = useKibana<ApmPluginStartDeps>().services;
 
   useEffect(() => {
     const fetchSpaceId = async () => {
       const space = await spaces?.getActiveSpace();
-      setDataViewId(getDataViewId(space?.id ?? 'default'));
+      if (space?.id) {
+        setDataViewId(getDataViewId(space?.id));
+      }
     };
 
     fetchSpaceId();


### PR DESCRIPTION
follow-up to https://github.com/elastic/kibana/pull/170857

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->