### PR TITLE
[Controls] Fix validation query for nested fields

### DIFF
--- a/src/plugins/controls/server/options_list/options_list_suggestions_route.ts
+++ b/src/plugins/controls/server/options_list/options_list_suggestions_route.ts
@@ -112,12 +112,8 @@ export const setupOptionsListSuggestionsRoute = (
     const validationBuilder = getValidationAggregationBuilder();
 
     const suggestionAggregation: any = suggestionBuilder.buildAggregation(request) ?? {};
-    const builtValidationAggregation = validationBuilder.buildAggregation(request);
-    const validationAggregations = builtValidationAggregation
-      ? {
-          validation: builtValidationAggregation,
-        }
-      : {};
+    const validationAggregation: any = validationBuilder.buildAggregation(request);
+
     const body: SearchRequest['body'] = {
       size: 0,
       ...timeoutSettings,
@@ -128,7 +124,7 @@ export const setupOptionsListSuggestionsRoute = (
       },
       aggs: {
         ...suggestionAggregation,
-        ...validationAggregations,
+        ...validationAggregation,
       },
       runtime_mappings: {
         ...runtimeFieldMap,
@@ -145,7 +141,7 @@ export const setupOptionsListSuggestionsRoute = (
      */
     const results = suggestionBuilder.parse(rawEsResult, request);
     const totalCardinality = results.totalCardinality;
-    const invalidSelections = validationBuilder.parse(rawEsResult);
+    const invalidSelections = validationBuilder.parse(rawEsResult, request);
     return {
       suggestions: results.suggestions,
       totalCardinality,

--- a/src/plugins/controls/server/options_list/types.ts
+++ b/src/plugins/controls/server/options_list/types.ts
@@ -19,7 +19,7 @@ export interface EsBucket {
 
 export interface OptionsListValidationAggregationBuilder {
   buildAggregation: (req: OptionsListRequestBody) => unknown;
-  parse: (response: SearchResponse) => string[];
+  parse: (response: SearchResponse, req: OptionsListRequestBody) => string[];
 }
 
 export interface OptionsListSuggestionAggregationBuilder {


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/172694

## Summary

Apparently, when we [originally added the options list queries](https://github.com/elastic/kibana/blob/d07c74d25087447458da8de6a277544e9dfa164c/src/plugins/controls/server/control_types/options_list/options_list_queries.ts#L145), we only considered nested fields for the **suggestion** aggregation; we completely forgot to consider nested fields in the **validation** aggregation. So, from the introduction of the new controls, options list selections would be always be marked "invalid" for nested fields - oops! 🙈 


This PR fixes the validation aggregation so that nested field selections behave as expected.


> [!TIP]
> Searching a nested field for specific values will always return slightly unexpected results, because if a subset of the nested field matches, we don't return the subset - we return the **entire set**. In other words, if you have one document where the nested field equals `["one", "two"]` and another document where the nested field equals `["one", "three"]`, searching for `"one"` will return `["one", "two", "three"]` as options, like so:
> 
> ![image](https://github.com/elastic/kibana/assets/8698078/866917fa-ac75-4784-92b5-54c6635d6d5e)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->