### PR TITLE
Quality Gates - Allow manual skipping of the bake time

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -30,6 +30,7 @@ steps:
     soft_fail:
       # A manual cancel of that step produces return code 255.
       # We're treating this case as a soft fail to allow manual bake time skipping.
+      # To stop the promotion entirely, instead click the "Cancel" button at the top of the page
       - exit_status: 255
     agents:
       # How long can this agent live for in minutes - 25 hours

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -27,6 +27,10 @@ steps:
   - label: ":cookie: 24h bake time before continuing promotion"
     if: build.env("ENVIRONMENT") == "production-canary"
     command: "sleep 86400"
+    soft_fail:
+      # A manual cancel of that step produces return code 255.
+      # We're treating this case as a soft fail to allow manual bake time skipping.
+      - exit_status: 255
     agents:
       # How long can this agent live for in minutes - 25 hours
       instanceMaxAge: 1500


### PR DESCRIPTION
## Summary

This PR modifies the serverless quality gate production pipeline to allow a manual skipping of the bake time step.

### Details

A manual step cancelling produces a status code 255 and this PR modifies the step to be soft failing for that case. Every other failure should produce a different status code and thus still fail the pipeline.
