### PR TITLE
[Security Solution] - skipping failing Cypress test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_charts.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_charts.cy.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../screens/search_bar';
 import { TOASTER } from '../../../screens/alerts_detection_rules';
 
-describe(
+describe.skip(
   'Histogram legend hover actions',
   { tags: ['@ess', '@serverless', '@brokenInServerlessQA'] },
   () => {


### PR DESCRIPTION
## Summary

Skipping test as it was failing on main (see https://github.com/elastic/kibana/issues/170520)