### PR TITLE
[Fleet] Add docs links for performance tuning presets

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -781,6 +781,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       elasticAgentInputConfiguration: `${FLEET_DOCS}elastic-agent-input-configuration.html`,
       policySecrets: `${FLEET_DOCS}agent-policy.html#agent-policy-secret-values`,
       remoteESOoutput: `${FLEET_DOCS}monitor-elastic-agent.html#external-elasticsearch-monitoring`,
+      performancePresets: `${FLEET_DOCS}es-output-settings.html#es-output-settings-performance-tuning-settings`,
     },
     ecs: {
       guide: `${ELASTIC_WEBSITE_URL}guide/en/ecs/current/index.html`,

--- a/packages/kbn-doc-links/src/types.ts
+++ b/packages/kbn-doc-links/src/types.ts
@@ -536,6 +536,7 @@ export interface DocLinks {
     elasticAgentInputConfiguration: string;
     policySecrets: string;
     remoteESOoutput: string;
+    performancePresets: string;
   }>;
   readonly ecs: {
     readonly guide: string;

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/index.tsx
@@ -570,38 +570,57 @@ export const EditOutputFlyout: React.FunctionComponent<EditOutputFlyoutProps> = 
             <>
               <EuiSpacer size="l" />
               <EuiFormRow
+                fullWidth
                 label={
                   <FormattedMessage
                     id="xpack.fleet.settings.editOutputFlyout.performanceTuningLabel"
                     defaultMessage="Performance tuning"
                   />
                 }
-              >
-                <>
-                  <EuiSelect
-                    data-test-subj="settingsOutputsFlyout.presetInput"
-                    {...inputs.presetInput.props}
-                    onChange={(e) => inputs.presetInput.setValue(e.target.value)}
-                    disabled={
-                      inputs.presetInput.props.disabled ||
-                      outputYmlIncludesReservedPerformanceKey(
-                        inputs.additionalYamlConfigInput.value,
-                        safeLoad
-                      )
-                    }
-                    options={[
-                      { value: 'balanced', text: 'Balanced' },
-                      { value: 'custom', text: 'Custom' },
-                      { value: 'throughput', text: 'Throughput' },
-                      { value: 'scale', text: 'Scale' },
-                      { value: 'latency', text: 'Latency' },
-                    ]}
+                helpText={
+                  <FormattedMessage
+                    id="xpack.fleet.settings.editOutputFlyout.performanceTuningHelpText"
+                    defaultMessage="Performance tuning presets are curated output settings for common use cases. You can also select {custom} to specify your own settings in the Advanced YAML Configuration box below. For a detailed list of settings configured by each preset, see {link}."
+                    values={{
+                      custom: <strong>Custom</strong>,
+                      link: (
+                        <EuiLink
+                          href={docLinks.links.fleet.performancePresets}
+                          external
+                          target="_blank"
+                        >
+                          <FormattedMessage
+                            id="xpack.fleet.settings.editOutputFlyout.performanceTuningHelpTextLink"
+                            defaultMessage="our documentation"
+                          />
+                        </EuiLink>
+                      ),
+                    }}
                   />
-                </>
+                }
+              >
+                <EuiSelect
+                  data-test-subj="settingsOutputsFlyout.presetInput"
+                  {...inputs.presetInput.props}
+                  onChange={(e) => inputs.presetInput.setValue(e.target.value)}
+                  disabled={
+                    inputs.presetInput.props.disabled ||
+                    outputYmlIncludesReservedPerformanceKey(
+                      inputs.additionalYamlConfigInput.value,
+                      safeLoad
+                    )
+                  }
+                  options={[
+                    { value: 'balanced', text: 'Balanced' },
+                    { value: 'custom', text: 'Custom' },
+                    { value: 'throughput', text: 'Throughput' },
+                    { value: 'scale', text: 'Scale' },
+                    { value: 'latency', text: 'Latency' },
+                  ]}
+                />
               </EuiFormRow>
             </>
           )}
-
           {supportsPresets &&
             outputYmlIncludesReservedPerformanceKey(
               inputs.additionalYamlConfigInput.value,


### PR DESCRIPTION
## Summary

Closes #172523 

Adds links to https://www.elastic.co/guide/en/fleet/master/es-output-settings.html#es-output-settings-performance-tuning-settings + help text for the performance preset form input.

![image](https://github.com/elastic/kibana/assets/6766512/91be33e3-fd62-4973-a2d6-b4f2e544bd69)

![image](https://github.com/elastic/kibana/assets/6766512/787f6784-842f-4e5a-8175-5c2057aee286)

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->