### PR TITLE
[8.12] [Security Solution] [Timelines] Fix FilterManager being undefined when opening timeline from url (#171443)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
+++ b/x-pack/plugins/security_solution/public/timelines/store/timeline/helpers.ts
@@ -1481,7 +1481,13 @@ export const setInitializeTimelineSettings = ({
           initialized: true,
         },
       }
-    : timelineById;
+    : {
+        ...timelineById,
+        [id]: {
+          ...timeline,
+          ...timelineSettingsProps,
+        },
+      };
 };
 
 interface ApplyDeltaToTableColumnWidth {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/filters.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/filters.cy.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { login } from '../../../tasks/login';
+import { visitWithTimeRange } from '../../../tasks/navigation';
+import {
+  createNewTimeline,
+  addNameAndDescriptionToTimeline,
+  populateTimeline,
+} from '../../../tasks/timeline';
+import { openTimelineUsingToggle } from '../../../tasks/security_main';
+import { ALERTS_URL } from '../../../urls/navigation';
+import { getTimeline } from '../../../objects/timeline';
+import {
+  GET_TIMELINE_GRID_CELL,
+  TIMELINE_FILTER_FOR,
+  TIMELINE_FILTER_OUT,
+  TIMELINE_EVENT,
+  TIMELINE_FILTER_BADGE_ENABLED,
+} from '../../../screens/timeline';
+
+describe(
+  `timleine cell actions`,
+  {
+    tags: ['@ess'],
+  },
+  () => {
+    beforeEach(() => {
+      login();
+      visitWithTimeRange(ALERTS_URL);
+      openTimelineUsingToggle();
+      createNewTimeline();
+      addNameAndDescriptionToTimeline(getTimeline());
+      populateTimeline();
+    });
+    it('filter in', () => {
+      cy.get(GET_TIMELINE_GRID_CELL('event.category')).trigger('mouseover');
+      cy.get(TIMELINE_FILTER_FOR).should('be.visible').click();
+      cy.get(TIMELINE_FILTER_BADGE_ENABLED).should('be.visible');
+    });
+
+    it('filter out', () => {
+      cy.get(GET_TIMELINE_GRID_CELL('event.category')).trigger('mouseover');
+      cy.get(TIMELINE_FILTER_OUT).should('be.visible').click();
+      cy.get(TIMELINE_EVENT).should('not.exist');
+    });
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
@@ -339,6 +339,12 @@ export const HOVER_ACTIONS = {
   SHOW_TOP: '[data-test-subj=show-top-field]',
 };
 
+export const TIMELINE_FILTER_OUT = '[data-test-subj="filter-out-value"]';
+
+export const TIMELINE_FILTER_FOR = '[data-test-subj="filter-for-value"]';
+
+export const TIMELINE_FILTER_BADGE_ENABLED = '[data-test-subj~="filter-enabled"]';
+
 export const GET_TIMELINE_HEADER = (fieldName: string) => {
   return `[data-test-subj="timeline"] [data-test-subj="header-text-${fieldName}"]`;
 };


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Security Solution] [Timelines] Fix FilterManager being undefined when opening timeline from url (#171443)](https://github.com/elastic/kibana/pull/171443)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-04T22:26:32Z","message":"[Security Solution] [Timelines] Fix FilterManager being undefined when opening timeline from url (#171443)\n\n## Summary\r\n\r\nFilter manager is not populated within redux if a user navigates to a\r\nurl with timeline opened as the first step of entering the app.\r\nInitializeTimeline action is called, but the reducer just ignores any\r\nparams at all if the initialize flag is set to true. Since this is only\r\nused in 2 places, and only 1 of which has an argument other than\r\ntimelineId, I think this solution is fine. Should only ever result in\r\nfixing this bug it seems, as filterManager is either created anew or\r\ncomes directly from the model.\r\n\r\nIssue: https://github.com/elastic/kibana/issues/171437\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"94bdc0d5212412e41e8281a5235654546e2102cb","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Threat Hunting:Investigations","8.12 candidate","v8.13.0"],"number":171443,"url":"https://github.com/elastic/kibana/pull/171443","mergeCommit":{"message":"[Security Solution] [Timelines] Fix FilterManager being undefined when opening timeline from url (#171443)\n\n## Summary\r\n\r\nFilter manager is not populated within redux if a user navigates to a\r\nurl with timeline opened as the first step of entering the app.\r\nInitializeTimeline action is called, but the reducer just ignores any\r\nparams at all if the initialize flag is set to true. Since this is only\r\nused in 2 places, and only 1 of which has an argument other than\r\ntimelineId, I think this solution is fine. Should only ever result in\r\nfixing this bug it seems, as filterManager is either created anew or\r\ncomes directly from the model.\r\n\r\nIssue: https://github.com/elastic/kibana/issues/171437\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"94bdc0d5212412e41e8281a5235654546e2102cb"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/171443","number":171443,"mergeCommit":{"message":"[Security Solution] [Timelines] Fix FilterManager being undefined when opening timeline from url (#171443)\n\n## Summary\r\n\r\nFilter manager is not populated within redux if a user navigates to a\r\nurl with timeline opened as the first step of entering the app.\r\nInitializeTimeline action is called, but the reducer just ignores any\r\nparams at all if the initialize flag is set to true. Since this is only\r\nused in 2 places, and only 1 of which has an argument other than\r\ntimelineId, I think this solution is fine. Should only ever result in\r\nfixing this bug it seems, as filterManager is either created anew or\r\ncomes directly from the model.\r\n\r\nIssue: https://github.com/elastic/kibana/issues/171437\r\n\r\n### Checklist\r\n\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"94bdc0d5212412e41e8281a5235654546e2102cb"}}]}] BACKPORT-->