### PR TITLE
[SecuritySolution] Disable Panel Settings for visualization context menu

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.test.tsx
@@ -20,6 +20,7 @@ import { kpiHostMetricLensAttributes } from './lens_attributes/hosts/kpi_host_me
 import { LensEmbeddable } from './lens_embeddable';
 import { useKibana } from '../../lib/kibana';
 import { useActions } from './use_actions';
+import { ACTION_CUSTOMIZE_PANEL } from '@kbn/embeddable-plugin/public';
 
 const mockActions = [
   { id: 'inspect' },
@@ -127,5 +128,11 @@ describe('LensEmbeddable', () => {
   it('should not sync highlight state between visualizations', () => {
     expect(mockEmbeddableComponent.mock.calls[0][0].syncTooltips).toEqual(false);
     expect(mockEmbeddableComponent.mock.calls[0][0].syncCursor).toEqual(false);
+  });
+
+  it('should not render Panel settings action', () => {
+    expect(
+      mockEmbeddableComponent.mock.calls[0][0].disabledActions.includes(ACTION_CUSTOMIZE_PANEL)
+    ).toBeTruthy();
   });
 });

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useMemo, useState } from 'react';
 import { useDispatch } from 'react-redux';
 
 import { FormattedMessage } from '@kbn/i18n-react';
-import { ViewMode } from '@kbn/embeddable-plugin/public';
+import { ACTION_CUSTOMIZE_PANEL, ViewMode } from '@kbn/embeddable-plugin/public';
 import styled from 'styled-components';
 import { EuiEmptyPrompt, EuiFlexGroup, EuiFlexItem, EuiText } from '@elastic/eui';
 import type { RangeFilterParams } from '@kbn/es-query';
@@ -29,6 +29,7 @@ import { SourcererScopeName } from '../../store/sourcerer/model';
 import { VisualizationActions } from './actions';
 
 const HOVER_ACTIONS_PADDING = 24;
+const DISABLED_ACTIONS = [ACTION_CUSTOMIZE_PANEL];
 
 const LensComponentWrapper = styled.div<{
   $height?: number;
@@ -278,6 +279,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
             style={style}
             timeRange={timerange}
             attributes={attributes}
+            disabledActions={DISABLED_ACTIONS}
             onLoad={onLoadCallback}
             onBrushEnd={updateDateRange}
             onFilter={onFilterCallback}


### PR DESCRIPTION
## Summary

`Panel Settings` action is not compatible with Security Solution ([bug](https://github.com/elastic/kibana/issues/168670)), removing them in this PR according to the advised solution [here](https://github.com/elastic/kibana/pull/170244).

Steps to verify:
1. Visit network / hosts / users / rules / alerts page
2. Find a visualization rendered with Lens Embeddable
3. Click on `...`, and find `Panel settings` should not exist

![Screenshot 2024-01-03 at 22 41 51](https://github.com/elastic/kibana/assets/6295984/f97866a4-0d97-42f5-94d1-46e1b4f3395e)



- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->