### PR TITLE
[ES|QL] Fixes suggestions break due to userMessages

### DIFF
--- a/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/partition/visualization.tsx
@@ -560,14 +560,16 @@ export const getPieVisualization = ({
 
   getUserMessages(state, { frame }) {
     const hasTooManyBucketDimensions = state.layers
-      .map((layer) => {
+      ?.map((layer) => {
+        const primaryGroups = layer?.primaryGroups ?? [];
+        const secondaryGroups = layer?.secondaryGroups ?? [];
         const totalBucketDimensions =
-          Array.from(new Set([...layer.primaryGroups, ...(layer.secondaryGroups ?? [])])).filter(
+          Array.from(new Set([...primaryGroups, ...(secondaryGroups ?? [])])).filter(
             (columnId) => !isCollapsed(columnId, layer)
           ).length +
           // multiple metrics counts as a dimension
-          (layer.metrics.length > 1 ? 1 : 0);
-        return totalBucketDimensions > PartitionChartsMeta[state.shape].maxBuckets;
+          (layer?.metrics?.length > 1 ? 1 : 0);
+        return totalBucketDimensions > PartitionChartsMeta[state.shape]?.maxBuckets;
       })
       .some(Boolean);
 
@@ -597,7 +599,7 @@ export const getPieVisualization = ({
       : [];
 
     const warningMessages: UserMessage[] = [];
-    if (state?.layers.length > 0 && frame.activeData) {
+    if (state?.layers?.length > 0 && frame.activeData) {
       for (const layer of state.layers) {
         const { layerId, metrics } = layer;
         const rows = frame.activeData[layerId]?.rows;
@@ -605,7 +607,7 @@ export const getPieVisualization = ({
           ({ meta }) => meta?.type === 'number'
         );
 
-        if (!rows || !metrics.length) {
+        if (!rows || !metrics?.length) {
           break;
         }
 

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization.tsx
@@ -799,7 +799,7 @@ export const getXyVisualization = ({
       seriesType.includes('percentage') && splitAccessor == null;
 
     // check if the layers in the state are compatible with this type of chart
-    if (state && state.layers.length > 1) {
+    if (state && state?.layers?.length > 1) {
       // Order is important here: Y Axis is fundamental to exist to make it valid
       const checks: Array<[string, (layer: XYDataLayerConfig) => boolean]> = [
         ['Y', hasNoAccessors],
@@ -870,7 +870,7 @@ export const getXyVisualization = ({
 
     const warnings: UserMessage[] = [];
 
-    if (state?.layers.length > 0 && activeData) {
+    if (state?.layers?.length > 0 && activeData) {
       const filteredLayers = [
         ...getDataLayers(state.layers),
         ...getReferenceLayers(state.layers),

--- a/x-pack/plugins/lens/public/visualizations/xy/visualization_helpers.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/visualization_helpers.tsx
@@ -81,7 +81,7 @@ export function checkXAccessorCompatibility(state: XYState, datasourceLayers: Da
   const hasOrdinalAxisIndex = dataLayers.findIndex(
     checkScaleOperation('ordinal', undefined, datasourceLayers)
   );
-  if (state.layers.length > 1) {
+  if (state?.layers?.length > 1) {
     const erroredLayers = [hasDateHistogramSetIndex, hasNumberHistogramIndex, hasOrdinalAxisIndex]
       .filter((v) => v >= 0)
       .sort((a, b) => a - b);


### PR DESCRIPTION
## Summary

I think due to this PR https://github.com/elastic/kibana/pull/172791 clicking the suggestions in ES|QL charts can cause failures on the dimension panel. This PR fixes them

To replicate the bug, create a ES|QL chart like below and start clicking on the suggestions

<img width="2497" alt="image" src="https://github.com/elastic/kibana/assets/17003240/49b6f5ff-679b-46fa-8cb2-cb8920bd287f">
