### PR TITLE
[Search] Fix missing apostrophe in cURL example

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
+++ b/x-pack/plugins/serverless_search/public/application/components/languages/curl.ts
@@ -55,7 +55,7 @@ export API_KEY="${apiKey}"`,
   -d'
 { "index" : { "_index" : "${indexName ?? 'index_name'}" } }
 {"name": "foo", "title": "bar" }
-`,
+'`,
   installClient: `# if cURL is not already installed on your system
 # then install it with the package manager of your choice
 


### PR DESCRIPTION
## Summary

This fixes a missing apostrophe in the cURL ingest data example in Serverless Search.