### PR TITLE
[Cloud Security] Add telemetry for muting rules

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/accounts_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/accounts_stats_collector.ts
@@ -224,7 +224,6 @@ const getCspmAccountsStats = (
     nodes_count: account.nodes_count.value,
     pods_count: account.resources.pods_count.value,
   }));
-  logger.info('CSPM telemetry: accounts stats was sent');
 
   return cspmAccountsStats;
 };

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/cloud_accounts_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/cloud_accounts_stats_collector.ts
@@ -345,8 +345,6 @@ export const getCloudAccountsStats = (
     };
   });
 
-  logger.info('Cloud Account Stats telemetry: accounts stats was sent');
-
   return cloudAccountsStats;
 };
 

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import {
+  ISavedObjectsRepository,
+  SavedObjectsClientContract,
+} from '@kbn/core-saved-objects-api-server';
+import type { Logger } from '@kbn/core/server';
+import { CSP_BENCHMARK_RULE_SAVED_OBJECT_TYPE } from '../../../../common/constants';
+import { CspBenchmarkRule } from '../../../../common/types/latest';
+import { getCspBenchmarkRulesStatesHandler } from '../../../routes/benchmark_rules/get_states/v1';
+import { MutedRulesStats } from './types';
+
+export const getMutedRulesStats = async (
+  soClient: SavedObjectsClientContract,
+  encryptedSoClient: ISavedObjectsRepository,
+  logger: Logger
+): Promise<MutedRulesStats[]> => {
+  try {
+    const benchmarkRulesStates = await getCspBenchmarkRulesStatesHandler(encryptedSoClient);
+    const mutedBenchmarkRules = Object.fromEntries(
+      Object.entries(benchmarkRulesStates).filter(([key, value]) => value.muted === true)
+    );
+
+    const mutedRulesStats = await Promise.all(
+      Object.values(mutedBenchmarkRules).map(async (mutedBenchmarkRule) => {
+        const cspBenchmarkRulesSo = await soClient.get<CspBenchmarkRule>(
+          CSP_BENCHMARK_RULE_SAVED_OBJECT_TYPE,
+          mutedBenchmarkRule.rule_id
+        );
+        const ruleMetadata = cspBenchmarkRulesSo.attributes.metadata;
+        if (ruleMetadata) {
+          return {
+            id: ruleMetadata.id,
+            name: ruleMetadata.name,
+            benchmark_id: ruleMetadata.benchmark.id,
+            benchmark_name: ruleMetadata.benchmark.name,
+            benchmark_version: mutedBenchmarkRule.benchmark_version, // state object may include different benchmark version then the latest one.
+            rule_number: ruleMetadata.benchmark.rule_number,
+            posture_type: ruleMetadata.benchmark.posture_type,
+            section: ruleMetadata.section,
+            version: ruleMetadata.version,
+          };
+        }
+        return null;
+      })
+    );
+
+    return mutedRulesStats.filter(
+      (filteredMetadata) => filteredMetadata !== null
+    ) as MutedRulesStats[];
+  } catch (e) {
+    logger.error(`Failed to get rules states stats ${e}`);
+    return [];
+  }
+};

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
@@ -23,7 +23,7 @@ export const getMutedRulesStats = async (
   try {
     const benchmarkRulesStates = await getCspBenchmarkRulesStatesHandler(encryptedSoClient);
     const mutedBenchmarkRules = Object.fromEntries(
-      Object.entries(benchmarkRulesStates).filter(([key, value]) => value.muted === true)
+      Object.entries(benchmarkRulesStates).filter(([_, value]) => value.muted === true)
     );
 
     const mutedRulesStats = await Promise.all(

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/muted_rules_stats_collector.ts
@@ -39,7 +39,7 @@ export const getMutedRulesStats = async (
             name: ruleMetadata.name,
             benchmark_id: ruleMetadata.benchmark.id,
             benchmark_name: ruleMetadata.benchmark.name,
-            benchmark_version: mutedBenchmarkRule.benchmark_version, // state object may include different benchmark version then the latest one.
+            benchmark_version: mutedBenchmarkRule.benchmark_version, // The state object may include different benchmark version then the latest one.
             rule_number: ruleMetadata.benchmark.rule_number,
             posture_type: ruleMetadata.benchmark.posture_type,
             section: ruleMetadata.section,

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/register.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/register.ts
@@ -17,6 +17,8 @@ import { getRulesStats } from './rules_stats_collector';
 import { getInstallationStats } from './installation_stats_collector';
 import { getAlertsStats } from './alert_stats_collector';
 import { getAllCloudAccountsStats } from './cloud_accounts_stats_collector';
+import { getMutedRulesStats } from './muted_rules_stats_collector';
+import { INTERNAL_CSP_SETTINGS_SAVED_OBJECT_TYPE } from '../../../../common/constants';
 
 export function registerCspmUsageCollector(
   logger: Logger,
@@ -42,6 +44,7 @@ export function registerCspmUsageCollector(
       ) => {
         try {
           const val = await promise;
+          logger.info(`Cloud Security telemetry: ${taskName} payload was sent successfully`);
           return val;
         } catch (error) {
           logger.error(`${taskName} task failed: ${error.message}`);
@@ -52,6 +55,10 @@ export function registerCspmUsageCollector(
 
       const esClient = collectorFetchContext.esClient;
       const soClient = collectorFetchContext.soClient;
+      const encryptedSoClient = (await coreServices)[0].savedObjects.createInternalRepository([
+        INTERNAL_CSP_SETTINGS_SAVED_OBJECT_TYPE,
+      ]);
+
       const [
         indicesStats,
         accountsStats,
@@ -60,6 +67,7 @@ export function registerCspmUsageCollector(
         installationStats,
         alertsStats,
         cloudAccountStats,
+        mutedRulesStats,
       ] = await Promise.all([
         awaitPromiseSafe('Indices', getIndicesStats(esClient, soClient, coreServices, logger)),
         awaitPromiseSafe('Accounts', getAccountsStats(esClient, logger)),
@@ -71,6 +79,7 @@ export function registerCspmUsageCollector(
         ),
         awaitPromiseSafe('Alerts', getAlertsStats(esClient, logger)),
         awaitPromiseSafe('Cloud Accounts', getAllCloudAccountsStats(esClient, logger)),
+        awaitPromiseSafe('Muted Rules', getMutedRulesStats(soClient, encryptedSoClient, logger)),
       ]);
       return {
         indices: indicesStats,
@@ -80,6 +89,7 @@ export function registerCspmUsageCollector(
         installation_stats: installationStats,
         alerts_stats: alertsStats,
         cloud_account_stats: cloudAccountStats,
+        muted_rules_stats: mutedRulesStats,
       };
     },
     schema: cspmUsageSchema,

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/resources_stats_collector.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/resources_stats_collector.ts
@@ -134,7 +134,6 @@ const getCspmResourcesStats = (
       });
     });
   });
-  logger.info('CSPM telemetry: resources stats was sent');
 
   return resourcesStats.flat(2);
 };

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/schema.ts
@@ -193,4 +193,18 @@ export const cspmUsageSchema: MakeSchemaFrom<CspmUsage> = {
       },
     },
   },
+  muted_rules_stats: {
+    type: 'array',
+    items: {
+      id: { type: 'keyword' },
+      name: { type: 'keyword' },
+      section: { type: 'keyword' },
+      benchmark_id: { type: 'keyword' },
+      benchmark_name: { type: 'keyword' },
+      benchmark_version: { type: 'keyword' },
+      rule_number: { type: 'keyword' },
+      posture_type: { type: 'keyword' },
+      version: { type: 'keyword' },
+    },
+  },
 };

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
@@ -7,6 +7,7 @@
 
 import { AggregationsMultiBucketBase } from '@elastic/elasticsearch/lib/api/types';
 import { CspStatusCode } from '../../../../common/types_old';
