### PR TITLE
[ci] Add jest retry

### DIFF
--- a/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
+++ b/.buildkite/pipeline-utils/ci-stats/pick_test_group_run_order.ts
@@ -218,6 +218,12 @@ export async function pickTestGroupRunOrder() {
   if (Number.isNaN(FTR_CONFIGS_RETRY_COUNT)) {
     throw new Error(`invalid FTR_CONFIGS_RETRY_COUNT: ${process.env.FTR_CONFIGS_RETRY_COUNT}`);
   }
+  const JEST_CONFIGS_RETRY_COUNT = process.env.JEST_CONFIGS_RETRY_COUNT
+    ? parseInt(process.env.JEST_CONFIGS_RETRY_COUNT, 10)
+    : 1;
+  if (Number.isNaN(JEST_CONFIGS_RETRY_COUNT)) {
+    throw new Error(`invalid JEST_CONFIGS_RETRY_COUNT: ${process.env.JEST_CONFIGS_RETRY_COUNT}`);
+  }
 
   const FTR_CONFIGS_DEPS =
     process.env.FTR_CONFIGS_DEPS !== undefined
@@ -417,10 +423,10 @@ export async function pickTestGroupRunOrder() {
             },
             retry: {
               automatic: [
-                {
-                  exit_status: '-1',
-                  limit: 3,
-                },
+                { exit_status: '-1', limit: 3 },
+                ...(JEST_CONFIGS_RETRY_COUNT > 0
+                  ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
+                  : []),
               ],
             },
           }
@@ -437,10 +443,10 @@ export async function pickTestGroupRunOrder() {
             },
             retry: {
               automatic: [
-                {
-                  exit_status: '-1',
-                  limit: 3,
-                },
+                { exit_status: '-1', limit: 3 },
+                ...(JEST_CONFIGS_RETRY_COUNT > 0
+                  ? [{ exit_status: '*', limit: JEST_CONFIGS_RETRY_COUNT }]
+                  : []),
               ],
             },
           }


### PR DESCRIPTION
If a jest test is flaky, we want to retry a single step instead of re-running the entire pipeline.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->