### PR TITLE
[8.12] [Index Management] Fix index templates flaky tests (#172949)

### DIFF
--- a/src/plugins/es_ui_shared/public/forms/form_wizard/form_wizard.tsx
+++ b/src/plugins/es_ui_shared/public/forms/form_wizard/form_wizard.tsx
@@ -94,6 +94,7 @@ export function FormWizard<T extends object = { [key: string]: any }, S extends 
                 ? 'complete'
                 : 'incomplete') as EuiStepStatus,
               disabled: getIsStepDisabled(index),
+              'data-test-subj': `formWizardStep-${index}`,
               onClick: () => navigateToStep(index),
             };
           });

--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/index_templates.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/index_templates.ts
@@ -13,16 +13,14 @@ import type { WebElementWrapper } from '../../../../../../../test/functional/ser
 export default ({ getPageObjects, getService }: FtrProviderContext) => {
   const pageObjects = getPageObjects(['svlCommonPage', 'common', 'indexManagement', 'header']);
   const browser = getService('browser');
-  const security = getService('security');
   const testSubjects = getService('testSubjects');
   const es = getService('es');
+  const retry = getService('retry');
 
   const TEST_TEMPLATE = 'a_test_template';
 
   describe('Index Templates', function () {
     before(async () => {
-      await security.testUser.setRoles(['index_management_user']);
-      // Navigate to the index management page
       await pageObjects.svlCommonPage.login();
     });
 
@@ -53,7 +51,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       });
 
       after(async () => {
-        await es.indices.deleteIndexTemplate({ name: TEST_TEMPLATE });
+        await es.indices.deleteIndexTemplate({ name: TEST_TEMPLATE }, { ignore: [404] });
       });
 
       it('Displays the test template in the list of templates', async () => {
@@ -77,25 +75,25 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
 
     describe('Create index template', () => {
+      const TEST_TEMPLATE_NAME = `test_template_${Math.random()}`;
+
       after(async () => {
-        await es.indices.deleteIndexTemplate({ name: TEST_TEMPLATE });
+        await es.indices.deleteIndexTemplate({ name: TEST_TEMPLATE_NAME }, { ignore: [404] });
       });
 
       it('Creates index template', async () => {
         await testSubjects.click('createTemplateButton');
 
-        await testSubjects.setValue('nameField', TEST_TEMPLATE);
+        await testSubjects.setValue('nameField', TEST_TEMPLATE_NAME);
         await testSubjects.setValue('indexPatternsField', 'test*');
 
-        // Finish wizard flow
-        await testSubjects.click('nextButton');
-        await testSubjects.click('nextButton');
-        await testSubjects.click('nextButton');
-        await testSubjects.click('nextButton');
-        await testSubjects.click('nextButton');
+        // Click form summary step and then the submit button
+        await testSubjects.click('formWizardStep-5');
         await testSubjects.click('nextButton');
 
-        expect(await testSubjects.getVisibleText('title')).to.contain(TEST_TEMPLATE);
+        await retry.try(async () => {
+          expect(await testSubjects.getVisibleText('stepTitle')).to.contain(TEST_TEMPLATE_NAME);
+        });
       });
     });
   });


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/172831
Closes https://github.com/elastic/kibana/issues/172832

# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Index Management] Fix index templates flaky tests (#172949)](https://github.com/elastic/kibana/pull/172949)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Ignacio Rivas","email":"rivasign@gmail.com"},"sourceCommit":{"committedDate":"2023-12-13T11:24:25Z","message":"[Index Management] Fix index templates flaky tests (#172949)","sha":"a3b4c0a2ce9e90a802ebc2851b5484f3c005a750","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Feature:Index Management","Team:Deployment Management","release_note:skip","backport:skip","v8.13.0"],"number":172949,"url":"https://github.com/elastic/kibana/pull/172949","mergeCommit":{"message":"[Index Management] Fix index templates flaky tests (#172949)","sha":"a3b4c0a2ce9e90a802ebc2851b5484f3c005a750"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/172949","number":172949,"mergeCommit":{"message":"[Index Management] Fix index templates flaky tests (#172949)","sha":"a3b4c0a2ce9e90a802ebc2851b5484f3c005a750"}}]}] BACKPORT-->