### PR TITLE
[8.11] [RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899)

### DIFF
--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_edit.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_edit.tsx
@@ -213,7 +213,7 @@ export const RuleEdit = ({
         aria-labelledby="flyoutRuleEditTitle"
         size="m"
         maxWidth={620}
-        ownFocus={false}
+        ownFocus
       >
         <EuiFlyoutHeader hasBorder>
           <EuiTitle size="s" data-test-subj="editRuleFlyoutTitle">


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899)](https://github.com/elastic/kibana/pull/172899)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Jiawei Wu","email":"74562234+JiaweiWu@users.noreply.github.com"},"sourceCommit":{"committedDate":"2023-12-20T20:21:51Z","message":"[RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899)\n\n## Summary\r\nResolves: https://github.com/elastic/kibana/issues/172594\r\n\r\nFixes the rule edit alerts search bar autocomplete causing background to\r\nalso scroll infinitely\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Xavier Mouligneau <xavier.mouligneau@elastic.co>","sha":"4465c1e090ab1179f12000d52b1dc0eefd14217f","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","Feature:Alerting/RulesManagement","v8.11.0","v8.12.0","v8.13.0"],"number":172899,"url":"https://github.com/elastic/kibana/pull/172899","mergeCommit":{"message":"[RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899)\n\n## Summary\r\nResolves: https://github.com/elastic/kibana/issues/172594\r\n\r\nFixes the rule edit alerts search bar autocomplete causing background to\r\nalso scroll infinitely\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Xavier Mouligneau <xavier.mouligneau@elastic.co>","sha":"4465c1e090ab1179f12000d52b1dc0eefd14217f"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/173789","number":173789,"state":"MERGED","mergeCommit":{"sha":"487baa7cd4c16500044a48d7cce450be51a8572e","message":"[8.12] [RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899) (#173789)\n\n# Backport\n\nThis will backport the following commits from `main` to `8.12`:\n- [[RAM] Fix rule edit flyout alerts search bar autocomplete scroll\n(#172899)](https://github.com/elastic/kibana/pull/172899)\n\n<!--- Backport version: 8.9.7 -->\n\n### Questions ?\nPlease refer to the [Backport tool\ndocumentation](https://github.com/sqren/backport)\n\n<!--BACKPORT [{\"author\":{\"name\":\"Jiawei\nWu\",\"email\":\"74562234+JiaweiWu@users.noreply.github.com\"},\"sourceCommit\":{\"committedDate\":\"2023-12-20T20:21:51Z\",\"message\":\"[RAM]\nFix rule edit flyout alerts search bar autocomplete scroll\n(#172899)\\n\\n## Summary\\r\\nResolves:\nhttps://github.com/elastic/kibana/issues/172594\\r\\n\\r\\nFixes the rule\nedit alerts search bar autocomplete causing background to\\r\\nalso scroll\ninfinitely\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nXavier Mouligneau\n<xavier.mouligneau@elastic.co>\",\"sha\":\"4465c1e090ab1179f12000d52b1dc0eefd14217f\",\"branchLabelMapping\":{\"^v8.13.0$\":\"main\",\"^v(\\\\d+).(\\\\d+).\\\\d+$\":\"$1.$2\"}},\"sourcePullRequest\":{\"labels\":[\"release_note:skip\",\"Team:ResponseOps\",\"Feature:Alerting/RulesManagement\",\"v8.11.0\",\"v8.12.0\",\"v8.13.0\"],\"number\":172899,\"url\":\"https://github.com/elastic/kibana/pull/172899\",\"mergeCommit\":{\"message\":\"[RAM]\nFix rule edit flyout alerts search bar autocomplete scroll\n(#172899)\\n\\n## Summary\\r\\nResolves:\nhttps://github.com/elastic/kibana/issues/172594\\r\\n\\r\\nFixes the rule\nedit alerts search bar autocomplete causing background to\\r\\nalso scroll\ninfinitely\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nXavier Mouligneau\n<xavier.mouligneau@elastic.co>\",\"sha\":\"4465c1e090ab1179f12000d52b1dc0eefd14217f\"}},\"sourceBranch\":\"main\",\"suggestedTargetBranches\":[\"8.11\",\"8.12\"],\"targetPullRequestStates\":[{\"branch\":\"8.11\",\"label\":\"v8.11.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"8.12\",\"label\":\"v8.12.0\",\"labelRegex\":\"^v(\\\\d+).(\\\\d+).\\\\d+$\",\"isSourceBranch\":false,\"state\":\"NOT_CREATED\"},{\"branch\":\"main\",\"label\":\"v8.13.0\",\"labelRegex\":\"^v8.13.0$\",\"isSourceBranch\":true,\"state\":\"MERGED\",\"url\":\"https://github.com/elastic/kibana/pull/172899\",\"number\":172899,\"mergeCommit\":{\"message\":\"[RAM]\nFix rule edit flyout alerts search bar autocomplete scroll\n(#172899)\\n\\n## Summary\\r\\nResolves:\nhttps://github.com/elastic/kibana/issues/172594\\r\\n\\r\\nFixes the rule\nedit alerts search bar autocomplete causing background to\\r\\nalso scroll\ninfinitely\\r\\n\\r\\n\\r\\n\\r\\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\\r\\n\\r\\n---------\\r\\n\\r\\nCo-authored-by:\nKibana Machine\n<42973632+kibanamachine@users.noreply.github.com>\\r\\nCo-authored-by:\nXavier Mouligneau\n<xavier.mouligneau@elastic.co>\",\"sha\":\"4465c1e090ab1179f12000d52b1dc0eefd14217f\"}}]}]\nBACKPORT-->\n\nCo-authored-by: Jiawei Wu <74562234+JiaweiWu@users.noreply.github.com>"}},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/172899","number":172899,"mergeCommit":{"message":"[RAM] Fix rule edit flyout alerts search bar autocomplete scroll (#172899)\n\n## Summary\r\nResolves: https://github.com/elastic/kibana/issues/172594\r\n\r\nFixes the rule edit alerts search bar autocomplete causing background to\r\nalso scroll infinitely\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/74562234/f55db528-b933-400a-80b5-8a3063f0f29c\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Xavier Mouligneau <xavier.mouligneau@elastic.co>","sha":"4465c1e090ab1179f12000d52b1dc0eefd14217f"}}]}] BACKPORT-->