### PR TITLE
[PoC] Semantic search support in KQL and Discover

### DIFF
--- a/packages/kbn-data-service/src/constants.ts
+++ b/packages/kbn-data-service/src/constants.ts
@@ -19,6 +19,7 @@ export const UI_SETTINGS = {
   COURIER_MAX_CONCURRENT_SHARD_REQUESTS: 'courier:maxConcurrentShardRequests',
   SEARCH_INCLUDE_FROZEN: 'search:includeFrozen',
   SEARCH_TIMEOUT: 'search:timeout',
+  SEARCH_DEFAULT_TEXT_EXPANSION_MODEL: 'search:defaultTextExpansionModel',
   HISTOGRAM_BAR_TARGET: 'histogram:barTarget',
   HISTOGRAM_MAX_BARS: 'histogram:maxBars',
   HISTORY_LIMIT: 'history:limit',

--- a/packages/kbn-data-service/src/es_query/get_es_query_config.ts
+++ b/packages/kbn-data-service/src/es_query/get_es_query_config.ts
@@ -21,11 +21,13 @@ export function getEsQueryConfig(config: KibanaConfig): EsQueryConfig {
     UI_SETTINGS.COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX
   );
   const dateFormatTZ = config.get('dateFormat:tz');
+  const textExpansionModel = config.get(UI_SETTINGS.SEARCH_DEFAULT_TEXT_EXPANSION_MODEL);
 
   return {
     allowLeadingWildcards,
     queryStringOptions,
     ignoreFilterIfFieldNotInIndex,
     dateFormatTZ,
+    textExpansionModel,
   };
 }

--- a/packages/kbn-es-query/index.ts
+++ b/packages/kbn-es-query/index.ts
@@ -118,6 +118,7 @@ export {
   toKqlExpression,
   nodeBuilder,
   nodeTypes,
+  functions,
   toElasticsearchQuery,
   escapeKuery,
   escapeQuotes,

--- a/packages/kbn-es-query/src/es_query/build_es_query.ts
+++ b/packages/kbn-es-query/src/es_query/build_es_query.ts
@@ -68,6 +68,7 @@ export function buildEsQuery(
       filtersInMustClause: config.filtersInMustClause,
       nestedIgnoreUnmapped: config.nestedIgnoreUnmapped,
       caseInsensitive: config.caseInsensitive,
+      textExpansionModel: config.textExpansionModel,
     }
   );
   const luceneQuery = buildQueryFromLucene(

--- a/packages/kbn-es-query/src/es_query/from_kuery.ts
+++ b/packages/kbn-es-query/src/es_query/from_kuery.ts
@@ -28,6 +28,7 @@ export function buildQueryFromKuery(
     dateFormatTZ,
     nestedIgnoreUnmapped,
     caseInsensitive,
+    textExpansionModel,
   }: KueryQueryOptions = {
     filtersInMustClause: false,
   }
@@ -41,6 +42,7 @@ export function buildQueryFromKuery(
     dateFormatTZ,
     nestedIgnoreUnmapped,
     caseInsensitive,
+    textExpansionModel,
   });
 }
 

--- a/packages/kbn-es-query/src/kuery/ast/ast.test.ts
+++ b/packages/kbn-es-query/src/kuery/ast/ast.test.ts
@@ -318,9 +318,9 @@ describe('kuery AST API', () => {
     });
 
     test('should allow escaping of special characters with a backslash', () => {
-      const expected = nodeTypes.literal.buildNode('\\():<>"*');
+      const expected = nodeTypes.literal.buildNode('\\():~<>"*');
       // yo dawg
-      const actual = fromLiteralExpression('\\\\\\(\\)\\:\\<\\>\\"\\*');
+      const actual = fromLiteralExpression('\\\\\\(\\)\\:\\~\\<\\>\\"\\*');
       expect(actual).toEqual(expected);
     });
 
@@ -331,8 +331,8 @@ describe('kuery AST API', () => {
     });
 
     test('should support double quoted strings that do not need escapes except for quotes', () => {
-      const expected = nodeTypes.literal.buildNode('\\():<>"*');
-      const actual = fromLiteralExpression('"\\():<>\\"*"');
+      const expected = nodeTypes.literal.buildNode('\\():~<>"*');
+      const actual = fromLiteralExpression('"\\():~<>\\"*"');
       expect(actual.value).toEqual(expected.value);
     });
 

