### PR TITLE
[Ops] Make unit-test agent agnostic

### DIFF
--- a/src/cli_plugin/install/zip.test.js
+++ b/src/cli_plugin/install/zip.test.js
@@ -15,7 +15,8 @@ import globby from 'globby';
 
 import { analyzeArchive, extractArchive } from './zip';
 
-const getMode = (path) => (fs.statSync(path).mode & parseInt('777', 8)).toString(8);
+const getExecFlags = (path) =>
+  (fs.statSync(path).mode & parseInt('111', 8)).toString(8).padStart(3, '0');
 
 describe('kibana cli', function () {
   describe('zip', function () {
@@ -83,8 +84,8 @@ describe('kibana cli', function () {
           ]
         `);
 
-        expect(getMode(path.resolve(tempPath, 'executable'))).toEqual('755');
-        expect(getMode(path.resolve(tempPath, 'not-executable'))).toEqual('644');
+        expect(getExecFlags(path.resolve(tempPath, 'executable'))).toEqual('111');
+        expect(getExecFlags(path.resolve(tempPath, 'not-executable'))).toEqual('000');
       });
     });
 


### PR DESCRIPTION
## Summary
This is not an error now but will be required for https://github.com/elastic/kibana-operations/issues/15 - this solution should work in both scenarios, so it can be done up-front.

Quote from Brian's notes regarding buildkite migration:
>The buildkite-agent process is running with a different umask in the new system. Files are being created with slightly different permissions by default. For example, when the kibana repo is checked out, files have 664 permissions instead of 644. This shouldn’t cause any major issues for Kibana, BUT a few tests check the permission flags on files during a copy process. They should probably be changed to check the permissions on the source file rather than just hard-coding them.

This is showing up in the unit tests like this: 
```
FAIL  src/cli_plugin/install/zip.test.js
--
  | ● kibana cli › zip › checkFilePermission › verify consistency of modes of files
  |  
  | expect(received).toEqual(expected) // deep equality
  |  
  | Expected: "755"
  | Received: "775"
```

We can't access the source files inside the zip file, the rights will only be revealed after unzipping. However, the difference in the default access rights is in the RW and not the X, which we're really curious about. 

So as a solution, I'm only checking if the executable file is indeed executable by all, and the non-executable is not executable by anyone.
