### PR TITLE
[Dataset quality] Sort by datasetname + Find degradedDocs using raw dataset name

### DIFF
--- a/x-pack/plugins/dataset_quality/common/data_streams_stats/data_stream_stat.ts
+++ b/x-pack/plugins/dataset_quality/common/data_streams_stats/data_stream_stat.ts
@@ -20,7 +20,7 @@ export class DataStreamStat {
   degradedDocs?: number;
 
   private constructor(dataStreamStat: DataStreamStat) {
-    this.rawName = dataStreamStat.name;
+    this.rawName = dataStreamStat.rawName;
     this.name = dataStreamStat.name;
     this.title = dataStreamStat.title ?? dataStreamStat.name;
     this.namespace = dataStreamStat.namespace;

--- a/x-pack/plugins/dataset_quality/public/hooks/use_dataset_quality_table.tsx
+++ b/x-pack/plugins/dataset_quality/public/hooks/use_dataset_quality_table.tsx
@@ -20,6 +20,7 @@ type DIRECTION = 'asc' | 'desc';
 type SORT_FIELD = keyof DataStreamStat;
 
 const sortingOverrides: Partial<{ [key in SORT_FIELD]: SORT_FIELD }> = {
+  ['title']: 'name',
   ['size']: 'sizeBytes',
 };
 
@@ -77,7 +78,7 @@ export const useDatasetQualityTable = () => {
   const renderedItems = useMemo(() => {
     const overridenSortingField = sortingOverrides[sortField] || sortField;
     const mergedData = data.map((dataStream) => {
-      const degradedDocs = find(degradedStats, { dataset: dataStream.name });
+      const degradedDocs = find(degradedStats, { dataset: dataStream.rawName });
 
       return {
         ...dataStream,


### PR DESCRIPTION
This PR focuses on solving a couple of issues:

1. In https://github.com/elastic/kibana/pull/173087 the dataset human title was brought to the table. Even though, we still need to sort the column by the `raw` name of the dataset.

#### Before

https://github.com/elastic/kibana/assets/1313018/e389ea24-55fc-4854-af32-67e3693fe4bb

#### After

https://github.com/elastic/kibana/assets/1313018/cbb529e5-12cf-4432-be02-828c61143f17


2. In https://github.com/elastic/kibana/pull/173272 `rawName` property was added to `DataStreamStat` class so we could keep the logic of splitting the raw dataset name in just one place. We need to find the `degradedDocs` number from the raw dataset instead of the name we are keeping in the class.

#### Before

https://github.com/elastic/kibana/assets/1313018/e8d41966-24cd-45e8-8ab2-3de3b043e730

#### After

https://github.com/elastic/kibana/assets/1313018/e9af6c9d-5081-41e5-bfb0-c88264e4b349
