### PR TITLE
Update configuring-reporting.asciidoc

### DIFF
--- a/docs/setup/configuring-reporting.asciidoc
+++ b/docs/setup/configuring-reporting.asciidoc
@@ -49,7 +49,9 @@ The reporting plugin has a built-in utility to check for common issues, such as 
 === Grant users access to reporting
 When security is enabled, you grant users access to {report-features} with <<kibana-privileges, {kib} application privileges>>, which allow you to create custom roles that control the spaces and applications where users generate reports.
 
-. Enable application privileges in Reporting. To enable, turn off the default user access control features in `kibana.yml`:
+. Enable application privileges in Reporting.
+
+.. You must turn off the default user access control features in `kibana.yml` to expose application privileges in Reporting by setting `xpack.reporting.roles.enabled` to `false`:
 +
 [source,yaml]
 ------------------------------------


### PR DESCRIPTION
A customer opened a case about the steps listed in https://www.elastic.co/guide/en/kibana/8.11/secure-reporting.html#grant-user-access

Per the customer, and I tend to agree, the existing wording is accurate but hard to follow, especially for a non-native english speaker.

In particular, this bit:

```
Enable application privileges in Reporting. To enable, turn off the default user access control features in kibana.yml:
```

It's technically accurate, but to dissect the "To enable, turn off..." part you have to do some further reading. I was hoping that maybe there's a way to just rephrase this part or slightly restructure it to make it clear that:

In order to enable application privilege reporting...you must disable the other setting first, otherwise you can't see it. That's my pre-coffee, non-technical-writer version.

Please feel free to modify this further if my change is lacking. I think you would want to backport this to all other versions of the page.

## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


\\

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
