### PR TITLE
[Lens] Loop color mapping in auto-mode

### DIFF
--- a/packages/kbn-coloring/src/shared_components/color_mapping/components/assignment/assignment.tsx
+++ b/packages/kbn-coloring/src/shared_components/color_mapping/components/assignment/assignment.tsx
@@ -13,6 +13,7 @@ import { i18n } from '@kbn/i18n';
 import { css } from '@emotion/react';
 import { euiThemeVars } from '@kbn/ui-theme';
 import {
+  assignStatically,
   removeAssignment,
   updateAssignmentColor,
   updateAssignmentRule,
@@ -30,7 +31,7 @@ export function Assignment({
   assignment,
   disableDelete,
   index,
-  total,
+  assignments,
   canPickColor,
   editable,
   palette,
@@ -42,7 +43,7 @@ export function Assignment({
 }: {
   data: ColorMappingInputData;
   index: number;
-  total: number;
+  assignments: ColorMapping.Config['assignments'];
   colorMode: ColorMapping.Config['colorMode'];
   assignment: ColorMapping.Config['assignments'][number];
   disableDelete: boolean;
@@ -74,8 +75,9 @@ export function Assignment({
           getPaletteFn={getPaletteFn}
           index={index}
           palette={palette}
-          total={total}
+          total={assignments.length}
           onColorChange={(color) => {
+            dispatch(assignStatically(assignments));
             dispatch(updateAssignmentColor({ assignmentIndex: index, color }));
           }}
         />
@@ -91,6 +93,7 @@ export function Assignment({
           options={data.type === 'categories' ? data.categories : []}
           specialTokens={specialTokens}
           updateValue={(values: Array<string | string[]>) => {
+            dispatch(assignStatically(assignments));
             dispatch(
               updateAssignmentRule({
                 assignmentIndex: index,
@@ -112,6 +115,7 @@ export function Assignment({
               minInclusive,
               maxInclusive,
             };
+            dispatch(assignStatically(assignments));
             dispatch(updateAssignmentRule({ assignmentIndex: index, rule }));
           }}
         />
@@ -122,7 +126,10 @@ export function Assignment({
           iconType="trash"
           size="xs"
           disabled={disableDelete}
-          onClick={() => dispatch(removeAssignment(index))}
+          onClick={() => {
+            dispatch(assignStatically(assignments));
+            dispatch(removeAssignment(index));
+          }}
           aria-label={i18n.translate(
             'coloring.colorMapping.assignments.deleteAssignmentButtonLabel',
             {

--- a/packages/kbn-coloring/src/shared_components/color_mapping/components/assignment/special_assignment.tsx
+++ b/packages/kbn-coloring/src/shared_components/color_mapping/components/assignment/special_assignment.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { EuiFieldText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { EuiText, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 import { useDispatch } from 'react-redux';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
@@ -61,18 +61,17 @@ export function SpecialAssignment({
           marginRight: 32,
         }}
       >
-        <EuiFieldText
-          compressed
-          fullWidth
-          disabled={true}
-          placeholder={i18n.translate('coloring.colorMapping.assignments.unassignedPlaceholder', {
-            defaultMessage: 'Unassigned terms',
-          })}
+        <EuiText
+          size="s"
           aria-label={i18n.translate('coloring.colorMapping.assignments.unassignedAriaLabel', {
             defaultMessage:
               'Assign this color to every unassigned not described in the assignment list',
           })}
-        />
+        >
+          {i18n.translate('coloring.colorMapping.assignments.unassignedPlaceholder', {
+            defaultMessage: 'Unassigned terms',
+          })}
+        </EuiText>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/packages/kbn-coloring/src/shared_components/color_mapping/components/container/container.tsx
+++ b/packages/kbn-coloring/src/shared_components/color_mapping/components/container/container.tsx
@@ -161,15 +161,15 @@ export function Container(props: {
                   <Assignment
                     data={props.data}
                     index={i}
-                    total={assignments.length}
+                    assignments={assignments}
                     colorMode={colorMode}
-                    editable={!autoAssignmentMode}
-                    canPickColor={!autoAssignmentMode && colorMode.type !== 'gradient'}
+                    editable={true}
+                    canPickColor={colorMode.type !== 'gradient'}
                     palette={palette}
                     isDarkMode={props.isDarkMode}
                     getPaletteFn={getPaletteFn}
                     assignment={assignment}
-                    disableDelete={assignments.length <= 1 || autoAssignmentMode}
+                    disableDelete={assignments.length <= 1}
                     specialTokens={props.specialTokens}
                     assignmentValuesCounter={assignmentValuesCounter}
                   />

--- a/packages/kbn-coloring/src/shared_components/color_mapping/components/container/container.tsx
+++ b/packages/kbn-coloring/src/shared_components/color_mapping/components/container/container.tsx
@@ -45,7 +45,7 @@ import { ColorMappingInputData } from '../../categorical_color_mapping';
 import { Gradient } from '../palette_selector/gradient';
 import { NeutralPalette } from '../../palettes/neutral';
 
-export const MAX_ASSIGNABLE_COLORS = 10;
+export const MAX_ASSIGNABLE_COLORS = Infinity;
 
 function selectComputedAssignments(
   data: ColorMappingInputData,
@@ -73,8 +73,6 @@ export function Container(props: {
   const autoAssignmentMode = useSelector(selectIsAutoAssignmentMode);
   const assignments = useSelector(selectComputedAssignments(props.data, palette, colorMode));
   const specialAssignments = useSelector(selectSpecialAssignments);
-
-  const canAddNewAssignment = !autoAssignmentMode && assignments.length < MAX_ASSIGNABLE_COLORS;
 
   const assignmentValuesCounter = assignments.reduce<Map<string | string[], number>>(
     (acc, assignment) => {
@@ -177,26 +175,29 @@ export function Container(props: {
               );
             })}
           </div>
-
-          <EuiHorizontalRule margin="xs" />
-          <EuiFlexGroup direction="row" gutterSize="s">
-            <EuiFlexItem data-test-subj="lns-colorMapping-specialAssignmentsList">
-              {props.data.type === 'categories' &&
-                specialAssignments.map((assignment, i) => {
-                  return (
-                    <SpecialAssignment
-                      key={i}
-                      index={i}
-                      palette={palette}
-                      isDarkMode={props.isDarkMode}
-                      getPaletteFn={getPaletteFn}
-                      assignment={assignment}
-                      total={specialAssignments.length}
-                    />
-                  );
-                })}
-            </EuiFlexItem>
-          </EuiFlexGroup>
+          {!autoAssignmentMode && (
+            <>
+              <EuiHorizontalRule margin="xs" />
+              <EuiFlexGroup direction="row" gutterSize="s">
+                <EuiFlexItem data-test-subj="lns-colorMapping-specialAssignmentsList">
+                  {props.data.type === 'categories' &&
+                    specialAssignments.map((assignment, i) => {
+                      return (
+                        <SpecialAssignment
+                          key={i}
+                          index={i}
+                          palette={palette}
+                          isDarkMode={props.isDarkMode}
+                          getPaletteFn={getPaletteFn}
+                          assignment={assignment}
+                          total={specialAssignments.length}
+                        />
+                      );
+                    })}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </>
+          )}
         </EuiPanel>
         <EuiFlexGroup direction="row">
           <EuiFlexItem style={{ display: 'block' }}>
@@ -206,6 +207,7 @@ export function Container(props: {
               size="xs"
               flush="both"
               onClick={() => {
+                dispatch(assignStatically(assignments));
                 dispatch(
                   addNewAssignment({
                     rule:
@@ -220,7 +222,6 @@ export function Container(props: {
                   })
                 );
               }}
-              disabled={!canAddNewAssignment}
               css={css`
                 margin-right: 8px;
               `}


### PR DESCRIPTION
## Summary

This PR brings back the legacy behavior of looping colors when more terms than the available colors are visualized in the chart.

fix https://github.com/elastic/kibana/issues/168891


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