--- a/packages/kbn-es-query/src/kuery/functions/and.ts
+++ b/packages/kbn-es-query/src/kuery/functions/and.ts
@@ -7,7 +7,10 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { difference } from 'lodash';
+import type { JsonObject } from '@kbn/utility-types';
 import * as ast from '../ast';
+import * as infer from './infer';
 import type { DataViewBase, KueryNode, KueryQueryOptions } from '../../..';
 import type { KqlFunctionNode } from '../node_types';
 import type { KqlContext } from '../types';
@@ -37,14 +40,23 @@ export function toElasticsearchQuery(
 ): QueryDslQueryContainer {
   const { filtersInMustClause } = config;
   const children = node.arguments || [];
-  const key = filtersInMustClause ? 'must' : 'filter';
+  const queries: { must: JsonObject[]; filter: JsonObject[] } = { must: [], filter: [] };
+  const toQuery = (child: KueryNode) => {
+    return ast.toElasticsearchQuery(child, indexPattern, config, context);
+  };
+
+  if (filtersInMustClause) {
+    queries.must = children.map(toQuery);
+  } else {
+    const inferNodes = children.filter(infer.isNode);
+    const otherNodes = difference(children, inferNodes);
+
+    queries.must = inferNodes.map(toQuery);
+    queries.filter = otherNodes.map(toQuery);
+  }
 
   return {
-    bool: {
-      [key]: children.map((child: KueryNode) => {
-        return ast.toElasticsearchQuery(child, indexPattern, config, context);
-      }),
-    },
+    bool: queries,
   };
 }
 

--- a/packages/kbn-es-query/src/kuery/functions/and.ts
+++ b/packages/kbn-es-query/src/kuery/functions/and.ts
@@ -7,13 +7,13 @@
  */
 
 import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
-import { difference, isObject } from 'lodash';
+import { difference } from 'lodash';
 import type { JsonObject } from '@kbn/utility-types';
 import * as ast from '../ast';
 import * as infer from './infer';
 import type { DataViewBase, KueryNode, KueryQueryOptions } from '../../..';
 import type { KqlFunctionNode } from '../node_types';
-import { KqlContext, nodeTypes } from '../types';
+import type { KqlContext } from '../types';
 
 export const KQL_FUNCTION_AND = 'and';
 
