### PR TITLE
[8.12] [Security Solution] Disable package v2 detection for now (#173686)

### DIFF
--- a/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
+++ b/x-pack/plugins/security_solution/common/endpoint/utils/package_v2.ts
@@ -5,14 +5,17 @@
  * 2.0.
  */
 
-import semverLte from 'semver/functions/lte';
+// import semverLte from 'semver/functions/lte';
 
-function parseSemver(semver: string) {
-  return semver.includes('-') ? semver.substring(0, semver.indexOf('-')) : semver;
-}
+// function parseSemver(semver: string) {
+//   return semver.includes('-') ? semver.substring(0, semver.indexOf('-')) : semver;
+// }
 
-const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.13.0';
+// until a release is confirmed, or another feature-detection method is used, do not automatically
+// switch to "v2" logic
+// const MIN_ENDPOINT_PACKAGE_V2_VERSION = '8.13.0';
 export function isEndpointPackageV2(version: string) {
-  const parsedVersion = parseSemver(version);
-  return semverLte(MIN_ENDPOINT_PACKAGE_V2_VERSION, parsedVersion);
+  // const parsedVersion = parseSemver(version);
+  // return semverLte(MIN_ENDPOINT_PACKAGE_V2_VERSION, parsedVersion);
+  return false;
 }

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/artifacts/artifacts_mocked_data.cy.ts
@@ -31,6 +31,7 @@ const loginWithoutAccess = (url: string) => {
   loadPage(url);
 };
 
+// Flaky: https://github.com/elastic/kibana/issues/171168
 describe('Artifacts pages', { tags: ['@ess', '@serverless'] }, () => {
   let endpointData: ReturnTypeFromChainable<typeof indexEndpointHosts> | undefined;
 

--- a/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
+++ b/x-pack/test/security_solution_endpoint/apps/endpoint/endpoint_list.ts
@@ -86,7 +86,8 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
   };
 
   // FLAKY: https://github.com/elastic/kibana/issues/170357
-  describe.skip('endpoint list', function () {
+  // FLAKY: https://github.com/elastic/kibana/issues/173670
+  describe('endpoint list', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
+++ b/x-pack/test/security_solution_endpoint/apps/integrations/policy_details.ts
@@ -30,7 +30,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   // FLAKY: https://github.com/elastic/kibana/issues/171653
   // FLAKY: https://github.com/elastic/kibana/issues/171654
-  describe.skip('When on the Endpoint Policy Details Page', function () {
+  describe('When on the Endpoint Policy Details Page', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;

--- a/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
+++ b/x-pack/test/security_solution_endpoint_api_int/apis/endpoint_response_actions/execute.ts
@@ -18,7 +18,7 @@ export default function ({ getService }: FtrProviderContext) {
 
   // FLAKY: https://github.com/elastic/kibana/issues/171666
   // FLAKY: https://github.com/elastic/kibana/issues/171667
-  describe.skip('Endpoint `execute` response action', function () {
+  describe('Endpoint `execute` response action', function () {
     targetTags(this, ['@ess', '@serverless']);
 
     let indexedData: IndexedHostsAndAlertsResponse;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Security Solution] Disable package v2 detection for now (#173686)](https://github.com/elastic/kibana/pull/173686)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dan Panzarella","email":"pzl@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-12-20T14:05:43Z","message":"[Security Solution] Disable package v2 detection for now (#173686)","sha":"c3b3194ea06bc5e22b6da798b814cab812cd01e1","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.12.0","v8.13.0"],"number":173686,"url":"https://github.com/elastic/kibana/pull/173686","mergeCommit":{"message":"[Security Solution] Disable package v2 detection for now (#173686)","sha":"c3b3194ea06bc5e22b6da798b814cab812cd01e1"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173686","number":173686,"mergeCommit":{"message":"[Security Solution] Disable package v2 detection for now (#173686)","sha":"c3b3194ea06bc5e22b6da798b814cab812cd01e1"}}]}] BACKPORT-->