### PR TITLE
[8.12] [DOCS] Add new sub feature privilege to prevent access to the cases settings (#174223)

### DIFF
--- a/docs/management/cases/setup-cases.asciidoc
+++ b/docs/management/cases/setup-cases.asciidoc
@@ -24,7 +24,7 @@ The *{connectors-feature}* feature privilege is required to create, add,
 delete, and modify case connectors and to send updates to external systems.
 
 By default, `All` for the *Cases* feature includes authority to delete cases
-and comments unless you customize the sub-feature privileges.
+and comments and edit case settings unless you customize the sub-feature privileges.
 ====
 
 | Give assignee access to cases
@@ -33,10 +33,10 @@ a| `All` for the *Cases* feature under *Management*.
 NOTE: Before a user can be assigned to a case, they must log into {kib} at
 least once, which creates a user profile.
 
-| Give view-only access for cases | `Read` for the *Cases* feature under *Management*.
+| Give view-only access to cases
+a| `Read` for the *Cases* feature under *Management*.
 
-| Give access to view and delete cases | `Read` for the *Cases* feature under
-*Management* with the deletion sub-feature enabled.
+NOTE: By default, `Read` for the *Cases* feature does not include authority to delete cases and comments or edit case settings. You can grant this authority by customizing the sub-feature privileges.
 
 | Revoke all access to cases | `None` for the *Cases* feature under *Management*.
 

--- a/x-pack/packages/security-solution/features/src/cases/kibana_sub_features.ts
+++ b/x-pack/packages/security-solution/features/src/cases/kibana_sub_features.ts
@@ -65,7 +65,7 @@ export const getCasesSubFeaturesMap = ({
     name: i18n.translate(
       'securitySolutionPackages.features.featureRegistry.casesSettingsSubFeatureName',
       {
-        defaultMessage: 'Case Settings',
+        defaultMessage: 'Case settings',
       }
     ),
     privilegeGroups: [
@@ -77,7 +77,7 @@ export const getCasesSubFeaturesMap = ({
             name: i18n.translate(
               'securitySolutionPackages.features.featureRegistry.casesSettingsSubFeatureDetails',
               {
-                defaultMessage: 'Edit Case Settings',
+                defaultMessage: 'Edit case settings',
               }
             ),
             includeIn: 'all',

--- a/x-pack/plugins/cases/server/features.ts
+++ b/x-pack/plugins/cases/server/features.ts
@@ -102,7 +102,7 @@ export const getCasesKibanaFeature = (): KibanaFeatureConfig => {
       },
       {
         name: i18n.translate('xpack.cases.features.casesSettingsSubFeatureName', {
-          defaultMessage: 'Case Settings',
+          defaultMessage: 'Case settings',
         }),
         privilegeGroups: [
           {
@@ -111,7 +111,7 @@ export const getCasesKibanaFeature = (): KibanaFeatureConfig => {
               {
                 id: 'cases_settings',
                 name: i18n.translate('xpack.cases.features.casesSettingsSubFeatureDetails', {
-                  defaultMessage: 'Edit Case Settings',
+                  defaultMessage: 'Edit case settings',
                 }),
                 includeIn: 'all',
                 savedObject: {

--- a/x-pack/plugins/observability/server/plugin.ts
+++ b/x-pack/plugins/observability/server/plugin.ts
@@ -177,7 +177,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
         },
         {
           name: i18n.translate('xpack.observability.featureRegistry.casesSettingsSubFeatureName', {
-            defaultMessage: 'Case Settings',
+            defaultMessage: 'Case settings',
           }),
           privilegeGroups: [
             {
@@ -188,7 +188,7 @@ export class ObservabilityPlugin implements Plugin<ObservabilityPluginSetup> {
                   name: i18n.translate(
                     'xpack.observability.featureRegistry.casesSettingsSubFeatureDetails',
                     {
-                      defaultMessage: 'Edit Case Settings',
+                      defaultMessage: 'Edit case settings',
                     }
                   ),
                   includeIn: 'all',

--- a/x-pack/test/cases_api_integration/common/plugins/security_solution/server/plugin.ts
+++ b/x-pack/test/cases_api_integration/common/plugins/security_solution/server/plugin.ts
@@ -91,13 +91,13 @@ export class FixturePlugin implements Plugin<void, void, FixtureSetupDeps, Fixtu
           ],
         },
         {
-          name: 'Case Settings',
+          name: 'Case settings',
           privilegeGroups: [
             {
               groupType: 'independent',
               privileges: [
                 {
-                  name: 'Edit Case Settings',
+                  name: 'Edit case settings',
                   id: 'cases_settings',
                   includeIn: 'all',
                   cases: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[DOCS] Add new sub feature privilege to prevent access to the cases settings (#174223)](https://github.com/elastic/kibana/pull/174223)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Lisa Cawley","email":"lcawley@elastic.co"},"sourceCommit":{"committedDate":"2024-01-08T15:58:38Z","message":"[DOCS] Add new sub feature privilege to prevent access to the cases settings (#174223)","sha":"ee0cb0b5418ce83ccc7c8681e2da6d0d24534ec6","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:ResponseOps","docs","Feature:Cases","Team:obs-ux-management","v8.12.1","v8.13.0"],"number":174223,"url":"https://github.com/elastic/kibana/pull/174223","mergeCommit":{"message":"[DOCS] Add new sub feature privilege to prevent access to the cases settings (#174223)","sha":"ee0cb0b5418ce83ccc7c8681e2da6d0d24534ec6"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/174467","number":174467,"state":"OPEN"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174223","number":174223,"mergeCommit":{"message":"[DOCS] Add new sub feature privilege to prevent access to the cases settings (#174223)","sha":"ee0cb0b5418ce83ccc7c8681e2da6d0d24534ec6"}}]}] BACKPORT-->