### PR TITLE
[Response Ops][Alerting] Changing log level of alert resource installation logs

### DIFF
--- a/x-pack/plugins/alerting/server/alerts_service/alerts_service.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/alerts_service.ts
@@ -283,7 +283,7 @@ export class AlertsService implements IAlertsService {
       return;
     }
 
-    this.options.logger.info(`Registering resources for context "${context}".`);
+    this.options.logger.debug(`Registering resources for context "${context}".`);
     this.registeredContexts.set(context, opts);
 
     // When a context is registered, we install resources in the default namespace by default

--- a/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_component_template.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_component_template.ts
@@ -108,7 +108,7 @@ export const createOrUpdateComponentTemplate = async ({
   template,
   totalFieldsLimit,
 }: CreateOrUpdateComponentTemplateOpts) => {
-  logger.info(`Installing component template ${template.name}`);
+  logger.debug(`Installing component template ${template.name}`);
 
   try {
     await createOrUpdateComponentTemplateHelper(esClient, template, totalFieldsLimit, logger);

--- a/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_ilm_policy.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_ilm_policy.ts
@@ -29,7 +29,7 @@ export const createOrUpdateIlmPolicy = async ({
 }: CreateOrUpdateIlmPolicyOpts) => {
   if (dataStreamAdapter.isUsingDataStreams()) return;
 
-  logger.info(`Installing ILM policy ${name}`);
+  logger.debug(`Installing ILM policy ${name}`);
 
   try {
     await retryTransientEsErrors(() => esClient.ilm.putLifecycle({ name, policy }), { logger });

--- a/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_index_template.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/create_or_update_index_template.ts
@@ -111,7 +111,7 @@ export const createOrUpdateIndexTemplate = async ({
   esClient,
   template,
 }: CreateOrUpdateIndexTemplateOpts) => {
-  logger.info(`Installing index template ${template.name}`);
+  logger.debug(`Installing index template ${template.name}`);
 
   let mappings: MappingTypeMapping = {};
   try {

--- a/x-pack/plugins/alerting/server/alerts_service/lib/data_stream_adapter.ts
+++ b/x-pack/plugins/alerting/server/alerts_service/lib/data_stream_adapter.ts
@@ -79,7 +79,7 @@ class AliasImplementation implements DataStreamAdapter {
 
 async function createDataStream(opts: CreateConcreteWriteIndexOpts): Promise<void> {
   const { logger, esClient, indexPatterns, totalFieldsLimit } = opts;
-  logger.info(`Creating data stream - ${indexPatterns.alias}`);
+  logger.debug(`Creating data stream - ${indexPatterns.alias}`);
 
   // check if data stream exists
   let dataStreamExists = false;
@@ -126,7 +126,7 @@ async function createDataStream(opts: CreateConcreteWriteIndexOpts): Promise<voi
 
 async function createAliasStream(opts: CreateConcreteWriteIndexOpts): Promise<void> {
   const { logger, esClient, indexPatterns, totalFieldsLimit } = opts;
-  logger.info(`Creating concrete write index - ${indexPatterns.name}`);
+  logger.debug(`Creating concrete write index - ${indexPatterns.name}`);
 
   // check if a concrete write index already exists
   let concreteIndices: ConcreteIndexInfo[] = [];

--- a/x-pack/plugins/alerting/server/task_runner/task_runner_alerts_client.test.ts
+++ b/x-pack/plugins/alerting/server/task_runner/task_runner_alerts_client.test.ts
@@ -424,19 +424,43 @@ describe('Task Runner', () => {
         expect(call.services.alertsClient?.setAlertData).toBeTruthy();
         expect(call.services.scopedClusterClient).toBeTruthy();
         expect(call.services).toBeTruthy();
-        expect(logger.debug).toHaveBeenCalledTimes(6);
-        expect(logger.debug).nthCalledWith(1, `Initializing resources for AlertsService`);
-        expect(logger.debug).nthCalledWith(2, 'executing rule test:1 at 1970-01-01T00:00:00.000Z');
+        expect(logger.debug).toHaveBeenCalledTimes(useDataStreamForAlerts ? 9 : 10);
+
+        let debugCall = 1;
+        expect(logger.debug).nthCalledWith(debugCall++, `Initializing resources for AlertsService`);
         expect(logger.debug).nthCalledWith(
-          3,
+          debugCall++,
+          'executing rule test:1 at 1970-01-01T00:00:00.000Z'
+        );
+
+        if (!useDataStreamForAlerts) {
+          expect(logger.debug).nthCalledWith(
+            debugCall++,
+            'Installing ILM policy .alerts-ilm-policy'
+          );
+        }
+        expect(logger.debug).nthCalledWith(
+          debugCall++,
+          'Installing component template .alerts-framework-mappings'
+        );
+        expect(logger.debug).nthCalledWith(
+          debugCall++,
+          'Installing component template .alerts-legacy-alert-mappings'
+        );
+        expect(logger.debug).nthCalledWith(
+          debugCall++,
+          'Installing component template .alerts-ecs-mappings'
+        );
+        expect(logger.debug).nthCalledWith(
+          debugCall++,
           'deprecated ruleRunStatus for test:1: {"lastExecutionDate":"1970-01-01T00:00:00.000Z","status":"ok"}'
         );
         expect(logger.debug).nthCalledWith(
-          4,
+          debugCall++,
           'ruleRunStatus for test:1: {"outcome":"succeeded","outcomeOrder":0,"outcomeMsg":null,"warning":null,"alertsCount":{"active":0,"new":0,"recovered":0,"ignored":0}}'
         );
         expect(logger.debug).nthCalledWith(
-          5,
+          debugCall++,
           'ruleRunMetrics for test:1: {"numSearches":3,"totalSearchDurationMs":23423,"esSearchDurationMs":33,"numberOfTriggeredActions":0,"numberOfGeneratedActions":0,"numberOfActiveAlerts":0,"numberOfRecoveredAlerts":0,"numberOfNewAlerts":0,"hasReachedAlertLimit":false,"hasReachedQueuedActionsLimit":false,"triggeredActionsStatus":"complete"}'
         );
         expect(


### PR DESCRIPTION
Towards https://github.com/elastic/kibana-team/issues/702

## Summary

Changing log level of logs for alert resource installation from `info` to `debug` to reduce the verbosity of the Kibana startup process.
