### PR TITLE
[Security Solution] - fix dark theme for alert details flyout footer

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/footer.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/footer.tsx
@@ -8,12 +8,17 @@
 import type { FC } from 'react';
 import React, { useCallback } from 'react';
 import { useExpandableFlyoutContext } from '@kbn/expandable-flyout';
-import { EuiPanel } from '@elastic/eui';
+import styled from 'styled-components';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { FlyoutFooter } from '../../../timelines/components/side_panel/event_details/flyout';
 import { useRightPanelContext } from './context';
 import { useHostIsolationTools } from '../../../timelines/components/side_panel/event_details/use_host_isolation_tools';
-import { DEFAULT_DARK_MODE } from '../../../../common/constants';
-import { useUiSetting } from '../../../common/lib/kibana';
+
+const ContainerDiv = styled('div')`
+  .side-panel-flyout-footer {
+    padding: ${euiThemeVars.euiPanelPaddingModifiers.paddingMedium};
+  }
+`;
 
 interface PanelFooterProps {
   /**
@@ -35,8 +40,6 @@ export const PanelFooter: FC<PanelFooterProps> = ({ isPreview }) => {
     refetchFlyoutData,
     scopeId,
   } = useRightPanelContext();
-  const isDarkMode = useUiSetting<boolean>(DEFAULT_DARK_MODE);
-
   const { isHostIsolationPanelOpen, showHostIsolationPanel } = useHostIsolationTools();
 
   const showHostIsolationPanelCallback = useCallback(
@@ -56,13 +59,7 @@ export const PanelFooter: FC<PanelFooterProps> = ({ isPreview }) => {
   );
 
   return !isPreview ? (
-    <EuiPanel
-      hasShadow={false}
-      borderRadius="none"
-      style={{
-        backgroundColor: isDarkMode ? `rgb(37, 38, 46)` : `rgb(241, 244, 250)`,
-      }}
-    >
+    <ContainerDiv>
       <FlyoutFooter
         detailsData={dataFormattedForFieldBrowser}
         detailsEcsData={dataAsNestedObject}
@@ -74,6 +71,6 @@ export const PanelFooter: FC<PanelFooterProps> = ({ isPreview }) => {
         scopeId={scopeId}
         refetchFlyoutData={refetchFlyoutData}
       />
-    </EuiPanel>
+    </ContainerDiv>
   ) : null;
 };


### PR DESCRIPTION
## Summary

This PR fixes an issues with the alert details flyout footer background color in dark mode.
It was raised in [this issue](https://github.com/elastic/kibana/issues/173529) that we should not be accessing directly the value of `theme:darkMode` UI setting.

While this is not the cleanest solution, it is the solution I felt was the safest to fix during BC period. Soon the sidepanel code will be removed entirely (when we use the new expandable flyout in timeline) and most of the code will be deleted.

Light theme
![Screenshot 2023-12-18 at 3 02 21 PM](https://github.com/elastic/kibana/assets/17276605/8e60fbd6-0e43-49d3-81df-e7852b9c4038)

Dark theme
![Screenshot 2023-12-18 at 3 01 56 PM](https://github.com/elastic/kibana/assets/17276605/d6e20bc5-6bc9-44a2-bfb3-cf68cef7df3a)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->