### PR TITLE
[Fleet] Fix asset creation during custom integration installation

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -88,7 +88,10 @@ const uploadPipeline = (pipelineContent: string | object) => {
     }
 
     if (
-      (await doAnyChangesMatch([/^x-pack\/plugins\/observability_onboarding/])) ||
+      (await doAnyChangesMatch([
+        /^x-pack\/plugins\/observability_onboarding/,
+        /^x-pack\/plugins\/fleet/,
+      ])) ||
       GITHUB_PR_LABELS.includes('ci:all-cypress-suites')
     ) {
       pipeline.push(

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -875,7 +875,7 @@ export async function installCustomPackage(
     acc.set(asset.path, asset.content);
     return acc;
   }, new Map<string, Buffer | undefined>());
-  const paths = [...Object.keys(assetsMap)];
+  const paths = [...assetsMap.keys()];
 
   const packageInstallContext: PackageInstallContext = {
     assetsMap,

--- a/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
@@ -125,17 +125,30 @@ Cypress.Commands.add('deleteIntegration', (integrationName: string) => {
 
   cy.request({
     log: false,
-    method: 'DELETE',
+    method: 'GET',
     url: `${kibanaUrl}/api/fleet/epm/packages/${integrationName}`,
-    body: {
-      force: false,
-    },
     headers: {
       'kbn-xsrf': 'e2e_test',
-      'Elastic-Api-Version': '1',
     },
     auth: { user: 'editor', pass: 'changeme' },
     failOnStatusCode: false,
+  }).then((response) => {
+    const status = response.body.item?.status;
+    if (status === 'installed') {
+      cy.request({
+        log: false,
+        method: 'DELETE',
+        url: `${kibanaUrl}/api/fleet/epm/packages/${integrationName}`,
+        body: {
+          force: false,
+        },
+        headers: {
+          'kbn-xsrf': 'e2e_test',
+          'Elastic-Api-Version': '1',
+        },
+        auth: { user: 'editor', pass: 'changeme' },
+      });
+    }
   });
 });
 


### PR DESCRIPTION
## :memo: Summary

This fixes the way the asset paths are extracted since https://github.com/elastic/kibana/pull/173965. Since the `assetMap` is a `Map`, the keys can be retrieved via `assetMap.keys()`.

- closes https://github.com/elastic/kibana/issues/174803


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->