### PR TITLE
Reduce verbosity of `plugins-service` logger

### DIFF
--- a/packages/core/plugins/core-plugins-server-internal/src/plugins_service.test.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugins_service.test.ts
@@ -462,40 +462,10 @@ describe('PluginsService', () => {
       expect(loggingSystemMock.collect(logger).info).toMatchInlineSnapshot(`
         Array [
           Array [
-            "Plugin \\"explicitly-disabled-plugin-preboot\\" is disabled.",
+            "The following plugins are disabled: \\"explicitly-disabled-plugin-preboot,explicitly-disabled-plugin-standard,another-explicitly-disabled-plugin-preboot,another-explicitly-disabled-plugin-standard\\".",
           ],
           Array [
-            "Plugin \\"explicitly-disabled-plugin-standard\\" is disabled.",
-          ],
-          Array [
-            "Plugin \\"plugin-with-missing-required-deps-preboot\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [missing-plugin-preboot]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-missing-required-deps-standard\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [missing-plugin-standard]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-disabled-transitive-dep-preboot\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [another-explicitly-disabled-plugin-preboot]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-disabled-transitive-dep-standard\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [another-explicitly-disabled-plugin-standard]",
-          ],
-          Array [
-            "Plugin \\"another-explicitly-disabled-plugin-preboot\\" is disabled.",
-          ],
-          Array [
-            "Plugin \\"another-explicitly-disabled-plugin-standard\\" is disabled.",
-          ],
-          Array [
-            "Plugin \\"plugin-with-disabled-nested-transitive-dep-preboot\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [plugin-with-disabled-transitive-dep-preboot]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-disabled-nested-transitive-dep-standard\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [plugin-with-disabled-transitive-dep-standard]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-missing-nested-dep-preboot\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [plugin-with-missing-required-deps-preboot]",
-          ],
-          Array [
-            "Plugin \\"plugin-with-missing-nested-dep-standard\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [plugin-with-missing-required-deps-standard]",
+            "Plugins \\"plugin-with-missing-required-deps-preboot,plugin-with-missing-required-deps-standard,plugin-with-disabled-transitive-dep-preboot,plugin-with-disabled-transitive-dep-standard,plugin-with-disabled-nested-transitive-dep-preboot,plugin-with-disabled-nested-transitive-dep-standard,plugin-with-missing-nested-dep-preboot,plugin-with-missing-nested-dep-standard\\" have been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [missing-plugin-preboot,missing-plugin-standard,another-explicitly-disabled-plugin-preboot,another-explicitly-disabled-plugin-standard,plugin-with-disabled-transitive-dep-preboot,plugin-with-disabled-transitive-dep-standard,plugin-with-missing-required-deps-preboot,plugin-with-missing-required-deps-standard].",
           ],
         ]
       `);
@@ -538,12 +508,12 @@ describe('PluginsService', () => {
         await pluginsService.preboot(prebootDeps);
 
         expect(loggingSystemMock.collect(logger).info).toMatchInlineSnapshot(`
-        Array [
           Array [
-            "Plugin \\"plugin-with-missing-required-deps-preboot\\" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [missing-plugin-preboot]",
-          ],
-        ]
-      `);
+            Array [
+              "Plugins \\"plugin-with-missing-required-deps-preboot\\" have been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [missing-plugin-preboot].",
+            ],
+          ]
+        `);
       });
     });
 

--- a/packages/core/plugins/core-plugins-server-internal/src/plugins_service.ts
+++ b/packages/core/plugins/core-plugins-server-internal/src/plugins_service.ts
@@ -327,6 +327,10 @@ export class PluginsService
     }
 
     // Add the plugins to the Plugin System if enabled and its dependencies are met
+    const disabledPlugins = [];
+    const disabledDependants = [];
+    const disabledDependantsCauses = new Set<string>();
+
     for (const [pluginName, { plugin, isEnabled }] of pluginEnableStatuses) {
       this.validatePluginDependencies(plugin, pluginEnableStatuses);
 
@@ -339,17 +343,26 @@ export class PluginsService
           this.standardPluginsSystem.addPlugin(plugin);
         }
       } else if (isEnabled) {
-        this.log.info(
-          `Plugin "${pluginName}" has been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [${pluginEnablement.missingOrIncompatibleDependencies.join(
-            ', '
-          )}]`
+        disabledDependants.push(pluginName);
+        pluginEnablement.missingOrIncompatibleDependencies.forEach((dependency) =>
+          disabledDependantsCauses.add(dependency)
         );
       } else {
-        this.log.info(`Plugin "${pluginName}" is disabled.`);
+        disabledPlugins.push(pluginName);
       }
     }
 
     this.log.debug(`Discovered ${pluginEnableStatuses.size} plugins.`);
+    if (disabledPlugins.length) {
+      this.log.info(`The following plugins are disabled: "${disabledPlugins}".`);
+    }
+    if (disabledDependants.length) {
+      this.log.info(
+        `Plugins "${disabledDependants}" have been disabled since the following direct or transitive dependencies are missing, disabled, or have incompatible types: [${Array.from(
+          disabledDependantsCauses
+        )}].`
+      );
+    }
   }
 
   /** Throws an error if the plugin's dependencies are invalid. */


### PR DESCRIPTION
## Summary
Part of https://github.com/elastic/kibana-team/issues/702

This PR aims at grouping all `Plugin "foo" is disabled` messages, as well as messages informing of plugins that are disabled because of their dependencies.