### PR TITLE
[Security Solution][Endpoint] Unskip alerts response console test

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -73,7 +73,7 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/alerts_response_console.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/cypress_base.config.ts
@@ -73,7 +73,7 @@ export const getCypressBaseConfig = (
         // baseUrl: To override, set Env. variable `CYPRESS_BASE_URL`
         baseUrl: 'http://localhost:5601',
         supportFile: 'public/management/cypress/support/e2e.ts',
-        specPattern: 'public/management/cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
+        specPattern: 'public/management/cypress/e2e/**/alerts_response_console.cy.{js,jsx,ts,tsx}',
         experimentalRunAllSpecs: true,
         experimentalMemoryManagement: true,
         experimentalInteractiveRunEvents: true,

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
@@ -67,7 +67,7 @@ describe('Response console', { tags: ['@ess', '@serverless', '@brokenInServerles
 
   // FLAKY: https://github.com/elastic/kibana/issues/169689
   // FLAKY: https://github.com/elastic/kibana/issues/173472
-  describe.skip('From Alerts', () => {
+  describe('From Alerts', () => {
     let ruleId: string;
     let ruleName: string;
 

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
@@ -26,60 +26,59 @@ import { enableAllPolicyProtections } from '../../tasks/endpoint_policy';
 import { createEndpointHost } from '../../tasks/create_endpoint_host';
 import { deleteAllLoadedEndpointData } from '../../tasks/delete_all_endpoint_data';
 
-describe('Response console', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
-  let indexedPolicy: IndexedFleetEndpointPolicyResponse;
-  let policy: PolicyData;
-  let createdHost: CreateAndEnrollEndpointHostResponse;
+describe(
+  'Response console: From Alerts',
+  { tags: ['@ess', '@serverless', '@brokenInServerless'] },
+  () => {
+    let indexedPolicy: IndexedFleetEndpointPolicyResponse;
+    let policy: PolicyData;
+    let createdHost: CreateAndEnrollEndpointHostResponse;
 
-  beforeEach(() => {
-    login();
-  });
-
-  before(() => {
-    getEndpointIntegrationVersion().then((version) =>
-      createAgentPolicyTask(version).then((data) => {
-        indexedPolicy = data;
-        policy = indexedPolicy.integrationPolicies[0];
-
-        return enableAllPolicyProtections(policy.id).then(() => {
-          // Create and enroll a new Endpoint host
-          return createEndpointHost(policy.policy_id).then((host) => {
-            createdHost = host as CreateAndEnrollEndpointHostResponse;
-          });
-        });
-      })
-    );
-  });
-
-  after(() => {
-    if (createdHost) {
-      cy.task('destroyEndpointHost', createdHost);
-    }
-
-    if (indexedPolicy) {
-      cy.task('deleteIndexedFleetEndpointPolicies', indexedPolicy);
-    }
-
-    if (createdHost) {
-      deleteAllLoadedEndpointData({ endpointAgentIds: [createdHost.agentId] });
-    }
-  });
-
-  describe('From Alerts', () => {
     let ruleId: string;
     let ruleName: string;
+    beforeEach(() => {
+      login();
+    });
 
     before(() => {
-      loadRule(
-        { query: `agent.name: ${createdHost.hostname} and agent.type: endpoint` },
-        false
-      ).then((data) => {
-        ruleId = data.id;
-        ruleName = data.name;
-      });
+      getEndpointIntegrationVersion()
+        .then((version) =>
+          createAgentPolicyTask(version).then((data) => {
+            indexedPolicy = data;
+            policy = indexedPolicy.integrationPolicies[0];
+
+            return enableAllPolicyProtections(policy.id).then(() => {
+              // Create and enroll a new Endpoint host
+              return createEndpointHost(policy.policy_id).then((host) => {
+                createdHost = host as CreateAndEnrollEndpointHostResponse;
+              });
+            });
+          })
+        )
+        .then(() => {
+          loadRule(
+            { query: `agent.name: ${createdHost.hostname} and agent.type: endpoint` },
+            false
+          ).then((data) => {
+            ruleId = data.id;
+            ruleName = data.name;
+          });
+        });
     });
 
     after(() => {
+      if (createdHost) {
+        cy.task('destroyEndpointHost', createdHost);
+      }
+
+      if (indexedPolicy) {
+        cy.task('deleteIndexedFleetEndpointPolicies', indexedPolicy);
+      }
+
+      if (createdHost) {
+        deleteAllLoadedEndpointData({ endpointAgentIds: [createdHost.agentId] });
+      }
+
       if (ruleId) {
         cleanupRule(ruleId);
       }
@@ -111,5 +110,5 @@ describe('Response console', { tags: ['@ess', '@serverless', '@brokenInServerles
       openResponderFromEndpointAlertDetails();
       ensureOnResponder();
     });
-  });
-});
+  }
+);

--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/alerts_response_console.cy.ts
@@ -65,8 +65,6 @@ describe('Response console', { tags: ['@ess', '@serverless', '@brokenInServerles
     }
   });
 
-  // FLAKY: https://github.com/elastic/kibana/issues/169689
-  // FLAKY: https://github.com/elastic/kibana/issues/173472
   describe('From Alerts', () => {
     let ruleId: string;
     let ruleName: string;


### PR DESCRIPTION
## Summary

Re-enable response console tests for Alerts page.

closes elastic/kibana/issues/169689
closes elastic/kibana/issues/173472

### Flaky test runner
- https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4766 x 100 (all pass)

### Checklist

- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
