### PR TITLE
Stabilize OpenID Connect API integration tests.

### DIFF
--- a/x-pack/plugins/security/server/routes/authentication/oidc.ts
+++ b/x-pack/plugins/security/server/routes/authentication/oidc.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import type { RouteDefinitionParams } from '..';
 import { OIDCAuthenticationProvider, OIDCLogin } from '../../authentication';
 import type { ProviderLoginAttempt } from '../../authentication/providers/oidc';
-import { wrapIntoCustomErrorResponse } from '../../errors';
+import { getDetailedErrorMessage, wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 import { ROUTE_TAG_AUTH_FLOW, ROUTE_TAG_CAN_REDIRECT } from '../tags';
 
@@ -271,6 +271,7 @@ export function defineOIDCRoutes({
 
       return response.unauthorized({ body: authenticationResult.error });
     } catch (error) {
+      logger.error(`Failed to perform OIDC login: ${getDetailedErrorMessage(error)}`);
       return response.customError(wrapIntoCustomErrorResponse(error));
     }
   }

--- a/x-pack/test/security_api_integration/plugins/oidc_provider/server/index.ts
+++ b/x-pack/test/security_api_integration/plugins/oidc_provider/server/index.ts
@@ -5,11 +5,13 @@
  * 2.0.
  */
 
-import type { PluginInitializer, Plugin } from '@kbn/core/server';
+import { PluginInitializer, Plugin, CoreSetup } from '@kbn/core/server';
 import { initRoutes } from './init_routes';
 
-export const plugin: PluginInitializer<void, void> = async (): Promise<Plugin> => ({
-  setup: (core) => initRoutes(core.http.createRouter()),
+export const plugin: PluginInitializer<void, void> = async (
+  initializerContext
+): Promise<Plugin> => ({
+  setup: (core: CoreSetup) => initRoutes(initializerContext, core),
   start: () => {},
   stop: () => {},
 });


### PR DESCRIPTION
## Summary

Stabilize OpenID Connect API integration tests.

__Flaky Test Runner#1 (added more logging):__ https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4668 (x200 - all :green_circle:)

__Fixes: https://github.com/elastic/kibana/issues/173142__