### PR TITLE
[Fleet] Allow to skipDatastreamRollover from preconfiguration

### DIFF
--- a/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/common/types/models/preconfiguration.ts
@@ -35,6 +35,7 @@ export interface PreconfiguredAgentPolicy extends Omit<NewAgentPolicy, 'namespac
 
 export interface PreconfiguredPackage extends Omit<PackagePolicyPackage, 'title'> {
   prerelease?: boolean;
+  skipDataStreamRollover?: boolean;
 }
 
 export interface PreconfiguredOutput extends Omit<Output, 'config_yaml'> {

--- a/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/bulk_install_packages.ts
@@ -19,7 +19,10 @@ import type { BulkInstallResponse, IBulkInstallPackageError } from './install';
 
 interface BulkInstallPackagesParams {
   savedObjectsClient: SavedObjectsClientContract;
-  packagesToInstall: Array<string | { name: string; version?: string; prerelease?: boolean }>;
+  packagesToInstall: Array<
+    | string
+    | { name: string; version?: string; prerelease?: boolean; skipDataStreamRollover?: boolean }
+  >;
   esClient: ElasticsearchClient;
   force?: boolean;
   spaceId: string;
@@ -48,10 +51,18 @@ export async function bulkInstallPackages({
           name: pkgRes.name,
           version: pkgRes.version,
           prerelease: undefined,
+          skipDataStreamRollover: undefined,
         }));
       }
       if (pkg.version !== undefined) {
-        return Promise.resolve(pkg as { name: string; version: string; prerelease?: boolean });
+        return Promise.resolve(
+          pkg as {
+            name: string;
+            version: string;
+            prerelease?: boolean;
+            skipDataStreamRollover?: boolean;
+          }
+        );
       }
 
       return Registry.fetchFindLatestPackageOrThrow(pkg.name, {
@@ -60,6 +71,7 @@ export async function bulkInstallPackages({
         name: pkgRes.name,
         version: pkgRes.version,
         prerelease: pkg.prerelease,
+        skipDataStreamRollover: pkg.skipDataStreamRollover,
       }));
     })
   );
@@ -114,6 +126,7 @@ export async function bulkInstallPackages({
         force,
         prerelease: prerelease || ('prerelease' in pkgKeyProps && pkgKeyProps.prerelease),
         authorizationHeader,
+        skipDataStreamRollover: pkgKeyProps.skipDataStreamRollover,
       });
 
       if (installResult.error) {

--- a/x-pack/plugins/fleet/server/services/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/services/preconfiguration.ts
@@ -81,7 +81,11 @@ export async function ensurePreconfiguredPackagesAndPolicies(
 
   const packagesToInstall = packages.map((pkg) =>
     pkg.version === PRECONFIGURATION_LATEST_KEYWORD
-      ? { name: pkg.name, prerelease: pkg.prerelease }
+      ? {
+          name: pkg.name,
+          prerelease: pkg.prerelease,
+          skipDataStreamRollover: pkg.skipDataStreamRollover,
+        }
       : pkg
   );
 

--- a/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
+++ b/x-pack/plugins/fleet/server/types/models/preconfiguration.ts
@@ -45,6 +45,7 @@ export const PreconfiguredPackagesSchema = schema.arrayOf(
       },
     }),
     prerelease: schema.maybe(schema.boolean()),
+    skipDataStreamRollover: schema.maybe(schema.boolean()),
   }),
   {
     defaultValue: [],


### PR DESCRIPTION
## Summary

Resolve #172371 


That PR allow to configure the `skipDatastreamRollover` flag when installing preconfigured package.


## How to tests

You can try to add  the following configuration and verify package is currently installed or upgrade without rollover

```yaml
xpack.fleet.packages:
  - name: apm
    version: latest
    skipDataStreamRollover: true
```

## Todo

- [ ] add tests
