### PR TITLE
Clean up full errors being logged

### DIFF
--- a/packages/core/http/core-http-server-internal/src/logging/get_payload_size.test.ts
+++ b/packages/core/http/core-http-server-internal/src/logging/get_payload_size.test.ts
@@ -285,8 +285,10 @@ describe('getPayloadSize', () => {
       } as unknown as Response,
       logger
     );
-    expect(logger.warn.mock.calls[0][0]).toMatchInlineSnapshot(
-      `"Failed to calculate response payload bytes."`
-    );
+    expect(logger.warn.mock.calls[0][0]).toMatchInlineSnapshot(`
+      "Failed to calculate response payload bytes: Converting circular structure to JSON
+          --> starting at object with constructor 'Object'
+          --- property 'circular' closes the circle"
+    `);
   });
 });

--- a/packages/core/http/core-http-server-internal/src/logging/get_payload_size.ts
+++ b/packages/core/http/core-http-server-internal/src/logging/get_payload_size.ts
@@ -81,7 +81,7 @@ export function getResponsePayloadBytes(response: Response, log: Logger): number
     // We intentionally swallow any errors as this information is
     // only a nicety for logging purposes, and should not cause the
     // server to crash if it cannot be determined.
-    log.warn('Failed to calculate response payload bytes.', e);
+    log.warn(`Failed to calculate response payload bytes: ${e.message}`);
   }
 
   return undefined;

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/model_version.ts
@@ -97,7 +97,7 @@ export const convertModelVersionTransformFn = ({
       const result = modelTransformFn(doc, context);
       return { transformedDoc: result.document, additionalDocs: [] };
     } catch (error) {
-      log.error(error);
+      log.error(`Error trying to transform document: ${error.message}`);
       throw new TransformSavedObjectDocumentError(error, virtualVersion);
     }
   };

--- a/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/utils.ts
+++ b/packages/core/saved-objects/core-saved-objects-migration-server-internal/src/document_migrator/utils.ts
@@ -56,7 +56,7 @@ export function convertMigrationFunction(
 
       return { transformedDoc: result, additionalDocs: [] };
     } catch (error) {
-      log.error(error);
+      log.error(`Error trying to transform document: ${error.message}`);
       throw new TransformSavedObjectDocumentError(error, version);
     }
   };

--- a/packages/kbn-health-gateway-server/src/index.ts
+++ b/packages/kbn-health-gateway-server/src/index.ts
@@ -37,7 +37,7 @@ export async function bootstrap() {
     server = new Server({ config: configService, logger });
     serverStart = await server.start();
   } catch (e) {
-    log.error(`Failed to start Server: ${e}`);
+    log.error(`Failed to start Server: ${e.message}`);
     process.exit(1);
   }
 
@@ -46,7 +46,7 @@ export async function bootstrap() {
     kibanaService = new KibanaService({ config: configService, logger });
     await kibanaService.start({ server: serverStart });
   } catch (e) {
-    log.error(`Failed to start Kibana service: ${e}`);
+    log.error(`Failed to start Kibana service: ${e.message}`);
     process.exit(1);
   }
 
@@ -58,7 +58,7 @@ export async function bootstrap() {
   };
 
   process.on('unhandledRejection', async (err: Error) => {
-    log.error(err);
+    log.error(`Unhandled rejection: ${err.message}`);
     await attemptGracefulShutdown(1);
   });
 


### PR DESCRIPTION
## Summary

Fix a few logging calls where the full `Error` object was being logged, either as string representation in the message, or as log meta.