### PR TITLE
[Fleet] Add flag for prerelease to templates/inputs endpoint

### DIFF
--- a/x-pack/plugins/fleet/common/openapi/bundled.json
+++ b/x-pack/plugins/fleet/common/openapi/bundled.json
@@ -1467,6 +1467,14 @@
           "name": "format",
           "description": "Format of response - json or yaml",
           "in": "query"
+        },
+        {
+          "schema": {
+            "type": "boolean"
+          },
+          "name": "prerelease",
+          "description": "Specify if version is prerelease",
+          "in": "query"
         }
       ]
     },

--- a/x-pack/plugins/fleet/common/openapi/bundled.yaml
+++ b/x-pack/plugins/fleet/common/openapi/bundled.yaml
@@ -925,6 +925,11 @@ paths:
         name: format
         description: Format of response - json or yaml
         in: query
+      - schema:
+          type: boolean
+        name: prerelease
+        description: Specify if version is prerelease
+        in: query
   /agents/setup:
     get:
       summary: Get agent setup info

--- a/x-pack/plugins/fleet/common/openapi/paths/epm@templates@{pkg_name}@{pkg_version}@inputs.yaml
+++ b/x-pack/plugins/fleet/common/openapi/paths/epm@templates@{pkg_name}@{pkg_version}@inputs.yaml
@@ -28,3 +28,8 @@ parameters:
     name: format
     description: 'Format of response - json or yaml'
     in: query
+  - schema:
+      type: boolean
+    name: prerelease
+    description: 'Specify if version is prerelease'
+    in: query

--- a/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/common/types/rest_spec/epm.ts
@@ -217,6 +217,7 @@ export interface GetInputsTemplatesRequest {
   };
   query: {
     format: 'json' | 'yml' | 'yaml';
+    prerelease?: boolean;
   };
 }
 

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/configs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/configs/index.tsx
@@ -23,22 +23,28 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import type { PackageInfo } from '../../../../../types';
 
 import { useGetInputsTemplatesQuery, useStartServices } from '../../../../../hooks';
+import { PrereleaseCallout } from '../overview/overview';
+
+import { isPackagePrerelease } from '../../../../../../../../common/services';
 
 interface ConfigsProps {
   packageInfo: PackageInfo;
-  prerelease?: boolean;
 }
 
