### PR TITLE
[Security Solution] Disable streaming when RAG Alerts is on

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.test.tsx
@@ -133,6 +133,28 @@ describe('API tests', () => {
       );
     });
 
+    it('calls the actions connector api with invoke when assistantStreamingEnabled is true when assistantLangChain is false and alerts is true', async () => {
+      const testProps: FetchConnectorExecuteAction = {
+        ...fetchConnectorArgs,
+        assistantLangChain: false,
+        alerts: true,
+      };
+
+      await fetchConnectorExecuteAction(testProps);
+
+      expect(mockHttp.fetch).toHaveBeenCalledWith(
+        '/internal/elastic_assistant/actions/connector/foo/_execute',
+        {
+          body: '{"params":{"subActionParams":{"model":"gpt-4","messages":[{"role":"user","content":"This is a test"}],"n":1,"stop":null,"temperature":0.2},"subAction":"invokeAI"},"assistantLangChain":false}',
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          signal: undefined,
+        }
+      );
+    });
+
     it('returns API_ERROR when the response status is error and langchain is on', async () => {
       (mockHttp.fetch as jest.Mock).mockResolvedValue({ status: 'error' });
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
@@ -84,7 +84,7 @@ export const fetchConnectorExecuteAction = async ({
   // tracked here: https://github.com/elastic/security-team/issues/7363
   // In part 3 I will make enhancements to langchain to introduce streaming
   // Once implemented, invokeAI can be removed
-  const isStream = assistantStreamingEnabled && !assistantLangChain;
+  const isStream = assistantStreamingEnabled && !assistantLangChain && !alerts;
   const optionalRequestParams = getOptionalRequestParams({
     alerts,
     alertsIndexPattern,


### PR DESCRIPTION
## Summary

RAG alerts expects the response from OpenAI to be a string, not a stream. Add a parameter to disable streaming when RAG alerts is enabled. 

### Testing

Enable both feature flags:
```
xpack.securitySolution.enableExperimental: ['assistantRagOnAlerts', 'assistantStreamingEnabled']
```

KB checkbox should remain unchecked for this test. Send any test message to the assistant with the RAG Alerts toggle on and off. When toggle is on, response should not be streamed. When it is off, response should stream.


