### PR TITLE
Update observability onboarding test to express state of the art

### DIFF
--- a/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/custom_logs/install_elastic_agent.cy.ts
@@ -623,7 +623,9 @@ describe('[Logs onboarding] Custom logs - install elastic agent', () => {
       cy.getByTestSubj('obltOnboardingExploreLogs').should('exist').click();
 
       cy.url().should('include', '/app/observability-log-explorer');
-      cy.get('button').contains('[Mylogs] mylogs').should('exist');
+      cy.get('[data-test-subj="datasetSelectorPopoverButton"]')
+        .contains('[Mylogs] mylogs', { matchCase: false })
+        .should('exist');
     });
   });
 });

--- a/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
@@ -125,30 +125,17 @@ Cypress.Commands.add('deleteIntegration', (integrationName: string) => {
 
   cy.request({
     log: false,
-    method: 'GET',
+    method: 'DELETE',
     url: `${kibanaUrl}/api/fleet/epm/packages/${integrationName}`,
+    body: {
+      force: false,
+    },
     headers: {
       'kbn-xsrf': 'e2e_test',
+      'Elastic-Api-Version': '1',
     },
     auth: { user: 'editor', pass: 'changeme' },
     failOnStatusCode: false,
-  }).then((response) => {
-    const status = response.body.item?.status;
-    if (status === 'installed') {
-      cy.request({
-        log: false,
-        method: 'DELETE',
-        url: `${kibanaUrl}/api/fleet/epm/packages/${integrationName}`,
-        body: {
-          force: false,
-        },
-        headers: {
-          'kbn-xsrf': 'e2e_test',
-          'Elastic-Api-Version': '1',
-        },
-        auth: { user: 'editor', pass: 'changeme' },
-      });
-    }
   });
 });
 


### PR DESCRIPTION
## Summary

TLDR; This PR updates the cypress test suite that tests the custom integration used to set up logs during onboarding. 

The PR https://github.com/elastic/kibana/pull/171720 surfaced the fact that this test suite isn't passing, especially given it doesn't run unless a file with the observability onboarding plugin directory is modified.

The most notable changes to the test suite, is opting to delete the provided integration without verifying if it is installed. Why would we do this one might ask;

- The existing API used to fetch integration packages expects packages to have assets definition, and given this particular one doesn't have assets so the request fails more details [here](https://github.com/elastic/kibana/issues/174739).
- With the previous approach it required at least one call to determine if the integration should be deleted, the only difference here is when the test kicks off an attempt to delete an integration that doesn't exist will be made once, but that's handled by setting setting the cy.request `failOnStatusCode` option as false, so it doesn't error. 
- it also unblocks the aforementioned PR

<!--
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
<!--
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
