### PR TITLE
[ci] Remove ubi8 step

### DIFF
--- a/.buildkite/pipelines/artifacts.yml
+++ b/.buildkite/pipelines/artifacts.yml
@@ -51,16 +51,6 @@ steps:
         - exit_status: '*'
           limit: 1
 
-  - command: KIBANA_DOCKER_CONTEXT=ubi8 .buildkite/scripts/steps/artifacts/docker_context.sh
-    label: 'Docker Context Verification'
-    agents:
-      queue: n2-2
-    timeout_in_minutes: 30
-    retry:
-      automatic:
-        - exit_status: '*'
-          limit: 1
-
   - command: KIBANA_DOCKER_CONTEXT=ubi .buildkite/scripts/steps/artifacts/docker_context.sh
     label: 'Docker Context Verification'
     agents:


### PR DESCRIPTION
UBI8 builds were removed in https://github.com/elastic/kibana/pull/173873, but I missed the CI step that verifies the docker context.  This removes the step.

<!--ONMERGE {"backportTargets":["7.17","8.12"]} ONMERGE-->