### PR TITLE
[Search] Fix crawler stat card counts

### DIFF
--- a/x-pack/plugins/enterprise_search/server/utils/get_sync_jobs_queries.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/get_sync_jobs_queries.ts
@@ -30,7 +30,7 @@ export const getOrphanedJobsCountQuery = (ids: string[], isCrawler?: boolean) =>
         must: [
           {
             term: {
-              service_type: CRAWLER_SERVICE_TYPE,
+              'connector.service_type': CRAWLER_SERVICE_TYPE,
             },
           },
         ],
@@ -55,7 +55,7 @@ export const getOrphanedJobsCountQuery = (ids: string[], isCrawler?: boolean) =>
         },
         {
           term: {
-            service_type: CRAWLER_SERVICE_TYPE,
+            'connector.service_type': CRAWLER_SERVICE_TYPE,
           },
         },
       ],
@@ -93,7 +93,7 @@ export const getInProgressJobsCountQuery = (isCrawler?: boolean) => {
             bool: {
               must: {
                 term: {
-                  service_type: CRAWLER_SERVICE_TYPE,
+                  'connector.service_type': CRAWLER_SERVICE_TYPE,
                 },
               },
             },
@@ -116,7 +116,7 @@ export const getInProgressJobsCountQuery = (isCrawler?: boolean) => {
           bool: {
             must_not: {
               term: {
-                service_type: CRAWLER_SERVICE_TYPE,
+                'connector.service_type': CRAWLER_SERVICE_TYPE,
               },
             },
           },
@@ -159,7 +159,7 @@ export const getIdleJobsCountQuery = (isCrawler?: boolean) => {
           },
           {
             term: {
-              service_type: CRAWLER_SERVICE_TYPE,
+              'connector.service_type': CRAWLER_SERVICE_TYPE,
             },
           },
           {
@@ -186,7 +186,7 @@ export const getIdleJobsCountQuery = (isCrawler?: boolean) => {
           bool: {
             must_not: {
               term: {
-                service_type: CRAWLER_SERVICE_TYPE,
+                'connector.service_type': CRAWLER_SERVICE_TYPE,
               },
             },
           },

--- a/x-pack/plugins/enterprise_search/server/utils/get_sync_jobs_queries.ts
+++ b/x-pack/plugins/enterprise_search/server/utils/get_sync_jobs_queries.ts
@@ -30,7 +30,7 @@ export const getOrphanedJobsCountQuery = (ids: string[], isCrawler?: boolean) =>
         must: [
           {
             term: {
-              'connector.service_type': CRAWLER_SERVICE_TYPE,
+              service_type: CRAWLER_SERVICE_TYPE,
             },
           },
         ],
@@ -55,7 +55,7 @@ export const getOrphanedJobsCountQuery = (ids: string[], isCrawler?: boolean) =>
         },
         {
           term: {
-            'connector.service_type': CRAWLER_SERVICE_TYPE,
+            service_type: CRAWLER_SERVICE_TYPE,
           },
         },
       ],
@@ -93,7 +93,7 @@ export const getInProgressJobsCountQuery = (isCrawler?: boolean) => {
             bool: {
               must: {
                 term: {
-                  'connector.service_type': CRAWLER_SERVICE_TYPE,
+                  service_type: CRAWLER_SERVICE_TYPE,
                 },
               },
             },
@@ -116,7 +116,7 @@ export const getInProgressJobsCountQuery = (isCrawler?: boolean) => {
           bool: {
             must_not: {
               term: {
-                'connector.service_type': CRAWLER_SERVICE_TYPE,
+                service_type: CRAWLER_SERVICE_TYPE,
               },
             },
           },
@@ -159,7 +159,7 @@ export const getIdleJobsCountQuery = (isCrawler?: boolean) => {
           },
           {
             term: {
-              'connector.service_type': CRAWLER_SERVICE_TYPE,
+              service_type: CRAWLER_SERVICE_TYPE,
             },
           },
           {
@@ -186,7 +186,7 @@ export const getIdleJobsCountQuery = (isCrawler?: boolean) => {
           bool: {
             must_not: {
               term: {
-                'connector.service_type': CRAWLER_SERVICE_TYPE,
+                service_type: CRAWLER_SERVICE_TYPE,
               },
             },
           },
@@ -295,14 +295,7 @@ export const getConnectedCountQuery = (isCrawler?: boolean) => {
           },
           {
             term: {
-              'connector.service_type': CRAWLER_SERVICE_TYPE,
-            },
-          },
-          {
-            range: {
-              last_seen: {
-                gte: moment().subtract(30, 'minutes').toISOString(),
-              },
+              service_type: CRAWLER_SERVICE_TYPE,
             },
           },
         ],
@@ -321,7 +314,7 @@ export const getConnectedCountQuery = (isCrawler?: boolean) => {
           bool: {
             must_not: {
               term: {
-                'connector.service_type': CRAWLER_SERVICE_TYPE,
+                service_type: CRAWLER_SERVICE_TYPE,
               },
             },
           },
@@ -366,21 +359,10 @@ export const getIncompleteCountQuery = (isCrawler?: boolean) => {
   if (isCrawler) {
     return {
       bool: {
-        should: [
+        must_not: [
           {
-            bool: {
-              must_not: {
-                terms: {
-                  status: [ConnectorStatus.CONNECTED, ConnectorStatus.ERROR],
-                },
-              },
-            },
-          },
-          {
-            range: {
-              last_seen: {
-                lt: moment().subtract(30, 'minutes').toISOString(),
-              },
+            terms: {
+              status: [ConnectorStatus.CONNECTED, ConnectorStatus.ERROR],
             },
           },
         ],


### PR DESCRIPTION
## Summary

Fix Crawler stat cards to correctly show connected status.

Crawler connected status is not depending on the last_seen, so it is updated to show correct stats.


### Checklist


- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed




<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->