### PR TITLE
fix(slo): Filter groupBy fields to keyword type only

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -20,6 +20,7 @@ export interface Field {
   type: string;
   aggregatable: boolean;
   searchable: boolean;
+  esTypes?: string[];
 }
 
 export function useFetchIndexPatternFields(

--- a/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/use_fetch_index_pattern_fields.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import { useQuery } from '@tanstack/react-query';
 import { useKibana } from '../../utils/kibana_react';
 
@@ -12,15 +13,7 @@ export interface UseFetchIndexPatternFieldsResponse {
   isLoading: boolean;
   isSuccess: boolean;
   isError: boolean;
-  data: Field[] | undefined;
-}
-
-export interface Field {
-  name: string;
-  type: string;
-  aggregatable: boolean;
-  searchable: boolean;
-  esTypes?: string[];
+  data: FieldSpec[] | undefined;
 }
 
 export function useFetchIndexPatternFields(

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_availability/apm_availability_indicator_type_form.tsx
@@ -30,7 +30,7 @@ export function ApmAvailabilityIndicatorTypeForm() {
 
   const { isLoading: isIndexFieldsLoading, data: indexFields = [] } =
     useFetchIndexPatternFields(apmIndex);
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/apm_latency/apm_latency_indicator_type_form.tsx
@@ -30,7 +30,7 @@ export function ApmLatencyIndicatorTypeForm() {
 
   const { isLoading: isIndexFieldsLoading, data: indexFields = [] } =
     useFetchIndexPatternFields(apmIndex);
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/common/index_field_selector.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/common/index_field_selector.tsx
@@ -6,14 +6,15 @@
  */
 
 import { EuiComboBox, EuiComboBoxOptionOption, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import React, { useEffect, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { Field } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
+
 import { createOptionsFromFields, Option } from '../../helpers/create_options';
 import { CreateSLOForm } from '../../types';
 
 interface Props {
-  indexFields: Field[];
+  indexFields: FieldSpec[];
   name: 'groupBy' | 'indicator.params.timestampField';
   label: React.ReactNode | string;
   placeholder: string;

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_kql/custom_kql_indicator_type_form.tsx
@@ -23,7 +23,7 @@ export function CustomKqlIndicatorTypeForm() {
   const { isLoading: isIndexFieldsLoading, data: indexFields = [] } =
     useFetchIndexPatternFields(index);
   const timestampFields = indexFields.filter((field) => field.type === 'date');
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
 
   return (
     <EuiFlexGroup direction="column" gutterSize="l">

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/custom_metric_type_form.tsx
@@ -36,7 +36,7 @@ export function CustomMetricIndicatorTypeForm() {
   const { isLoading: isIndexFieldsLoading, data: indexFields = [] } =
     useFetchIndexPatternFields(index);
   const timestampFields = indexFields.filter((field) => field.type === 'date');
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
   const metricFields = indexFields.filter((field) =>
     SUPPORTED_METRIC_FIELD_TYPES.includes(field.type)
   );

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/metric_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/custom_metric/metric_indicator.tsx
@@ -16,12 +16,12 @@ import {
   EuiIconTip,
   EuiSpacer,
 } from '@elastic/eui';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { first, range, xor } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-import { Field } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import {
   aggValueToLabel,
   CUSTOM_METRIC_AGGREGATION_OPTIONS,
@@ -32,7 +32,7 @@ import { QueryBuilder } from '../common/query_builder';
 
 interface MetricIndicatorProps {
   type: 'good' | 'total';
-  metricFields: Field[];
+  metricFields: FieldSpec[];
   isLoadingIndex: boolean;
 }
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator.tsx
@@ -15,17 +15,17 @@ import {
   EuiIconTip,
   EuiSpacer,
 } from '@elastic/eui';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import React, { Fragment, useEffect, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { Field } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import { createOptionsFromFields, Option } from '../../helpers/create_options';
 import { CreateSLOForm } from '../../types';
 import { QueryBuilder } from '../common/query_builder';
 
 interface HistogramIndicatorProps {
   type: 'good' | 'total';
-  histogramFields: Field[];
+  histogramFields: FieldSpec[];
   isLoadingIndex: boolean;
 }
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator_type_form.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/histogram/histogram_indicator_type_form.tsx
@@ -34,7 +34,7 @@ export function HistogramIndicatorTypeForm() {
     useFetchIndexPatternFields(index);
   const histogramFields = indexFields.filter((field) => field.type === 'histogram');
   const timestampFields = indexFields.filter((field) => field.type === 'date');
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
 
   return (
     <>

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/metric_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/metric_indicator.tsx
@@ -17,18 +17,18 @@ import {
   EuiSpacer,
   EuiText,
 } from '@elastic/eui';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { first, range, xor } from 'lodash';
 import React from 'react';
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form';
-import { Field } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import { COMPARATOR_OPTIONS } from '../../constants';
 import { CreateSLOForm } from '../../types';
 import { MetricInput } from './metric_input';
 
 interface MetricIndicatorProps {
-  indexFields: Field[];
+  indexFields: FieldSpec[];
   isLoadingIndex: boolean;
 }
 

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/metric_input.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/metric_input.tsx
@@ -12,10 +12,10 @@ import {
   EuiFormRow,
   EuiIconTip,
 } from '@elastic/eui';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 import { i18n } from '@kbn/i18n';
 import React, { useEffect, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
-import { Field } from '../../../../hooks/slo/use_fetch_index_pattern_fields';
 import { AGGREGATION_OPTIONS, aggValueToLabel } from '../../helpers/aggregation_options';
 import { createOptionsFromFields, Option } from '../../helpers/create_options';
 import { CreateSLOForm } from '../../types';
@@ -55,7 +55,7 @@ interface MetricInputProps {
   metricIndex: number;
   indexPattern: string;
   isLoadingIndex: boolean;
-  indexFields: Field[];
+  indexFields: FieldSpec[];
 }
 
 export function MetricInput({

--- a/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/timeslice_metric_indicator.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_edit/components/timeslice_metric/timeslice_metric_indicator.tsx
@@ -37,7 +37,7 @@ export function TimesliceMetricIndicatorTypeForm() {
   const { isLoading: isIndexFieldsLoading, data: indexFields = [] } =
     useFetchIndexPatternFields(index);
   const timestampFields = indexFields.filter((field) => field.type === 'date');
-  const groupByFields = indexFields.filter((field) => field.aggregatable);
+  const groupByFields = indexFields.filter((field) => !!field.esTypes?.includes('keyword'));
   const { uiSettings } = useKibana().services;
   const threshold = watch('indicator.params.metric.threshold');
   const comparator = watch('indicator.params.metric.comparator');

--- a/x-pack/plugins/observability/public/pages/slo_edit/helpers/create_options.ts
+++ b/x-pack/plugins/observability/public/pages/slo_edit/helpers/create_options.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { Field } from '../../../hooks/slo/use_fetch_index_pattern_fields';
+import { FieldSpec } from '@kbn/data-views-plugin/public';
 
 export interface Option {
   label: string;
@@ -13,7 +13,7 @@ export interface Option {
 }
 
 export function createOptionsFromFields(
-  fields: Field[],
+  fields: FieldSpec[],
   filterFn?: (option: Option) => boolean
 ): Option[] {
   const options = fields


### PR DESCRIPTION
Resolves [#172487](https://github.com/elastic/kibana/issues/172487)

## Summary

This PR limits the groupBy fields to `keywords` es types only, for all SLI indicators using the groupBy feature.