### PR TITLE
[Search] Fix endpoints header persisting beyond search pages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/index.tsx
@@ -199,5 +199,5 @@ export const renderHeaderActions = (
     </I18nProvider>,
     kibanaHeaderEl
   );
-  return () => ReactDOM.unmountComponentAtNode(kibanaHeaderEl);
+  return () => ReactDOM.render(<></>, kibanaHeaderEl);
 };

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -76,7 +76,7 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
       renderHeaderActions(EndpointsHeaderAction);
     }
     return () => {
-      renderHeaderActions();
+      renderHeaderActions(undefined);
     };
   }, []);
   return (


### PR DESCRIPTION
## Summary

Unmounting the header action was failing in some cases and throwing console errors in all cases. This caused the header component to persist onto pages where it shouldn't be. Instead of explicitly unmounting, which should be done by the parent component of our non-root element, we render an empty element on unmount, which removes the header action in all unmount cases.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->