### PR TITLE
[Investigations] - Unskip alert page not found test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/not_found.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/urls/not_found.cy.ts
@@ -31,9 +31,7 @@ describe('Display not found page', { tags: ['@ess', '@serverless'] }, () => {
     visitWithTimeRange(TIMELINES_URL);
   });
 
-  // Tracked by https://github.com/elastic/kibana/issues/143705
-  // TODO: We need to determine what we want the behavior to be here
-  it.skip('navigates to the alerts page with incorrect link', () => {
+  it('navigates to the alerts page with incorrect link', () => {
     visitWithTimeRange(`${ALERTS_URL}/randomUrl`);
     cy.get(NOT_FOUND).should('exist');
   });


### PR DESCRIPTION
## Summary

This test can be unskipped as the alert details page no longer exists in favor of the expanded flyout, so this test can be re-enabled

fixes: https://github.com/elastic/kibana/issues/143705

