### PR TITLE
[8.12] [Security Solution] [Timeline] Delete saved searches on timeline delete, prevent creating double saved searches (#174562)

### DIFF
--- a/x-pack/plugins/security_solution/common/api/timeline/delete_timelines/delete_timelines_route.ts
+++ b/x-pack/plugins/security_solution/common/api/timeline/delete_timelines/delete_timelines_route.ts
@@ -7,6 +7,10 @@
 
 import * as rt from 'io-ts';
 
-export const deleteTimelinesSchema = rt.type({
+const searchId = rt.partial({ searchIds: rt.array(rt.string) });
+
+const baseDeleteTimelinesSchema = rt.type({
   savedObjectIds: rt.array(rt.string),
 });
+
+export const deleteTimelinesSchema = rt.intersection([baseDeleteTimelinesSchema, searchId]);

--- a/x-pack/plugins/security_solution/common/api/timeline/delete_timelines/delete_timelines_route_schema.yaml
+++ b/x-pack/plugins/security_solution/common/api/timeline/delete_timelines/delete_timelines_route_schema.yaml
@@ -33,6 +33,10 @@ paths:
                   type: array
                   items:
                     type: string
+                searchId:
+                  type: array
+                  items:
+                    type: string
       responses:
         200:
           description: Indicates the timeline was successfully deleted.

--- a/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx
@@ -48,7 +48,7 @@ export const useDiscoverInTimelineActions = (
   const timeline = useShallowEqualSelector(
     (state) => getTimeline(state, TimelineId.active) ?? timelineDefaults
   );
-  const { savedSearchId } = timeline;
+  const { savedSearchId, version } = timeline;
 
   // We're using a ref here to prevent a cyclic hook-dependency chain of updateSavedSearch
   const timelineRef = useRef(timeline);
@@ -56,7 +56,7 @@ export const useDiscoverInTimelineActions = (
 
   const queryClient = useQueryClient();
 
-  const { mutateAsync: saveSavedSearch } = useMutation({
+  const { mutateAsync: saveSavedSearch, status } = useMutation({
     mutationFn: ({
       savedSearch,
       savedSearchOptions,
@@ -75,6 +75,7 @@ export const useDiscoverInTimelineActions = (
       }
       queryClient.invalidateQueries({ queryKey: ['savedSearchById', savedSearchId] });
     },
+    mutationKey: [version],
   });
 
   const getDefaultDiscoverAppState: () => Promise<DiscoverAppState> = useCallback(async () => {
@@ -217,7 +218,7 @@ export const useDiscoverInTimelineActions = (
           const responseIsEmpty = !response || !response?.id;
           if (responseIsEmpty) {
             throw new Error('Response is empty');
-          } else if (!savedSearchId && !responseIsEmpty) {
+          } else if (!savedSearchId && !responseIsEmpty && status !== 'loading') {
             dispatch(
               timelineActions.updateSavedSearchId({
                 id: TimelineId.active,
@@ -236,7 +237,7 @@ export const useDiscoverInTimelineActions = (
         }
       }
     },
-    [persistSavedSearch, savedSearchId, dispatch, discoverDataService]
+    [persistSavedSearch, savedSearchId, dispatch, discoverDataService, status]
   );
 
   const initializeLocalSavedSearch = useCallback(

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/delete_timeline_modal/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/delete_timeline_modal/index.tsx
@@ -27,13 +27,14 @@ interface Props {
   onComplete?: () => void;
   isModalOpen: boolean;
   savedObjectIds: string[];
+  savedSearchIds?: string[];
   title: string | null;
 }
 /**
  * Renders a button that when clicked, displays the `Delete Timeline` modal
  */
 export const DeleteTimelineModalOverlay = React.memo<Props>(
-  ({ deleteTimelines, isModalOpen, savedObjectIds, title, onComplete }) => {
+  ({ deleteTimelines, isModalOpen, savedObjectIds, title, onComplete, savedSearchIds }) => {
     const { addSuccess } = useAppToasts();
     const { tabName: timelineType } = useParams<{ tabName: TimelineType }>();
 
@@ -43,9 +44,16 @@ export const DeleteTimelineModalOverlay = React.memo<Props>(
       }
     }, [onComplete]);
     const onDelete = useCallback(() => {
-      if (savedObjectIds.length > 0) {
+      if (savedObjectIds.length > 0 && savedSearchIds != null && savedSearchIds.length > 0) {
+        deleteTimelines(savedObjectIds, savedSearchIds);
+        addSuccess({
+          title:
+            timelineType === TimelineType.template
+              ? i18n.SUCCESSFULLY_DELETED_TIMELINE_TEMPLATES(savedObjectIds.length)
+              : i18n.SUCCESSFULLY_DELETED_TIMELINES(savedObjectIds.length),
+        });
+      } else if (savedObjectIds.length > 0) {
         deleteTimelines(savedObjectIds);
-
         addSuccess({
           title:
             timelineType === TimelineType.template
@@ -53,10 +61,11 @@ export const DeleteTimelineModalOverlay = React.memo<Props>(
               : i18n.SUCCESSFULLY_DELETED_TIMELINES(savedObjectIds.length),
         });
       }
+
       if (onComplete != null) {
         onComplete();
       }
-    }, [deleteTimelines, savedObjectIds, onComplete, addSuccess, timelineType]);
+    }, [deleteTimelines, savedObjectIds, onComplete, addSuccess, timelineType, savedSearchIds]);
     return (
       <>
         {isModalOpen && <RemovePopover data-test-subj="remove-popover" />}

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/edit_timeline_batch_actions.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/edit_timeline_batch_actions.tsx
@@ -15,14 +15,7 @@ import * as i18n from './translations';
 import type { DeleteTimelines, OpenTimelineResult } from './types';
 import { EditTimelineActions } from './export_timeline';
 import { useEditTimelineActions } from './edit_timeline_actions';
-
-const getExportedIds = (selectedTimelines: OpenTimelineResult[]) => {
-  const array = Array.isArray(selectedTimelines) ? selectedTimelines : [selectedTimelines];
-  return array.reduce(
-    (acc, item) => (item.savedObjectId != null ? [...acc, item.savedObjectId] : [...acc]),
-    [] as string[]
-  );
-};
+import { getSelectedTimelineIdsAndSearchIds, getRequestIds } from '.';
 
 export const useEditTimelineBatchActions = ({
   deleteTimelines,
@@ -56,7 +49,13 @@ export const useEditTimelineBatchActions = ({
     [disableExportTimelineDownloader, onCloseDeleteTimelineModal, tableRef]
   );
 
-  const selectedIds = useMemo(() => getExportedIds(selectedItems ?? []), [selectedItems]);
+  const { timelineIds, searchIds } = useMemo(() => {
+    if (selectedItems != null) {
+      return getRequestIds(getSelectedTimelineIdsAndSearchIds(selectedItems));
+    } else {
+      return { timelineIds: [], searchIds: undefined };
+    }
+  }, [selectedItems]);
 
   const handleEnableExportTimelineDownloader = useCallback(
     () => enableExportTimelineDownloader(),
@@ -102,7 +101,8 @@ export const useEditTimelineBatchActions = ({
         <>
           <EditTimelineActions
             deleteTimelines={deleteTimelines}
-            ids={selectedIds}
+            ids={timelineIds}
+            savedSearchIds={searchIds}
             isEnableDownloader={isEnableDownloader}
             isDeleteTimelineModalOpen={isDeleteTimelineModalOpen}
             onComplete={onCompleteBatchActions.bind(null, closePopover)}
@@ -121,7 +121,8 @@ export const useEditTimelineBatchActions = ({
     [
       selectedItems,
       deleteTimelines,
-      selectedIds,
+      timelineIds,
+      searchIds,
       isEnableDownloader,
       isDeleteTimelineModalOpen,
       onCompleteBatchActions,

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/export_timeline/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/export_timeline/index.tsx
@@ -20,6 +20,7 @@ export interface ExportTimeline {
 export const EditTimelineActionsComponent: React.FC<{
   deleteTimelines: DeleteTimelines | undefined;
   ids: string[];
+  savedSearchIds?: string[];
   isEnableDownloader: boolean;
   isDeleteTimelineModalOpen: boolean;
   onComplete: () => void;
@@ -27,6 +28,7 @@ export const EditTimelineActionsComponent: React.FC<{
 }> = ({
   deleteTimelines,
   ids,
+  savedSearchIds,
   isEnableDownloader,
   isDeleteTimelineModalOpen,
   onComplete,
@@ -46,6 +48,7 @@ export const EditTimelineActionsComponent: React.FC<{
         isModalOpen={isDeleteTimelineModalOpen}
         onComplete={onComplete}
         savedObjectIds={ids}
+        savedSearchIds={savedSearchIds}
         title={title}
       />
     )}

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/open_timeline.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/open_timeline.tsx
@@ -129,6 +129,12 @@ export const OpenTimeline = React.memo<OpenTimelineProps>(
       [actionItem]
     );
 
+    const actionItemSavedSearchId = useMemo(() => {
+      return actionItem != null && actionItem.savedSearchId != null
+        ? [actionItem.savedSearchId]
+        : undefined;
+    }, [actionItem]);
+
     const onRefreshBtnClick = useCallback(() => {
       if (refetch != null) {
         refetch();
@@ -197,6 +203,7 @@ export const OpenTimeline = React.memo<OpenTimelineProps>(
         <EditTimelineActions
           deleteTimelines={deleteTimelines}
           ids={actionItemId}
+          savedSearchIds={actionItemSavedSearchId}
           isDeleteTimelineModalOpen={isDeleteTimelineModalOpen}
           isEnableDownloader={isEnableDownloader}
           onComplete={onCompleteEditTimelineAction}

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
@@ -6,7 +6,6 @@
  */
 
 import type React from 'react';
-import type { AllTimelinesVariables } from '../../containers/all';
 import type { TimelineModel } from '../../store/timeline/model';
 import type {
   RowRendererId,

--- a/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/open_timeline/types.ts
@@ -59,6 +59,7 @@ export interface OpenTimelineResult {
   pinnedEventIds?: Readonly<Record<string, boolean>> | null;
   queryType?: { hasEql: boolean; hasQuery: boolean };
   savedObjectId?: string | null;
+  savedSearchId?: string | null;
   status?: TimelineStatus | null;
   title?: string | null;
   templateTimelineId?: string | null;
@@ -77,7 +78,7 @@ export interface EuiSearchBarQuery {
 }
 
 /** Performs IO to delete the specified timelines */
-export type DeleteTimelines = (timelineIds: string[], variables?: AllTimelinesVariables) => void;
+export type DeleteTimelines = (timelineIds: string[], searchIds?: string[]) => void;
 
 /** Invoked when the user clicks the action create rule from timeline */
 export type OnCreateRuleFromTimeline = (savedObjectId: string) => void;

--- a/x-pack/plugins/security_solution/public/timelines/containers/all/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/containers/all/index.tsx
@@ -88,6 +88,7 @@ export const getAllTimeline = memoizeOne(
             )
           : null,
       savedObjectId: timeline.savedObjectId,
+      savedSearchId: timeline.savedSearchId,
       status: timeline.status,
       title: timeline.title,
       updated: timeline.updated,

--- a/x-pack/plugins/security_solution/public/timelines/containers/api.ts
+++ b/x-pack/plugins/security_solution/public/timelines/containers/api.ts
@@ -480,13 +480,20 @@ export const persistFavorite = async ({
   return decodeResponseFavoriteTimeline(response);
 };
 
-export const deleteTimelinesByIds = async (savedObjectIds: string[]) => {
+export const deleteTimelinesByIds = async (savedObjectIds: string[], searchIds?: string[]) => {
   let requestBody;
 
   try {
-    requestBody = JSON.stringify({
-      savedObjectIds,
-    });
+    if (searchIds) {
+      requestBody = JSON.stringify({
+        savedObjectIds,
+        searchIds,
+      });
+    } else {
+      requestBody = JSON.stringify({
+        savedObjectIds,
+      });
+    }
   } catch (err) {
     return Promise.reject(new Error(`Failed to stringify query: ${JSON.stringify(err)}`));
   }

--- a/x-pack/plugins/security_solution/server/lib/timeline/routes/timelines/delete_timelines/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/routes/timelines/delete_timelines/index.ts
@@ -42,9 +42,9 @@ export const deleteTimelinesRoute = (
 
         try {
           const frameworkRequest = await buildFrameworkRequest(context, security, request);
-          const { savedObjectIds } = request.body;
+          const { savedObjectIds, searchIds } = request.body;
 
-          await deleteTimeline(frameworkRequest, savedObjectIds);
+          await deleteTimeline(frameworkRequest, savedObjectIds, searchIds);
           return response.ok({ body: { data: { deleteTimeline: true } } });
         } catch (err) {
           const error = transformError(err);

--- a/x-pack/plugins/security_solution/server/lib/timeline/saved_object/saved_search/index.ts
+++ b/x-pack/plugins/security_solution/server/lib/timeline/saved_object/saved_search/index.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { FrameworkRequest } from '../../../framework';
+
+export const deleteSearchByTimelineId = async (
+  request: FrameworkRequest,
+  savedSearchIds?: string[]
+) => {
+  if (savedSearchIds !== undefined) {
+    const savedObjectsClient = (await request.context.core).savedObjects.client;
+    const objects = savedSearchIds.map((id) => ({ id, type: 'search' }));
+
+    await savedObjectsClient.bulkDelete(objects);
+  } else {
+    return Promise.resolve();
+  }
+};


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Security Solution] [Timeline] Delete saved searches on timeline delete, prevent creating double saved searches (#174562)](https://github.com/elastic/kibana/pull/174562)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kevin Qualters","email":"56408403+kqualters-elastic@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-12T17:10:20Z","message":"[Security Solution] [Timeline] Delete saved searches on timeline delete, prevent creating double saved searches (#174562)\n\n## Summary\r\n\r\nThis pr fixes 2 issues currently present in the timeline es|ql via\r\ndiscover integration: first, when timelines are deleted, the saved\r\nobject ids associated with those timelines that point to saved searches\r\nare currently not deleted. If a user deletes a timeline and then tries\r\nto create another with the same name, the esql is not able to be\r\npersisted because no new saved search saved object can be created, as\r\nthe name of the old one collides with the new one. This pr fixes that by\r\ndeleting the saved search saved object on delete, although the issue\r\nwith timeline allowing multiple timelines with the same name while saved\r\nsearch does not will remain an issue, need to use the onDuplicateTitle\r\ncallback that is currently a no-op to handle this here\r\nhttps://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx#L213\r\n. Second, the use of react-query useMutation that creates the saved\r\nsearch saved object will no longer create two, as it currently does, as\r\nwe check the status of the request in the useEffect that fires the\r\nrequest. This might be a race condition bug with the saved search saved\r\nobjects client too, as normally objects are not supposed to be created\r\nwith the same name,\r\nhttps://github.com/elastic/kibana/blob/main/src/plugins/saved_search/public/services/saved_searches/save_saved_searches.ts#L68,\r\nbut I'm not sure.\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"7b69611234ef7979f9f00df14609aeba40a66d62","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Threat Hunting:Investigations","v8.12.1","v8.13.0"],"number":174562,"url":"https://github.com/elastic/kibana/pull/174562","mergeCommit":{"message":"[Security Solution] [Timeline] Delete saved searches on timeline delete, prevent creating double saved searches (#174562)\n\n## Summary\r\n\r\nThis pr fixes 2 issues currently present in the timeline es|ql via\r\ndiscover integration: first, when timelines are deleted, the saved\r\nobject ids associated with those timelines that point to saved searches\r\nare currently not deleted. If a user deletes a timeline and then tries\r\nto create another with the same name, the esql is not able to be\r\npersisted because no new saved search saved object can be created, as\r\nthe name of the old one collides with the new one. This pr fixes that by\r\ndeleting the saved search saved object on delete, although the issue\r\nwith timeline allowing multiple timelines with the same name while saved\r\nsearch does not will remain an issue, need to use the onDuplicateTitle\r\ncallback that is currently a no-op to handle this here\r\nhttps://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx#L213\r\n. Second, the use of react-query useMutation that creates the saved\r\nsearch saved object will no longer create two, as it currently does, as\r\nwe check the status of the request in the useEffect that fires the\r\nrequest. This might be a race condition bug with the saved search saved\r\nobjects client too, as normally objects are not supposed to be created\r\nwith the same name,\r\nhttps://github.com/elastic/kibana/blob/main/src/plugins/saved_search/public/services/saved_searches/save_saved_searches.ts#L68,\r\nbut I'm not sure.\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"7b69611234ef7979f9f00df14609aeba40a66d62"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174562","number":174562,"mergeCommit":{"message":"[Security Solution] [Timeline] Delete saved searches on timeline delete, prevent creating double saved searches (#174562)\n\n## Summary\r\n\r\nThis pr fixes 2 issues currently present in the timeline es|ql via\r\ndiscover integration: first, when timelines are deleted, the saved\r\nobject ids associated with those timelines that point to saved searches\r\nare currently not deleted. If a user deletes a timeline and then tries\r\nto create another with the same name, the esql is not able to be\r\npersisted because no new saved search saved object can be created, as\r\nthe name of the old one collides with the new one. This pr fixes that by\r\ndeleting the saved search saved object on delete, although the issue\r\nwith timeline allowing multiple timelines with the same name while saved\r\nsearch does not will remain an issue, need to use the onDuplicateTitle\r\ncallback that is currently a no-op to handle this here\r\nhttps://github.com/elastic/kibana/blob/main/x-pack/plugins/security_solution/public/common/components/discover_in_timeline/use_discover_in_timeline_actions.tsx#L213\r\n. Second, the use of react-query useMutation that creates the saved\r\nsearch saved object will no longer create two, as it currently does, as\r\nwe check the status of the request in the useEffect that fires the\r\nrequest. This might be a race condition bug with the saved search saved\r\nobjects client too, as normally objects are not supposed to be created\r\nwith the same name,\r\nhttps://github.com/elastic/kibana/blob/main/src/plugins/saved_search/public/services/saved_searches/save_saved_searches.ts#L68,\r\nbut I'm not sure.\r\n\r\n### Checklist\r\n\r\n- [x]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed","sha":"7b69611234ef7979f9f00df14609aeba40a66d62"}}]}] BACKPORT-->