### PR TITLE
[ML] Fixes Allocation rendering for failed deployments

### DIFF
--- a/x-pack/plugins/ml/common/types/trained_models.ts
+++ b/x-pack/plugins/ml/common/types/trained_models.ts
@@ -203,8 +203,8 @@ export interface AllocatedModel {
     number_of_pending_requests: number;
     start_time: number;
     throughput_last_minute: number;
-    number_of_allocations: number;
-    threads_per_allocation: number;
+    number_of_allocations?: number;
+    threads_per_allocation?: number;
     error_count?: number;
   };
 }

--- a/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
+++ b/x-pack/plugins/ml/public/application/memory_usage/nodes_overview/allocated_models.tsx
@@ -118,6 +118,12 @@ export const AllocatedModels: FC<AllocatedModelsProps> = ({
       truncateText: false,
       'data-test-subj': 'mlAllocatedModelsTableAllocation',
       render: (v: AllocatedModel) => {
+        if (
+          v.node.number_of_allocations === undefined ||
+          v.node.threads_per_allocation === undefined
+        ) {
+          return '-';
+        }
         return `${v.node.number_of_allocations} * ${v.node.threads_per_allocation}`;
       },
     },


### PR DESCRIPTION
## Summary

Fixes "Allocation" rendering for failed deployments of trained models.

_We should also update the type definition in elasticsearch specification marking `number_of_allocations` and `threads_per_allocation` as optional for [Get Trained Model Stats](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-trained-models-stats.html) endpoint._ 

#### How to reproduce
1. Start a model deployment 
2. Find a Process ID 
```
ps -ef | grep pytorch_inference
```
3. Kill the inference process manually 
```
kill -9 <PID>
```

Before:
![image](https://github.com/elastic/kibana/assets/5236598/b89545a6-6216-4ac8-b0c3-f2b755a41179)

After: 
<img width="1732" alt="image" src="https://github.com/elastic/kibana/assets/5236598/be970ae8-f4a2-4b06-aff4-f27ce374178c">



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->