### PR TITLE
Skip connectors overview serverless suite for MKI

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
@@ -16,6 +16,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   describe('connectors', function () {
+    // failsOnMKI, see https://github.com/elastic/kibana/issues/173929
+    this.tags(['failsOnMKI']);
     before(async () => {
       await pageObjects.svlCommonPage.login();
       await pageObjects.svlCommonNavigation.sidenav.clickLink({


### PR DESCRIPTION
## Summary

This PR skips the search project connectors overview test suite for MKI runs.

Details about the failure in https://github.com/elastic/kibana/issues/173929
