### PR TITLE
[Lens] Updates the tests to use esql queries instead of sql

### DIFF
--- a/x-pack/plugins/lens/public/datasources/text_based/components/datapanel.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/components/datapanel.test.tsx
@@ -106,7 +106,7 @@ const initialState: TextBasedPrivateState = {
     first: {
       index: '1',
       columns: [],
-      query: { esql: 'SELECT * FROM foo' },
+      query: { esql: 'FROM foo' },
     },
   },
   indexPatternRefs: [
@@ -116,7 +116,7 @@ const initialState: TextBasedPrivateState = {
   ],
 };
 
-addColumnsToCache({ esql: 'SELECT * FROM my-fake-index-pattern' }, fieldsFromQuery);
+addColumnsToCache({ esql: 'FROM my-fake-index-pattern' }, fieldsFromQuery);
 
 function getFrameAPIMock({
   indexPatterns,
@@ -190,7 +190,7 @@ describe('TextBased Query Languages Data Panel', () => {
         fromDate: 'now-7d',
         toDate: 'now',
       },
-      query: { esql: 'SELECT * FROM my-fake-index-pattern' } as unknown as Query,
+      query: { esql: 'FROM my-fake-index-pattern' } as unknown as Query,
       filters: [],
       showNoDataPopover: jest.fn(),
       dropOntoWorkspace: jest.fn(),

--- a/x-pack/plugins/lens/public/datasources/text_based/dnd/mocks.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/dnd/mocks.tsx
@@ -152,7 +152,7 @@ export const defaultProps = {
       first: {
         index: 'indexId',
         query: {
-          esql: 'SELECT * FROM "kibana_sample_data_ecommerce"',
+          esql: 'FROM "kibana_sample_data_ecommerce"',
         },
         columns: [column1, column2, column3],
         errors: [],

--- a/x-pack/plugins/lens/public/datasources/text_based/dnd/on_drop.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/dnd/on_drop.test.ts
@@ -16,7 +16,7 @@ import { addColumnsToCache } from '../fieldlist_cache';
 describe('onDrop', () => {
   addColumnsToCache(
     {
-      esql: 'SELECT * FROM "kibana_sample_data_ecommerce"',
+      esql: 'FROM "kibana_sample_data_ecommerce"',
     },
     fieldList.map((f) => {
       return {

--- a/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/text_based_languages.test.ts
@@ -322,7 +322,7 @@ describe('Textbased Data Source', () => {
         layers: {},
         initialContext: {
           textBasedColumns: textBasedQueryColumns,
-          query: { sql: 'SELECT * FROM "foo"' },
+          query: { esql: 'FROM "foo"' },
           dataViewSpec: {
             title: 'foo',
             id: '1',
@@ -367,7 +367,7 @@ describe('Textbased Data Source', () => {
             ],
             index: '1',
             query: {
-              sql: 'SELECT * FROM "foo"',
+              esql: 'FROM "foo"',
             },
           },
         },

--- a/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/utils.test.ts
@@ -189,7 +189,7 @@ describe('Text based languages utils', () => {
         indexPatternRefs: [],
         initialContext: {
           textBasedColumns: textBasedQueryColumns,
-          query: { sql: 'SELECT * FROM "foo"' },
+          query: { esql: 'from foo' },
           fieldName: '',
           dataViewSpec: {
             title: 'foo',
@@ -203,7 +203,7 @@ describe('Text based languages utils', () => {
       const expressionsMock = expressionsPluginMock.createStartContract();
       const updatedState = await getStateFromAggregateQuery(
         state,
-        { sql: 'SELECT * FROM my-fake-index-pattern' },
+        { esql: 'FROM my-fake-index-pattern' },
         {
           ...dataViewsMock,
           getIdsWithTitle: jest.fn().mockReturnValue(
@@ -237,7 +237,7 @@ describe('Text based languages utils', () => {
       expect(updatedState).toStrictEqual({
         initialContext: {
           textBasedColumns: textBasedQueryColumns,
-          query: { sql: 'SELECT * FROM "foo"' },
+          query: { esql: 'from foo' },
           fieldName: '',
           dataViewSpec: {
             title: 'foo',
@@ -273,7 +273,7 @@ describe('Text based languages utils', () => {
             errors: [],
             index: '4',
             query: {
-              sql: 'SELECT * FROM my-fake-index-pattern',
+              esql: 'FROM my-fake-index-pattern',
             },
             timeField: 'timeField',
           },
@@ -293,7 +293,7 @@ describe('Text based languages utils', () => {
         indexPatternRefs: [],
         initialContext: {
           textBasedColumns: textBasedQueryColumns,
-          query: { sql: 'SELECT * FROM "foo"' },
+          query: { esql: 'from foo' },
           fieldName: '',
           dataViewSpec: {
             title: 'foo',
@@ -307,7 +307,7 @@ describe('Text based languages utils', () => {
       const expressionsMock = expressionsPluginMock.createStartContract();
       const updatedState = await getStateFromAggregateQuery(
         state,
-        { sql: 'SELECT * FROM my-fake-index-*' },
+        { esql: 'FROM my-fake-index-*' },
         {
           ...dataViewsMock,
           getIdsWithTitle: jest.fn().mockReturnValue(
@@ -346,7 +346,7 @@ describe('Text based languages utils', () => {
       expect(updatedState).toStrictEqual({
         initialContext: {
           textBasedColumns: textBasedQueryColumns,
-          query: { sql: 'SELECT * FROM "foo"' },
+          query: { esql: 'from foo' },
           fieldName: '',
           dataViewSpec: {
             title: 'foo',
@@ -382,7 +382,7 @@ describe('Text based languages utils', () => {
             errors: [],
             index: 'adHoc-id',
             query: {
-              sql: 'SELECT * FROM my-fake-index-*',
+              esql: 'FROM my-fake-index-*',
             },
             timeField: '@timestamp',
           },


### PR DESCRIPTION
## Summary

Updates the tests of the textbased datasource to use esql queries instead of sql

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios