### PR TITLE
[Cases] Unskip alerts tab functional test

### DIFF
--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/view_case.ts
@@ -1018,8 +1018,7 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
         await testSubjects.existOrFail('case-view-tab-content-activity');
       });
 
-      // there are no alerts in stack management yet
-      it.skip("shows the 'alerts' tab when clicked", async () => {
+      it("shows the 'alerts' tab when clicked", async () => {
         await testSubjects.click('case-view-tab-title-alerts');
         await testSubjects.existOrFail('case-view-tab-content-alerts');
       });


### PR DESCRIPTION
## Summary

PR https://github.com/elastic/kibana/pull/172217 enabled the alerts table for cases in the stack management. All of our functional tests use stack cases to test the various features. Now that the table is enabled in stack cases we can test alerts. This PR unkskips a test that tests the alerts tab.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4788

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
