### PR TITLE
skip type check in build_api_docs

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -25,6 +25,8 @@ steps:
       queue: n2-4-spot
     key: build_api_docs
     timeout_in_minutes: 60
+    depends_on:
+      check_types
     retry:
       automatic:
         - exit_status: '-1'
@@ -151,7 +153,7 @@ steps:
     retry:
       automatic:
         - exit_status: '*'
-          limit: 1        
+          limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_entity_analytics.sh
     label: 'Entity Analytics - Security Solution Cypress Tests'
@@ -200,7 +202,7 @@ steps:
       automatic:
         - exit_status: '*'
           limit: 1
-          
+
   - command: .buildkite/scripts/steps/functional/security_solution_detection_engine.sh
     label: 'Detection Engine - Security Solution Cypress Tests'
     agents:
@@ -235,7 +237,7 @@ steps:
     retry:
       automatic:
         - exit_status: '*'
-          limit: 1        
+          limit: 1
 
   - command: .buildkite/scripts/steps/functional/security_solution_investigations.sh
     label: 'Investigations - Security Solution Cypress Tests'

--- a/.buildkite/pipelines/pull_request/type_check.yml
+++ b/.buildkite/pipelines/pull_request/type_check.yml
@@ -1,6 +1,7 @@
 steps:
   - command: .buildkite/scripts/steps/check_types.sh
     label: 'Check Types'
+    key: check_types
     agents:
       queue: n2-16-spot
     timeout_in_minutes: 60

--- a/.buildkite/scripts/steps/build_api_docs.sh
+++ b/.buildkite/scripts/steps/build_api_docs.sh
@@ -4,8 +4,10 @@ set -euo pipefail
 
 .buildkite/scripts/bootstrap.sh
 
-echo "--- Run scripts/type_check to ensure that all build available"
-node scripts/type_check
+if [[ "${PUBLISH_API_DOCS_CHANGES:-}" == "true" ]]; then
+  echo "--- Run scripts/type_check to ensure that all build available"
+  node scripts/type_check
+fi
 
 echo "--- Build API Docs"
 node --max-old-space-size=12000 scripts/build_api_docs


### PR DESCRIPTION
## Summary

Does it makes sense to do type_check in build_api_docs when there is a separate type_check step