### PR TITLE
[Fleet] Fix exception when trying to install cspm with a secret

### DIFF
--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -787,7 +787,7 @@ function getPolicyWithSecretReferences(
       const isLast = secretPathComponentIndex === secretPath.path.length - 1;
 
       if (isLast) {
-        acc[val].value = toVarSecretRef(secrets[secretPathIndex].id);
+        acc[val].value = toVarSecretRef(secrets[secretPathIndex]?.id);
       }
 
       return acc[val];


### PR DESCRIPTION
## Summary

Fixing a very small bug found when trying to install CSPM integration with a secret. The installation was failing with exception:

![Screenshot 2023-12-19 at 14 50 15](https://github.com/elastic/kibana/assets/16084106/8be4bc4d-3c6d-4ec1-920d-54d4f8559abe)

## Testing
- Install `cloud_security_posture-1.8.0-preview02`, select `Setup access: manual` and `Preferred manual method: Direct access keys`
- Note that a licence is needed to install CSPM
- Add some test values a secrets and try to install
- The integration should install successfully
