### PR TITLE
[Cases] Create and Update cases with custom fields default values

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/components/custom_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/custom_fields.test.tsx
@@ -133,7 +133,11 @@ describe('Case View Page files tab', () => {
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith([
-        { type: CustomFieldTypes.TEXT, key: 'test_key_1', value: null },
+        {
+          type: CustomFieldTypes.TEXT,
+          key: 'test_key_1',
+          value: customFieldsConfigurationMock[0].defaultValue,
+        },
         { type: CustomFieldTypes.TOGGLE, key: 'test_key_2', value: true },
         customFieldsMock[2],
         customFieldsMock[3],
@@ -155,10 +159,82 @@ describe('Case View Page files tab', () => {
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith([
-        { type: CustomFieldTypes.TEXT, key: 'test_key_1', value: null },
+        {
+          type: CustomFieldTypes.TEXT,
+          key: 'test_key_1',
+          value: customFieldsConfigurationMock[0].defaultValue,
+        },
         { type: CustomFieldTypes.TOGGLE, key: 'test_key_2', value: false },
         customFieldsMock[2],
         customFieldsMock[3],
+      ]);
+    });
+  });
+
+  it('adds missing defaultValues to required custom fields without value', async () => {
+    appMockRender.render(
+      <CustomFields
+        isLoading={false}
+        customFields={[
+          { ...customFieldsMock[0], value: null },
+          { ...customFieldsMock[1], value: null },
+        ]}
+        customFieldsConfiguration={[
+          customFieldsConfigurationMock[0],
+          customFieldsConfigurationMock[1],
+        ]}
+        onSubmit={onSubmit}
+      />
+    );
+
+    userEvent.click((await screen.findAllByRole('switch'))[0]);
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith([
+        {
+          type: CustomFieldTypes.TEXT,
+          key: 'test_key_1',
+          value: customFieldsConfigurationMock[0].defaultValue,
+        },
+        {
+          type: CustomFieldTypes.TOGGLE,
+          key: 'test_key_2',
+          value: customFieldsConfigurationMock[1].defaultValue,
+        },
+      ]);
+    });
+  });
+
+  it('does not overwrite existing text values with a configured defaultValue', async () => {
+    appMockRender.render(
+      <CustomFields
+        isLoading={false}
+        customFields={[
+          { key: customFieldsMock[0].key, type: CustomFieldTypes.TEXT, value: 'existing value' },
+          { ...customFieldsMock[1] },
+        ]}
+        customFieldsConfiguration={[
+          customFieldsConfigurationMock[0],
+          customFieldsConfigurationMock[1],
+        ]}
+        onSubmit={onSubmit}
+      />
+    );
+
+    userEvent.click((await screen.findAllByRole('switch'))[0]);
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith([
+        {
+          type: CustomFieldTypes.TEXT,
+          key: 'test_key_1',
+          value: 'existing value',
+        },
+        {
+          type: CustomFieldTypes.TOGGLE,
+          key: 'test_key_2',
+          value: false,
+        },
       ]);
     });
   });

--- a/x-pack/plugins/cases/public/components/case_view/components/custom_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/custom_fields.test.tsx
@@ -40,6 +40,8 @@ describe('Case View Page files tab', () => {
 
     expect(await screen.findByTestId('case-custom-field-wrapper-test_key_1')).toBeInTheDocument();
     expect(await screen.findByTestId('case-custom-field-wrapper-test_key_2')).toBeInTheDocument();
+    expect(await screen.findByTestId('case-custom-field-wrapper-test_key_3')).toBeInTheDocument();
+    expect(await screen.findByTestId('case-custom-field-wrapper-test_key_4')).toBeInTheDocument();
   });
 
   it('should render the custom fields types when the custom fields are empty', async () => {
@@ -171,14 +173,11 @@ describe('Case View Page files tab', () => {
     });
   });
 
