### PR TITLE
[Enterprise Search] Clean up copy

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
@@ -225,7 +225,7 @@ export const SelectConnector: React.FC = () => {
                       'xpack.enterpriseSearch.selectConnector.p.areAvailableDirectlyWithinLabel',
                       {
                         defaultMessage:
-                          'Are available directly within Elastic Cloud deployments No additional infrastructure is required You can also convert them as self hosted Connectors client at any moment',
+                          'Available directly within Elastic Cloud deployments. No additional infrastructure is required. You can also convert native connectors to self-hosted connector clients.',
                       }
                     )}
                   </p>
@@ -259,7 +259,7 @@ export const SelectConnector: React.FC = () => {
                       'xpack.enterpriseSearch.selectConnector.p.deployConnectorsOnYourLabel',
                       {
                         defaultMessage:
-                          'Deploy connectors on your own infrastructure You can also customize existing Connector clients or build your own using our connector framework',
+                          'Deploy connectors on your own infrastructure. You can also customize existing connector clients, or build your own using our connector framework.',
                       }
                     )}
                   </p>


### PR DESCRIPTION
Somehow this copy snuck in without being edited, looks like a copy paste from a former tooltip or something, with no punctuation.

This PR cleans the text up.


## Before

<img width="225" alt="Screenshot 2023-12-19 at 14 05 56" src="https://github.com/elastic/kibana/assets/32779855/bb3cc4cd-ae9a-4f32-a51d-25ed804302b4">


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->