### PR TITLE
[Enterprise Search] Button typo fix

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -116,7 +116,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
               >
                 {i18n.translate(
                   'xpack.enterpriseSearch.connectors.newConnectorsClientButtonLabel',
-                  { defaultMessage: 'New Connectors Client' }
+                  { defaultMessage: 'New Connector Client' }
                 )}
               </EuiButton>,
             ]


### PR DESCRIPTION
Button uses incorrect plural

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->