### PR TITLE
[Security solution] Assistant telemetry conversation id fix

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/index.tsx
@@ -83,7 +83,7 @@ const AssistantComponent: React.FC<Props> = ({
     http,
     promptContexts,
     setLastConversationId,
-    localStorageLastConversationId,
+    getConversationId,
     title,
     allSystemPrompts,
   } = useAssistantContext();
@@ -113,12 +113,7 @@ const AssistantComponent: React.FC<Props> = ({
   );
 
   const [selectedConversationId, setSelectedConversationId] = useState<string>(
-    isAssistantEnabled
-      ? // if a conversationId has been provided, use that
-        // if not, check local storage
-        // last resort, go to welcome conversation
-        conversationId ?? localStorageLastConversationId ?? WELCOME_CONVERSATION_TITLE
-      : WELCOME_CONVERSATION_TITLE
+    isAssistantEnabled ? getConversationId(conversationId) : WELCOME_CONVERSATION_TITLE
   );
 
   useEffect(() => {

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.test.tsx
@@ -12,7 +12,11 @@ import { AssistantProvider, useAssistantContext } from '.';
 import { httpServiceMock } from '@kbn/core-http-browser-mocks';
 import { actionTypeRegistryMock } from '@kbn/triggers-actions-ui-plugin/public/application/action_type_registry.mock';
 import { AssistantAvailability } from '../..';
+import { useLocalStorage } from 'react-use';
 
+jest.mock('react-use', () => ({
+  useLocalStorage: jest.fn().mockReturnValue(['456', jest.fn()]),
+}));
 const actionTypeRegistry = actionTypeRegistryMock.create();
 const mockGetInitialConversations = jest.fn(() => ({}));
 const mockGetComments = jest.fn(() => []);
@@ -69,5 +73,24 @@ describe('AssistantContext', () => {
     await http.fetch(path);
 
     expect(mockHttp.fetch).toBeCalledWith(path);
+  });
+
+  test('getConversationId defaults to provided id', async () => {
+    const { result } = renderHook(useAssistantContext, { wrapper: ContextWrapper });
+    const id = result.current.getConversationId('123');
+    expect(id).toEqual('123');
+  });
+
+  test('getConversationId uses local storage id when no id is provided ', async () => {
+    const { result } = renderHook(useAssistantContext, { wrapper: ContextWrapper });
+    const id = result.current.getConversationId();
+    expect(id).toEqual('456');
+  });
+
+  test('getConversationId defaults to Welcome when no local storage id and no id is provided ', async () => {
+    (useLocalStorage as jest.Mock).mockReturnValue([undefined, jest.fn()]);
+    const { result } = renderHook(useAssistantContext, { wrapper: ContextWrapper });
+    const id = result.current.getConversationId();
+    expect(id).toEqual('Welcome');
   });
 });

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -13,6 +13,7 @@ import type { IToasts } from '@kbn/core-notifications-browser';
 import { ActionTypeRegistryContract } from '@kbn/triggers-actions-ui-plugin/public';
 import { useLocalStorage } from 'react-use';
 import type { DocLinksStart } from '@kbn/core-doc-links-browser';
+import { WELCOME_CONVERSATION_TITLE } from '../assistant/use_conversation/translations';
 import { updatePromptContexts } from './helpers';
 import type {
   PromptContext,
@@ -136,7 +137,7 @@ export interface UseAssistantContext {
   }) => EuiCommentProps[];
   http: HttpSetup;
   knowledgeBase: KnowledgeBaseConfig;
-  localStorageLastConversationId: string | undefined;
+  getConversationId: (id?: string) => string;
   promptContexts: Record<string, PromptContext>;
   modelEvaluatorEnabled: boolean;
   nameSpace: string;
@@ -147,7 +148,7 @@ export interface UseAssistantContext {
   setAllSystemPrompts: React.Dispatch<React.SetStateAction<Prompt[] | undefined>>;
   setConversations: React.Dispatch<React.SetStateAction<Record<string, Conversation>>>;
   setDefaultAllow: React.Dispatch<React.SetStateAction<string[]>>;
-  setDefaultAllowReplacement: React.Dispatch<React.SetStateAction<string[]>>;
+  setDefaultAllowRepflacement: React.Dispatch<React.SetStateAction<string[]>>;
   setKnowledgeBase: React.Dispatch<React.SetStateAction<KnowledgeBaseConfig | undefined>>;
   setLastConversationId: React.Dispatch<React.SetStateAction<string | undefined>>;
   setSelectedSettingsTab: React.Dispatch<React.SetStateAction<SettingsTabs>>;
@@ -292,6 +293,14 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
     [setConversations]
   );
 
+  const getConversationId = useCallback(
+    // if a conversationId has been provided, use that
+    // if not, check local storage
+    // last resort, go to welcome conversation
+    (id?: string) => id ?? localStorageLastConversationId ?? WELCOME_CONVERSATION_TITLE,
+    [localStorageLastConversationId]
+  );
+
   const value = useMemo(
     () => ({
       actionTypeRegistry,
@@ -334,7 +343,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       title,
       toasts,
       unRegisterPromptContext,
-      localStorageLastConversationId,
+      getConversationId,
       setLastConversationId: setLocalStorageLastConversationId,
     }),
     [
@@ -358,7 +367,7 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       getComments,
       http,
       localStorageKnowledgeBase,
-      localStorageLastConversationId,
+      getConversationId,
       localStorageQuickPrompts,
       localStorageSystemPrompts,
       modelEvaluatorEnabled,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -148,7 +148,7 @@ export interface UseAssistantContext {
   setAllSystemPrompts: React.Dispatch<React.SetStateAction<Prompt[] | undefined>>;
   setConversations: React.Dispatch<React.SetStateAction<Record<string, Conversation>>>;
   setDefaultAllow: React.Dispatch<React.SetStateAction<string[]>>;
-  setDefaultAllowRepflacement: React.Dispatch<React.SetStateAction<string[]>>;
+  setDefaultAllowReplacement: React.Dispatch<React.SetStateAction<string[]>>;
   setKnowledgeBase: React.Dispatch<React.SetStateAction<KnowledgeBaseConfig | undefined>>;
   setLastConversationId: React.Dispatch<React.SetStateAction<string | undefined>>;
   setSelectedSettingsTab: React.Dispatch<React.SetStateAction<SettingsTabs>>;


### PR DESCRIPTION
## Summary

We track telemetry when the AI Assistant button is clicked into, including the `conversationId`. However, when we [introduced the new global header menu](https://github.com/elastic/kibana/pull/164763), the `conversationId` got dropped. This PR fixes that by introducing a new method, `getConversationId` that will default to the `localStorageLastConversationId` and then the Welcome id if no local storage id is present. This method is shared anywhere the `conversationId` is referenced.

## To test

1. Ensure `telemetry.optIn: true` is defined in your dev yml
2. Open the assistant by clicking the AI Assistant button
3. Observe in the console the event `Report event "Assistant Invoked" `. Expand the event and find the id in `properties.conversationId`. Ensure that it is the same conversation that was opened
    <img width="1015" alt="Screenshot 2023-12-20 at 4 41 44 PM" src="https://github.com/elastic/kibana/assets/6935300/5fc78f6c-e1c7-4c95-afa5-cfdb551007ad">
4. Change the selected conversation
5. Close the Assistant
6. Open the assistant by clicking the AI Assistant button
7. Observe in the console the event `Report event "Assistant Invoked" `. Expand the event and ensure the expected `properties.conversationId` was sent

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->