### PR TITLE
[Security Solution] Rule upgrade JSON diff: Hide runtime and internal properties

### DIFF
--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -16,10 +16,16 @@ import {
   EuiTitle,
   EuiIconTip,
 } from '@elastic/eui';
-import { parseDuration } from '@kbn/alerting-plugin/common';
+import type { Filter } from '@kbn/es-query';
+import { normalizeMachineLearningJobIds } from '../../../../../common/detection_engine/utils';
+import {
+  formatScheduleStepData,
+  filterEmptyThreats,
+} from '../../../rule_creation_ui/pages/rule_creation/helpers';
 import type { RuleResponse } from '../../../../../common/api/detection_engine/model/rule_schema/rule_schemas.gen';
 import { DiffView } from './json_diff/diff_view';
 import * as i18n from './json_diff/translations';
+import { getHumanizedDuration } from '../../../../detections/pages/detection_engine/rules/helpers';
 
 /* Inclding these properties in diff display might be confusing to users. */
 const HIDDEN_PROPERTIES = [
@@ -48,30 +54,73 @@ const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
   stringify(jsObject, { space: 2 });
 
 /**
- * Normalizes the representation of the 'from' property in rule responses.
+ * Normalizes the rule object, making it suitable for comparison with another normalized rule.
  *
- * Helpful when different time units represent the same duration. For instance, 'now-1m' and 'now-60s'
- * both indicate a duration of one minute. If the durations represented by the 'from' properties in
- * oldRule and newRule are the same, the function updates the oldRule's 'from' property to match
- * that of newRule. This would ensure that the 'from' property is not shown as a diff in the UI.
+ * Normalization is needed to avoid showing diffs for semantically equal property values.
+ * Saving a rule via the rule editing UI might change the format of some properties or set default values.
+ * This function compensates for those changes.
  *
- * @param {RuleResponse} oldRule - The original rule.
- * @param {RuleResponse} newRule - The new rule to compare with.
- * @returns {RuleResponse} - The updated rule object with a potentially normalized 'from' property.
+ * @param {RuleResponse} originalRule - Rule of a RuleResponse type.
+ * @returns {RuleResponse} - The updated normalized rule object.
  */
-const normalizeFromProperty = (oldRule: RuleResponse, newRule: RuleResponse): RuleResponse => {
-  let oldRuleFrom = oldRule.from;
+const normalizeRule = (originalRule: RuleResponse): RuleResponse => {
+  const rule = { ...originalRule };
 
-  if (
-    oldRule.from.startsWith('now-') &&
-    newRule.from.startsWith('now-') &&
-    parseDuration(oldRule.from.slice('now-'.length)) ===
-      parseDuration(newRule.from.slice('now-'.length))
-  ) {
-    oldRuleFrom = newRule.from;
+  /*
+    Convert the "from" property value to a humanized duration string, like 'now-1m' or 'now-2h'. 
+    Conversion is needed to skip showing the diff for the "from" property when the same 
+    duration is represented in different time units. For instance, 'now-1h' and 'now-3600s' 
+    indicate a one-hour duration.
+    The same helper is used in the rule editing UI to format "from" before submitting the edits. 
+    So, after the rule is saved, the "from" property unit/value might differ from what's in the package.
+  */
+  rule.from = formatScheduleStepData({
+    interval: rule.interval,
+    from: getHumanizedDuration(rule.from, rule.interval),
+    to: rule.to,
+  }).from;
+
+  /*
+    Default "note" to an empty string if it's not present.
+    Sometimes, in a new version of a rule, the "note" value equals an empty string, while 
+    in the old version, it wasn't specified at all (undefined becomes ''). In this case, 
+    it doesn't make sense to show diff, so we default falsy values to ''.
+  */
+  rule.note = rule.note ?? '';
+
+  /*
+    Removes empty arrays (techniques, subtechniques) from the MITRE ATT&CK value.
+    The same processing is done in the rule editing UI before submitting the edits.
+  */
+  rule.threat = filterEmptyThreats(rule.threat);
+
+  /*
+    The "machine_learning_job_id" property is converted from the legacy string format 
+    to the new array format during installation and upgrade. Thus, all installed rules 
+    use the new format. For correct comparison, we must ensure that the new rule is 
+    also in the new format before showing the diff.
+  */
+  if ('machine_learning_job_id' in rule) {
+    rule.machine_learning_job_id = normalizeMachineLearningJobIds(rule.machine_learning_job_id);
   }
 
-  return { ...oldRule, from: oldRuleFrom };
+  /*
+    Default the "alias" property to null for all threat filters that don't have it.
+    Setting a default is needed to match the behavior of the rule editing UI, 
+    which also defaults the "alias" property to null.
+  */
+  if (rule.type === 'threat_match' && Array.isArray(rule.threat_filters)) {
+    const threatFiltersWithDefaultMeta = (rule.threat_filters as Filter[]).map((filter) => {
+      if (!filter.meta.alias) {
+        return { ...filter, meta: { ...filter.meta, alias: null } };
+      }
+      return filter;
+    });
+
+    rule.threat_filters = threatFiltersWithDefaultMeta;
+  }
+
+  return rule;
 };
 
 interface RuleDiffTabProps {
@@ -81,12 +130,11 @@ interface RuleDiffTabProps {
 
 export const RuleDiffTab = ({ oldRule, newRule }: RuleDiffTabProps) => {
   const [oldSource, newSource] = useMemo(() => {
+    const visibleNewRuleProperties = omit(normalizeRule(newRule), ...HIDDEN_PROPERTIES);
     const visibleOldRuleProperties = omit(
       /* Only compare properties that are present in the update. */
-      pick(normalizeFromProperty(oldRule, newRule), Object.keys(newRule)),
-      ...HIDDEN_PROPERTIES
+      pick(normalizeRule(oldRule), Object.keys(visibleNewRuleProperties))
     );
-    const visibleNewRuleProperties = omit(newRule, ...HIDDEN_PROPERTIES);
 
     return [
       sortAndStringifyJson(visibleOldRuleProperties),

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -23,6 +23,14 @@ import * as i18n from './json_diff/translations';
 const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
   stringify(jsObject, { space: 2 });
 
+const HIDDEN_PROPERTIES = [
+  'revision',
+  'output_index',
+  'enabled',
+  'exceptions_list',
+  'execution_summary',
+];
+
 interface RuleDiffTabProps {
   oldRule: RuleResponse;
   newRule: RuleResponse;
@@ -30,8 +38,8 @@ interface RuleDiffTabProps {
 
 export const RuleDiffTab = ({ oldRule, newRule }: RuleDiffTabProps) => {
   const [oldSource, newSource] = useMemo(() => {
-    const visibleOldRuleProperties = omit(oldRule, 'revision');
-    const visibleNewRuleProperties = omit(newRule, 'revision');
+    const visibleOldRuleProperties = omit(oldRule, ...HIDDEN_PROPERTIES);
+    const visibleNewRuleProperties = omit(newRule, ...HIDDEN_PROPERTIES);
 
     return [
       sortAndStringifyJson(visibleOldRuleProperties),

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -97,7 +97,7 @@ const normalizeRule = (originalRule: RuleResponse): RuleResponse => {
   /*
     The "machine_learning_job_id" property is converted from the legacy string format 
     to the new array format during installation and upgrade. Thus, all installed rules 
-    use the new format. For correct comparison, we must ensure that the new rule is 
+    use the new format. For correct comparison, we must ensure that the rule update is 
     also in the new format before showing the diff.
   */
   if ('machine_learning_job_id' in rule) {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -38,8 +38,8 @@ const HIDDEN_PROPERTIES = [
   'revision',
 
   /*
-    This info is not yet exposed by prebuilt rules.
-    Ticket to add support: https://github.com/elastic/detection-rules/issues/2826
+    "updated_at" value is regenerated on every '/upgrade/_review' endpoint run 
+    and will therefore always show a diff. It adds no value to display it to the user.
   */
   'updated_at',
 ];

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -21,62 +21,6 @@ import type { RuleResponse } from '../../../../../common/api/detection_engine/mo
 import { DiffView } from './json_diff/diff_view';
 import * as i18n from './json_diff/translations';
 
-const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
-  stringify(jsObject, { space: 2 });
-
-// const PROPERTIES_NOT_PRESENT_IN_PREBUILT_RULES = [
-//   'actions',
-//   'alias_purpose',
-//   'alias_target_id',
-//   'data_view_id',
-//   'execution_summary',
-//   'meta',
-//   'namespace',
-//   'outcome',
-//   'output_index',
-//   'response_actions',
-//   'saved_id',
-//   'saved_id',
-//   'throttle',
-//   'to',
-// ];
-
-// const HIDDEN_PROPERTIES = [
-//   /* Not a user-facing property. Can be confused with "version" by users. */
-//   'revision',
-
-//   /* Generates diff when the rule is enabled/disabled by user */
-//   'enabled',
-
-//   /* Never present in prebuilt rule updates. Generates diff if user adds exceptions to installed rule. Rule's exception list is preseved on rule update. */
-//   'exceptions_list',
-
-//   /* Never present in prebuilt rule updates. Actions are preseved on rule update */
-//   'actions',
-
-//   /* Not used anymore, but gets defaulted to an empty string when the rule is updated */
-//   'output_index',
-
-//   /* Never present in prebuilt rule updates. Gets added to installed rule after execution. */
-//   'execution_summary',
-
-//   /* Never present in prebuilt rule updates. These get added to installed rule once user saves the rule after editing. */
-//   'meta',
-//   'filters',
-//   'timestamp_override_fallback_disabled',
-
-//   /* Not relevant to the upgrade flow until we allow rule customisation. */
-//   'updated_at',
-//   'updated_by',
-//   'created_at',
-//   'created_by',
-
-//   /* Never present in prebuilt rule updates. */
-//   'outcome',
-//   'alias_target_id',
-//   'alias_purpose',
-// ];
-
 /* Inclding these properties in diff display might be confusing to users. */
 const HIDDEN_PROPERTIES = [
   /*
@@ -99,6 +43,9 @@ const HIDDEN_PROPERTIES = [
   */
   'updated_at',
 ];
+
+const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
+  stringify(jsObject, { space: 2 });
 
 /**
  * Normalizes the representation of the 'from' property in rule responses.

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -16,6 +16,7 @@ import {
   EuiTitle,
   EuiIconTip,
 } from '@elastic/eui';
+import { parseDuration } from '@kbn/alerting-plugin/common';
 import type { RuleResponse } from '../../../../../common/api/detection_engine/model/rule_schema/rule_schemas.gen';
 import { DiffView } from './json_diff/diff_view';
 import * as i18n from './json_diff/translations';
@@ -24,11 +25,32 @@ const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
   stringify(jsObject, { space: 2 });
 
 const HIDDEN_PROPERTIES = [
-  'revision',
-  'output_index',
+  /* Generates diff when the rule is enabled/disabled by user */
   'enabled',
+
+  /* Never present in prebuilt rule updates. Generates diff if user adds exceptions to installed rule. */
   'exceptions_list',
+
+  /* Techical property. Can be confused with "version" by users. */
+  'revision',
+
+  /* Not used anymore, but gets defaulted to an empty string when the rule is updated */
+  'output_index',
+
+  /* Never present in prebuilt rule updates. Gets added to installed rule after execution. */
   'execution_summary',
+
+  /* Never present in prebuilt rule updates. These get added to installed rule once user saves the rule after editing. */
+  'actions',
+  'meta',
+  'filters',
+  'timestamp_override_fallback_disabled',
+
+  /* Not relevant to the upgrade flow. */
+  'updated_at',
+  'updated_by',
+  'created_at',
+  'created_by',
 ];
 
 interface RuleDiffTabProps {
@@ -38,7 +60,23 @@ interface RuleDiffTabProps {
 
 export const RuleDiffTab = ({ oldRule, newRule }: RuleDiffTabProps) => {
   const [oldSource, newSource] = useMemo(() => {
-    const visibleOldRuleProperties = omit(oldRule, ...HIDDEN_PROPERTIES);
+    let oldRuleFrom = oldRule.from;
+
+    if (
+      oldRule.from.startsWith('now-') &&
+      newRule.from.startsWith('now-') &&
+      parseDuration(oldRule.from.slice('now-'.length)) ===
+        parseDuration(newRule.from.slice('now-'.length))
+    ) {
+      /* 
+        We want to avoid showing the diff for the `from` property when duration is the same.
+        There are cases where different time units are used to represent the same duration.
+        For example, `now-1m` and `now-60s` both represent the same duration of 1 minute.
+      */
+      oldRuleFrom = newRule.from;
+    }
+
+    const visibleOldRuleProperties = { ...omit(oldRule, ...HIDDEN_PROPERTIES), from: oldRuleFrom };
     const visibleNewRuleProperties = omit(newRule, ...HIDDEN_PROPERTIES);
 
     return [

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useMemo } from 'react';
-import { omit } from 'lodash';
+import { omit, pick } from 'lodash';
 import stringify from 'json-stable-stringify';
 import {
   EuiSpacer,
@@ -24,39 +24,108 @@ import * as i18n from './json_diff/translations';
 const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
   stringify(jsObject, { space: 2 });
 
+// const PROPERTIES_NOT_PRESENT_IN_PREBUILT_RULES = [
+//   'actions',
+//   'alias_purpose',
+//   'alias_target_id',
+//   'data_view_id',
+//   'execution_summary',
+//   'meta',
+//   'namespace',
+//   'outcome',
+//   'output_index',
+//   'response_actions',
+//   'saved_id',
+//   'saved_id',
+//   'throttle',
+//   'to',
+// ];
+
+// const HIDDEN_PROPERTIES = [
+//   /* Not a user-facing property. Can be confused with "version" by users. */
+//   'revision',
+
+//   /* Generates diff when the rule is enabled/disabled by user */
+//   'enabled',
+
+//   /* Never present in prebuilt rule updates. Generates diff if user adds exceptions to installed rule. Rule's exception list is preseved on rule update. */
+//   'exceptions_list',
+
+//   /* Never present in prebuilt rule updates. Actions are preseved on rule update */
+//   'actions',
+
+//   /* Not used anymore, but gets defaulted to an empty string when the rule is updated */
+//   'output_index',
+
+//   /* Never present in prebuilt rule updates. Gets added to installed rule after execution. */
+//   'execution_summary',
+
+//   /* Never present in prebuilt rule updates. These get added to installed rule once user saves the rule after editing. */
+//   'meta',
+//   'filters',
+//   'timestamp_override_fallback_disabled',
+
+//   /* Not relevant to the upgrade flow until we allow rule customisation. */
+//   'updated_at',
+//   'updated_by',
+//   'created_at',
+//   'created_by',
+
+//   /* Never present in prebuilt rule updates. */
+//   'outcome',
+//   'alias_target_id',
+//   'alias_purpose',
+// ];
+
+/* Inclding these properties in diff display might be confusing to users. */
 const HIDDEN_PROPERTIES = [
-  /* Not a user-facing property. Can be confused with "version" by users. */
-  'revision',
-
-  /* Generates diff when the rule is enabled/disabled by user */
-  'enabled',
-
-  /* Never present in prebuilt rule updates. Generates diff if user adds exceptions to installed rule. */
+  /*
+    By default, prebuilt rules don't have any actions or exception lists. So if a user has defined actions or exception lists for a rule, it'll show up as diff. This looks confusing as the user might think that their actions and exceptions lists will get removed after the upgrade, which is not the case - they will be preserved.
+  */
+  'actions',
   'exceptions_list',
 
-  /* Not used anymore, but gets defaulted to an empty string when the rule is updated */
-  'output_index',
+  /*
+    Most prebuilt rules are installed as "disabled". Once user enables a rule, it'll show as diff, which doesn't add value.
+  */
+  'enabled',
 
-  /* Never present in prebuilt rule updates. Gets added to installed rule after execution. */
-  'execution_summary',
+  /* Technical property. Hidden because it can be confused with "version" by users. */
+  'revision',
 
-  /* Never present in prebuilt rule updates. These get added to installed rule once user saves the rule after editing. */
-  'actions',
-  'meta',
-  'filters',
-  'timestamp_override_fallback_disabled',
-
-  /* Not relevant to the upgrade flow until we allow rule customisation. */
+  /*
+    This info is not yet exposed by prebuilt rules.
+    Ticket to add support: https://github.com/elastic/detection-rules/issues/2826
+  */
   'updated_at',
-  'updated_by',
-  'created_at',
-  'created_by',
-
-  /* Never present in prebuilt rule updates. */
-  'outcome',
-  'alias_target_id',
-  'alias_purpose',
 ];
+
+/**
+ * Normalizes the representation of the 'from' property in rule responses.
+ *
+ * Helpful when different time units represent the same duration. For instance, 'now-1m' and 'now-60s'
+ * both indicate a duration of one minute. If the durations represented by the 'from' properties in
+ * oldRule and newRule are the same, the function updates the oldRule's 'from' property to match
+ * that of newRule. This would ensure that the 'from' property is not shown as a diff in the UI.
+ *
+ * @param {RuleResponse} oldRule - The original rule.
+ * @param {RuleResponse} newRule - The new rule to compare with.
+ * @returns {RuleResponse} - The updated rule object with a potentially normalized 'from' property.
+ */
+const normalizeFromProperty = (oldRule: RuleResponse, newRule: RuleResponse): RuleResponse => {
+  let oldRuleFrom = oldRule.from;
+
+  if (
+    oldRule.from.startsWith('now-') &&
+    newRule.from.startsWith('now-') &&
+    parseDuration(oldRule.from.slice('now-'.length)) ===
+      parseDuration(newRule.from.slice('now-'.length))
+  ) {
+    oldRuleFrom = newRule.from;
+  }
+
+  return { ...oldRule, from: oldRuleFrom };
+};
 
 interface RuleDiffTabProps {
   oldRule: RuleResponse;
@@ -65,23 +134,11 @@ interface RuleDiffTabProps {
 
 export const RuleDiffTab = ({ oldRule, newRule }: RuleDiffTabProps) => {
   const [oldSource, newSource] = useMemo(() => {
-    let oldRuleFrom = oldRule.from;
-
-    if (
-      oldRule.from.startsWith('now-') &&
-      newRule.from.startsWith('now-') &&
-      parseDuration(oldRule.from.slice('now-'.length)) ===
-        parseDuration(newRule.from.slice('now-'.length))
-    ) {
-      /* 
-        We want to avoid showing the diff for the `from` property when duration is the same.
-        There are cases where different time units are used to represent the same duration.
-        For example, `now-1m` and `now-60s` both represent the same duration of 1 minute.
-      */
-      oldRuleFrom = newRule.from;
-    }
-
-    const visibleOldRuleProperties = { ...omit(oldRule, ...HIDDEN_PROPERTIES), from: oldRuleFrom };
+    const visibleOldRuleProperties = omit(
+      /* Only compare properties that are present in the update. */
+      pick(normalizeFromProperty(oldRule, newRule), Object.keys(newRule)),
+      ...HIDDEN_PROPERTIES
+    );
     const visibleNewRuleProperties = omit(newRule, ...HIDDEN_PROPERTIES);
 
     return [

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/components/rule_details/rule_diff_tab.tsx
@@ -25,14 +25,14 @@ const sortAndStringifyJson = (jsObject: Record<string, unknown>): string =>
   stringify(jsObject, { space: 2 });
 
 const HIDDEN_PROPERTIES = [
+  /* Not a user-facing property. Can be confused with "version" by users. */
+  'revision',
+
   /* Generates diff when the rule is enabled/disabled by user */
   'enabled',
 
   /* Never present in prebuilt rule updates. Generates diff if user adds exceptions to installed rule. */
   'exceptions_list',
-
-  /* Techical property. Can be confused with "version" by users. */
-  'revision',
 
   /* Not used anymore, but gets defaulted to an empty string when the rule is updated */
   'output_index',
@@ -46,11 +46,16 @@ const HIDDEN_PROPERTIES = [
   'filters',
   'timestamp_override_fallback_disabled',
 
-  /* Not relevant to the upgrade flow. */
+  /* Not relevant to the upgrade flow until we allow rule customisation. */
   'updated_at',
   'updated_by',
   'created_at',
   'created_by',
+
+  /* Never present in prebuilt rule updates. */
+  'outcome',
+  'alias_target_id',
+  'alias_purpose',
 ];
 
 interface RuleDiffTabProps {

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_converters.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_management/normalization/rule_converters.ts
@@ -745,6 +745,7 @@ export const convertPrebuiltRuleAssetToRuleResponse = (
     related_integrations: [],
     required_fields: [],
     setup: '',
+    note: '',
     references: [],
     threat: [],
     tags: [],


### PR DESCRIPTION
**Resolves: https://github.com/elastic/kibana/issues/174844**

## Summary
Hides technical/runtime fields that shouldn't be displayed in the JSON diff view.
We used to hide only the `revision` field because it can be confused with `version`. This PR hides more fields.

Properties that might be displayed as having diff, but shouldn't be displayed:
- `actions`: shown as diff if user defined an action for a rule
- `exceptions_list`: shown as diff if user defined an exception list for a rule
- `execution_summary`: shown as diff if user has enabled a rule and it executed at least once
- `enabled`: shown as diff if user enabled a rule that's disabled by default (or vice versa)
- `updated_at`: always shown as diff because its value is a timestamp of when an API request made
- `note`: shown as diff if an old version of a rule didn't define this property, but a new version of a rule has it defined as ''
- `threat`: might be shown as diff if user has clicked "save" after editing a rule, because edit screen's FE code adds empty arrays as defaults if threats/techniques/subtechniques weren't set by the user
- `machine_learning_job_id`: might be shown as diff if a prebuilt rule uses the legacy string format for this property. On installation, the value is converted into a new array format, which creates a difference between the installed rule (array format) and the update (string format)
- `threat_filters`: might be shown as diff if user has clicked "save" after editing a rule, because edit screen's FE code adds null as a default value for "meta" subproperty
- `filters`: might be shown as diff if user has clicked "save" after editing a rule, because edit screen's FE code adds [] as a default value
- `timestamp_override_fallback_disabled`: might be shown as diff if user has clicked "save" after editing a rule
- `meta`: might be shown as diff if user has clicked "save" after editing a rule
- `output_index`: unused, shouldn't be shown
- `updated_at`, `updated_by`, `created_at`, `created_by`: should be hidden because these are not relevant for the upgrade flow

Also the `from` property might be incorrectly shown as diff if user has clicked "save" after editing a rule, because edit screen's FE code converts value to a different time unit, like 7200s -> 2h. Since 2h = 7200s, user shouldn't see a diff in cases where the old and new values represent the same duration with different time units.




#### Before
<img width="1271" alt="Scherm­afbeelding 2024-01-16 om 13 50 00" src="https://github.com/elastic/kibana/assets/15949146/f72283dc-9a8a-4c95-a9b6-daa84d9356da">



#### After
<img width="1271" alt="Scherm­afbeelding 2024-01-16 om 13 50 36" src="https://github.com/elastic/kibana/assets/15949146/080ef2ea-c108-4d05-8814-0a2ce7f5a0b0">






<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->