### PR TITLE
[Security Solution] Skip flaky suites

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
@@ -31,7 +31,7 @@ const loginWithoutAccess = (url: string) => {
   loadPage(url);
 };
 
-//Flaky: https://github.com/elastic/kibana/issues/171168
+// Flaky: https://github.com/elastic/kibana/issues/171168
 describe.skip('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
@@ -31,7 +31,8 @@ const loginWithoutAccess = (url: string) => {
   loadPage(url);
 };
 
-describe('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
+//Flaky: https://github.com/elastic/kibana/issues/171168
+describe.skip('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 
   before(() => {

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -85,7 +85,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     return tableData;
   };
 
-  describe('endpoint list', function () {
+  //Flaky: https://github.com/elastic/kibana/issues/170357
+  describe.skip('endpoint list', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -85,7 +85,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     return tableData;
   };
 
-  //Flaky: https://github.com/elastic/kibana/issues/170357
+  // Flaky: https://github.com/elastic/kibana/issues/170357
   describe.skip('endpoint list', function () {
     targetTags(this, ['@ess', '@serverless']);
 

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -28,7 +28,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const endpointTestResources = getService('endpointTestResources');
   const retry = getService('retry');
 
-  describe('When on the Endpoint Policy Details Page', function () {
+  //Flaky: https://github.com/elastic/kibana/issues/171653
+  describe.skip('When on the Endpoint Policy Details Page', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -28,7 +28,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const endpointTestResources = getService('endpointTestResources');
   const retry = getService('retry');
 
-  //Flaky: https://github.com/elastic/kibana/issues/171653
+  // Flaky: https://github.com/elastic/kibana/issues/171653
   describe.skip('When on the Endpoint Policy Details Page', function () {
     targetTags(this, ['@ess', '@serverless']);
 

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -16,7 +16,7 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const endpointTestResources = getService('endpointTestResources');
 
-  //Flaky: https://github.com/elastic/kibana/issues/171666
+  // Flaky: https://github.com/elastic/kibana/issues/171666
   describe.skip('Endpoint `execute` response action', function () {
     targetTags(this, ['@ess', '@serverless']);
 

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -16,7 +16,8 @@ export default function ({ getService }: FtrProviderContext) {
   const supertestWithoutAuth = getService('supertestWithoutAuth');
   const endpointTestResources = getService('endpointTestResources');
 
-  describe('Endpoint `execute` response action', function () {
+  //Flaky: https://github.com/elastic/kibana/issues/171666
+  describe.skip('Endpoint `execute` response action', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
## Summary

Skip suites failing in Serverless.  Will also backport to 8.12.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->