### PR TITLE
[ES|QL] Display the correct language string

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -21,6 +21,7 @@ import {
   isOfQueryType,
   getAggregateQueryMode,
   ExecutionContextSearch,
+  getLanguageDisplayName,
 } from '@kbn/es-query';
 import type { PaletteOutput } from '@kbn/coloring';
 import {
@@ -740,7 +741,7 @@ export class Embeddable
     }
     const query = this.savedVis?.state.query as unknown as AggregateQuery;
     const language = getAggregateQueryMode(query);
-    return String(language).toUpperCase();
+    return getLanguageDisplayName(language).toUpperCase();
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes the action title to use the correct language name

<img width="217" alt="Screenshot 2023-12-20 at 11 29 34" src="https://github.com/elastic/kibana/assets/924948/33edba48-d9f8-4f64-af13-488dcb2948a2">