-  it('adds missing defaultValues to required custom fields without value', async () => {
+  it('adds missing defaultValues to required text custom fields without value', async () => {
     appMockRender.render(
       <CustomFields
         isLoading={false}
-        customFields={[
-          { ...customFieldsMock[0], value: null },
-          { ...customFieldsMock[1], value: null },
-        ]}
+        customFields={[{ ...customFieldsMock[0], value: null }, customFieldsMock[1]]}
         customFieldsConfiguration={[
           customFieldsConfigurationMock[0],
           customFieldsConfigurationMock[1],
@@ -187,6 +186,7 @@ describe('Case View Page files tab', () => {
       />
     );
 
+    // Clicking the toggle triggers the form submit
     userEvent.click((await screen.findAllByRole('switch'))[0]);
 
     await waitFor(() => {
@@ -199,7 +199,7 @@ describe('Case View Page files tab', () => {
         {
           type: CustomFieldTypes.TOGGLE,
           key: 'test_key_2',
-          value: customFieldsConfigurationMock[1].defaultValue,
+          value: false,
         },
       ]);
     });

--- a/x-pack/plugins/cases/public/components/case_view/components/custom_fields.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/custom_fields.tsx
@@ -97,11 +97,26 @@ const createMissingAndRemoveExtraCustomFields = (
       (customField) => customField.key === confCustomField.key
     );
 
+    let result;
     if (foundCustomField) {
-      return foundCustomField;
+      result = foundCustomField;
+    } else {
+      result = {
+        key: confCustomField.key,
+        type: confCustomField.type,
+        value: null,
+      };
     }
 
-    return { key: confCustomField.key, type: confCustomField.type, value: null };
+    if (
+      result.value === null &&
+      confCustomField.required &&
+      confCustomField?.defaultValue !== undefined
+    ) {
+      result.value = confCustomField.defaultValue;
+    }
+
+    return result as CaseUICustomField;
   });
 
   return createdCustomFields;

--- a/x-pack/plugins/cases/public/components/case_view/components/custom_fields.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/custom_fields.tsx
@@ -97,26 +97,25 @@ const createMissingAndRemoveExtraCustomFields = (
       (customField) => customField.key === confCustomField.key
     );
 
-    let result;
+    const shouldUseDefaultValue = Boolean(
+      confCustomField.required && confCustomField?.defaultValue
+    );
+
     if (foundCustomField) {
-      result = foundCustomField;
-    } else {
-      result = {
-        key: confCustomField.key,
-        type: confCustomField.type,
-        value: null,
-      };
+      return {
+        ...foundCustomField,
+        value:
+          foundCustomField.value == null && shouldUseDefaultValue
+            ? confCustomField.defaultValue
+            : foundCustomField.value,
+      } as CaseUICustomField;
     }
 
-    if (
-      result.value === null &&
-      confCustomField.required &&
-      confCustomField?.defaultValue !== undefined
-    ) {
-      result.value = confCustomField.defaultValue;
-    }
-
-    return result as CaseUICustomField;
+    return {
+      key: confCustomField.key,
+      type: confCustomField.type,
+      value: shouldUseDefaultValue ? confCustomField.defaultValue : null,
+    } as CaseUICustomField;
   });
 
   return createdCustomFields;

--- a/x-pack/plugins/cases/public/components/create/custom_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/custom_fields.test.tsx
@@ -83,8 +83,8 @@ describe('CustomFields', () => {
       </FormTestComponent>
     );
 
-    const textField = customFieldsConfigurationMock[0];
-    const toggleField = customFieldsConfigurationMock[1];
+    const textField = customFieldsConfigurationMock[2];
+    const toggleField = customFieldsConfigurationMock[3];
 
     userEvent.type(
       await screen.findByTestId(`${textField.key}-${textField.type}-create-custom-field`),
@@ -101,9 +101,10 @@ describe('CustomFields', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         {
           customFields: {
+            [customFieldsConfigurationMock[0].key]: customFieldsConfigurationMock[0].defaultValue,
+            [customFieldsConfigurationMock[1].key]: customFieldsConfigurationMock[1].defaultValue,
             [textField.key]: 'hello',
             [toggleField.key]: true,
-            [customFieldsConfigurationMock[3].key]: false,
           },
         },
         true

--- a/x-pack/plugins/cases/public/components/custom_fields/text/config.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/config.ts
@@ -15,9 +15,11 @@ const { emptyField } = fieldValidators;
 export const getTextFieldConfig = ({
   required,
   label,
+  defaultValue,
 }: {
   required: boolean;
   label: string;
+  defaultValue?: string | null;
 }): FieldConfig<string> => {
   const validators = [];
 
@@ -28,6 +30,7 @@ export const getTextFieldConfig = ({
   }
 
   return {
+    ...(defaultValue && { defaultValue }),
     validations: [
       ...validators,
       {

--- a/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
@@ -30,9 +30,9 @@ describe('Create ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByText(customFieldConfiguration.label)).toBeInTheDocument();
+    expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
     expect(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
+      await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
     ).toBeInTheDocument();
   });
 
@@ -43,7 +43,7 @@ describe('Create ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(await screen.findByRole('progressbar')).toBeInTheDocument();
   });
 
   it('disables the text when loading', async () => {
@@ -54,7 +54,7 @@ describe('Create ', () => {
     );
 
     expect(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
+      await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
     ).toHaveAttribute('disabled');
   });
 
@@ -65,12 +65,13 @@ describe('Create ', () => {
       </FormTestComponent>
     );
 
-    userEvent.type(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
-      'this is a sample text!'
+    const textCustomField = await screen.findByTestId(
+      `${customFieldConfiguration.key}-text-create-custom-field`
     );
 
-    userEvent.click(screen.getByText('Submit'));
+    userEvent.clear(textCustomField);
+    userEvent.paste(textCustomField, 'this is a sample text!');
+    userEvent.click(await screen.findByText('Submit'));
 
     await waitFor(() => {
       // data, isValid
@@ -95,18 +96,19 @@ describe('Create ', () => {
     const sampleText = 'a'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1);
 
     userEvent.paste(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
+      await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
       sampleText
     );
 
-    userEvent.click(screen.getByText('Submit'));
+    userEvent.click(await screen.findByText('Submit'));
+
+    expect(
+      await screen.findByText(
+        `The length of the ${customFieldConfiguration.label} is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
+      )
+    ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          `The length of the ${customFieldConfiguration.label} is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
-        )
-      ).toBeInTheDocument();
       expect(onSubmit).toHaveBeenCalledWith({}, false);
     });
   });
@@ -124,18 +126,18 @@ describe('Create ', () => {
     const sampleText = 'a'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1);
 
     userEvent.paste(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
+      await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
       sampleText
     );
+    userEvent.click(await screen.findByText('Submit'));
 
-    userEvent.click(screen.getByText('Submit'));
+    expect(
+      await screen.findByText(
+        `The length of the ${customFieldConfiguration.label} is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
+      )
+    ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          `The length of the ${customFieldConfiguration.label} is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
-        )
-      ).toBeInTheDocument();
       expect(onSubmit).toHaveBeenCalledWith({}, false);
     });
   });
@@ -150,12 +152,14 @@ describe('Create ', () => {
       </FormTestComponent>
     );
 
-    userEvent.paste(
-      screen.getByTestId(`${customFieldConfiguration.key}-text-create-custom-field`),
-      ''
+    userEvent.clear(
+      await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
     );
+    userEvent.click(await screen.findByText('Submit'));
 
-    userEvent.click(screen.getByText('Submit'));
+    expect(
+      await screen.findByText(`${customFieldConfiguration.label} is required.`)
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -170,12 +174,17 @@ describe('Create ', () => {
       <FormTestComponent onSubmit={onSubmit}>
         <Create
           isLoading={false}
-          customFieldConfiguration={{ ...customFieldConfiguration, required: false }}
+          customFieldConfiguration={{
+            key: customFieldConfiguration.key,
+            type: customFieldConfiguration.type,
+            label: customFieldConfiguration.label,
+            required: false,
+          }}
         />
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByText('Submit'));
+    userEvent.click(await screen.findByText('Submit'));
 
     await waitFor(() => {
       expect(onSubmit).toHaveBeenCalledWith({}, true);

--- a/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
@@ -158,13 +158,10 @@ describe('Create ', () => {
     userEvent.click(await screen.findByText('Submit'));
 
     expect(
-      await screen.findByText(`${customFieldConfiguration.label} is required.`)
+      await screen.findByText(`A ${customFieldConfiguration.label} is required.`)
     ).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(
-        screen.getByText(`A ${customFieldConfiguration.label} is required.`)
-      ).toBeInTheDocument();
       expect(onSubmit).toHaveBeenCalledWith({}, false);
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/create.test.tsx
@@ -21,9 +21,10 @@ describe('Create ', () => {
     jest.clearAllMocks();
   });
 
+  // required text custom field with a default value
   const customFieldConfiguration = customFieldsConfigurationMock[0];
 
-  it('renders correctly', async () => {
+  it('renders correctly with default values', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Create isLoading={false} customFieldConfiguration={customFieldConfiguration} />
@@ -31,9 +32,25 @@ describe('Create ', () => {
     );
 
     expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
+
     expect(
       await screen.findByTestId(`${customFieldConfiguration.key}-text-create-custom-field`)
-    ).toBeInTheDocument();
+    ).toHaveValue(customFieldConfiguration.defaultValue as string);
+  });
+
+  it('renders correctly with optional fields', async () => {
+    const optionalField = customFieldsConfigurationMock[2]; // optional text custom field
+
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Create isLoading={false} customFieldConfiguration={optionalField} />
+      </FormTestComponent>
+    );
+
+    expect(await screen.findByText(optionalField.label)).toBeInTheDocument();
+    expect(await screen.findByTestId(`${optionalField.key}-text-create-custom-field`)).toHaveValue(
+      ''
+    );
   });
 
   it('renders loading state correctly', async () => {

--- a/x-pack/plugins/cases/public/components/custom_fields/text/create.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/create.tsx
@@ -16,8 +16,12 @@ const CreateComponent: CustomFieldType<CaseCustomFieldText>['Create'] = ({
   customFieldConfiguration,
   isLoading,
 }) => {
-  const { key, label, required } = customFieldConfiguration;
-  const config = getTextFieldConfig({ required, label });
+  const { key, label, required, defaultValue } = customFieldConfiguration;
+  const config = getTextFieldConfig({
+    required,
+    label,
+    ...(typeof defaultValue === 'string' && { defaultValue }),
+  });
 
   return (
     <UseField

--- a/x-pack/plugins/cases/public/components/custom_fields/text/create.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/create.tsx
@@ -20,7 +20,7 @@ const CreateComponent: CustomFieldType<CaseCustomFieldText>['Create'] = ({
   const config = getTextFieldConfig({
     required,
     label,
-    ...(typeof defaultValue === 'string' && { defaultValue }),
+    ...(defaultValue && { defaultValue: String(defaultValue) }),
   });
 
   return (

--- a/x-pack/plugins/cases/public/components/custom_fields/text/edit.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/edit.test.tsx
@@ -14,6 +14,7 @@ import { customFieldsMock, customFieldsConfigurationMock } from '../../../contai
 import userEvent from '@testing-library/user-event';
 import { MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH } from '../../../../common/constants';
 import type { CaseCustomFieldText } from '../../../../common/types/domain';
+import { POPULATED_WITH_DEFAULT } from '../translations';
 
 describe('Edit ', () => {
   const onSubmit = jest.fn();
@@ -38,10 +39,12 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByTestId('case-text-custom-field-test_key_1')).toBeInTheDocument();
-    expect(screen.getByTestId('case-text-custom-field-edit-button-test_key_1')).toBeInTheDocument();
-    expect(screen.getByText(customFieldConfiguration.label)).toBeInTheDocument();
-    expect(screen.getByText('My text test value 1')).toBeInTheDocument();
+    expect(await screen.findByTestId('case-text-custom-field-test_key_1')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('case-text-custom-field-edit-button-test_key_1')
+    ).toBeInTheDocument();
+    expect(await screen.findByText(customFieldConfiguration.label)).toBeInTheDocument();
+    expect(await screen.findByText('My text test value 1')).toBeInTheDocument();
   });
 
   it('does not shows the edit button if the user does not have permissions', async () => {
@@ -93,7 +96,9 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByTestId('case-text-custom-field-loading-test_key_1')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('case-text-custom-field-loading-test_key_1')
+    ).toBeInTheDocument();
   });
 
   it('shows the no value text if the custom field is undefined', async () => {
@@ -108,7 +113,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByText('No value is added')).toBeInTheDocument();
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
   });
 
   it('shows the no value text if the the value is null', async () => {
@@ -124,7 +129,7 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    expect(screen.getByText('No value is added')).toBeInTheDocument();
+    expect(await screen.findByText('No value is added')).toBeInTheDocument();
   });
 
   it('does not show the value when the custom field is undefined', async () => {
@@ -195,21 +200,58 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.paste(screen.getByTestId('case-text-custom-field-form-field-test_key_1'), '!!!');
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.paste(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1'),
+      '!!!'
+    );
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('case-text-custom-field-submit-button-test_key_1')
-      ).not.toBeDisabled();
-    });
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-submit-button-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-submit-button-test_key_1'));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
         ...customField,
         value: 'My text test value 1!!!',
+      });
+    });
+  });
+
+  it('calls onSubmit with defaultValue if no initialValue exists', async () => {
+    render(
+      <FormTestComponent onSubmit={onSubmit}>
+        <Edit
+          customField={{
+            ...customField,
+            value: null,
+          }}
+          customFieldConfiguration={customFieldConfiguration}
+          onSubmit={onSubmit}
+          isLoading={false}
+          canUpdate={true}
+        />
+      </FormTestComponent>
+    );
+
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+
+    expect(await screen.findByText(POPULATED_WITH_DEFAULT)).toBeInTheDocument();
+    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
+      customFieldConfiguration.defaultValue as string
+    );
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
+
+    userEvent.click(await screen.findByTestId('case-text-custom-field-submit-button-test_key_1'));
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
       });
     });
   });
@@ -227,16 +269,14 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.clear(screen.getByTestId('case-text-custom-field-form-field-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.clear(await screen.findByTestId('case-text-custom-field-form-field-test_key_1'));
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('case-text-custom-field-submit-button-test_key_1')
-      ).not.toBeDisabled();
-    });
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-submit-button-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-submit-button-test_key_1'));
 
     await waitFor(() => {
       expect(onSubmit).toBeCalledWith({
@@ -259,11 +299,13 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
 
-    expect(screen.getByTestId('case-text-custom-field-form-field-test_key_1')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1')
+    ).toBeInTheDocument();
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-cancel-button-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1'));
 
     expect(
       screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
@@ -283,23 +325,24 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.paste(screen.getByTestId('case-text-custom-field-form-field-test_key_1'), '!!!');
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.paste(
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1'),
+      '!!!'
+    );
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('case-text-custom-field-submit-button-test_key_1')
-      ).not.toBeDisabled();
-    });
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-cancel-button-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-cancel-button-test_key_1'));
 
     expect(
       screen.queryByTestId('case-text-custom-field-form-field-test_key_1')
     ).not.toBeInTheDocument();
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    expect(screen.getByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    expect(await screen.findByTestId('case-text-custom-field-form-field-test_key_1')).toHaveValue(
       'My text test value 1'
     );
   });
@@ -317,12 +360,10 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.clear(screen.getByTestId('case-text-custom-field-form-field-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.clear(await screen.findByTestId('case-text-custom-field-form-field-test_key_1'));
 
-    await waitFor(() => {
-      expect(screen.getByText('A My test label 1 is required.')).toBeInTheDocument();
-    });
+    expect(await screen.findByText('A My test label 1 is required.')).toBeInTheDocument();
   });
 
   it('does not shows a validation error if the field is not required', async () => {
@@ -338,14 +379,12 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.clear(screen.getByTestId('case-text-custom-field-form-field-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.clear(await screen.findByTestId('case-text-custom-field-form-field-test_key_1'));
 
-    await waitFor(() => {
-      expect(
-        screen.getByTestId('case-text-custom-field-submit-button-test_key_1')
-      ).not.toBeDisabled();
-    });
+    expect(
+      await screen.findByTestId('case-text-custom-field-submit-button-test_key_1')
+    ).not.toBeDisabled();
 
     expect(screen.queryByText('My test label 1 is required.')).not.toBeInTheDocument();
   });
@@ -363,19 +402,17 @@ describe('Edit ', () => {
       </FormTestComponent>
     );
 
-    userEvent.click(screen.getByTestId('case-text-custom-field-edit-button-test_key_1'));
-    userEvent.clear(screen.getByTestId('case-text-custom-field-form-field-test_key_1'));
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+    userEvent.clear(await screen.findByTestId('case-text-custom-field-form-field-test_key_1'));
     userEvent.paste(
-      screen.getByTestId('case-text-custom-field-form-field-test_key_1'),
+      await screen.findByTestId('case-text-custom-field-form-field-test_key_1'),
       'a'.repeat(MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH + 1)
     );
 
-    await waitFor(() => {
-      expect(
-        screen.getByText(
-          `The length of the My test label 1 is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
-        )
-      ).toBeInTheDocument();
-    });
+    expect(
+      await screen.findByText(
+        `The length of the My test label 1 is too long. The maximum length is ${MAX_CUSTOM_FIELD_TEXT_VALUE_LENGTH} characters.`
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/text/edit.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/edit.test.tsx
@@ -116,7 +116,7 @@ describe('Edit ', () => {
     expect(await screen.findByText('No value is added')).toBeInTheDocument();
   });
 
-  it('shows the no value text if the the value is null', async () => {
+  it('uses the required value correctly if a required field is empty', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Edit
@@ -130,6 +130,23 @@ describe('Edit ', () => {
     );
 
     expect(await screen.findByText('No value is added')).toBeInTheDocument();
+    userEvent.click(await screen.findByTestId('case-text-custom-field-edit-button-test_key_1'));
+
+    expect(
+      await screen.findByTestId(`case-text-custom-field-form-field-${customFieldConfiguration.key}`)
+    ).toHaveValue(customFieldConfiguration.defaultValue as string);
+    expect(
+      await screen.findByText('This field is populated with the default value.')
+    ).toBeInTheDocument();
+
+    userEvent.click(await screen.findByTestId('case-text-custom-field-submit-button-test_key_1'));
+
+    await waitFor(() => {
+      expect(onSubmit).toBeCalledWith({
+        ...customField,
+        value: customFieldConfiguration.defaultValue,
+      });
+    });
   });
 
   it('does not show the value when the custom field is undefined', async () => {

--- a/x-pack/plugins/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/edit.tsx
@@ -18,17 +18,29 @@ import {
   EuiText,
 } from '@elastic/eui';
 import type { FormHook } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
-import { useForm, UseField, Form } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
+import {
+  useForm,
+  UseField,
+  Form,
+  useFormData,
+} from '@kbn/es-ui-shared-plugin/static/forms/hook_form_lib';
 import { TextField } from '@kbn/es-ui-shared-plugin/static/forms/components';
 import type { CaseCustomFieldText } from '../../../../common/types/domain';
 import { CustomFieldTypes } from '../../../../common/types/domain';
 import type { CasesConfigurationUICustomField } from '../../../../common/ui';
 import type { CustomFieldType } from '../types';
 import { View } from './view';
-import { CANCEL, EDIT_CUSTOM_FIELDS_ARIA_LABEL, NO_CUSTOM_FIELD_SET, SAVE } from '../translations';
+import {
+  CANCEL,
+  EDIT_CUSTOM_FIELDS_ARIA_LABEL,
+  NO_CUSTOM_FIELD_SET,
+  SAVE,
+  POPULATED_WITH_DEFAULT,
+} from '../translations';
 import { getTextFieldConfig } from './config';
 
 interface FormState {
+  value: string;
   isValid: boolean | undefined;
   submit: FormHook<{ value: string }>['submit'];
 }
@@ -46,20 +58,30 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   isLoading,
   onChange,
 }) => {
-  const { form } = useForm({
-    defaultValue: { value: initialValue },
+  const { form } = useForm<{ value: string }>({
+    defaultValue: {
+      value:
+        typeof customFieldConfiguration?.defaultValue === 'string' && isEmpty(initialValue)
+          ? customFieldConfiguration?.defaultValue
+          : initialValue,
+    },
   });
-
-  const { submit, isValid: isFormValid } = form;
-
-  useEffect(() => {
-    onChange({ isValid: isFormValid, submit });
-  }, [isFormValid, onChange, submit]);
-
+  const [{ value }] = useFormData({ form });
+  const { submit, isValid } = form;
   const formFieldConfig = getTextFieldConfig({
     required: customFieldConfiguration.required,
     label: customFieldConfiguration.label,
   });
+  const populatedWithDefault =
+    value === customFieldConfiguration?.defaultValue && isEmpty(initialValue);
+
+  useEffect(() => {
+    onChange({
+      value,
+      isValid,
+      submit,
+    });
+  }, [isValid, onChange, submit, value]);
 
   return (
     <Form form={form}>
@@ -67,6 +89,7 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
         path="value"
         config={formFieldConfig}
         component={TextField}
+        helpText={populatedWithDefault && POPULATED_WITH_DEFAULT}
         componentProps={{
           euiFieldProps: {
             fullWidth: true,
@@ -89,11 +112,12 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
   isLoading,
   canUpdate,
 }) => {
+  const initialValue = customField?.value ?? '';
   const [isEdit, setIsEdit] = useState(false);
-
   const [formState, setFormState] = useState<FormState>({
     isValid: undefined,
     submit: async () => ({ isValid: false, data: { value: '' } }),
+    value: initialValue,
   });
 
   const onEdit = () => {
@@ -121,9 +145,10 @@ const EditComponent: CustomFieldType<CaseCustomFieldText>['Edit'] = ({
     setIsEdit(false);
   };
 
-  const initialValue = customField?.value ?? '';
   const title = customFieldConfiguration.label;
-  const isTextFieldValid = formState.isValid;
+  const isTextFieldValid =
+    formState.isValid ||
+    (formState.value === customFieldConfiguration.defaultValue && !initialValue);
   const isCustomFieldValueDefined = !isEmpty(customField?.value);
 
   return (

--- a/x-pack/plugins/cases/public/components/custom_fields/text/edit.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/edit.tsx
@@ -61,8 +61,8 @@ const FormWrapperComponent: React.FC<FormWrapper> = ({
   const { form } = useForm<{ value: string }>({
     defaultValue: {
       value:
-        typeof customFieldConfiguration?.defaultValue === 'string' && isEmpty(initialValue)
-          ? customFieldConfiguration?.defaultValue
+        customFieldConfiguration?.defaultValue != null && isEmpty(initialValue)
+          ? String(customFieldConfiguration.defaultValue)
           : initialValue,
     },
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/create.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/create.test.tsx
@@ -22,7 +22,7 @@ describe('Create ', () => {
 
   const customFieldConfiguration = customFieldsConfigurationMock[1];
 
-  it('renders correctly', async () => {
+  it('renders correctly with required and defaultValue', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Create isLoading={false} customFieldConfiguration={customFieldConfiguration} />
@@ -33,7 +33,7 @@ describe('Create ', () => {
     expect(
       await screen.findByTestId(`${customFieldConfiguration.key}-toggle-create-custom-field`)
     ).toBeInTheDocument();
-    expect(await screen.findByRole('switch')).not.toBeChecked();
+    expect(await screen.findByRole('switch')).toBeChecked(); // defaultValue true
   });
 
   it('updates the value correctly', async () => {
@@ -51,7 +51,7 @@ describe('Create ', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         {
           customFields: {
-            [customFieldConfiguration.key]: true,
+            [customFieldConfiguration.key]: false,
           },
         },
         true
@@ -59,12 +59,17 @@ describe('Create ', () => {
     });
   });
 
-  it('sets value to false by default', async () => {
+  it('sets value to false by default when there is no defaultValue configured', async () => {
     render(
       <FormTestComponent onSubmit={onSubmit}>
         <Create
           isLoading={false}
-          customFieldConfiguration={{ ...customFieldConfiguration, required: true }}
+          customFieldConfiguration={{
+            key: customFieldConfiguration.key,
+            type: customFieldConfiguration.type,
+            label: customFieldConfiguration.label,
+            required: false,
+          }}
         />
       </FormTestComponent>
     );

--- a/x-pack/plugins/cases/public/components/custom_fields/toggle/create.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/toggle/create.tsx
@@ -15,13 +15,13 @@ const CreateComponent: CustomFieldType<CaseCustomFieldToggle>['Create'] = ({
   customFieldConfiguration,
   isLoading,
 }) => {
-  const { key, label } = customFieldConfiguration;
+  const { key, label, defaultValue } = customFieldConfiguration;
 
   return (
     <UseField
       path={`customFields.${key}`}
       component={ToggleField}
-      defaultValue={false}
+      config={{ defaultValue: defaultValue ? defaultValue : false }}
       key={key}
       label={label}
       componentProps={{

--- a/x-pack/plugins/cases/public/components/custom_fields/translations.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/translations.ts
@@ -120,3 +120,10 @@ export const TOGGLE_FIELD_OFF_LABEL = i18n.translate(
     defaultMessage: 'Off',
   }
 );
+
+export const POPULATED_WITH_DEFAULT = i18n.translate(
+  'xpack.cases.customFields.fieldOptions.PopulatedWithDefault',
+  {
+    defaultMessage: 'This field was populated with the default value.',
+  }
+);

--- a/x-pack/plugins/cases/public/components/custom_fields/translations.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/translations.ts
@@ -122,8 +122,8 @@ export const TOGGLE_FIELD_OFF_LABEL = i18n.translate(
 );
 
 export const POPULATED_WITH_DEFAULT = i18n.translate(
-  'xpack.cases.customFields.fieldOptions.PopulatedWithDefault',
+  'xpack.cases.customFields.fieldOptions.populatedWithDefault',
   {
-    defaultMessage: 'This field was populated with the default value.',
+    defaultMessage: 'This field is populated with the default value.',
   }
 );

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
@@ -134,15 +134,13 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
             key: 'valid_key_1',
             label: 'Summary',
             type: CustomFieldTypes.TEXT as const,
-            defaultValue: 'foobar',
-            required: true,
+            required: false,
           },
           {
             key: 'valid_key_2',
             label: 'Sync',
             type: CustomFieldTypes.TOGGLE as const,
-            defaultValue: false,
-            required: true,
+            required: false,
           },
         ];
 
@@ -183,6 +181,55 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
           `case-toggle-custom-field-form-field-${customFields[1].key}`
         );
         expect(await sync.getAttribute('aria-checked')).equal('true');
+      });
+
+      it('creates a case with custom fields that have default values', async () => {
+        const customFields = [
+          {
+            key: 'valid_key_1',
+            label: 'Summary',
+            type: CustomFieldTypes.TEXT as const,
+            defaultValue: 'Default value',
+            required: true,
+          },
+          {
+            key: 'valid_key_2',
+            label: 'Sync',
+            type: CustomFieldTypes.TOGGLE as const,
+            defaultValue: true,
+            required: true,
+          },
+        ];
+
+        await cases.api.createConfigWithCustomFields({ customFields, owner: 'cases' });
+
+        const caseTitle = 'test-' + uuidv4();
+        await cases.create.openCreateCasePage();
+
+        // verify custom fields on create case page
+        await testSubjects.existOrFail('create-case-custom-fields');
+
+        await cases.create.setTitle(caseTitle);
+        await cases.create.setDescription('this is a test description');
+
+        // submit without touching the custom fields
+        await cases.create.submitCase();
+
+        await header.waitUntilLoadingHasFinished();
+
+        await testSubjects.existOrFail('case-view-title');
+
+        // validate custom fields
+        const textCustomField = await testSubjects.find(
+          `case-text-custom-field-${customFields[0].key}`
+        );
+
+        expect(await textCustomField.getVisibleText()).equal(customFields[0].defaultValue);
+
+        const toggleCustomField = await testSubjects.find(
+          `case-toggle-custom-field-form-field-${customFields[1].key}`
+        );
+        expect(await toggleCustomField.getAttribute('aria-checked')).equal('true');
       });
     });
   });

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group1/create_case_form.ts
@@ -186,15 +186,15 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
       it('creates a case with custom fields that have default values', async () => {
         const customFields = [
           {
-            key: 'valid_key_1',
-            label: 'Summary',
+            key: 'valid_key_3',
+            label: 'Summary required',
             type: CustomFieldTypes.TEXT as const,
             defaultValue: 'Default value',
             required: true,
           },
           {
-            key: 'valid_key_2',
-            label: 'Sync',
+            key: 'valid_key_4',
+            label: 'Sync required',
             type: CustomFieldTypes.TOGGLE as const,
             defaultValue: true,
             required: true,

--- a/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/cases/create_case_form.ts
@@ -81,15 +81,13 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
             key: 'valid_key_1',
             label: 'Summary',
             type: CustomFieldTypes.TEXT as const,
-            defaultValue: 'foobar',
-            required: true,
+            required: false,
           },
           {
             key: 'valid_key_2',
             label: 'Sync',
             type: CustomFieldTypes.TOGGLE as const,
-            defaultValue: false,
-            required: true,
+            required: false,
           },
         ];
 

--- a/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
+++ b/x-pack/test_serverless/functional/test_suites/security/ftr/cases/create_case_form.ts
@@ -81,15 +81,13 @@ export default ({ getService, getPageObject }: FtrProviderContext) => {
             key: 'valid_key_1',
             label: 'Summary',
             type: CustomFieldTypes.TEXT as const,
-            defaultValue: 'foobar',
-            required: true,
+            required: false,
           },
           {
             key: 'valid_key_2',
             label: 'Sync',
             type: CustomFieldTypes.TOGGLE as const,
-            defaultValue: false,
-            required: true,
+            required: false,
           },
         ];
 


### PR DESCRIPTION
See https://github.com/elastic/kibana/issues/171747 for more info.

## Summary

**Merging into a feature branch.**

This PR handles only the UI in the `Create` and `Update` case pages.

### Create case

- Custom fields where `required: true` will have their default values pre-filled.
- If the `required` custom field was created before this feature, the field will not be populated.

### Update case

This is only relevant if `required` custom fields have no value and we navigate to the edit case page.

To reach this scenario do:
1. Create a text custom field where `required: false `
2. Create a case and leave that field empty
3. Change that custom field to `required: true` and define a `default value`
4. Go to the edit case page

How this is handled:

<details><summary>Demo video.</summary>

https://github.com/elastic/kibana/assets/1533137/0812016a-9303-4e34-8264-10750c60c350

</details>

- If a single `required` custom field has no value:
  - `No value is added` is displayed.
  - When a user clicks the `Edit` button, the form is filled with the `default value`(when it exists).
  - The `Save` button will be enabled by default.
  - The help text `This field was populated with the default value.` is shown.
- When there are multiple required custom fields without a value, editing one will save the others with their default value


