### PR TITLE
[Fleet] Fix package edit redirect

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -238,6 +238,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
               return canWriteIntegrationPolicies ? (
                 <PackagePolicyActionsMenu
                   agentPolicy={agentPolicy}
+                  from={'fleet-policy-list'}
                   packagePolicy={packagePolicy}
                   upgradePackagePolicyHref={`${getHref('upgrade_package_policy', {
                     policyId: agentPolicy.id,

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -31,7 +31,6 @@ export const Policy = memo(() => {
 
   let from: EditPackagePolicyFrom | undefined;
 
-  // Shorten query strings to make them more presentable in the URL
   if (fromQs && fromQs === 'fleet-policy-list') {
     from = 'edit';
   } else {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/policy/index.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { memo } from 'react';
-import { useRouteMatch } from 'react-router-dom';
+import { useLocation, useRouteMatch } from 'react-router-dom';
 
 // TODO: Needs to be moved
 import { EditPackagePolicyForm } from '../../../../../fleet/sections/agent_policy/edit_package_policy_page';
+import type { EditPackagePolicyFrom } from '../../../../../fleet/sections/agent_policy/create_package_policy_page/types';
 import { useGetOnePackagePolicyQuery, useUIExtension } from '../../../../hooks';
 
 export const Policy = memo(() => {
@@ -17,6 +18,7 @@ export const Policy = memo(() => {
     params: { packagePolicyId },
   } = useRouteMatch<{ packagePolicyId: string }>();
 
+  const { search } = useLocation();
   const { data: packagePolicyData } = useGetOnePackagePolicyQuery(packagePolicyId);
 
   const extensionView = useUIExtension(
@@ -24,10 +26,22 @@ export const Policy = memo(() => {
     'package-policy-edit'
   );
 
+  const qs = new URLSearchParams(search);
+  const fromQs = qs.get('from');
+
+  let from: EditPackagePolicyFrom | undefined;
+
+  // Shorten query strings to make them more presentable in the URL
+  if (fromQs && fromQs === 'fleet-policy-list') {
+    from = 'edit';
+  } else {
+    from = 'package-edit';
+  }
+
   return (
     <EditPackagePolicyForm
       packagePolicyId={packagePolicyId}
-      from="package-edit"
+      from={from}
       forceUpgrade={extensionView?.useLatestPackageVersion}
     />
   );

--- a/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
+++ b/x-pack/plugins/fleet/public/components/package_policy_actions_menu.tsx
@@ -24,12 +24,14 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
   showAddAgent?: boolean;
   defaultIsOpen?: boolean;
   upgradePackagePolicyHref?: string;
+  from?: 'fleet-policy-list' | undefined;
 }> = ({
   agentPolicy,
   packagePolicy,
   showAddAgent,
   upgradePackagePolicyHref,
   defaultIsOpen = false,
+  from,
 }) => {
   const [isEnrollmentFlyoutOpen, setIsEnrollmentFlyoutOpen] = useState(false);
   const { getHref } = useLink();
@@ -80,9 +82,9 @@ export const PackagePolicyActionsMenu: React.FunctionComponent<{
       data-test-subj="PackagePolicyActionsEditItem"
       disabled={!canWriteIntegrationPolicies || !agentPolicy}
       icon="pencil"
-      href={getHref('integration_policy_edit', {
+      href={`${getHref('integration_policy_edit', {
         packagePolicyId: packagePolicy.id,
-      })}
+      })}${from ? `?from=${from}` : ''}`}
       key="packagePolicyEdit"
     >
       <FormattedMessage


### PR DESCRIPTION
## Description

Resolve https://github.com/elastic/kibana/issues/173805

Redirect to the agent package policy list when editing an integration from that page. This is done the same way we do for the upgrade using a query string parameter `from`.

## How to tests

try to edit an integration from the agent policy details page => save it => you should go back to the agent policy details page.

