### PR TITLE
[SLO] Unified Search and Grouping

### DIFF
--- a/x-pack/plugins/observability/public/hooks/slo/query_key_factory.ts
+++ b/x-pack/plugins/observability/public/hooks/slo/query_key_factory.ts
@@ -13,6 +13,7 @@ interface SloListFilter {
   perPage: number;
   sortBy: string;
   sortDirection: string;
+  groupBy?: string;
 }
 
 export const sloKeys = {

--- a/x-pack/plugins/observability/public/pages/slos/components/grouped_slos/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/grouped_slos/slo_list.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+import React, { memo } from 'react';
+import { EuiPanel, EuiAccordion } from '@elastic/eui';
+import { SloListEmpty } from '../slo_list_empty';
+
+export function GroupedSlos({ sloList, groupBy, loading }) {
+  const groupByKey = `group_by_${groupBy}`;
+  if (!loading && Object.keys(sloList).length === 0) {
+    return <SloListEmpty />;
+  }
+  const groups = sloList && sloList[groupByKey];
+  console.log(groups, '!!groups');
+
+  return (
+    <>
+      <h1>
+        {i18n.translate('xpack.observability.groupedSlos.h1.groupedSLOsLabel', {
+          defaultMessage: 'Grouped SLOs',
+        })}
+      </h1>
+      {groups &&
+        Object.keys(groups).map((group, index) => {
+          console.log(group, '!!group');
+          if (groups[group].length > 0) {
+            return (
+              <EuiPanel>
+                <MemoEuiAccordion buttonContent={group}>
+                  {groups[group].map((sloId) => {
+                    return <div>{sloId}</div>;
+                  })}
+                </MemoEuiAccordion>
+              </EuiPanel>
+            );
+          }
+        })}
+    </>
+  );
+}
+
+const MemoEuiAccordion = memo(EuiAccordion);

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list.tsx
@@ -13,7 +13,8 @@ import { useUrlSearchState } from '../hooks/use_url_search_state';
 import { SlosView } from './slos_view';
 import { SloListSearchBar, SortDirection, SortField } from './slo_list_search_bar';
 import { SLOView, ToggleSLOView } from './toggle_slo_view';
-
+import { GroupByField, SloGroupBy } from './slo_list_group_by';
+import { GroupedSlos } from './grouped_slos/slo_list';
 export interface Props {
   autoRefresh: boolean;
 }
@@ -27,7 +28,7 @@ export function SloList({ autoRefresh }: Props) {
   const [direction] = useState<SortDirection>(state.sort.direction);
   const [view, setView] = useState<SLOView>(state.view);
   const [isCompact, setCompact] = useState<boolean>(state.compact);
-
+  const [groupBy, setGroupBy] = useState(state.groupBy);
   const {
     isLoading,
     isRefetching,
@@ -40,8 +41,10 @@ export function SloList({ autoRefresh }: Props) {
     sortBy: sort,
     sortDirection: direction,
     shouldRefetch: autoRefresh,
+    groupBy,
   });
-
+  const x = sloList;
+  console.log(x, '!!xx');
   const { results = [], total = 0 } = sloList ?? {};
 
   const isCreatingSlo = Boolean(useIsMutating(['creatingSlo']));
@@ -77,6 +80,12 @@ export function SloList({ autoRefresh }: Props) {
     storeState({ compact: newCompact });
   };
 
+  const handleChangeGroupBy = (newGroupBy: GroupByField) => {
+    setPage(0);
+    setGroupBy(newGroupBy);
+    storeState({ page: 0, groupBy: newGroupBy });
+  };
+
   return (
     <EuiFlexGroup direction="column" gutterSize="m" data-test-subj="sloList">
       <EuiFlexItem grow>
@@ -87,21 +96,50 @@ export function SloList({ autoRefresh }: Props) {
           initialState={state}
         />
       </EuiFlexItem>
-      <EuiFlexItem grow={false}>
-        <ToggleSLOView
-          sloView={view}
-          onChangeView={handleChangeView}
-          onToggleCompactView={handleToggleCompactView}
-          isCompact={isCompact}
-        />
+      <EuiFlexItem>
+        <EuiFlexGroup direction="row">
+          <EuiFlexItem>
+            <SloGroupBy
+              onChangeGroupBy={handleChangeGroupBy}
+              initialState={state}
+              loading={isLoading || isCreatingSlo || isCloningSlo || isUpdatingSlo || isDeletingSlo}
+            />
+          </EuiFlexItem>
+
+          <EuiFlexItem grow={false}>
+            <ToggleSLOView
+              sloView={view}
+              onChangeView={handleChangeView}
+              onToggleCompactView={handleToggleCompactView}
+              isCompact={isCompact}
+            />
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiFlexItem>
-      <SlosView
-        sloList={results}
-        loading={isLoading || isRefetching}
-        error={isError}
-        isCompact={isCompact}
-        sloView={view}
-      />
+
+      {groupBy === 'ungrouped' && (
+        <SlosView
+          sloList={results}
+          loading={isLoading || isRefetching}
+          error={isError}
+          isCompact={isCompact}
+          sloView={view}
+        />
+      )}
+
+      {groupBy !== 'ungrouped' && (
+        <GroupedSlos
+          sloList={sloList}
+          loading={isLoading || isRefetching}
+          groupBy={groupBy}
+          perPage={perPage}
+          kqlQuery={query}
+          sortBy={sort}
+          sortDirection={direction}
+          page={page + 1}
+          shouldRefetch={autoRefresh}
+        />
+      )}
 
       {total > 0 ? (
         <EuiFlexItem>

--- a/x-pack/plugins/observability/public/pages/slos/components/slo_list_group_by.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/components/slo_list_group_by.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { i18n } from '@kbn/i18n';
+import React, { useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiSelectable,
+  EuiSelectableOption,
+  EuiFilterGroup,
+  EuiFilterButton,
+} from '@elastic/eui';
+import { EuiSelectableOptionCheckedType } from '@elastic/eui/src/components/selectable/selectable_option';
+import { SearchState } from '../hooks/use_url_search_state';
+
+export type GroupByField = 'ungrouped' | 'sli_indicator' | 'status' | 'tags';
+export interface Props {
+  loading: boolean;
+  onChangeGroupBy: (groupBy: GroupByField) => void;
+  initialState: SearchState;
+}
+
+export type Item<T> = EuiSelectableOption & {
+  label: string;
+  type: T;
+  checked?: EuiSelectableOptionCheckedType;
+};
+
+const GROUP_BY_OPTIONS: Array<Item<GroupByField>> = [
+  {
+    label: i18n.translate('xpack.observability.slo.list.groupBy.sliIndicator', {
+      defaultMessage: 'Ungrouped',
+    }),
+    type: 'ungrouped',
+  },
+  {
+    label: i18n.translate('xpack.observability.slo.list.groupBy.sliIndicator', {
+      defaultMessage: 'SLI Indicator',
+    }),
+    type: 'sli_indicator',
+  },
+  {
+    label: i18n.translate('xpack.observability.slo.list.sortBy.status', {
+      defaultMessage: 'Status',
+    }),
+    type: 'status',
+  },
+  {
+    label: i18n.translate('xpack.observability.slo.list.sortBy.tags', {
+      defaultMessage: 'Tags',
+    }),
+    type: 'tags',
+  },
+  // TODO add group_by_instanceId
+];
+export function SloGroupBy({ loading, onChangeGroupBy, initialState }: Props) {
+  const [isGroupByPopoverOpen, setGroupByPopoverOpen] = useState(false);
+  const [groupByOptions, setGroupByOptions] = useState<Array<Item<GroupByField>>>(
+    GROUP_BY_OPTIONS.map((option) => ({
+      ...option,
+      checked: option.type === initialState.groupBy ? 'on' : undefined,
+    }))
+  );
+
+  const selectedGroupBy = groupByOptions.find((option) => option.checked === 'on');
+  const handleToggleGroupByButton = () => setGroupByPopoverOpen(!isGroupByPopoverOpen);
+
+  const handleChangeGroupBy = (newOptions: Array<Item<GroupByField>>) => {
+    setGroupByOptions(newOptions);
+    setGroupByPopoverOpen(false);
+    onChangeGroupBy(newOptions.find((o) => o.checked)!.type);
+  };
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiFlexGroup direction="row" gutterSize="s" responsive>
+        <EuiFlexItem style={{ maxWidth: 250 }}>
+          <EuiFilterGroup>
+            <EuiPopover
+              button={
+                <EuiFilterButton
+                  disabled={loading}
+                  iconType="arrowDown"
+                  onClick={handleToggleGroupByButton}
+                  isSelected={isGroupByPopoverOpen}
+                >
+                  {i18n.translate('xpack.observability.slo.list.sortByType', {
+                    defaultMessage: 'Group by {type}',
+                    values: { type: selectedGroupBy?.label.toLowerCase() ?? '' },
+                  })}
+                </EuiFilterButton>
+              }
+              isOpen={isGroupByPopoverOpen}
+              closePopover={handleToggleGroupByButton}
+              panelPaddingSize="none"
+              anchorPosition="downCenter"
+            >
+              <div style={{ width: 250 }}>
+                <EuiPopoverTitle paddingSize="s">
+                  {i18n.translate('xpack.observability.slo.list.sortBy', {
+                    defaultMessage: 'Group by',
+                  })}
+                </EuiPopoverTitle>
+                <EuiSelectable<Item<GroupByField>>
+                  singleSelection="always"
+                  options={groupByOptions}
+                  onChange={handleChangeGroupBy}
+                  isLoading={loading}
+                >
+                  {(list) => list}
+                </EuiSelectable>
+              </div>
+            </EuiPopover>
+          </EuiFilterGroup>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiFlexItem>
+  );
+}

--- a/x-pack/plugins/observability/public/pages/slos/hooks/use_url_search_state.ts
+++ b/x-pack/plugins/observability/public/pages/slos/hooks/use_url_search_state.ts
@@ -10,6 +10,7 @@ import deepmerge from 'deepmerge';
 import { useHistory } from 'react-router-dom';
 import { DEFAULT_SLO_PAGE_SIZE } from '../../../../common/slo/constants';
 import type { SortField, SortDirection } from '../components/slo_list_search_bar';
+import type { GroupByField } from '../components/slo_list_group_by';
 import type { SLOView } from '../components/toggle_slo_view';
 
 export const SLO_LIST_SEARCH_URL_STORAGE_KEY = 'search';
@@ -24,6 +25,7 @@ export interface SearchState {
   };
   view: SLOView;
   compact: boolean;
+  groupBy: GroupByField;
 }
 
 export const DEFAULT_STATE = {
@@ -33,6 +35,7 @@ export const DEFAULT_STATE = {
   sort: { by: 'status' as const, direction: 'desc' as const },
   view: 'cardView' as const,
   compact: true,
+  groupBy: 'ungrouped' as const,
 };
 
 export function useUrlSearchState(): {

--- a/x-pack/plugins/observability/public/pages/slos/slos.tsx
+++ b/x-pack/plugins/observability/public/pages/slos/slos.tsx
@@ -34,6 +34,7 @@ export function SlosPage() {
   const { hasAtLeast } = useLicense();
 
   const { isLoading, isError, data: sloList } = useFetchSloList();
+  console.log(sloList, '!!sloList');
   const { total } = sloList ?? { total: 0 };
 
   const { storeAutoRefreshState, getAutoRefreshState } = useAutoRefreshStorage();


### PR DESCRIPTION
This is a first quick attempt to add grouping to SLO list page. It contains the basic functionality of 
- storing the grouped response in the following data structure and 
- rendering the grouped SLOs in panels using an accordion for the content (for now only the slo ids)

```
const groupedResponse = {
  group_by_sli_indicator: {
    'sli.kql.custom': ["sloId1", "sloId2", "sloId3"],
    'sli.metric.custom': [],
    'sli.apm.transactionErrorRate': [],
    'sli.apm.transactionDuration': [],
  },
  group_by_status: {
    healthy: ["sloId1", "sloId2", "sloId3"],
    violated: [],
    degraded: [],
    nodata: [],
  },
  group_by_tags: {
    "tag1": ["sloId1", "sloId2"],
    "tag2": ["sloId1", "sloId3"],
    "tag3": ["sloId3"]
  },
}
```

https://github.com/elastic/kibana/assets/2852703/4efc271b-0510-4592-8a03-72c6e3989a8b

