### PR TITLE
[Observability Overview] Fix unable to load page due to an error in MetricWithSparkline

### DIFF
--- a/x-pack/plugins/observability/public/pages/overview/components/sections/metrics/metric_with_sparkline.tsx
+++ b/x-pack/plugins/observability/public/pages/overview/components/sections/metrics/metric_with_sparkline.tsx
@@ -36,7 +36,7 @@ export function MetricWithSparkline({ id, formatter, value, timeseries, color }:
   const theme = [EUI_SPARKLINE_THEME_PARTIAL];
   const baseTheme = isDarkTheme ? DARK_THEME : LIGHT_THEME;
 
-  const colors = theme[1].colors?.vizColors ?? [];
+  const colors = baseTheme.colors?.vizColors ?? [];
 
   if (!value) {
     return (


### PR DESCRIPTION
Fixes #173768

## Summary

In order to check the issue, you need to generate some host data and then check the observability overview page.

|Local|Oblt|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/c3113dd3-0b30-4c7b-a222-70f9045ebbdd)![image](https://github.com/elastic/kibana/assets/12370520/434d2266-e033-4761-92ad-c4cea6c351a0)|![image](https://github.com/elastic/kibana/assets/12370520/02af7c79-9119-44c6-a4ce-d24591014b09)|

