### PR TITLE
feat(slo): Add groupBy and instanceId in filter when redirecting to apm

### DIFF
--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
@@ -81,6 +81,8 @@ export function HeaderControl({ isLoading, slo }: Props) {
           params: { environment, filter, service, transactionName, transactionType },
         },
         timeWindow: { duration },
+        groupBy,
+        instanceId,
       } = slo;
 
       const url = convertSliApmParamsToApmAppDeeplinkUrl({
@@ -90,6 +92,8 @@ export function HeaderControl({ isLoading, slo }: Props) {
         service,
         transactionName,
         transactionType,
+        groupBy,
+        instanceId,
       });
 
       navigate(basePath.prepend(url));

--- a/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/header_control.tsx
@@ -5,22 +5,22 @@
  * 2.0.
  */
 
-import React, { useCallback, useState } from 'react';
-import { i18n } from '@kbn/i18n';
 import { EuiButton, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
 import { SLOWithSummaryResponse } from '@kbn/slo-schema';
+import React, { useCallback, useState } from 'react';
 
-import { useCloneSlo } from '../../../hooks/slo/use_clone_slo';
+import { rulesLocatorID, sloFeatureId } from '../../../../common';
+import { SLO_BURN_RATE_RULE_TYPE_ID } from '../../../../common/constants';
+import { paths } from '../../../../common/locators/paths';
 import { SloDeleteConfirmationModal } from '../../../components/slo/delete_confirmation_modal/slo_delete_confirmation_modal';
 import { useCapabilities } from '../../../hooks/slo/use_capabilities';
-import { useKibana } from '../../../utils/kibana_react';
+import { useCloneSlo } from '../../../hooks/slo/use_clone_slo';
 import { useDeleteSlo } from '../../../hooks/slo/use_delete_slo';
-import { isApmIndicatorType } from '../../../utils/slo/indicator';
-import { convertSliApmParamsToApmAppDeeplinkUrl } from '../../../utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url';
-import { SLO_BURN_RATE_RULE_TYPE_ID } from '../../../../common/constants';
-import { rulesLocatorID, sloFeatureId } from '../../../../common';
-import { paths } from '../../../../common/locators/paths';
 import type { RulesParams } from '../../../locators/rules';
+import { useKibana } from '../../../utils/kibana_react';
+import { convertSliApmParamsToApmAppDeeplinkUrl } from '../../../utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url';
+import { isApmIndicatorType } from '../../../utils/slo/indicator';
 
 export interface Props {
   slo: SLOWithSummaryResponse | undefined;
@@ -72,31 +72,13 @@ export function HeaderControl({ isLoading, slo }: Props) {
   };
 
   const handleNavigateToApm = () => {
-    if (
-      slo?.indicator.type === 'sli.apm.transactionDuration' ||
-      slo?.indicator.type === 'sli.apm.transactionErrorRate'
-    ) {
-      const {
-        indicator: {
-          params: { environment, filter, service, transactionName, transactionType },
-        },
-        timeWindow: { duration },
-        groupBy,
-        instanceId,
-      } = slo;
+    if (!slo) {
+      return undefined;
+    }
 
-      const url = convertSliApmParamsToApmAppDeeplinkUrl({
-        duration,
-        environment,
-        filter,
-        service,
-        transactionName,
-        transactionType,
-        groupBy,
-        instanceId,
-      });
-
-      navigate(basePath.prepend(url));
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(slo);
+    if (url) {
+      navigateToUrl(basePath.prepend(url));
     }
   };
 
@@ -193,7 +175,7 @@ export function HeaderControl({ isLoading, slo }: Props) {
             </EuiContextMenuItem>,
           ]
             .concat(
-              !!slo && isApmIndicatorType(slo.indicator.type) ? (
+              !!slo && isApmIndicatorType(slo.indicator) ? (
                 <EuiContextMenuItem
                   key="exploreInApm"
                   icon="bullseye"

--- a/x-pack/plugins/observability/public/pages/slo_details/components/overview/apm_indicator_overview.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/overview/apm_indicator_overview.tsx
@@ -9,8 +9,9 @@ import { EuiBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import {
   ALL_VALUE,
-  APMTransactionDurationIndicator,
-  APMTransactionErrorRateIndicator,
+  apmTransactionDurationIndicatorSchema,
+  apmTransactionErrorRateIndicatorSchema,
+  SLOWithSummaryResponse,
 } from '@kbn/slo-schema';
 import React from 'react';
 import { useKibana } from '../../../../utils/kibana_react';
@@ -18,24 +19,30 @@ import { convertSliApmParamsToApmAppDeeplinkUrl } from '../../../../utils/slo/co
 import { OverviewItem } from './overview_item';
 
 interface Props {
-  indicator: APMTransactionDurationIndicator | APMTransactionErrorRateIndicator;
+  slo: SLOWithSummaryResponse;
 }
 
-export function ApmIndicatorOverview({ indicator }: Props) {
+export function ApmIndicatorOverview({ slo }: Props) {
   const {
     http: { basePath },
   } = useKibana().services;
-  const { service, transactionType, transactionName, environment, filter } = indicator.params;
 
-  const link = basePath.prepend(
-    convertSliApmParamsToApmAppDeeplinkUrl({
-      environment,
-      filter,
-      service,
-      transactionName,
-      transactionType,
-    })
-  );
+  const indicator = slo.indicator;
+  if (
+    !apmTransactionDurationIndicatorSchema.is(indicator) ||
+    !apmTransactionErrorRateIndicatorSchema.is(indicator)
+  ) {
+    return null;
+  }
+
+  const url = convertSliApmParamsToApmAppDeeplinkUrl(slo);
+  if (!url) {
+    return null;
+  }
+  const link = basePath.prepend(url);
+  const {
+    params: { environment, service, transactionName, transactionType },
+  } = indicator;
 
   return (
     <OverviewItem

--- a/x-pack/plugins/observability/public/pages/slo_details/components/overview/overview.tsx
+++ b/x-pack/plugins/observability/public/pages/slo_details/components/overview/overview.tsx
@@ -48,7 +48,7 @@ export function Overview({ slo }: Props) {
   switch (slo.indicator.type) {
     case 'sli.apm.transactionDuration':
     case 'sli.apm.transactionErrorRate':
-      IndicatorOverview = <ApmIndicatorOverview indicator={slo.indicator} />;
+      IndicatorOverview = <ApmIndicatorOverview slo={slo} />;
       break;
   }
 

--- a/x-pack/plugins/observability/public/pages/slos/components/badges/slo_indicator_type_badge.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/badges/slo_indicator_type_badge.tsx
@@ -5,14 +5,18 @@
  * 2.0.
  */
 
-import React from 'react';
-import { EuiBadge, EuiFlexItem, EuiToolTip, EuiBadgeProps } from '@elastic/eui';
-import { SLOResponse, SLOWithSummaryResponse } from '@kbn/slo-schema';
-import { euiLightVars } from '@kbn/ui-theme';
+import { EuiBadge, EuiBadgeProps, EuiFlexItem, EuiToolTip } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import {
+  apmTransactionDurationIndicatorSchema,
+  apmTransactionErrorRateIndicatorSchema,
+  SLOResponse,
+  SLOWithSummaryResponse,
+} from '@kbn/slo-schema';
+import { euiLightVars } from '@kbn/ui-theme';
+import React from 'react';
 import { useKibana } from '../../../../utils/kibana_react';
 import { convertSliApmParamsToApmAppDeeplinkUrl } from '../../../../utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url';
-import { isApmIndicatorType } from '../../../../utils/slo/indicator';
 import { toIndicatorTypeLabel } from '../../../../utils/slo/labels';
 
 export interface Props {
@@ -27,26 +31,8 @@ export function SloIndicatorTypeBadge({ slo, color }: Props) {
   } = useKibana().services;
 
   const handleNavigateToApm = () => {
-    if (
-      slo.indicator.type === 'sli.apm.transactionDuration' ||
-      slo.indicator.type === 'sli.apm.transactionErrorRate'
-    ) {
-      const {
-        indicator: {
-          params: { environment, filter, service, transactionName, transactionType },
-        },
-        timeWindow: { duration },
-      } = slo;
-
-      const url = convertSliApmParamsToApmAppDeeplinkUrl({
-        duration,
-        environment,
-        filter,
-        service,
-        transactionName,
-        transactionType,
-      });
-
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(slo);
+    if (url) {
       navigateToUrl(basePath.prepend(url));
     }
   };
@@ -58,7 +44,8 @@ export function SloIndicatorTypeBadge({ slo, color }: Props) {
           {toIndicatorTypeLabel(slo.indicator.type)}
         </EuiBadge>
       </EuiFlexItem>
-      {isApmIndicatorType(slo.indicator.type) && 'service' in slo.indicator.params && (
+      {(apmTransactionDurationIndicatorSchema.is(slo.indicator) ||
+        apmTransactionErrorRateIndicatorSchema.is(slo.indicator)) && (
         <EuiFlexItem grow={false} style={{ maxWidth: 100 }}>
           <EuiToolTip
             position="top"

--- a/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
+++ b/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
@@ -6,99 +6,102 @@
  */
 
 import { convertSliApmParamsToApmAppDeeplinkUrl } from './convert_sli_apm_params_to_apm_app_deeplink_url';
+import { buildSlo } from '../../data/slo/slo';
+import { buildApmLatencyIndicator } from '../../data/slo/indicator';
+import { ALL_VALUE } from '@kbn/slo-schema';
 
-const SLI_APM_PARAMS = {
-  duration: '30-d',
+const DEFAULT_PARAMS = {
   environment: 'fooEnvironment',
   filter: 'agent.name : "beats" and agent.version : 3.4.12 ',
   service: 'barService',
   transactionName: 'bazName',
   transactionType: 'blarfType',
-  groupBy: '*',
 };
 
 describe('convertSliApmParamsToApmAppDeeplinkUrl', () => {
   it('should return a correct APM deeplink when all params have a value', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl(SLI_APM_PARAMS);
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator(DEFAULT_PARAMS),
+      })
+    );
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
     );
   });
 
-  it('should return a correct APM deeplink when empty duration is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      duration: '',
-    });
-
-    expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+  it('should return a correct APM deeplink when all environment is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator({ ...DEFAULT_PARAMS, environment: ALL_VALUE }),
+      })
     );
-  });
-
-  it('should return a correct APM deeplink when empty environment is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      environment: '',
-    });
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=ENVIRONMENT_ALL&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
     );
   });
 
   it('should return a correct APM deeplink when empty filter is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      filter: '',
-    });
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator({ ...DEFAULT_PARAMS, filter: '' }),
+      })
+    );
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22"`
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22"`
     );
   });
 
-  it('should return an empty string if an empty service is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      service: '',
-    });
-
-    expect(url).toMatchInlineSnapshot(`""`);
-  });
-
-  it('should return a correct APM deeplink when empty transactionName is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      transactionName: '',
-    });
+  it('should return an empty string if all service is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator({ ...DEFAULT_PARAMS, service: ALL_VALUE }),
+      })
+    );
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+      `"/app/apm/services/*/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
     );
   });
 
-  it('should return a correct APM deeplink when empty transactionType is passed', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      transactionType: '',
-    });
+  it('should return a correct APM deeplink when all transactionName is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator({ ...DEFAULT_PARAMS, transactionName: ALL_VALUE }),
+      })
+    );
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+    );
+  });
+
+  it('should return a correct APM deeplink when all transactionType is passed', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator({ ...DEFAULT_PARAMS, transactionType: ALL_VALUE }),
+      })
+    );
+
+    expect(url).toMatchInlineSnapshot(
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
     );
   });
 
   it('should return a correct APM deeplink when groupBy and instanceId are provided', () => {
-    const url = convertSliApmParamsToApmAppDeeplinkUrl({
-      ...SLI_APM_PARAMS,
-      groupBy: 'label.project_id',
-      instanceId: 'bf6689b383749812f35c7a408f57d113',
-    });
+    const url = convertSliApmParamsToApmAppDeeplinkUrl(
+      buildSlo({
+        indicator: buildApmLatencyIndicator(DEFAULT_PARAMS),
+        groupBy: 'label.project_id',
+        instanceId: 'bf6689b383749812f35c7a408f57d113',
+      })
+    );
 
     expect(url).toMatchInlineSnapshot(
-      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12++and+label.project_id+%3A+%22bf6689b383749812f35c7a408f57d113%22"`
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12++and+label.project_id+%3A+%22bf6689b383749812f35c7a408f57d113%22"`
     );
   });
 });

