### PR TITLE
[Ops] Work around unit-tests in watch mode fails to set 'structuredClone'

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -124,4 +124,10 @@ module.exports = {
   watchPathIgnorePatterns: ['.*/__tmp__/.*'],
 
   resolver: '<rootDir>/packages/kbn-test/src/jest/resolver.js',
+
+  // Workaround to "TypeError: Cannot assign to read only property 'structuredClone' of object '[object global]'"
+  // This happens when we run jest tests with --watch after node20+
+  globals: {
+    structuredClone: {},
+  },
 };


### PR DESCRIPTION
## Summary
@CoenWarmer found that `--watch` on jest tests will cause this sort of error:
```
    TypeError: Cannot assign to read only property 'structuredClone' of object '[object global]'
```

There's some workaround suggested on this thread (although not necessarily related): https://github.com/zloirock/core-js/issues/1281

In the workaround, we set `structuredClone` to `{}`, this would allow the currently offending 3rd party to overwrite it where it's currently getting an error. 