### PR TITLE
[Serverless Search] Fix failing MKI tests for connectors UI

### DIFF
--- a/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
@@ -40,6 +40,12 @@ export function SvlSearchConnectorsPageProvider({ getService }: FtrProviderConte
         await testSubjects.existOrFail('serverlessSearchCancelNameButton');
         await testSubjects.setValue('serverlessSearchEditNameFieldText', name);
         await testSubjects.click('serverlessSearchSaveNameButton');
+        await retry.waitForWithTimeout('edit name form to disappear', 2000, () =>
+          testSubjects
+            .missingOrFail('serverlessSearchSaveNameButton')
+            .then(() => true)
+            .catch(() => false)
+        );
         await testSubjects.exists('serverlessSearchConnectorName');
         expect(await testSubjects.getVisibleText('serverlessSearchConnectorName')).to.be(name);
       },

--- a/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
@@ -16,8 +16,6 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
   describe('connectors', function () {
-    // failsOnMKI, see https://github.com/elastic/kibana/issues/173929
-    this.tags(['failsOnMKI']);
     before(async () => {
       await pageObjects.svlCommonPage.login();
       await pageObjects.svlCommonNavigation.sidenav.clickLink({
@@ -65,7 +63,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectSearchBarToExist();
       });
 
-      it('searchBar and select filter connector table', async () => {
+      it('searchBar and select, filters connector table', async () => {
         pageObjects.svlSearchConnectorsPage.connectorOverviewPage.getConnectorFromConnectorTable(
           TEST_CONNECTOR_NAME
         );


### PR DESCRIPTION
In this PR, 
* Added fix to wait for connector edit name form to disappear, before validating connector name 
* Removed `failsOnMKI` tag added for connectors FTR tests

Thus, fixing failing MKI tests for connectors UI in cloud project. 

Tested in : 
* Serverless [QA](https://console.qa.cld.elstc.co/) cloud project following instructions from  [Kibana Serverless e2e Test Guide](https://docs.google.com/document/d/1tiax7xoDYwFXYZjRTgVKkVMjN-SQzBWk4yn1JY6Z5UY/edit?pli=1#heading=h.ece2z8p74izh)  
* [Production](https://cloud.elastic.co) deployment 
* local FTR tests. 