### PR TITLE
[Fleet] Add `xpack.fleet.isAirGapped` flag 

### DIFF
--- a/docs/settings/fleet-settings.asciidoc
+++ b/docs/settings/fleet-settings.asciidoc
@@ -24,6 +24,8 @@ See the {fleet-guide}/index.html[{fleet}] docs for more information about {fleet
 `xpack.fleet.agents.enabled` {ess-icon}::
 Set to `true` (default) to enable {fleet}.
 
+`xpack.fleet.isAirGapped`::
+Set to `true` to indicate {fleet} is running in an air-gapped environment. Refer to {fleet-guide}/air-gapped.html[Air-gapped environments] for details. Enabling this flag helps Fleet skip needless requests and improve the user experience for air-gapped environments.
 
 [[fleet-data-visualizer-settings]]
 

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -16,6 +16,7 @@ import type {
 
 export interface FleetConfigType {
   enabled: boolean;
+  isAirGapped: boolean;
   registryUrl?: string;
   registryProxyUrl?: string;
   agents: {

--- a/x-pack/plugins/fleet/common/types/index.ts
+++ b/x-pack/plugins/fleet/common/types/index.ts
@@ -16,7 +16,7 @@ import type {
 
 export interface FleetConfigType {
   enabled: boolean;
-  isAirGapped: boolean;
+  isAirGapped?: boolean;
   registryUrl?: string;
   registryProxyUrl?: string;
   agents: {

--- a/x-pack/plugins/fleet/server/config.ts
+++ b/x-pack/plugins/fleet/server/config.ts
@@ -126,6 +126,7 @@ export const config: PluginConfigDescriptor = {
   ],
   schema: schema.object(
     {
+      isAirGapped: schema.maybe(schema.boolean({ defaultValue: false })),
       registryUrl: schema.maybe(schema.uri({ scheme: ['http', 'https'] })),
       registryProxyUrl: schema.maybe(schema.uri({ scheme: ['http', 'https'] })),
       agents: schema.object({

--- a/x-pack/plugins/fleet/server/services/agents/versions.ts
+++ b/x-pack/plugins/fleet/server/services/agents/versions.ts
@@ -111,6 +111,11 @@ export const getAvailableVersions = async ({
 };
 
 async function fetchAgentVersionsFromApi() {
+  // If the airgapped flag is set, do not attempt to reach out to the product versions API
+  if (appContextService.getConfig()?.isAirGapped) {
+    return [];
+  }
+
   const logger = appContextService.getLogger();
 
   const options = {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/173125

Adds a new `xpack.fleet.isAirGapped` flag to `kibana.yml` that allow users in air-gapped environments to inform Fleet that it should "fail fast" and skip unnecessary requests that won't be possible as Kibana doesn't have internet access.

This PR also uses the new flag to skip the API request to the `product_versions` API if the airgapped flag is set to true. There are probably other places we could use this flag in a similar way, but they can be handled separately from this PR. 

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