-export const Configs: React.FC<ConfigsProps> = ({ packageInfo, prerelease }) => {
+export const Configs: React.FC<ConfigsProps> = ({ packageInfo }) => {
   const { notifications, docLinks } = useStartServices();
   const { name: pkgName, version: pkgVersion, title: pkgTitle } = packageInfo;
   const notInstalled = packageInfo.status !== 'installing';
 
+  const isPrerelease = isPackagePrerelease(packageInfo.version);
   const {
     data: configs,
     error,
     isLoading,
-  } = useGetInputsTemplatesQuery({ pkgName, pkgVersion }, { format: 'yaml', prerelease });
+  } = useGetInputsTemplatesQuery(
+    { pkgName, pkgVersion },
+    { format: 'yaml', prerelease: isPrerelease }
+  );
 
   if (error) {
     notifications.toasts.addError(error, {
@@ -56,6 +62,15 @@ export const Configs: React.FC<ConfigsProps> = ({ packageInfo, prerelease }) => 
           <EuiSkeletonText lines={10} />
         ) : (
           <>
+            {isPrerelease && (
+              <>
+                <EuiSpacer size="s" />
+                <PrereleaseCallout
+                  packageName={packageInfo.name}
+                  packageTitle={packageInfo.title}
+                />
+              </>
+            )}
             <EuiText>
               <p>
                 <FormattedMessage
@@ -83,7 +98,7 @@ export const Configs: React.FC<ConfigsProps> = ({ packageInfo, prerelease }) => 
             </EuiText>
             {notInstalled && (
               <>
-                <EuiSpacer size="m" />
+                <EuiSpacer size="s" />
                 <EuiCallOut
                   title={
                     <FormattedMessage
@@ -96,7 +111,7 @@ export const Configs: React.FC<ConfigsProps> = ({ packageInfo, prerelease }) => 
                 />
               </>
             )}
-            <EuiSpacer size="m" />
+            <EuiSpacer size="s" />
             <EuiCodeBlock language="yaml" isCopyable={true} paddingSize="s" overflowHeight={1000}>
               {configs}
             </EuiCodeBlock>

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/configs/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/configs/index.tsx
@@ -26,9 +26,10 @@ import { useGetInputsTemplatesQuery, useStartServices } from '../../../../../hoo
 
 interface ConfigsProps {
   packageInfo: PackageInfo;
+  prerelease?: boolean;
 }
 
-export const Configs: React.FC<ConfigsProps> = ({ packageInfo }) => {
+export const Configs: React.FC<ConfigsProps> = ({ packageInfo, prerelease }) => {
   const { notifications, docLinks } = useStartServices();
   const { name: pkgName, version: pkgVersion, title: pkgTitle } = packageInfo;
   const notInstalled = packageInfo.status !== 'installing';
@@ -37,7 +38,7 @@ export const Configs: React.FC<ConfigsProps> = ({ packageInfo }) => {
     data: configs,
     error,
     isLoading,
-  } = useGetInputsTemplatesQuery({ pkgName, pkgVersion }, { format: 'yaml' });
+  } = useGetInputsTemplatesQuery({ pkgName, pkgVersion }, { format: 'yaml', prerelease });
 
   if (error) {
     notifications.toasts.addError(error, {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -779,7 +779,7 @@ export function Detail() {
             <AssetsPage packageInfo={packageInfo} />
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_configs}>
-            <Configs packageInfo={packageInfo} />
+            <Configs packageInfo={packageInfo} prerelease={prereleaseIntegrationsEnabled} />
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_policies}>
             <PackagePoliciesPage name={packageInfo.name} version={packageInfo.version} />

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/index.tsx
@@ -779,7 +779,7 @@ export function Detail() {
             <AssetsPage packageInfo={packageInfo} />
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_configs}>
-            <Configs packageInfo={packageInfo} prerelease={prereleaseIntegrationsEnabled} />
+            <Configs packageInfo={packageInfo} />
           </Route>
           <Route path={INTEGRATIONS_ROUTING_PATHS.integration_details_policies}>
             <PackagePoliciesPage name={packageInfo.name} version={packageInfo.version} />

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -107,7 +107,7 @@ const UnverifiedCallout: React.FC = () => {
   );
 };
 
-const PrereleaseCallout: React.FC<{
+export const PrereleaseCallout: React.FC<{
   packageName: string;
   latestGAVersion?: string;
   packageTitle: string;

--- a/x-pack/plugins/fleet/server/routes/epm/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/handlers.ts
@@ -579,12 +579,12 @@ export const getInputsHandler: FleetRequestHandler<
 
   try {
     const { pkgName, pkgVersion } = request.params;
-    const { format } = request.query;
+    const { format, prerelease } = request.query;
     let body;
     if (format === 'json') {
-      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'json');
+      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'json', prerelease);
     } else if (format === 'yml' || format === 'yaml') {
-      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'yml');
+      body = await getTemplateInputs(soClient, pkgName, pkgVersion, 'yml', prerelease);
     }
     return response.ok({ body });
   } catch (error) {

--- a/x-pack/plugins/fleet/server/services/epm/packages/get_template_inputs.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get_template_inputs.ts
@@ -74,7 +74,8 @@ export async function getTemplateInputs(
   soClient: SavedObjectsClientContract,
   pkgName: string,
   pkgVersion: string,
-  format: Format
+  format: Format,
+  prerelease?: boolean
 ) {
   const packageInfoMap = new Map<string, PackageInfo>();
   let packageInfo: PackageInfo;
@@ -86,6 +87,7 @@ export async function getTemplateInputs(
       savedObjectsClient: soClient,
       pkgName,
       pkgVersion,
+      prerelease,
     });
   }
   const emptyPackagePolicy = packageToPackagePolicy(packageInfo, '');

--- a/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
+++ b/x-pack/plugins/fleet/server/types/rest_spec/epm.ts
@@ -261,5 +261,6 @@ export const GetInputsRequestSchema = {
     format: schema.oneOf([schema.literal('json'), schema.literal('yml'), schema.literal('yaml')], {
       defaultValue: 'json',
     }),
+    prerelease: schema.maybe(schema.boolean()),
   }),
 };

--- a/x-pack/test/fleet_api_integration/apis/epm/get_templates_inputs.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/get_templates_inputs.ts
@@ -22,8 +22,8 @@ export default function (providerContext: FtrProviderContext) {
   const testPkgName = 'apache';
   const testPkgVersion = '0.1.4';
 
-  const prereleasePkgName = 'istio';
-  const prereleasePkgVersion = '0.3.3';
+  const prereleasePkgName = 'prerelease';
+  const prereleasePkgVersion = '0.1.0-dev.0+abc';
 
   const uninstallPackage = async (name: string, version: string) => {
     await supertest.delete(`/api/fleet/epm/packages/${name}/${version}`).set('kbn-xsrf', 'xxxx');
@@ -32,10 +32,6 @@ export default function (providerContext: FtrProviderContext) {
   const testPkgArchiveZip = path.join(
     path.dirname(__filename),
     '../fixtures/direct_upload_packages/apache_0.1.4.zip'
-  );
-  const istioArchiveZip = path.join(
-    path.dirname(__filename),
-    '../fixtures/test_packages/istio/istio-0.3.3.zip'
   );
 
   describe('EPM Templates - Get Inputs', () => {
@@ -48,13 +44,6 @@ export default function (providerContext: FtrProviderContext) {
         .set('kbn-xsrf', 'xxxx')
         .type('application/zip')
         .send(buf)
-        .expect(200);
-      const buf2 = fs.readFileSync(istioArchiveZip);
-      await supertest
-        .post(`/api/fleet/epm/packages`)
-        .set('kbn-xsrf', 'xxxx')
-        .type('application/zip')
-        .send(buf2)
         .expect(200);
     });
     after(async () => {
@@ -193,54 +182,13 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     it('returns inputs template for a prerelease package if prerelease=true', async function () {
-      const res = await supertest
+      await supertest
         .get(
           `/api/fleet/epm/templates/${prereleasePkgName}/${prereleasePkgVersion}/inputs?format=json&prerelease=true`
         )
         .expect(200);
-      const inputs = res.body.inputs;
-      expect(inputs).to.eql([
-        {
-          id: 'filestream-istio.access_logs',
-          type: 'filestream',
-          data_stream: { type: 'logs', dataset: 'istio.access_logs' },
-          paths: ['/var/log/containers/*${kubernetes.container.id}.log'],
-          condition: "${kubernetes.container.name} == 'istio-proxy'",
-          'prospector.scanner.symlinks': true,
-          parsers: [{ container: { stream: 'stdout', format: 'cri' } }],
-          tags: null,
-        },
-        {
-          id: 'prometheus/metrics-istio.istiod_metrics',
-          type: 'prometheus/metrics',
-          data_stream: { type: 'metrics', dataset: 'istio.istiod_metrics' },
-          metricsets: ['collector'],
-          period: '10s',
-          hosts: ['istiod.istio-system:15014'],
-          condition: '${kubernetes_leaderelection.leader} == true',
-          metrics_path: '/metrics',
-          'metrics_filters.exclude': ['^up$'],
-          'metrics_filters.include': ['galley_*', 'pilot_*', 'citadel_*', 'istio_*'],
-          use_types: true,
-          rate_counters: true,
-        },
-        {
-          id: 'prometheus/metrics-istio.proxy_metrics',
-          type: 'prometheus/metrics',
-          data_stream: { type: 'metrics', dataset: 'istio.proxy_metrics' },
-          metricsets: ['collector'],
-          period: '10s',
-          hosts: ['${kubernetes.pod.ip}:15020'],
-          condition:
-            "${kubernetes.container.name} == 'istio-proxy' and ${kubernetes.annotations.prometheus.io/scrape} == 'true'",
-          metrics_path: '/stats/prometheus',
-          'metrics_filters.exclude': ['^up$'],
-          'metrics_filters.include': ['istio_*'],
-          use_types: true,
-          rate_counters: true,
-        },
-      ]);
     });
+
     it('returns a 404 for a version that does not exists', async function () {
       await supertest
         .get(`/api/fleet/epm/templates/${testPkgName}/0.1.0/inputs?format=json`)


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/172667

## Summary
Some of the integrations show directly the prerelease version of the package in the overview section, but this wasn't happening in the "configs" section. Here I'm adding a flag to the `templates/{pkgName}/{pkgVersion}/inputs` endpoint that allows to select the prerelease tag as well:
```
  GET kbn:api/fleet/epm/templates/{pkgName}/{pkgVersion}/inputs?format=yaml&prerelease=true
```
One example is the Istio package:
```
  GET kbn:api/fleet/epm/templates/istio/0.5.0/inputs?format=yaml&prerelease=true
```

### Istio overview - before

![Screenshot 2024-01-08 at 17 45 16](https://github.com/elastic/kibana/assets/16084106/bd48faac-5499-4de5-87f0-8addf5ec9961)

### Istio overview - after
![Screenshot 2024-01-09 at 10 15 02](https://github.com/elastic/kibana/assets/16084106/1aac5cfa-911a-498e-bc9b-4422e3c11c02)


### Checklist
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
