### PR TITLE
Unskip `Session Concurrent Limit cleanup` tests.

### DIFF
--- a/x-pack/test/security_api_integration/tests/session_concurrent_limit/cleanup.ts
+++ b/x-pack/test/security_api_integration/tests/session_concurrent_limit/cleanup.ts
@@ -150,8 +150,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
   }
 
-  // Failing: See https://github.com/elastic/kibana/issues/149091
-  describe.skip('Session Concurrent Limit cleanup', () => {
+  describe('Session Concurrent Limit cleanup', () => {
     before(async () => {
       await security.user.create('anonymous_user', {
         password: 'changeme',
@@ -181,7 +180,10 @@ export default function ({ getService }: FtrProviderContext) {
       await setTimeoutAsync(500);
       const basicSessionCookieThree = await loginWithBasic(testUser);
 
-      expect(await getNumberOfSessionDocuments()).to.be(3);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(3);
+      });
 
       // Poke the background task to run
       await runCleanupTaskSoon();
@@ -210,7 +212,10 @@ export default function ({ getService }: FtrProviderContext) {
       const basicSessionCookieThree = await loginWithBasic(testUser);
       const samlSessionCookieThree = await loginWithSAML();
 
-      expect(await getNumberOfSessionDocuments()).to.be(6);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(6);
+      });
 
       // Poke the background task to run
       await runCleanupTaskSoon();
@@ -243,7 +248,10 @@ export default function ({ getService }: FtrProviderContext) {
       const basicSessionCookieThree = await loginWithBasic(testUser);
       const samlSessionCookieThree = await loginWithSAML();
 
-      expect(await getNumberOfSessionDocuments()).to.be(6);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(6);
+      });
 
       // Remove `createdAt` field from the most recent sessions to emulate legacy sessions.
       // 1. Get the latest session for every unique credentials.
@@ -305,7 +313,10 @@ export default function ({ getService }: FtrProviderContext) {
       await setTimeoutAsync(500);
       const basicSessionCookieTwo = await loginWithBasic(testUser);
 
-      expect(await getNumberOfSessionDocuments()).to.be(2);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(2);
+      });
 
       // Poke the background task to run
       await runCleanupTaskSoon();
@@ -328,7 +339,10 @@ export default function ({ getService }: FtrProviderContext) {
       const anonymousSessionCookieTwo = await loginWithAnonymous();
       const anonymousSessionCookieThree = await loginWithAnonymous();
 
-      expect(await getNumberOfSessionDocuments()).to.be(3);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(3);
+      });
 
       // Poke the background task to run
       await runCleanupTaskSoon();
@@ -357,7 +371,10 @@ export default function ({ getService }: FtrProviderContext) {
       const unauthenticatedSessionTwo = await startSAMLHandshake();
       const unauthenticatedSessionThree = await startSAMLHandshake();
 
-      expect(await getNumberOfSessionDocuments()).to.be(3);
+      log.debug('Waiting for all sessions to be persisted...');
+      await retry.tryForTime(20000, async () => {
+        expect(await getNumberOfSessionDocuments()).to.be(3);
+      });
 
       // Poke the background task to run
       await runCleanupTaskSoon();


### PR DESCRIPTION
## Summary

Unskip `Session Concurrent Limit cleanup` tests.

__Flaky Test Runner#1 (no changes, only unskipped tests):__ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4666 (x100 - :red_circle: 1 out of 100)
__Flaky Test Runner#2 (added additional `retry`):__ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4667 (x200 - all :green_circle:)

__Fixes: https://github.com/elastic/kibana/issues/149091__

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->