### PR TITLE
[8.12] Handle content stream errors in report pre-deletion (#173792)

### DIFF
--- a/x-pack/plugins/reporting/server/routes/common/jobs/get_job_routes.ts
+++ b/x-pack/plugins/reporting/server/routes/common/jobs/get_job_routes.ts
@@ -81,17 +81,43 @@ export const commonJobsRouteHandlerFactory = (reporting: ReportingCore) => {
     return jobManagementPreRouting(reporting, res, docId, user, counters, async (doc) => {
       const docIndex = doc.index;
       const stream = await getContentStream(reporting, { id: docId, index: docIndex });
-      /** @note Overwriting existing content with an empty buffer to remove all the chunks. */
-      await new Promise<void>((resolve) => {
-        stream.end('', 'utf8', () => {
-          resolve();
-        });
-      });
-      await jobsQuery.delete(docIndex, docId);
+      const reportingSetup = reporting.getPluginSetupDeps();
+      const logger = reportingSetup.logger.get('delete-report');
 
-      return res.ok({
-        body: { deleted: true },
+      // An "error" event is emitted if an error is
+      // passed to the `stream.end` callback from
+      // the _final method of the ContentStream.
+      // This event must be handled.
+      stream.on('error', (err) => {
+        logger.error(err);
       });
+
+      try {
+        // Overwriting existing content with an
+        // empty buffer to remove all the chunks.
+        await new Promise<void>((resolve, reject) => {
+          stream.end('', 'utf8', (error?: Error) => {
+            if (error) {
+              // handle error that could be thrown
+              // from the _write method of the ContentStream
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+
+        await jobsQuery.delete(docIndex, docId);
+
+        return res.ok({
+          body: { deleted: true },
+        });
+      } catch (error) {
+        logger.error(error);
+        return res.customError({
+          statusCode: 500,
+        });
+      }
     });
   };
 

--- a/x-pack/plugins/reporting/server/routes/public/integration_tests/jobs.test.ts
+++ b/x-pack/plugins/reporting/server/routes/public/integration_tests/jobs.test.ts
@@ -36,7 +36,7 @@ import { registerJobInfoRoutesPublic } from '../jobs';
 
 type SetupServerReturn = Awaited<ReturnType<typeof setupServer>>;
 
-describe(`GET ${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}`, () => {
+describe(`Reporting Job Management Routes: Public`, () => {
   const reportingSymbol = Symbol('reporting');
   let server: SetupServerReturn['server'];
   let usageCounter: IUsageCounter;
@@ -135,114 +135,114 @@ describe(`GET ${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}`, () => {
     await server.stop();
   });
 
-  it('fails on malformed download IDs', async () => {
-    mockEsClient.search.mockResponseOnce(getHits());
-    registerJobInfoRoutesPublic(core);
+  describe('download report', () => {
+    it('fails on malformed download IDs', async () => {
+      mockEsClient.search.mockResponseOnce(getHits());
+      registerJobInfoRoutesPublic(core);
 
-    await server.start();
+      await server.start();
 
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/1`)
-      .expect(400)
-      .then(({ body }) =>
-        expect(body.message).toMatchInlineSnapshot(
-          '"[request params.docId]: value has length [1] but it must have a minimum length of [3]."'
-        )
-      );
-  });
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/1`)
+        .expect(400)
+        .then(({ body }) =>
+          expect(body.message).toMatchInlineSnapshot(
+            '"[request params.docId]: value has length [1] but it must have a minimum length of [3]."'
+          )
+        );
+    });
 
-  it('fails on unauthenticated users', async () => {
-    mockStartDeps = await createMockPluginStart(
-      {
-        licensing: {
-          ...licensingMock.createStart(),
-          license$: new BehaviorSubject({ isActive: true, isAvailable: true, type: 'gold' }),
+    it('fails on unauthenticated users', async () => {
+      mockStartDeps = await createMockPluginStart(
+        {
+          licensing: {
+            ...licensingMock.createStart(),
+            license$: new BehaviorSubject({ isActive: true, isAvailable: true, type: 'gold' }),
+          },
+          security: { authc: { getCurrentUser: () => undefined } },
         },
-        security: { authc: { getCurrentUser: () => undefined } },
-      },
-      mockConfigSchema
-    );
-    core = await createMockReportingCore(mockConfigSchema, mockSetupDeps, mockStartDeps);
-    registerJobInfoRoutesPublic(core);
-
-    await server.start();
-
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dope`)
-      .expect(401)
-      .then(({ body }) =>
-        expect(body.message).toMatchInlineSnapshot(`"Sorry, you aren't authenticated"`)
+        mockConfigSchema
       );
-  });
+      core = await createMockReportingCore(mockConfigSchema, mockSetupDeps, mockStartDeps);
+      registerJobInfoRoutesPublic(core);
 
-  it('returns 404 if job not found', async () => {
-    mockEsClient.search.mockResponseOnce(getHits());
-    registerJobInfoRoutesPublic(core);
+      await server.start();
 
-    await server.start();
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dope`)
+        .expect(401)
+        .then(({ body }) =>
+          expect(body.message).toMatchInlineSnapshot(`"Sorry, you aren't authenticated"`)
+        );
+    });
 
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/poo`)
-      .expect(404);
-  });
+    it('returns 404 if job not found', async () => {
+      mockEsClient.search.mockResponseOnce(getHits());
+      registerJobInfoRoutesPublic(core);
 
-  it('returns a 403 if not a valid job type', async () => {
-    mockEsClient.search.mockResponseOnce(
-      getHits({
-        jobtype: 'invalidJobType',
-        payload: { title: 'invalid!' },
-      })
-    );
-    registerJobInfoRoutesPublic(core);
+      await server.start();
 
-    await server.start();
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/poo`)
+        .expect(404);
+    });
 
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/poo`)
-      .expect(403);
-  });
-
-  it('when a job is incomplete', async () => {
-    mockEsClient.search.mockResponseOnce(
-      getHits({
-        jobtype: 'unencodedJobType',
-        status: 'pending',
-        payload: { title: 'incomplete!' },
-      })
-    );
-    registerJobInfoRoutesPublic(core);
-
-    await server.start();
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dank`)
-      .expect(503)
-      .expect('Content-Type', 'text/plain; charset=utf-8')
-      .expect('Retry-After', '30')
-      .then(({ text }) => expect(text).toEqual('pending'));
-  });
-
-  it('when a job fails', async () => {
-    mockEsClient.search.mockResponse(
-      getHits({
-        jobtype: 'unencodedJobType',
-        status: 'failed',
-        output: { content: 'job failure message' },
-        payload: { title: 'failing job!' },
-      })
-    );
-    registerJobInfoRoutesPublic(core);
-
-    await server.start();
-    await supertest(httpSetup.server.listener)
-      .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dank`)
-      .expect(500)
-      .expect('Content-Type', 'application/json; charset=utf-8')
-      .then(({ body }) =>
-        expect(body.message).toEqual('Reporting generation failed: job failure message')
+    it('returns a 403 if not a valid job type', async () => {
+      mockEsClient.search.mockResponseOnce(
+        getHits({
+          jobtype: 'invalidJobType',
+          payload: { title: 'invalid!' },
+        })
       );
-  });
+      registerJobInfoRoutesPublic(core);
 
-  describe('successful downloads', () => {
+      await server.start();
+
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/poo`)
+        .expect(403);
+    });
+
+    it('when a job is incomplete', async () => {
+      mockEsClient.search.mockResponseOnce(
+        getHits({
+          jobtype: 'unencodedJobType',
+          status: 'pending',
+          payload: { title: 'incomplete!' },
+        })
+      );
+      registerJobInfoRoutesPublic(core);
+
+      await server.start();
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dank`)
+        .expect(503)
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect('Retry-After', '30')
+        .then(({ text }) => expect(text).toEqual('pending'));
+    });
+
+    it('when a job fails', async () => {
+      mockEsClient.search.mockResponse(
+        getHits({
+          jobtype: 'unencodedJobType',
+          status: 'failed',
+          output: { content: 'job failure message' },
+          payload: { title: 'failing job!' },
+        })
+      );
+      registerJobInfoRoutesPublic(core);
+
+      await server.start();
+      await supertest(httpSetup.server.listener)
+        .get(`${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}/dank`)
+        .expect(500)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+        .then(({ body }) =>
+          expect(body.message).toEqual('Reporting generation failed: job failure message')
+        );
+    });
+
     it('when a known job-type is complete', async () => {
       mockEsClient.search.mockResponseOnce(getCompleteHits());
       registerJobInfoRoutesPublic(core);
@@ -290,6 +290,30 @@ describe(`GET ${PUBLIC_ROUTES.JOBS.DOWNLOAD_PREFIX}`, () => {
         counterName: 'delete /api/reporting/jobs/delete/{docId}:unencodedJobType',
         counterType: 'reportingApi',
       });
+    });
+  });
+
+  describe('delete report', () => {
+    it('handles content stream errors', async () => {
+      stream = new Readable({
+        read() {
+          this.push('test');
+          this.push(null);
+        },
+      }) as typeof stream;
+      stream.end = jest.fn().mockImplementation((_name, _encoding, callback) => {
+        callback(new Error('An error occurred in ending the content stream'));
+      });
+
+      (getContentStream as jest.MockedFunction<typeof getContentStream>).mockResolvedValue(stream);
+      mockEsClient.search.mockResponseOnce(getCompleteHits());
+      registerJobInfoRoutesPublic(core);
+
+      await server.start();
+      await supertest(httpSetup.server.listener)
+        .delete('/api/reporting/jobs/delete/denk')
+        .expect(500)
+        .expect('Content-Type', 'application/json; charset=utf-8');
     });
   });
 });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Handle content stream errors in report pre-deletion (#173792)](https://github.com/elastic/kibana/pull/173792)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Sullivan","email":"tsullivan@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-02T23:00:53Z","message":"Handle content stream errors in report pre-deletion (#173792)\n\nRe-addresses https://github.com/elastic/kibana/issues/171363\r\n\r\nThe bug was still evident, especially when using network throttling to\r\nadd slight lag to the request turnaround times.\r\n\r\nThis PR adds more handling of errors that could be thrown slightly prior\r\nto deleting the report document, when we try to clear all chunks of the\r\nreport using the content stream.\r\n\r\n<details>\r\n<summary>Before</summary>\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/c27fe314-0f93-42b4-8076-99a1e30b8d2f\r\n\r\n\r\n</details>\r\n\r\n<details>\r\n<summary>After</summary>\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/4c1f5edd-73f1-4ca4-a40a-f900ca5f9c78\r\n\r\n\r\n</details>\r\n\r\n### Checklist\r\n- [x] Unit tests","sha":"dc813c351fe111c895e85a188372ad31625d8c8c","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","backport:prev-MAJOR","v8.12.0","v8.13.0","v8.11.4"],"number":173792,"url":"https://github.com/elastic/kibana/pull/173792","mergeCommit":{"message":"Handle content stream errors in report pre-deletion (#173792)\n\nRe-addresses https://github.com/elastic/kibana/issues/171363\r\n\r\nThe bug was still evident, especially when using network throttling to\r\nadd slight lag to the request turnaround times.\r\n\r\nThis PR adds more handling of errors that could be thrown slightly prior\r\nto deleting the report document, when we try to clear all chunks of the\r\nreport using the content stream.\r\n\r\n<details>\r\n<summary>Before</summary>\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/c27fe314-0f93-42b4-8076-99a1e30b8d2f\r\n\r\n\r\n</details>\r\n\r\n<details>\r\n<summary>After</summary>\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/4c1f5edd-73f1-4ca4-a40a-f900ca5f9c78\r\n\r\n\r\n</details>\r\n\r\n### Checklist\r\n- [x] Unit tests","sha":"dc813c351fe111c895e85a188372ad31625d8c8c"}},"sourceBranch":"main","suggestedTargetBranches":["8.12","8.11"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173792","number":173792,"mergeCommit":{"message":"Handle content stream errors in report pre-deletion (#173792)\n\nRe-addresses https://github.com/elastic/kibana/issues/171363\r\n\r\nThe bug was still evident, especially when using network throttling to\r\nadd slight lag to the request turnaround times.\r\n\r\nThis PR adds more handling of errors that could be thrown slightly prior\r\nto deleting the report document, when we try to clear all chunks of the\r\nreport using the content stream.\r\n\r\n<details>\r\n<summary>Before</summary>\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/c27fe314-0f93-42b4-8076-99a1e30b8d2f\r\n\r\n\r\n</details>\r\n\r\n<details>\r\n<summary>After</summary>\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/908371/4c1f5edd-73f1-4ca4-a40a-f900ca5f9c78\r\n\r\n\r\n</details>\r\n\r\n### Checklist\r\n- [x] Unit tests","sha":"dc813c351fe111c895e85a188372ad31625d8c8c"}},{"branch":"8.11","label":"v8.11.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->