+import { CspBenchmarkRuleMetadata } from '../../../../common/types/latest';
 
 export type CloudSecurityUsageCollectorType =
   | 'Indices'
@@ -15,7 +16,8 @@ export type CloudSecurityUsageCollectorType =
   | 'Rules'
   | 'Installation'
   | 'Alerts'
-  | 'Cloud Accounts';
+  | 'Cloud Accounts'
+  | 'Muted Rules';
 
 export type CloudProviderKey = 'cis_eks' | 'cis_gke' | 'cis_k8s' | 'cis_ake';
 export type CloudbeatConfigKeyType =
@@ -32,11 +34,31 @@ export interface CspmUsage {
   installation_stats: CloudSecurityInstallationStats[];
   alerts_stats: CloudSecurityAlertsStats[];
   cloud_account_stats: CloudSecurityAccountsStats[];
+  muted_rules_stats: MutedRulesStats[];
 }
+
+export type MutedRulesStats = Pick<
+  CspBenchmarkRuleMetadata,
+  'id' | 'name' | 'section' | 'version'
+> & {
+  benchmark_id: string;
+  benchmark_name: string;
+  rule_number: string;
+  posture_type: string;
+  benchmark_version: string;
+};
 
 export interface PackageSetupStatus {
   status: CspStatusCode;
   installedPackagePolicies: number;
+  healthyAgents: number;
+}
+export interface BenchmarkMutedRule {
+  id: string;
+  name: string;
+  section: string;
+  tags: string;
+  benchmark: CspStatusCode;
   healthyAgents: number;
 }
 

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
@@ -7,7 +7,6 @@
 
 import { AggregationsMultiBucketBase } from '@elastic/elasticsearch/lib/api/types';
 import { CspStatusCode } from '../../../../common/types_old';