--- a/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
+++ b/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.test.ts
@@ -14,6 +14,7 @@ const SLI_APM_PARAMS = {
   service: 'barService',
   transactionName: 'bazName',
   transactionType: 'blarfType',
+  groupBy: '*',
 };
 
 describe('convertSliApmParamsToApmAppDeeplinkUrl', () => {
@@ -86,6 +87,18 @@ describe('convertSliApmParamsToApmAppDeeplinkUrl', () => {
 
     expect(url).toMatchInlineSnapshot(
       `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12+"`
+    );
+  });
+
+  it('should return a correct APM deeplink when groupBy and instanceId are provided', () => {
+    const url = convertSliApmParamsToApmAppDeeplinkUrl({
+      ...SLI_APM_PARAMS,
+      groupBy: 'label.project_id',
+      instanceId: 'bf6689b383749812f35c7a408f57d113',
+    });
+
+    expect(url).toMatchInlineSnapshot(
+      `"/app/apm/services/barService/overview?comparisonEnabled=true&environment=fooEnvironment&transactionType=blarfType&rangeFrom=now-30-d&rangeTo=now&kuery=transaction.name+%3A+%22bazName%22+and+agent.name+%3A+%22beats%22+and+agent.version+%3A+3.4.12++and+label.project_id+%3A+%22bf6689b383749812f35c7a408f57d113%22"`
     );
   });
 });

