### PR TITLE
[Lens] fix annotations tooltip non breaking on long lines

### DIFF
--- a/src/plugins/chart_expressions/expression_xy/public/components/annotations.scss
+++ b/src/plugins/chart_expressions/expression_xy/public/components/annotations.scss
@@ -44,13 +44,13 @@
 }
 
 .xyAnnotationTooltip__extraFieldsKey {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   hyphens: auto;
 }
 
 .xyAnnotationTooltip__extraFieldsValue {
   text-align: right;
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
   hyphens: auto;
 }
 


### PR DESCRIPTION
## Summary

Fixes #174836

![image](https://github.com/elastic/kibana/assets/4283304/63232df5-0c01-4d8a-82dc-4b77cf9a655e)



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->