### PR TITLE
Require page reload when changing `timepicker:quickRanges` 

### DIFF
--- a/src/plugins/data/server/ui_settings.ts
+++ b/src/plugins/data/server/ui_settings.ts
@@ -471,6 +471,7 @@ export function getUiSettings(
             '</a>',
         },
       }),
+      requiresPageReload: true,
       schema: enableValidations
         ? schema.arrayOf(
             schema.object({


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/172601

I reviewed how this setting is used. It is directly used in a lot of places and it is hard to guarantee/fix that all places pick up the new setting. Safer to ask to reload.





<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->