### PR TITLE
[Fleet] Allow Remote ES to be the default data output

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/use_output_form.tsx
@@ -874,7 +874,7 @@ export function useOutputForm(onSucess: () => void, output?: Output) {
               name: nameInput.value,
               type: outputType.RemoteElasticsearch,
               hosts: elasticsearchUrlInput.value,
-              is_default: false,
+              is_default: defaultOutputInput.value,
               is_default_monitoring: defaultMonitoringOutputInput.value,
               preset: presetInput.value,
               config_yaml: additionalYamlConfigInput.value,


### PR DESCRIPTION
## Summary

Resolve #173984

That PR allow remote ES to be the default data output, there was a bug in the UI that prevented this.

<img width="717" alt="Screenshot 2023-12-29 at 11 24 00 AM" src="https://github.com/elastic/kibana/assets/1336873/c83f9b2d-83dd-432f-9494-5ba3e11f09fc">
<img width="961" alt="Screenshot 2023-12-29 at 11 26 58 AM" src="https://github.com/elastic/kibana/assets/1336873/e4021162-b6aa-4374-b51c-05462290b9b2">


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->