### PR TITLE
[Security Solution] Event renderers - passing scopeId to renderers and customize hover actions in rule preview

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper.tsx
@@ -18,7 +18,6 @@ import { Draggable, Droppable } from '@hello-pangea/dnd';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
 
-import { TableId } from '@kbn/securitysolution-data-table';
 import { dragAndDropActions } from '../../store/drag_and_drop';
 import type { DataProvider } from '../../../timelines/components/timeline/data_providers/data_provider';
 import { ROW_RENDERER_BROWSER_EXAMPLE_TIMELINE_ID } from '../../../timelines/components/row_renderers_browser/constants';
@@ -110,7 +109,7 @@ interface Props {
 }
 
 export const disableHoverActions = (timelineId: string | undefined): boolean =>
-  [TableId.rulePreview, ROW_RENDERER_BROWSER_EXAMPLE_TIMELINE_ID].includes(timelineId ?? '');
+  [ROW_RENDERER_BROWSER_EXAMPLE_TIMELINE_ID].includes(timelineId ?? '');
 
 /**
  * Wraps a draggable component to handle registration / unregistration of the
@@ -386,6 +385,7 @@ const DraggableWrapperComponent: React.FC<Props> = ({
     ),
     [dataProvider, render, setContainerRef, truncate]
   );
+
   if (!isDraggable) {
     return (
       <WithHoverActions

--- a/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx
@@ -10,6 +10,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { DraggableId } from '@hello-pangea/dnd';
 import styled from 'styled-components';
 import { i18n } from '@kbn/i18n';
+import { TableId } from '@kbn/securitysolution-data-table';
 
 import { stopPropagationAndPreventDefault } from '@kbn/timelines-plugin/public';
 import type { ColumnHeaderOptions, DataProvider } from '../../../../common/types/timeline';
@@ -219,10 +220,10 @@ export const HoverActions: React.FC<Props> = React.memo(
     const isTimelineView = scopeId === TimelineId.active;
     // TODO Provide a list of disabled/enabled actions as props
     const isEntityAnalyticsPage = scopeId === SecurityPageName.entityAnalytics;
-
+    const isAlertPreview = scopeId === TableId.rulePreview;
     const hideFilters = useMemo(
-      () => isEntityAnalyticsPage && !isTimelineView,
-      [isTimelineView, isEntityAnalyticsPage]
+      () => (isEntityAnalyticsPage || isAlertPreview) && !isTimelineView,
+      [isTimelineView, isEntityAnalyticsPage, isAlertPreview]
     );
 
     const hiddenActionsCount = useMemo(() => {

--- a/x-pack/plugins/security_solution/public/explore/network/components/direction/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/direction/index.tsx
@@ -61,7 +61,8 @@ export const DirectionBadge = React.memo<{
   direction?: string | null;
   eventId: string;
   isDraggable?: boolean;
-}>(({ contextId, eventId, direction, isDraggable }) => (
+  scopeId: string;
+}>(({ contextId, eventId, direction, isDraggable, scopeId }) => (
   <DraggableBadge
     contextId={contextId}
     eventId={eventId}
@@ -71,6 +72,7 @@ export const DirectionBadge = React.memo<{
     value={direction}
     isAggregatable={true}
     fieldType="keyword"
+    scopeId={scopeId}
   />
 ));
 

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/geo_fields.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/geo_fields.tsx
@@ -75,7 +75,8 @@ const GeoFieldValues = React.memo<{
   fieldName: string;
   isDraggable?: boolean;
   values?: string[] | null;
-}>(({ contextId, eventId, fieldName, isDraggable, values }) =>
+  scopeId: string;
+}>(({ contextId, eventId, fieldName, isDraggable, values, scopeId }) =>
   values != null ? (
     <>
       {uniq(values).map((value) => (
@@ -96,6 +97,7 @@ const GeoFieldValues = React.memo<{
                 isDraggable={isDraggable}
                 tooltipContent={fieldName}
                 value={value}
+                scopeId={scopeId}
               />
             </EuiFlexItem>
           </EuiFlexGroup>
@@ -116,7 +118,7 @@ GeoFieldValues.displayName = 'GeoFieldValues';
  * - `source|destination.geo.city_name`
  */
 export const GeoFields = React.memo<GeoFieldsProps>((props) => {
-  const { contextId, eventId, isDraggable, type } = props;
+  const { contextId, eventId, isDraggable, type, scopeId } = props;
 
   const propNameToFieldName = getGeoFieldPropNameToFieldNameMap(type);
   return (
@@ -129,6 +131,7 @@ export const GeoFields = React.memo<GeoFieldsProps>((props) => {
           isDraggable={isDraggable}
           key={geo.fieldName}
           values={get(geo.prop, props)}
+          scopeId={scopeId}
         />
       ))}
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/index.test.tsx
@@ -103,6 +103,7 @@ const getSourceDestinationInstance = () => (
     sourcePackets={asArrayIfExists(get(SOURCE_PACKETS_FIELD_NAME, getMockNetflowData()))}
     sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
     transport={asArrayIfExists(get(NETWORK_TRANSPORT_FIELD_NAME, getMockNetflowData()))}
+    scopeId="test"
   />
 );
 

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/index.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/index.tsx
@@ -52,6 +52,7 @@ export const SourceDestination = React.memo<SourceDestinationProps>(
     sourcePackets,
     sourcePort,
     transport,
+    scopeId,
   }) => (
     <EuiFlexGroup alignItems="center" direction="column" justifyContent="center" gutterSize="none">
       <EuiFlexItem grow={false}>
@@ -65,6 +66,7 @@ export const SourceDestination = React.memo<SourceDestinationProps>(
           isDraggable={isDraggable}
           protocol={networkProtocol}
           transport={transport}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
 
@@ -91,6 +93,7 @@ export const SourceDestination = React.memo<SourceDestinationProps>(
           sourceIp={sourceIp}
           sourcePackets={sourcePackets}
           sourcePort={sourcePort}
+          scopeId={scopeId}
         />
       </EuiFlexItemMarginTop>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/network.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/network.tsx
@@ -49,6 +49,7 @@ export const Network = React.memo<{
   packets?: string[] | null;
   protocol?: string[] | null;
   transport?: string[] | null;
+  scopeId: string;
 }>(
   ({
     bytes,
@@ -60,6 +61,7 @@ export const Network = React.memo<{
     packets,
     protocol,
     transport,
+    scopeId,
   }) => (
     <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="none">
       {direction != null
@@ -70,6 +72,7 @@ export const Network = React.memo<{
                 direction={dir}
                 eventId={eventId}
                 isDraggable={isDraggable}
+                scopeId={scopeId}
               />
             </EuiFlexItemMarginRight>
           ))
@@ -86,6 +89,7 @@ export const Network = React.memo<{
                 value={proto}
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </EuiFlexItemMarginRight>
           ))
@@ -100,6 +104,7 @@ export const Network = React.memo<{
                   id={`network-default-draggable-${contextId}-${eventId}-${NETWORK_BYTES_FIELD_NAME}-${b}`}
                   isDraggable={isDraggable}
                   value={b}
+                  scopeId={scopeId}
                 >
                   <Stats size="xs">
                     <span>
@@ -120,6 +125,7 @@ export const Network = React.memo<{
                 id={`network-default-draggable-${contextId}-${eventId}-${NETWORK_PACKETS_FIELD_NAME}-${p}`}
                 isDraggable={isDraggable}
                 value={p}
+                scopeId={scopeId}
               >
                 <Stats size="xs">
                   <span>{`${p} ${i18n.PACKETS}`}</span>
@@ -141,6 +147,7 @@ export const Network = React.memo<{
                 value={trans}
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </EuiFlexItemMarginRight>
           ))
@@ -157,6 +164,7 @@ export const Network = React.memo<{
                 value={trans}
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </EuiFlexItem>
           ))

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_arrows.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_arrows.tsx
@@ -60,67 +60,80 @@ const SourceArrow = React.memo<{
   sourceBytes: string | undefined;
   sourceBytesPercent: number | undefined;
   sourcePackets: string | undefined;
-}>(({ contextId, eventId, isDraggable, sourceBytes, sourceBytesPercent, sourcePackets }) => {
-  const sourceArrowHeight =
-    sourceBytesPercent != null
-      ? getArrowHeightFromPercent(sourceBytesPercent)
-      : DEFAULT_ARROW_HEIGHT;
+  scopeId?: string;
+}>(
+  ({
+    contextId,
+    eventId,
+    isDraggable,
+    sourceBytes,
+    sourceBytesPercent,
+    sourcePackets,
+    scopeId,
+  }) => {
+    const sourceArrowHeight =
+      sourceBytesPercent != null
+        ? getArrowHeightFromPercent(sourceBytesPercent)
+        : DEFAULT_ARROW_HEIGHT;
 
-  return (
-    <EuiFlexGroup alignItems="center" gutterSize="none" justifyContent="center">
-      <EuiFlexItem grow={false}>
-        <ArrowBody height={sourceArrowHeight ?? 0} />
-      </EuiFlexItem>
-
-      {sourceBytes != null && !isNaN(Number(sourceBytes)) ? (
+    return (
+      <EuiFlexGroup alignItems="center" gutterSize="none" justifyContent="center">
         <EuiFlexItem grow={false}>
-          <DefaultDraggable
-            field={SOURCE_BYTES_FIELD_NAME}
-            id={`source-arrow-default-draggable-${contextId}-${eventId}-${SOURCE_BYTES_FIELD_NAME}-${sourceBytes}`}
-            isDraggable={isDraggable}
-            value={sourceBytes}
-          >
-            <Data size="xs">
-              {sourceBytesPercent != null ? (
-                <Percent>{`(${numeral(sourceBytesPercent).format('0.00')}%)`}</Percent>
-              ) : null}
-              <span>
-                <PreferenceFormattedBytes value={sourceBytes} />
-              </span>
-            </Data>
-          </DefaultDraggable>
+          <ArrowBody height={sourceArrowHeight ?? 0} />
         </EuiFlexItem>
-      ) : null}
 
-      <EuiFlexItem grow={false}>
-        <ArrowBody height={sourceArrowHeight ?? 0} />
-      </EuiFlexItem>
+        {sourceBytes != null && !isNaN(Number(sourceBytes)) ? (
+          <EuiFlexItem grow={false}>
+            <DefaultDraggable
+              field={SOURCE_BYTES_FIELD_NAME}
+              id={`source-arrow-default-draggable-${contextId}-${eventId}-${SOURCE_BYTES_FIELD_NAME}-${sourceBytes}`}
+              isDraggable={isDraggable}
+              value={sourceBytes}
+              scopeId={scopeId}
+            >
+              <Data size="xs">
+                {sourceBytesPercent != null ? (
+                  <Percent>{`(${numeral(sourceBytesPercent).format('0.00')}%)`}</Percent>
+                ) : null}
+                <span>
+                  <PreferenceFormattedBytes value={sourceBytes} />
+                </span>
+              </Data>
+            </DefaultDraggable>
+          </EuiFlexItem>
+        ) : null}
 
-      {sourcePackets != null && !isNaN(Number(sourcePackets)) ? (
         <EuiFlexItem grow={false}>
-          <DefaultDraggable
-            field={SOURCE_PACKETS_FIELD_NAME}
-            id={`source-arrow-default-draggable-${contextId}-${eventId}-${SOURCE_PACKETS_FIELD_NAME}-${sourcePackets}`}
-            isDraggable={isDraggable}
-            value={sourcePackets}
-          >
-            <Data size="xs">
-              <span>{`${sourcePackets} ${i18n.PACKETS}`}</span>
-            </Data>
-          </DefaultDraggable>
+          <ArrowBody height={sourceArrowHeight ?? 0} />
         </EuiFlexItem>
-      ) : null}
 
-      <EuiFlexItem grow={false}>
-        <ArrowBody height={sourceArrowHeight ?? 0} />
-      </EuiFlexItem>
+        {sourcePackets != null && !isNaN(Number(sourcePackets)) ? (
+          <EuiFlexItem grow={false}>
+            <DefaultDraggable
+              field={SOURCE_PACKETS_FIELD_NAME}
+              id={`source-arrow-default-draggable-${contextId}-${eventId}-${SOURCE_PACKETS_FIELD_NAME}-${sourcePackets}`}
+              isDraggable={isDraggable}
+              value={sourcePackets}
+              scopeId={scopeId}
+            >
+              <Data size="xs">
+                <span>{`${sourcePackets} ${i18n.PACKETS}`}</span>
+              </Data>
+            </DefaultDraggable>
+          </EuiFlexItem>
+        ) : null}
 
-      <EuiFlexItem grow={false}>
-        <ArrowHead direction="arrowRight" />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-});
+        <EuiFlexItem grow={false}>
+          <ArrowBody height={sourceArrowHeight ?? 0} />
+        </EuiFlexItem>
+
+        <EuiFlexItem grow={false}>
+          <ArrowHead direction="arrowRight" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);
 
 SourceArrow.displayName = 'SourceArrow';
 
@@ -135,6 +148,7 @@ const DestinationArrow = React.memo<{
   destinationPackets: string | undefined;
   eventId: string;
   isDraggable?: boolean;
+  scopeId?: string;
 }>(
   ({
     contextId,
@@ -143,6 +157,7 @@ const DestinationArrow = React.memo<{
     destinationPackets,
     eventId,
     isDraggable,
+    scopeId,
   }) => {
     const destinationArrowHeight =
       destinationBytesPercent != null
@@ -166,6 +181,7 @@ const DestinationArrow = React.memo<{
               id={`destination-arrow-default-draggable-${contextId}-${eventId}-${DESTINATION_BYTES_FIELD_NAME}-${destinationBytes}`}
               isDraggable={isDraggable}
               value={destinationBytes}
+              scopeId={scopeId}
             >
               <Data size="xs">
                 {destinationBytesPercent != null ? (
@@ -190,6 +206,7 @@ const DestinationArrow = React.memo<{
               id={`destination-arrow-default-draggable-${contextId}-${eventId}-${DESTINATION_PACKETS_FIELD_NAME}-${destinationPackets}`}
               isDraggable={isDraggable}
               value={destinationPackets}
+              scopeId={scopeId}
             >
               <Data size="xs">
                 <span>{`${numeral(destinationPackets).format('0,0')} ${i18n.PACKETS}`}</span>
@@ -220,6 +237,7 @@ export const SourceDestinationArrows = React.memo<{
   isDraggable?: boolean;
   sourceBytes?: string[] | null;
   sourcePackets?: string[] | null;
+  scopeId?: string;
 }>(
   ({
     contextId,
@@ -229,6 +247,7 @@ export const SourceDestinationArrows = React.memo<{
     isDraggable,
     sourceBytes,
     sourcePackets,
+    scopeId,
   }) => {
     const maybeSourceBytes =
       sourceBytes != null && hasOneValue(sourceBytes) ? sourceBytes[0] : undefined;
@@ -271,6 +290,7 @@ export const SourceDestinationArrows = React.memo<{
               sourceBytes={maybeSourceBytes}
               sourcePackets={maybeSourcePackets}
               sourceBytesPercent={maybeSourceBytesPercent}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : null}
@@ -283,6 +303,7 @@ export const SourceDestinationArrows = React.memo<{
               destinationBytesPercent={maybeDestinationBytesPercent}
               eventId={eventId}
               isDraggable={isDraggable}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : null}

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_ip.test.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_ip.test.tsx
@@ -370,6 +370,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={undefined}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -419,6 +420,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -468,6 +470,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={undefined}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -517,6 +520,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -567,6 +571,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -616,6 +621,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -665,6 +671,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={[]}
           sourcePort={[]}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -714,6 +721,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -763,6 +771,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -812,6 +821,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={[]}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -861,6 +871,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -910,6 +921,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -960,6 +972,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1010,6 +1023,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1060,6 +1074,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={undefined}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1111,6 +1126,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1161,6 +1177,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={undefined}
           sourcePort={undefined}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1211,6 +1228,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -1261,6 +1279,7 @@ describe('SourceDestinationIp', () => {
           sourceIp={asArrayIfExists(get(SOURCE_IP_FIELD_NAME, getMockNetflowData()))}
           sourcePort={asArrayIfExists(get(SOURCE_PORT_FIELD_NAME, getMockNetflowData()))}
           type={type}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_ip.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_ip.tsx
@@ -182,6 +182,7 @@ export const SourceDestinationIp = React.memo<SourceDestinationIpProps>(
     sourceIp,
     sourcePort,
     type,
+    scopeId,
   }) => {
     const label = type === 'source' ? i18n.SOURCE : i18n.DESTINATION;
 
@@ -242,6 +243,7 @@ export const SourceDestinationIp = React.memo<SourceDestinationIpProps>(
               sourceGeoRegionName={sourceGeoRegionName}
               sourceGeoCityName={sourceGeoCityName}
               type={type}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_with_arrows.tsx
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/source_destination_with_arrows.tsx
@@ -42,6 +42,7 @@ export const SourceDestinationWithArrows = React.memo<SourceDestinationWithArrow
     sourcePackets,
     sourceIp,
     sourcePort,
+    scopeId,
   }) => (
     <EuiFlexGroup justifyContent="center" gutterSize="none">
       <EuiFlexItem grow={false}>
@@ -64,6 +65,7 @@ export const SourceDestinationWithArrows = React.memo<SourceDestinationWithArrow
           sourceIp={sourceIp}
           sourcePort={sourcePort}
           type="source"
+          scopeId={scopeId}
         />
       </EuiFlexItem>
 
@@ -75,6 +77,7 @@ export const SourceDestinationWithArrows = React.memo<SourceDestinationWithArrow
         isDraggable={isDraggable}
         sourceBytes={sourceBytes}
         sourcePackets={sourcePackets}
+        scopeId={scopeId}
       />
 
       <EuiFlexItem grow={false}>
@@ -97,6 +100,7 @@ export const SourceDestinationWithArrows = React.memo<SourceDestinationWithArrow
           sourceIp={sourceIp}
           sourcePort={sourcePort}
           type="destination"
+          scopeId={scopeId}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/explore/network/components/source_destination/types.ts
+++ b/x-pack/plugins/security_solution/public/explore/network/components/source_destination/types.ts
@@ -22,6 +22,7 @@ export interface GeoFieldsProps {
   sourceGeoRegionName?: string[] | null;
   sourceGeoCityName?: string[] | null;
   type: SourceDestinationType;
+  scopeId: string;
 }
 
 export interface SourceDestinationProps {
@@ -53,6 +54,7 @@ export interface SourceDestinationProps {
   sourcePackets?: string[] | null;
   sourcePort?: string[] | null;
   transport?: string[] | null;
+  scopeId: string;
 }
 
 export interface SourceDestinationIpProps {
@@ -74,6 +76,7 @@ export interface SourceDestinationIpProps {
   sourceIp?: string[] | null;
   sourcePort?: Array<number | string | null> | null;
   type: SourceDestinationType;
+  scopeId: string;
 }
 
 export interface SourceDestinationWithArrowsProps {
@@ -98,4 +101,5 @@ export interface SourceDestinationWithArrowsProps {
   sourceIp?: string[] | null;
   sourcePackets?: string[] | null;
   sourcePort?: string[] | null;
+  scopeId: string;
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/certificate_fingerprint/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/certificate_fingerprint/index.test.tsx
@@ -25,6 +25,7 @@ describe('CertificateFingerprint', () => {
           contextId="test"
           fieldName="tls.client_certificate.fingerprint.sha1"
           value="3f4c57934e089f02ae7511200aee2d7e7aabd272"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -40,6 +41,7 @@ describe('CertificateFingerprint', () => {
           contextId="test"
           fieldName="tls.client_certificate.fingerprint.sha1"
           value="3f4c57934e089f02ae7511200aee2d7e7aabd272"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -55,6 +57,7 @@ describe('CertificateFingerprint', () => {
           contextId="test"
           fieldName="tls.client_certificate.fingerprint.sha1"
           value="3f4c57934e089f02ae7511200aee2d7e7aabd272"
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/certificate_fingerprint/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/certificate_fingerprint/index.tsx
@@ -42,7 +42,8 @@ export const CertificateFingerprint = React.memo<{
   fieldName: string;
   isDraggable?: boolean;
   value?: string | null;
-}>(({ eventId, certificateType, contextId, fieldName, isDraggable, value }) => {
+  scopeId: string;
+}>(({ eventId, certificateType, contextId, fieldName, isDraggable, value, scopeId }) => {
   return (
     <DraggableBadge
       contextId={contextId}
@@ -59,6 +60,7 @@ export const CertificateFingerprint = React.memo<{
       value={value}
       isAggregatable={true}
       fieldType="keyword"
+      scopeId={scopeId}
     >
       <FingerprintLabel>
         {certificateType === 'client' ? i18n.CLIENT_CERT : i18n.SERVER_CERT}

--- a/x-pack/plugins/security_solution/public/timelines/components/ja3_fingerprint/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/ja3_fingerprint/index.test.tsx
@@ -24,6 +24,7 @@ describe('Ja3Fingerprint', () => {
           contextId="test"
           fieldName="tls.fingerprints.ja3.hash"
           value="fff799d91b7c01ae3fe6787cfc895552"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -39,6 +40,7 @@ describe('Ja3Fingerprint', () => {
           contextId="test"
           fieldName="tls.fingerprints.ja3.hash"
           value="fff799d91b7c01ae3fe6787cfc895552"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -54,6 +56,7 @@ describe('Ja3Fingerprint', () => {
           contextId="test"
           fieldName="tls.fingerprints.ja3.hash"
           value="fff799d91b7c01ae3fe6787cfc895552"
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/ja3_fingerprint/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/ja3_fingerprint/index.tsx
@@ -32,7 +32,8 @@ export const Ja3Fingerprint = React.memo<{
   fieldName: string;
   isDraggable?: boolean;
   value?: string | null;
-}>(({ contextId, eventId, fieldName, isDraggable, value }) => (
+  scopeId: string;
+}>(({ contextId, eventId, fieldName, isDraggable, value, scopeId }) => (
   <DraggableBadge
     contextId={contextId}
     data-test-subj="ja3-hash"
@@ -43,6 +44,7 @@ export const Ja3Fingerprint = React.memo<{
     value={value}
     isAggregatable={true}
     fieldType="keyword"
+    scopeId={scopeId}
   >
     <Ja3FingerprintLabel>{i18n.JA3_FINGERPRINT_LABEL}</Ja3FingerprintLabel>
     <Ja3FingerprintLink data-test-subj="ja3-hash-link" ja3Fingerprint={value || ''} />

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/fingerprints/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/fingerprints/index.tsx
@@ -24,6 +24,7 @@ export const Fingerprints = React.memo<{
   contextId: string;
   eventId: string;
   isDraggable?: boolean;
+  scopeId: string;
   tlsClientCertificateFingerprintSha1?: string[] | null;
   tlsFingerprintsJa3Hash?: string[] | null;
   tlsServerCertificateFingerprintSha1?: string[] | null;
@@ -32,6 +33,7 @@ export const Fingerprints = React.memo<{
     contextId,
     eventId,
     isDraggable,
+    scopeId,
     tlsClientCertificateFingerprintSha1,
     tlsFingerprintsJa3Hash,
     tlsServerCertificateFingerprintSha1,
@@ -52,6 +54,7 @@ export const Fingerprints = React.memo<{
                 contextId={contextId}
                 isDraggable={isDraggable}
                 value={ja3}
+                scopeId={scopeId}
               />
             </EuiFlexItem>
           ))
@@ -66,6 +69,7 @@ export const Fingerprints = React.memo<{
                 fieldName={TLS_CLIENT_CERTIFICATE_FINGERPRINT_SHA1_FIELD_NAME}
                 isDraggable={isDraggable}
                 value={clientCert}
+                scopeId={scopeId}
               />
             </EuiFlexItem>
           ))
@@ -80,6 +84,7 @@ export const Fingerprints = React.memo<{
                 fieldName={TLS_SERVER_CERTIFICATE_FINGERPRINT_SHA1_FIELD_NAME}
                 isDraggable={isDraggable}
                 value={serverCert}
+                scopeId={scopeId}
               />
             </EuiFlexItem>
           ))

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/index.test.tsx
@@ -131,6 +131,7 @@ const getNetflowInstance = () => (
     )}
     transport={asArrayIfExists(get(NETWORK_TRANSPORT_FIELD_NAME, getMockNetflowData()))}
     userName={asArrayIfExists(get(USER_NAME_FIELD_NAME, getMockNetflowData()))}
+    scopeId="test"
   />
 );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/index.tsx
@@ -58,6 +58,7 @@ export const Netflow = React.memo<NetflowProps>(
     tlsServerCertificateFingerprintSha1,
     transport,
     userName,
+    scopeId,
   }) => (
     <EuiFlexGroup
       alignItems="center"
@@ -101,6 +102,7 @@ export const Netflow = React.memo<NetflowProps>(
           sourcePort={sourcePort}
           transport={transport}
           userName={userName}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
@@ -111,6 +113,7 @@ export const Netflow = React.memo<NetflowProps>(
           tlsClientCertificateFingerprintSha1={tlsClientCertificateFingerprintSha1}
           tlsFingerprintsJa3Hash={tlsFingerprintsJa3Hash}
           tlsServerCertificateFingerprintSha1={tlsServerCertificateFingerprintSha1}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/duration_event_start_end.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/duration_event_start_end.tsx
@@ -39,7 +39,8 @@ export const DurationEventStartEnd = React.memo<{
   eventEnd?: string[] | null;
   eventStart?: string[] | null;
   isDraggable?: boolean;
-}>(({ contextId, eventDuration, eventId, eventEnd, eventStart, isDraggable }) => (
+  scopeId: string;
+}>(({ contextId, eventDuration, eventId, eventEnd, eventStart, isDraggable, scopeId }) => (
   <EuiFlexGroup
     alignItems="flexStart"
     data-test-subj="duration-and-start-group"
@@ -58,6 +59,7 @@ export const DurationEventStartEnd = React.memo<{
               name={name}
               tooltipContent={null}
               value={duration}
+              scopeId={scopeId}
             >
               <EuiText size="xs">
                 <TimeIcon size="m" type="clock" />
@@ -79,6 +81,7 @@ export const DurationEventStartEnd = React.memo<{
               isDraggable={isDraggable}
               tooltipContent={null}
               value={start}
+              scopeId={scopeId}
             >
               <EuiText size="xs">
                 <TimeIcon size="m" type="clock" />
@@ -97,6 +100,7 @@ export const DurationEventStartEnd = React.memo<{
               isDraggable={isDraggable}
               tooltipContent={null}
               value={end}
+              scopeId={scopeId}
             >
               <EuiText size="xs">
                 <TimeIcon size="m" type="clock" />

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/index.tsx
@@ -63,6 +63,7 @@ export const NetflowColumns = React.memo<NetflowColumnsProps>(
     sourcePort,
     transport,
     userName,
+    scopeId,
   }) => (
     <EuiFlexGroup
       data-test-subj="netflow-columns"
@@ -77,6 +78,7 @@ export const NetflowColumns = React.memo<NetflowColumnsProps>(
           isDraggable={isDraggable}
           processName={processName}
           userName={userName}
+          scopeId={scopeId}
         />
       </EuiFlexItemMarginRight>
 
@@ -88,6 +90,7 @@ export const NetflowColumns = React.memo<NetflowColumnsProps>(
           eventEnd={eventEnd}
           eventStart={eventStart}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       </EuiFlexItemMarginRight>
 
@@ -120,6 +123,7 @@ export const NetflowColumns = React.memo<NetflowColumnsProps>(
           sourcePackets={sourcePackets}
           sourcePort={sourcePort}
           transport={transport}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/types.ts
@@ -39,4 +39,5 @@ export interface NetflowColumnsProps {
   sourcePort?: string[] | null;
   transport?: string[] | null;
   userName?: string[] | null;
+  scopeId: string;
 }

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/user_process.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/netflow_columns/user_process.tsx
@@ -25,7 +25,8 @@ export const UserProcess = React.memo<{
   isDraggable?: boolean;
   processName?: string[] | null;
   userName?: string[] | null;
-}>(({ contextId, eventId, isDraggable, processName, userName }) => (
+  scopeId: string;
+}>(({ contextId, eventId, isDraggable, processName, userName, scopeId }) => (
   <EuiFlexGroup
     alignItems="flexStart"
     data-test-subj="user-process"
@@ -46,6 +47,7 @@ export const UserProcess = React.memo<{
               iconType="user"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ))
@@ -63,6 +65,7 @@ export const UserProcess = React.memo<{
               iconType="console"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ))

--- a/x-pack/plugins/security_solution/public/timelines/components/netflow/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/netflow/types.ts
@@ -27,6 +27,7 @@ export interface NetflowProps {
   networkPackets?: string[] | null;
   networkProtocol?: string[] | null;
   processName?: string[] | null;
+  scopeId: string;
   sourceBytes?: string[] | null;
   sourceGeoContinentName?: string[] | null;
   sourceGeoCountryName?: string[] | null;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/args.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/args.test.tsx
@@ -34,6 +34,7 @@ describe('Args', () => {
           eventId="event-123"
           args={['arg1', 'arg2', 'arg3']}
           processTitle="process-title-1"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -47,6 +48,7 @@ describe('Args', () => {
             eventId="event-123"
             args={undefined}
             processTitle={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -61,6 +63,7 @@ describe('Args', () => {
             eventId="event-123"
             args={null}
             processTitle={null}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -70,7 +73,13 @@ describe('Args', () => {
     test('it returns an empty string when args is an empty array, and title is an empty string', () => {
       const wrapper = mount(
         <TestProviders>
-          <ArgsComponent contextId="context-123" eventId="event-123" args={[]} processTitle="" />
+          <ArgsComponent
+            contextId="context-123"
+            eventId="event-123"
+            args={[]}
+            processTitle=""
+            scopeId="test"
+          />
         </TestProviders>
       );
       expect(wrapper.text()).toEqual('');
@@ -84,6 +93,7 @@ describe('Args', () => {
             eventId="event-123"
             args={['arg1', 'arg2', 'arg3']}
             processTitle={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -98,6 +108,7 @@ describe('Args', () => {
             eventId="event-123"
             args={null}
             processTitle="process-title-1"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -112,6 +123,7 @@ describe('Args', () => {
             eventId="event-123"
             args={['arg1', 'arg2', 'arg3']}
             processTitle="process-title-1"
+            scopeId="test"
           />
         </TestProviders>
       );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/args.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/args.tsx
@@ -16,9 +16,17 @@ interface Props {
   eventId: string;
   processTitle: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
-export const ArgsComponent = ({ args, contextId, eventId, processTitle, isDraggable }: Props) => {
+export const ArgsComponent = ({
+  args,
+  contextId,
+  eventId,
+  processTitle,
+  isDraggable,
+  scopeId,
+}: Props) => {
   if (isNillEmptyOrNotFinite(args) && isNillEmptyOrNotFinite(processTitle)) {
     return null;
   }
@@ -36,6 +44,7 @@ export const ArgsComponent = ({ args, contextId, eventId, processTitle, isDragga
               value={arg}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         ))}
@@ -50,6 +59,7 @@ export const ArgsComponent = ({ args, contextId, eventId, processTitle, isDragga
             value={processTitle}
             fieldType="keyword"
             isAggregatable={true}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
       )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_details.test.tsx
@@ -33,7 +33,7 @@ describe('GenericDetails', () => {
           contextId="contextid-123"
           text="generic-text-123"
           data={mockTimelineData[21].ecs}
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -46,7 +46,7 @@ describe('GenericDetails', () => {
             contextId="contextid-123"
             text="generic-text-123"
             data={mockTimelineData[19].ecs}
-            timelineId="test"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -61,7 +61,7 @@ describe('GenericDetails', () => {
           contextId="contextid-123"
           text="generic-text-123"
           data={mockTimelineData[0].ecs}
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -88,6 +88,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -115,6 +116,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -142,6 +144,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -169,6 +172,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -196,6 +200,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -223,6 +228,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -250,6 +256,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -277,6 +284,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -304,6 +312,7 @@ describe('GenericDetails', () => {
             workingDirectory="working-directory-1"
             args={['arg1', 'arg2', 'arg3']}
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -331,6 +340,7 @@ describe('GenericDetails', () => {
             workingDirectory={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -356,6 +366,7 @@ describe('GenericDetails', () => {
             workingDirectory={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -381,6 +392,7 @@ describe('GenericDetails', () => {
             workingDirectory={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -406,6 +418,7 @@ describe('GenericDetails', () => {
             workingDirectory={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -431,6 +444,7 @@ describe('GenericDetails', () => {
             workingDirectory={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -456,6 +470,7 @@ describe('GenericDetails', () => {
             processTitle={undefined}
             args={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -481,6 +496,7 @@ describe('GenericDetails', () => {
             processTitle={undefined}
             workingDirectory={undefined}
             result={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_details.tsx
@@ -36,6 +36,7 @@ interface Props {
   args: string[] | null | undefined;
   session: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const AuditdGenericLine = React.memo<Props>(
@@ -56,6 +57,7 @@ export const AuditdGenericLine = React.memo<Props>(
     session,
     text,
     isDraggable,
+    scopeId,
   }) => (
     <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="none" wrap={true}>
       <SessionUserHostWorkingDir
@@ -68,6 +70,7 @@ export const AuditdGenericLine = React.memo<Props>(
         workingDirectory={workingDirectory}
         session={session}
         isDraggable={isDraggable}
+        scopeId={scopeId}
       />
       {processExecutable != null && (
         <TokensFlexItem grow={false} component="span">
@@ -84,6 +87,7 @@ export const AuditdGenericLine = React.memo<Props>(
           processName={processName}
           processExecutable={processExecutable}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       <Args
@@ -92,6 +96,7 @@ export const AuditdGenericLine = React.memo<Props>(
         contextId={contextId}
         isDraggable={isDraggable}
         processTitle={processTitle}
+        scopeId={scopeId}
       />
       {result != null && (
         <TokensFlexItem grow={false} component="span">
@@ -108,6 +113,7 @@ export const AuditdGenericLine = React.memo<Props>(
           value={result}
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       </TokensFlexItem>
     </EuiFlexGroup>
@@ -121,11 +127,11 @@ interface GenericDetailsProps {
   isDraggable?: boolean;
   contextId: string;
   text: string;
-  timelineId: string;
+  scopeId: string;
 }
 
 export const AuditdGenericDetails = React.memo<GenericDetailsProps>(
-  ({ data, contextId, isDraggable, text, timelineId }) => {
+  ({ data, contextId, isDraggable, text, scopeId }) => {
     const id = data._id;
     const session: string | null | undefined = get('auditd.session[0]', data);
     const hostName: string | null | undefined = get('host.name[0]', data);
@@ -159,9 +165,10 @@ export const AuditdGenericDetails = React.memo<GenericDetailsProps>(
             result={result}
             secondary={secondary}
             isDraggable={isDraggable}
+            scopeId={scopeId}
           />
           <EuiSpacer size="s" />
-          <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+          <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
         </Details>
       );
     } else {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_file_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_file_details.test.tsx
@@ -34,7 +34,7 @@ describe('GenericFileDetails', () => {
           text="generic-text-123"
           data={mockTimelineData[27].ecs}
           fileIcon="document"
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -48,7 +48,7 @@ describe('GenericFileDetails', () => {
             text="generic-text-123"
             data={mockTimelineData[19].ecs}
             fileIcon="document"
-            timelineId="test"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -64,7 +64,7 @@ describe('GenericFileDetails', () => {
           text="generic-text-123"
           data={mockTimelineData[0].ecs}
           fileIcon="document"
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -93,6 +93,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -122,6 +123,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -151,6 +153,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -180,6 +183,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -209,6 +213,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -238,6 +243,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -267,6 +273,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -296,6 +303,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -325,6 +333,7 @@ describe('GenericFileDetails', () => {
             filePath="/somepath"
             fileIcon="document"
             result="success"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -354,6 +363,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -381,6 +391,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -408,6 +419,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -435,6 +447,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -462,6 +475,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -489,6 +503,7 @@ describe('GenericFileDetails', () => {
             args={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -516,6 +531,7 @@ describe('GenericFileDetails', () => {
             workingDirectory={undefined}
             result={undefined}
             filePath={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_file_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_file_details.tsx
@@ -39,6 +39,7 @@ interface Props {
   args: string[] | null | undefined;
   session: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const AuditdGenericFileLine = React.memo<Props>(
@@ -61,6 +62,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
     text,
     fileIcon,
     isDraggable,
+    scopeId,
   }) => (
     <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="none" wrap={true}>
       <SessionUserHostWorkingDir
@@ -73,6 +75,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
         workingDirectory={workingDirectory}
         session={session}
         isDraggable={isDraggable}
+        scopeId={scopeId}
       />
       {(filePath != null || processExecutable != null) && (
         <TokensFlexItem grow={false} component="span">
@@ -87,6 +90,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
           isDraggable={isDraggable}
           value={filePath}
           iconType={fileIcon}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       {processExecutable != null && (
@@ -104,6 +108,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
           processPid={processPid}
           processName={processName}
           processExecutable={processExecutable}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       <Args
@@ -112,6 +117,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
         contextId={contextId}
         isDraggable={isDraggable}
         processTitle={processTitle}
+        scopeId={scopeId}
       />
       {result != null && (
         <TokensFlexItem grow={false} component="span">
@@ -126,6 +132,7 @@ export const AuditdGenericFileLine = React.memo<Props>(
           isDraggable={isDraggable}
           queryValue={result}
           value={result}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
     </EuiFlexGroup>
@@ -139,12 +146,12 @@ interface GenericDetailsProps {
   data: Ecs;
   text: string;
   fileIcon: IconType;
-  timelineId: string;
+  scopeId: string;
   isDraggable?: boolean;
 }
 
 export const AuditdGenericFileDetails = React.memo<GenericDetailsProps>(
-  ({ data, contextId, text, fileIcon = 'document', timelineId, isDraggable }) => {
+  ({ data, contextId, text, fileIcon = 'document', scopeId, isDraggable }) => {
     const id = data._id;
     const session: string | null | undefined = get('auditd.session[0]', data);
     const hostName: string | null | undefined = get('host.name[0]', data);
@@ -182,9 +189,10 @@ export const AuditdGenericFileDetails = React.memo<GenericDetailsProps>(
             fileIcon={fileIcon}
             result={result}
             isDraggable={isDraggable}
+            scopeId={scopeId}
           />
           <EuiSpacer size="s" />
-          <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+          <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
         </Details>
       );
     } else {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_row_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/generic_row_renderer.tsx
@@ -42,7 +42,7 @@ export const createGenericAuditRowRenderer = ({
         isDraggable={isDraggable}
         contextId={`${actionName}-${scopeId}`}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -76,7 +76,7 @@ export const createGenericFileRowRenderer = ({
         fileIcon={fileIcon}
         isDraggable={isDraggable}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/primary_secondary_user_info.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/primary_secondary_user_info.test.tsx
@@ -35,6 +35,7 @@ describe('UserPrimarySecondary', () => {
           userName="user-name-1"
           primary="primary-1"
           secondary="secondary-1"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -49,6 +50,7 @@ describe('UserPrimarySecondary', () => {
             userName="user-name-1"
             primary={undefined}
             secondary={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -64,6 +66,7 @@ describe('UserPrimarySecondary', () => {
             userName="user-name-1"
             primary="unset"
             secondary="unset"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -79,6 +82,7 @@ describe('UserPrimarySecondary', () => {
             primary="primary-1"
             userName={undefined}
             secondary={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -94,6 +98,7 @@ describe('UserPrimarySecondary', () => {
             primary="primary-1"
             userName="unset"
             secondary="unset"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -109,6 +114,7 @@ describe('UserPrimarySecondary', () => {
             userName={undefined}
             primary={undefined}
             secondary="secondary-1"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -124,6 +130,7 @@ describe('UserPrimarySecondary', () => {
             secondary="secondary-1"
             primary="unset"
             userName="unset"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -139,6 +146,7 @@ describe('UserPrimarySecondary', () => {
             userName="username-1"
             primary="username-1"
             secondary="username-1"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -154,6 +162,7 @@ describe('UserPrimarySecondary', () => {
             userName="[username]"
             primary="[primary]"
             secondary="[secondary]"
+            scopeId="test"
           />
         </TestProviders>
       );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/primary_secondary_user_info.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/primary_secondary_user_info.tsx
@@ -22,10 +22,11 @@ interface Props {
   primary: string | null | undefined;
   secondary: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const PrimarySecondary = React.memo<Props>(
-  ({ contextId, eventId, primary, secondary, isDraggable }) => {
+  ({ contextId, eventId, primary, secondary, isDraggable, scopeId }) => {
     if (nilOrUnSet(primary) && nilOrUnSet(secondary)) {
       return null;
     } else if (!nilOrUnSet(primary) && nilOrUnSet(secondary)) {
@@ -39,6 +40,7 @@ export const PrimarySecondary = React.memo<Props>(
           iconType="user"
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       );
     } else if (nilOrUnSet(primary) && !nilOrUnSet(secondary)) {
@@ -52,6 +54,7 @@ export const PrimarySecondary = React.memo<Props>(
           iconType="user"
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       );
     } else if (primary === secondary) {
@@ -65,6 +68,7 @@ export const PrimarySecondary = React.memo<Props>(
           iconType="user"
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       );
     } else {
@@ -80,6 +84,7 @@ export const PrimarySecondary = React.memo<Props>(
               iconType="user"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
           <TokensFlexItem grow={false} component="span">
@@ -95,6 +100,7 @@ export const PrimarySecondary = React.memo<Props>(
               iconType="user"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         </EuiFlexGroup>
@@ -112,10 +118,11 @@ interface PrimarySecondaryUserInfoProps {
   primary: string | null | undefined;
   secondary: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const PrimarySecondaryUserInfo = React.memo<PrimarySecondaryUserInfoProps>(
-  ({ contextId, eventId, userName, primary, secondary, isDraggable }) => {
+  ({ contextId, eventId, userName, primary, secondary, isDraggable, scopeId }) => {
     if (nilOrUnSet(userName) && nilOrUnSet(primary) && nilOrUnSet(secondary)) {
       return null;
     } else if (
@@ -135,6 +142,7 @@ export const PrimarySecondaryUserInfo = React.memo<PrimarySecondaryUserInfoProps
           iconType="user"
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       );
     } else if (!nilOrUnSet(userName) && nilOrUnSet(primary) && nilOrUnSet(secondary)) {
@@ -148,6 +156,7 @@ export const PrimarySecondaryUserInfo = React.memo<PrimarySecondaryUserInfoProps
           iconType="user"
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       );
     } else {
@@ -158,6 +167,7 @@ export const PrimarySecondaryUserInfo = React.memo<PrimarySecondaryUserInfoProps
           isDraggable={isDraggable}
           primary={primary}
           secondary={secondary}
+          scopeId={scopeId}
         />
       );
     }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/session_user_host_working_dir.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/session_user_host_working_dir.test.tsx
@@ -40,6 +40,7 @@ describe('SessionUserHostWorkingDir', () => {
             primary="primary-123"
             secondary="secondary-123"
             workingDirectory="workingdir-123"
+            scopeId="test"
           />
         </EuiFlexItem>
       );
@@ -59,6 +60,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary={undefined}
               secondary={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -79,6 +81,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary={undefined}
               secondary={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -99,6 +102,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary={undefined}
               secondary={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -119,6 +123,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary={undefined}
               secondary={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -139,6 +144,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary="primary-123"
               secondary={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -159,6 +165,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary="primary-123"
               secondary="secondary-123"
               workingDirectory={undefined}
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>
@@ -179,6 +186,7 @@ describe('SessionUserHostWorkingDir', () => {
               primary="primary-123"
               secondary="secondary-123"
               workingDirectory="workingdirectory-123"
+              scopeId="test"
             />
           </EuiFlexItem>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/session_user_host_working_dir.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/auditd/session_user_host_working_dir.tsx
@@ -24,6 +24,7 @@ interface Props {
   workingDirectory: string | null | undefined;
   session: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const SessionUserHostWorkingDir = React.memo<Props>(
@@ -37,6 +38,7 @@ export const SessionUserHostWorkingDir = React.memo<Props>(
     workingDirectory,
     session,
     isDraggable,
+    scopeId,
   }) => (
     <>
       <TokensFlexItem grow={false} component="span">
@@ -52,6 +54,7 @@ export const SessionUserHostWorkingDir = React.memo<Props>(
           isDraggable={isDraggable}
           isAggregatable={true}
           fieldType="keyword"
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       <TokensFlexItem grow={false} component="span">
@@ -62,6 +65,7 @@ export const SessionUserHostWorkingDir = React.memo<Props>(
           primary={primary}
           secondary={secondary}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       {hostName != null && (
@@ -75,6 +79,7 @@ export const SessionUserHostWorkingDir = React.memo<Props>(
         workingDirectory={workingDirectory}
         hostName={hostName}
         isDraggable={isDraggable}
+        scopeId={scopeId}
       />
     </>
   )

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/bytes/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/bytes/index.test.tsx
@@ -30,6 +30,7 @@ describe('Bytes', () => {
           isAggregatable={true}
           isDraggable={true}
           value={`1234567`}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/indicator_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/indicator_details.tsx
@@ -25,6 +25,7 @@ interface IndicatorDetailsProps {
   indicatorReference: string | undefined;
   indicatorType: string | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const IndicatorDetails: React.FC<IndicatorDetailsProps> = ({
@@ -34,6 +35,7 @@ export const IndicatorDetails: React.FC<IndicatorDetailsProps> = ({
   indicatorReference,
   indicatorType,
   isDraggable,
+  scopeId,
 }) => (
   <EuiFlexGroup
     alignItems="flexStart"
@@ -54,6 +56,7 @@ export const IndicatorDetails: React.FC<IndicatorDetailsProps> = ({
           value={indicatorType}
           isAggregatable={true}
           fieldType={'keyword'}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
     )}
@@ -77,6 +80,7 @@ export const IndicatorDetails: React.FC<IndicatorDetailsProps> = ({
             value={feedName}
             isAggregatable={true}
             fieldType={'keyword'}
+            scopeId={scopeId}
           />
         </EuiFlexItem>
       </>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/match_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/match_details.tsx
@@ -19,6 +19,7 @@ interface MatchDetailsProps {
   isDraggable?: boolean;
   sourceField: string;
   sourceValue: string;
+  scopeId: string;
 }
 
 export const MatchDetails: React.FC<MatchDetailsProps> = ({
@@ -27,6 +28,7 @@ export const MatchDetails: React.FC<MatchDetailsProps> = ({
   isDraggable,
   sourceField,
   sourceValue,
+  scopeId,
 }) => (
   <EuiFlexGroup
     alignItems="center"
@@ -46,6 +48,7 @@ export const MatchDetails: React.FC<MatchDetailsProps> = ({
         value={sourceField}
         isAggregatable={true}
         fieldType={'keyword'}
+        scopeId={scopeId}
       />
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
@@ -66,6 +69,7 @@ export const MatchDetails: React.FC<MatchDetailsProps> = ({
         value={sourceValue}
         isAggregatable={true}
         fieldType={'keyword'}
+        scopeId={scopeId}
       />
     </EuiFlexItem>
   </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_row.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_row.test.tsx
@@ -28,6 +28,7 @@ describe('ThreatMatchRowView', () => {
         indicatorType="domain"
         sourceField="host.name"
         sourceValue="http://elastic.co"
+        scopeId="test"
       />
     );
 
@@ -44,6 +45,7 @@ describe('ThreatMatchRowView', () => {
         indicatorType="domain"
         sourceField="host.name"
         sourceValue="http://elastic.co"
+        scopeId="test"
       />
     );
 
@@ -68,6 +70,7 @@ describe('ThreatMatchRowView', () => {
         indicatorType: 'domain',
         sourceField: 'host.name',
         sourceValue: 'http://elastic.co',
+        scopeId: 'test',
       };
     });
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_row.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_row.tsx
@@ -29,6 +29,7 @@ export interface ThreatMatchRowProps {
   isDraggable?: boolean;
   sourceField: string;
   sourceValue: string;
+  scopeId: string;
 }
 
 export const ThreatMatchRow = ({
@@ -36,11 +37,13 @@ export const ThreatMatchRow = ({
   data,
   eventId,
   isDraggable,
+  scopeId,
 }: {
   contextId: string;
   data: Fields;
   eventId: string;
   isDraggable?: boolean;
+  scopeId: string;
 }) => {
   const props = {
     contextId,
@@ -51,6 +54,7 @@ export const ThreatMatchRow = ({
     isDraggable,
     sourceField: get(MATCHED_FIELD, data)[0] as string,
     sourceValue: get(MATCHED_ATOMIC, data)[0] as string,
+    scopeId,
   };
 
   return <ThreatMatchRowView {...props} />;
@@ -65,6 +69,7 @@ export const ThreatMatchRowView = ({
   isDraggable,
   sourceField,
   sourceValue,
+  scopeId,
 }: ThreatMatchRowProps) => {
   return (
     <EuiFlexGroup
@@ -80,6 +85,7 @@ export const ThreatMatchRowView = ({
           isDraggable={isDraggable}
           sourceField={sourceField}
           sourceValue={sourceValue}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
@@ -90,6 +96,7 @@ export const ThreatMatchRowView = ({
           indicatorReference={indicatorReference}
           indicatorType={indicatorType}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       </EuiFlexItem>
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_rows.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/cti/threat_match_rows.tsx
@@ -72,6 +72,7 @@ const ThreatMatchRowWrapper: FC<ThreatMatchRowProps> = ({ data, isDraggable, sco
                     data={indicator}
                     eventId={eventId}
                     isDraggable={isDraggable}
+                    scopeId={scopeId}
                   />
                   {index < indicators.length - 1 && <EuiHorizontalRule margin="s" />}
                 </Fragment>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details.test.tsx
@@ -33,7 +33,7 @@ describe('DnsRequestEventDetails', () => {
         <DnsRequestEventDetails
           contextId="test-context"
           data={mockEndgameDnsRequest}
-          timelineId="timeline-id-test"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details.tsx
@@ -19,11 +19,11 @@ interface Props {
   contextId: string;
   data: Ecs;
   isDraggable?: boolean;
-  timelineId: string;
+  scopeId: string;
 }
 
 export const DnsRequestEventDetails = React.memo<Props>(
-  ({ data, contextId, isDraggable, timelineId }) => {
+  ({ data, contextId, isDraggable, scopeId }) => {
     const dnsQuestionName: string | null | undefined = get('dns.question.name[0]', data);
     const dnsQuestionType: string | null | undefined = get('dns.question.type[0]', data);
     const dnsResolvedIp: string | null | undefined = get('dns.resolved_ip[0]', data);
@@ -56,9 +56,10 @@ export const DnsRequestEventDetails = React.memo<Props>(
           userDomain={userDomain}
           userName={userName}
           winlogEventId={winlogEventId}
+          scopeId={scopeId}
         />
         <EuiSpacer size="s" />
-        <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+        <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
       </Details>
     );
   }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details_line.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details_line.test.tsx
@@ -43,6 +43,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -69,6 +70,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -95,6 +97,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -121,6 +124,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -147,6 +151,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -173,6 +178,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -199,6 +205,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -225,6 +232,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -251,6 +259,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -277,6 +286,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -303,6 +313,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain={undefined}
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -329,6 +340,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName={undefined}
           winlogEventId="[winlogEventId]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -355,6 +367,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -381,6 +394,7 @@ describe('DnsRequestEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details_line.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/dns/dns_request_event_details_line.tsx
@@ -31,6 +31,7 @@ interface Props {
   userDomain: string | null | undefined;
   userName: string | null | undefined;
   winlogEventId: string | null | undefined;
+  scopeId: string;
 }
 
 export const DnsRequestEventDetailsLine = React.memo<Props>(
@@ -50,6 +51,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
     userDomain,
     userName,
     winlogEventId,
+    scopeId,
   }) => {
     return (
       <>
@@ -62,6 +64,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
             userDomain={userDomain}
             userName={userName}
             workingDirectory={undefined}
+            scopeId={scopeId}
           />
 
           {!isNillEmptyOrNotFinite(dnsQuestionName) && (
@@ -78,6 +81,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                   value={dnsQuestionName}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -97,6 +101,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                   value={dnsQuestionType}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -116,6 +121,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                   value={dnsResolvedIp}
                   isAggregatable={true}
                   fieldType="ip"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -138,6 +144,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                   value={dnsResponseCode}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
               <TokensFlexItem component="span" grow={false}>
@@ -160,6 +167,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
               processPid={processPid}
               processName={processName}
               processExecutable={processExecutable}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
 
@@ -175,6 +183,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                     value={eventCode}
                     isAggregatable={true}
                     fieldType="number"
+                    scopeId={scopeId}
                   />
                 </TokensFlexItem>
               ) : (
@@ -188,6 +197,7 @@ export const DnsRequestEventDetailsLine = React.memo<Props>(
                     value={winlogEventId}
                     isAggregatable={true}
                     fieldType="keyword"
+                    scopeId={scopeId}
                   />
                 </TokensFlexItem>
               )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details.test.tsx
@@ -38,7 +38,7 @@ describe('EndgameSecurityEventDetails', () => {
         <EndgameSecurityEventDetails
           contextId="test-context"
           data={mockEndgameUserLogon}
-          timelineId="timeline-id-test"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -53,7 +53,7 @@ describe('EndgameSecurityEventDetails', () => {
         <EndgameSecurityEventDetails
           contextId="test-context"
           data={mockEndgameAdminLogon}
-          timelineId="timeline-id-test"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -68,7 +68,7 @@ describe('EndgameSecurityEventDetails', () => {
         <EndgameSecurityEventDetails
           contextId="test-context"
           data={mockEndgameExplicitUserLogon}
-          timelineId="timeline-id-test"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -83,7 +83,7 @@ describe('EndgameSecurityEventDetails', () => {
         <EndgameSecurityEventDetails
           contextId="test-context"
           data={mockEndgameUserLogoff}
-          timelineId="timeline-id-test"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details.tsx
@@ -19,11 +19,11 @@ interface Props {
   contextId: string;
   data: Ecs;
   isDraggable?: boolean;
-  timelineId: string;
+  scopeId: string;
 }
 
 export const EndgameSecurityEventDetails = React.memo<Props>(
-  ({ data, contextId, isDraggable, timelineId }) => {
+  ({ data, contextId, isDraggable, scopeId }) => {
     const endgameLogonType: number | null | undefined = get('endgame.logon_type[0]', data);
     const endgameSubjectDomainName: string | null | undefined = get(
       'endgame.subject_domain_name[0]',
@@ -81,9 +81,10 @@ export const EndgameSecurityEventDetails = React.memo<Props>(
           userDomain={userDomain}
           userName={userName}
           winlogEventId={winlogEventId}
+          scopeId={scopeId}
         />
         <EuiSpacer size="s" />
-        <NetflowRenderer data={data} timelineId={timelineId} />
+        <NetflowRenderer data={data} scopeId={scopeId} />
       </Details>
     );
   }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details_line.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details_line.test.tsx
@@ -49,6 +49,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -80,6 +81,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -111,6 +113,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -142,6 +145,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -173,6 +177,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -204,6 +209,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -235,6 +241,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -266,6 +273,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -297,6 +305,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -328,6 +337,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -359,6 +369,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -390,6 +401,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -421,6 +433,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -452,6 +465,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -483,6 +497,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -514,6 +529,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain={undefined}
           userName="[userName]"
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -545,6 +561,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName={undefined}
           winlogEventId="[winlogEventId]"
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -576,6 +593,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId={undefined}
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );
@@ -607,6 +625,7 @@ describe('EndgameSecurityEventDetailsLine', () => {
           userDomain="[userDomain]"
           userName="[userName]"
           winlogEventId={undefined}
+          scopeId="scope-id-test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details_line.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/endgame/endgame_security_event_details_line.tsx
@@ -45,6 +45,7 @@ interface Props {
   userDomain: string | null | undefined;
   userName: string | null | undefined;
   winlogEventId: string | null | undefined;
+  scopeId: string;
 }
 
 export const EndgameSecurityEventDetailsLine = React.memo<Props>(
@@ -69,6 +70,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
     userDomain,
     userName,
     winlogEventId,
+    scopeId,
   }) => {
     const domain = getTargetUserAndTargetDomain(eventAction) ? endgameTargetDomainName : userDomain;
     const eventDetails = getEventDetails({ eventAction, eventOutcome });
@@ -103,6 +105,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
             userName={user}
             userNameField={userNameField}
             workingDirectory={undefined}
+            scopeId={scopeId}
           />
 
           <TokensFlexItem component="span" data-test-subj="event-details" grow={false}>
@@ -124,6 +127,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                   value={`${endgameLogonType} - ${getHumanReadableLogonType(endgameLogonType)}`}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -146,6 +150,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                   value={endgameTargetLogonId}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
               <TokensFlexItem component="span" grow={false}>
@@ -168,6 +173,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
               processPid={processPid}
               processName={processName}
               processExecutable={processExecutable}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
 
@@ -191,6 +197,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                   value={endgameSubjectUserName}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -214,6 +221,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                   value={endgameSubjectDomainName}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
             </>
@@ -236,6 +244,7 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                   value={endgameSubjectLogonId}
                   isAggregatable={true}
                   fieldType="keyword"
+                  scopeId={scopeId}
                 />
               </TokensFlexItem>
               <TokensFlexItem component="span" grow={false}>
@@ -252,9 +261,11 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                     contextId={contextId}
                     eventId={id}
                     field="event.code"
+                    isDraggable={isDraggable}
                     value={eventCode}
                     isAggregatable={true}
                     fieldType="keyword"
+                    scopeId={scopeId}
                   />
                 </TokensFlexItem>
               ) : (
@@ -264,9 +275,11 @@ export const EndgameSecurityEventDetailsLine = React.memo<Props>(
                     eventId={id}
                     iconType="logoWindows"
                     field="winlog.event_id"
+                    isDraggable={isDraggable}
                     value={winlogEventId}
                     isAggregatable={true}
                     fieldType="keyword"
+                    scopeId={scopeId}
                   />
                 </TokensFlexItem>
               )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/exit_code_draggable.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/exit_code_draggable.test.tsx
@@ -35,6 +35,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={-1}
           text="with exit code"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -50,6 +51,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={undefined}
           text="with exit code"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -65,6 +67,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={null}
           text="with exit code"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -80,6 +83,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={undefined}
           text="with exit code"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -95,6 +99,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={undefined}
           text={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -110,6 +115,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={-1}
           text={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -125,6 +131,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={undefined}
           text={null}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -140,6 +147,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={-1}
           text={null}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -155,6 +163,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={undefined}
           text=""
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -170,6 +179,7 @@ describe('ExitCodeDraggable', () => {
           eventId="1"
           processExitCode={-1}
           text=""
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/exit_code_draggable.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/exit_code_draggable.tsx
@@ -18,10 +18,11 @@ interface Props {
   isDraggable?: boolean;
   processExitCode: number | null | undefined;
   text: string | null | undefined;
+  scopeId: string;
 }
 
 export const ExitCodeDraggable = React.memo<Props>(
-  ({ contextId, endgameExitCode, eventId, isDraggable, processExitCode, text }) => {
+  ({ contextId, endgameExitCode, eventId, isDraggable, processExitCode, text, scopeId }) => {
     if (isNillEmptyOrNotFinite(processExitCode) && isNillEmptyOrNotFinite(endgameExitCode)) {
       return null;
     }
@@ -44,6 +45,7 @@ export const ExitCodeDraggable = React.memo<Props>(
               value={`${processExitCode}`}
               fieldType="number"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}
@@ -58,6 +60,7 @@ export const ExitCodeDraggable = React.memo<Props>(
               value={endgameExitCode}
               fieldType="number"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_draggable.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_draggable.test.tsx
@@ -37,6 +37,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath="[fileExtOriginalPath]"
           fileName="[fileName]"
           filePath="[filePath]"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -56,6 +57,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath={undefined}
           fileName={undefined}
           filePath={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -73,6 +75,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath={undefined}
           fileName={undefined}
           filePath={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -90,6 +93,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath={undefined}
           fileName={undefined}
           filePath={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -107,6 +111,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath={undefined}
           fileName="[fileName]"
           filePath={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -124,6 +129,7 @@ describe('FileDraggable', () => {
           fileExtOriginalPath={undefined}
           fileName={undefined}
           filePath="[filePath]"
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_draggable.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_draggable.tsx
@@ -21,6 +21,7 @@ interface Props {
   filePath: string | null | undefined;
   fileExtOriginalPath: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const FileDraggable = React.memo<Props>(
@@ -33,6 +34,7 @@ export const FileDraggable = React.memo<Props>(
     fileName,
     filePath,
     isDraggable,
+    scopeId,
   }) => {
     if (
       isNillEmptyOrNotFinite(fileName) &&
@@ -59,6 +61,7 @@ export const FileDraggable = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         ) : !isNillEmptyOrNotFinite(endgameFileName) ? (
@@ -72,6 +75,7 @@ export const FileDraggable = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         ) : null}
@@ -93,6 +97,7 @@ export const FileDraggable = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         ) : !isNillEmptyOrNotFinite(endgameFilePath) ? (
@@ -106,6 +111,7 @@ export const FileDraggable = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         ) : null}
@@ -125,6 +131,7 @@ export const FileDraggable = React.memo<Props>(
                 iconType="document"
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </TokensFlexItem>
           </>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_hash.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_hash.test.tsx
@@ -35,7 +35,7 @@ describe('FileHash', () => {
   test('displays the fileHashSha256 when provided', () => {
     const wrapper = mount(
       <TestProviders>
-        <FileHash {...allProps} fileHashSha256="[fileHashSha256]" />
+        <FileHash {...allProps} fileHashSha256="[fileHashSha256]" scopeId="test" />
       </TestProviders>
     );
     expect(wrapper.text()).toEqual('[fileHashSha256]');
@@ -44,7 +44,7 @@ describe('FileHash', () => {
   test('displays nothing when fileHashSha256 is null', () => {
     const wrapper = mount(
       <TestProviders>
-        <FileHash {...allProps} fileHashSha256={null} />
+        <FileHash {...allProps} fileHashSha256={null} scopeId="test" />
       </TestProviders>
     );
     expect(wrapper.text()).toEqual('');
@@ -53,7 +53,7 @@ describe('FileHash', () => {
   test('displays nothing when fileHashSha256 is undefined', () => {
     const wrapper = mount(
       <TestProviders>
-        <FileHash {...allProps} />
+        <FileHash {...allProps} scopeId="test" />
       </TestProviders>
     );
     expect(wrapper.text()).toEqual('');

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_hash.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/file_hash.tsx
@@ -22,29 +22,33 @@ interface Props {
   eventId: string;
   fileHashSha256: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
-export const FileHash = React.memo<Props>(({ contextId, eventId, fileHashSha256, isDraggable }) => {
-  if (isNillEmptyOrNotFinite(fileHashSha256)) {
-    return null;
-  }
+export const FileHash = React.memo<Props>(
+  ({ contextId, eventId, fileHashSha256, isDraggable, scopeId }) => {
+    if (isNillEmptyOrNotFinite(fileHashSha256)) {
+      return null;
+    }
 
-  return (
-    <HashFlexGroup alignItems="center" direction="column" gutterSize="none">
-      <TokensFlexItem grow={false} component="div">
-        <DraggableBadge
-          contextId={contextId}
-          eventId={eventId}
-          field="file.hash.sha256"
-          isDraggable={isDraggable}
-          iconType="number"
-          value={fileHashSha256}
-          isAggregatable={true}
-          fieldType="keyword"
-        />
-      </TokensFlexItem>
-    </HashFlexGroup>
-  );
-});
+    return (
+      <HashFlexGroup alignItems="center" direction="column" gutterSize="none">
+        <TokensFlexItem grow={false} component="div">
+          <DraggableBadge
+            contextId={contextId}
+            eventId={eventId}
+            field="file.hash.sha256"
+            isDraggable={isDraggable}
+            iconType="number"
+            value={fileHashSha256}
+            isAggregatable={true}
+            fieldType="keyword"
+            scopeId={scopeId}
+          />
+        </TokensFlexItem>
+      </HashFlexGroup>
+    );
+  }
+);
 
 FileHash.displayName = 'FileHash';

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_name.test.tsx
@@ -81,6 +81,7 @@ describe('HostName', () => {
     fieldType: 'keyword',
     isAggregatable: true,
     value: 'Mock Host',
+    scopeId: 'test',
   };
 
   let toggleExpandedDetail: jest.SpyInstance;

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_working_dir.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_working_dir.test.tsx
@@ -33,6 +33,7 @@ describe('HostWorkingDir', () => {
         contextId="test"
         hostName="[hostname-123]"
         workingDirectory="[working-directory-123]"
+        scopeId="test"
       />
     );
     expect(wrapper).toMatchSnapshot();
@@ -47,6 +48,7 @@ describe('HostWorkingDir', () => {
             contextId="test"
             hostName="[hostname-123]"
             workingDirectory={undefined}
+            scopeId="test"
           />
         </div>
       </TestProviders>
@@ -64,6 +66,7 @@ describe('HostWorkingDir', () => {
             contextId="test"
             hostName="[hostname-123]"
             workingDirectory={null}
+            scopeId="test"
           />
         </div>
       </TestProviders>
@@ -81,6 +84,7 @@ describe('HostWorkingDir', () => {
             contextId="test"
             hostName={undefined}
             workingDirectory="[working-directory-123]"
+            scopeId="test"
           />
         </div>
       </TestProviders>
@@ -98,6 +102,7 @@ describe('HostWorkingDir', () => {
             contextId="test"
             hostName={null}
             workingDirectory="[working-directory-123]"
+            scopeId="test"
           />
         </div>
       </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_working_dir.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/host_working_dir.tsx
@@ -18,10 +18,11 @@ interface Props {
   hostName: string | null | undefined;
   workingDirectory: string | null | undefined;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const HostWorkingDir = React.memo<Props>(
-  ({ contextId, eventId, hostName, workingDirectory, isDraggable }) => (
+  ({ contextId, eventId, hostName, workingDirectory, isDraggable, scopeId }) => (
     <>
       <TokensFlexItem grow={false} component="span">
         <DraggableBadge
@@ -32,6 +33,7 @@ export const HostWorkingDir = React.memo<Props>(
           isDraggable={isDraggable}
           fieldType="keyword"
           isAggregatable={true}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
       {workingDirectory != null && (
@@ -49,6 +51,7 @@ export const HostWorkingDir = React.memo<Props>(
           isDraggable={isDraggable}
           fieldType="keyword"
           isAggregatable={true}
+          scopeId={scopeId}
         />
       </TokensFlexItem>
     </>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/netflow.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/netflow.tsx
@@ -59,14 +59,14 @@ import {
 
 interface NetflowRendererProps {
   data: Ecs;
-  timelineId: string;
+  scopeId: string;
   isDraggable?: boolean;
 }
 
 export const NetflowRenderer = React.memo<NetflowRendererProps>(
-  ({ data, timelineId, isDraggable }) => (
+  ({ data, scopeId, isDraggable }) => (
     <Netflow
-      contextId={`netflow-renderer-${timelineId}-${data._id}`}
+      contextId={`netflow-renderer-${scopeId}-${data._id}`}
       destinationBytes={asArrayIfExists(get(DESTINATION_BYTES_FIELD_NAME, data))}
       destinationGeoContinentName={asArrayIfExists(
         get(DESTINATION_GEO_CONTINENT_NAME_FIELD_NAME, data)
@@ -110,6 +110,7 @@ export const NetflowRenderer = React.memo<NetflowRendererProps>(
       )}
       transport={asArrayIfExists(get(NETWORK_TRANSPORT_FIELD_NAME, data))}
       userName={undefined}
+      scopeId={scopeId}
     />
   )
 );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/netflow/netflow_row_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/netflow/netflow_row_renderer.tsx
@@ -142,6 +142,7 @@ export const netflowRowRenderer: RowRenderer = {
           )}
           transport={asArrayIfExists(get(NETWORK_TRANSPORT_FIELD_NAME, data))}
           userName={asArrayIfExists(get(USER_NAME_FIELD_NAME, data))}
+          scopeId={scopeId}
         />
       </Details>
     </RowRendererContainer>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parent_process_draggable.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parent_process_draggable.test.tsx
@@ -37,6 +37,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={789}
           processPpid={456}
           text="via parent process"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -56,6 +57,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={undefined}
           processPpid={undefined}
           text="via parent process"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -73,6 +75,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={undefined}
           processPpid={undefined}
           text="via parent process"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -90,6 +93,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={undefined}
           processPpid={undefined}
           text="via parent process"
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -107,6 +111,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={undefined}
           processPpid={undefined}
           text={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -124,6 +129,7 @@ describe('ParentProcessDraggable', () => {
           processParentPid={undefined}
           processPpid={undefined}
           text={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parent_process_draggable.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/parent_process_draggable.tsx
@@ -20,6 +20,7 @@ interface Props {
   processParentName: string | null | undefined;
   processPpid: number | undefined | null;
   text: string | null | undefined;
+  scopeId: string;
 }
 
 export const ParentProcessDraggable = React.memo<Props>(
@@ -32,6 +33,7 @@ export const ParentProcessDraggable = React.memo<Props>(
     processParentPid,
     processPpid,
     text,
+    scopeId,
   }) => {
     if (
       isNillEmptyOrNotFinite(processParentName) &&
@@ -62,6 +64,7 @@ export const ParentProcessDraggable = React.memo<Props>(
               value={processParentName}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}
@@ -76,6 +79,7 @@ export const ParentProcessDraggable = React.memo<Props>(
               value={endgameParentProcessName}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}
@@ -91,6 +95,7 @@ export const ParentProcessDraggable = React.memo<Props>(
               value={`(${String(processParentPid)})`}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}
@@ -106,6 +111,7 @@ export const ParentProcessDraggable = React.memo<Props>(
               value={`(${String(processPpid)})`}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_draggable.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_draggable.test.tsx
@@ -37,6 +37,7 @@ describe('ProcessDraggable', () => {
           processExecutable="process-executable-1"
           processName="process-name-1"
           processPid={123}
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -52,6 +53,7 @@ describe('ProcessDraggable', () => {
           processExecutable={null}
           processName={null}
           processPid={null}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -67,6 +69,7 @@ describe('ProcessDraggable', () => {
           processExecutable={undefined}
           processName={undefined}
           processPid={undefined}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -83,6 +86,7 @@ describe('ProcessDraggable', () => {
             processExecutable={undefined}
             processName="[process-name]"
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -100,6 +104,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName={null}
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -117,6 +122,7 @@ describe('ProcessDraggable', () => {
             processExecutable={null}
             processName={null}
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -134,6 +140,7 @@ describe('ProcessDraggable', () => {
             processExecutable=""
             processName="[process-name]"
             processPid={NaN}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -151,6 +158,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName=""
             processPid={NaN}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -168,6 +176,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName=""
             processPid={NaN}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -185,6 +194,7 @@ describe('ProcessDraggable', () => {
             processExecutable=""
             processName=""
             processPid={NaN}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -202,6 +212,7 @@ describe('ProcessDraggable', () => {
             processExecutable=""
             processName=""
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -219,6 +230,7 @@ describe('ProcessDraggable', () => {
             processExecutable=""
             processName=""
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -236,6 +248,7 @@ describe('ProcessDraggable', () => {
             processExecutable=""
             processName=""
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -253,6 +266,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName="[process-name]"
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -270,6 +284,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName={null}
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -287,6 +302,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName={null}
             processPid={null}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -304,6 +320,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName={undefined}
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -321,6 +338,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName=""
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -338,6 +356,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName="[process-name]"
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -355,6 +374,7 @@ describe('ProcessDraggable', () => {
             processExecutable="[process-executable]"
             processName={undefined}
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -372,6 +392,7 @@ describe('ProcessDraggable', () => {
             processExecutable={undefined}
             processName={undefined}
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -389,6 +410,7 @@ describe('ProcessDraggable', () => {
             processExecutable={undefined}
             processName={undefined}
             processPid={123}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -406,6 +428,7 @@ describe('ProcessDraggable', () => {
             processExecutable={undefined}
             processName={undefined}
             processPid={undefined}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -428,6 +451,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable={undefined}
           processName={undefined}
           processPid={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -445,6 +469,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable={undefined}
           processName={undefined}
           processPid={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -462,6 +487,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable={undefined}
           processName={undefined}
           processPid={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -479,6 +505,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable="[processExecutable]"
           processName={undefined}
           processPid={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -496,6 +523,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable={undefined}
           processName="[processName]"
           processPid={undefined}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -513,6 +541,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable={undefined}
           processName={undefined}
           processPid={123}
+          scopeId="test"
         />
       </TestProviders>
     );
@@ -530,6 +559,7 @@ describe('ProcessDraggableWithNonExistentProcess', () => {
           processExecutable="[processExecutable]"
           processName="[processName]"
           processPid={123}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_draggable.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_draggable.tsx
@@ -22,6 +22,7 @@ interface Props {
   processPid: number | undefined | null;
   processName: string | undefined | null;
   isDraggable?: boolean;
+  scopeId: string;
 }
 
 export const ProcessDraggable = React.memo<Props>(
@@ -34,6 +35,7 @@ export const ProcessDraggable = React.memo<Props>(
     processName,
     processPid,
     isDraggable,
+    scopeId,
   }) => {
     if (
       isNillEmptyOrNotFinite(processName) &&
@@ -58,6 +60,7 @@ export const ProcessDraggable = React.memo<Props>(
               isDraggable={isDraggable}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : !isNillEmptyOrNotFinite(processExecutable) ? (
@@ -71,6 +74,7 @@ export const ProcessDraggable = React.memo<Props>(
               isDraggable={isDraggable}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : !isNillEmptyOrNotFinite(endgameProcessName) ? (
@@ -84,6 +88,7 @@ export const ProcessDraggable = React.memo<Props>(
               isDraggable={isDraggable}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : null}
@@ -99,6 +104,7 @@ export const ProcessDraggable = React.memo<Props>(
               isDraggable={isDraggable}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : !isNillEmptyOrNotFinite(endgamePid) ? (
@@ -112,6 +118,7 @@ export const ProcessDraggable = React.memo<Props>(
               isDraggable={isDraggable}
               fieldType="keyword"
               isAggregatable={true}
+              scopeId={scopeId}
             />
           </EuiFlexItem>
         ) : null}
@@ -132,6 +139,7 @@ export const ProcessDraggableWithNonExistentProcess = React.memo<Props>(
     processName,
     processPid,
     isDraggable,
+    scopeId,
   }) => {
     if (
       endgamePid == null &&
@@ -152,6 +160,7 @@ export const ProcessDraggableWithNonExistentProcess = React.memo<Props>(
           processName={processName}
           processPid={processPid}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       );
     }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_hash.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_hash.test.tsx
@@ -27,6 +27,7 @@ const allProps = {
   contextId: 'test',
   eventId: '1',
   processHashSha256: undefined,
+  scopeId: 'test',
 };
 
 describe('ProcessHash', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_hash.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/process_hash.tsx
@@ -22,10 +22,11 @@ interface Props {
   eventId: string;
   isDraggable?: boolean;
   processHashSha256: string | null | undefined;
+  scopeId: string;
 }
 
 export const ProcessHash = React.memo<Props>(
-  ({ contextId, eventId, isDraggable, processHashSha256 }) => {
+  ({ contextId, eventId, isDraggable, processHashSha256, scopeId }) => {
     if (isNillEmptyOrNotFinite(processHashSha256)) {
       return null;
     }
@@ -42,6 +43,7 @@ export const ProcessHash = React.memo<Props>(
             value={processHashSha256}
             fieldType="keyword"
             isAggregatable={true}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
       </HashFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details.test.tsx
@@ -37,6 +37,7 @@ describe('RegistryEventDetails', () => {
           contextId="test-context"
           data={mockEndpointRegistryModificationEvent}
           text={MODIFIED_REGISTRY_KEY}
+          scopeId="test"
         />
       </TestProviders>
     );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details.tsx
@@ -18,9 +18,16 @@ interface Props {
   data: Ecs;
   isDraggable?: boolean;
   text: string;
+  scopeId: string;
 }
 
-const RegistryEventDetailsComponent: React.FC<Props> = ({ contextId, data, isDraggable, text }) => {
+const RegistryEventDetailsComponent: React.FC<Props> = ({
+  contextId,
+  data,
+  isDraggable,
+  text,
+  scopeId,
+}) => {
   const hostName: string | null | undefined = get('host.name[0]', data);
   const id = data._id;
   const processName: string | null | undefined = get('process.name[0]', data);
@@ -48,6 +55,7 @@ const RegistryEventDetailsComponent: React.FC<Props> = ({ contextId, data, isDra
         text={text}
         userDomain={userDomain}
         userName={userName}
+        scopeId={scopeId}
       />
     </Details>
   );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details_line.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details_line.test.tsx
@@ -37,6 +37,7 @@ describe('DnsRequestEventDetailsLine', () => {
     text: MODIFIED_REGISTRY_KEY,
     userDomain: '[userDomain]',
     userName: '[userName]',
+    scopeId: 'test',
   };
 
   test('it renders the expected text when all properties are provided', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details_line.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/registry/registry_event_details_line.tsx
@@ -27,6 +27,7 @@ interface Props {
   text: string;
   userDomain: string | null | undefined;
   userName: string | null | undefined;
+  scopeId: string;
 }
 
 const RegistryEventDetailsLineComponent: React.FC<Props> = ({
@@ -41,6 +42,7 @@ const RegistryEventDetailsLineComponent: React.FC<Props> = ({
   text,
   userDomain,
   userName,
+  scopeId,
 }) => {
   const registryKeyTooltipContent = useMemo(
     () => (
@@ -77,6 +79,7 @@ const RegistryEventDetailsLineComponent: React.FC<Props> = ({
           userDomain={userDomain}
           userName={userName}
           workingDirectory={undefined}
+          scopeId={scopeId}
         />
 
         {!isNillEmptyOrNotFinite(registryKey) && (
@@ -94,6 +97,7 @@ const RegistryEventDetailsLineComponent: React.FC<Props> = ({
                 value={registryKey}
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </TokensFlexItem>
           </>
@@ -114,6 +118,7 @@ const RegistryEventDetailsLineComponent: React.FC<Props> = ({
                 value={registryPath}
                 isAggregatable={true}
                 fieldType="keyword"
+                scopeId={scopeId}
               />
             </TokensFlexItem>
           </>
@@ -133,6 +138,7 @@ const RegistryEventDetailsLineComponent: React.FC<Props> = ({
             processPid={processPid}
             processName={processName}
             processExecutable={undefined}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_details.test.tsx
@@ -38,14 +38,14 @@ describe('SuricataDetails', () => {
   };
   describe('rendering', () => {
     test('it renders the default SuricataDetails', () => {
-      const wrapper = shallow(<SuricataDetails data={mockTimelineData[2].ecs} timelineId="test" />);
+      const wrapper = shallow(<SuricataDetails data={mockTimelineData[2].ecs} scopeId="test" />);
       expect(wrapper).toMatchSnapshot();
     });
 
     test('it returns text if the data does contain suricata data', async () => {
       const wrapper = await getWrapper(
         <TestProviders>
-          <SuricataDetails data={mockTimelineData[2].ecs} timelineId="test" />
+          <SuricataDetails data={mockTimelineData[2].ecs} scopeId="test" />
         </TestProviders>
       );
       const removeEuiIconText = removeExternalLinkText(wrapper.text()).replaceAll(
@@ -58,7 +58,7 @@ describe('SuricataDetails', () => {
     });
 
     test('it returns null for text if the data contains no suricata data', () => {
-      const wrapper = shallow(<SuricataDetails data={mockTimelineData[0].ecs} timelineId="test" />);
+      const wrapper = shallow(<SuricataDetails data={mockTimelineData[0].ecs} scopeId="test" />);
       expect(wrapper.isEmptyRender()).toBeTruthy();
     });
   });

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_details.tsx
@@ -25,8 +25,8 @@ Details.displayName = 'Details';
 export const SuricataDetails = React.memo<{
   data: Ecs;
   isDraggable?: boolean;
-  timelineId: string;
-}>(({ data, isDraggable, timelineId }) => {
+  scopeId: string;
+}>(({ data, isDraggable, scopeId }) => {
   const signature: string | null | undefined = get('suricata.eve.alert.signature[0]', data);
   const signatureId: number | null | undefined = get('suricata.eve.alert.signature_id[0]', data);
 
@@ -34,15 +34,16 @@ export const SuricataDetails = React.memo<{
     return (
       <Details>
         <SuricataSignature
-          contextId={`suricata-signature-${timelineId}-${data._id}`}
+          contextId={`suricata-signature-${scopeId}-${data._id}`}
           id={data._id}
           isDraggable={isDraggable}
           signature={signature}
           signatureId={signatureId}
+          scopeId={scopeId}
         />
         <SuricataRefs signatureId={signatureId} />
         <EuiSpacer size="s" />
-        <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+        <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
       </Details>
     );
   } else {

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_row_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_row_renderer.tsx
@@ -22,7 +22,7 @@ export const suricataRowRenderer: RowRenderer = {
   },
   renderRow: ({ data, isDraggable, scopeId }) => (
     <RowRendererContainer>
-      <SuricataDetails data={data} isDraggable={isDraggable} timelineId={scopeId} />
+      <SuricataDetails data={data} isDraggable={isDraggable} scopeId={scopeId} />
     </RowRendererContainer>
   ),
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_signature.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_signature.test.tsx
@@ -39,6 +39,7 @@ describe('SuricataSignature', () => {
           id="doc-id-123"
           signatureId={123}
           signature="ET SCAN ATTACK Hello"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -74,7 +75,7 @@ describe('SuricataSignature', () => {
     test('it renders the default SuricataSignature', () => {
       const wrapper = mount(
         <TestProviders>
-          <DraggableSignatureId id="id-123" signatureId={123} />
+          <DraggableSignatureId id="id-123" signatureId={123} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.text()).toEqual('123');
@@ -83,7 +84,7 @@ describe('SuricataSignature', () => {
     test('it renders a tooltip for the signature field', () => {
       const wrapper = mount(
         <TestProviders>
-          <DraggableSignatureId id="id-123" signatureId={123} />
+          <DraggableSignatureId id="id-123" signatureId={123} scopeId="test" />
         </TestProviders>
       );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_signature.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/suricata/suricata_signature.tsx
@@ -62,7 +62,8 @@ export const DraggableSignatureId = React.memo<{
   id: string;
   isDraggable?: boolean;
   signatureId: number;
-}>(({ id, isDraggable, signatureId }) => {
+  scopeId: string;
+}>(({ id, isDraggable, signatureId, scopeId }) => {
   const dataProviderProp = useMemo(
     () => ({
       and: [],
@@ -107,6 +108,7 @@ export const DraggableSignatureId = React.memo<{
         render={render}
         isAggregatable={true}
         fieldType={'keyword'}
+        scopeId={scopeId}
       />
     </SignatureFlexItem>
   );
@@ -120,7 +122,8 @@ export const SuricataSignature = React.memo<{
   isDraggable?: boolean;
   signature: string;
   signatureId: number;
-}>(({ contextId, id, isDraggable, signature, signatureId }) => {
+  scopeId: string;
+}>(({ contextId, id, isDraggable, signature, signatureId, scopeId }) => {
   const tokens = getBeginningTokens(signature);
   return (
     <EuiFlexGroup justifyContent="center" gutterSize="none" wrap={true}>
@@ -128,6 +131,7 @@ export const SuricataSignature = React.memo<{
         id={`draggable-signature-id-${contextId}-${id}`}
         isDraggable={isDraggable}
         signatureId={signatureId}
+        scopeId={scopeId}
       />
       <Tokens tokens={tokens} />
       <LinkFlexItem grow={false}>
@@ -138,6 +142,7 @@ export const SuricataSignature = React.memo<{
           isDraggable={isDraggable}
           value={signature}
           tooltipPosition="bottom"
+          scopeId={scopeId}
         >
           <div>
             <GoogleLink link={signature}>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/auth_ssh.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/auth_ssh.test.tsx
@@ -20,6 +20,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature="[ssh-signature]"
           sshMethod="[ssh-method]"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -32,6 +33,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature={null}
           sshMethod={null}
+          scopeId="test"
         />
       );
       expect(wrapper.children().length).toEqual(0);
@@ -44,6 +46,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature={undefined}
           sshMethod={undefined}
+          scopeId="test"
         />
       );
       expect(wrapper.children().length).toEqual(0);
@@ -56,6 +59,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature={null}
           sshMethod={undefined}
+          scopeId="test"
         />
       );
       expect(wrapper.children().length).toEqual(0);
@@ -68,6 +72,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature={undefined}
           sshMethod={null}
+          scopeId="test"
         />
       );
       expect(wrapper.children().length).toEqual(0);
@@ -79,6 +84,7 @@ describe('AuthSsh', () => {
           contextId="[context-123]"
           eventId="[event-123]"
           sshSignature="[sshSignature-1]"
+          scopeId="test"
           sshMethod={null}
         />
       );
@@ -92,6 +98,7 @@ describe('AuthSsh', () => {
           eventId="[event-123]"
           sshSignature={null}
           sshMethod="[sshMethod-1]"
+          scopeId="test"
         />
       );
       expect(wrapper.find('DraggableBadge').prop('value')).toEqual('[sshMethod-1]');

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/auth_ssh.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/auth_ssh.tsx
@@ -14,12 +14,13 @@ interface Props {
   contextId: string;
   eventId: string;
   isDraggable?: boolean;
+  scopeId: string;
   sshSignature: string | null | undefined;
   sshMethod: string | null | undefined;
 }
 
 export const AuthSsh = React.memo<Props>(
-  ({ contextId, eventId, isDraggable, sshSignature, sshMethod }) => (
+  ({ contextId, eventId, isDraggable, sshSignature, sshMethod, scopeId }) => (
     <>
       {sshSignature != null && (
         <TokensFlexItem grow={false} component="span">
@@ -32,6 +33,7 @@ export const AuthSsh = React.memo<Props>(
             iconType="document"
             isAggregatable={true}
             fieldType="keyword"
+            scopeId={scopeId}
           />
         </TokensFlexItem>
       )}
@@ -46,6 +48,7 @@ export const AuthSsh = React.memo<Props>(
             iconType="document"
             isAggregatable={true}
             fieldType="keyword"
+            scopeId={scopeId}
           />
         </TokensFlexItem>
       )}

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_details.test.tsx
@@ -35,7 +35,7 @@ describe('SystemGenericDetails', () => {
           contextId="[contextid-123]"
           text="[generic-text-123]"
           data={mockTimelineData[28].ecs}
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -48,7 +48,7 @@ describe('SystemGenericDetails', () => {
             contextId="[contextid-123]"
             text="[generic-text-123]"
             data={mockTimelineData[28].ecs}
-            timelineId="test"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -81,6 +81,7 @@ describe('SystemGenericDetails', () => {
               userDomain="[userDomain-123]"
               userName="[username-123]"
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -112,6 +113,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -141,6 +143,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -170,6 +173,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -199,6 +203,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -228,6 +233,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -259,6 +265,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -290,6 +297,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -321,6 +329,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -352,6 +361,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -383,6 +393,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -414,6 +425,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -445,6 +457,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -476,6 +489,7 @@ describe('SystemGenericDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -507,6 +521,7 @@ describe('SystemGenericDetails', () => {
               userDomain="[userDomain-123]"
               userName="[username-123]"
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -538,6 +553,7 @@ describe('SystemGenericDetails', () => {
               userDomain="[userDomain-123]"
               userName="[username-123]"
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_details.tsx
@@ -35,6 +35,7 @@ interface Props {
   processExecutable: string | null | undefined;
   processPid: number | null | undefined;
   processName: string | null | undefined;
+  scopeId: string;
   sshMethod: string | null | undefined;
   sshSignature: string | null | undefined;
   text: string | null | undefined;
@@ -57,6 +58,7 @@ export const SystemGenericLine = React.memo<Props>(
     processPid,
     processName,
     processExecutable,
+    scopeId,
     sshSignature,
     sshMethod,
     text,
@@ -74,6 +76,7 @@ export const SystemGenericLine = React.memo<Props>(
           userDomain={userDomain}
           userName={userName}
           workingDirectory={workingDirectory}
+          scopeId={scopeId}
         />
         <TokensFlexItem grow={false} component="span">
           {text}
@@ -88,6 +91,7 @@ export const SystemGenericLine = React.memo<Props>(
             processPid={processPid}
             processName={processName}
             processExecutable={processExecutable}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
         {outcome != null && (
@@ -105,6 +109,7 @@ export const SystemGenericLine = React.memo<Props>(
             value={outcome}
             isAggregatable={true}
             fieldType="keyword"
+            scopeId={scopeId}
           />
         </TokensFlexItem>
         <AuthSsh
@@ -113,6 +118,7 @@ export const SystemGenericLine = React.memo<Props>(
           isDraggable={isDraggable}
           sshSignature={sshSignature}
           sshMethod={sshMethod}
+          scopeId={scopeId}
         />
         <Package
           contextId={contextId}
@@ -121,6 +127,7 @@ export const SystemGenericLine = React.memo<Props>(
           packageName={packageName}
           packageSummary={packageSummary}
           packageVersion={packageVersion}
+          scopeId={scopeId}
         />
       </EuiFlexGroup>
       {message != null && (
@@ -146,11 +153,11 @@ interface GenericDetailsProps {
   data: Ecs;
   isDraggable?: boolean;
   text: string;
-  timelineId: string;
+  scopeId: string;
 }
 
 export const SystemGenericDetails = React.memo<GenericDetailsProps>(
-  ({ contextId, data, isDraggable, text, timelineId }) => {
+  ({ contextId, data, isDraggable, text, scopeId }) => {
     const id = data._id;
     const message: string | null = data.message != null ? data.message[0] : null;
     const hostName: string | null | undefined = get('host.name[0]', data);
@@ -188,9 +195,10 @@ export const SystemGenericDetails = React.memo<GenericDetailsProps>(
           userDomain={userDomain}
           userName={userName}
           workingDirectory={workingDirectory}
+          scopeId={scopeId}
         />
         <EuiSpacer size="s" />
-        <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+        <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
       </Details>
     );
   }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_file_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_file_details.test.tsx
@@ -46,7 +46,7 @@ describe('SystemGenericFileDetails', () => {
           contextId="[contextid-123]"
           text="[generic-text-123]"
           data={mockTimelineData[29].ecs}
-          timelineId="test"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -59,7 +59,7 @@ describe('SystemGenericFileDetails', () => {
             contextId="[contextid-123]"
             text="[generic-text-123]"
             data={mockTimelineData[29].ecs}
-            timelineId="test"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -75,7 +75,7 @@ describe('SystemGenericFileDetails', () => {
             contextId="[contextid-123]"
             text="[generic-text-123]"
             data={mockEndgameCreationEvent}
-            timelineId="test"
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -127,6 +127,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain="[userDomain-123]"
               userName="[username-123]"
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -177,6 +178,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={null}
               userName={null}
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -225,6 +227,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -273,6 +276,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -321,6 +325,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -371,6 +376,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -421,6 +427,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -471,6 +478,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -521,6 +529,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -571,6 +580,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -621,6 +631,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -671,6 +682,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -721,6 +733,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -771,6 +784,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -821,6 +835,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -871,6 +886,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -921,6 +937,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -971,6 +988,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1021,6 +1039,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1071,6 +1090,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory={null}
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1121,6 +1141,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory="[working-directory-123]"
               processTitle={null}
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1171,6 +1192,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory="[working-directory-123]"
               processTitle="[process-title-123]"
               args={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1221,6 +1243,7 @@ describe('SystemGenericFileDetails', () => {
               workingDirectory="[working-directory-123]"
               processTitle="[process-title-123]"
               args={['[arg-1]', '[arg-2]', '[arg-3]']}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1271,6 +1294,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1319,6 +1343,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1369,6 +1394,7 @@ describe('SystemGenericFileDetails', () => {
                 userDomain={undefined}
                 userName={undefined}
                 workingDirectory={undefined}
+                scopeId="test"
               />
             </div>
           </TestProviders>
@@ -1421,6 +1447,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1472,6 +1499,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1525,6 +1553,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1576,6 +1605,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1625,6 +1655,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1674,6 +1705,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1723,6 +1755,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -1772,6 +1805,7 @@ describe('SystemGenericFileDetails', () => {
               userDomain={undefined}
               userName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_file_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_file_details.tsx
@@ -68,6 +68,7 @@ interface Props {
   userDomain: string | null | undefined;
   userName: string | null | undefined;
   workingDirectory: string | null | undefined;
+  scopeId: string;
 }
 
 export const SystemGenericFileLine = React.memo<Props>(
@@ -111,6 +112,7 @@ export const SystemGenericFileLine = React.memo<Props>(
     userDomain,
     userName,
     workingDirectory,
+    scopeId,
   }) => (
     <>
       <EuiFlexGroup alignItems="center" justifyContent="center" gutterSize="none" wrap={true}>
@@ -122,6 +124,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           userName={userName}
           workingDirectory={workingDirectory}
           hostName={hostName}
+          scopeId={scopeId}
         />
         <TokensFlexItem grow={false} component="span">
           {text}
@@ -137,6 +140,7 @@ export const SystemGenericFileLine = React.memo<Props>(
             fileName={fileName}
             filePath={filePath}
             isDraggable={isDraggable}
+            scopeId={scopeId}
           />
         )}
         {showVia(eventAction) && (
@@ -154,6 +158,7 @@ export const SystemGenericFileLine = React.memo<Props>(
             processPid={processPid}
             processName={processName}
             processExecutable={processExecutable}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
         <Args
@@ -162,6 +167,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           eventId={id}
           processTitle={processTitle}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
         <ExitCodeDraggable
           contextId={contextId}
@@ -170,6 +176,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           isDraggable={isDraggable}
           processExitCode={processExitCode}
           text={i18n.WITH_EXIT_CODE}
+          scopeId={scopeId}
         />
         {!isProcessStoppedOrTerminationEvent(eventAction) && (
           <ParentProcessDraggable
@@ -181,6 +188,7 @@ export const SystemGenericFileLine = React.memo<Props>(
             processParentPid={processParentPid}
             processPpid={processPpid}
             text={i18n.VIA_PARENT_PROCESS}
+            scopeId={scopeId}
           />
         )}
         {outcome != null && (
@@ -198,6 +206,7 @@ export const SystemGenericFileLine = React.memo<Props>(
             value={outcome}
             isAggregatable={true}
             fieldType="keyword"
+            scopeId={scopeId}
           />
         </TokensFlexItem>
         <AuthSsh
@@ -206,6 +215,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           isDraggable={isDraggable}
           sshSignature={sshSignature}
           sshMethod={sshMethod}
+          scopeId={scopeId}
         />
         <Package
           contextId={contextId}
@@ -214,6 +224,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           packageName={packageName}
           packageSummary={packageSummary}
           packageVersion={packageVersion}
+          scopeId={scopeId}
         />
       </EuiFlexGroup>
       {!skipRedundantFileDetails && (
@@ -222,6 +233,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           eventId={id}
           fileHashSha256={fileHashSha256}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
       )}
       {!skipRedundantProcessDetails && (
@@ -230,6 +242,7 @@ export const SystemGenericFileLine = React.memo<Props>(
           eventId={id}
           isDraggable={isDraggable}
           processHashSha256={processHashSha256}
+          scopeId={scopeId}
         />
       )}
 
@@ -259,7 +272,7 @@ interface GenericDetailsProps {
   skipRedundantFileDetails?: boolean;
   skipRedundantProcessDetails?: boolean;
   text: string;
-  timelineId: string;
+  scopeId: string;
 }
 
 export const SystemGenericFileDetails = React.memo<GenericDetailsProps>(
@@ -271,7 +284,7 @@ export const SystemGenericFileDetails = React.memo<GenericDetailsProps>(
     skipRedundantFileDetails = false,
     skipRedundantProcessDetails = false,
     text,
-    timelineId,
+    scopeId,
   }) => {
     const id = data._id;
     const message: string | null = data.message != null ? data.message[0] : null;
@@ -352,9 +365,10 @@ export const SystemGenericFileDetails = React.memo<GenericDetailsProps>(
           sshMethod={sshMethod}
           outcome={outcome}
           isDraggable={isDraggable}
+          scopeId={scopeId}
         />
         <EuiSpacer size="s" />
-        <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+        <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
       </Details>
     );
   }

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_row_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/generic_row_renderer.tsx
@@ -46,7 +46,7 @@ export const createGenericSystemRowRenderer = ({
         data={data}
         isDraggable={isDraggable}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -78,7 +78,7 @@ export const createEndgameProcessRowRenderer = ({
         isDraggable={isDraggable}
         showMessage={false}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -109,7 +109,7 @@ export const createFimRowRenderer = ({
         isDraggable={isDraggable}
         showMessage={false}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -160,7 +160,7 @@ export const createEndpointAlertsRowRenderer = ({
         skipRedundantFileDetails={skipRedundantFileDetails}
         skipRedundantProcessDetails={skipRedundantProcessDetails}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -189,7 +189,7 @@ export const createEndpointLibraryRowRenderer = ({
         isDraggable={isDraggable}
         showMessage={false}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -220,7 +220,7 @@ export const createGenericFileRowRenderer = ({
         data={data}
         isDraggable={isDraggable}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -245,7 +245,7 @@ export const createSocketRowRenderer = ({
         data={data}
         isDraggable={isDraggable}
         text={text}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -273,7 +273,7 @@ export const createSecurityEventRowRenderer = ({
         contextId={`authentication-${actionName}-${scopeId}`}
         data={data}
         isDraggable={isDraggable}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -292,7 +292,7 @@ export const createDnsRowRenderer = (): RowRenderer => ({
         contextId={`dns-request-${scopeId}`}
         data={data}
         isDraggable={isDraggable}
-        timelineId={scopeId}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),
@@ -321,6 +321,7 @@ export const createEndpointRegistryRowRenderer = ({
         data={data}
         isDraggable={isDraggable}
         text={text}
+        scopeId={scopeId}
       />
     </RowRendererContainer>
   ),

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/package.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/package.test.tsx
@@ -35,6 +35,7 @@ describe('Package', () => {
           packageName="package-name-123"
           packageSummary="package-summary-123"
           packageVersion="package-version-123"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -48,6 +49,7 @@ describe('Package', () => {
           packageName={null}
           packageSummary={null}
           packageVersion={null}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -61,6 +63,7 @@ describe('Package', () => {
           packageName={undefined}
           packageSummary={undefined}
           packageVersion={undefined}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -76,6 +79,7 @@ describe('Package', () => {
               packageName="[package-name-123]"
               packageSummary={undefined}
               packageVersion={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -93,6 +97,7 @@ describe('Package', () => {
               packageName="[package-name-123]"
               packageSummary="[package-summary-123]"
               packageVersion={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -110,6 +115,7 @@ describe('Package', () => {
               packageName="[package-name-123]"
               packageSummary="[package-summary-123]"
               packageVersion="[package-version-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/package.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/system/package.tsx
@@ -17,10 +17,11 @@ interface Props {
   packageName: string | null | undefined;
   packageSummary: string | null | undefined;
   packageVersion: string | null | undefined;
+  scopeId: string;
 }
 
 export const Package = React.memo<Props>(
-  ({ contextId, eventId, isDraggable, packageName, packageSummary, packageVersion }) => {
+  ({ contextId, eventId, isDraggable, packageName, packageSummary, packageVersion, scopeId }) => {
     if (packageName != null || packageSummary != null || packageVersion != null) {
       return (
         <>
@@ -34,6 +35,7 @@ export const Package = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
           <TokensFlexItem grow={false} component="span">
@@ -46,6 +48,7 @@ export const Package = React.memo<Props>(
               iconType="document"
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
           <TokensFlexItem grow={false} component="span">
@@ -57,6 +60,7 @@ export const Package = React.memo<Props>(
               value={packageSummary}
               isAggregatable={true}
               fieldType="keyword"
+              scopeId={scopeId}
             />
           </TokensFlexItem>
         </>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_host_working_dir.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_host_working_dir.test.tsx
@@ -36,6 +36,7 @@ describe('UserHostWorkingDir', () => {
           userName="[userName-123]"
           hostName="[hostName-123]"
           workingDirectory="[working-directory-123]"
+          scopeId="test"
         />
       );
       expect(wrapper).toMatchSnapshot();
@@ -50,6 +51,7 @@ describe('UserHostWorkingDir', () => {
           userName={null}
           hostName={null}
           workingDirectory={null}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -64,6 +66,7 @@ describe('UserHostWorkingDir', () => {
           userName={undefined}
           hostName={undefined}
           workingDirectory={undefined}
+          scopeId="test"
         />
       );
       expect(wrapper.isEmptyRender()).toBeTruthy();
@@ -80,6 +83,7 @@ describe('UserHostWorkingDir', () => {
               userName={undefined}
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -98,6 +102,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -116,6 +121,7 @@ describe('UserHostWorkingDir', () => {
               userName={null}
               hostName="[host-name-123]"
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -134,6 +140,7 @@ describe('UserHostWorkingDir', () => {
               userName={null}
               hostName={null}
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -152,6 +159,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName={null}
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -170,6 +178,7 @@ describe('UserHostWorkingDir', () => {
               userName={null}
               hostName="[host-name-123]"
               workingDirectory="[working-directory-123]"
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -188,6 +197,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName="[host-name-123]"
               workingDirectory={null}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -206,6 +216,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName="[host-name-123]"
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -226,6 +237,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName="[host-name-123]"
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -246,6 +258,7 @@ describe('UserHostWorkingDir', () => {
               userName={undefined}
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -267,6 +280,7 @@ describe('UserHostWorkingDir', () => {
               userName={undefined}
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -289,6 +303,7 @@ describe('UserHostWorkingDir', () => {
               userName="[user-name-123]"
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>
@@ -310,6 +325,7 @@ describe('UserHostWorkingDir', () => {
               userNameField="overridden.field.name"
               hostName={undefined}
               workingDirectory={undefined}
+              scopeId="test"
             />
           </div>
         </TestProviders>

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_host_working_dir.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/user_host_working_dir.tsx
@@ -22,6 +22,7 @@ interface Props {
   userName: string | null | undefined;
   userNameField?: string;
   workingDirectory: string | null | undefined;
+  scopeId: string;
 }
 
 export const UserHostWorkingDir = React.memo<Props>(
@@ -36,6 +37,7 @@ export const UserHostWorkingDir = React.memo<Props>(
     userName,
     userNameField = 'user.name',
     workingDirectory,
+    scopeId,
   }) =>
     userName != null || userDomain != null || hostName != null || workingDirectory != null ? (
       <>
@@ -49,6 +51,7 @@ export const UserHostWorkingDir = React.memo<Props>(
             iconType="user"
             fieldType="keyword"
             isAggregatable={true}
+            scopeId={scopeId}
           />
         </TokensFlexItem>
 
@@ -70,6 +73,7 @@ export const UserHostWorkingDir = React.memo<Props>(
                 value={userDomain}
                 fieldType="keyword"
                 isAggregatable={true}
+                scopeId={scopeId}
               />
             </TokensFlexItem>
           </>
@@ -86,6 +90,7 @@ export const UserHostWorkingDir = React.memo<Props>(
           hostName={hostName}
           isDraggable={isDraggable}
           workingDirectory={workingDirectory}
+          scopeId={scopeId}
         />
       </>
     ) : null

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_details.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_details.test.tsx
@@ -38,7 +38,7 @@ describe('ZeekDetails', () => {
     test('it renders the default ZeekDetails', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[2].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[2].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.find('ZeekDetails')).toMatchSnapshot();
@@ -47,7 +47,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.connection if the data does contain zeek.connection data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[13].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[13].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(extractEuiIconText(removeExternalLinkText(wrapper.text()))).toEqual(
@@ -58,7 +58,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.dns if the data does contain zeek.dns data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[14].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[14].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(extractEuiIconText(removeExternalLinkText(wrapper.text()))).toEqual(
@@ -69,7 +69,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.http if the data does contain zeek.http data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[15].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[15].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(extractEuiIconText(removeExternalLinkText(wrapper.text()))).toEqual(
@@ -80,7 +80,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.notice if the data does contain zeek.notice data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[16].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[16].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(extractEuiIconText(removeExternalLinkText(wrapper.text()))).toEqual(
@@ -91,7 +91,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.ssl if the data does contain zeek.ssl data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[17].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[17].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(extractEuiIconText(removeExternalLinkText(wrapper.text()))).toEqual(
@@ -102,7 +102,7 @@ describe('ZeekDetails', () => {
     test('it returns zeek.files if the data does contain zeek.files data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[18].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[18].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.text()).toEqual('Cu0n232QMyvNtzb75jfilessha1: fa5195a...md5: f7653f1...');
@@ -111,7 +111,7 @@ describe('ZeekDetails', () => {
     test('it returns null for text if the data contains no zeek data', () => {
       const wrapper = mount(
         <TestProviders>
-          <ZeekDetails data={mockTimelineData[0].ecs} timelineId="test" />
+          <ZeekDetails data={mockTimelineData[0].ecs} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.find('ZeekDetails').children().exists()).toBeFalsy();

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_details.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_details.tsx
@@ -23,15 +23,15 @@ Details.displayName = 'Details';
 interface ZeekDetailsProps {
   data: Ecs;
   isDraggable?: boolean;
-  timelineId: string;
+  scopeId: string;
 }
 
-export const ZeekDetails = React.memo<ZeekDetailsProps>(({ data, isDraggable, timelineId }) =>
+export const ZeekDetails = React.memo<ZeekDetailsProps>(({ data, isDraggable, scopeId }) =>
   data.zeek != null ? (
     <Details>
-      <ZeekSignature data={data} isDraggable={isDraggable} timelineId={timelineId} />
+      <ZeekSignature data={data} isDraggable={isDraggable} scopeId={scopeId} />
       <EuiSpacer size="s" />
-      <NetflowRenderer data={data} isDraggable={isDraggable} timelineId={timelineId} />
+      <NetflowRenderer data={data} isDraggable={isDraggable} scopeId={scopeId} />
     </Details>
   ) : null
 );

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_row_renderer.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_row_renderer.tsx
@@ -22,7 +22,7 @@ export const zeekRowRenderer: RowRenderer = {
   },
   renderRow: ({ data, isDraggable, scopeId }) => (
     <RowRendererContainer>
-      <ZeekDetails data={data} isDraggable={isDraggable} timelineId={scopeId} />
+      <ZeekDetails data={data} isDraggable={isDraggable} scopeId={scopeId} />
     </RowRendererContainer>
   ),
 };

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_signature.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_signature.test.tsx
@@ -48,7 +48,7 @@ describe('ZeekSignature', () => {
 
   describe('rendering', () => {
     test('it renders the default Zeek', () => {
-      const wrapper = shallow(<ZeekSignature data={zeek} timelineId="test" />);
+      const wrapper = shallow(<ZeekSignature data={zeek} scopeId="test" />);
       expect(wrapper).toMatchSnapshot();
     });
   });
@@ -120,7 +120,7 @@ describe('ZeekSignature', () => {
     test('it returns null if value is null', () => {
       const wrapper = mount(
         <TestProviders>
-          <DraggableZeekElement id="id-123" field="zeek.notice" value={null} />
+          <DraggableZeekElement id="id-123" field="zeek.notice" value={null} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.find('DraggableZeekElement').children().exists()).toBeFalsy();
@@ -129,7 +129,7 @@ describe('ZeekSignature', () => {
     test('it renders the default ZeekSignature', () => {
       const wrapper = mount(
         <TestProviders>
-          <DraggableZeekElement id="id-123" field="zeek.notice" value={'mynote'} />
+          <DraggableZeekElement id="id-123" field="zeek.notice" value={'mynote'} scopeId="test" />
         </TestProviders>
       );
       expect(wrapper.text()).toEqual('mynote');
@@ -143,6 +143,7 @@ describe('ZeekSignature', () => {
             field="zeek.notice"
             value={'mynote'}
             stringRenderer={(value) => `->${value}<-`}
+            scopeId="test"
           />
         </TestProviders>
       );
@@ -154,7 +155,12 @@ describe('ZeekSignature', () => {
         const field = 'zeek.notice';
         const wrapper = mount(
           <TestProviders>
-            <DraggableZeekElement id="id-123" field={field} value={'the people you love'} />
+            <DraggableZeekElement
+              id="id-123"
+              field={field}
+              value={'the people you love'}
+              scopeId="test"
+            />
           </TestProviders>
         );
 

--- a/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_signature.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/zeek/zeek_signature.tsx
@@ -71,7 +71,8 @@ export const DraggableZeekElement = React.memo<{
   isDraggable?: boolean;
   value: string | null | undefined;
   stringRenderer?: StringRenderer;
-}>(({ id, field, isDraggable, value, stringRenderer = defaultStringRenderer }) => {
+  scopeId: string;
+}>(({ id, field, isDraggable, value, stringRenderer = defaultStringRenderer, scopeId }) => {
   const dataProviderProp = useMemo(
     () => ({
       and: [],
@@ -113,6 +114,7 @@ export const DraggableZeekElement = React.memo<{
         render={render}
         isAggregatable={true}
         fieldType={'keyword'}
+        scopeId={scopeId}
       />
     </TokensFlexItem>
   ) : null;
@@ -212,11 +214,11 @@ export const constructDroppedValue = (dropped: boolean | null | undefined): stri
 interface ZeekSignatureProps {
   data: Ecs;
   isDraggable?: boolean;
-  timelineId: string;
+  scopeId: string;
 }
 
-export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable, timelineId }) => {
-  const id = `zeek-signature-draggable-zeek-element-${timelineId}-${data._id}`;
+export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable, scopeId }) => {
+  const id = `zeek-signature-draggable-zeek-element-${scopeId}-${data._id}`;
   const sessionId: string | null | undefined = get('zeek.session_id[0]', data);
   const dataSet: string | null | undefined = get('event.dataset[0]', data);
   const sslVersion: string | null | undefined = get('zeek.ssl.version[0]', data);
@@ -248,6 +250,7 @@ export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable
           field="zeek.session_id"
           isDraggable={isDraggable}
           value={sessionId}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
@@ -255,6 +258,7 @@ export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable
           isDraggable={isDraggable}
           value={dataSet}
           stringRenderer={moduleStringRenderer}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
@@ -262,6 +266,7 @@ export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable
           isDraggable={isDraggable}
           value={fileSha1}
           stringRenderer={sha1StringRenderer}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
@@ -269,6 +274,7 @@ export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable
           isDraggable={isDraggable}
           value={filemd5}
           stringRenderer={md5StringRenderer}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
@@ -276,60 +282,70 @@ export const ZeekSignature = React.memo<ZeekSignatureProps>(({ data, isDraggable
           isDraggable={isDraggable}
           value={dropped}
           stringRenderer={droppedStringRenderer}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.ssl.version"
           isDraggable={isDraggable}
           value={sslVersion}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.ssl.cipher"
           isDraggable={isDraggable}
           value={cipher}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.connection.state"
           isDraggable={isDraggable}
           value={state}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="http.request.method"
           isDraggable={isDraggable}
           value={httpMethod}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.connection.history"
           isDraggable={isDraggable}
           value={history}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.notice.note"
           isDraggable={isDraggable}
           value={note}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.dns.query"
           isDraggable={isDraggable}
           value={dnsQuery}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="zeek.dns.qclass_name"
           isDraggable={isDraggable}
           value={qClassName}
+          scopeId={scopeId}
         />
         <DraggableZeekElement
           id={id}
           field="http.response.status_code"
           isDraggable={isDraggable}
           value={httpResponseStatusCode}
+          scopeId={scopeId}
         />
       </EuiFlexGroup>
       <EuiFlexGroup justifyContent="center" gutterSize="none">


### PR DESCRIPTION
Related: https://github.com/elastic/kibana/issues/141026, https://github.com/elastic/kibana/issues/173608

### Background

Row renderers are used when rendering an event, each field in the box is it's own rendering with hover actions, they all utilize [draggable wrapper](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/drag_and_drop/draggable_wrapper.tsx#L318) as the field renderer. Note: top row (red box) is the [alert renderer](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/timelines/components/timeline/body/renderers/alert_renderer/index.tsx#L59), the bottom is an event renderer, which varies depending on the type of events.

![image](https://github.com/elastic/kibana/assets/18648970/c87fe064-4557-450f-b3b2-a33d54585573) 

Event rendering was initially used in timeline and alert table (event rendering view), and was added as 'Alert reason' in the new alert flyout in 8.10+. Since the alert flyout is now available in the rule creation workflow, and it does not have the global KQL bar, we want to limit the filter actions in the hover actions.

**Current state**
- When opening alert flyout in rule preview table -> show full reason, there are different behaviors between alert renderers (hover actions disabled) and event renderers (has hover actions) 
![image](https://github.com/elastic/kibana/assets/18648970/ba8d4b2a-9bc4-4304-9445-071243c0a756)

**Desired state**
- Alert renderers and event renderers behaves the same
- Remove filter in and filter out when flyout is in rule preview

### Summary
`scopeId` is commonly used to check the location/page the component is in and render custom hover actions (as seen [here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx#L221)). A challenge with the row renderer is that although scopeId is being passed at the table/flyout level, the scopeId is missing in the long chain of nested component that eventually being passed to draggable wrapper. This PR explore one way to address the issue by including scopeId in all the event renderer components.

File changes:
- [x] Exclude filter in/filter out hover actions when in rule creation workflow [here](https://github.com/elastic/kibana/pull/174662/files#diff-a3f8e5130025969a6892761a38c7bbd69e289e7686101256fb74f8505a1f85deR225)
- [x] Passing scopeId to row renderers (everything else)

![image](https://github.com/elastic/kibana/assets/18648970/63e60c06-bf32-414e-a21d-6d7521628b29)


**Pros:**
- `scopeId` is already being passed in components that have row renderers i.e. [flyout](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/flyout/document_details/preview/components/alert_reason_preview.tsx#L44)
- hover actions also take scopeId and return customized hover actions ([here](https://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/hover_actions/index.tsx#L132))

**Cons:**
- Prop drilling and passing scopeId in a long chain
- May not make sense to pass a scopeId prop when the property we want to set is hover actions

(WIP) **Limitation & next step**
- This PR does not enforce 'scopeId' to be a required prop, and components not in event renderer but utilize draggable wrapper does not need scopeId. It can be the next step if this approach is selected

### Other ideas/approach proposed:
1. Specify a hover action prop
  - clear what the prop is for and isolate hover action from everything else
  - hover actions must be set when calling the renderer(?) contradict with the useHoverAction logic which is done at the draggable level
2. Use a context to store
 - wrapping a context provider is simpler and likely less LOC
 - it may not be clear to a user that they need to pass a context when using any of the renderer components

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
