### PR TITLE
[Enterprise Search] Fix Continue button not activating when deploying model

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -598,7 +598,7 @@ describe('MlInferenceLogic', () => {
           MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
         ).toBe(true);
       });
-    });    
+    });
     describe('createPipeline', () => {
       const mockModelConfiguration = {
         ...DEFAULT_VALUES.addInferencePipelineModal,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -573,6 +573,32 @@ describe('MlInferenceLogic', () => {
   });
 
   describe('listeners', () => {
+    describe('clearModelPlaceholderFlag', () => {
+      it('sets placeholder flag false for selected model', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          modelID: 'unit-test-model',
+          isModelPlaceholderSelected: true,
+        });
+        MLInferenceLogic.actions.clearModelPlaceholderFlag('unit-test-model');
+
+        expect(
+          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
+        ).toBe(false);
+      });
+      it('leaves placeholder flag unmodified if another model was selected', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          modelID: 'unit-test-model',
+          isModelPlaceholderSelected: true,
+        });
+        MLInferenceLogic.actions.clearModelPlaceholderFlag('some-other-model-id');
+
+        expect(
+          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
+        ).toBe(true);
+      });
+    });    
     describe('createPipeline', () => {
       const mockModelConfiguration = {
         ...DEFAULT_VALUES.addInferencePipelineModal,
@@ -618,32 +644,6 @@ describe('MlInferenceLogic', () => {
           pipelineDefinition: expect.any(Object), // Generation logic is tested elsewhere
           pipelineName: mockModelConfiguration.configuration.pipelineName,
         });
-      });
-    });
-    describe('setSelectedModelNotPlaceholder', () => {
-      it('sets placeholder flag false for selected model', () => {
-        MLInferenceLogic.actions.setInferencePipelineConfiguration({
-          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
-          modelID: 'unit-test-model',
-          isModelPlaceholderSelected: true,
-        });
-        MLInferenceLogic.actions.setSelectedModelNotPlaceholder('unit-test-model');
-
-        expect(
-          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
-        ).toBe(false);
-      });
-      it('leaves placeholder flag unmodified if another model was selected', () => {
-        MLInferenceLogic.actions.setInferencePipelineConfiguration({
-          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
-          modelID: 'unit-test-model',
-          isModelPlaceholderSelected: true,
-        });
-        MLInferenceLogic.actions.setSelectedModelNotPlaceholder('some-other-model-id');
-
-        expect(
-          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
-        ).toBe(true);
       });
     });
     describe('startTextExpansionModelSuccess', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.test.ts
@@ -620,6 +620,32 @@ describe('MlInferenceLogic', () => {
         });
       });
     });
