### PR TITLE
[Search] Fix Connector Status fields on Connector and Crawler pages.

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
@@ -20,7 +20,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { Connector } from '@kbn/search-connectors';
+import { Connector, ConnectorStatus } from '@kbn/search-connectors';
 
 import { Meta } from '../../../../../common/types/pagination';
 
@@ -114,9 +114,9 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
           defaultMessage: 'Ingestion status',
         }
       ),
-      render: (connector: Connector) => {
-        const label = connectorStatusToText(connector.status);
-        return <EuiBadge color={connectorStatusToColor(connector.status)}>{label}</EuiBadge>;
+      render: (connectorStatus: ConnectorStatus) => {
+        const label = connectorStatusToText(connectorStatus);
+        return <EuiBadge color={connectorStatusToColor(connectorStatus)}>{label}</EuiBadge>;
       },
       truncateText: true,
     },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
@@ -30,6 +30,12 @@ export function connectorStatusToText(connectorStatus: ConnectorStatus): string 
       { defaultMessage: 'Configured' }
     );
   }
+  if (connectorStatus === ConnectorStatus.CONNECTED) {
+    return i18n.translate(
+      'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.connected.label',
+      { defaultMessage: 'Connected' }
+    );
+  }
 
   return i18n.translate(
     'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.incomplete.label',


### PR DESCRIPTION
## Summary

Connector status fields was stuck "Incomplete" due to misconfigured table. This fixes them to show proper status from the connector.


### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->