### PR TITLE
[8.12] [Security Solution] Fix related_integrations Cypress test flake (#173393)

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/rule_management/related_integrations/related_integrations.cy.ts
@@ -18,7 +18,7 @@ import {
 } from '../../../../screens/alerts_detection_rules';
 import {
   installPrebuiltRuleAssets,
-  installAllPrebuiltRulesRequest,
+  installSpecificPrebuiltRulesRequest,
   SAMPLE_PREBUILT_RULE,
 } from '../../../../tasks/api_calls/prebuilt_rules';
 import { cleanFleet } from '../../../../tasks/api_calls/fleet';
@@ -63,7 +63,13 @@ describe('Related integrations', { tags: ['@ess', '@serverless', '@brokenInServe
       installed: true,
       enabled: false,
     },
-    { package: 'aws', version: '1.17.0', integration: 'unknown', installed: false, enabled: false },
+    {
+      package: 'aws',
+      version: '1.17.0',
+      integration: 'unknown',
+      installed: false,
+      enabled: false,
+    },
     { package: 'system', version: '1.17.0', installed: true, enabled: true },
   ];
   const PREBUILT_RULE = createRuleAssetSavedObject({
@@ -276,7 +282,7 @@ const INSTALLED_PREBUILT_RULES_RESPONSE_ALIAS = 'prebuiltRules';
 
 function addAndInstallPrebuiltRules(rules: Array<typeof SAMPLE_PREBUILT_RULE>): void {
   installPrebuiltRuleAssets(rules);
-  installAllPrebuiltRulesRequest().as(INSTALLED_PREBUILT_RULES_RESPONSE_ALIAS);
+  installSpecificPrebuiltRulesRequest(rules).as(INSTALLED_PREBUILT_RULES_RESPONSE_ALIAS);
 }
 
 function visitFirstInstalledPrebuiltRuleDetailsPage(): void {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Security Solution] Fix related_integrations Cypress test flake (#173393)](https://github.com/elastic/kibana/pull/173393)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Juan Pablo Djeredjian","email":"jpdjeredjian@gmail.com"},"sourceCommit":{"committedDate":"2023-12-19T13:00:17Z","message":"[Security Solution] Fix related_integrations Cypress test flake (#173393)\n\n## Summary\r\n\r\n- Replaces the installation of all available prebuilt rule for the rule\r\nthat was just created. This stops flake in which a race condition would\r\ncase the full Fleet package installation to be installed, and then us\r\npurposely installing **all** rules.\r\n\r\n## Flaky test runner\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4574\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0e5c290789b7a5bb40a4099ede169dafc6f5ad3","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Detections and Resp","Team: SecuritySolution","Team:Detection Rule Management","v8.12.0","v8.13.0"],"number":173393,"url":"https://github.com/elastic/kibana/pull/173393","mergeCommit":{"message":"[Security Solution] Fix related_integrations Cypress test flake (#173393)\n\n## Summary\r\n\r\n- Replaces the installation of all available prebuilt rule for the rule\r\nthat was just created. This stops flake in which a race condition would\r\ncase the full Fleet package installation to be installed, and then us\r\npurposely installing **all** rules.\r\n\r\n## Flaky test runner\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4574\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0e5c290789b7a5bb40a4099ede169dafc6f5ad3"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173393","number":173393,"mergeCommit":{"message":"[Security Solution] Fix related_integrations Cypress test flake (#173393)\n\n## Summary\r\n\r\n- Replaces the installation of all available prebuilt rule for the rule\r\nthat was just created. This stops flake in which a race condition would\r\ncase the full Fleet package installation to be installed, and then us\r\npurposely installing **all** rules.\r\n\r\n## Flaky test runner\r\n\r\nhttps://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4574\r\n\r\n### For maintainers\r\n\r\n- [ ] This was checked for breaking API changes and was [labeled\r\nappropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"d0e5c290789b7a5bb40a4099ede169dafc6f5ad3"}}]}] BACKPORT-->