+    describe('setSelectedModelNotPlaceholder', () => {
+      it('sets placeholder flag false for selected model', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          modelID: 'unit-test-model',
+          isModelPlaceholderSelected: true,
+        });
+        MLInferenceLogic.actions.setSelectedModelNotPlaceholder('unit-test-model');
+
+        expect(
+          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
+        ).toBe(false);
+      });
+      it('leaves placeholder flag unmodified if another model was selected', () => {
+        MLInferenceLogic.actions.setInferencePipelineConfiguration({
+          ...MLInferenceLogic.values.addInferencePipelineModal.configuration,
+          modelID: 'unit-test-model',
+          isModelPlaceholderSelected: true,
+        });
+        MLInferenceLogic.actions.setSelectedModelNotPlaceholder('some-other-model-id');
+
+        expect(
+          MLInferenceLogic.values.addInferencePipelineModal.configuration.isModelPlaceholderSelected
+        ).toBe(true);
+      });
+    });
     describe('startTextExpansionModelSuccess', () => {
       it('fetches ml models', () => {
         jest.spyOn(MLInferenceLogic.actions, 'makeMLModelsRequest');

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -133,6 +133,7 @@ export interface MLInferenceProcessorsActions {
   >['apiSuccess'];
   attachPipeline: () => void;
   clearFetchedPipeline: FetchPipelineApiLogicActions['apiReset'];
+  clearModelPlaceholderFlag: (modelId: string) => { modelId: string };
   createApiError: Actions<
     CreateMlInferencePipelineApiLogicArgs,
     CreateMlInferencePipelineResponse
@@ -179,7 +180,6 @@ export interface MLInferenceProcessorsActions {
   setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => {
     configuration: InferencePipelineConfiguration;
   };
-  setSelectedModelNotPlaceholder: (modelId: string) => { modelId: string };
   setTargetField: (targetFieldName: string) => { targetFieldName: string };
   startTextExpansionModelSuccess: StartTextExpansionModelApiLogicActions['apiSuccess'];
 }
@@ -223,6 +223,7 @@ export const MLInferenceLogic = kea<
     }),
     attachPipeline: true,
     clearFormErrors: true,
+    clearModelPlaceholderFlag: (modelId: string) => ({ modelId }),
     createPipeline: true,
     onAddInferencePipelineStepChange: (step: AddInferencePipelineSteps) => ({ step }),
     removeFieldFromMapping: (fieldName: string) => ({ fieldName }),
@@ -233,7 +234,6 @@ export const MLInferenceLogic = kea<
     setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => ({
       configuration,
     }),
-    setSelectedModelNotPlaceholder: (modelId: string) => ({ modelId }),
     setTargetField: (targetFieldName: string) => ({ targetFieldName }),
   },
   connect: {
@@ -300,6 +300,19 @@ export const MLInferenceLogic = kea<
         pipelineName,
       });
     },
