### PR TITLE
[Security Solution] [Elastic AI Assistant] Delete the _Retrieval Augmented Generation (RAG) for Alerts_ Feature Flag

### DIFF
--- a/x-pack/packages/kbn-elastic-assistant/impl/alerts/settings/alerts_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/alerts/settings/alerts_settings.tsx
@@ -70,12 +70,6 @@ const AlertsSettingsComponent = ({ knowledgeBase, setUpdatedKnowledgeBaseSetting
       <EuiSpacer size="xs" />
 
       <EuiFlexGroup direction="column" gutterSize="none">
-        <EuiFlexItem grow={false}>
-          <EuiText color="subdued" size="xs">
-            <span>{i18n.ASK_QUESTIONS_ABOUT}</span>
-          </EuiText>
-        </EuiFlexItem>
-
         <EuiFlexItem
           css={css`
             width: ${RANGE_CONTAINER_WIDTH}px;
@@ -106,7 +100,7 @@ const AlertsSettingsComponent = ({ knowledgeBase, setUpdatedKnowledgeBaseSetting
 
         <EuiFlexItem grow={false}>
           <EuiText color="subdued" size="xs">
-            <span>{i18n.LATEST_AND_RISKIEST_OPEN_ALERTS}</span>
+            <span>{i18n.LATEST_AND_RISKIEST_OPEN_ALERTS(knowledgeBase.latestAlerts)}</span>
           </EuiText>
         </EuiFlexItem>
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.test.tsx
@@ -42,7 +42,6 @@ const fetchConnectorArgs: FetchConnectorExecuteAction = {
   http: mockHttp,
   messages,
   onNewReplacements: jest.fn(),
-  ragOnAlerts: false,
 };
 describe('API tests', () => {
   beforeEach(() => {
@@ -91,7 +90,6 @@ describe('API tests', () => {
         alertsIndexPattern: '.alerts-security.alerts-default',
         allow: ['a', 'b', 'c'],
         allowReplacement: ['b', 'c'],
-        ragOnAlerts: true,
         replacements: { auuid: 'real.hostname' },
         size: 30,
       };

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/api.tsx
@@ -29,7 +29,6 @@ export interface FetchConnectorExecuteAction {
   http: HttpSetup;
   messages: Message[];
   onNewReplacements: (newReplacements: Record<string, string>) => void;
-  ragOnAlerts: boolean;
   replacements?: Record<string, string>;
   signal?: AbortSignal | undefined;
   size?: number;
@@ -55,7 +54,6 @@ export const fetchConnectorExecuteAction = async ({
   http,
   messages,
   onNewReplacements,
-  ragOnAlerts,
   replacements,
   apiConfig,
   signal,
@@ -90,7 +88,6 @@ export const fetchConnectorExecuteAction = async ({
     alertsIndexPattern,
     allow,
     allowReplacement,
-    ragOnAlerts,
     replacements,
     size,
   });
@@ -192,7 +189,6 @@ export const fetchConnectorExecuteAction = async ({
       response: hasParsableResponse({
         alerts,
         assistantLangChain,
-        ragOnAlerts,
       })
         ? getFormattedMessageContent(response.data)
         : response.data,

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/helpers.test.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/helpers.test.ts
@@ -235,29 +235,12 @@ describe('getBlockBotConversation', () => {
   });
 
   describe('getOptionalRequestParams', () => {
-    it('should return an empty object when ragOnAlerts is false', () => {
-      const params = {
-        alerts: true,
-        alertsIndexPattern: 'indexPattern',
-        allow: ['a', 'b', 'c'],
-        allowReplacement: ['b', 'c'],
-        ragOnAlerts: false, // <-- false
-        replacements: { key: 'value' },
-        size: 10,
-      };
-
-      const result = getOptionalRequestParams(params);
-
-      expect(result).toEqual({});
-    });
-
     it('should return an empty object when alerts is false', () => {
       const params = {
         alerts: false, // <-- false
         alertsIndexPattern: 'indexPattern',
         allow: ['a', 'b', 'c'],
         allowReplacement: ['b', 'c'],
-        ragOnAlerts: true,
         replacements: { key: 'value' },
         size: 10,
       };
@@ -267,13 +250,12 @@ describe('getBlockBotConversation', () => {
       expect(result).toEqual({});
     });
 
-    it('should return the optional request params when ragOnAlerts is true and alerts is true', () => {
+    it('should return the optional request params when alerts is true', () => {
       const params = {
         alerts: true,
         alertsIndexPattern: 'indexPattern',
         allow: ['a', 'b', 'c'],
         allowReplacement: ['b', 'c'],
-        ragOnAlerts: true,
         replacements: { key: 'value' },
         size: 10,
       };
@@ -292,7 +274,6 @@ describe('getBlockBotConversation', () => {
     it('should return (only) the optional request params that are defined when some optional params are not provided', () => {
       const params = {
         alerts: true,
-        ragOnAlerts: true,
         allow: ['a', 'b', 'c'], // all the others are undefined
       };
 
@@ -305,31 +286,37 @@ describe('getBlockBotConversation', () => {
   });
 
   describe('hasParsableResponse', () => {
-    it('returns true when assistantLangChain is true', () => {
+    it('returns true when just assistantLangChain is true', () => {
       const result = hasParsableResponse({
         alerts: false,
         assistantLangChain: true,
-        ragOnAlerts: false,
       });
 
       expect(result).toBe(true);
     });
 
-    it('returns true when ragOnAlerts is true and alerts is true', () => {
+    it('returns true when just alerts is true', () => {
       const result = hasParsableResponse({
         alerts: true,
         assistantLangChain: false,
-        ragOnAlerts: true,
       });
 
       expect(result).toBe(true);
     });
 
-    it('returns false when assistantLangChain, ragOnAlerts, and alerts are all false', () => {
+    it('returns true when both assistantLangChain and alerts are true', () => {
+      const result = hasParsableResponse({
+        alerts: true,
+        assistantLangChain: true,
+      });
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when both assistantLangChain and alerts are false', () => {
       const result = hasParsableResponse({
         alerts: false,
         assistantLangChain: false,
-        ragOnAlerts: false,
       });
 
       expect(result).toBe(false);

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/helpers.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/helpers.ts
@@ -101,7 +101,6 @@ export const getOptionalRequestParams = ({
   alertsIndexPattern,
   allow,
   allowReplacement,
-  ragOnAlerts,
   replacements,
   size,
 }: {
@@ -109,7 +108,6 @@ export const getOptionalRequestParams = ({
   alertsIndexPattern?: string;
   allow?: string[];
   allowReplacement?: string[];
-  ragOnAlerts: boolean;
   replacements?: Record<string, string>;
   size?: number;
 }): OptionalRequestParams => {
@@ -119,10 +117,8 @@ export const getOptionalRequestParams = ({
   const optionalReplacements = replacements ? { replacements } : undefined;
   const optionalSize = size ? { size } : undefined;
 
-  if (
-    !ragOnAlerts || // the feature flag must be enabled
-    !alerts // the settings toggle must also be enabled
-  ) {
+  // the settings toggle must be enabled:
+  if (!alerts) {
     return {}; // don't send any optional params
   }
 
@@ -138,9 +134,7 @@ export const getOptionalRequestParams = ({
 export const hasParsableResponse = ({
   alerts,
   assistantLangChain,
-  ragOnAlerts,
 }: {
   alerts: boolean;
   assistantLangChain: boolean;
-  ragOnAlerts: boolean;
-}): boolean => assistantLangChain || (ragOnAlerts && alerts);
+}): boolean => assistantLangChain || alerts;

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant/use_send_messages/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant/use_send_messages/index.tsx
@@ -37,7 +37,6 @@ export const useSendMessages = (): UseSendMessages => {
     assistantStreamingEnabled,
     defaultAllow,
     defaultAllowReplacement,
-    ragOnAlerts,
     knowledgeBase,
   } = useAssistantContext();
   const [isLoading, setIsLoading] = useState(false);
@@ -56,7 +55,6 @@ export const useSendMessages = (): UseSendMessages => {
           assistantLangChain: knowledgeBase.assistantLangChain,
           assistantStreamingEnabled,
           http,
-          ragOnAlerts, // feature flag
           replacements,
           messages,
           size: knowledgeBase.latestAlerts,
@@ -74,7 +72,6 @@ export const useSendMessages = (): UseSendMessages => {
       knowledgeBase.alerts,
       knowledgeBase.assistantLangChain,
       knowledgeBase.latestAlerts,
-      ragOnAlerts,
     ]
   );
 

--- a/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/assistant_context/index.tsx
@@ -89,7 +89,6 @@ export interface AssistantProviderProps {
   getInitialConversations: () => Record<string, Conversation>;
   modelEvaluatorEnabled?: boolean;
   nameSpace?: string;
-  ragOnAlerts?: boolean;
   setConversations: React.Dispatch<React.SetStateAction<Record<string, Conversation>>>;
   setDefaultAllow: React.Dispatch<React.SetStateAction<string[]>>;
   setDefaultAllowReplacement: React.Dispatch<React.SetStateAction<string[]>>;
@@ -141,7 +140,6 @@ export interface UseAssistantContext {
   promptContexts: Record<string, PromptContext>;
   modelEvaluatorEnabled: boolean;
   nameSpace: string;
-  ragOnAlerts: boolean;
   registerPromptContext: RegisterPromptContext;
   selectedSettingsTab: SettingsTabs;
   setAllQuickPrompts: React.Dispatch<React.SetStateAction<QuickPrompt[] | undefined>>;
@@ -183,7 +181,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
   getInitialConversations,
   modelEvaluatorEnabled = false,
   nameSpace = DEFAULT_ASSISTANT_NAMESPACE,
-  ragOnAlerts = false,
   setConversations,
   setDefaultAllow,
   setDefaultAllowReplacement,
@@ -328,7 +325,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       modelEvaluatorEnabled,
       promptContexts,
       nameSpace,
-      ragOnAlerts,
       registerPromptContext,
       selectedSettingsTab,
       setAllQuickPrompts: setLocalStorageQuickPrompts,
@@ -374,7 +370,6 @@ export const AssistantProvider: React.FC<AssistantProviderProps> = ({
       nameSpace,
       onConversationsUpdated,
       promptContexts,
-      ragOnAlerts,
       registerPromptContext,
       selectedSettingsTab,
       setDefaultAllow,

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings.test.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings.test.tsx
@@ -22,7 +22,6 @@ const mockUseAssistantContext = {
       prepend: jest.fn(),
     },
   },
-  ragOnAlerts: true,
   setAllSystemPrompts: jest.fn(),
   setConversations: jest.fn(),
 };
@@ -210,7 +209,7 @@ describe('Knowledge base settings', () => {
     expect(queryByTestId('knowledgeBaseActionButton')).not.toBeInTheDocument();
   });
 
-  it('renders the alerts settings when ragOnAlerts is true', () => {
+  it('renders the alerts settings', () => {
     const { getByTestId } = render(
       <TestProviders>
         <KnowledgeBaseSettings {...defaultProps} />

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings.tsx
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/knowledge_base_settings.tsx
@@ -47,7 +47,7 @@ interface Props {
  */
 export const KnowledgeBaseSettings: React.FC<Props> = React.memo(
   ({ knowledgeBase, setUpdatedKnowledgeBaseSettings }) => {
-    const { http, ragOnAlerts } = useAssistantContext();
+    const { http } = useAssistantContext();
     const {
       data: kbStatus,
       isLoading,
@@ -303,12 +303,10 @@ export const KnowledgeBaseSettings: React.FC<Props> = React.memo(
 
         <EuiSpacer size="s" />
 
-        {ragOnAlerts && (
-          <AlertsSettings
-            knowledgeBase={knowledgeBase}
-            setUpdatedKnowledgeBaseSettings={setUpdatedKnowledgeBaseSettings}
-          />
-        )}
+        <AlertsSettings
+          knowledgeBase={knowledgeBase}
+          setUpdatedKnowledgeBaseSettings={setUpdatedKnowledgeBaseSettings}
+        />
       </>
     );
   }

--- a/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/translations.ts
+++ b/x-pack/packages/kbn-elastic-assistant/impl/knowledge_base/translations.ts
@@ -21,25 +21,27 @@ export const ASK_QUESTIONS_ABOUT = i18n.translate(
   }
 );
 
-export const LATEST_AND_RISKIEST_OPEN_ALERTS = i18n.translate(
-  'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.latestAndRiskiestOpenAlertsLabel',
-  {
-    defaultMessage: 'latest and riskiest open and acknowledged alerts in your environment.',
-  }
-);
+export const LATEST_AND_RISKIEST_OPEN_ALERTS = (alertsCount: number) =>
+  i18n.translate(
+    'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.latestAndRiskiestOpenAlertsLabel',
+    {
+      defaultMessage:
+        'Send AI Assistant information about your {alertsCount} newest and riskiest open or acknowledged alerts.',
+      values: { alertsCount },
+    }
+  );
 
 export const YOUR_ANONYMIZATION_SETTINGS = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.yourAnonymizationSettingsLabel',
   {
-    defaultMessage: 'Your Anonymization settings will be applied to the alerts.',
+    defaultMessage: 'Your anonymization settings will apply to these alerts.',
   }
 );
 
 export const SELECT_FEWER_ALERTS = i18n.translate(
   'xpack.elasticAssistant.assistant.settings.knowledgeBaseSettings.selectFewerAlertsLabel',
   {
-    defaultMessage:
-      "Select fewer alerts if the model's maximum context length is frequently exceeded.",
+    defaultMessage: "Send fewer alerts if the model's context window is too small.",
   }
 );
 

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -99,11 +99,6 @@ export const allowedExperimentalValues = Object.freeze({
    */
   assistantModelEvaluation: false,
 
-  /**
-   * Enables Retrieval Augmented Generation (RAG) on Alerts in the assistant
-   */
-  assistantRagOnAlerts: false,
-
   /*
    * Enables the new user details flyout displayed on the Alerts page and timeline.
    *

--- a/x-pack/plugins/security_solution/public/assistant/provider.tsx
+++ b/x-pack/plugins/security_solution/public/assistant/provider.tsx
@@ -57,7 +57,6 @@ export const AssistantProvider: React.FC = ({ children }) => {
 
   const { signalIndexName } = useSignalIndex();
   const alertsIndexPattern = signalIndexName ?? undefined;
-  const ragOnAlerts = useIsExperimentalFeatureEnabled('assistantRagOnAlerts');
   const toasts = useAppToasts() as unknown as IToasts; // useAppToasts is the current, non-deprecated method of getting the toasts service in the Security Solution, but it doesn't return the IToasts interface (defined by core)
 
   return (
@@ -82,7 +81,6 @@ export const AssistantProvider: React.FC = ({ children }) => {
       assistantStreamingEnabled={assistantStreamingEnabled}
       modelEvaluatorEnabled={isModelEvaluationEnabled}
       nameSpace={nameSpace}
-      ragOnAlerts={ragOnAlerts}
       setConversations={setConversations}
       setDefaultAllow={setDefaultAllow}
       setDefaultAllowReplacement={setDefaultAllowReplacement}


### PR DESCRIPTION
## [Security Solution] [Elastic AI Assistant] Delete the _Retrieval Augmented Generation (RAG) for Alerts_ Feature Flag

This PR deletes the `assistantRagOnAlerts` feature flag introduced in [[Security Solution] [Elastic AI Assistant] Retrieval Augmented Generation (RAG) for Alerts #172542](https://github.com/elastic/kibana/pull/172542).

Deleting the `assistantRagOnAlerts` feature flag makes the `Alerts` toggle available in the assistant settings, per the screenshot below:

![alerts_setting](https://github.com/elastic/kibana/assets/4459398/1647a92c-653b-49de-926a-d0a3b65d270a)

This PR should not be merged until the docs describing the feature in <https://github.com/elastic/security-docs/issues/4456> have been merged.

This PR also includes @benironside improvements to the Alerts setting in the video below:

https://github.com/elastic/kibana/assets/4459398/73ea2717-ad2a-4998-afe2-cc154d8d19a9

### Desk testing

To desk test this change:

1) Delete the following `assistantRagOnAlerts` feature flag from your local `config/kibana.dev.yml`:

```
xpack.securitySolution.enableExperimental: ['assistantRagOnAlerts']
```

2) Start Kibana

3) Generate alerts with a variety of severity (e.g. `low`, `medium`, `high`, and `critical`)

4) Navigate to Security > Alerts

5) Click the `AI Assistant` button to open the assistant

6) Click the `X` button to clear the conversation

7) Click the assistant's `Settings` gear

8) Click the `Knowledge Base` category

**Expected result**

- The `Alerts` toggle shown in the screenshot below is available

![alerts_setting](https://github.com/elastic/kibana/assets/4459398/1647a92c-653b-49de-926a-d0a3b65d270a)

9) Click the `Alerts` toggle to enable the feature

10) Click the `Save` button to close settings

11) Enter the following prompt:

```
How many open alerts do I have?
```

**Expected result**

- A response with alert counts grouped by workflow status will be returned, similar to the example below:

```
You currently have 48 open alerts in your system. These are categorized by severity as following: 19 of them are low severity, 16 are high severity, 12 are of medium severity and 1 is of critical severity. There is also 1 critical severity alert which is acknowledged.
```

12) Enter the following prompt:

```
Which alerts should I look at first?
```

**Expected result**

A response with alert details, similar to the following is returned:

```
Based on the latest information, the alerts to prioritize first are those related to a mimikatz process starting on the hosts, which have a critical severity and the highest risk score of 99. There are also a series of alerts related to an EQL process sequence with a high severity and risk scores of 73. There is one alert about an Elastic Endpoint Security alert with a medium severity and risk score of 47.
```

13) Once again, click the assistant's `Settings` gear

14) Click the `Knowledge Base` category

15) Click the `Alerts` toggle to disable the feature

16) Click the `Save` button to close settings

17) Once again, enter the following prompt:

```
How many open alerts do I have?
```

**Expected result**

- The assistant does NOT respond with a breakdown of alerts by severity. Instead it replies with something like the following example response:

```
I'm sorry for any confusion, but as an AI, I don't have real-time access to your data or system to provide the number of your current open alerts. You can check your Elastic Security dashboard or use the appropriate querying commands to get the updated count of your open alerts.
```

18) One more time, enter the following prompt:

```
Which alerts should I look at first?
```

**Expected result**

- The assistant does NOT respond with alert details. Instead it replies with something like  the following example response:

```
As an AI model, I don't have the capability to access real-time data. However, when it comes to managing alerts in Elastic Security, it's generally recommended to first look at the ones with the highest severity and risk score. Alerts related to malware, unauthorized access attempts, and abnormal data transfers or process activities, for example, may need immediate attention due to their potential high impact.
```


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->