### PR TITLE
[8.11] [Timeline] [ES|QL] Make default esql query empty (#174393)

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/esql_tab_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/esql_tab_content/index.tsx
@@ -29,7 +29,7 @@ import { timelineSelectors } from '../../../store/timeline';
 import { useShallowEqualSelector } from '../../../../common/hooks/use_selector';
 import { timelineDefaults } from '../../../store/timeline/defaults';
 import { savedSearchComparator } from './utils';
-import { setIsDiscoverSavedSearchLoaded } from '../../../store/timeline/actions';
+import { setIsDiscoverSavedSearchLoaded, endTimelineSaving } from '../../../store/timeline/actions';
 import { GET_TIMELINE_DISCOVER_SAVED_SEARCH_TITLE } from './translations';
 
 const HideSearchSessionIndicatorBreadcrumbIcon = createGlobalStyle`
@@ -130,6 +130,13 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
         resetDiscoverAppState().then(() => {
           setSavedSearchLoaded(true);
         });
+      } else {
+        dispatch(
+          endTimelineSaving({
+            id: timelineId,
+          })
+        );
+        setSavedSearchLoaded(true);
       }
       return;
     }
@@ -147,6 +154,8 @@ export const DiscoverTabContent: FC<DiscoverTabContentProps> = ({ timelineId }) 
     restoreDiscoverAppStateFromSavedSearch,
     isFetching,
     setSavedSearchLoaded,
+    dispatch,
+    timelineId,
   ]);
 
   const getCombinedDiscoverSavedSearchState: () => SavedSearch | undefined = useCallback(() => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/tabs_content/index.tsx
@@ -134,6 +134,7 @@ const ActiveTimelineTab = memo<ActiveTimelineTabProps>(
     showTimeline,
   }) => {
     const { hasAssistantPrivilege } = useAssistantAvailability();
+
     const getTab = useCallback(
       (tab: TimelineTabs) => {
         switch (tab) {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
@@ -17,7 +17,7 @@ import { createTimeline } from '../../../tasks/api_calls/timelines';
 
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
-import { addEqlToTimeline } from '../../../tasks/timeline';
+import { addEqlToTimeline, saveTimeline, clearEqlInTimeline } from '../../../tasks/timeline';
 
 import { TIMELINES_URL } from '../../../urls/navigation';
 import { EQL_QUERY_VALIDATION_ERROR } from '../../../screens/create_new_rule';
@@ -46,8 +46,8 @@ describe('Correlation tab', { tags: ['@ess', '@serverless'] }, () => {
   });
 
   it('should update timeline after removing eql', () => {
-    cy.get(TIMELINE_CORRELATION_INPUT).type('{selectAll} {del}');
-    cy.get(TIMELINE_CORRELATION_INPUT).clear();
+    clearEqlInTimeline();
+    saveTimeline();
     cy.wait('@updateTimeline');
     cy.reload();
     cy.get(TIMELINE_CORRELATION_INPUT).should('be.visible');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/correlation_tab.cy.ts
@@ -17,7 +17,7 @@ import { createTimeline } from '../../../tasks/api_calls/timelines';
 
 import { login } from '../../../tasks/login';
 import { visit } from '../../../tasks/navigation';
-import { addEqlToTimeline, saveTimeline, clearEqlInTimeline } from '../../../tasks/timeline';
+import { addEqlToTimeline, clearEqlInTimeline } from '../../../tasks/timeline';
 
 import { TIMELINES_URL } from '../../../urls/navigation';
 import { EQL_QUERY_VALIDATION_ERROR } from '../../../screens/create_new_rule';
@@ -47,7 +47,6 @@ describe('Correlation tab', { tags: ['@ess', '@serverless'] }, () => {
 
   it('should update timeline after removing eql', () => {
     clearEqlInTimeline();
-    saveTimeline();
     cy.wait('@updateTimeline');
     cy.reload();
     cy.get(TIMELINE_CORRELATION_INPUT).should('be.visible');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
@@ -20,16 +20,23 @@ import {
 import { updateDateRangeInLocalDatePickers } from '../../../../tasks/date_picker';
 import { login } from '../../../../tasks/login';
 import { visitWithTimeRange } from '../../../../tasks/navigation';
-import { closeTimeline, goToEsqlTab, openActiveTimeline } from '../../../../tasks/timeline';
+import {
+  closeTimeline,
+  goToEsqlTab,
+  openActiveTimeline,
+  addNameAndDescriptionToTimeline,
+  saveTimeline,
+} from '../../../../tasks/timeline';
 import { ALERTS_URL } from '../../../../urls/navigation';
+import { getTimeline } from '../../../../objects/timeline';
 import { ALERTS, CSP_FINDINGS } from '../../../../screens/security_header';
 
 const INITIAL_START_DATE = 'Jan 18, 2021 @ 20:33:29.186';
 const INITIAL_END_DATE = 'Jan 19, 2024 @ 20:33:29.186';
-const DEFAULT_ESQL_QUERY =
-  'from .alerts-security.alerts-default,apm-*-transaction*,auditbeat-*,endgame-*,filebeat-*,logs-*,packetbeat-*,traces-apm*,winlogbeat-*,-*elastic-cloud-logs-* | limit 10 | keep @timestamp, message, event.category, event.action, host.name, source.ip, destination.ip, user.name';
+const DEFAULT_ESQL_QUERY = '';
 
-describe(
+// FAILURE introduced by the fix for 8.11.4 related to the default empty string and fix for the infinite loop on the esql tab
+describe.skip(
   'Timeline Discover ESQL State',
   {
     tags: ['@ess'],
@@ -39,6 +46,9 @@ describe(
       login();
       visitWithTimeRange(ALERTS_URL);
       openActiveTimeline();
+      cy.window().then((win) => {
+        win.onbeforeunload = null;
+      });
       goToEsqlTab();
       updateDateRangeInLocalDatePickers(DISCOVER_CONTAINER, INITIAL_START_DATE, INITIAL_END_DATE);
     });
@@ -52,6 +62,8 @@ describe(
       const esqlQuery = 'from auditbeat-* | limit 5';
       addDiscoverEsqlQuery(esqlQuery);
       submitDiscoverSearchBar();
+      addNameAndDescriptionToTimeline(getTimeline());
+      saveTimeline();
       closeTimeline();
       navigateFromHeaderTo(CSP_FINDINGS);
       navigateFromHeaderTo(ALERTS);
@@ -61,8 +73,13 @@ describe(
       verifyDiscoverEsqlQuery(esqlQuery);
     });
     it('should remember columns when navigating away and back to discover ', () => {
+      const esqlQuery = 'from auditbeat-* | limit 5';
+      addDiscoverEsqlQuery(esqlQuery);
+      submitDiscoverSearchBar();
+      addNameAndDescriptionToTimeline(getTimeline());
       addFieldToTable('host.name');
       addFieldToTable('user.name');
+      saveTimeline();
       closeTimeline();
       navigateFromHeaderTo(CSP_FINDINGS);
       navigateFromHeaderTo(ALERTS);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/esql_state.cy.ts
@@ -25,7 +25,6 @@ import {
   goToEsqlTab,
   openActiveTimeline,
   addNameAndDescriptionToTimeline,
-  saveTimeline,
 } from '../../../../tasks/timeline';
 import { ALERTS_URL } from '../../../../urls/navigation';
 import { getTimeline } from '../../../../objects/timeline';
@@ -63,7 +62,6 @@ describe.skip(
       addDiscoverEsqlQuery(esqlQuery);
       submitDiscoverSearchBar();
       addNameAndDescriptionToTimeline(getTimeline());
-      saveTimeline();
       closeTimeline();
       navigateFromHeaderTo(CSP_FINDINGS);
       navigateFromHeaderTo(ALERTS);
@@ -79,7 +77,6 @@ describe.skip(
       addNameAndDescriptionToTimeline(getTimeline());
       addFieldToTable('host.name');
       addFieldToTable('user.name');
-      saveTimeline();
       closeTimeline();
       navigateFromHeaderTo(CSP_FINDINGS);
       navigateFromHeaderTo(ALERTS);

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/search_filter.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/search_filter.cy.ts
@@ -42,6 +42,10 @@ describe(
     beforeEach(() => {
       login();
       visitWithTimeRange(ALERTS_URL);
+      openActiveTimeline();
+      cy.window().then((win) => {
+        win.onbeforeunload = null;
+      });
       createNewTimeline();
       goToEsqlTab();
       updateDateRangeInLocalDatePickers(DISCOVER_CONTAINER, INITIAL_START_DATE, INITIAL_END_DATE);
@@ -53,6 +57,8 @@ describe(
       cy.get(DISCOVER_RESULT_HITS).should('have.text', 1);
     });
     it('should be able to add fields to the table', () => {
+      addDiscoverEsqlQuery(`${esqlQuery} | limit 1`);
+      submitDiscoverSearchBar();
       addFieldToTable('host.name');
       addFieldToTable('user.name');
       cy.get(GET_DISCOVER_DATA_GRID_CELL_HEADER('host.name')).should('be.visible');

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/search_filter.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/esql/search_filter.cy.ts
@@ -23,7 +23,7 @@ import {
   addFieldToTable,
   convertNBSPToSP,
 } from '../../../../tasks/discover';
-import { createNewTimeline, goToEsqlTab } from '../../../../tasks/timeline';
+import { createNewTimeline, goToEsqlTab, openActiveTimeline } from '../../../../tasks/timeline';
 import { login } from '../../../../tasks/login';
 import { visitWithTimeRange } from '../../../../tasks/navigation';
 import { ALERTS_URL } from '../../../../urls/navigation';

--- a/x-pack/test/security_solution_cypress/cypress/tasks/discover.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/discover.ts
@@ -51,7 +51,6 @@ export const selectCurrentDiscoverEsqlQuery = (
 ) => {
   goToEsqlTab();
   cy.get(discoverEsqlInput).should('be.visible').click();
-  cy.get(discoverEsqlInput).should('be.focused');
   cy.get(DISCOVER_ESQL_INPUT_EXPAND).click();
   cy.get(discoverEsqlInput).type(Cypress.platform === 'darwin' ? '{cmd+a}' : '{ctrl+a}');
 };

--- a/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -12,6 +12,7 @@ import { ALL_CASES_CREATE_NEW_CASE_TABLE_BTN } from '../screens/all_cases';
 import { BASIC_TABLE_LOADING } from '../screens/common';
 import { FIELDS_BROWSER_CHECKBOX } from '../screens/fields_browser';
 import { LOADING_INDICATOR } from '../screens/security_header';
+import { EQL_QUERY_VALIDATION_SPINNER } from '../screens/create_new_rule';
 
 import {
   ADD_FILTER,

--- a/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/timeline.ts
@@ -191,6 +191,12 @@ export const addEqlToTimeline = (eql: string) => {
   });
 };
 
+export const clearEqlInTimeline = () => {
+  cy.get(TIMELINE_CORRELATION_INPUT).type('{selectAll} {del}');
+  cy.get(TIMELINE_CORRELATION_INPUT).clear();
+  cy.get(EQL_QUERY_VALIDATION_SPINNER).should('not.exist');
+};
+
 export const addFilter = (filter: TimelineFilter): Cypress.Chainable<JQuery<HTMLElement>> => {
   cy.get(ADD_FILTER).click();
   cy.get(TIMELINE_FILTER_FIELD).type(`${filter.field}{downarrow}{enter}`);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[Timeline] [ES|QL] Make default esql query empty (#174393)](https://github.com/elastic/kibana/pull/174393)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-06T17:13:48Z","message":"[Timeline] [ES|QL] Make default esql query empty (#174393)\n\nBecause default queries can be prohibitively expensive, decision was\r\nmade to make the default query when users open the ES|QL tab of timeline\r\nbe an empty string, this prevents expensive queries from being run\r\nunless a user tries to do so, however there is an error state shown\r\nbefore any interaction, which will be changed in an upcoming pr, but not\r\nin 8.11.x.","sha":"ecfa61ad3480fd88254841bfa5e5d5539773f4cb","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Threat Hunting:Investigations","v8.12.0","v8.13.0","v8.11.4"],"number":174393,"url":"https://github.com/elastic/kibana/pull/174393","mergeCommit":{"message":"[Timeline] [ES|QL] Make default esql query empty (#174393)\n\nBecause default queries can be prohibitively expensive, decision was\r\nmade to make the default query when users open the ES|QL tab of timeline\r\nbe an empty string, this prevents expensive queries from being run\r\nunless a user tries to do so, however there is an error state shown\r\nbefore any interaction, which will be changed in an upcoming pr, but not\r\nin 8.11.x.","sha":"ecfa61ad3480fd88254841bfa5e5d5539773f4cb"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/174417","number":174417,"state":"OPEN"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174393","number":174393,"mergeCommit":{"message":"[Timeline] [ES|QL] Make default esql query empty (#174393)\n\nBecause default queries can be prohibitively expensive, decision was\r\nmade to make the default query when users open the ES|QL tab of timeline\r\nbe an empty string, this prevents expensive queries from being run\r\nunless a user tries to do so, however there is an error state shown\r\nbefore any interaction, which will be changed in an upcoming pr, but not\r\nin 8.11.x.","sha":"ecfa61ad3480fd88254841bfa5e5d5539773f4cb"}},{"branch":"8.11","label":"v8.11.4","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->