### PR TITLE
[Enterprise Search] Fix pipeline generation after deploying a model in place

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -639,7 +639,7 @@ describe('MlInferenceLogic', () => {
           AddInferencePipelineSteps.Fields
         );
       });
-      it('triggers pipeline fetch when moving from configuration step', () => {
+      it('triggers pipeline and model fetch when moving from configuration step', () => {
         MLInferenceLogic.actions.setInferencePipelineConfiguration({
           ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
           pipelineName: 'unit-test-pipeline',
@@ -647,12 +647,14 @@ describe('MlInferenceLogic', () => {
           existingPipeline: false,
         });
         jest.spyOn(MLInferenceLogic.actions, 'fetchPipelineByName');
+        jest.spyOn(MLInferenceLogic.actions, 'makeMLModelsRequest');
         MLInferenceLogic.actions.onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
         expect(MLInferenceLogic.actions.fetchPipelineByName).toHaveBeenCalledWith({
           pipelineName: 'ml-inference-unit-test-pipeline',
         });
+        expect(MLInferenceLogic.actions.makeMLModelsRequest).toHaveBeenCalledWith(undefined);
       });
-      it('does not trigger pipeline fetch existing pipeline is selected', () => {
+      it('does not trigger pipeline and model fetch existing pipeline is selected', () => {
         MLInferenceLogic.actions.setInferencePipelineConfiguration({
           ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
           pipelineName: 'unit-test-pipeline',
@@ -660,8 +662,10 @@ describe('MlInferenceLogic', () => {
           existingPipeline: true,
         });
         jest.spyOn(MLInferenceLogic.actions, 'fetchPipelineByName');
+        jest.spyOn(MLInferenceLogic.actions, 'makeMLModelsRequest');
         MLInferenceLogic.actions.onAddInferencePipelineStepChange(AddInferencePipelineSteps.Fields);
         expect(MLInferenceLogic.actions.fetchPipelineByName).not.toHaveBeenCalled();
+        expect(MLInferenceLogic.actions.makeMLModelsRequest).not.toHaveBeenCalled();
       });
     });
     describe('fetchPipelineSuccess', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -361,6 +361,9 @@ export const MLInferenceLogic = kea<
         });
         // Continue to the next step so we don't have to save it to state, we will change
         // back to the Configuration step if we find a pipeline with the same name
+
+        // Re-fetch ML model list to include those that were deployed in this step
+        actions.makeMLModelsRequest(undefined);
       }
       actions.setAddInferencePipelineStep(step);
     },


### PR DESCRIPTION
## Summary

Fix for a bug that occurs after deploying a curated ML model (ELSER/E5) and selecting it for an inference pipeline. The generated pipeline is empty and the create action fails. This PR fixes this issue.

Before

https://github.com/elastic/kibana/assets/14224983/9b32ac68-4303-44f3-9e9d-6441d7716905

After

https://github.com/elastic/kibana/assets/14224983/d2e67a31-814c-4b1c-aca7-92909f6c47e5


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->