### PR TITLE
[Security Solution] Fixes ML Security Job fetch failure when `securitySolution:defaultIndex` contains special characters

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/ml_popover/api.ts
+++ b/x-pack/plugins/security_solution/public/common/components/ml_popover/api.ts
@@ -33,7 +33,7 @@ export const checkRecognizer = async ({
   signal,
 }: CheckRecognizerProps): Promise<RecognizerModule[]> =>
   KibanaServices.get().http.fetch<RecognizerModule[]>(
-    `/internal/ml/modules/recognize/${indexPatternName}`,
+    `/internal/ml/modules/recognize/${indexPatternName.map((i) => encodeURIComponent(i))}`,
     {
       method: 'GET',
       version: '1',
@@ -52,13 +52,16 @@ export const checkRecognizer = async ({
  * @throws An error if response is not OK
  */
 export const getModules = async ({ moduleId = '', signal }: GetModulesProps): Promise<Module[]> =>
-  KibanaServices.get().http.fetch<Module[]>(`/internal/ml/modules/get_module/${moduleId}`, {
-    method: 'GET',
-    version: '1',
-    asSystemRequest: true,
-    signal,
-    query: { filter: 'security' },
-  });
+  KibanaServices.get().http.fetch<Module[]>(
+    `/internal/ml/modules/get_module/${encodeURIComponent(moduleId)}`,
+    {
+      method: 'GET',
+      version: '1',
+      asSystemRequest: true,
+      signal,
+      query: { filter: 'security' },
+    }
+  );
 
 /**
  * Creates ML Jobs + Datafeeds for the given configTemplate + indexPatternName
@@ -79,7 +82,7 @@ export const setupMlJob = async ({
   prefix = '',
 }: MlSetupArgs): Promise<SetupMlResponse> => {
   const response = await KibanaServices.get().http.fetch<SetupMlResponse>(
-    `/internal/ml/modules/setup/${configTemplate}`,
+    `/internal/ml/modules/setup/${encodeURIComponent(configTemplate)}`,
     {
       method: 'POST',
       version: '1',


### PR DESCRIPTION
## Summary

It was reported that some `securitySolution:defaultIndex`'s could result in the Security Job request failing. This was identified to be an issue with the query params not being properly encoded. This PR updates the `ml_popover` api requests to call `encodeURIComponent()` for all variables used within the request URL's.

## Test instructions

Set your `securitySolution:defaultIndex` to be something that includes special characters that wouldn't be encoded in the URL, e.g.:

```
.internal.alerts-security.alerts-siem-, <winlogbeat-{now/d-1d{yyyy.MM.dd}}>, <winlogbeat-{now/d{yyyy.MM.dd}}*>
```

Then navigate to a page that has the `ML job settings` UI (which fetches the Security ML Jobs), and verify that no errors are displayed. You can open the network panel and ensure that the URL params are correctly encoded, and that the request was successful:

<img width="2284" alt="Detection_rules__SIEM__-_Kibana" src="https://github.com/elastic/kibana/assets/2946766/1e7d039d-3248-409b-acf4-e65e67808b4c">


Additionally, enable a job and ensure it enables successfully.


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->