### PR TITLE
Allow roles to have an optional description

### DIFF
--- a/x-pack/packages/security/plugin_types_common/src/authorization/role.ts
+++ b/x-pack/packages/security/plugin_types_common/src/authorization/role.ts
@@ -30,6 +30,7 @@ export interface RoleKibanaPrivilege {
 
 export interface Role {
   name: string;
+  description?: string;
   elasticsearch: {
     cluster: string[];
     indices: RoleIndexPrivilege[];

--- a/x-pack/plugins/security/common/constants.ts
+++ b/x-pack/plugins/security/common/constants.ts
@@ -92,3 +92,8 @@ export const SESSION_EXTENSION_THROTTLE_MS = 60 * 1000;
  * Route to get session info and extend session expiration
  */
 export const SESSION_ROUTE = '/internal/security/session';
+
+/**
+ * Name of the role metadata key that stores the role description.
+ */
+export const ROLE_DESCRIPTION_METADATA_KEY = 'kibana_description';

--- a/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/edit_role/edit_role_page.tsx
@@ -17,6 +17,7 @@ import {
   EuiPanel,
   EuiSpacer,
   EuiText,
+  EuiTextArea,
   EuiTitle,
 } from '@elastic/eui';
 import type { ChangeEvent, FocusEvent, FunctionComponent, HTMLProps } from 'react';
@@ -415,39 +416,66 @@ export const EditRolePage: FunctionComponent<Props> = ({
 
   const getRoleName = () => {
     return (
-      <EuiPanel hasShadow={false} hasBorder={true}>
-        <EuiFormRow
-          data-test-subj={'roleNameFormRow'}
-          label={
+      <EuiFormRow
+        data-test-subj={'roleNameFormRow'}
+        fullWidth={true}
+        label={
+          <h3>
             <FormattedMessage
               id="xpack.security.management.editRole.roleNameFormRowTitle"
               defaultMessage="Role name"
             />
-          }
-          helpText={
-            !isRoleReserved && isEditingExistingRole ? (
-              <FormattedMessage
-                id="xpack.security.management.editRole.roleNameFormRowHelpText"
-                defaultMessage="A role's name cannot be changed once it has been created."
-              />
-            ) : undefined
-          }
-          {...validator.validateRoleName(role)}
-          {...(creatingRoleAlreadyExists
-            ? { error: 'A role with this name already exists.', isInvalid: true }
-            : {})}
-        >
-          <EuiFieldText
-            name={'name'}
-            value={role.name || ''}
-            onChange={onNameChange}
-            onBlur={onNameBlur}
-            data-test-subj={'roleFormNameInput'}
-            disabled={isRoleReserved || isEditingExistingRole || isRoleReadOnly}
-            isInvalid={creatingRoleAlreadyExists}
-          />
-        </EuiFormRow>
-      </EuiPanel>
+          </h3>
+        }
+        helpText={
+          !isRoleReserved && isEditingExistingRole ? (
+            <FormattedMessage
+              id="xpack.security.management.editRole.roleNameFormRowHelpText"
+              defaultMessage="A role's name cannot be changed once it has been created."
+            />
+          ) : undefined
+        }
+        {...validator.validateRoleName(role)}
+        {...(creatingRoleAlreadyExists
+          ? { error: 'A role with this name already exists.', isInvalid: true }
+          : {})}
+      >
+        <EuiFieldText
+          name={'name'}
+          value={role.name || ''}
+          onChange={onNameChange}
+          onBlur={onNameBlur}
+          data-test-subj={'roleFormNameInput'}
+          disabled={isRoleReserved || isEditingExistingRole || isRoleReadOnly}
+          isInvalid={creatingRoleAlreadyExists}
+        />
+      </EuiFormRow>
+    );
+  };
+
+  const getRoleDescription = () => {
+    return (
+      <EuiFormRow
+        data-test-subj={'roleDescriptionFormRow'}
+        label={
+          <h3>
+            <FormattedMessage
+              id="xpack.security.management.editRole.roleDescriptionFormRowTitle"
+              defaultMessage="Description (optional)"
+            />
+          </h3>
+        }
+        {...validator.validateRoleDescription(role)}
+      >
+        <EuiTextArea
+          name={'description'}
+          value={role.description || ''}
+          onChange={onDescriptionChange}
+          data-test-subj={'roleFormDescriptionInput'}
+          disabled={isRoleReserved || isRoleReadOnly}
+          compressed
+        />
+      </EuiFormRow>
     );
   };
 
@@ -465,6 +493,12 @@ export const EditRolePage: FunctionComponent<Props> = ({
       });
     }
   };
+
+  const onDescriptionChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
+    setRole({
+      ...role,
+      description: e.target.value,
+    });
 
   const getElasticsearchPrivileges = () => {
     return (
@@ -680,7 +714,10 @@ export const EditRolePage: FunctionComponent<Props> = ({
           </Fragment>
         )}
         <EuiSpacer />
-        {getRoleName()}
+        <EuiPanel hasShadow={false} hasBorder={true}>
+          {getRoleName()}
+          {getRoleDescription()}
+        </EuiPanel>
         {getElasticsearchPrivileges()}
         {getKibanaPrivileges()}
         <EuiSpacer />

--- a/x-pack/plugins/security/public/management/roles/edit_role/validate_role.ts
+++ b/x-pack/plugins/security/public/management/roles/edit_role/validate_role.ts
@@ -81,6 +81,29 @@ export class RoleValidator {
     return valid();
   }
 
+  public validateRoleDescription(role: Role): RoleValidationResult {
+    if (!this.shouldValidate) {
+      return valid();
+    }
+
+    if (!role.description) {
+      return valid();
+    }
+
+    if (role.description.length > MAX_NAME_LENGTH) {
+      return invalid(
+        i18n.translate(
+          'xpack.security.management.editRole.validateRole.descriptionLengthWarningMessage',
+          {
+            defaultMessage: 'Description must not exceed {maxLength} characters.',
+            values: { maxLength: MAX_NAME_LENGTH },
+          }
+        )
+      );
+    }
+    return valid();
+  }
+
   public validateIndexPrivileges(role: Role): RoleValidationResult {
     if (!this.shouldValidate) {
       return valid();
@@ -310,12 +333,14 @@ export class RoleValidator {
 
   public validateForSave(role: Role): RoleValidationResult {
     const { isInvalid: isNameInvalid } = this.validateRoleName(role);
+    const { isInvalid: isDescriptionInvalid } = this.validateRoleDescription(role);
     const { isInvalid: areIndicesInvalid } = this.validateIndexPrivileges(role);
     const { isInvalid: areRemoteIndicesInvalid } = this.validateRemoteIndexPrivileges(role);
     const { isInvalid: areSpacePrivilegesInvalid } = this.validateSpacePrivileges(role);
 
     if (
       isNameInvalid ||
+      isDescriptionInvalid ||
       areIndicesInvalid ||
       areRemoteIndicesInvalid ||
       areSpacePrivilegesInvalid

--- a/x-pack/plugins/security/public/management/roles/roles_api_client.ts
+++ b/x-pack/plugins/security/public/management/roles/roles_api_client.ts
@@ -8,6 +8,7 @@
 import type { HttpStart } from '@kbn/core/public';
 
 import type { Role, RoleIndexPrivilege, RoleRemoteIndexPrivilege } from '../../../common';
+import { ROLE_DESCRIPTION_METADATA_KEY } from '../../../common/constants';
 import { copyRole } from '../../../common/model';
 
 export class RolesAPIClient {
@@ -64,8 +65,14 @@ export class RolesAPIClient {
       }
     });
 
+    role.metadata = {
+      ...role.metadata,
+      [ROLE_DESCRIPTION_METADATA_KEY]: role.description?.trim(),
+    };
+
     // @ts-expect-error
     delete role.name;
+    delete role.description;
     delete role.transient_metadata;
     delete role._unrecognized_applications;
     delete role._transform_error;

--- a/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.test.tsx
+++ b/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.test.tsx
@@ -53,23 +53,33 @@ describe('<RolesGridPage />', () => {
     apiClientMock.getRoles.mockResolvedValue([
       {
         name: 'test-role-1',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },
       {
         name: 'reserved-role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
         metadata: { _reserved: true },
       },
       {
         name: 'disabled-role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
         transient_metadata: { enabled: false },
       },
       {
         name: 'special%chars%role',
+        description: '',
+        elasticsearch: { cluster: [], indices: [], run_as: [] },
+        kibana: [{ base: [], spaces: [], feature: {} }],
+      },
+      {
+        name: 'role-with-description',
+        description: 'role-description',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },
@@ -191,23 +201,33 @@ describe('<RolesGridPage />', () => {
     expect(wrapper.find(EuiBasicTable).props().items).toEqual([
       {
         name: 'disabled-role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
         transient_metadata: { enabled: false },
       },
       {
         name: 'reserved-role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
         metadata: { _reserved: true },
       },
       {
+        name: 'role-with-description',
+        description: 'role-description',
+        elasticsearch: { cluster: [], indices: [], run_as: [] },
+        kibana: [{ base: [], spaces: [], feature: {} }],
+      },
+      {
         name: 'special%chars%role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },
       {
         name: 'test-role-1',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },
@@ -218,17 +238,26 @@ describe('<RolesGridPage />', () => {
     expect(wrapper.find(EuiBasicTable).props().items).toEqual([
       {
         name: 'disabled-role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
         transient_metadata: { enabled: false },
       },
       {
+        name: 'role-with-description',
+        description: 'role-description',
+        elasticsearch: { cluster: [], indices: [], run_as: [] },
+        kibana: [{ base: [], spaces: [], feature: {} }],
+      },
+      {
         name: 'special%chars%role',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },
       {
         name: 'test-role-1',
+        description: '',
         elasticsearch: { cluster: [], indices: [], run_as: [] },
         kibana: [{ base: [], spaces: [], feature: {} }],
       },

--- a/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
@@ -223,6 +223,13 @@ export class RolesGridPage extends Component<Props, State> {
         },
       },
       {
+        field: 'description',
+        name: i18n.translate('xpack.security.management.roles.descriptionColumnName', {
+          defaultMessage: 'Description',
+        }),
+        truncateText: true,
+      },
+      {
         field: 'metadata',
         name: i18n.translate('xpack.security.management.roles.statusColumnName', {
           defaultMessage: 'Status',

--- a/x-pack/plugins/security/server/authorization/roles/elasticsearch_role.test.ts
+++ b/x-pack/plugins/security/server/authorization/roles/elasticsearch_role.test.ts
@@ -11,6 +11,7 @@ import { loggerMock } from '@kbn/logging-mocks';
 
 import { transformElasticsearchRoleToRole } from './elasticsearch_role';
 import type { ElasticsearchRole } from './elasticsearch_role';
+import { ROLE_DESCRIPTION_METADATA_KEY } from '../../../common/constants';
 
 const roles = [
   {
@@ -289,4 +290,38 @@ describe('#transformElasticsearchRoleToRole', () => {
       { name: 'default-malformed', _transform_error: ['kibana'] },
     ]
   );
+
+  describe('description', () => {
+    const elasticsearchRole = roles[0];
+
+    it('should be set to empty string if metadata description is not set', () => {
+      const role = transformElasticsearchRoleToRole(
+        [],
+        {
+          ...omit(elasticsearchRole, 'name'),
+          metadata: {},
+        },
+        elasticsearchRole.name,
+        'kibana-.kibana',
+        loggerMock.create()
+      );
+      expect(role).toHaveProperty('description', '');
+    });
+
+    it('should contain the description if metadata description is set', () => {
+      const role = transformElasticsearchRoleToRole(
+        [],
+        {
+          ...omit(elasticsearchRole, 'name'),
+          metadata: {
+            [ROLE_DESCRIPTION_METADATA_KEY]: 'role-description',
+          },
+        },
+        elasticsearchRole.name,
+        'kibana-.kibana',
+        loggerMock.create()
+      );
+      expect(role).toHaveProperty('description', 'role-description');
+    });
+  });
 });

--- a/x-pack/plugins/security/server/authorization/roles/elasticsearch_role.ts
+++ b/x-pack/plugins/security/server/authorization/roles/elasticsearch_role.ts
@@ -10,7 +10,10 @@ import type { KibanaFeature } from '@kbn/features-plugin/common';
 import { GLOBAL_RESOURCE } from '@kbn/security-plugin-types-server';
 
 import type { Role, RoleKibanaPrivilege } from '../../../common';
-import { RESERVED_PRIVILEGES_APPLICATION_WILDCARD } from '../../../common/constants';
+import {
+  RESERVED_PRIVILEGES_APPLICATION_WILDCARD,
+  ROLE_DESCRIPTION_METADATA_KEY,
+} from '../../../common/constants';
 import { getDetailedErrorMessage } from '../../errors';
 import { PrivilegeSerializer } from '../privilege_serializer';
 import { ResourceSerializer } from '../resource_serializer';
@@ -42,6 +45,7 @@ export function transformElasticsearchRoleToRole(
   );
   return {
     name,
+    description: elasticsearchRole?.metadata?.[ROLE_DESCRIPTION_METADATA_KEY] || '',
     metadata: elasticsearchRole.metadata,
     transient_metadata: elasticsearchRole.transient_metadata,
     elasticsearch: {

--- a/x-pack/plugins/security/server/routes/authorization/roles/model/put_payload.test.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/model/put_payload.test.ts
@@ -8,7 +8,7 @@
 import { KibanaFeature } from '@kbn/features-plugin/common';
 
 import { getPutPayloadSchema } from './put_payload';
-import { ALL_SPACES_ID } from '../../../../../common/constants';
+import { ALL_SPACES_ID, ROLE_DESCRIPTION_METADATA_KEY } from '../../../../../common/constants';
 import { validateKibanaPrivileges } from '../../../../lib';
 
 const basePrivilegeNamesMap = {
@@ -63,6 +63,16 @@ describe('Put payload schema', () => {
       })
     ).toThrowErrorMatchingInlineSnapshot(
       `"[kibana.0]: definition of [feature] isn't allowed when non-empty [base] is defined."`
+    );
+  });
+
+  test(`doesn't allow metadata description to exceed 1024 characters`, () => {
+    expect(() =>
+      getPutPayloadSchema(() => basePrivilegeNamesMap).validate({
+        metadata: { [ROLE_DESCRIPTION_METADATA_KEY]: 'a'.repeat(1025) },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"[metadata.kibana_description]: value has length [1025] but it must have a maximum length of [1024]."`
     );
   });
 

--- a/x-pack/plugins/security/server/routes/authorization/roles/model/put_payload.ts
+++ b/x-pack/plugins/security/server/routes/authorization/roles/model/put_payload.ts
@@ -9,6 +9,7 @@ import type { TypeOf } from '@kbn/config-schema';
 import { schema } from '@kbn/config-schema';
 import { elasticsearchRoleSchema, getKibanaRoleSchema } from '@kbn/security-plugin-types-server';
 
+import { MAX_NAME_LENGTH, ROLE_DESCRIPTION_METADATA_KEY } from '../../../../../common/constants';
 import type { ElasticsearchRole } from '../../../../authorization';
 import { transformPrivilegesToElasticsearchPrivileges } from '../../../../lib';
 
@@ -51,7 +52,16 @@ export function getPutPayloadSchema(
      * An optional meta-data dictionary. Within the metadata, keys that begin with _ are reserved
      * for system usage.
      */
-    metadata: schema.maybe(schema.recordOf(schema.string(), schema.any())),
+    metadata: schema.maybe(
+      schema.object(
+        {
+          [ROLE_DESCRIPTION_METADATA_KEY]: schema.maybe(
+            schema.string({ maxLength: MAX_NAME_LENGTH })
+          ),
+        },
+        { unknowns: 'allow' }
+      )
+    ),
 
     /**
      * Elasticsearch specific portion of the role definition.


### PR DESCRIPTION
## Summary

Implements a proof of concept for https://github.com/elastic/kibana/issues/173570

- Stores Kibana role description in the Elasticsearch role metadata (assuming the [underlying Elasticsearch endpoint](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-put-role.html#security-api-put-role-request-body) will stay as is)
- Allows specifying the role on the Role Edit/Create page in UI
- Shows role descriptions on the Role Listing Page

## Pending questions

1. Confirm the approach with the Elasticsearch role metadata as storage for role descriptions
  1.1. Are there ways to use a system key, i.e. `_kibana_description`, to protect the property from external overrides?
3. Validate UI changes
4. Extend affected integration/E2E tests (I would appreciate help setting up necessary tests)
5. Do we want to make roles searchable by description in UI? Currently, they are searchable by role name only.
6. Update affected documentation

https://github.com/elastic/kibana/assets/264922/0042af2f-763e-4727-ac39-c29b36781102


## Alternative UI options to consider

Two-column layout

<img width="1063" alt="kibana-role-description-ui-1" src="https://github.com/elastic/kibana/assets/264922/e7835066-fc7c-40d4-9fa5-aca8a183ce2d">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
