### PR TITLE
[ES|QL] Reverts getUserMessages function in inline editing flyout

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
@@ -26,7 +26,6 @@ export function LayerConfiguration({
   framePublicAPI,
   hasPadding,
   setIsInlineFlyoutVisible,
-  getUserMessages,
 }: LayerConfigurationProps) {
   const dispatch = useLensDispatch();
   const { euiTheme } = useEuiTheme();
@@ -59,7 +58,6 @@ export function LayerConfiguration({
     hideLayerHeader: datasourceId === 'textBased',
     indexPatternService,
     setIsInlineFlyoutVisible,
-    getUserMessages,
   };
   return (
     <div

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -40,7 +40,6 @@ import type { EditConfigPanelProps } from './types';
 import { FlyoutWrapper } from './flyout_wrapper';
 import { getSuggestions } from './helpers';
 import { SuggestionPanel } from '../../../editor_frame_service/editor_frame/suggestion_panel';
-import { useApplicationUserMessages } from '../../get_application_user_messages';
 
 export function LensEditConfigurationFlyout({
   attributes,
@@ -221,17 +220,17 @@ export function LensEditConfigurationFlyout({
     datasourceMap,
   ]);
 
-  const { getUserMessages } = useApplicationUserMessages({
-    coreStart,
-    framePublicAPI,
-    activeDatasourceId: datasourceId,
-    datasourceState: datasourceStates[datasourceId],
-    datasource: datasourceMap[datasourceId],
-    dispatch,
-    visualization: activeVisualization,
-    visualizationType: visualization.activeId,
-    visualizationState: visualization,
-  });
+  // const { getUserMessages } = useApplicationUserMessages({
+  //   coreStart,
+  //   framePublicAPI,
+  //   activeDatasourceId: datasourceId,
+  //   datasourceState: datasourceStates[datasourceId],
+  //   datasource: datasourceMap[datasourceId],
+  //   dispatch,
+  //   visualization: activeVisualization,
+  //   visualizationType: visualization.activeId,
+  //   visualizationState: visualization,
+  // });
 
   // needed for text based languages mode which works ONLY with adHoc dataviews
   const adHocDataViews = Object.values(attributes.state.adHocDataViews ?? {});
@@ -278,7 +277,6 @@ export function LensEditConfigurationFlyout({
         attributesChanged={attributesChanged}
       >
         <LayerConfiguration
-          getUserMessages={getUserMessages}
           attributes={attributes}
           coreStart={coreStart}
           startDependencies={startDependencies}
@@ -408,7 +406,6 @@ export function LensEditConfigurationFlyout({
             >
               <LayerConfiguration
                 attributes={attributes}
-                getUserMessages={getUserMessages}
                 coreStart={coreStart}
                 startDependencies={startDependencies}
                 visualizationMap={visualizationMap}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
@@ -8,12 +8,7 @@ import type { Observable } from 'rxjs';
 import type { CoreStart } from '@kbn/core/public';
 import type { TypedLensByValueInput } from '../../../embeddable/embeddable_component';
 import type { LensPluginStartDependencies } from '../../../plugin';
-import type {
-  DatasourceMap,
-  VisualizationMap,
-  FramePublicAPI,
-  UserMessagesGetter,
-} from '../../../types';
+import type { DatasourceMap, VisualizationMap, FramePublicAPI } from '../../../types';
 import type { LensEmbeddableOutput } from '../../../embeddable';
 import type { LensInspector } from '../../../lens_inspector_service';
 import type { Document } from '../../../persistence';
@@ -87,5 +82,4 @@ export interface LayerConfigurationProps {
   framePublicAPI: FramePublicAPI;
   hasPadding?: boolean;
   setIsInlineFlyoutVisible: (flag: boolean) => void;
-  getUserMessages: UserMessagesGetter;
 }


### PR DESCRIPTION
## Summary

Reverts https://github.com/elastic/kibana/pull/172791

This is causing the getUserMessages to run for every suggested visualization but their state is not the same. For example heatmap doesnt expect layers but partition does. This is causing the getUserMessages to fail because if I select a heatmap suggestion (no layers) the getUserMessages for partition will run (without layers, while this is required) and the inline flyout will fail
