### PR TITLE
[Lens] Fix crash on chart type change via suggestions

### DIFF
--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -72,11 +72,13 @@ export function LensEditConfigurationFlyout({
   const [isLayerAccordionOpen, setIsLayerAccordionOpen] = useState(true);
   const [isSuggestionsAccordionOpen, setIsSuggestionsAccordionOpen] = useState(false);
   const datasourceState = attributes.state.datasourceStates[datasourceId];
-  const activeVisualization = visualizationMap[attributes.visualizationType];
   const activeDatasource = datasourceMap[datasourceId];
   const { datasourceStates, visualization, isLoading, annotationGroups } = useLensSelector(
     (state) => state.lens
   );
+  // use the latest activeId, but fallback to attributes
+  const activeVisualization =
+    visualizationMap[visualization.activeId ?? attributes.visualizationType];
   const framePublicAPI = useLensSelector((state) => selectFramePublicAPI(state, datasourceMap));
   const suggestsLimitedColumns = activeDatasource?.suggestsLimitedColumns?.(datasourceState);
 

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/suggestion_panel.tsx
@@ -270,14 +270,13 @@ export function SuggestionPanel({
   const framePublicAPI = useLensSelector((state) => selectFramePublicAPI(state, datasourceMap));
   const changesApplied = useLensSelector(selectChangesApplied);
   // get user's selection from localStorage, this key defines if the suggestions panel will be hidden or not
-  const initialAccordionStatusValue =
-    typeof isAccordionOpen !== 'undefined' ? !Boolean(isAccordionOpen) : false;
+  const initialAccordionStatusValue = isAccordionOpen != null ? !Boolean(isAccordionOpen) : false;
   const [hideSuggestions, setHideSuggestions] = useLocalStorage(
     LOCAL_STORAGE_SUGGESTIONS_PANEL,
     initialAccordionStatusValue
   );
   useEffect(() => {
-    if (typeof isAccordionOpen !== 'undefined') {
+    if (isAccordionOpen != null) {
       setHideSuggestions(!Boolean(isAccordionOpen));
     }
   }, [isAccordionOpen, setHideSuggestions]);


### PR DESCRIPTION
## Summary

Use the correct `activeVisualization` on chart type change by suggestions:

![esql_dashboard_crash_fixed](https://github.com/elastic/kibana/assets/924948/6142647f-6a74-4f95-8ebb-df984624b596)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->