### PR TITLE
[ML] Trained models functional test: ensure field map is clear before attempting to add content

### DIFF
--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -17,8 +17,7 @@ export default function ({ getService }: FtrProviderContext) {
     id: model.name,
   }));
 
-  // FLAKY: https://github.com/elastic/kibana/issues/165084
-  describe.skip('trained models', function () {
+  describe('trained models', function () {
     // 'Created at' will be different on each run,
     // so we will just assert that the value is in the expected timestamp format.
     const builtInModelData = {

--- a/x-pack/test/functional/services/ml/deploy_models_flyout.ts
+++ b/x-pack/test/functional/services/ml/deploy_models_flyout.ts
@@ -108,10 +108,13 @@ export function DeployDFAModelFlyoutProvider(
       const editor = await configElement.findByClassName('kibanaCodeEditor');
       await editor.click();
       const input = await find.activeElement();
-      await input.clearValueWithKeyboard();
-      // Ensure the editor is cleared before adding input
-      const editorContentAfterClearing = await input.getAttribute('value');
-      expect(editorContentAfterClearing).to.eql('');
+
+      await retry.tryForTime(5000, async () => {
+        await input.clearValueWithKeyboard();
+        // Ensure the editor is cleared before adding input
+        const editorContentAfterClearing = await input.getAttribute('value');
+        expect(editorContentAfterClearing).to.eql('');
+      });
 
       for (const chr of value) {
         await retry.tryForTime(5000, async () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/165084
Flaky test runner build https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4635


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




