### PR TITLE
[Obs ai assistant] Uses eui scrollbar styles

### DIFF
--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -22,6 +22,8 @@ import {
   EuiAccordion,
   EuiText,
   EuiNotificationBadge,
+  euiScrollBarStyles,
+  useEuiTheme,
 } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { IconType } from '@elastic/eui/src/components/icon/icon';

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -22,8 +22,6 @@ import {
   EuiAccordion,
   EuiText,
   EuiNotificationBadge,
-  euiScrollBarStyles,
-  useEuiTheme,
 } from '@elastic/eui';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { IconType } from '@elastic/eui/src/components/icon/icon';

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
@@ -14,6 +14,8 @@ import {
   EuiHorizontalRule,
   EuiPanel,
   EuiSpacer,
+  useEuiTheme,
+  euiScrollBarStyles,
 } from '@elastic/eui';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { euiThemeVars } from '@kbn/ui-theme';
@@ -40,8 +42,9 @@ const fullHeightClassName = css`
   height: 100%;
 `;
 
-const timelineClassName = css`
+const timelineClassName = (scrollBarStyles: string) => css`
   overflow-y: auto;
+  ${scrollBarStyles}
 `;
 
 const promptEditorClassname = css`
@@ -104,6 +107,8 @@ export function ChatBody({
 }) {
   const license = useLicense();
   const hasCorrectLicense = license?.hasAtLeast('enterprise');
+  const euiTheme = useEuiTheme();
+  const scrollBarStyles = euiScrollBarStyles(euiTheme);
 
   const chatService = useObservabilityAIAssistantChatService();
 
@@ -217,7 +222,7 @@ export function ChatBody({
   } else {
     footer = (
       <>
-        <EuiFlexItem grow className={timelineClassName}>
+        <EuiFlexItem grow className={timelineClassName(scrollBarStyles)}>
           <div ref={timelineContainerRef} className={fullHeightClassName}>
             <EuiPanel
               grow

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/conversation_list.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/conversation_list.tsx
@@ -16,6 +16,8 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  useEuiTheme,
+  euiScrollBarStyles,
 } from '@elastic/eui';
 import { css } from '@emotion/css';
 import { i18n } from '@kbn/i18n';
@@ -33,8 +35,9 @@ const panelClassName = css`
   max-height: 100%;
 `;
 
-const overflowScrollClassName = css`
+const overflowScrollClassName = (scrollBarStyles: string) => css`
   overflow-y: auto;
+  ${scrollBarStyles}
 `;
 
 const newChatButtonWrapperClassName = css`
@@ -56,10 +59,12 @@ export function ConversationList({
   onClickNewChat: () => void;
   onClickDeleteConversation: (id: string) => void;
 }) {
+  const euiTheme = useEuiTheme();
+  const scrollBarStyles = euiScrollBarStyles(euiTheme);
   return (
     <EuiPanel paddingSize="s" hasShadow={false} className={panelClassName}>
       <EuiFlexGroup direction="column" gutterSize="none" className={containerClassName}>
-        <EuiFlexItem grow className={overflowScrollClassName}>
+        <EuiFlexItem grow className={overflowScrollClassName(scrollBarStyles)}>
           <EuiFlexGroup direction="column" gutterSize="xs">
             <EuiFlexItem grow={false}>
               <EuiPanel hasBorder={false} hasShadow={false} paddingSize="s">


### PR DESCRIPTION
## Summary

Elegance is everything. 💅 

This PR uses the eui scrollbar styles to align the scrollbar with the rest of kibana. Right now the scrollbars look differently in some machines. 

One example:
![image (24)](https://github.com/elastic/kibana/assets/17003240/cb5bf061-b82f-4d37-a40c-a42f27d71fb0)

But now with this PR we have the same scrollbars as in other places (for example check the kibana sidebar scrollbar):

<img width="2016" alt="image" src="https://github.com/elastic/kibana/assets/17003240/c7cb2a8f-b369-43f2-8bc2-9fe04e35feff">
