### PR TITLE
[Lens][ES|QL] Editing listens the advanced setting

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -1507,6 +1507,10 @@ export class Embeddable
   }
 
   public getIsEditable() {
+    // for ES|QL, editing is allowed only if the advanced setting is on
+    if (Boolean(this.isTextBasedLanguage()) && !this.deps.uiSettings.get('discover:enableESQL')) {
+      return false;
+    }
     return (
       this.deps.capabilities.canSaveVisualizations ||
       (!this.inputIsRefType(this.getInput()) &&


### PR DESCRIPTION
## Summary

Create ES|QL panels already listen to this setting. I added the check to editing too

<img width="1391" alt="image" src="https://github.com/elastic/kibana/assets/17003240/eccab316-9041-41de-a621-076112308fa0">

<img width="559" alt="image" src="https://github.com/elastic/kibana/assets/17003240/f5925dd4-5191-4187-ba8d-2376661ed7e7">