@@ -48,7 +48,7 @@ export function toElasticsearchQuery(
   if (filtersInMustClause) {
     queries.must = children.map(toQuery);
   } else {
-    const inferNodes = children.filter(hasInferNode);
+    const inferNodes = children.filter(infer.nodeContains);
     const otherNodes = difference(children, inferNodes);
 
     queries.must = inferNodes.map(toQuery);
@@ -63,12 +63,3 @@ export function toElasticsearchQuery(
 export function toKqlExpression(node: KqlAndFunctionNode): string {
   return `(${node.arguments.map(ast.toKqlExpression).join(' AND ')})`;
 }
-
-const isKueryNode = (node: unknown): node is KueryNode => isObject(node) && 'type' in node;
-const hasInferNode = (node: unknown) => {
-  return (
-    isKueryNode(node) &&
-    nodeTypes.function.isNode(node) &&
-    (infer.isNode(node) || node.arguments.some(hasInferNode))
-  );
-};

--- a/packages/kbn-es-query/src/kuery/functions/index.ts
+++ b/packages/kbn-es-query/src/kuery/functions/index.ts
@@ -7,6 +7,7 @@
  */
 
 import * as is from './is';
+import * as infer from './infer';
 import * as and from './and';
 import * as or from './or';
 import * as not from './not';
@@ -17,6 +18,7 @@ import * as nested from './nested';
 export { KQL_FUNCTION_AND } from './and';
 export { KQL_FUNCTION_EXISTS } from './exists';
 export { KQL_FUNCTION_IS } from './is';
+export { KQL_FUNCTION_INFER } from './infer';
 export { KQL_FUNCTION_NESTED } from './nested';
 export { KQL_FUNCTION_NOT } from './not';
 export { KQL_FUNCTION_OR } from './or';
@@ -24,6 +26,7 @@ export { KQL_FUNCTION_RANGE } from './range';
 
 export const functions = {
   is,
+  infer,
   and,
   or,
   not,

--- a/packages/kbn-es-query/src/kuery/functions/infer.ts
+++ b/packages/kbn-es-query/src/kuery/functions/infer.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { isUndefined } from 'lodash';
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import { getFields } from './utils/get_fields';
+import { getDataViewFieldSubtypeNested } from '../../utils';
+import { getFullFieldNameNode } from './utils/get_full_field_name_node';
+import type { DataViewBase, DataViewFieldBase, KueryQueryOptions } from '../../..';
+import type { KqlFunctionNode, KqlLiteralNode, KqlWildcardNode } from '../node_types';
+import type { KqlContext } from '../types';
+
+import * as ast from '../ast';
+import * as literal from '../node_types/literal';
+import * as wildcard from '../node_types/wildcard';
+
+export const KQL_FUNCTION_INFER = 'infer';
+
+export interface KqlInferFunctionNode extends KqlFunctionNode {
+  function: typeof KQL_FUNCTION_INFER;
+  arguments: [KqlLiteralNode | KqlWildcardNode, KqlLiteralNode | KqlWildcardNode];
+}
+
+export function isNode(node: KqlFunctionNode): node is KqlInferFunctionNode {
+  return node.function === KQL_FUNCTION_INFER;
+}
+
+export function buildNodeParams(fieldName: string, value: any) {
+  if (isUndefined(fieldName)) {
+    throw new Error('fieldName is a required argument');
+  }
+  if (isUndefined(value)) {
+    throw new Error('value is a required argument');
+  }
+  const fieldNode =
+    typeof fieldName === 'string'
+      ? ast.fromLiteralExpression(fieldName)
+      : literal.buildNode(fieldName);
+  const valueNode =
+    typeof value === 'string' ? ast.fromLiteralExpression(value) : literal.buildNode(value);
+  return {
+    arguments: [fieldNode, valueNode],
+  };
+}
+
+export function toElasticsearchQuery(
+  node: KqlInferFunctionNode,
+  indexPattern?: DataViewBase,
+  config: KueryQueryOptions = {},
+  context: KqlContext = {}
+): QueryDslQueryContainer {
+  const {
+    arguments: [fieldNameArg, valueArg],
+  } = node;
+
+  const fullFieldNameArg = getFullFieldNameNode(
+    fieldNameArg,
+    indexPattern,
+    context?.nested ? context.nested.path : undefined
+  );
+
+  if (fullFieldNameArg.value === null) {
+    throw new Error('fieldName is a required argument');
+  }
+
+  const value = !isUndefined(valueArg) ? ast.toElasticsearchQuery(valueArg) : valueArg;
+  const fields = indexPattern ? getFields(fullFieldNameArg, indexPattern) ?? [] : [];
+
+  // If no fields are found in the index pattern we send through the given field name as-is. We do this to preserve
+  // the behaviour of lucene on dashboards where there are panels based on different index patterns that have different
+  // fields. If a user queries on a field that exists in one pattern but not the other, the index pattern without the
+  // field should return no results. It's debatable whether this is desirable, but it's been that way forever, so we'll
+  // keep things familiar for now.
+  if (fields.length === 0) {
+    fields.push({
+      name: ast.toElasticsearchQuery(fullFieldNameArg) as unknown as string,
+      scripted: false,
+      type: '',
+    });
+  }
+
+  const wrapWithNestedQuery = (field: DataViewFieldBase, query: any) => {
+    // Wildcards can easily include nested and non-nested fields. There isn't a good way to let
+    // users handle this themselves so we automatically add nested queries in this scenario.
+    const subTypeNested = getDataViewFieldSubtypeNested(field);
+    if (!wildcard.isNode(fullFieldNameArg) || !subTypeNested?.nested || context?.nested) {
+      return query;
+    } else {
+      return {
+        nested: {
+          path: subTypeNested.nested.path,
+          query,
+          score_mode: 'none',
+          ...(typeof config.nestedIgnoreUnmapped === 'boolean' && {
+            ignore_unmapped: config.nestedIgnoreUnmapped,
+          }),
+        },
+      };
+    }
+  };
+
+  const queries = fields.map(
+    (field: DataViewFieldBase) =>
+      wrapWithNestedQuery(field, {
+        text_expansion: {
+          [field.name]: {
+            model_id: '.elser_model_2',
+            model_text: value,
+          },
+        },
+      }),
+    []
+  );
+
+  return queries.length === 1
+    ? queries[0]
+    : {
+        bool: {
+          should: queries,
+          minimum_should_match: 1,
+        },
+      };
+}
+
+export function toKqlExpression(node: KqlInferFunctionNode): string {
+  const [field, value] = node.arguments;
+  if (field.value === null) return `${ast.toKqlExpression(value)}`;
+  return `${ast.toKqlExpression(field)} ~ ${ast.toKqlExpression(value)}`;
+}

--- a/packages/kbn-es-query/src/kuery/grammar/grammar.peggy
+++ b/packages/kbn-es-query/src/kuery/grammar/grammar.peggy
@@ -87,6 +87,7 @@ Expression
   = FieldRangeExpression
   / FieldValueExpression
   / FieldInferExpression
+  / InferExpression
   / ValueExpression
 
 Field "fieldName"
@@ -139,6 +140,20 @@ ValueExpression
     }
     const field = buildLiteralNode(null);
     return partial(field);
+  }
+
+InferExpression
+  = '~' Space* partial:Value {
+    if (partial.type === 'cursor') {
+      const fieldName = `${partial.prefix}${partial.suffix}`.trim();
+      return {
+        ...partial,
+        fieldName,
+        suggestionTypes: ['field', 'operator', 'conjunction']
+      };
+    }
+    const field = buildLiteralNode(null);
+    return partial(field, 'infer');
   }
 
 ListOfValues

--- a/packages/kbn-es-query/src/kuery/grammar/grammar.peggy
+++ b/packages/kbn-es-query/src/kuery/grammar/grammar.peggy
@@ -86,6 +86,7 @@ NestedQuery
 Expression
   = FieldRangeExpression
   / FieldValueExpression
+  / FieldInferExpression
   / ValueExpression
 
 Field "fieldName"
@@ -112,6 +113,18 @@ FieldValueExpression
       };
     }
     return partial(field);
