### PR TITLE
[Onboarding] Cards Redesign Stage 2

### DIFF
--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_card.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_card.tsx
@@ -137,8 +137,7 @@ export const GuideCard = ({
   const progress = getProgressLabel(guideState);
 
   const cardCss = css`
-    position: relative;
-    height: 125px;
+    height: 75px;
     width: 380px;
     .euiCard__top {
       margin-block-end: 8px;
@@ -149,7 +148,7 @@ export const GuideCard = ({
     }
     @media (min-width: 768px) and (max-width: 1210px) {
       max-width: 230px;
-      height: 175px;
+      height: 75px;
       justify-content: center;
     }
   `;
@@ -163,9 +162,10 @@ export const GuideCard = ({
       css={cardCss}
       display={isHighlighted ? undefined : 'transparent'}
       hasBorder={!isHighlighted}
-      title={<h3 style={{ fontWeight: 600 }}>{card.title}</h3>}
+      title={<h3 style={{ fontWeight: 500 }}>{card.title}</h3>}
       titleSize="xs"
-      icon={<EuiIcon size="l" type={card.icon} />}
+      icon={<EuiIcon size="xl" type={card.icon} />}
+      layout="horizontal"
       description={
         <>
           {progress && (

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.constants.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.constants.tsx
@@ -73,9 +73,9 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'search',
-    icon: 'magnifyWithPlus',
+    icon: 'searchProfilerApp',
     title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.aiSearch.title', {
-      defaultMessage: 'Build an AI-powered search experience',
+      defaultMessage: 'Build a semantic search experience',
     }),
     navigateTo: {
       appId: 'enterpriseSearchAISearch',
@@ -85,7 +85,7 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'search',
-    icon: 'wrench',
+    icon: 'consoleApp',
     title: (
       <FormattedMessage
         id="guidedOnboardingPackage.gettingStarted.cards.appSearch.title"
@@ -123,7 +123,7 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'observability',
-    icon: 'apmTrace',
+    icon: 'watchesApp',
     title: (
       <FormattedMessage
         id="guidedOnboardingPackage.gettingStarted.cards.apmObservability.title"
@@ -142,7 +142,7 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'observability',
-    icon: 'visBarVertical',
+    icon: 'sqlApp',
     title: i18n.translate('guidedOnboardingPackage.gettingStarted.cards.hostsObservability.title', {
       defaultMessage: 'Monitor my host metrics',
     }),
@@ -155,7 +155,7 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'observability',
-    icon: 'cluster',
+    icon: 'dataVisualizer',
     title: i18n.translate(
       'guidedOnboardingPackage.gettingStarted.cards.kubernetesObservability.title',
       {
@@ -168,7 +168,7 @@ export const guideCards: GuideCardConstants[] = [
   },
   {
     solution: 'observability',
-    icon: 'videoPlayer',
+    icon: 'packetbeatApp',
     title: i18n.translate(
       'guidedOnboardingPackage.gettingStarted.cards.syntheticsObservability.title',
       {
@@ -249,5 +249,18 @@ export const guideCards: GuideCardConstants[] = [
     },
     telemetryId: 'onboarding--security--cloud',
     order: 9,
+  },
+  {
+    solution: 'search',
+    title: (
+      <FormattedMessage
+        id="guidedOnboardingPackage.gettingStarted.cards.search.skip"
+        defaultMessage="Something else..."
+        values={{
+          lineBreak: <br />,
+        }}
+      />
+    ),
+    order: 13,
   },
 ].sort((cardA, cardB) => cardA.order - cardB.order) as GuideCardConstants[];

--- a/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.tsx
+++ b/packages/kbn-guided-onboarding/src/components/landing_page/guide/guide_cards.tsx
@@ -42,7 +42,7 @@ export interface GuideCardsProps {
 export const GuideCards = (props: GuideCardsProps) => {
   const { filteredCards } = props;
   return (
-    <EuiFlexGroup wrap alignItems="center" justifyContent="center">
+    <EuiFlexGroup wrap alignItems="center" justifyContent="center" direction="column">
       {filteredCards?.map((card, index) => (
         <EuiFlexItem key={index}>
           <GuideCard card={card} {...props} />

--- a/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
+++ b/src/plugins/home/public/application/components/guided_onboarding/getting_started.tsx
@@ -10,7 +10,6 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { parse } from 'query-string';
 import {
   EuiButton,
-  EuiLink,
   EuiLoadingSpinner,
   EuiPageTemplate,
   EuiSpacer,
@@ -45,12 +44,6 @@ const gettingStartedBreadcrumb = i18n.translate('home.breadcrumbs.gettingStarted
 });
 const title = i18n.translate('home.guidedOnboarding.gettingStarted.useCaseSelectionTitle', {
   defaultMessage: 'What would you like to do first?',
-});
-const subtitle = i18n.translate('home.guidedOnboarding.gettingStarted.useCaseSelectionSubtitle', {
-  defaultMessage: `Filter by solution to see related use cases`,
-});
-const skipText = i18n.translate('home.guidedOnboarding.gettingStarted.skip.buttonLabel', {
-  defaultMessage: `I’d like to explore on my own.`,
 });
 
 export const GettingStarted = () => {
@@ -128,16 +121,6 @@ export const GettingStarted = () => {
     localStorage.setItem(KEY_ENABLE_WELCOME, JSON.stringify(false));
   }, []);
 
-  const onSkip = async () => {
-    try {
-      await guidedOnboardingService?.skipGuidedOnboarding();
-    } catch (error) {
-      // if the state update fails, it's safe to ignore the error
-    }
-    trackUiMetric(METRIC_TYPE.CLICK, 'guided_onboarding__skipped');
-    application.navigateToApp('home');
-  };
-
   const activateGuide = useCallback(
     async (guideId: GuideId, guideState?: GuideState) => {
       try {
@@ -164,7 +147,7 @@ export const GettingStarted = () => {
   if (isLoading) {
     return (
       <KibanaPageTemplate.EmptyPrompt
-        title={<EuiLoadingSpinner size="xl" />}
+        title={<EuiLoadingSpinner size="l" />}
         body={
           <EuiText color="subdued">
             {i18n.translate('home.guidedOnboarding.gettingStarted.loadingIndicator', {
@@ -262,20 +245,11 @@ export const GettingStarted = () => {
           <h1>{title}</h1>
         </EuiTitle>
         <EuiSpacer size="l" />
-        <EuiText size="m" textAlign="center">
-          <p>{subtitle}</p>
-        </EuiText>
         <EuiSpacer size="l" />
         {setGuideFilters}
         <EuiSpacer size="xxl" />
         {setGuideCards}
         <EuiSpacer size="xxl" />
-        <div className="eui-textCenter">
-          {/* data-test-subj used for FS tracking */}
-          <EuiLink onClick={onSkip} data-test-subj="onboarding--skipGuideLink">
-            {skipText}
-          </EuiLink>
-        </div>
       </EuiPageTemplate.Section>
     </KibanaPageTemplate>
   );


### PR DESCRIPTION
## Summary

This PR continues the work implemented in https://github.com/elastic/kibana/pull/171586

Design is subject to change in [Figma](https://www.figma.com/file/RK76YsiCH3TXTh34HR5iZY/GO-v2?type=design&node-id=122-698&mode=design&t=YiqU5OJFKDJnwMfY-0)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


