### PR TITLE
[Security Solution][Endpoint] Fix index name pattern in SentinelOne dev. script

### DIFF
--- a/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
@@ -265,7 +265,7 @@ export const createDetectionEngineSentinelOneRuleIfNeeded = async (
   log: ToolingLog
 ): Promise<RuleResponse> => {
   const ruleName = 'Promote SentinelOne alerts';
-  const sentinelOneAlertsIndexPattern = 'logs-sentinel_one.alert';
+  const sentinelOneAlertsIndexPattern = 'logs-sentinel_one.alert*';
   const ruleQueryValue = 'observer.serial_number:*';
 
   const { data } = await findRules(kbnClient, {


### PR DESCRIPTION
## Summary

- Corrects index name pattern for S1 alerts in the SIEM Rule that the SentinelOne dev script uses

🤦 


