### PR TITLE
Fix canvas runtime sass outputStyle

### DIFF
--- a/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
+++ b/x-pack/plugins/canvas/shareable_runtime/webpack.config.js
@@ -150,7 +150,7 @@ module.exports = {
               implementation: require('sass-embedded'),
               webpackImporter: false,
               sassOptions: {
-                outputStyle: 'nested',
+                outputStyle: 'expanded',
                 includePaths: [path.resolve(KIBANA_ROOT, 'node_modules')],
               },
             },


### PR DESCRIPTION
node-sass was replaced in https://github.com/elastic/kibana/pull/161813.