### PR TITLE
[Security Solution][Detection Engine] removes threshold alert suppression feature flag

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -126,11 +126,6 @@ export const allowedExperimentalValues = Object.freeze({
   protectionUpdatesEnabled: true,
 
   /**
-   * Enables alerts suppression for threshold rules
-   */
-  alertSuppressionForThresholdRuleEnabled: false,
-
-  /**
    * Disables the timeline save tour.
    * This flag is used to disable the tour in cypress tests.
    */

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -54,7 +54,6 @@ import { TechnicalPreviewBadge } from '../../../../detections/components/rules/t
 import { BadgeList } from './badge_list';
 import { DEFAULT_DESCRIPTION_LIST_COLUMN_WIDTHS } from './constants';
 import * as i18n from './translations';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import type { ExperimentalFeatures } from '../../../../../common/experimental_features';
 
 interface SavedQueryNameProps {
@@ -427,7 +426,7 @@ const prepareDefinitionSectionListItems = (
   rule: Partial<RuleResponse>,
   isInteractive: boolean,
   savedQuery: SavedQuery | undefined,
-  { alertSuppressionForThresholdRuleEnabled }: Partial<ExperimentalFeatures>
+  experimentalFeatures: Partial<ExperimentalFeatures>
 ): EuiDescriptionListProps['listItems'] => {
   const definitionSectionListItems: EuiDescriptionListProps['listItems'] = [];
 
@@ -669,7 +668,7 @@ const prepareDefinitionSectionListItems = (
       });
     }
 
-    if (rule.type !== 'threshold' || alertSuppressionForThresholdRuleEnabled) {
+    if (rule.type !== 'threshold') {
       definitionSectionListItems.push({
         title: (
           <span data-test-subj="alertSuppressionDurationPropertyTitle">
@@ -741,15 +740,10 @@ export const RuleDefinitionSection = ({
     ruleType: rule.type,
   });
 
-  const alertSuppressionForThresholdRuleEnabled = useIsExperimentalFeatureEnabled(
-    'alertSuppressionForThresholdRuleEnabled'
-  );
-
   const definitionSectionListItems = prepareDefinitionSectionListItems(
     rule,
     isInteractive,
-    savedQuery,
-    { alertSuppressionForThresholdRuleEnabled }
+    savedQuery
   );
 
   return (

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -426,7 +426,7 @@ const prepareDefinitionSectionListItems = (
   rule: Partial<RuleResponse>,
   isInteractive: boolean,
   savedQuery: SavedQuery | undefined,
-  experimentalFeatures: Partial<ExperimentalFeatures>
+  experimentalFeatures?: Partial<ExperimentalFeatures>
 ): EuiDescriptionListProps['listItems'] => {
   const definitionSectionListItems: EuiDescriptionListProps['listItems'] = [];
 

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_definition_section.tsx
@@ -668,16 +668,14 @@ const prepareDefinitionSectionListItems = (
       });
     }
 
-    if (rule.type !== 'threshold') {
-      definitionSectionListItems.push({
-        title: (
-          <span data-test-subj="alertSuppressionDurationPropertyTitle">
-            <AlertSuppressionTitle title={i18n.SUPPRESS_ALERTS_DURATION_FIELD_LABEL} />
-          </span>
-        ),
-        description: <SuppressAlertsDuration duration={rule.alert_suppression.duration} />,
-      });
-    }
+    definitionSectionListItems.push({
+      title: (
+        <span data-test-subj="alertSuppressionDurationPropertyTitle">
+          <AlertSuppressionTitle title={i18n.SUPPRESS_ALERTS_DURATION_FIELD_LABEL} />
+        </span>
+      ),
+      description: <SuppressAlertsDuration duration={rule.alert_suppression.duration} />,
+    });
 
     if ('missing_fields_strategy' in rule.alert_suppression) {
       definitionSectionListItems.push({

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -83,7 +83,6 @@ import { useLicense } from '../../../../common/hooks/use_license';
 import { AlertSuppressionMissingFieldsStrategyEnum } from '../../../../../common/api/detection_engine/model/rule_schema';
 import { DurationInput } from '../duration_input';
 import { MINIMUM_LICENSE_FOR_SUPPRESSION } from '../../../../../common/detection_engine/constants';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
 import { useUpsellingMessage } from '../../../../common/hooks/use_upselling';
 
 const CommonUseField = getUseField({ component: Field });

--- a/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/rules/step_define_rule/index.tsx
@@ -182,9 +182,6 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
 
   const esqlQueryRef = useRef<DefineStepRule['queryBar'] | undefined>(undefined);
 
-  const isAlertSuppressionForThresholdRuleFeatureEnabled = useIsExperimentalFeatureEnabled(
-    'alertSuppressionForThresholdRuleEnabled'
-  );
   const isAlertSuppressionLicenseValid = license.isAtLeast(MINIMUM_LICENSE_FOR_SUPPRESSION);
 
   const isThresholdRule = getIsThresholdRule(ruleType);
@@ -808,8 +805,7 @@ const StepDefineRuleComponent: FC<StepDefineRuleProps> = ({
     [isUpdateView, mlCapabilities]
   );
 
-  const isAlertSuppressionEnabled =
-    isQueryRule(ruleType) || (isThresholdRule && isAlertSuppressionForThresholdRuleFeatureEnabled);
+  const isAlertSuppressionEnabled = isQueryRule(ruleType) || isThresholdRule;
 
   return (
     <>

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/threshold/threshold.ts
@@ -156,11 +156,7 @@ export const thresholdExecutor = async ({
     let createResult: GenericBulkCreateResponse<BaseFieldsLatest>;
     let newSignalHistory: ThresholdSignalHistory;
 
-    if (
-      alertSuppression?.duration &&
-      runOpts?.experimentalFeatures?.alertSuppressionForThresholdRuleEnabled &&
-      hasPlatinumLicense
-    ) {
+    if (alertSuppression?.duration && hasPlatinumLicense) {
       const suppressedResults = await bulkCreateSuppressedThresholdAlerts({
         buckets,
         completeRule,

--- a/x-pack/test/security_solution_api_integration/config/ess/config.base.ts
+++ b/x-pack/test/security_solution_api_integration/config/ess/config.base.ts
@@ -81,7 +81,6 @@ export function createTestConfig(options: CreateTestConfigOptions, testFiles?: s
             'previewTelemetryUrlEnabled',
             'riskScoringPersistence',
             'riskScoringRoutesEnabled',
-            'alertSuppressionForThresholdRuleEnabled',
           ])}`,
           '--xpack.task_manager.poll_interval=1000',
           `--xpack.actions.preconfigured=${JSON.stringify({

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/default_license/rule_execution_logic/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/default_license/rule_execution_logic/configs/serverless.config.ts
@@ -16,8 +16,5 @@ export default createTestConfig({
       'testing_ignored.constant',
       '/testing_regex*/',
     ])}`, // See tests within the file "ignore_fields.ts" which use these values in "alertIgnoreFields"
-    `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-      'alertSuppressionForThresholdRuleEnabled',
-    ])}`,
   ],
 });

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -46,7 +46,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'chartEmbeddablesEnabled',
-          'alertSuppressionForThresholdRuleEnabled',
         ])}`,
         // mock cloud to enable the guided onboarding tour in e2e tests
         '--xpack.cloud.id=test',

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule.cy.ts
@@ -72,15 +72,6 @@ describe(
   'Threshold rules',
   {
     tags: ['@ess', '@serverless'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForThresholdRuleEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     const rule = getNewThresholdRule();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule_serverless_essentials.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/threshold_rule_serverless_essentials.cy.ts
@@ -23,11 +23,6 @@ describe(
           { product_line: 'security', product_tier: 'essentials' },
           { product_line: 'endpoint', product_tier: 'essentials' },
         ],
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForThresholdRuleEnabled',
-          ])}`,
-        ],
       },
     },
   },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/threshold_rule.cy.ts
@@ -41,15 +41,6 @@ describe(
   'Detection threshold rules, edit',
   {
     tags: ['@ess', '@serverless'],
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForThresholdRuleEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     describe('without suppression', () => {

--- a/x-pack/test/security_solution_cypress/serverless_config.ts
+++ b/x-pack/test/security_solution_cypress/serverless_config.ts
@@ -34,9 +34,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
           { product_line: 'endpoint', product_tier: 'complete' },
           { product_line: 'cloud', product_tier: 'complete' },
         ])}`,
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-          'alertSuppressionForThresholdRuleEnabled',
-        ])}`,
       ],
     },
     testRunner: SecuritySolutionConfigurableCypressTestRunner,


### PR DESCRIPTION
## Summary

- removes threshold alert suppression experimental feature flag introduced in https://github.com/elastic/kibana/pull/171423
- docs [issue](https://github.com/elastic/security-docs/issues/4315) for reference 

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->