### PR TITLE
[Dataset quality] using euiHealth instead of EuiIcon

### DIFF
--- a/x-pack/plugins/dataset_quality/public/components/dataset_quality/columns.tsx
+++ b/x-pack/plugins/dataset_quality/public/components/dataset_quality/columns.tsx
@@ -14,7 +14,6 @@ import {
   EuiFlexItem,
   EuiIcon,
   EuiSkeletonRectangle,
-  EuiText,
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -65,22 +64,19 @@ const degradedDocsColumnTooltip = (
       visualQueue: (
         <EuiFlexGroup direction="column" gutterSize="xs">
           <EuiFlexItem>
-            <EuiText>
-              <QualityIndicator quality="poor" />
-              {` ${degradedDocsDescription(POOR_QUALITY_MINIMUM_PERCENTAGE)}`}
-            </EuiText>
+            <QualityIndicator
+              quality="poor"
+              description={` ${degradedDocsDescription(POOR_QUALITY_MINIMUM_PERCENTAGE)}`}
+            />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText>
-              <QualityIndicator quality="degraded" />
-              {` ${degradedDocsDescription(DEGRADED_QUALITY_MINIMUM_PERCENTAGE)}`}
-            </EuiText>
+            <QualityIndicator
+              quality="degraded"
+              description={` ${degradedDocsDescription(DEGRADED_QUALITY_MINIMUM_PERCENTAGE)}`}
+            />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiText>
-              <QualityIndicator quality="good" />
-              {' 0%'}
-            </EuiText>
+            <QualityIndicator quality="good" description={' 0%'} />
           </EuiFlexItem>
         </EuiFlexGroup>
       ),
@@ -160,10 +156,7 @@ export const getDatasetQualitTableColumns = ({
           contentAriaLabel="Example description"
         >
           <EuiFlexGroup alignItems="center" gutterSize="s">
-            <EuiFlexItem grow={false}>
-              <QualityPercentageIndicator percentage={dataStreamStat.degradedDocs} />
-            </EuiFlexItem>
-            <EuiFlexItem grow={false}>{`${dataStreamStat.degradedDocs ?? 0}%`}</EuiFlexItem>
+            <QualityPercentageIndicator percentage={dataStreamStat.degradedDocs} />
           </EuiFlexGroup>
         </EuiSkeletonRectangle>
       ),

--- a/x-pack/plugins/dataset_quality/public/components/quality_indicator/indicator.tsx
+++ b/x-pack/plugins/dataset_quality/public/components/quality_indicator/indicator.tsx
@@ -5,17 +5,21 @@
  * 2.0.
  */
 
-import { EuiIcon, useEuiTheme } from '@elastic/eui';
-import React from 'react';
+import { EuiHealth } from '@elastic/eui';
+import React, { ReactNode } from 'react';
 
-export function QualityIndicator({ quality }: { quality: 'good' | 'degraded' | 'poor' }) {
-  const { euiTheme } = useEuiTheme();
-
+export function QualityIndicator({
+  quality,
+  description,
+}: {
+  quality: 'good' | 'degraded' | 'poor';
+  description: string | ReactNode;
+}) {
   const qualityColors = {
-    poor: euiTheme.colors.dangerText,
-    degraded: euiTheme.colors.warningText,
-    good: euiTheme.colors.successText,
+    poor: 'danger',
+    degraded: 'warning',
+    good: 'success',
   };
 
-  return <EuiIcon type="dot" color={qualityColors[quality]} />;
+  return <EuiHealth color={qualityColors[quality]}>{description}</EuiHealth>;
 }

--- a/x-pack/plugins/dataset_quality/public/components/quality_indicator/percentage_indicator.tsx
+++ b/x-pack/plugins/dataset_quality/public/components/quality_indicator/percentage_indicator.tsx
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { EuiText } from '@elastic/eui';
+import { FormattedNumber } from '@kbn/i18n-react';
 import React from 'react';
 import {
   DEGRADED_QUALITY_MINIMUM_PERCENTAGE,
@@ -20,5 +22,11 @@ export function QualityPercentageIndicator({ percentage = 0 }: { percentage?: nu
       ? 'degraded'
       : 'good';
 
-  return <QualityIndicator quality={quality} />;
+  const description = (
+    <EuiText>
+      <FormattedNumber value={percentage} />%
+    </EuiText>
+  );
+
+  return <QualityIndicator quality={quality} description={description} />;
 }


### PR DESCRIPTION
This PR focuses on using [EuiHealth](https://eui.elastic.co/#/display/health) component instead of using `EuiIcon` with `type=dot` and custom colors.

Visually this PR doesn't change anything in the page, however I'm placing bellow a small video with the latests changes

https://github.com/elastic/kibana/assets/1313018/5adca4e4-5670-4a9f-bd54-123bb70e2eec

