### PR TITLE
kibana_utils url stop falling back to `window.location`

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.test.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/listing_page/dashboard_listing_page.test.tsx
@@ -11,6 +11,7 @@ import { act } from 'react-dom/test-utils';
 import { mount, ReactWrapper } from 'enzyme';
 import { I18nProvider } from '@kbn/i18n-react';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+import { createBrowserHistory } from 'history';
 
 import { pluginServices } from '../../services/plugin_services';
 import { DashboardListingPage, DashboardListingPageProps } from './dashboard_listing_page';
@@ -39,7 +40,7 @@ jest.mock('../no_data/dashboard_app_no_data', () => {
 function makeDefaultProps(): DashboardListingPageProps {
   return {
     redirectTo: jest.fn(),
-    kbnUrlStateStorage: createKbnUrlStateStorage(),
+    kbnUrlStateStorage: createKbnUrlStateStorage({ history: createBrowserHistory() }),
   };
 }
 

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -158,7 +158,7 @@ export function ShowShareModal({
   if (_g?.filters && _g.filters.length === 0) {
     _g = omit(_g, 'filters');
   }
-  const baseUrl = setStateToKbnUrl('_g', _g, undefined, window.location.href);
+  const baseUrl = setStateToKbnUrl('_g', _g, {}, window.location.href);
 
   const shareableUrl = setStateToKbnUrl(
     '_a',

--- a/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
+++ b/src/plugins/dashboard/public/dashboard_container/embeddable/create/create_dashboard.test.ts
@@ -23,6 +23,7 @@ import {
 import { Filter } from '@kbn/es-query';
 import { EmbeddablePackageState, ViewMode } from '@kbn/embeddable-plugin/public';
 import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+import { createBrowserHistory } from 'history';
 
 import { createDashboard } from './create_dashboard';
 import { getSampleDashboardPanel } from '../../../mocks';
@@ -212,7 +213,7 @@ test('applies filters and query from state to query service', async () => {
   await createDashboard({
     useUnifiedSearchIntegration: true,
     unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
+      kbnUrlStateStorage: createKbnUrlStateStorage({ history: createBrowserHistory() }),
     },
     getInitialInput: () => ({ filters, query }),
   });
@@ -228,7 +229,7 @@ test('applies time range and refresh interval from initial input to query servic
   await createDashboard({
     useUnifiedSearchIntegration: true,
     unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
+      kbnUrlStateStorage: createKbnUrlStateStorage({ history: createBrowserHistory() }),
     },
     getInitialInput: () => ({ timeRange, refreshInterval, timeRestore: true }),
   });
@@ -246,7 +247,7 @@ test('applies time range from query service to initial input if time restore is 
   pluginServices.getServices().data.query.timefilter.timefilter.getTime = jest
     .fn()
     .mockReturnValue(urlTimeRange);
-  const kbnUrlStateStorage = createKbnUrlStateStorage();
+  const kbnUrlStateStorage = createKbnUrlStateStorage({ history: createBrowserHistory() });
   kbnUrlStateStorage.get = jest.fn().mockReturnValue({ time: urlTimeRange });
 
   const dashboard = await createDashboard({
@@ -271,7 +272,7 @@ test('applies time range from query service to initial input if time restore is 
   const dashboard = await createDashboard({
     useUnifiedSearchIntegration: true,
     unifiedSearchSettings: {
-      kbnUrlStateStorage: createKbnUrlStateStorage(),
+      kbnUrlStateStorage: createKbnUrlStateStorage({ history: createBrowserHistory() }),
     },
   });
   expect(dashboard).toBeDefined();

--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_links.tsx
@@ -166,12 +166,7 @@ export const getTopNavLinks = ({
       // Since our locator doesn't add the '_g' parameter if it's not needed, UrlPanelContent
       // will interpret it as undefined and add '?_g=' to the URL, which is invalid in Discover,
       // so instead we add an empty object for the '_g' parameter to the URL.
-      shareableUrlForSavedObject = setStateToKbnUrl(
-        '_g',
-        {},
-        undefined,
-        shareableUrlForSavedObject
-      );
+      shareableUrlForSavedObject = setStateToKbnUrl('_g', {}, {}, shareableUrlForSavedObject);
 
       services.share.toggleShareContextMenu({
         anchorElement,

--- a/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_saved_search_container.test.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { createBrowserHistory } from 'history';
 import { getSavedSearchContainer, isEqualSavedSearch } from './discover_saved_search_container';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { discoverServiceMock } from '../../../__mocks__/services';
@@ -18,7 +19,9 @@ import { createKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 describe('DiscoverSavedSearchContainer', () => {
   const savedSearch = savedSearchMock;
   const services = discoverServiceMock;
-  const globalStateContainer = getDiscoverGlobalStateContainer(createKbnUrlStateStorage());
+  const globalStateContainer = getDiscoverGlobalStateContainer(
+    createKbnUrlStateStorage({ history: createBrowserHistory() })
+  );
 
   describe('getTitle', () => {
     it('returns undefined for new saved searches', () => {

--- a/src/plugins/kibana_utils/.eslintrc.json
+++ b/src/plugins/kibana_utils/.eslintrc.json
@@ -1,5 +1,0 @@
-{
-  "rules": {
-    "@typescript-eslint/consistent-type-definitions": 0
-  }
-}

--- a/src/plugins/kibana_utils/common/state_management/set_state_to_kbn_url.ts
+++ b/src/plugins/kibana_utils/common/state_management/set_state_to_kbn_url.ts
@@ -10,7 +10,10 @@ import { encodeState } from './encode_state';
 import { replaceUrlHashQuery, replaceUrlQuery } from './format';
 import { createStateHash } from './state_hash';
 
-export type SetStateToKbnUrlHashOptions = { useHash: boolean; storeInHashQuery?: boolean };
+export interface SetStateToKbnUrlHashOptions {
+  useHash?: boolean;
+  storeInHashQuery?: boolean;
+}
 
 export function createSetStateToKbnUrl(createHash: <State>(rawState: State) => string) {
   return <State>(

--- a/src/plugins/kibana_utils/demos/state_sync/url.ts
+++ b/src/plugins/kibana_utils/demos/state_sync/url.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import { createBrowserHistory } from 'history';
 import { defaultState, pureTransitions, TodoActions, TodoState } from '../state_containers/todomvc';
 import { BaseState, BaseStateContainer, createStateContainer } from '../../common/state_containers';
 import {
@@ -21,7 +22,9 @@ const stateContainer = createStateContainer<TodoState, TodoActions>(defaultState
 const { start, stop } = syncState({
   stateContainer: withDefaultState(stateContainer, defaultState),
   storageKey: '_s',
-  stateStorage: createKbnUrlStateStorage(),
+  stateStorage: createKbnUrlStateStorage({
+    history: createBrowserHistory(),
+  }),
 });
 
 start();

--- a/src/plugins/kibana_utils/public/state_management/url/kbn_url_storage.ts
+++ b/src/plugins/kibana_utils/public/state_management/url/kbn_url_storage.ts
@@ -102,11 +102,8 @@ export function getStateFromKbnUrl<State>(
 export function setStateToKbnUrl<State>(
   key: string,
   state: State,
-  { useHash = false, storeInHashQuery = true }: SetStateToKbnUrlHashOptions = {
-    useHash: false,
-    storeInHashQuery: true,
-  },
-  rawUrl = window.location.href
+  { useHash = false, storeInHashQuery = true }: SetStateToKbnUrlHashOptions,
+  rawUrl: string
 ) {
   return internalSetStateToKbnUrl(key, state, { useHash, storeInHashQuery }, rawUrl);
 }

--- a/src/plugins/kibana_utils/public/state_management/url/kbn_url_storage.ts
+++ b/src/plugins/kibana_utils/public/state_management/url/kbn_url_storage.ts
@@ -8,7 +8,7 @@
 
 import { format as formatUrl } from 'url';
 import { stringify } from 'query-string';
-import { createBrowserHistory, History } from 'history';
+import { History } from 'history';
 import { parseUrl, parseUrlHash } from '../../../common/state_management/parse';
 import { decodeState } from '../state_encoder';
 import { url as urlUtils } from '../../../common';
@@ -39,7 +39,7 @@ export const getCurrentUrl = (history: History) => history.createHref(history.lo
  *
  */
 export function getStatesFromKbnUrl<State extends object = Record<string, unknown>>(
-  url: string = window.location.href,
+  url: string,
   keys?: Array<keyof State>,
   { getFromHashQuery = true }: { getFromHashQuery: boolean } = { getFromHashQuery: true }
 ): State {
@@ -75,7 +75,7 @@ export function getStatesFromKbnUrl<State extends object = Record<string, unknow
  */
 export function getStateFromKbnUrl<State>(
   key: string,
-  url: string = window.location.href,
+  url: string,
   { getFromHashQuery = true }: { getFromHashQuery: boolean } = { getFromHashQuery: true }
 ): State | null {
   return (getStatesFromKbnUrl(url, [key], { getFromHashQuery })[key] as State) || null;
@@ -145,8 +145,9 @@ export interface IKbnUrlControls {
 
   /**
    * If there is a pending url update - returns url that is scheduled for update
+   * Otherwise - returns current url
    */
-  getPendingUrl: () => string | undefined;
+  getPendingUrl: () => string;
 
   /**
    * Synchronously flushes scheduled url updates. Returns new flushed url, if there was an update. Otherwise - undefined.
@@ -161,9 +162,7 @@ export interface IKbnUrlControls {
 }
 export type UrlUpdaterFnType = (currentUrl: string) => string | undefined;
 
-export const createKbnUrlControls = (
-  history: History = createBrowserHistory()
-): IKbnUrlControls => {
+export const createKbnUrlControls = (history: History): IKbnUrlControls => {
   const updateQueue: UrlUpdaterFnType[] = [];
 
   // if we should replace or push with next async update,

--- a/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
+++ b/src/plugins/kibana_utils/public/state_sync/state_sync_state_storage/create_kbn_url_state_storage.ts
@@ -56,24 +56,19 @@ export interface IKbnUrlStateStorage extends IStateStorage {
  * @returns - {@link IKbnUrlStateStorage}
  * @public
  */
-export const createKbnUrlStateStorage = (
-  {
-    useHash = false,
-    useHashQuery = true,
-    history,
-    onGetError,
-    onSetError,
-  }: {
-    useHash: boolean;
-    useHashQuery?: boolean;
-    history?: History;
-    onGetError?: (error: Error) => void;
-    onSetError?: (error: Error) => void;
-  } = {
-    useHash: false,
-    useHashQuery: true,
-  }
-): IKbnUrlStateStorage => {
+export const createKbnUrlStateStorage = ({
+  history,
+  useHash = false,
+  useHashQuery = true,
+  onGetError,
+  onSetError,
+}: {
+  history: History;
+  useHash?: boolean;
+  useHashQuery?: boolean;
+  onGetError?: (error: Error) => void;
+  onSetError?: (error: Error) => void;
+}): IKbnUrlStateStorage => {
   const url = createKbnUrlControls(history);
   const onGetErrorThrottled = onGetError ? throttle((e) => onGetError(e), 100) : undefined;
   return {
@@ -117,7 +112,7 @@ export const createKbnUrlStateStorage = (
         };
       }).pipe(
         map(() =>
-          getStateFromKbnUrl<State>(key, history?.createHref(history.location), {
+          getStateFromKbnUrl<State>(key, history.createHref(history.location), {
             getFromHashQuery: useHashQuery,
           })
         ),


### PR DESCRIPTION
## Summary

Small follow up to kibana_utils url changes from https://github.com/elastic/kibana/pull/170200, 

- change `getPendingUrl` type and docs according to the changes in logic
- stop falling back to window.location, require history instance instead   


this PR shouldn't change any logic 