### PR TITLE
Remove default timeline esql query + revert esql tab load

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx
@@ -14,15 +14,12 @@ import type { SavedSearch } from '@kbn/saved-search-plugin/common';
 import type { DiscoverAppState } from '@kbn/discover-plugin/public/application/main/services/discover_app_state_container';
 import type { TimeRange } from '@kbn/es-query';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { defaultHeaders } from '@kbn/securitysolution-data-table';
 import { timelineDefaults } from '../../../timelines/store/defaults';
 import { TimelineId } from '../../../../common/types';
 import { timelineActions, timelineSelectors } from '../../../timelines/store';
 import { useAppToasts } from '../../hooks/use_app_toasts';
 import { useShallowEqualSelector } from '../../hooks/use_selector';
 import { useKibana } from '../../lib/kibana';
-import { useSourcererDataView } from '../../containers/sourcerer';
-import { SourcererScopeName } from '../../store/sourcerer/model';
 import {
   DISCOVER_SEARCH_SAVE_ERROR_TITLE,
   DISCOVER_SEARCH_SAVE_ERROR_UNKNOWN,
@@ -40,16 +37,10 @@ export const useDiscoverInTimelineActions = (
   const { addError } = useAppToasts();
 
   const {
-    services: {
-      customDataService: discoverDataService,
-      savedSearch: savedSearchService,
-      dataViews: dataViewService,
-    },
+    services: { customDataService: discoverDataService, savedSearch: savedSearchService },
   } = useKibana();
 
   const dispatch = useDispatch();
-
-  const { dataViewId } = useSourcererDataView(SourcererScopeName.detections);
 
   const getTimeline = useMemo(() => timelineSelectors.getTimelineByIdSelector(), []);
   const timeline = useShallowEqualSelector(
@@ -78,15 +69,9 @@ export const useDiscoverInTimelineActions = (
   });
 
   const getDefaultDiscoverAppState: () => Promise<DiscoverAppState> = useCallback(async () => {
-    const localDataViewId = dataViewId ?? 'security-solution-default';
-
-    const dataView = await dataViewService.get(localDataViewId);
-    const defaultColumns = defaultHeaders.map((header) => header.id);
     return {
       query: {
-        esql: dataView
-          ? `from ${dataView.getIndexPattern()} | limit 10 | keep ${defaultColumns.join(', ')}`
-          : '',
+        esql: '',
       },
       sort: [['@timestamp', 'desc']],
       columns: [],
@@ -95,7 +80,7 @@ export const useDiscoverInTimelineActions = (
       hideChart: true,
       grid: {},
     };
-  }, [dataViewService, dataViewId]);
+  }, []);
 
   /*
    * generates Appstate from a given saved Search object

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -135,7 +135,6 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
     setConversationId,
     showTimeline,
   }) => {
-    const isEsqlSettingEnabled = useKibana().services.configSettings.ESQLEnabled;
     const { hasAssistantPrivilege } = useAssistantAvailability();
     const getTab = useCallback(
       (tab: TimelineTabs) => {
@@ -183,14 +182,12 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
             timelineId={timelineId}
           />
         </HideShowContainer>
-        {showTimeline && isEsqlSettingEnabled && activeTimelineTab === TimelineTabs.esql && (
-          <HideShowContainer
-            $isVisible={true}
-            data-test-subj={`timeline-tab-content-${TimelineTabs.esql}`}
-          >
-            <EsqlTab timelineId={timelineId} />
-          </HideShowContainer>
-        )}
+        <HideShowContainer
+          $isVisible={TimelineTabs.esql === activeTimelineTab}
+          data-test-subj={`timeline-tab-content-${TimelineTabs.esql}`}
+        >
+          <EsqlTab timelineId={timelineId} />
+        </HideShowContainer>
         <HideShowContainer
           $isVisible={TimelineTabs.pinned === activeTimelineTab}
           data-test-subj={`timeline-tab-content-${TimelineTabs.pinned}`}

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
@@ -26,8 +26,7 @@ import { ALERTS, CSP_FINDINGS } from '../../../../screens/security_header';
 
 const INITIAL_START_DATE = 'Jan 18, 2021 @ 20:33:29.186';
 const INITIAL_END_DATE = 'Jan 19, 2024 @ 20:33:29.186';
-const DEFAULT_ESQL_QUERY =
-  'from .alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-* | limit 10 | keep @timestamp, message, event.category, event.action, host.name, source.ip, destination.ip, user.name';
+const DEFAULT_ESQL_QUERY = '';
 
 describe(
   'Timeline Discover ESQL State',


### PR DESCRIPTION
## Summary

This PR reverts the changes made in [this PR](https://github.com/elastic/kibana/pull/173640). The esql tab is now always rendered again. This is necessary to fix the issue related to esql and saving a timeline.

This PR removes the default esql query when users navigate to the ESQL tab in timeline. This change was requested after a few issues reported by customers.
This previous [PR](https://github.com/elastic/kibana/pull/174022) tried to mitigate the issue, but the changes aren't sufficient, hence removing the default query entirely for now, until we find a more robust solution.

### How/what to test

See [this document](https://docs.google.com/document/d/1dVL7QhS4ruIj9RRTab3iVnMTe01IcHHgebTWVk9j0A8/edit#heading=h.qz5brrh48bdl)

![esql_default](https://github.com/elastic/kibana/assets/56408403/0ccecd80-5e27-4cd4-87b7-c6b4c5285d36)

### TODO

- [ ]  run through the suite of test (see link above)
- [ ] verify unit tests
- [ ] verify Cypress tests