### PR TITLE
skip Security Solution Cypress test for 8.11.4 release

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/detection_page_filters.cy.ts
@@ -110,7 +110,7 @@ const assertFilterControlsWithFilterObject = (
 
 // Failing: See https://github.com/elastic/kibana/issues/167914
 // Failing: See https://github.com/elastic/kibana/issues/167915
-describe(`Detections : Page Filters`, { tags: ['@ess', '@brokenInServerless'] }, () => {
+describe.skip(`Detections : Page Filters`, { tags: ['@ess', '@brokenInServerless'] }, () => {
   before(() => {
     cleanKibana();
     createRule(getNewRule({ rule_id: 'custom_rule_filters' }));


### PR DESCRIPTION
## Summary

This PR skips a Security Solution Cypress test that is currently skipped in `main`