### PR TITLE
[Fleet] fix output host validator when host url is empty

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.test.tsx
@@ -83,6 +83,12 @@ describe('Output form validation', () => {
       expect(res).toEqual([{ message: 'URL is required' }]);
     });
 
+    it('should not work with empty url', () => {
+      const res = validateESHosts(['']);
+
+      expect(res).toEqual([{ index: 0, message: 'URL is required' }]);
+    });
+
     it('should work with valid url', () => {
       const res = validateESHosts(['https://test.fr:9200']);
 
@@ -116,6 +122,11 @@ describe('Output form validation', () => {
         { index: 0, message: 'Duplicate URL' },
         { index: 1, message: 'Duplicate URL' },
       ]);
+    });
+    it('should return an error when invalid protocol', () => {
+      const res = validateESHosts(['ftp://test.fr']);
+
+      expect(res).toEqual([{ index: 0, message: 'Invalid protocol' }]);
     });
   });
 

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/settings/components/edit_output_flyout/output_form_validators.tsx
@@ -88,14 +88,29 @@ export function validateKafkaHosts(value: string[]) {
 export function validateESHosts(value: string[]) {
   const res: Array<{ message: string; index?: number }> = [];
   const urlIndexes: { [key: string]: number[] } = {};
+  const urlRequiredMessage = i18n.translate(
+    'xpack.fleet.settings.outputForm.elasticUrlRequiredError',
+    {
+      defaultMessage: 'URL is required',
+    }
+  );
   value.forEach((val, idx) => {
     try {
       if (!val) {
-        throw new Error('Host URL required');
-      }
-      const urlParsed = new URL(val);
-      if (!['http:', 'https:'].includes(urlParsed.protocol)) {
-        throw new Error('Invalid protocol');
+        res.push({
+          message: urlRequiredMessage,
+          index: idx,
+        });
+      } else {
+        const urlParsed = new URL(val);
+        if (!['http:', 'https:'].includes(urlParsed.protocol)) {
+          res.push({
+            message: i18n.translate('xpack.fleet.settings.outputForm.invalidProtocolError', {
+              defaultMessage: 'Invalid protocol',
+            }),
+            index: idx,
+          });
+        }
       }
     } catch (error) {
       res.push({
@@ -125,9 +140,7 @@ export function validateESHosts(value: string[]) {
 
   if (value.length === 0) {
     res.push({
-      message: i18n.translate('xpack.fleet.settings.outputForm.elasticUrlRequiredError', {
-        defaultMessage: 'URL is required',
-      }),
+      message: urlRequiredMessage,
     });
   }
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/174076

Fix output host url validation when url is empty.
To verify:
- Go to Add output flyout
- Click Add another URL
- Delete the second URL box
- Expect to see validation message `URL is required`

<img width="639" alt="image" src="https://github.com/elastic/kibana/assets/90178898/d5ee45f3-dd7d-43dd-8edf-9a3568b18d0d">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->