### PR TITLE
[Security Solution] update Threat Intelligence codeowners to Threat Hunting Investigations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -796,7 +796,7 @@ packages/kbn-text-based-editor @elastic/kibana-visualizations
 src/plugins/text_based_languages @elastic/kibana-visualizations
 x-pack/examples/third_party_lens_navigation_prompt @elastic/kibana-visualizations
 x-pack/examples/third_party_vis_lens_example @elastic/kibana-visualizations
-x-pack/plugins/threat_intelligence @elastic/security-threat-hunting-investigations
+x-pack/plugins/threat_intelligence @elastic/protections-experience
 x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
 packages/kbn-timelion-grammar @elastic/kibana-visualizations
 packages/kbn-tinymath @elastic/kibana-visualizations

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -796,7 +796,7 @@ packages/kbn-text-based-editor @elastic/kibana-visualizations
 src/plugins/text_based_languages @elastic/kibana-visualizations
 x-pack/examples/third_party_lens_navigation_prompt @elastic/kibana-visualizations
 x-pack/examples/third_party_vis_lens_example @elastic/kibana-visualizations
-x-pack/plugins/threat_intelligence @elastic/protections-experience
+x-pack/plugins/threat_intelligence @elastic/security-threat-hunting-investigations
 x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
 packages/kbn-timelion-grammar @elastic/kibana-visualizations
 packages/kbn-tinymath @elastic/kibana-visualizations
@@ -1295,6 +1295,7 @@ x-pack/test/security_solution_api_integration/test_suites/detections_response/de
 
 /x-pack/test/security_solution_cypress/cypress/e2e/investigations @elastic/security-threat-hunting-investigations
 /x-pack/test/security_solution_cypress/cypress/e2e/sourcerer/sourcerer_timeline.cy.ts @elastic/security-threat-hunting-investigations
+/x-pack/test/threat_intelligence_cypress @elastic/security-threat-hunting-investigations
 
 x-pack/test/security_solution_cypress/cypress/screens/expandable_flyout  @elastic/security-threat-hunting-investigations
 x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/security-threat-hunting-investigations
@@ -1310,6 +1311,7 @@ x-pack/test/security_solution_cypress/cypress/tasks/expandable_flyout  @elastic/
 /x-pack/plugins/security_solution/public/flyout/document_details @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/flyout/shared @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/resolver @elastic/security-threat-hunting-investigations
+/x-pack/plugins/security_solution/public/threat_intelligence @elastic/security-threat-hunting-investigations
 /x-pack/plugins/security_solution/public/timelines @elastic/security-threat-hunting-investigations
 
 /x-pack/plugins/security_solution/server/lib/timeline @elastic/security-threat-hunting-investigations
@@ -1491,10 +1493,6 @@ x-pack/test/security_solution_api_integration/test_suites/detections_response/de
 ## Security Solution sub teams - adaptive-workload-protection
 x-pack/plugins/security_solution/public/common/components/sessions_viewer @elastic/kibana-cloud-security-posture
 x-pack/plugins/security_solution/public/kubernetes @elastic/kibana-cloud-security-posture
-
-## Security Solution sub teams - Protections Experience
-x-pack/plugins/security_solution/public/threat_intelligence @elastic/protections-experience
-x-pack/test/threat_intelligence_cypress @elastic/protections-experience
 
 ## Security Solution sub teams - Entity Analytics
 x-pack/plugins/security_solution/common/entity_analytics @elastic/security-entity-analytics

--- a/x-pack/plugins/threat_intelligence/README.md
+++ b/x-pack/plugins/threat_intelligence/README.md
@@ -92,7 +92,7 @@ how the test suite is executed & extra options regarding parallelism, retrying e
 ### How is the Threat Intelligence code loaded in Kibana?
 
 The Threat Intelligence plugin is loaded lazily within the [security_solution](https://github.com/elastic/kibana/tree/main/x-pack/plugins/security_solution) plugin,
-from `x-pack/plugins/security_solution/public/threat_intelligence` owned by the Protections Experience Team.
+from `x-pack/plugins/security_solution/public/threat_intelligence` owned by the Threat Hunting Investigations Team.
 
 ## QA and demo for implemented features
 


### PR DESCRIPTION
## Summary

This PR makes the codeowners change from the [Protections Experience team](https://github.com/orgs/elastic/teams/protections-experience) (which we should probably remove to avoid confusion) to the [Threat Hunting Investigations team](https://github.com/orgs/elastic/teams/security-threat-hunting-investigations) which now owns Threat Intelligence.
