### PR TITLE
[Chore] Remove savedObjects plugin dependencies

### DIFF
--- a/src/plugins/dashboard/kibana.jsonc
+++ b/src/plugins/dashboard/kibana.jsonc
@@ -15,7 +15,6 @@
       "controls",
       "inspector",
       "navigation",
-      "savedObjects",
       "savedObjectsFinder",
       "savedObjectsManagement",
       "contentManagement",
@@ -37,6 +36,6 @@
       "serverless",
       "noDataPage"
     ],
-    "requiredBundles": ["kibanaReact", "kibanaUtils", "presentationUtil"]
+    "requiredBundles": ["kibanaReact", "kibanaUtils", "presentationUtil", "savedObjects"]
   }
 }

--- a/src/plugins/presentation_util/kibana.jsonc
+++ b/src/plugins/presentation_util/kibana.jsonc
@@ -8,7 +8,6 @@
     "server": true,
     "browser": true,
     "requiredPlugins": [
-      "savedObjects",
       "kibanaReact",
       "contentManagement",
       "embeddable",
@@ -16,6 +15,7 @@
       "dataViews",
       "uiActions"
     ],
-    "extraPublicDirs": ["common"]
+    "extraPublicDirs": ["common"],
+    "requiredBundles": ["savedObjects"],
   }
 }

--- a/x-pack/plugins/canvas/kibana.jsonc
+++ b/x-pack/plugins/canvas/kibana.jsonc
@@ -45,8 +45,7 @@
       "lens",
       "maps",
       "visualizations",
-      "fieldFormats",
-      "savedObjects",
+      "fieldFormats"
     ],
   }
 }

--- a/x-pack/plugins/canvas/kibana.jsonc
+++ b/x-pack/plugins/canvas/kibana.jsonc
@@ -38,7 +38,6 @@
       "reporting",
       "spaces",
       "usageCollection",
-      "savedObjects",
     ],
     "requiredBundles": [
       "kibanaReact",
@@ -46,7 +45,8 @@
       "lens",
       "maps",
       "visualizations",
-      "fieldFormats"
+      "fieldFormats",
+      "savedObjects",
     ],
   }
 }

--- a/x-pack/plugins/graph/kibana.jsonc
+++ b/x-pack/plugins/graph/kibana.jsonc
@@ -14,7 +14,6 @@
       "licensing",
       "data",
       "navigation",
-      "savedObjects",
       "unifiedSearch",
       "inspector",
       "savedObjectsManagement",
@@ -28,7 +27,8 @@
     ],
     "requiredBundles": [
       "kibanaUtils",
-      "kibanaReact"
+      "kibanaReact",
+      "savedObjects"
     ]
   }
 }

--- a/x-pack/plugins/stack_alerts/kibana.jsonc
+++ b/x-pack/plugins/stack_alerts/kibana.jsonc
@@ -16,7 +16,6 @@
       "features",
       "triggersActionsUi",
       "kibanaReact",
-      "savedObjects",
       "data",
       "dataViews",
       "kibanaUtils"

--- a/x-pack/plugins/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/plugins/triggers_actions_ui/kibana.jsonc
@@ -38,8 +38,7 @@
       "esUiShared",
       "kibanaReact",
       "kibanaUtils",
-      "actions",
-      "savedObjects"
+      "actions"
     ],
     "extraPublicDirs": [
       "public/common",

--- a/x-pack/plugins/triggers_actions_ui/kibana.jsonc
+++ b/x-pack/plugins/triggers_actions_ui/kibana.jsonc
@@ -16,7 +16,6 @@
       "data",
       "kibanaReact",
       "kibanaUtils",
-      "savedObjects",
       "unifiedSearch",
       "fieldFormats",
       "dataViews",
@@ -39,7 +38,8 @@
       "esUiShared",
       "kibanaReact",
       "kibanaUtils",
-      "actions"
+      "actions",
+      "savedObjects"
     ],
     "extraPublicDirs": [
       "public/common",


### PR DESCRIPTION
## Summary

Removes savedObjects-plugin dependencies.

### Checklist

Delete any items that are not applicable to this PR.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
