### PR TITLE
[Security Solution] Reduce flakiness in ransomware tests

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
@@ -29,18 +29,20 @@ describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () =>
     cy.task('esArchiverUnload', 'ransomware_detection');
   });
 
-  describe('Ransomware display on Alerts Page', () => {
+  describe('Ransomware in Alerts Page', () => {
     beforeEach(() => {
       login();
       visitWithTimeRange(ALERTS_URL);
       waitForAlertsToPopulate();
     });
 
-    it('should show Ransomware Alerts in alerts table', () => {
-      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Detection Alert');
-    });
+    it('should show ransomware alerts on alerts page', () => {
+      cy.log('should show ransomware alerts in alerts table');
 
-    it('should show Ransomware Prevention Alert in the trend chart', () => {
+      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Detection Alert');
+
+      cy.log('should show ransomware prevention alert in the trend chart');
+
       selectAlertsHistogram();
       cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Detection Alert');
     });
@@ -54,7 +56,7 @@ describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () =>
       createTimeline();
     });
 
-    it('Renders ransomware entries in timelines table', () => {
+    it('should show ransomware entries in timelines table', () => {
       cy.get(TIMELINE_QUERY).type('event.code: "ransomware"{enter}');
 
       // Wait for grid to load, it should have an analyzer icon

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_detection.cy.ts
@@ -14,6 +14,7 @@ import { ALERTS_HISTOGRAM_SERIES, ALERT_RULE_NAME, MESSAGE } from '../../../scre
 import { TIMELINE_QUERY, TIMELINE_VIEW_IN_ANALYZER } from '../../../screens/timeline';
 import { selectAlertsHistogram } from '../../../tasks/alerts';
 import { createTimeline } from '../../../tasks/timelines';
+import { deleteTimelines } from '../../../tasks/api_calls/common';
 
 describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
@@ -24,33 +25,30 @@ describe('Ransomware Detection Alerts', { tags: ['@ess', '@serverless'] }, () =>
     });
   });
 
-  describe('Ransomware display in Alerts Section', () => {
+  after(() => {
+    cy.task('esArchiverUnload', 'ransomware_detection');
+  });
+
+  describe('Ransomware display on Alerts Page', () => {
     beforeEach(() => {
       login();
       visitWithTimeRange(ALERTS_URL);
       waitForAlertsToPopulate();
     });
 
-    describe('Alerts table', () => {
-      it('shows Ransomware Alerts', () => {
-        cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Detection Alert');
-      });
+    it('should show Ransomware Alerts in alerts table', () => {
+      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Detection Alert');
     });
 
-    describe('Trend Chart', () => {
-      beforeEach(() => {
-        selectAlertsHistogram();
-      });
-
-      it('shows Ransomware Detection Alert in the trend chart', () => {
-        cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Detection Alert');
-      });
+    it('should show Ransomware Prevention Alert in the trend chart', () => {
+      selectAlertsHistogram();
+      cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Detection Alert');
     });
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/170846
-  describe.skip('Ransomware in Timelines', () => {
-    before(() => {
+  describe('Ransomware in Timelines', () => {
+    beforeEach(() => {
+      deleteTimelines();
       login();
       visitWithTimeRange(TIMELINES_URL);
       createTimeline();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_prevention.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_prevention.cy.ts
@@ -29,17 +29,19 @@ describe('Ransomware Prevention Alerts', { tags: ['@ess', '@serverless'] }, () =
     cy.task('esArchiverUnload', 'ransomware_prevention');
   });
 
-  describe('Ransomware display on Alerts Page', () => {
+  describe('Ransomware in Alerts Page', () => {
     beforeEach(() => {
       login();
       visitWithTimeRange(ALERTS_URL);
     });
 
-    it('should show Ransomware Alerts in alerts table', () => {
-      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Prevention Alert');
-    });
+    it('should show ransomware alerts on alerts page', () => {
+      cy.log('should show ransomware alerts in alert table');
 
-    it('should show Ransomware Prevention Alert in the trend chart', () => {
+      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Prevention Alert');
+
+      cy.log('should show ransomware prevention alert in the trend chart');
+
       selectAlertsHistogram();
       cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Prevention Alert');
     });
@@ -48,13 +50,13 @@ describe('Ransomware Prevention Alerts', { tags: ['@ess', '@serverless'] }, () =
   describe('Ransomware in Timelines', function () {
     beforeEach(() => {
       deleteTimelines();
+      login();
       createTimeline({ ...getTimeline(), query: 'event.code: "ransomware"' }).then((response) => {
         cy.wrap(response.body.data.persistTimeline.timeline.savedObjectId).as('timelineId');
       });
     });
 
-    it('Renders ransomware entries in timelines table', function () {
-      login();
+    it('should render ransomware entries in timelines table', function () {
       const timeline = this.timelineId;
       visitTimeline(timeline);
       // Wait for grid to load, it should have an analyzer icon

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_prevention.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/ransomware_prevention.cy.ts
@@ -29,31 +29,24 @@ describe('Ransomware Prevention Alerts', { tags: ['@ess', '@serverless'] }, () =
     cy.task('esArchiverUnload', 'ransomware_prevention');
   });
 
-  describe('Ransomware display in Alerts Section', () => {
+  describe('Ransomware display on Alerts Page', () => {
     beforeEach(() => {
       login();
       visitWithTimeRange(ALERTS_URL);
     });
 
-    describe('Alerts table', () => {
-      it('shows Ransomware Alerts', () => {
-        cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Prevention Alert');
-      });
+    it('should show Ransomware Alerts in alerts table', () => {
+      cy.get(ALERT_RULE_NAME).should('have.text', 'Ransomware Prevention Alert');
     });
 
-    describe('Trend Chart', () => {
-      beforeEach(() => {
-        selectAlertsHistogram();
-      });
-
-      it('shows Ransomware Prevention Alert in the trend chart', () => {
-        cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Prevention Alert');
-      });
+    it('should show Ransomware Prevention Alert in the trend chart', () => {
+      selectAlertsHistogram();
+      cy.get(ALERTS_HISTOGRAM_SERIES).should('have.text', 'Ransomware Prevention Alert');
     });
   });
 
   describe('Ransomware in Timelines', function () {
-    before(() => {
+    beforeEach(() => {
       deleteTimelines();
       createTimeline({ ...getTimeline(), query: 'event.code: "ransomware"' }).then((response) => {
         cy.wrap(response.body.data.persistTimeline.timeline.savedObjectId).as('timelineId');

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts
@@ -273,7 +273,7 @@ export const selectCountTable = () => {
 };
 
 export const selectAlertsHistogram = () => {
-  cy.get(SELECT_HISTOGRAM).click({ force: true });
+  cy.get(SELECT_HISTOGRAM).click();
 };
 
 export const goToAcknowledgedAlerts = () => {


### PR DESCRIPTION
## Summary

`before` -> `beforeEach` to prevent missing timeline on retry
Unload data after test finish

Fixes: https://github.com/elastic/kibana/issues/170310
Fixes: https://github.com/elastic/kibana/issues/170846

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed [100/100 ESS and 100/100 Serverless](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4575#_)
