### PR TITLE
[8.12] [SLOs] Use named keys to reference range aggregations for APM Latency and Histogram Metric (#173548)

### DIFF
--- a/x-pack/plugins/observability/server/services/slo/aggregations/__snapshots__/get_histogram_indicator_aggregation.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/aggregations/__snapshots__/get_histogram_indicator_aggregation.test.ts.snap
@@ -11,6 +11,7 @@ Object {
           "ranges": Array [
             Object {
               "from": 0,
+              "key": "target",
               "to": 100,
             },
           ],
@@ -24,7 +25,7 @@ Object {
   "goodEvents": Object {
     "bucket_script": Object {
       "buckets_path": Object {
-        "value": "_good>total['0.0-100.0']>_count",
+        "value": "_good>total['target']>_count",
       },
       "script": "params.value",
     },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/apm_transaction_duration.test.ts.snap
@@ -433,8 +433,10 @@ Object {
       "_numerator": Object {
         "range": Object {
           "field": "transaction.duration.histogram",
+          "keyed": true,
           "ranges": Array [
             Object {
+              "key": "target",
               "to": 500000,
             },
           ],
@@ -457,7 +459,7 @@ Object {
       "slo.numerator": Object {
         "bucket_script": Object {
           "buckets_path": Object {
-            "numerator": "_numerator['*-500000.0']>_count",
+            "numerator": "_numerator['target']>_count",
           },
           "script": "params.numerator",
         },
@@ -612,8 +614,10 @@ Object {
       "_numerator": Object {
         "range": Object {
           "field": "transaction.duration.histogram",
+          "keyed": true,
           "ranges": Array [
             Object {
+              "key": "target",
               "to": 500000,
             },
           ],
@@ -627,7 +631,7 @@ Object {
       "slo.numerator": Object {
         "bucket_script": Object {
           "buckets_path": Object {
-            "numerator": "_numerator['*-500000.0']>_count",
+            "numerator": "_numerator['target']>_count",
           },
           "script": "params.numerator",
         },

--- a/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
+++ b/x-pack/plugins/observability/server/services/slo/transform_generators/__snapshots__/histogram.test.ts.snap
@@ -26,7 +26,7 @@ exports[`Histogram Transform Generator aggregates using the numerator equation 1
 Object {
   "bucket_script": Object {
     "buckets_path": Object {
-      "value": "_good>total['0.0-100.0']>_count",
+      "value": "_good>total['target']>_count",
     },
     "script": "params.value",
   },
@@ -37,7 +37,7 @@ exports[`Histogram Transform Generator aggregates using the numerator equation w
 Object {
   "bucket_script": Object {
     "buckets_path": Object {
-      "value": "_good>total['0.0-100.0']>_count",
+      "value": "_good>total['target']>_count",
     },
     "script": "params.value",
   },
@@ -96,6 +96,7 @@ Object {
               "ranges": Array [
                 Object {
                   "from": 0,
+                  "key": "target",
                   "to": 100,
                 },
               ],
@@ -138,7 +139,7 @@ Object {
       "slo.numerator": Object {
         "bucket_script": Object {
           "buckets_path": Object {
-            "value": "_good>total['0.0-100.0']>_count",
+            "value": "_good>total['target']>_count",
           },
           "script": "params.value",
         },
@@ -257,6 +258,7 @@ Object {
               "ranges": Array [
                 Object {
                   "from": 0,
+                  "key": "target",
                   "to": 100,
                 },
               ],
@@ -290,7 +292,7 @@ Object {
       "slo.numerator": Object {
         "bucket_script": Object {
           "buckets_path": Object {
-            "value": "_good>total['0.0-100.0']>_count",
+            "value": "_good>total['target']>_count",
           },
           "script": "params.value",
         },

--- a/x-pack/plugins/observability/server/utils/queries.ts
+++ b/x-pack/plugins/observability/server/utils/queries.ts
@@ -8,6 +8,8 @@ import { reject } from 'lodash';
 import { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import { fromKueryExpression, toElasticsearchQuery } from '@kbn/es-query';
+import { ESSearchResponse } from '@kbn/es-types';
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
 
 export function isUndefinedOrNull(value: any): value is undefined | null {
   return value === undefined || value === null;
@@ -67,4 +69,14 @@ export function kqlQuery(kql?: string): estypes.QueryDslQueryContainer[] {
 
   const ast = fromKueryExpression(kql);
   return [toElasticsearchQuery(ast)];
+}
+
+export async function typedSearch<
+  DocumentSource extends unknown,
+  TParams extends estypes.SearchRequest
+>(
+  esClient: ElasticsearchClient,
+  params: TParams
+): Promise<ESSearchResponse<DocumentSource, TParams>> {
+  return (await esClient.search(params)) as unknown as ESSearchResponse<DocumentSource, TParams>;
 }

--- a/x-pack/plugins/observability/tsconfig.json
+++ b/x-pack/plugins/observability/tsconfig.json
@@ -96,7 +96,8 @@
     "@kbn/lens-embeddable-utils",
     "@kbn/serverless",
     "@kbn/dashboard-plugin",
-    "@kbn/calculate-auto"
+    "@kbn/calculate-auto",
+    "@kbn/es-types"
   ],
   "exclude": [
     "target/**/*"


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[SLOs] Use named keys to reference range aggregations for APM Latency and Histogram Metric (#173548)](https://github.com/elastic/kibana/pull/173548)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2024-01-05T19:24:58Z","message":"[SLOs] Use named keys to reference range aggregations for APM Latency and Histogram Metric (#173548)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/171329\n\nit now works for value over 9999\n\nFix APM SLI Preview value calculation !!\n\n\n<img width=\"1726\" alt=\"image\"\nsrc=\"https://github.com/elastic/kibana/assets/3505601/d875e2cf-6195-455f-9b28-35c49c6d5eee\">","sha":"57e50a6f47f7c4cb084fddb75b1b2031db10913f","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:prev-minor","Team:obs-ux-management","v8.13.0"],"number":173548,"url":"https://github.com/elastic/kibana/pull/173548","mergeCommit":{"message":"[SLOs] Use named keys to reference range aggregations for APM Latency and Histogram Metric (#173548)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/171329\n\nit now works for value over 9999\n\nFix APM SLI Preview value calculation !!\n\n\n<img width=\"1726\" alt=\"image\"\nsrc=\"https://github.com/elastic/kibana/assets/3505601/d875e2cf-6195-455f-9b28-35c49c6d5eee\">","sha":"57e50a6f47f7c4cb084fddb75b1b2031db10913f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173548","number":173548,"mergeCommit":{"message":"[SLOs] Use named keys to reference range aggregations for APM Latency and Histogram Metric (#173548)\n\n## Summary\n\nFixes https://github.com/elastic/kibana/issues/171329\n\nit now works for value over 9999\n\nFix APM SLI Preview value calculation !!\n\n\n<img width=\"1726\" alt=\"image\"\nsrc=\"https://github.com/elastic/kibana/assets/3505601/d875e2cf-6195-455f-9b28-35c49c6d5eee\">","sha":"57e50a6f47f7c4cb084fddb75b1b2031db10913f"}}]}] BACKPORT-->