+  }
+
+FieldInferExpression
+  = field:Field Space* '~' Space* partial:Value {
+    if (partial.type === 'cursor') {
+      return {
+        ...partial,
+        fieldName: field.value,
+        suggestionTypes: ['value', 'conjunction']
+      };
+    }
+    return partial(field, 'infer');
   }
 
 ValueExpression
@@ -183,7 +196,7 @@ NotListOfValues
 Value "value"
   = value:QuotedString {
     if (value.type === 'cursor') return value;
-    return (field) => buildFunctionNode('is', [field, value]);
+    return (field, functionName = 'is') => buildFunctionNode(functionName, [field, value]);
   }
   / value:UnquotedLiteral {
     if (value.type === 'cursor') return value;
@@ -192,7 +205,7 @@ Value "value"
       error('Leading wildcards are disabled. See query:allowLeadingWildcards in Advanced Settings.');
     }
 
-    return (field) => buildFunctionNode('is', [field, value]);
+    return (field, functionName = 'is') => buildFunctionNode(functionName, [field, value]);
   }
 
 Or "OR"
@@ -290,7 +303,7 @@ Keyword
   = Or / And / Not
 
 SpecialCharacter
-  = [\\():<>"*{}]
+  = [\\():~<>"*{}]
 
 EscapedUnicodeSequence
  = '\\' sequence:UnicodeSequence { return sequence; }

--- a/packages/kbn-es-query/src/kuery/index.ts
+++ b/packages/kbn-es-query/src/kuery/index.ts
@@ -24,4 +24,5 @@ export { KQLSyntaxError } from './kuery_syntax_error';
 export { nodeTypes, nodeBuilder } from './node_types';
 export { fromKueryExpression, toKqlExpression } from './ast';
 export { escapeKuery, escapeQuotes } from './utils';
+export { functions } from './functions';
 export type { DslQuery, KueryNode, KueryQueryOptions, KueryParseOptions } from './types';

--- a/packages/kbn-es-query/src/kuery/node_types/function.ts
+++ b/packages/kbn-es-query/src/kuery/node_types/function.ts
@@ -14,6 +14,7 @@ import {
   KQL_FUNCTION_EXISTS,
   KQL_FUNCTION_NESTED,
   KQL_FUNCTION_IS,
+  KQL_FUNCTION_INFER,
   KQL_FUNCTION_NOT,
   KQL_FUNCTION_OR,
   KQL_FUNCTION_RANGE,
@@ -27,6 +28,7 @@ export type KqlFunctionName =
   | typeof KQL_FUNCTION_AND
   | typeof KQL_FUNCTION_EXISTS
   | typeof KQL_FUNCTION_IS
+  | typeof KQL_FUNCTION_INFER
   | typeof KQL_FUNCTION_NESTED
   | typeof KQL_FUNCTION_NOT
   | typeof KQL_FUNCTION_OR
@@ -85,6 +87,8 @@ export function toElasticsearchQuery(
     return functions.exists.toElasticsearchQuery(node), indexPattern, config, context;
   if (functions.is.isNode(node))
     return functions.is.toElasticsearchQuery(node, indexPattern, config, context);
+  if (functions.infer.isNode(node))
+    return functions.infer.toElasticsearchQuery(node, indexPattern, config, context);
   if (functions.nested.isNode(node))
     return functions.nested.toElasticsearchQuery(node, indexPattern, config, context);
   if (functions.not.isNode(node))
@@ -100,6 +104,7 @@ export function toKqlExpression(node: KqlFunctionNode): string {
   if (functions.and.isNode(node)) return functions.and.toKqlExpression(node);
   if (functions.exists.isNode(node)) return functions.exists.toKqlExpression(node);
   if (functions.is.isNode(node)) return functions.is.toKqlExpression(node);
+  if (functions.infer.isNode(node)) return functions.infer.toKqlExpression(node);
   if (functions.nested.isNode(node)) return functions.nested.toKqlExpression(node);
   if (functions.not.isNode(node)) return functions.not.toKqlExpression(node);
   if (functions.or.isNode(node)) return functions.or.toKqlExpression(node);

--- a/packages/kbn-es-query/src/kuery/node_types/node_builder.ts
+++ b/packages/kbn-es-query/src/kuery/node_types/node_builder.ts
@@ -16,6 +16,12 @@ export const nodeBuilder = {
       typeof value === 'string' ? nodeTypes.literal.buildNode(value) : value,
     ]);
   },
+  infer: (fieldName: string, value: string | KueryNode): KueryNode => {
+    return nodeTypes.function.buildNodeWithArgumentNodes('infer', [
+      nodeTypes.literal.buildNode(fieldName),
+      typeof value === 'string' ? nodeTypes.literal.buildNode(value) : value,
+    ]);
+  },
   or: (nodes: KueryNode[]): KueryNode => {
     return nodes.length === 1 ? nodes[0] : nodeTypes.function.buildNode('or', nodes);
   },

--- a/packages/kbn-es-query/src/kuery/types.ts
+++ b/packages/kbn-es-query/src/kuery/types.ts
@@ -57,6 +57,10 @@ export interface KueryQueryOptions {
    * (See https://www.elastic.co/guide/en/elasticsearch/reference/8.6/query-dsl-term-query.html#term-field-params)
    */
   caseInsensitive?: boolean;
+  /**
+   * The ML model to use for text expansion semantic searches.
+   */
+  textExpansionModel?: string;
 }
 
 /** @public */

--- a/packages/kbn-es-query/src/kuery/utils/escape_kuery.ts
+++ b/packages/kbn-es-query/src/kuery/utils/escape_kuery.ts
@@ -24,7 +24,7 @@ export const escapeKuery = flow(escapeSpecialCharacters, escapeAndOr, escapeNot,
 
 // See the SpecialCharacter rule in kuery.peg
 function escapeSpecialCharacters(str: string) {
-  return str.replace(/[\\():<>"*]/g, '\\$&'); // $& means the whole matched string
+  return str.replace(/[\\():~<>"*]/g, '\\$&'); // $& means the whole matched string
 }
 
 // See the Keyword rule in kuery.peg

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -80,8 +80,6 @@ import {
   isOfQueryType,
   isPhraseFilter,
   isPhrasesFilter,
-  KueryNode,
-  nodeTypes,
 } from '@kbn/es-query';
 import { fieldWildcardFilter } from '@kbn/kibana-utils-plugin/common';
 import { getHighlightRequest } from '@kbn/field-formats-plugin/common';
@@ -912,21 +910,12 @@ export class SearchSource {
     );
 
     if (!hasScoreSort) {
-      const isNode = (node: unknown): node is KueryNode => isObject(node) && 'type' in node;
-      const hasInferNode = (node: unknown) => {
-        return (
-          isNode(node) &&
-          nodeTypes.function.isNode(node) &&
-          (functions.infer.isNode(node) || node.arguments.some(hasInferNode))
-        );
-      };
-
       const queryArray = Array.isArray(query) ? query : [query];
       const anyQueryHasInferNode = queryArray.some(
         (currentQuery) =>
           isOfQueryType(currentQuery) &&
           currentQuery.language === 'kuery' &&
-          hasInferNode(fromKueryExpression(currentQuery.query))
+          functions.infer.nodeContains(fromKueryExpression(currentQuery.query))
       );
 
       if (anyQueryHasInferNode) {

--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -75,9 +75,13 @@ import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
   buildEsQuery,
   Filter,
+  fromKueryExpression,
+  functions,
   isOfQueryType,
   isPhraseFilter,
   isPhrasesFilter,
+  KueryNode,
+  nodeTypes,
 } from '@kbn/es-query';
 import { fieldWildcardFilter } from '@kbn/kibana-utils-plugin/common';
 import { getHighlightRequest } from '@kbn/field-formats-plugin/common';
@@ -903,13 +907,37 @@ export class SearchSource {
       body.fields = filteredDocvalueFields;
     }
 
-    // If sorting by _score, build queries in the "must" clause instead of "filter" clause to enable scoring
-    const filtersInMustClause = (body.sort ?? []).some((sort: EsQuerySortValue[]) =>
+    const hasScoreSort = (body.sort ?? []).some((sort: EsQuerySortValue[]) =>
       sort.hasOwnProperty('_score')
     );
+
+    if (!hasScoreSort) {
+      const isNode = (node: unknown): node is KueryNode => isObject(node) && 'type' in node;
+      const hasInferNode = (node: unknown) => {
+        return (
+          isNode(node) &&
+          nodeTypes.function.isNode(node) &&
+          (functions.infer.isNode(node) || node.arguments.some(hasInferNode))
+        );
+      };
+
+      const queryArray = Array.isArray(query) ? query : [query];
+      const anyQueryHasInferNode = queryArray.some(
+        (currentQuery) =>
+          isOfQueryType(currentQuery) &&
+          currentQuery.language === 'kuery' &&
+          hasInferNode(fromKueryExpression(currentQuery.query))
+      );
+
+      if (anyQueryHasInferNode) {
+        body.sort = [{ _score: { order: 'desc' } }, ...(body.sort ?? [])];
+      }
+    }
+
     const esQueryConfigs = {
       ...getEsQueryConfig({ get: getConfig }),
-      filtersInMustClause,
+      // If sorting by _score, build queries in the "must" clause instead of "filter" clause to enable scoring
+      filtersInMustClause: hasScoreSort,
     };
     body.query = buildEsQuery(index, query, filters, esQueryConfigs);
 

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -580,6 +580,7 @@ export function getUiSettings(
       }),
       type: 'string',
       category: ['search'],
+      requiresPageReload: true,
       schema: schema.string(),
     },
   };

--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -570,5 +570,17 @@ export function getUiSettings(
       category: ['search'],
       schema: schema.number(),
     },
+    [UI_SETTINGS.SEARCH_DEFAULT_TEXT_EXPANSION_MODEL]: {
+      name: i18n.translate('data.advancedSettings.defaultTextExpansionModel', {
+        defaultMessage: 'Default text expansion model',
+      }),
+      value: '',
+      description: i18n.translate('data.advancedSettings.defaultTextExpansionModelDesc', {
+        defaultMessage: 'Sets the default ML model to use for text expansion semantic searches.',
+      }),
+      type: 'string',
+      category: ['search'],
+      schema: schema.string(),
+    },
   };
 }


### PR DESCRIPTION
## Summary

WIP.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)