### PR TITLE
[RAM] Allow initialization of the scope form the rule list component

### DIFF
--- a/x-pack/plugins/observability/public/pages/rules/rules_tab.tsx
+++ b/x-pack/plugins/observability/public/pages/rules/rules_tab.tsx
@@ -9,6 +9,7 @@ import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import { RuleStatus } from '@kbn/triggers-actions-ui-plugin/public';
+import { AlertConsumers } from '@kbn/rule-data-utils';
 import { useKibana } from '../../utils/kibana_react';
 import { useGetFilteredRuleTypes } from '../../hooks/use_get_filtered_rule_types';
 import { observabilityAlertFeatureIds } from '../../../common/constants';
@@ -97,6 +98,7 @@ export function RulesTab({ setRefresh, stateRefresh }: RulesTabProps) {
       onSearchFilterChange={handleSearchFilterChange}
       onStatusFilterChange={handleStatusFilterChange}
       onTypeFilterChange={handleTypeFilterChange}
+      initialSelectedConsumer={AlertConsumers.LOGS}
     />
   );
 }

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_add.tsx
@@ -315,6 +315,7 @@ const RuleAdd = ({
                 onChangeMetaData={onChangeMetaData}
                 setConsumer={setSelectedConsumer}
                 useRuleProducer={useRuleProducer}
+                initialSelectedConsumer={initialSelectedConsumer}
               />
             </EuiFlyoutBody>
             <RuleAddFooter

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form.tsx
@@ -157,6 +157,7 @@ interface RuleFormProps<MetaData = Record<string, any>> {
   validConsumers?: RuleCreationValidConsumer[];
   onChangeMetaData: (metadata: MetaData) => void;
   useRuleProducer?: boolean;
+  initialSelectedConsumer?: RuleCreationValidConsumer | null;
 }
 
 const EMPTY_ARRAY: string[] = [];
@@ -183,6 +184,7 @@ export const RuleForm = ({
   validConsumers,
   onChangeMetaData,
   useRuleProducer,
+  initialSelectedConsumer,
 }: RuleFormProps) => {
   const {
     notifications: { toasts },
@@ -818,6 +820,7 @@ export const RuleForm = ({
               onChange={setConsumer}
               errors={errors}
               selectedConsumer={selectedConsumer}
+              initialSelectedConsumer={initialSelectedConsumer}
             />
           </EuiFlexItem>
         </>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.test.tsx
@@ -54,6 +54,58 @@ describe('RuleFormConsumerSelectionModal', () => {
     expect(mockOnChange).toHaveBeenLastCalledWith('logs');
   });
 
+  it('should NOT initialize if initialSelectedConsumer is equal to null', () => {
+    render(
+      <RuleFormConsumerSelection
+        selectedConsumer={null}
+        consumers={mockConsumers}
+        onChange={mockOnChange}
+        initialSelectedConsumer={null}
+        errors={{}}
+      />
+    );
+    expect(mockOnChange).not.toBeCalled();
+  });
+
+  it('should initialize to the first valid consumers if initialSelectedConsumer is not valid', () => {
+    render(
+      <RuleFormConsumerSelection
+        selectedConsumer={null}
+        consumers={['logs', 'infrastructure']}
+        onChange={mockOnChange}
+        initialSelectedConsumer={'apm' as RuleCreationValidConsumer}
+        errors={{}}
+      />
+    );
+    expect(mockOnChange).toHaveBeenLastCalledWith('logs');
+  });
+
+  it('should initialize to stackAlerts if the initialSelectedConsumer is not a valid and consumers has stackAlerts', () => {
+    render(
+      <RuleFormConsumerSelection
+        selectedConsumer={null}
+        consumers={['infrastructure', 'stackAlerts']}
+        onChange={mockOnChange}
+        initialSelectedConsumer={'logs'}
+        errors={{}}
+      />
+    );
+    expect(mockOnChange).toHaveBeenLastCalledWith('stackAlerts');
+  });
+
+  it('should initialize to stackAlerts if the initialSelectedConsumer is undefined and consumers has stackAlerts', () => {
+    render(
+      <RuleFormConsumerSelection
+        selectedConsumer={null}
+        consumers={['infrastructure', 'stackAlerts']}
+        onChange={mockOnChange}
+        initialSelectedConsumer={undefined}
+        errors={{}}
+      />
+    );
+    expect(mockOnChange).toHaveBeenLastCalledWith('stackAlerts');
+  });
+
   it('should be able to select infrastructure and call onChange', () => {
     render(
       <RuleFormConsumerSelection

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.test.tsx
@@ -41,6 +41,19 @@ describe('RuleFormConsumerSelectionModal', () => {
     expect(screen.getByText('Stack Rules')).toBeInTheDocument();
   });
 
+  it('should be able to initialize to the prop initialSelectedConsumer', () => {
+    render(
+      <RuleFormConsumerSelection
+        selectedConsumer={null}
+        consumers={mockConsumers}
+        onChange={mockOnChange}
+        initialSelectedConsumer={'logs'}
+        errors={{}}
+      />
+    );
+    expect(mockOnChange).toHaveBeenLastCalledWith('logs');
+  });
+
   it('should be able to select infrastructure and call onChange', () => {
     render(
       <RuleFormConsumerSelection

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
@@ -67,13 +67,20 @@ export interface RuleFormConsumerSelectionProps {
   consumers: RuleCreationValidConsumer[];
   onChange: (consumer: RuleCreationValidConsumer | null) => void;
   errors: IErrorObject;
-  selectedConsumer: RuleCreationValidConsumer | null | undefined;
+  selectedConsumer?: RuleCreationValidConsumer | null;
+  initialSelectedConsumer?: RuleCreationValidConsumer | null;
 }
 
 const SINGLE_SELECTION = { asPlainText: true };
 
 export const RuleFormConsumerSelection = (props: RuleFormConsumerSelectionProps) => {
-  const { consumers, errors, onChange, selectedConsumer } = props;
+  const {
+    consumers,
+    errors,
+    onChange,
+    selectedConsumer,
+    initialSelectedConsumer = STACK_ALERTS_FEATURE_ID,
+  } = props;
   const isInvalid = errors?.consumer?.length > 0;
   const handleOnChange = useCallback(
     (selected: Array<EuiComboBoxOptionOption<RuleCreationValidConsumer>>) => {
@@ -125,8 +132,8 @@ export const RuleFormConsumerSelection = (props: RuleFormConsumerSelectionProps)
   useEffect(() => {
     // At initialization, select Stack Alerts, or the first value
     if (!validatedSelectedConsumer) {
-      if (consumers.includes(STACK_ALERTS_FEATURE_ID)) {
-        onChange(STACK_ALERTS_FEATURE_ID);
+      if (initialSelectedConsumer && consumers.includes(initialSelectedConsumer)) {
+        onChange(initialSelectedConsumer);
         return;
       }
       onChange(consumers[0] as RuleCreationValidConsumer);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
@@ -74,13 +74,7 @@ export interface RuleFormConsumerSelectionProps {
 const SINGLE_SELECTION = { asPlainText: true };
 
 export const RuleFormConsumerSelection = (props: RuleFormConsumerSelectionProps) => {
-  const {
-    consumers,
-    errors,
-    onChange,
-    selectedConsumer,
-    initialSelectedConsumer = STACK_ALERTS_FEATURE_ID,
-  } = props;
+  const { consumers, errors, onChange, selectedConsumer, initialSelectedConsumer } = props;
   const isInvalid = errors?.consumer?.length > 0;
   const handleOnChange = useCallback(
     (selected: Array<EuiComboBoxOptionOption<RuleCreationValidConsumer>>) => {
@@ -134,6 +128,9 @@ export const RuleFormConsumerSelection = (props: RuleFormConsumerSelectionProps)
     if (!validatedSelectedConsumer) {
       if (initialSelectedConsumer && consumers.includes(initialSelectedConsumer)) {
         onChange(initialSelectedConsumer);
+        return;
+      } else if (consumers.includes(STACK_ALERTS_FEATURE_ID)) {
+        onChange(STACK_ALERTS_FEATURE_ID);
         return;
       }
       onChange(consumers[0] as RuleCreationValidConsumer);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rule_form/rule_form_consumer_selection.tsx
@@ -68,6 +68,11 @@ export interface RuleFormConsumerSelectionProps {
   onChange: (consumer: RuleCreationValidConsumer | null) => void;
   errors: IErrorObject;
   selectedConsumer?: RuleCreationValidConsumer | null;
+  /* FUTURE ENGINEER
+   * if this prop is set to null then we wont initialize the value and the user will have to set it
+   * if this prop is set to a valid consumers then we will set it up to what was passed
+   * if this prop is not valid or undefined but the valid consumers has stackAlerts then we will default it to stackAlerts
+   */
   initialSelectedConsumer?: RuleCreationValidConsumer | null;
 }
 
@@ -124,16 +129,18 @@ export const RuleFormConsumerSelection = (props: RuleFormConsumerSelectionProps)
     }, [consumers]);
 
   useEffect(() => {
-    // At initialization, select Stack Alerts, or the first value
+    // At initialization, select initialSelectedConsumer or the first value
     if (!validatedSelectedConsumer) {
-      if (initialSelectedConsumer && consumers.includes(initialSelectedConsumer)) {
+      if (initialSelectedConsumer === null) {
+        return;
+      } else if (initialSelectedConsumer && consumers.includes(initialSelectedConsumer)) {
         onChange(initialSelectedConsumer);
         return;
       } else if (consumers.includes(STACK_ALERTS_FEATURE_ID)) {
         onChange(STACK_ALERTS_FEATURE_ID);
         return;
       }
-      onChange(consumers[0] as RuleCreationValidConsumer);
+      onChange(consumers[0]);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/rules_list/components/rules_list.tsx
@@ -41,6 +41,7 @@ import {
   RuleLastRunOutcomeValues,
 } from '@kbn/alerting-plugin/common';
 import {
+  RuleCreationValidConsumer,
   ruleDetailsRoute as commonRuleDetailsRoute,
   STACK_ALERTS_FEATURE_ID,
 } from '@kbn/rule-data-utils';
@@ -136,6 +137,7 @@ export interface RulesListProps {
   onTypeFilterChange?: (type: string[]) => void;
   onRefresh?: (refresh: Date) => void;
   setHeaderActions?: (components?: React.ReactNode[]) => void;
+  initialSelectedConsumer?: RuleCreationValidConsumer | null;
 }
 
 export const percentileFields = {
@@ -176,6 +178,7 @@ export const RulesList = ({
   onTypeFilterChange,
   onRefresh,
   setHeaderActions,
+  initialSelectedConsumer = STACK_ALERTS_FEATURE_ID,
 }: RulesListProps) => {
   const history = useHistory();
   const kibanaServices = useKibana().services;
@@ -1007,7 +1010,7 @@ export const RulesList = ({
               ruleTypeRegistry={ruleTypeRegistry}
               ruleTypeIndex={ruleTypesState.data}
               onSave={refreshRules}
-              initialSelectedConsumer={STACK_ALERTS_FEATURE_ID}
+              initialSelectedConsumer={initialSelectedConsumer}
             />
           </Suspense>
         )}


### PR DESCRIPTION
## Summary

FIx _> https://github.com/elastic/kibana/issues/172785


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->