### PR TITLE
[Security Solution] - alert details expandable flyout table width 50-50 to 30-70

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/highlighted_fields.tsx
@@ -60,7 +60,7 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
       />
     ),
     'data-test-subj': 'fieldCell',
-    width: '50%',
+    width: '30%',
   },
   {
     field: 'description',
@@ -71,7 +71,7 @@ const columns: Array<EuiBasicTableColumn<HighlightedFieldsTableRow>> = [
       />
     ),
     'data-test-subj': 'valueCell',
-    width: '50%',
+    width: '70%',
     render: (description: {
       field: string;
       values: string[] | null | undefined;

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/tabs/table_tab.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/tabs/table_tab.tsx
@@ -47,6 +47,7 @@ export const getColumns: ColumnsProvider = ({
         <strong>{i18n.FIELD}</strong>
       </EuiText>
     ),
+    width: '30%',
     render: (field, data) => {
       return (
         <FieldNameCell data={data as EventFieldsData} field={field} fieldMapping={undefined} />
@@ -60,6 +61,7 @@ export const getColumns: ColumnsProvider = ({
         <strong>{i18n.VALUE}</strong>
       </EuiText>
     ),
+    width: '70%',
     render: (values, data) => {
       const fieldFromBrowserField = getFieldFromBrowserField(
         [data.category as string, 'fields', data.field],


### PR DESCRIPTION
## Summary

This PR makes a very small UI improvement to the alert details expandable flyout table tab and highlighted fields tables. Customers have been asking to change the width of the field and value columns from 50%-50% to 30%-70% in favor of the value column.

#### Overview Highlighted Field table

| Before  | After |
| ------------- | ------------- |
| <img width="703" alt="Screenshot 2023-12-14 at 9 54 35 AM" src="https://github.com/elastic/kibana/assets/17276605/4f120ca9-10e4-426d-9fcc-6c8484ab2e20">  | <img width="702" alt="Screenshot 2023-12-14 at 9 52 38 AM" src="https://github.com/elastic/kibana/assets/17276605/69cd3ec2-f527-4204-a081-c7e822ffa6a8">  |

#### Table tab table

| Before  | After |
| ------------- | ------------- |
| <img width="703" alt="Screenshot 2023-12-14 at 9 54 42 AM" src="https://github.com/elastic/kibana/assets/17276605/a95b4448-504f-42d1-a262-d7ed81b8bd81">  | <img width="703" alt="Screenshot 2023-12-14 at 9 52 28 AM" src="https://github.com/elastic/kibana/assets/17276605/452f33e7-5a58-4a2e-9443-28de00018710">  |


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->