### PR TITLE
Stabilize index templates and cases navigation tests for MKI

### DIFF
--- a/x-pack/test_serverless/functional/services/svl_sec_navigation.ts
+++ b/x-pack/test_serverless/functional/services/svl_sec_navigation.ts
@@ -19,10 +19,7 @@ export function SvlSecNavigationServiceProvider({
     async navigateToLandingPage() {
       await retry.tryForTime(60 * 1000, async () => {
         await PageObjects.common.navigateToApp('landingPage');
-        // Currently, the security landing page app is not loading correctly.
-        // Replace '~kbnAppWrapper' with a proper test subject of the landing
-        // page once it loads successfully.
-        await testSubjects.existOrFail('~kbnAppWrapper', { timeout: 2000 });
+        await testSubjects.existOrFail('welcome-header', { timeout: 2000 });
       });
     },
   };

--- a/x-pack/test_serverless/functional/test_suites/common/management/index_management/index_templates.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/index_management/index_templates.ts
@@ -75,7 +75,7 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
     });
 
     describe('Create index template', () => {
-      const TEST_TEMPLATE_NAME = `test_template_${Math.random()}`;
+      const TEST_TEMPLATE_NAME = `test_template_${Date.now()}`;
 
       after(async () => {
         await es.indices.deleteIndexTemplate({ name: TEST_TEMPLATE_NAME }, { ignore: [404] });

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/navigation.ts
@@ -16,6 +16,8 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
   const svlCommonNavigation = getPageObject('svlCommonNavigation');
   const testSubjects = getService('testSubjects');
   const browser = getService('browser');
+  const headerPage = getPageObject('header');
+  const retry = getService('retry');
 
   describe('navigation', function () {
     before(async () => {
@@ -49,6 +51,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await svlCommonNavigation.search.searchFor('security dashboards');
       await svlCommonNavigation.search.clickOnOption(0);
       await svlCommonNavigation.search.hideSearch();
+      await headerPage.waitUntilLoadingHasFinished();
 
       await expect(await browser.getCurrentUrl()).contain('app/security/dashboards');
     });
@@ -63,12 +66,17 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
     });
 
     it('navigates to cases app', async () => {
-      await svlCommonNavigation.sidenav.clickLink({
-        deepLinkId: 'securitySolutionUI:cases' as AppDeepLinkId,
-      });
+      await retry.tryForTime(30 * 1000, async () => {
+        // start navigation to the cases app from the landing page
+        await svlSecNavigation.navigateToLandingPage();
+        await svlCommonNavigation.sidenav.clickLink({
+          deepLinkId: 'securitySolutionUI:cases' as AppDeepLinkId,
+        });
+        await headerPage.waitUntilLoadingHasFinished();
 
-      expect(await browser.getCurrentUrl()).contain('/app/security/cases');
-      await testSubjects.existOrFail('cases-all-title');
+        expect(await browser.getCurrentUrl()).contain('/app/security/cases');
+        await testSubjects.existOrFail('cases-all-title');
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR stabilizes the index templates and cases navigation FTR test suites for MKI runs on the security project.

### Details

- The index templates tests was failing on a retried step, because the cleanup of `TEST_TEMPLATE_NAME` didn't work as intended. Changing the name to include the date as "random" part instead of a random floating point number fixes the cleanup.
- The navigation to the cases app in a security project sometimes failed with error that look like incomplete loading of assets. This PR wraps this navigation step in a retry and adds some waits for global loading between navigation and assertion. As part of that, the security `navigateToLandingPage` has been adjusted to check for an actual object on the landing page.
