### PR TITLE
[Enterprise Search] Fix polling causing a rewrite on form

### DIFF
--- a/packages/kbn-search-connectors/components/configuration/connector_configuration_form.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration_form.tsx
@@ -66,12 +66,12 @@ export const ConnectorConfigurationForm: React.FC<ConnectorConfigurationForm> = 
   );
 
   useEffect(() => {
-    setConfigView(sortAndFilterConnectorConfiguration(localConfig, isNative));
-  }, [localConfig, isNative]);
+    setLocalConfig((localConf) => ({ ...configuration, ...localConf }));
+  }, [configuration]);
 
   useEffect(() => {
-    setLocalConfig(configuration);
-  }, [configuration]);
+    setConfigView(sortAndFilterConnectorConfiguration(localConfig, isNative));
+  }, [localConfig, isNative]);
 
   return (
     <EuiForm


### PR DESCRIPTION
## Summary

This fixes polling rewriting user input when configuration is changed.



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->