### PR TITLE
[8.12] [Security Solution][Detections] Flaky alert assignments tests (#173284)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments.cy.ts
@@ -23,12 +23,12 @@ import { waitForAlertsToPopulate } from '../../../../../tasks/create_new_rule';
 import {
   alertDetailsFlyoutShowsAssignees,
   alertDetailsFlyoutShowsAssigneesBadge,
-  alertsTableShowsAssigneesBadgeForAlert,
+  alertsTableShowsAssigneesBadgeForFirstAlert,
   alertsTableShowsAssigneesForAlert,
-  updateAssigneesForAlert,
+  updateAssigneesForFirstAlert,
   checkEmptyAssigneesStateInAlertDetailsFlyout,
   checkEmptyAssigneesStateInAlertsTable,
-  removeAllAssigneesForAlert,
+  removeAllAssigneesForFirstAlert,
   bulkUpdateAssignees,
   alertsTableShowsAssigneesForAllAlerts,
   bulkRemoveAllAssignees,
@@ -42,8 +42,7 @@ import {
 } from '../../../../../tasks/alert_assignments';
 import { ALERTS_COUNT } from '../../../../../screens/alerts';
 
-// FLAKY: https://github.com/elastic/kibana/issues/172611
-describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@serverless'] }, () => {
+describe('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@serverless'] }, () => {
   before(() => {
     cy.task('esArchiverLoad', { archiveName: 'auditbeat_multiple' });
 
@@ -79,13 +78,13 @@ describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@ser
 
     it('alert with some assignees in alerts table', () => {
       const users = [ROLES.detections_admin, ROLES.t1_analyst];
-      updateAssigneesForAlert(users);
+      updateAssigneesForFirstAlert(users);
       alertsTableShowsAssigneesForAlert(users);
     });
 
     it(`alert with some assignees in alert's details flyout`, () => {
       const users = [ROLES.detections_admin, ROLES.t1_analyst];
-      updateAssigneesForAlert(users);
+      updateAssigneesForFirstAlert(users);
       expandFirstAlert();
       alertDetailsFlyoutShowsAssignees(users);
     });
@@ -98,13 +97,13 @@ describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@ser
         ROLES.soc_manager,
         ROLES.detections_admin,
       ];
-      updateAssigneesForAlert(users);
-      alertsTableShowsAssigneesBadgeForAlert(users);
+      updateAssigneesForFirstAlert(users);
+      alertsTableShowsAssigneesBadgeForFirstAlert(users);
     });
 
     it(`alert with many assignees (collapsed into badge) in alert's details flyout`, () => {
       const users = [ROLES.detections_admin, ROLES.t1_analyst, ROLES.t2_analyst];
-      updateAssigneesForAlert(users);
+      updateAssigneesForFirstAlert(users);
       expandFirstAlert();
       alertDetailsFlyoutShowsAssigneesBadge(users);
     });
@@ -114,7 +113,7 @@ describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@ser
     it('adding new assignees via `More actions` in alerts table', () => {
       // Assign users
       const users = [ROLES.detections_admin, ROLES.t1_analyst];
-      updateAssigneesForAlert(users);
+      updateAssigneesForFirstAlert(users);
 
       // Assignees should appear in the alerts table
       alertsTableShowsAssigneesForAlert(users);
@@ -157,12 +156,12 @@ describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@ser
     it('updating assignees via `More actions` in alerts table', () => {
       // Initially assigned users
       const initialAssignees = [ROLES.detections_admin, ROLES.t1_analyst];
-      updateAssigneesForAlert(initialAssignees);
+      updateAssigneesForFirstAlert(initialAssignees);
       alertsTableShowsAssigneesForAlert(initialAssignees);
 
       // Update assignees
       const updatedAssignees = [ROLES.t1_analyst, ROLES.t2_analyst];
-      updateAssigneesForAlert(updatedAssignees);
+      updateAssigneesForFirstAlert(updatedAssignees);
 
       const expectedAssignees = [ROLES.detections_admin, ROLES.t2_analyst];
 
@@ -221,10 +220,10 @@ describe.skip('Alert user assignment - ESS & Serverless', { tags: ['@ess', '@ser
     it('removing all assignees via `More actions` in alerts table', () => {
       // Initially assigned users
       const initialAssignees = [ROLES.detections_admin, ROLES.t1_analyst];
-      updateAssigneesForAlert(initialAssignees);
+      updateAssigneesForFirstAlert(initialAssignees);
       alertsTableShowsAssigneesForAlert(initialAssignees);
 
-      removeAllAssigneesForAlert();
+      removeAllAssigneesForFirstAlert();
 
       // Alert should not show any assignee in alerts table or in details flyout
       checkEmptyAssigneesStateInAlertsTable();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments_serverless_complete.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments_serverless_complete.cy.ts
@@ -15,7 +15,7 @@ import { ALERTS_URL } from '../../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../../tasks/create_new_rule';
 import {
   alertsTableShowsAssigneesForAlert,
-  updateAssigneesForAlert,
+  updateAssigneesForFirstAlert,
   bulkRemoveAllAssignees,
   loadPageAs,
 } from '../../../../../tasks/alert_assignments';
@@ -78,7 +78,7 @@ describe.skip(
           bulkRemoveAllAssignees();
           refreshAlertPageFilter();
 
-          updateAssigneesForAlert([role]);
+          updateAssigneesForFirstAlert([role]);
 
           // Assignees should appear in the alerts table
           alertsTableShowsAssigneesForAlert([role]);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments_serverless_essentials.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/detection_alerts/assignments/assignments_serverless_essentials.cy.ts
@@ -15,7 +15,7 @@ import { ALERTS_URL } from '../../../../../urls/navigation';
 import { waitForAlertsToPopulate } from '../../../../../tasks/create_new_rule';
 import {
   alertsTableShowsAssigneesForAlert,
-  updateAssigneesForAlert,
+  updateAssigneesForFirstAlert,
   bulkRemoveAllAssignees,
   loadPageAs,
 } from '../../../../../tasks/alert_assignments';
@@ -78,7 +78,7 @@ describe.skip(
           bulkRemoveAllAssignees();
           refreshAlertPageFilter();
 
-          updateAssigneesForAlert([role]);
+          updateAssigneesForFirstAlert([role]);
 
           // Assignees should appear in the alerts table
           alertsTableShowsAssigneesForAlert([role]);

--- a/x-pack/test/security_solution_cypress/cypress/tasks/alert_assignments.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/alert_assignments.ts
@@ -27,7 +27,7 @@ import {
 } from '../screens/alerts';
 import { PAGE_TITLE } from '../screens/common/page';
 import { DOCUMENT_DETAILS_FLYOUT_HEADER_ASSIGNEES } from '../screens/expandable_flyout/alert_details_right_panel';
-import { selectFirstPageAlerts } from './alerts';
+import { expandFirstAlertActions, selectFirstPageAlerts } from './alerts';
 import { login } from './login';
 import { visitWithTimeRange } from './navigation';
 
@@ -56,8 +56,8 @@ export const loadPageAs = (url: string, role?: SecurityRoleName) => {
   waitForPageTitleToBeShown();
 };
 
-export const openAlertAssigningActionMenu = (alertIndex = 0) => {
-  cy.get(TIMELINE_CONTEXT_MENU_BTN).eq(alertIndex).click();
+export const openFirstAlertAssigningActionMenu = () => {
+  expandFirstAlertActions();
   cy.get(ALERT_ASSIGN_CONTEXT_MENU_ITEM).click();
 };
 
@@ -93,8 +93,8 @@ export const alertsTableMoreActionsAreNotAvailable = () => {
   cy.get(TIMELINE_CONTEXT_MENU_BTN).should('not.exist');
 };
 
-export const asigneesMenuItemsAreNotAvailable = (alertIndex = 0) => {
-  cy.get(TIMELINE_CONTEXT_MENU_BTN).eq(alertIndex).click();
+export const asigneesMenuItemsAreNotAvailable = () => {
+  expandFirstAlertActions();
   cy.get(ALERT_ASSIGN_CONTEXT_MENU_ITEM).should('not.exist');
   cy.get(ALERT_UNASSIGN_CONTEXT_MENU_ITEM).should('not.exist');
 };
@@ -126,12 +126,9 @@ export const alertsTableShowsAssigneesForAllAlerts = (users: SecurityRoleName[])
   });
 };
 
-export const alertsTableShowsAssigneesBadgeForAlert = (
-  users: SecurityRoleName[],
-  alertIndex = 0
-) => {
+export const alertsTableShowsAssigneesBadgeForFirstAlert = (users: SecurityRoleName[]) => {
   cy.get(ALERT_ASIGNEES_COLUMN)
-    .eq(alertIndex)
+    .first()
     .within(() => {
       cy.get(ALERT_ASSIGNEES_COUNT_BADGE).contains(users.length);
       users.forEach((user) => cy.get(`.euiAvatar${ALERT_USER_AVATAR(user)}`).should('not.exist'));
@@ -166,10 +163,9 @@ export const selectAlertAssignee = (assignee: string) => {
 /**
  * This will update assignees for selected alert
  * @param users The list of assugnees to update. If assignee is not assigned yet it will be assigned, otherwise it will be unassigned
- * @param alertIndex The index of the alert in the alerts table
  */
-export const updateAssigneesForAlert = (users: SecurityRoleName[], alertIndex = 0) => {
-  openAlertAssigningActionMenu(alertIndex);
+export const updateAssigneesForFirstAlert = (users: SecurityRoleName[]) => {
+  openFirstAlertAssigningActionMenu();
   waitForAssigneesToPopulatePopover();
   users.forEach((user) => selectAlertAssignee(user));
   updateAlertAssignees();
@@ -201,8 +197,8 @@ export const bulkUpdateAssignees = (users: SecurityRoleName[]) => {
   cy.get(ALERTS_TABLE_ROW_LOADER).should('not.exist');
 };
 
-export const removeAllAssigneesForAlert = (alertIndex = 0) => {
-  cy.get(TIMELINE_CONTEXT_MENU_BTN).eq(alertIndex).click();
+export const removeAllAssigneesForFirstAlert = () => {
+  expandFirstAlertActions();
   cy.get(ALERT_UNASSIGN_CONTEXT_MENU_ITEM).click();
   cy.get(ALERTS_TABLE_ROW_LOADER).should('not.exist');
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Security Solution][Detections] Flaky alert assignments tests (#173284)](https://github.com/elastic/kibana/pull/173284)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ievgen Sorokopud","email":"ievgen.sorokopud@elastic.co"},"sourceCommit":{"committedDate":"2023-12-13T20:56:12Z","message":"[Security Solution][Detections] Flaky alert assignments tests (#173284)\n\n## Summary\r\n\r\nWith these changes we fix flaky tests caused by the flakiness of the\r\nalert actions button. There is a [`expandFirstAlertActions`\r\nmethod](https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts#L125)\r\nwhich workarounds this issue.\r\n\r\n### Flaky tests:\r\n1. https://github.com/elastic/kibana/issues/172611\r\n2. https://github.com/elastic/kibana/issues/172623\r\n3. https://github.com/elastic/kibana/issues/172663\r\n\r\n### Flaky test runner (100 times)\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4538","sha":"17bc0c9fa2f7a2d5d0f3ff0c71f848686f182373","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team: SecuritySolution","backport:prev-minor","Team:Detection Engine","v8.13.0"],"number":173284,"url":"https://github.com/elastic/kibana/pull/173284","mergeCommit":{"message":"[Security Solution][Detections] Flaky alert assignments tests (#173284)\n\n## Summary\r\n\r\nWith these changes we fix flaky tests caused by the flakiness of the\r\nalert actions button. There is a [`expandFirstAlertActions`\r\nmethod](https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts#L125)\r\nwhich workarounds this issue.\r\n\r\n### Flaky tests:\r\n1. https://github.com/elastic/kibana/issues/172611\r\n2. https://github.com/elastic/kibana/issues/172623\r\n3. https://github.com/elastic/kibana/issues/172663\r\n\r\n### Flaky test runner (100 times)\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4538","sha":"17bc0c9fa2f7a2d5d0f3ff0c71f848686f182373"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173284","number":173284,"mergeCommit":{"message":"[Security Solution][Detections] Flaky alert assignments tests (#173284)\n\n## Summary\r\n\r\nWith these changes we fix flaky tests caused by the flakiness of the\r\nalert actions button. There is a [`expandFirstAlertActions`\r\nmethod](https://github.com/elastic/kibana/blob/main/x-pack/test/security_solution_cypress/cypress/tasks/alerts.ts#L125)\r\nwhich workarounds this issue.\r\n\r\n### Flaky tests:\r\n1. https://github.com/elastic/kibana/issues/172611\r\n2. https://github.com/elastic/kibana/issues/172623\r\n3. https://github.com/elastic/kibana/issues/172663\r\n\r\n### Flaky test runner (100 times)\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4538","sha":"17bc0c9fa2f7a2d5d0f3ff0c71f848686f182373"}}]}] BACKPORT-->