### PR TITLE
[Security Solution] [Elastic AI Assistant] Include `acknowledged` alerts in the LangChain `AlertCountsTool` aggregation

### DIFF
--- a/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.test.ts
@@ -96,18 +96,64 @@ describe('AlertCountsTool', () => {
       await tool.func('');
 
       expect(esClient.search).toHaveBeenCalledWith({
-        aggs: { statusBySeverity: { terms: { field: 'kibana.alert.severity' } } },
+        aggs: {
+          kibanaAlertSeverity: {
+            terms: {
+              field: 'kibana.alert.severity',
+            },
+            aggs: {
+              kibanaAlertWorkflowStatus: {
+                terms: {
+                  field: 'kibana.alert.workflow_status',
+                },
+              },
+            },
+          },
+        },
         index: ['alerts-index'],
         query: {
           bool: {
             filter: [
               {
                 bool: {
-                  filter: [{ match_phrase: { 'kibana.alert.workflow_status': 'open' } }],
-                  must_not: [{ exists: { field: 'kibana.alert.building_block_type' } }],
+                  filter: [
+                    {
+                      bool: {
+                        should: [
+                          {
+                            match_phrase: {
+                              'kibana.alert.workflow_status': 'open',
+                            },
+                          },
+                          {
+                            match_phrase: {
+                              'kibana.alert.workflow_status': 'acknowledged',
+                            },
+                          },
+                        ],
+                        minimum_should_match: 1,
+                      },
+                    },
+                  ],
+                  should: [],
+                  must: [],
+                  must_not: [
+                    {
+                      exists: {
+                        field: 'kibana.alert.building_block_type',
+                      },
+                    },
+                  ],
                 },
               },
-              { range: { '@timestamp': { gte: 'now/d', lte: 'now/d' } } },
+              {
+                range: {
+                  '@timestamp': {
+                    gte: 'now-24h',
+                    lte: 'now',
+                  },
+                },
+              },
             ],
           },
         },

--- a/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/alert_counts_tool.ts
@@ -17,7 +17,7 @@ export interface AlertCountsToolParams extends AssistantToolParams {
   alertsIndexPattern: string;
 }
 export const ALERT_COUNTS_TOOL_DESCRIPTION =
-  'Call this for the counts of last 24 hours of open alerts in the environment, grouped by their severity';
+  'Call this for the counts of last 24 hours of open and acknowledged alerts in the environment, grouped by their severity and workflow status.';
 
 export const ALERT_COUNTS_TOOL: AssistantTool = {
   id: 'alert-counts-tool',

--- a/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/get_alert_counts_query.test.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/alert_counts/get_alert_counts_query.test.ts
@@ -14,9 +14,16 @@ describe('getAlertsCountQuery', () => {
 
     expect(query).toEqual({
       aggs: {
-        statusBySeverity: {
+        kibanaAlertSeverity: {
           terms: {
             field: 'kibana.alert.severity',
+          },
+          aggs: {
+            kibanaAlertWorkflowStatus: {
+              terms: {
+                field: 'kibana.alert.workflow_status',
+              },
+            },
           },
         },
       },
@@ -26,13 +33,27 @@ describe('getAlertsCountQuery', () => {
           filter: [
             {
               bool: {
+                must: [],
                 filter: [
                   {
-                    match_phrase: {
-                      'kibana.alert.workflow_status': 'open',
+                    bool: {
+                      should: [
+                        {
+                          match_phrase: {
+                            'kibana.alert.workflow_status': 'open',
+                          },
+                        },
+                        {
+                          match_phrase: {
+                            'kibana.alert.workflow_status': 'acknowledged',
+                          },
+                        },
+                      ],
+                      minimum_should_match: 1,
                     },
                   },
                 ],
+                should: [],
                 must_not: [
                   {
                     exists: {
@@ -45,8 +66,8 @@ describe('getAlertsCountQuery', () => {
             {
               range: {
                 '@timestamp': {
-                  gte: 'now/d',
-                  lte: 'now/d',
+                  gte: 'now-24h',
+                  lte: 'now',
                 },
               },
             },

--- a/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/get_open_and_acknowledged_alerts_query.test.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/get_open_and_acknowledged_alerts_query.test.ts
@@ -49,8 +49,8 @@ describe('getOpenAndAcknowledgedAlertsQuery', () => {
                     {
                       range: {
                         '@timestamp': {
-                          gte: 'now-1d/d',
-                          lte: 'now/d',
+                          gte: 'now-24h',
+                          lte: 'now',
                           format: 'strict_date_optional_time',
                         },
                       },

--- a/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/get_open_and_acknowledged_alerts_query.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/get_open_and_acknowledged_alerts_query.ts
@@ -47,8 +47,8 @@ export const getOpenAndAcknowledgedAlertsQuery = ({
                 {
                   range: {
                     '@timestamp': {
-                      gte: 'now-1d/d',
-                      lte: 'now/d',
+                      gte: 'now-24h',
+                      lte: 'now',
                       format: 'strict_date_optional_time',
                     },
                   },

--- a/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
+++ b/x-pack/plugins/security_solution/server/assistant/tools/open_and_acknowledged_alerts/open_and_acknowledged_alerts_tool.test.ts
@@ -174,8 +174,8 @@ describe('OpenAndAcknowledgedAlertsTool', () => {
                         range: {
                           '@timestamp': {
                             format: 'strict_date_optional_time',
-                            gte: 'now-1d/d',
-                            lte: 'now/d',
+                            gte: 'now-24h',
+                            lte: 'now',
                           },
                         },
                       },


### PR DESCRIPTION
## [Security Solution] [Elastic AI Assistant] Include `acknowledged` alerts in the LangChain `AlertCountsTool` aggregation

This PR updates the LangChain `AlertCountsTool` aggregation, which answers questions like `How many open alerts do I have?`, to include `acknowledged` alerts. The `AlertCountsTool` was introduced as part of [[Security Solution] [Elastic AI Assistant] Retrieval Augmented Generation (RAG) for Alerts #172542](https://github.com/elastic/kibana/pull/172542)

- This PR is similar to <https://github.com/elastic/kibana/pull/173121>, where `acknowledged` alerts were added to the `OpenAndAcknowledgedAlertsTool`, which returns the _details_ of alerts
  - In contrast to [#173121](https://github.com/elastic/kibana/pull/173121), this PR is focused on the alert counts _aggregation_

- This PR also updates the `range` of **both** the `AlertCountsTool` and the `OpenAndAcknowledgedAlertsTool` queries to standardize on the following syntax, which aligns with the `Last 24 hours` option in the _Commonly used_ section of the Kibana date picker:

```json
          "range": {
            "@timestamp": {
              "gte": "now-24h",
              "lte": "now"
            }
          }
```

### Desk testing

To desk test this change:

- The `assistantRagOnAlerts` feature flag described in [#172542](https://github.com/elastic/kibana/pull/172542) must be enabled, per the following example:

```
xpack.securitySolution.enableExperimental: ['assistantRagOnAlerts']
```

- The `Alerts` feature must be enabled in the assistant settings, per the screenshot below:

 ![enable_alerts](https://github.com/elastic/kibana/assets/4459398/f6a3077d-5815-4225-9a8e-7f5b51d5f2d4)

1) Generate alerts with a variety of severity (e.g. `low`, `medium`, `high`, and `critical`)

2) After the alerts have been generated, disable all detection rules to keep the counts static during testing

3) Navigate to Security > Alerts

4) Select `Last 24 hours` from the _Commonly used_ section of the global date picker

5) Click the `Treemap` button to select the Treemap visualization

6) In the Treemap's `Group by` input, enter `kibana.alert.severity`

7) Next, in the Treemap's `Group by top` input, enter `kibana.alert.workflow_status`

8) Click the `AI Assistant` button to open the assistant

9) Click the `X` button to clear the conversation

10) Close the assistant

11) Add the following two fields as columns to the Alerts page table:

```
kibana.alert.workflow_status
_id
```

12) Sort the Alerts table, first by `kibana.alert.risk_score` from high to low, and then by `@timestamp` from new to old, per the screenshot below:

![fields_sorted](https://github.com/elastic/kibana/assets/4459398/e84f06d4-790d-4227-afbf-a233d4848178)

**Expected results**

- The alerts page date range is `Last 24 hours`
- The `Treemap` is selected
- The treemap is grouped by `kibana.alert.severity` and then `kibana.alert.workflow_status`
- The alerts table has custom sorting and columns, per the screenshot below:

![alerts_page_setup](https://github.com/elastic/kibana/assets/4459398/f4700abc-b2ca-483e-92d8-5a186142e1fb)

13) Click the `AI Assistant` button to open the assistant

14) Ask the assistant:

```
How many open alerts do I have?
```

**Expected results**

- The assistant will report on the counts and workflow status of alerts, per the example response and screenshot below:

```
You have a total of 47 open alerts. Here's the breakdown: 24 alerts with low severity, 12 alerts with medium severity, 7 alerts with high severity, and 4 alerts with critical severity.
```

![assistant_open_alerts](https://github.com/elastic/kibana/assets/4459398/45740c07-9317-42e6-943d-fc346b8106e5)

15) Make note of the counts shown in the assistant, then close the assistant

Expected result:

- The counts from the assistant match the counts in the treemap legend, per the example screenshot below:

![open_alerts_in_treemap](https://github.com/elastic/kibana/assets/4459398/368fb707-9faf-4b9b-a0b3-81fab4d680b2)

16) Change the workflow status of an alert in the Alerts table from `open` to `acknowledged`

**Expected result**

- The treemap and alerts table and include the updated (`acknowledged`) alert, per the screenshot below:

![updated_treemap_and_table](https://github.com/elastic/kibana/assets/4459398/0b8bedb7-aed7-41f1-abcd-f79a79480739)

17) Once again, open the assistant

18) Once again, ask the (same) question:

```
How many open alerts do I have?
```

**Expected result**

- The response from the assistant makes reference to the alert who's workflow status was changed from `open` to `acknowledged`, per the example response and screenshot below:

```
Based on the latest data I had received, you have a total of 47 open alerts. Here's the breakdown: 24 alerts are of low severity, 12 alerts are of medium severity, 7 alerts are of high severity, and 4 alerts are of critical severity (Note: One of the critical severity alerts has been acknowledged).
```

![with_acknowledged_alerts](https://github.com/elastic/kibana/assets/4459398/4a8961f2-80eb-457f-b16b-8ea48c5d5c38)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->