### PR TITLE
[8.12][Fleet] Upgrade details telemetry (#173356)

### DIFF
--- a/x-pack/plugins/fleet/server/collectors/agents_per_output.ts
+++ b/x-pack/plugins/fleet/server/collectors/agents_per_output.ts
@@ -61,5 +61,6 @@ export async function getAgentsPerOutput(
       }
       outputTypes[monitoringOutputType].count_as_monitoring += item.agents ?? 0;
     });
+
   return Object.values(outputTypes);
 }

--- a/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
+++ b/x-pack/plugins/fleet/server/integration_tests/fleet_usage_telemetry.test.ts
@@ -146,6 +146,13 @@ describe('fleet usage telemetry', () => {
               status: 'HEALTHY',
             },
           ],
+          upgrade_details: {
+            target_version: '8.12.0',
+            state: 'UPG_FAILED',
+            metadata: {
+              error_msg: 'Download failed',
+            },
+          },
         },
         {
           create: {
@@ -176,6 +183,13 @@ describe('fleet usage telemetry', () => {
               status: 'HEALTHY',
             },
           ],
+          upgrade_details: {
+            target_version: '8.12.0',
+            state: 'UPG_FAILED',
+            metadata: {
+              error_msg: 'Agent crash detected',
+            },
+          },
         },
         {
           create: {
@@ -220,6 +234,11 @@ describe('fleet usage telemetry', () => {
           last_checkin: new Date(Date.now() - 1000 * 60 * 6).toISOString(),
           active: true,
           policy_id: 'policy2',
+          upgrade_details: {
+            target_version: '8.11.0',
+            state: 'UPG_ROLLBACK',
+            metadata: {},
+          },
         },
       ],
       refresh: 'wait_for',
@@ -498,5 +517,24 @@ describe('fleet usage telemetry', () => {
         fleet_server_logs_top_errors: ['failed to unenroll offline agents'],
       })
     );
+    expect(usage?.upgrade_details.length).toBe(3);
+    expect(usage?.upgrade_details).toContainEqual({
+      target_version: '8.12.0',
+      state: 'UPG_FAILED',
+      error_msg: 'Download failed',
+      agent_count: 1,
+    });
+    expect(usage?.upgrade_details).toContainEqual({
+      target_version: '8.12.0',
+      state: 'UPG_FAILED',
+      error_msg: 'Agent crash detected',
+      agent_count: 1,
+    });
+    expect(usage?.upgrade_details).toContainEqual({
+      target_version: '8.11.0',
+      state: 'UPG_ROLLBACK',
+      error_msg: '',
+      agent_count: 1,
+    });
   });
 });

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usage_sender.ts
@@ -24,7 +24,7 @@ const FLEET_AGENTS_EVENT_TYPE = 'fleet_agents';
 
 export class FleetUsageSender {
   private taskManager?: TaskManagerStartContract;
-  private taskVersion = '1.1.3';
+  private taskVersion = '1.1.4';
   private taskType = 'Fleet-Usage-Sender';
   private wasStarted: boolean = false;
   private interval = '1h';
@@ -83,6 +83,7 @@ export class FleetUsageSender {
       const {
         agents_per_version: agentsPerVersion,
         agents_per_output_type: agentsPerOutputType,
+        upgrade_details: upgradeDetails,
         ...fleetUsageData
       } = usageData;
       appContextService
@@ -105,6 +106,13 @@ export class FleetUsageSender {
         core.analytics.reportEvent(FLEET_AGENTS_EVENT_TYPE, {
           agents_per_output_type: byOutputType,
         });
+      });
+
+      appContextService
+        .getLogger()
+        .debug('Agents upgrade details telemetry: ' + JSON.stringify(upgradeDetails));
+      upgradeDetails.forEach((upgradeDetailsObj) => {
+        core.analytics.reportEvent(FLEET_AGENTS_EVENT_TYPE, { upgrade_details: upgradeDetailsObj });
       });
     } catch (error) {
       appContextService

--- a/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
+++ b/x-pack/plugins/fleet/server/services/telemetry/fleet_usages_schema.ts
@@ -90,6 +90,38 @@ export const fleetAgentsSchema: RootSchema<any> = {
       },
     },
   },
+  upgrade_details: {
+    _meta: {
+      description: 'Agent upgrade details telemetry',
+      optional: true,
+    },
+    properties: {
+      target_version: {
+        type: 'keyword',
+        _meta: {
+          description: 'Target version of the agent upgrade',
+        },
+      },
+      state: {
+        type: 'keyword',
+        _meta: {
+          description: 'State of the agent upgrade',
+        },
+      },
+      error_msg: {
+        type: 'keyword',
+        _meta: {
+          description: 'Error message of the agent upgrade if failed',
+        },
+      },
+      agent_count: {
+        type: 'long',
+        _meta: {
+          description: 'How many agents have this upgrade details',
+        },
+      },
+    },
+  },
 };
 
 export const fleetUsagesSchema: RootSchema<any> = {


### PR DESCRIPTION
Backport https://github.com/elastic/kibana/pull/173356

I got a merge conflict on backporting to 8.12, because the presets telemetry was not backportet, is that intentional? https://github.com/elastic/kibana/pull/172838