### PR TITLE
[Cases] Fixes registered attachments property actions flaky test

### DIFF
--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -33,112 +33,108 @@ describe('RegisteredAttachmentsPropertyActions', () => {
     appMock = createAppMockRenderer();
   });
 
-  for (let index = 0; index < 100; index++) {
-    it('renders the correct number of actions', async () => {
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+  it('renders the correct number of actions', async () => {
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
 
-      await waitForEuiPopoverOpen();
+    await waitForEuiPopoverOpen();
 
-      expect(
-        (await screen.findByTestId('property-actions-user-action-group')).children.length
-      ).toBe(1);
+    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
+      1
+    );
 
-      expect(screen.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect(screen.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+  });
+
+  it('renders the modal info correctly', async () => {
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+    await waitForEuiPopoverOpen();
+
+    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
+
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+
+    expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent(
+      'Delete attachment'
+    );
+
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
+  });
+
+  it('remove attachments correctly', async () => {
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+    await waitForEuiPopoverOpen();
+
+    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+
+    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
+
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Delete'));
+
+    await waitFor(() => {
+      expect(props.onDelete).toHaveBeenCalled();
     });
+  });
 
-    it('renders the modal info correctly', async () => {
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+  it('does not show the property actions without delete permissions', async () => {
+    appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+  });
 
-      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-      await waitForEuiPopoverOpen();
+  it('does not show the property actions when hideDefaultActions is enabled', async () => {
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
 
-      expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+  });
 
-      userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
+  it('does show the property actions with only delete permissions', async () => {
+    appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+  });
 
-      expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent(
-        'Delete attachment'
-      );
+  it('renders correctly registered attachments', async () => {
+    const onClick = jest.fn();
+    const action = [
+      {
+        type: AttachmentActionType.BUTTON as const,
+        label: 'My button',
+        iconType: 'download',
+        onClick,
+      },
+    ];
 
-      expect(await screen.findByText('Delete')).toBeInTheDocument();
-    });
+    appMock.render(
+      <RegisteredAttachmentsPropertyActions {...props} registeredAttachmentActions={action} />
+    );
 
-    it('remove attachments correctly', async () => {
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+    await waitForEuiPopoverOpen();
 
-      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-      await waitForEuiPopoverOpen();
+    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
+      2
+    );
 
-      expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
-
-      userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
-
-      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
-
-      userEvent.click(screen.getByText('Delete'));
-
-      await waitFor(() => {
-        expect(props.onDelete).toHaveBeenCalled();
-      });
-    });
-
-    it('does not show the property actions without delete permissions', async () => {
-      appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
-
-      expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
-    });
-
-    it('does not show the property actions when hideDefaultActions is enabled', async () => {
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
-
-      expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
-    });
-
-    it('does show the property actions with only delete permissions', async () => {
-      appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
-      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
-
-      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-    });
-
-    it('renders correctly registered attachments', async () => {
-      const onClick = jest.fn();
-      const action = [
-        {
-          type: AttachmentActionType.BUTTON as const,
-          label: 'My button',
-          iconType: 'download',
-          onClick,
-        },
-      ];
-
-      appMock.render(
-        <RegisteredAttachmentsPropertyActions {...props} registeredAttachmentActions={action} />
-      );
-
-      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-
-      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-      await waitForEuiPopoverOpen();
-
-      expect(
-        (await screen.findByTestId('property-actions-user-action-group')).children.length
-      ).toBe(2);
-
-      expect(
-        await screen.findByTestId('property-actions-user-action-download')
-      ).toBeInTheDocument();
-    });
-  }
+    expect(await screen.findByTestId('property-actions-user-action-download')).toBeInTheDocument();
+  });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
-import { waitFor } from '@testing-library/react';
+import { waitFor, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { AppMockRenderer } from '../../../common/mock';
 import {
@@ -23,7 +23,7 @@ import { AttachmentActionType } from '../../../client/attachment_framework/types
 // FLAKY: https://github.com/elastic/kibana/issues/174386
 // FLAKY: https://github.com/elastic/kibana/issues/174387
 // FLAKY: https://github.com/elastic/kibana/issues/174388
-describe.skip('RegisteredAttachmentsPropertyActions', () => {
+describe('RegisteredAttachmentsPropertyActions', () => {
   let appMock: AppMockRenderer;
 
   const props = {
@@ -34,82 +34,86 @@ describe.skip('RegisteredAttachmentsPropertyActions', () => {
   };
 
   beforeEach(() => {
-    appMock = createAppMockRenderer();
     jest.clearAllMocks();
+    appMock = createAppMockRenderer();
   });
 
   it('renders the correct number of actions', async () => {
-    const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(1);
-    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
+      1
+    );
+
+    expect(screen.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
   });
 
   it('renders the modal info correctly', async () => {
-    const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-trash'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
 
-    await waitFor(() => {
-      expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
-    });
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
 
-    expect(result.getByTestId('confirmModalTitleText')).toHaveTextContent('Delete attachment');
-    expect(result.getByText('Delete')).toBeInTheDocument();
+    expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent(
+      'Delete attachment'
+    );
+
+    expect(await screen.findByText('Delete')).toBeInTheDocument();
   });
 
   it('remove attachments correctly', async () => {
-    const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-trash'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
+
+    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+
+    userEvent.click(screen.getByText('Delete'));
 
     await waitFor(() => {
-      expect(result.queryByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+      expect(props.onDelete).toHaveBeenCalled();
     });
-
-    userEvent.click(result.getByText('Delete'));
-    expect(props.onDelete).toHaveBeenCalled();
   });
 
   it('does not show the property actions without delete permissions', async () => {
     appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
-    const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('does not show the property actions when hideDefaultActions is enabled', async () => {
-    const result = appMock.render(
-      <RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />
-    );
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
 
-    expect(result.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
   });
 
   it('does show the property actions with only delete permissions', async () => {
     appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
-    const result = appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
   });
 
   it('renders correctly registered attachments', async () => {
@@ -123,16 +127,19 @@ describe.skip('RegisteredAttachmentsPropertyActions', () => {
       },
     ];
 
-    const result = appMock.render(
+    appMock.render(
       <RegisteredAttachmentsPropertyActions {...props} registeredAttachmentActions={action} />
     );
 
-    expect(result.getByTestId('property-actions-user-action')).toBeInTheDocument();
+    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(result.getByTestId('property-actions-user-action-ellipses'));
+    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
     await waitForEuiPopoverOpen();
 
-    expect(result.getByTestId('property-actions-user-action-group').children.length).toBe(2);
-    expect(result.queryByTestId('property-actions-user-action-download')).toBeInTheDocument();
+    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
+      2
+    );
+
+    expect(await screen.findByTestId('property-actions-user-action-download')).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -18,11 +18,6 @@ import {
 import { RegisteredAttachmentsPropertyActions } from './registered_attachments_property_actions';
 import { AttachmentActionType } from '../../../client/attachment_framework/types';
 
-// FLAKY: https://github.com/elastic/kibana/issues/174384
-// FLAKY: https://github.com/elastic/kibana/issues/174385
-// FLAKY: https://github.com/elastic/kibana/issues/174386
-// FLAKY: https://github.com/elastic/kibana/issues/174387
-// FLAKY: https://github.com/elastic/kibana/issues/174388
 describe('RegisteredAttachmentsPropertyActions', () => {
   let appMock: AppMockRenderer;
 
@@ -38,108 +33,112 @@ describe('RegisteredAttachmentsPropertyActions', () => {
     appMock = createAppMockRenderer();
   });
 
-  it('renders the correct number of actions', async () => {
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+  for (let index = 0; index < 100; index++) {
+    it('renders the correct number of actions', async () => {
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
 
-    await waitForEuiPopoverOpen();
+      await waitForEuiPopoverOpen();
 
-    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
-      1
-    );
+      expect(
+        (await screen.findByTestId('property-actions-user-action-group')).children.length
+      ).toBe(1);
 
-    expect(screen.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
-  });
-
-  it('renders the modal info correctly', async () => {
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
-
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
-
-    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
-
-    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
-
-    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
-
-    expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent(
-      'Delete attachment'
-    );
-
-    expect(await screen.findByText('Delete')).toBeInTheDocument();
-  });
-
-  it('remove attachments correctly', async () => {
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
-
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
-
-    expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
-
-    userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
-
-    expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
-
-    userEvent.click(screen.getByText('Delete'));
-
-    await waitFor(() => {
-      expect(props.onDelete).toHaveBeenCalled();
+      expect(screen.queryByTestId('property-actions-user-action-trash')).toBeInTheDocument();
     });
-  });
 
-  it('does not show the property actions without delete permissions', async () => {
-    appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+    it('renders the modal info correctly', async () => {
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-  it('does not show the property actions when hideDefaultActions is enabled', async () => {
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
 
-    expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
 
-  it('does show the property actions with only delete permissions', async () => {
-    appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
-    appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+      userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
 
-  it('renders correctly registered attachments', async () => {
-    const onClick = jest.fn();
-    const action = [
-      {
-        type: AttachmentActionType.BUTTON as const,
-        label: 'My button',
-        iconType: 'download',
-        onClick,
-      },
-    ];
+      expect(await screen.findByTestId('confirmModalTitleText')).toHaveTextContent(
+        'Delete attachment'
+      );
 
-    appMock.render(
-      <RegisteredAttachmentsPropertyActions {...props} registeredAttachmentActions={action} />
-    );
+      expect(await screen.findByText('Delete')).toBeInTheDocument();
+    });
 
-    expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    it('remove attachments correctly', async () => {
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
 
-    userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
-    await waitForEuiPopoverOpen();
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
 
-    expect((await screen.findByTestId('property-actions-user-action-group')).children.length).toBe(
-      2
-    );
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
 
-    expect(await screen.findByTestId('property-actions-user-action-download')).toBeInTheDocument();
-  });
+      expect(await screen.findByTestId('property-actions-user-action-trash')).toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('property-actions-user-action-trash'));
+
+      expect(await screen.findByTestId('property-actions-confirm-modal')).toBeInTheDocument();
+
+      userEvent.click(screen.getByText('Delete'));
+
+      await waitFor(() => {
+        expect(props.onDelete).toHaveBeenCalled();
+      });
+    });
+
+    it('does not show the property actions without delete permissions', async () => {
+      appMock = createAppMockRenderer({ permissions: noCasesPermissions() });
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+
+      expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+    });
+
+    it('does not show the property actions when hideDefaultActions is enabled', async () => {
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} hideDefaultActions={true} />);
+
+      expect(screen.queryByTestId('property-actions-user-action')).not.toBeInTheDocument();
+    });
+
+    it('does show the property actions with only delete permissions', async () => {
+      appMock = createAppMockRenderer({ permissions: onlyDeleteCasesPermission() });
+      appMock.render(<RegisteredAttachmentsPropertyActions {...props} />);
+
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+    });
+
+    it('renders correctly registered attachments', async () => {
+      const onClick = jest.fn();
+      const action = [
+        {
+          type: AttachmentActionType.BUTTON as const,
+          label: 'My button',
+          iconType: 'download',
+          onClick,
+        },
+      ];
+
+      appMock.render(
+        <RegisteredAttachmentsPropertyActions {...props} registeredAttachmentActions={action} />
+      );
+
+      expect(await screen.findByTestId('property-actions-user-action')).toBeInTheDocument();
+
+      userEvent.click(await screen.findByTestId('property-actions-user-action-ellipses'));
+      await waitForEuiPopoverOpen();
+
+      expect(
+        (await screen.findByTestId('property-actions-user-action-group')).children.length
+      ).toBe(2);
+
+      expect(
+        await screen.findByTestId('property-actions-user-action-download')
+      ).toBeInTheDocument();
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Fixes: https://github.com/elastic/kibana/issues/174384, https://github.com/elastic/kibana/issues/174385, https://github.com/elastic/kibana/issues/174386, https://github.com/elastic/kibana/issues/174387, https://github.com/elastic/kibana/issues/174388

Successfully run 3x100 times: https://buildkite.com/elastic/kibana-pull-request/builds?branch=cnasikas%3Afix_ua_actions_flaky_tests

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
