### PR TITLE
[DOCS] Update tech preview to warn against using ES|QL in production

### DIFF
--- a/docs/concepts/esql.asciidoc
+++ b/docs/concepts/esql.asciidoc
@@ -1,7 +1,7 @@
 [[esql]]
 === {esql}
 
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 The Elasticsearch Query Language, {esql}, has been created to make exploring your data faster and easier using the **Discover** application. From version 8.11 you can try this new feature, which is enabled by default. 
 

--- a/docs/discover/try-esql.asciidoc
+++ b/docs/discover/try-esql.asciidoc
@@ -1,7 +1,7 @@
 [[try-esql]]
 == Try {esql}
 
-preview::[]
+preview::["Do not use {esql} on production environments. This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features."]
 
 The Elasticsearch Query Language, {esql}, makes it easier to explore your data without leaving Discover. 
 


### PR DESCRIPTION
## Summary
Adds the sentence "Do not use ES|QL on production environments." to the ES|QL tech preview banner on pages:

https://www.elastic.co/guide/en/kibana/current/esql.html
https://www.elastic.co/guide/en/kibana/current/try-esql.html

Relates to: [#103797](https://github.com/elastic/elasticsearch/pull/103797)


<!--ONMERGE {"backportTargets":["8.11","8.12"]} ONMERGE-->