### PR TITLE
[Observability Inspector] Make id unique to capture multiple invocations of the same query

### DIFF
--- a/x-pack/plugins/observability_shared/common/utils/get_inspect_response.ts
+++ b/x-pack/plugins/observability_shared/common/utils/get_inspect_response.ts
@@ -159,7 +159,7 @@ export function getInspectResponse({
   startTime: number;
 }): InspectResponse[0] {
   const name = `${operationName} (${kibanaRequest.route.path})`;
-  const id = `${name} #${uuidv4().slice(0, 5)}`;
+  const id = `${name} ${uuidv4()}`;
 
   return {
     id,

--- a/x-pack/plugins/observability_shared/common/utils/get_inspect_response.ts
+++ b/x-pack/plugins/observability_shared/common/utils/get_inspect_response.ts
@@ -6,6 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
+import { v4 as uuidv4 } from 'uuid';
 import type { KibanaRequest } from '@kbn/core/server';
 import type { RequestStatistics, RequestStatus } from '@kbn/inspector-plugin/common';
 import { Request } from '@kbn/inspector-plugin/common';
@@ -157,12 +158,13 @@ export function getInspectResponse({
   operationName: string;
   startTime: number;
 }): InspectResponse[0] {
-  const id = `${operationName} (${kibanaRequest.route.path})`;
+  const name = `${operationName} (${kibanaRequest.route.path})`;
+  const id = `${name} #${uuidv4().slice(0, 5)}`;
 
   return {
     id,
     json: esRequestParams.body ?? esRequestParams,
-    name: id,
+    name,
     response: {
       json: esError ? esError.originalError : esResponse,
     },

--- a/x-pack/plugins/observability_shared/public/contexts/inspector/inspector_context.tsx
+++ b/x-pack/plugins/observability_shared/public/contexts/inspector/inspector_context.tsx
@@ -49,7 +49,7 @@ export function InspectorContextProvider({ children }: { children: ReactNode }) 
         const requestParams = { id, name };
 
         const requestResponder = inspectorAdapters.requests.start(
-          id,
+          name,
           requestParams,
           operation.startTime
         );


### PR DESCRIPTION
Observability apps that use the inspector functionality can capture Elasticsearch queries and have them show up in the Inspector UI for debugging purposes.

There is one problem: the same id is generated if a query is called multiple times, meaning we can only see one instance of a specific query that might have been called several times. This change makes the id unique. 
This also fixes a bug where we `id` is passed instead of `name`. 

<img width="866" alt="image" src="https://github.com/elastic/kibana/assets/209966/013f0da7-eb0e-4ee4-9d93-1ff26dc9c27a">
