### PR TITLE
[Docs] remove .map from bundle_filepath value

### DIFF
--- a/docs/apm/api.asciidoc
+++ b/docs/apm/api.asciidoc
@@ -573,7 +573,7 @@ curl -X POST "http://localhost:5601/api/apm/sourcemaps" \
 -H 'Authorization: ApiKey ${YOUR_API_KEY}' \
 -F 'service_name="foo"' \
 -F 'service_version="1.0.0"' \
--F 'bundle_filepath="/test/e2e/general-usecase/bundle.js.map"' \
+-F 'bundle_filepath="/test/e2e/general-usecase/bundle.js"' \
 -F 'sourcemap="{\"version\":3,\"file\":\"static/js/main.chunk.js\",\"sources\":[\"fleet-source-map-client/src/index.css\",\"fleet-source-map-client/src/App.js\",\"webpack:///./src/index.css?bb0a\",\"fleet-source-map-client/src/index.js\",\"fleet-source-map-client/src/reportWebVitals.js\"],\"sourcesContent\":[\"content\"],\"mappings\":\"mapping\",\"sourceRoot\":\"\"}"' <1>
 --------------------------------------------------
 <1> Alternatively, upload the source map as a file with `-F 'sourcemap=@path/to/source_map/bundle.js.map'`
@@ -647,7 +647,7 @@ curl -X GET "http://localhost:5601/api/apm/sourcemaps" \
       "body": {
         "serviceName": "foo",
         "serviceVersion": "1.0.0",
-        "bundleFilepath": "/test/e2e/general-usecase/bundle.js.map",
+        "bundleFilepath": "/test/e2e/general-usecase/bundle.js",
         "sourceMap": {
           "version": 3,
           "file": "static/js/main.chunk.js",


### PR DESCRIPTION
Part of https://github.com/elastic/observability-docs/issues/3354#issuecomment-1849730927

## Summary

`bundle_filepath` should not contain `.map`.



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->