### PR TITLE
[Security Solution][Endpoint] Map `unisolate` to `release` and `running-processes` to `processes` commands on response actions history output tray

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_log_expanded_tray.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/action_log_expanded_tray.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { memo, useMemo } from 'react';
-import { EuiCodeBlock, EuiFlexGroup, EuiFlexItem, EuiDescriptionList } from '@elastic/eui';
+import { EuiCodeBlock, EuiDescriptionList, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { css, euiStyled } from '@kbn/kibana-react-plugin/common';
 import { map } from 'lodash';
 import { EndpointUploadActionResult } from '../../endpoint_upload_action_result';
@@ -96,7 +96,8 @@ const OutputContent = memo<{ action: MaybeImmutable<ActionDetails>; 'data-test-s
       canAccessEndpointActionsLogManagement,
     } = useUserPrivileges().endpointPrivileges;
 
-    const { command, isCompleted, isExpired, wasSuccessful, errors } = action;
+    const { command: _command, isCompleted, isExpired, wasSuccessful, errors } = action;
+    const command = getUiCommand(_command);
 
     if (errors?.length) {
       return (

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/integration_tests/response_actions_log.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/integration_tests/response_actions_log.test.tsx
@@ -34,6 +34,7 @@ import { getEndpointAuthzInitialStateMock } from '../../../../../common/endpoint
 import { useGetEndpointActionList as _useGetEndpointActionList } from '../../../hooks/response_actions/use_get_endpoint_action_list';
 import { OUTPUT_MESSAGES } from '../translations';
 import { EndpointActionGenerator } from '../../../../../common/endpoint/data_generators/endpoint_action_generator';
+import { getUiCommand } from '../components/hooks';
 
 const useGetEndpointActionListMock = _useGetEndpointActionList as jest.Mock;
 
@@ -981,10 +982,12 @@ describe('Response actions history', () => {
 
         render();
 
+        const outputCommand = getUiCommand(command);
+
         const outputs = expandRows();
         expect(outputs.map((n) => n.textContent)).toEqual([
-          expect.stringContaining(`${command} completed successfully`),
-          expect.stringContaining(`${command} completed successfully`),
+          expect.stringContaining(`${outputCommand} completed successfully`),
+          expect.stringContaining(`${outputCommand} completed successfully`),
         ]);
         expect(
           renderResult.getAllByTestId(`${testPrefix}-column-status`).map((n) => n.textContent)
@@ -1006,10 +1009,11 @@ describe('Response actions history', () => {
         });
         render();
 
+        const outputCommand = getUiCommand(command);
         const outputs = expandRows();
         expect(outputs.map((n) => n.textContent)).toEqual([
-          `${command} failed`,
-          `${command} failed`,
+          `${outputCommand} failed`,
+          `${outputCommand} failed`,
         ]);
         expect(
           renderResult.getAllByTestId(`${testPrefix}-column-status`).map((n) => n.textContent)
@@ -1032,10 +1036,11 @@ describe('Response actions history', () => {
         });
         render();
 
+        const outputCommand = getUiCommand(command);
         const outputs = expandRows();
         expect(outputs.map((n) => n.textContent)).toEqual([
-          `${command} failed: action expired`,
-          `${command} failed: action expired`,
+          `${outputCommand} failed: action expired`,
+          `${outputCommand} failed: action expired`,
         ]);
         expect(
           renderResult.getAllByTestId(`${testPrefix}-column-status`).map((n) => n.textContent)


### PR DESCRIPTION
## Summary

Shows `release` instead of `unisolate` and `processes` instead of `running-processes` on the response actions history output tray.

**with this change**
![Screenshot 2023-12-21 at 2 40 03 PM](https://github.com/elastic/kibana/assets/1849116/3fb0ffe5-4f8b-4caa-9238-380d39f199bf)

![Screenshot 2023-12-21 at 3 43 57 PM](https://github.com/elastic/kibana/assets/1849116/1d3e67f4-d2f9-49a3-8a7b-01979e7ecbcd)

closes elastic/kibana/issues/168779

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->