### PR TITLE
[APM UI] Add option to pass number of services to a scenario

### DIFF
--- a/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
@@ -14,8 +14,8 @@ import { withClient } from '../lib/utils/with_client';
 
 const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
-const scenario: Scenario<ApmFields> = async ({ logger }) => {
-  const numServices = 500;
+const scenario: Scenario<ApmFields> = async ({ logger, scenarioOpts }) => {
+  const { services: numServices = 500 } = scenarioOpts ?? {};
   const languages = ['go', 'dotnet', 'java', 'python'];
   const services = ['web', 'order-processing', 'api-backend', 'proxy'];
   const agentVersions: Record<string, string[]> = {

--- a/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
+++ b/packages/kbn-apm-synthtrace/src/scenarios/many_services.ts
@@ -14,8 +14,8 @@ import { withClient } from '../lib/utils/with_client';
 
 const ENVIRONMENT = getSynthtraceEnvironment(__filename);
 
-const scenario: Scenario<ApmFields> = async ({ logger, scenarioOpts }) => {
-  const { services: numServices = 500 } = scenarioOpts ?? {};
+const scenario: Scenario<ApmFields> = async ({ logger, scenarioOpts = { services: 500 } }) => {
+  const numServices = scenarioOpts.services;
   const languages = ['go', 'dotnet', 'java', 'python'];
   const services = ['web', 'order-processing', 'api-backend', 'proxy'];
   const agentVersions: Record<string, string[]> = {


### PR DESCRIPTION
## Summary

This PR adds an option to pass number of services to the scenario running `many_services` as running 500 services on the CI causes it to fail

With this change, the scenario can now be run like this

```
node scripts/synthtrace many_services.ts --scenarioOpts.services=2
```