-import { CspBenchmarkRuleMetadata } from '../../../../common/types/latest';
 
 export type CloudSecurityUsageCollectorType =
   | 'Indices'
@@ -217,13 +216,15 @@ export interface AccountEntity {
     pods_count: Value;
   };
 }
-export type MutedRulesStats = Pick<
-  CspBenchmarkRuleMetadata,
-  'id' | 'name' | 'section' | 'version'
-> & {
+
+export interface MutedRulesStats {
+  id: string;
+  name: string;
+  section: string;
+  version: string;
   benchmark_id: string;
   benchmark_name: string;
-  rule_number: string;
-  posture_type: string;
   benchmark_version: string;
-};
+  posture_type: string;
+  rule_number: string;
+}

--- a/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
+++ b/x-pack/plugins/cloud_security_posture/server/lib/telemetry/collectors/types.ts
@@ -37,28 +37,9 @@ export interface CspmUsage {
   muted_rules_stats: MutedRulesStats[];
 }
 
-export type MutedRulesStats = Pick<
-  CspBenchmarkRuleMetadata,
-  'id' | 'name' | 'section' | 'version'
-> & {
-  benchmark_id: string;
-  benchmark_name: string;
-  rule_number: string;
-  posture_type: string;
-  benchmark_version: string;
-};
-
 export interface PackageSetupStatus {
   status: CspStatusCode;
   installedPackagePolicies: number;
-  healthyAgents: number;
-}
-export interface BenchmarkMutedRule {
-  id: string;
-  name: string;
-  section: string;
-  tags: string;
-  benchmark: CspStatusCode;
   healthyAgents: number;
 }
 
@@ -236,3 +217,13 @@ export interface AccountEntity {
     pods_count: Value;
   };
 }
+export type MutedRulesStats = Pick<
+  CspBenchmarkRuleMetadata,
+  'id' | 'name' | 'section' | 'version'
+> & {
+  benchmark_id: string;
+  benchmark_name: string;
+  rule_number: string;
+  posture_type: string;
+  benchmark_version: string;
+};

--- a/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
+++ b/x-pack/plugins/telemetry_collection_xpack/schema/xpack_plugins.json
@@ -7716,6 +7716,40 @@
               }
             }
           }
+        },
+        "muted_rules_stats": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "id": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "keyword"
+              },
+              "section": {
+                "type": "keyword"
+              },
+              "benchmark_id": {
+                "type": "keyword"
+              },
+              "benchmark_name": {
+                "type": "keyword"
+              },
+              "benchmark_version": {
+                "type": "keyword"
+              },
+              "rule_number": {
+                "type": "keyword"
+              },
+              "posture_type": {
+                "type": "keyword"
+              },
+              "version": {
+                "type": "keyword"
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
solves:
- https://github.com/elastic/security-team/issues/7960
## Summary
Introducing telemetry for cloud security muting rules.

Payload example:

```typescript
"muted_rules": [
    {
        "id": "fe083488-fa0f-5408-9624-ac27607ac2ff",
        "name": "Ensure that VPC Flow Logs is Enabled for Every Subnet in a VPC Network",
        "benchmark_id": "cis_gcp",
        "benchmark_name": "CIS Google Cloud Platform Foundation",
        "benchmark_version": "v2.0.0",
        "rule_number": "3.8",
        "posture_type": "cspm",
        "section": "Networking",
        "version": "1.0"
    },
    {
        "id": "fdd3f5ce-cbfb-5abf-8b4e-988168d5e5a4",
        "name": "Minimize wildcard use in Roles and ClusterRoles",
        "benchmark_id": "cis_k8s",
        "benchmark_name": "CIS Kubernetes V1.23",
        "benchmark_version": "v1.0.1",
        "rule_number": "5.1.3",
        "posture_type": "kspm",
        "section": "RBAC and Service Accounts",
        "version": "1.0"
    },
    {
        "id": "a97eb244-d583-528c-a49a-17b0aa14decd",
        "name": "Ensure that default service accounts are not actively used.",
        "benchmark_id": "cis_k8s",
        "benchmark_name": "CIS Kubernetes V1.23",
        "benchmark_version": "v1.0.1",
        "rule_number": "5.1.5",
        "posture_type": "kspm",
        "section": "RBAC and Service Accounts",
        "version": "1.0"
    }
]
```