### PR TITLE
[8.12] [Synthetics] Increase Project monitor payload limit to 50MiB (#174470)

### DIFF
--- a/x-pack/plugins/synthetics/e2e/synthetics/journeys/test_run_details.journey.ts
+++ b/x-pack/plugins/synthetics/e2e/synthetics/journeys/test_run_details.journey.ts
@@ -68,7 +68,13 @@ journey(`TestRunDetailsPage`, async ({ page, params }) => {
 
   step('Go to test run page', async () => {
     await page.click(byTestId('superDatePickerToggleQuickMenuButton'));
-    await page.click('text=Last 1 year');
+    await page.getByTestId('superDatePickerQuickMenu').getByLabel('Time value').fill('10');
+    await page
+      .getByTestId('superDatePickerQuickMenu')
+      .getByLabel('Time unit')
+      .selectOption('Years');
+    await page.getByTestId('superDatePickerQuickMenu').getByText('Apply').click();
+    await page.mouse.wheel(0, 1000);
     await page.click(byTestId('row-ab240846-8d22-11ed-8fac-52bb19a2321e'));
 
     await page.waitForSelector('text=Test run details');

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor_project.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor_project.ts
@@ -13,7 +13,7 @@ import { ProjectMonitor } from '../../../common/runtime_types';
 import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { ProjectMonitorFormatter } from '../../synthetics_service/project_monitor/project_monitor_formatter';
 
-const MAX_PAYLOAD_SIZE = 1048576 * 20; // 20MiB
+const MAX_PAYLOAD_SIZE = 1048576 * 50; // 20MiB
 
 export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Synthetics] Increase Project monitor payload limit to 50MiB (#174470)](https://github.com/elastic/kibana/pull/174470)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Shahzad","email":"shahzad31comp@gmail.com"},"sourceCommit":{"committedDate":"2024-01-09T10:11:51Z","message":"[Synthetics] Increase Project monitor payload limit to 50MiB (#174470)\n\n## Summary\r\nFollow up to https://github.com/elastic/synthetics/pull/884\r\n\r\nIncrease Project monitor payload route  limit to 50MiB !!","sha":"8f9e11d001a53d64d593bf49c4570523d8e48704","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","auto-backport","backport:prev-minor","Team:obs-ux-infra_services","v8.13.0"],"number":174470,"url":"https://github.com/elastic/kibana/pull/174470","mergeCommit":{"message":"[Synthetics] Increase Project monitor payload limit to 50MiB (#174470)\n\n## Summary\r\nFollow up to https://github.com/elastic/synthetics/pull/884\r\n\r\nIncrease Project monitor payload route  limit to 50MiB !!","sha":"8f9e11d001a53d64d593bf49c4570523d8e48704"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174470","number":174470,"mergeCommit":{"message":"[Synthetics] Increase Project monitor payload limit to 50MiB (#174470)\n\n## Summary\r\nFollow up to https://github.com/elastic/synthetics/pull/884\r\n\r\nIncrease Project monitor payload route  limit to 50MiB !!","sha":"8f9e11d001a53d64d593bf49c4570523d8e48704"}}]}] BACKPORT-->