### PR TITLE
[Fleet] Fix form state for input integration

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/prepare_input_pkg_policy_dataset.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/create_package_policy_page/services/prepare_input_pkg_policy_dataset.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { cloneDeep } from 'lodash';
+
 import { DATASET_VAR_NAME } from '../../../../../../../common/constants';
 
 import type { NewPackagePolicy } from '../../../../types';
@@ -14,7 +16,7 @@ export function prepareInputPackagePolicyDataset(newPolicy: NewPackagePolicy): {
   forceCreateNeeded: boolean;
 } {
   let forceCreateNeeded = false;
-  const { inputs } = newPolicy;
+  const { inputs } = cloneDeep(newPolicy);
 
   if (!inputs || !inputs.length) {
     return { policy: newPolicy, forceCreateNeeded: false };


### PR DESCRIPTION
## Summary

The form state for input integration (custom logs) for example was not correct, allowing user to create multiple time the submit button (creating multiple package policies) and not displaying a loading state.

This was due to a function mutating his parameters, that PR fix that.

## UI Changes

Look at the save and continue button

#### Before 
https://github.com/elastic/kibana/assets/1336873/27f5fbc4-8735-4ed8-aa17-aedcfe0a7a52

#### After 
https://github.com/elastic/kibana/assets/1336873/5da0f524-b833-40ac-a224-e9cc2a4666a8


