### PR TITLE
Double check conditional to send EBT event on Feedback

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
@@ -140,12 +140,12 @@ export function ChatBody({
     parent.scrollTop + parent.clientHeight >= parent.scrollHeight;
 
   const handleFeedback = (message: Message, feedback: Feedback) => {
-    if (conversation.value?.conversation && 'user' in conversation.value.conversation) {
+    if (conversation.value?.conversation && 'user' in conversation.value) {
       sendEvent(chatService.analytics, {
         type: TELEMETRY.observability_ai_assistant_chat_feedback,
         payload: {
           messageWithFeedback: { message, feedback },
-          conversation: conversation.value.conversation,
+          conversation: conversation.value,
         },
       });
     }


### PR DESCRIPTION
## Summary

A tiny bugfix that allows sending of EBT events when giving feedback on Chats.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->