### PR TITLE
[Cases] Create `custom_field` api types folder

### DIFF
--- a/x-pack/plugins/cases/common/types/api/case/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/case/v1.ts
@@ -22,7 +22,6 @@ import {
   MAX_CATEGORY_FILTER_LENGTH,
   MAX_ASSIGNEES_PER_CASE,
   MAX_CUSTOM_FIELDS_PER_CASE,
-  MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
 } from '../../../constants';
 import {
   limitedStringSchema,
@@ -42,12 +41,7 @@ import {
 import { CaseConnectorRt } from '../../domain/connector/v1';
 import { CaseUserProfileRt, UserRt } from '../../domain/user/v1';
 import { CasesStatusResponseRt } from '../stats/v1';
-
-export const CaseCustomFieldTextWithValidationValueRt = limitedStringSchema({
-  fieldName: 'value',
-  min: 1,
-  max: MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
-});
+import { CaseCustomFieldTextWithValidationValueRt } from '../custom_field/v1';
 
 const CaseCustomFieldTextWithValidationRt = rt.strict({
   key: rt.string,

--- a/x-pack/plugins/cases/common/types/api/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.ts
@@ -16,7 +16,7 @@ import { CustomFieldTextTypeRt, CustomFieldToggleTypeRt } from '../../domain';
 import type { Configurations, Configuration } from '../../domain/configure/v1';
 import { ConfigurationBasicWithoutOwnerRt, ClosureTypeRt } from '../../domain/configure/v1';
 import { CaseConnectorRt } from '../../domain/connector/v1';
-import { CaseCustomFieldTextWithValidationValueRt } from '../case/v1';
+import { CaseCustomFieldTextWithValidationValueRt } from '../custom_field/v1';
 
 export const CustomFieldConfigurationWithoutTypeRt = rt.strict({
   /**

--- a/x-pack/plugins/cases/common/types/api/custom_field/latest.ts
+++ b/x-pack/plugins/cases/common/types/api/custom_field/latest.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export * from './v1';

--- a/x-pack/plugins/cases/common/types/api/custom_field/v1.test.ts
+++ b/x-pack/plugins/cases/common/types/api/custom_field/v1.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { PathReporter } from 'io-ts/lib/PathReporter';
+import { MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH } from '../../../constants';
+import { CaseCustomFieldTextWithValidationValueRt } from './v1';
+
+describe('Custom Fields', () => {
+  describe('CaseCustomFieldTextWithValidationValueRt', () => {
+    it('decodes strings correctly', () => {
+      const query = CaseCustomFieldTextWithValidationValueRt.decode('foobar');
+
+      expect(query).toStrictEqual({
+        _tag: 'Right',
+        right: 'foobar',
+      });
+    });
+
+    it('the value cannot be empty', () => {
+      expect(PathReporter.report(CaseCustomFieldTextWithValidationValueRt.decode(''))[0]).toContain(
+        'The value field cannot be an empty string.'
+      );
+    });
+
+    it(`limits the length to ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}`, () => {
+      expect(
+        PathReporter.report(
+          CaseCustomFieldTextWithValidationValueRt.decode(
+            '#'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1)
+          )
+        )[0]
+      ).toContain(
+        `The length of the value is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH}.`
+      );
+    });
+  });
+});

--- a/x-pack/plugins/cases/common/types/api/custom_field/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/custom_field/v1.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH } from '../../../constants';
+import { limitedStringSchema } from '../../../schema';
+
+export const CaseCustomFieldTextWithValidationValueRt = limitedStringSchema({
+  fieldName: 'value',
+  min: 1,
+  max: MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH,
+});

--- a/x-pack/plugins/cases/common/types/api/index.ts
+++ b/x-pack/plugins/cases/common/types/api/index.ts
@@ -29,4 +29,4 @@ export * as userApiV1 from './user/v1';
 export * as connectorApiV1 from './connector/v1';
 export * as attachmentApiV1 from './attachment/v1';
 export * as metricsApiV1 from './metrics/v1';
-export * as CustomFieldsApiV1 from './custom_field/v1';
+export * as customFieldsApiV1 from './custom_field/v1';

--- a/x-pack/plugins/cases/common/types/api/index.ts
+++ b/x-pack/plugins/cases/common/types/api/index.ts
@@ -16,6 +16,7 @@ export * from './user/latest';
 export * from './connector/latest';
 export * from './attachment/latest';
 export * from './metrics/latest';
+export * from './custom_field/latest';
 
 // V1
 export * as configureApiV1 from './configure/v1';
@@ -28,3 +29,4 @@ export * as userApiV1 from './user/v1';
 export * as connectorApiV1 from './connector/v1';
 export * as attachmentApiV1 from './attachment/v1';
 export * as metricsApiV1 from './metrics/v1';
+export * as CustomFieldsApiV1 from './custom_field/v1';


### PR DESCRIPTION
## Summary

**Merging into a feature branch.**

Leftover changes requested [in this PR](https://github.com/elastic/kibana/pull/174043).

- Create a `custom_fields` folder in `x-pack/plugins/cases/common/types/api` and put `CaseCustomFieldTextWithValidationValueRt`
- Use `CaseCustomFieldTextWithValidationValueRt` from the folder created above in `x-pack/plugins/cases/common/types/api/configure/v1.ts`
- Updated imports of `CaseCustomFieldTextWithValidationValueRt` in `x-pack/plugins/cases/common/types/api/cases` and `x-pack/plugins/cases/common/types/api/configure`