### PR TITLE
Adjust wording in Set up KB message

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message_knowledge_base.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message_knowledge_base.tsx
@@ -113,7 +113,7 @@ export function WelcomeMessageKnowledgeBase({
             <EuiText color="subdued" size="s">
               {i18n.translate(
                 'xpack.observabilityAiAssistant.welcomeMessageKnowledgeBase.yourKnowledgeBaseIsNotSetUpCorrectlyLabel',
-                { defaultMessage: 'Your Knowledge base is not set up correctly' }
+                { defaultMessage: `Your Knowledge base hasn't been set up.` }
               )}
             </EuiText>
 
@@ -127,13 +127,13 @@ export function WelcomeMessageKnowledgeBase({
                     data-test-subj="observabilityAiAssistantWelcomeMessageSetUpKnowledgeBaseButton"
                     fill
                     isLoading={checkForInstallStatus}
-                    iconType="refresh"
+                    iconType="importAction"
                     onClick={handleRetryInstall}
                   >
                     {i18n.translate(
                       'xpack.observabilityAiAssistant.welcomeMessage.retryButtonLabel',
                       {
-                        defaultMessage: 'Retry install',
+                        defaultMessage: 'Install Knowledge base',
                       }
                     )}
                   </EuiButton>

--- a/x-pack/plugins/observability_ai_assistant/public/components/feedback_buttons.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/feedback_buttons.tsx
@@ -16,6 +16,11 @@ interface FeedbackButtonsProps {
   onClickFeedback: (feedback: Feedback) => void;
 }
 
+const THANK_YOU_MESSAGE = i18n.translate(
+  'xpack.observabilityAiAssistant.feedbackButtons.em.thanksForYourFeedbackLabel',
+  { defaultMessage: 'Thanks for your feedback' }
+);
+
 export function FeedbackButtons({ onClickFeedback }: FeedbackButtonsProps) {
   const { notifications } = useKibana().services;
 
@@ -24,13 +29,13 @@ export function FeedbackButtons({ onClickFeedback }: FeedbackButtonsProps) {
   const handleClickPositive = () => {
     onClickFeedback('positive');
     setHasBeenClicked(true);
-    notifications.toasts.addSuccess('Thanks for your feedback!');
+    notifications.toasts.addSuccess(THANK_YOU_MESSAGE);
   };
 
   const handleClickNegative = () => {
     onClickFeedback('negative');
     setHasBeenClicked(true);
-    notifications.toasts.addSuccess('Thanks for your feedback!');
+    notifications.toasts.addSuccess(THANK_YOU_MESSAGE);
   };
 
   return (


### PR DESCRIPTION
## Summary

Adjust wording in Set up Knowledge base panel to be this:

<img width="533" alt="Screenshot 2023-12-21 at 10 53 36" src="https://github.com/elastic/kibana/assets/535564/c8a01255-12ab-45c6-ba59-7e91408fa70d">


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->