### PR TITLE
[Actions] Pass the Kibana requests to the executor of system actions

### DIFF
--- a/x-pack/plugins/actions/server/lib/action_executor.ts
+++ b/x-pack/plugins/actions/server/lib/action_executor.ts
@@ -259,6 +259,7 @@ export class ActionExecutor {
             configurationUtilities,
             logger,
             source,
+            ...(actionType.isSystemActionType ? { request } : {}),
           });
         } catch (err) {
           if (

--- a/x-pack/plugins/actions/server/types.ts
+++ b/x-pack/plugins/actions/server/types.ts
@@ -76,6 +76,7 @@ export interface ActionTypeExecutorOptions<
   taskInfo?: TaskInfo;
   configurationUtilities: ActionsConfigurationUtilities;
   source?: ActionExecutionSource<unknown>;
+  request?: KibanaRequest;
 }
 
 export type ActionResult = Connector;


### PR DESCRIPTION
## Summary

System actions, like the case action, may need access to the Kibana request to initiate clients (cases client for example) or services. This PR passes the Kibana request to the `executor` of system actions. It does not pass the request to nonsystem action types.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