+    clearModelPlaceholderFlag: ({ modelId }) => {
+      const {
+        addInferencePipelineModal: { configuration },
+      } = values;
+
+      // Don't change the flag if the user clicked away from the selected model
+      if (modelId !== configuration.modelID) return;
+
+      actions.setInferencePipelineConfiguration({
+        ...configuration,
+        isModelPlaceholderSelected: false,
+      });
+    },
     createPipeline: () => {
       const {
         addInferencePipelineModal: { configuration, indexName },
@@ -331,19 +344,6 @@ export const MLInferenceLogic = kea<
       actions.makeMlInferencePipelinesRequest(undefined);
       actions.makeMLModelsRequest(undefined);
       actions.makeMappingRequest({ indexName });
-    },
-    setSelectedModelNotPlaceholder: ({ modelId }) => {
-      const {
-        addInferencePipelineModal: { configuration },
-      } = values;
-
-      // Don't change the flag if the user clicked away from the selected model
-      if (modelId !== configuration.modelID) return;
-
-      actions.setInferencePipelineConfiguration({
-        ...configuration,
-        isModelPlaceholderSelected: false,
-      });
     },
     mlInferencePipelinesSuccess: (data) => {
       if (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/ml_inference_logic.ts
@@ -179,6 +179,7 @@ export interface MLInferenceProcessorsActions {
   setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => {
     configuration: InferencePipelineConfiguration;
   };
+  setSelectedModelNotPlaceholder: (modelId: string) => { modelId: string };
   setTargetField: (targetFieldName: string) => { targetFieldName: string };
   startTextExpansionModelSuccess: StartTextExpansionModelApiLogicActions['apiSuccess'];
 }
@@ -228,11 +229,11 @@ export const MLInferenceLogic = kea<
     selectExistingPipeline: (pipelineName: string) => ({ pipelineName }),
     selectFields: (fieldNames: string[]) => ({ fieldNames }),
     setAddInferencePipelineStep: (step: AddInferencePipelineSteps) => ({ step }),
-    setFormErrors: (inputErrors: AddInferencePipelineFormErrors) => ({ inputErrors }),
     setIndexName: (indexName: string) => ({ indexName }),
     setInferencePipelineConfiguration: (configuration: InferencePipelineConfiguration) => ({
       configuration,
     }),
+    setSelectedModelNotPlaceholder: (modelId: string) => ({ modelId }),
     setTargetField: (targetFieldName: string) => ({ targetFieldName }),
   },
   connect: {
@@ -330,6 +331,19 @@ export const MLInferenceLogic = kea<
       actions.makeMlInferencePipelinesRequest(undefined);
       actions.makeMLModelsRequest(undefined);
       actions.makeMappingRequest({ indexName });
+    },
+    setSelectedModelNotPlaceholder: ({ modelId }) => {
+      const {
+        addInferencePipelineModal: { configuration },
+      } = values;
+
+      // Don't change the flag if the user clicked away from the selected model
+      if (modelId !== configuration.modelID) return;
+
+      actions.setInferencePipelineConfiguration({
+        ...configuration,
+        isModelPlaceholderSelected: false,
+      });
     },
     mlInferencePipelinesSuccess: (data) => {
       if (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
@@ -72,12 +72,12 @@ describe('ModelSelectLogic', () => {
         expect(ModelSelectLogic.actions.startPollingModels).toHaveBeenCalled();
       });
       it('sets selected model as non-placeholder', () => {
-        jest.spyOn(ModelSelectLogic.actions, 'setSelectedModelNotPlaceholderFromMLInferenceLogic');
+        jest.spyOn(ModelSelectLogic.actions, 'clearModelPlaceholderFlagFromMLInferenceLogic');
 
         ModelSelectLogic.actions.createModelSuccess(CREATE_MODEL_API_RESPONSE);
 
         expect(
-          ModelSelectLogic.actions.setSelectedModelNotPlaceholderFromMLInferenceLogic
+          ModelSelectLogic.actions.clearModelPlaceholderFlagFromMLInferenceLogic
         ).toHaveBeenCalledWith(CREATE_MODEL_API_RESPONSE.modelId);
       });
     });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
@@ -71,6 +71,15 @@ describe('ModelSelectLogic', () => {
 
         expect(ModelSelectLogic.actions.startPollingModels).toHaveBeenCalled();
       });
+      it('sets selected model as non-placeholder', () => {
+        jest.spyOn(ModelSelectLogic.actions, 'setSelectedModelNotPlaceholderFromMLInferenceLogic');
+
+        ModelSelectLogic.actions.createModelSuccess(CREATE_MODEL_API_RESPONSE);
+
+        expect(
+          ModelSelectLogic.actions.setSelectedModelNotPlaceholderFromMLInferenceLogic
+        ).toHaveBeenCalledWith(CREATE_MODEL_API_RESPONSE.modelId);
+      });
     });
 
     describe('fetchModels', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
@@ -32,6 +32,7 @@ import {
 } from './ml_inference_logic';
 
 export interface ModelSelectActions {
+  clearModelPlaceholderFlagFromMLInferenceLogic: MLInferenceProcessorsActions['clearModelPlaceholderFlag'];
   createModel: (modelId: string) => { modelId: string };
   createModelError: CreateModelApiLogicActions['apiError'];
   createModelMakeRequest: CreateModelApiLogicActions['makeRequest'];
@@ -42,7 +43,6 @@ export interface ModelSelectActions {
   fetchModelsSuccess: CachedFetchModlesApiLogicActions['apiSuccess'];
   setInferencePipelineConfiguration: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
   setInferencePipelineConfigurationFromMLInferenceLogic: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
-  setSelectedModelNotPlaceholderFromMLInferenceLogic: MLInferenceProcessorsActions['setSelectedModelNotPlaceholder'];
   startModel: (modelId: string) => { modelId: string };
   startModelError: CreateModelApiLogicActions['apiError'];
   startModelMakeRequest: StartModelApiLogicActions['makeRequest'];
@@ -94,7 +94,7 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
       MLInferenceLogic,
       [
         'setInferencePipelineConfiguration as setInferencePipelineConfigurationFromMLInferenceLogic',
-        'setSelectedModelNotPlaceholder as setSelectedModelNotPlaceholderFromMLInferenceLogic',
+        'clearModelPlaceholderFlag as clearModelPlaceholderFlagFromMLInferenceLogic',
       ],
       StartModelApiLogic,
       [
@@ -128,7 +128,7 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
     createModelSuccess: (response) => {
       actions.startPollingModels();
       // The create action succeeded, so the model is no longer a placeholder
-      actions.setSelectedModelNotPlaceholderFromMLInferenceLogic(response.modelId);
+      actions.clearModelPlaceholderFlagFromMLInferenceLogic(response.modelId);
     },
     fetchModels: () => {
       actions.fetchModelsMakeRequest({});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
@@ -36,20 +36,18 @@ export interface ModelSelectActions {
   createModelError: CreateModelApiLogicActions['apiError'];
   createModelMakeRequest: CreateModelApiLogicActions['makeRequest'];
   createModelSuccess: CreateModelApiLogicActions['apiSuccess'];
-
   fetchModels: () => void;
   fetchModelsError: CachedFetchModlesApiLogicActions['apiError'];
   fetchModelsMakeRequest: CachedFetchModlesApiLogicActions['makeRequest'];
   fetchModelsSuccess: CachedFetchModlesApiLogicActions['apiSuccess'];
-  startPollingModels: CachedFetchModlesApiLogicActions['startPolling'];
-
+  setInferencePipelineConfiguration: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
+  setInferencePipelineConfigurationFromMLInferenceLogic: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
+  setSelectedModelNotPlaceholderFromMLInferenceLogic: MLInferenceProcessorsActions['setSelectedModelNotPlaceholder'];
   startModel: (modelId: string) => { modelId: string };
   startModelError: CreateModelApiLogicActions['apiError'];
   startModelMakeRequest: StartModelApiLogicActions['makeRequest'];
   startModelSuccess: StartModelApiLogicActions['apiSuccess'];
-
-  setInferencePipelineConfiguration: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
-  setInferencePipelineConfigurationFromMLInferenceLogic: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
+  startPollingModels: CachedFetchModlesApiLogicActions['startPolling'];
 }
 
 export interface ModelSelectValues {
@@ -96,6 +94,7 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
       MLInferenceLogic,
       [
         'setInferencePipelineConfiguration as setInferencePipelineConfigurationFromMLInferenceLogic',
+        'setSelectedModelNotPlaceholder as setSelectedModelNotPlaceholderFromMLInferenceLogic',
       ],
       StartModelApiLogic,
       [
@@ -126,17 +125,19 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
     createModel: ({ modelId }) => {
       actions.createModelMakeRequest({ modelId });
     },
-    createModelSuccess: () => {
+    createModelSuccess: (response) => {
       actions.startPollingModels();
+      // The create action succeeded, so the model is no longer a placeholder
+      actions.setSelectedModelNotPlaceholderFromMLInferenceLogic(response.modelId);
     },
     fetchModels: () => {
       actions.fetchModelsMakeRequest({});
     },
-    startModel: ({ modelId }) => {
-      actions.startModelMakeRequest({ modelId });
-    },
     setInferencePipelineConfiguration: ({ configuration }) => {
       actions.setInferencePipelineConfigurationFromMLInferenceLogic(configuration);
+    },
+    startModel: ({ modelId }) => {
+      actions.startModelMakeRequest({ modelId });
     },
     startModelSuccess: () => {
       actions.startPollingModels();


### PR DESCRIPTION
## Summary

Fix for a minor usability issue the ML inference pipeline creation flow. When selecting an undeployed model, the Continue button is disabled, because the model needs to be at least in the deploying state to be eligible for selection. However after clicking Deploy and seeing the model transition to deploying, the button is still disabled. This PR fixes this issue.

Before

https://github.com/elastic/kibana/assets/14224983/f0633b42-6c3c-4aaa-8ffb-f516c3fe8376

After

https://github.com/elastic/kibana/assets/14224983/5ac37471-86fd-4fee-beb2-d6e89af17902

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->