### PR TITLE
[Security Solution] Unskip bulk actions integration tests

### DIFF
--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
@@ -28,7 +28,6 @@ import {
   getLegacyActionSO,
   getSimpleRule,
   getWebHookAction,
-  removeServerGeneratedProperties,
   waitForRuleSuccess,
   getRuleSOById,
   createRuleThroughAlertingEndpoint,
@@ -64,7 +63,7 @@ export default ({ getService }: FtrProviderContext): void => {
   const createWebHookConnector = () => createConnector(getWebHookAction());
 
   // Failing: See https://github.com/elastic/kibana/issues/173804
-  describe.skip('@ess perform_bulk_action - ESS specific logic', () => {
+  describe('@ess perform_bulk_action - ESS specific logic', () => {
     beforeEach(async () => {
       await createAlertsIndex(supertest, log);
       await esArchiver.load('x-pack/test/functional/es_archives/auditbeat/hosts');
@@ -481,10 +480,12 @@ export default ({ getService }: FtrProviderContext): void => {
           supertest,
           getRuleSavedObjectWithLegacyInvestigationFields()
         );
+
         ruleWithLegacyInvestigationFieldEmptyArray = await createRuleThroughAlertingEndpoint(
           supertest,
           getRuleSavedObjectWithLegacyInvestigationFieldsEmptyArray()
         );
+
         ruleWithIntendedInvestigationField = await createRule(supertest, log, {
           ...getSimpleRule('rule-with-investigation-field'),
           name: 'Test investigation fields object',
@@ -505,23 +506,26 @@ export default ({ getService }: FtrProviderContext): void => {
           .parse(binaryToString);
 
         const [rule1, rule2, rule3, exportDetailsJson] = body.toString().split(/\n/);
+        const exportedRules = [rule1, rule2, rule3].map((rule) => JSON.parse(rule));
 
-        const ruleToCompareWithLegacyInvestigationField = removeServerGeneratedProperties(
-          JSON.parse(rule1)
+        const exportedRuleWithLegacyInvestigationField = exportedRules.find(
+          (rule) => rule.id === ruleWithLegacyInvestigationField.id
         );
-        expect(ruleToCompareWithLegacyInvestigationField.investigation_fields).to.eql({
+        expect(exportedRuleWithLegacyInvestigationField.investigation_fields).to.eql({
           field_names: ['client.address', 'agent.name'],
         });
 
-        const ruleToCompareWithLegacyInvestigationFieldEmptyArray = removeServerGeneratedProperties(
-          JSON.parse(rule2)
+        const exportedRuleWithLegacyInvestigationFieldEmptyArray = exportedRules.find(
+          (rule) => rule.id === ruleWithLegacyInvestigationFieldEmptyArray.id
         );
-        expect(ruleToCompareWithLegacyInvestigationFieldEmptyArray.investigation_fields).to.eql(
+        expect(exportedRuleWithLegacyInvestigationFieldEmptyArray.investigation_fields).to.eql(
           undefined
         );
 
-        const ruleWithInvestigationField = removeServerGeneratedProperties(JSON.parse(rule3));
-        expect(ruleWithInvestigationField.investigation_fields).to.eql({
+        const exportedRuleWithInvestigationField = exportedRules.find(
+          (rule) => rule.id === ruleWithIntendedInvestigationField.id
+        );
+        expect(exportedRuleWithInvestigationField.investigation_fields).to.eql({
           field_names: ['host.name'],
         });
 

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/rules_management/rule_bulk_actions/trial_license_complete_tier/perform_bulk_action_ess.ts
@@ -798,16 +798,19 @@ export default ({ getService }: FtrProviderContext): void => {
           );
         expect(isInvestigationFieldForRuleWithEmptyArrayMigratedInSo).to.eql(false);
 
-        const isInvestigationFieldForRuleWithIntendedTypeMigratedInSo =
+        /*
+          It's duplicate of a rule with properly formatted "investigation fields".
+          So we just check that "investigation fields" are in intended format.
+          No migration needs to happen. 
+        */
+        const isInvestigationFieldForRuleWithIntendedTypeInSo =
           await checkInvestigationFieldSoValue(
             undefined,
             { field_names: ['host.name'] },
             es,
             ruleWithIntendedType.id
           );
-        expect(isInvestigationFieldForRuleWithIntendedTypeMigratedInSo).to.eql({
-          field_names: ['host.name'],
-        });
+        expect(isInvestigationFieldForRuleWithIntendedTypeInSo).to.eql(true);
 
         // ORIGINAL RULES - rules selected to be duplicated
         /**
@@ -834,16 +837,18 @@ export default ({ getService }: FtrProviderContext): void => {
           );
         expect(isInvestigationFieldForOriginalRuleWithEmptyArrayMigratedInSo).to.eql(false);
 
-        const isInvestigationFieldForOriginalRuleWithIntendedTypeMigratedInSo =
+        /*
+          Since this rule was created with intended "investigation fields" format,
+          it shouldn't change - no need to migrate. 
+        */
+        const isInvestigationFieldForOriginalRuleWithIntendedTypeInSo =
           await checkInvestigationFieldSoValue(
             undefined,
             { field_names: ['host.name'] },
             es,
             ruleWithIntendedInvestigationField.id
           );
-        expect(isInvestigationFieldForOriginalRuleWithIntendedTypeMigratedInSo).to.eql({
-          field_names: ['host.name'],
-        });
+        expect(isInvestigationFieldForOriginalRuleWithIntendedTypeInSo).to.eql(true);
       });
 
       it('should edit rules with legacy investigation fields', async () => {


### PR DESCRIPTION
**Resolves: #173804** 

500 runs of the flaky test file in ESS env: [Buildkite 4833](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4833)

## Summary
Even though I couldn't reproduce flakiness (1.5K runs), I've updated the test to fix a suspected race condition.

What seems to be happening:
In the `beforeEach` [here](https://github.com/nikitaindik/kibana/blob/b7b95111e010cc9fba618b625bb6f8c8969de1ec/x-pack/test/security_solution_api_integration/test_suites/detections_response/default_license/rule_bulk_actions/perform_bulk_action_ess.ts#L477), three rules are created:
 - one with investigation_fields equal to `['client.address', 'agent.name']`
 - one with investigation_fields equal to `[]`
 - one with investigation_fields equal to `{ field_names: ['host.name'] }`

Then, in the [test](https://github.com/nikitaindik/kibana/blob/b7b95111e010cc9fba618b625bb6f8c8969de1ec/x-pack/test/security_solution_api_integration/test_suites/detections_response/default_license/rule_bulk_actions/perform_bulk_action_ess.ts#L506), we read all three rules and check them in that same order. But if the `[]` rule  is created on the backend before the `['client.address', 'agent.name']` rule, our first check would fail.

Other tests in this file don't expect rules to come in a particular order. Instead, they search for a needed rule in the array. I used the same approach for this flaky test.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->