### PR TITLE
[ML][Enterprise Search] Reword E5 model description

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/ml/utils.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/utils.ts
@@ -87,7 +87,7 @@ export const E5_MODEL_PLACEHOLDER: MlModel = {
   title: 'E5 (EmbEddings from bidirEctional Encoder rEpresentations)',
   description: i18n.translate('xpack.enterpriseSearch.modelCard.e5Placeholder.description', {
     defaultMessage:
-      'E5 is an NLP model that enables you to perform multi-lingual semantic search by using dense vector representations. This model performs best for non-English language documents and queries.',
+      'E5 is a third party NLP model that enables you to perform multi-lingual semantic search by using dense vector representations. This model performs best for non-English language documents and queries.',
   }),
   licenseType: 'mit',
   modelDetailsPageUrl: 'https://ela.st/multilingual-e5-small',

--- a/x-pack/plugins/ml/public/application/model_management/add_model_flyout.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/add_model_flyout.tsx
@@ -212,7 +212,7 @@ const ClickToDownloadTabContent: FC<ClickToDownloadTabContentProps> = ({
                   <EuiText color={'subdued'} size={'s'}>
                     <FormattedMessage
                       id="xpack.ml.trainedModels.addModelFlyout.e5Description"
-                      defaultMessage="E5 is an NLP model that enables you to perform multi-lingual semantic search by using dense vector representations. This model performs best for non-English language documents and queries."
+                      defaultMessage="E5 is a third party NLP model that enables you to perform multi-lingual semantic search by using dense vector representations. This model performs best for non-English language documents and queries."
                     />
                   </EuiText>
                 </p>


### PR DESCRIPTION
## Summary

Adding "third party" to E5 ML model description as per legal requirements.

<img width="1372" alt="Screenshot 2024-01-03 at 09 11 25" src="https://github.com/elastic/kibana/assets/14224983/29522e9a-d532-45da-93bd-efed6a1090eb">
<img width="960" alt="Screenshot 2024-01-03 at 09 12 04" src="https://github.com/elastic/kibana/assets/14224983/1e5c2128-7111-4bdf-b1a5-8fe89b450a4e">


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->