### PR TITLE
[ObsUX][Profiling, Infra] Show "No Data" messages when there is no profiling data

### DIFF
--- a/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/empty_data_prompt.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/empty_data_prompt.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiEmptyPrompt, EuiSpacer } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+export function EmptyDataPrompt() {
+  return (
+    <>
+      <EuiSpacer />
+      <EuiEmptyPrompt
+        color="subdued"
+        iconType="search"
+        titleSize="xs"
+        title={
+          <h2>
+            {i18n.translate('xpack.infra.profiling.emptyDataPromptTitle', {
+              defaultMessage: 'No data found',
+            })}
+          </h2>
+        }
+        body={
+          <p>
+            {i18n.translate('xpack.infra.profiling.emptyDataPromptBody', {
+              defaultMessage:
+                'Make sure this host is sending profiling data or try selecting a different date range.',
+            })}
+          </p>
+        }
+      />
+    </>
+  );
+}

--- a/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/flamegraph.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/flamegraph.tsx
@@ -17,6 +17,7 @@ import { useTabSwitcherContext } from '../../hooks/use_tab_switcher';
 import { ContentTabIds } from '../../types';
 import { ErrorPrompt } from './error_prompt';
 import { ProfilingLinks } from './profiling_links';
+import { EmptyDataPrompt } from './empty_data_prompt';
 
 export function Flamegraph() {
   const { services } = useKibanaContextForPlugin();
@@ -45,6 +46,10 @@ export function Flamegraph() {
 
   if (error !== null) {
     return <ErrorPrompt />;
+  }
+
+  if (!loading && response?.TotalSamples === 0) {
+    return <EmptyDataPrompt />;
   }
 
   return (

--- a/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/functions.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/functions.tsx
@@ -17,6 +17,7 @@ import { useTabSwitcherContext } from '../../hooks/use_tab_switcher';
 import { ContentTabIds } from '../../types';
 import { ErrorPrompt } from './error_prompt';
 import { ProfilingLinks } from './profiling_links';
+import { EmptyDataPrompt } from './empty_data_prompt';
 
 export function Functions() {
   const { services } = useKibanaContextForPlugin();
@@ -48,6 +49,10 @@ export function Functions() {
 
   if (error !== null) {
     return <ErrorPrompt />;
+  }
+
+  if (!loading && response?.TotalCount === 0) {
+    return <EmptyDataPrompt />;
   }
 
   return (


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/173153

## Summary

Adds a message when there is no data for flamegraph or top functions.

https://github.com/elastic/kibana/assets/793851/2a6158ca-86d3-4b23-9807-dc177ce0361b

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->