### PR TITLE
[ON Week] Add integration selection to custom threshold and save it in the rule saved object

### DIFF
--- a/x-pack/plugins/log_explorer/common/index.ts
+++ b/x-pack/plugins/log_explorer/common/index.ts
@@ -18,7 +18,7 @@ export {
   hydrateDatasetSelection,
   UnresolvedDatasetSelection,
 } from './dataset_selection';
-export type { DatasetSelectionPlain } from './dataset_selection';
+export type { DatasetSelectionPlain, DatasetSelection } from './dataset_selection';
 export type {
   ChartDisplayOptions,
   DisplayOptions,

--- a/x-pack/plugins/log_explorer/public/components/dataset_selector/dataset_selector.tsx
+++ b/x-pack/plugins/log_explorer/public/components/dataset_selector/dataset_selector.tsx
@@ -43,6 +43,7 @@ export function DatasetSelector({
   dataViews,
   dataViewsError,
   discoverEsqlUrlProps,
+  hideDataViews,
   integrations,
   integrationsError,
   isEsqlEnabled,
@@ -186,15 +187,19 @@ export function DatasetSelector({
       },
       'data-test-subj': 'datasetSelectorUncategorizedTab',
     },
-    {
-      id: DATA_VIEWS_TAB_ID,
-      name: dataViewsLabel,
-      onClick: () => {
-        onDataViewsTabClick(); // Lazy-load data views only when accessing the Data Views tab
-        switchToDataViewsTab();
-      },
-      'data-test-subj': 'datasetSelectorDataViewsTab',
-    },
+    ...(hideDataViews
+      ? []
+      : [
+          {
+            id: DATA_VIEWS_TAB_ID,
+            name: dataViewsLabel,
+            onClick: () => {
+              onDataViewsTabClick(); // Lazy-load data views only when accessing the Data Views tab
+              switchToDataViewsTab();
+            },
+            'data-test-subj': 'datasetSelectorDataViewsTab',
+          },
+        ]),
   ];
 
   const tabEntries = tabs.map((tab) => (

--- a/x-pack/plugins/log_explorer/public/components/dataset_selector/types.ts
+++ b/x-pack/plugins/log_explorer/public/components/dataset_selector/types.ts
@@ -42,6 +42,8 @@ export interface DatasetSelectorProps {
   dataViewsError: Error | null;
   /* url props to navigate to discover ES|QL */
   discoverEsqlUrlProps: DiscoverEsqlUrlProps;
+  /* Flag for hiding data views tab */
+  hideDataViews?: boolean;
   /* The integrations list, each integration includes its data streams */
   integrations: Integration[] | null;
   /* Any error occurred to show when the user preview the integrations */

--- a/x-pack/plugins/log_explorer/public/index.ts
+++ b/x-pack/plugins/log_explorer/public/index.ts
@@ -24,6 +24,18 @@ export {
   getDiscoverFiltersFromState,
 } from './utils/convert_discover_app_state';
 
+export { createLogExplorer } from './components/log_explorer';
+export { useKibanaContextForPluginProvider } from './utils/use_kibana';
+
+export { DatasetSelector } from './components/dataset_selector';
+export { DatasetsProvider, useDatasetsContext } from './hooks/use_datasets';
+export { useDatasetSelection } from './hooks/use_dataset_selection';
+export { DataViewsProvider, useDataViewsContext } from './hooks/use_data_views';
+export { useEsql } from './hooks/use_esql';
+export { IntegrationsProvider, useIntegrationsContext } from './hooks/use_integrations';
+export type { IDatasetsClient } from './services/datasets';
+export { DatasetsService } from './services/datasets';
+
 export function plugin(context: PluginInitializerContext<LogExplorerConfig>) {
   return new LogExplorerPlugin(context);
 }

--- a/x-pack/plugins/observability/kibana.jsonc
+++ b/x-pack/plugins/observability/kibana.jsonc
@@ -19,6 +19,7 @@
       "data",
       "dataViews",
       "dataViewEditor",
+      "discover",
       "embeddable",
       "fieldFormats",
       "uiActions",
@@ -43,7 +44,6 @@
       "licensing"
     ],
     "optionalPlugins": [
-      "discover",
       "home",
       "usageCollection",
       "cloud",

--- a/x-pack/plugins/observability/public/components/custom_threshold/components/validation.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/components/validation.tsx
@@ -5,15 +5,16 @@
  * 2.0.
  */
 
-import { Query, SerializedSearchSourceFields } from '@kbn/data-plugin/common';
+import { isEmpty } from 'lodash';
+import { Query } from '@kbn/data-plugin/common';
 import { buildEsQuery, fromKueryExpression } from '@kbn/es-query';
 import { i18n } from '@kbn/i18n';
 import { ValidationResult } from '@kbn/triggers-actions-ui-plugin/public';
-import { isEmpty } from 'lodash';
 import {
   Comparator,
   CustomMetricExpressionParams,
 } from '../../../../common/custom_threshold_rule/types';
+import { SearchConfiguration } from '../types';
 
 export const EQUATION_REGEX = /[^A-Z|+|\-|\s|\d+|\.|\(|\)|\/|\*|>|<|=|\?|\:|&|\!|\|]+/g;
 
@@ -22,7 +23,7 @@ export function validateCustomThreshold({
   searchConfiguration,
 }: {
   criteria: CustomMetricExpressionParams[];
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SearchConfiguration;
 }): ValidationResult {
   const validationResult = { errors: {} };
   const errors: {
@@ -40,16 +41,16 @@ export function validateCustomThreshold({
   } & { filterQuery?: string[]; searchConfiguration?: string[] } = {};
   validationResult.errors = errors;
 
-  if (!searchConfiguration || !searchConfiguration.index) {
-    errors.searchConfiguration = [
-      i18n.translate(
-        'xpack.observability.customThreshold.rule.alertFlyout.error.invalidSearchConfiguration',
-        {
-          defaultMessage: 'Data view is required.',
-        }
-      ),
-    ];
-  }
+  // if (!searchConfiguration || (!searchConfiguration.index || !searchConfiguration.selectionType)) {
+  //   errors.searchConfiguration = [
+  //     i18n.translate(
+  //       'xpack.observability.customThreshold.rule.alertFlyout.error.invalidSearchConfiguration',
+  //       {
+  //         defaultMessage: 'Data view is required.',
+  //       }
+  //     ),
+  //   ];
+  // }
 
   if (searchConfiguration && searchConfiguration.query) {
     try {

--- a/x-pack/plugins/observability/public/components/custom_threshold/custom_dataset_selector.tsx
+++ b/x-pack/plugins/observability/public/components/custom_threshold/custom_dataset_selector.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
+import { DiscoverStart } from '@kbn/discover-plugin/public';
+import { DatasetSelection } from '@kbn/log-explorer-plugin/common';
+import {
+  DatasetSelector,
+  DatasetsProvider,
+  useDatasetsContext,
+  DataViewsProvider,
+  useDataViewsContext,
+  IntegrationsProvider,
+  useIntegrationsContext,
+  IDatasetsClient,
+  useEsql,
+} from '@kbn/log-explorer-plugin/public';
+
+interface CustomDatasetSelectorProps {
+  selectedDataset: DatasetSelection;
+  onSelectionChange: (datasetSelection: DatasetSelection) => void;
+}
+
+export const CustomDatasetSelector = withProviders(({ selectedDataset, onSelectionChange }) => {
+  const {
+    error: integrationsError,
+    integrations,
+    isLoading: isLoadingIntegrations,
+    isSearching: isSearchingIntegrations,
+    loadMore,
+    reloadIntegrations,
+    searchIntegrations,
+    searchIntegrationsStreams,
+    sortIntegrations,
+    sortIntegrationsStreams,
+  } = useIntegrationsContext();
+
+  const {
+    datasets,
+    error: datasetsError,
+    isLoading: isLoadingUncategorized,
+    loadDatasets,
+    reloadDatasets,
+    searchDatasets,
+    sortDatasets,
+  } = useDatasetsContext();
+
+  const {
+    dataViews,
+    error: dataViewsError,
+    isLoading: isLoadingDataViews,
+    loadDataViews,
+    reloadDataViews,
+    selectDataView,
+    searchDataViews,
+    sortDataViews,
+  } = useDataViewsContext();
+
+  const { discoverEsqlUrlProps } = useEsql({ datasetSelection: selectedDataset });
+
+  return (
+    <DatasetSelector
+      datasets={datasets}
+      datasetSelection={selectedDataset}
+      datasetsError={datasetsError}
+      dataViews={dataViews}
+      dataViewsError={dataViewsError}
+      discoverEsqlUrlProps={discoverEsqlUrlProps}
+      hideDataViews
+      integrations={integrations}
+      integrationsError={integrationsError}
+      isEsqlEnabled={false}
+      isLoadingDataViews={isLoadingDataViews}
+      isLoadingIntegrations={isLoadingIntegrations}
+      isLoadingUncategorized={isLoadingUncategorized}
+      isSearchingIntegrations={isSearchingIntegrations}
+      onDataViewSelection={selectDataView}
+      onDataViewsReload={reloadDataViews}
+      onDataViewsSearch={searchDataViews}
+      onDataViewsSort={sortDataViews}
+      onDataViewsTabClick={loadDataViews}
+      onIntegrationsLoadMore={loadMore}
+      onIntegrationsReload={reloadIntegrations}
+      onIntegrationsSearch={searchIntegrations}
+      onIntegrationsSort={sortIntegrations}
+      onIntegrationsStreamsSearch={searchIntegrationsStreams}
+      onIntegrationsStreamsSort={sortIntegrationsStreams}
+      onSelectionChange={onSelectionChange}
+      onUncategorizedReload={reloadDatasets}
+      onUncategorizedSearch={searchDatasets}
+      onUncategorizedSort={sortDatasets}
+      onUncategorizedTabClick={loadDatasets}
+    />
+  );
+});
+
+// eslint-disable-next-line import/no-default-export
+export default CustomDatasetSelector;
+
+export type CustomDatasetSelectorBuilderProps = CustomDatasetSelectorProps & {
+  datasetsClient: IDatasetsClient;
+  dataViews: DataViewsPublicPluginStart;
+  discover: DiscoverStart;
+};
+
+function withProviders(Component: React.FunctionComponent<CustomDatasetSelectorProps>) {
+  return function ComponentWithProviders({
+    datasetsClient,
+    dataViews,
+    discover,
+    selectedDataset,
+    onSelectionChange,
+  }: CustomDatasetSelectorBuilderProps) {
+    return (
+      <IntegrationsProvider datasetsClient={datasetsClient}>
+        <DatasetsProvider datasetsClient={datasetsClient}>
+          <DataViewsProvider dataViewsService={dataViews} discoverService={discover}>
+            <Component selectedDataset={selectedDataset} onSelectionChange={onSelectionChange} />
+          </DataViewsProvider>
+        </DatasetsProvider>
+      </IntegrationsProvider>
+    );
+  };
+}

--- a/x-pack/plugins/observability/public/components/custom_threshold/types.ts
+++ b/x-pack/plugins/observability/public/components/custom_threshold/types.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { AggregateQuery, Query } from '@kbn/es-query';
 import * as rt from 'io-ts';
 import { CasesUiStart } from '@kbn/cases-plugin/public';
 import { ChartsPluginStart } from '@kbn/charts-plugin/public';
@@ -53,6 +54,20 @@ export interface TimeRange {
   to?: string;
 }
 
+export interface DatasetSource {
+  index: {
+    // TODO use DatasetSelection
+    selectionType: string;
+    selection: {
+      integration?: string;
+      dataset: string;
+    };
+  };
+  query?: Query | AggregateQuery;
+}
+
+export type SearchConfiguration = SerializedSearchSourceFields | DatasetSource;
+
 export interface AlertParams {
   criteria: MetricExpression[];
   groupBy?: string | string[];
@@ -60,7 +75,7 @@ export interface AlertParams {
   filterQuery?: string;
   alertOnNoData?: boolean;
   alertOnGroupDisappear?: boolean;
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SearchConfiguration;
   shouldDropPartialBuckets?: boolean;
 }
 

--- a/x-pack/plugins/observability/server/lib/rules/custom_threshold/register_custom_threshold_rule_type.ts
+++ b/x-pack/plugins/observability/server/lib/rules/custom_threshold/register_custom_threshold_rule_type.ts
@@ -50,8 +50,16 @@ export const MetricsRulesTypeAlertDefinition: IRuleTypeAlerts = {
   useLegacyAlerts: false,
 };
 
+export const datasetSourceSchema = schema.object({
+  selectionType: schema.string(),
+  selection: schema.object({
+    integration: schema.string(),
+    dataset: schema.string(),
+  }),
+});
+
 export const searchConfigurationSchema = schema.object({
-  index: schema.oneOf([schema.string(), dataViewSpecSchema]),
+  index: schema.oneOf([schema.string(), datasetSourceSchema, dataViewSpecSchema]),
   query: schema.object({
     language: schema.string({
       validate: validateKQLStringFilter,


### PR DESCRIPTION
Related to https://github.com/elastic/observability-dev/issues/3016

## Summary

This is an ON week project to add integration selection to the custom threshold rule:

https://github.com/elastic/kibana/assets/12370520/95cbc338-b2b9-47be-99c8-a40b4e229fe4

Also, the data is saved in the rule as follows:

|Rule with data view| Rule with integration|
|---|---|
|![image](https://github.com/elastic/kibana/assets/12370520/e64f15e6-f391-4f2a-aa5e-9fa48aa99411)|![image](https://github.com/elastic/kibana/assets/12370520/175c084a-1bb4-4d16-9d29-bd0901e01819)|

#### What is not covered
- [ ] Load selected integration in the rule's flyout
- [ ] Use related index in rule's execution
- [ ] Decide how to handle data view: Use the data view tab in the data selection or a separate input similar to the current version.