--- a/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.ts
+++ b/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.ts
@@ -5,32 +5,29 @@
  * 2.0.
  */
 
-import { ALL_VALUE } from '@kbn/slo-schema';
+import {
+  ALL_VALUE,
+  apmTransactionDurationIndicatorSchema,
+  apmTransactionErrorRateIndicatorSchema,
+  SLOResponse,
+} from '@kbn/slo-schema';
 
-interface Props {
-  duration?: string;
-  environment: string;
-  filter: string | undefined;
-  service: string;
-  transactionName: string;
-  transactionType: string;
-  groupBy: string;
-  instanceId?: string;
-}
-
-export function convertSliApmParamsToApmAppDeeplinkUrl({
-  duration,
-  environment,
-  filter,
-  service,
-  transactionName,
-  transactionType,
-  groupBy,
-  instanceId,
-}: Props) {
-  if (!service) {
-    return '';
+export function convertSliApmParamsToApmAppDeeplinkUrl(slo: SLOResponse): string | undefined {
+  if (
+    !apmTransactionDurationIndicatorSchema.is(slo.indicator) &&
+    !apmTransactionErrorRateIndicatorSchema.is(slo.indicator)
+  ) {
+    return undefined;
   }
+
+  const {
+    indicator: {
+      params: { environment, filter, service, transactionName, transactionType },
+    },
+    timeWindow: { duration },
+    groupBy,
+    instanceId,
+  } = slo;
 
   const qs = new URLSearchParams('comparisonEnabled=true');
 

--- a/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.ts
+++ b/x-pack/plugins/observability/public/utils/slo/convert_sli_apm_params_to_apm_app_deeplink_url.ts
@@ -14,6 +14,8 @@ interface Props {
   service: string;
   transactionName: string;
   transactionType: string;
+  groupBy: string;
+  instanceId?: string;
 }
 
 export function convertSliApmParamsToApmAppDeeplinkUrl({
@@ -23,6 +25,8 @@ export function convertSliApmParamsToApmAppDeeplinkUrl({
   service,
   transactionName,
   transactionType,
+  groupBy,
+  instanceId,
 }: Props) {
   if (!service) {
     return '';
@@ -49,6 +53,9 @@ export function convertSliApmParamsToApmAppDeeplinkUrl({
   }
   if (filter && filter.length > 0) {
     kueryParams.push(filter);
+  }
+  if (groupBy !== ALL_VALUE && instanceId !== ALL_VALUE) {
+    kueryParams.push(`${groupBy} : "${instanceId}"`);
   }
 
   if (kueryParams.length > 0) {

--- a/x-pack/plugins/observability/public/utils/slo/indicator.ts
+++ b/x-pack/plugins/observability/public/utils/slo/indicator.ts
@@ -5,7 +5,12 @@
  * 2.0.
  */
 
-import { SLOWithSummaryResponse } from '@kbn/slo-schema';
+import {
+  apmTransactionDurationIndicatorSchema,
+  apmTransactionErrorRateIndicatorSchema,
+  Indicator,
+} from '@kbn/slo-schema';
 
-export const isApmIndicatorType = (indicatorType: SLOWithSummaryResponse['indicator']['type']) =>
-  ['sli.apm.transactionDuration', 'sli.apm.transactionErrorRate'].includes(indicatorType);
+export const isApmIndicatorType = (indicator: Indicator): boolean =>
+  apmTransactionDurationIndicatorSchema.is(indicator) ||
+  apmTransactionErrorRateIndicatorSchema.is(indicator);


### PR DESCRIPTION
Resolves https://github.com/elastic/actionable-observability/issues/155

## Summary

This PR uses the groupBy and instanceId when defined on an SLO, when redirecting to the APM service view.

![image](https://github.com/elastic/kibana/assets/1376800/fec7729a-b9b1-423b-87df-49feee735f4f)
