### PR TITLE
[Logs Explorer] Fix caching on data views updates

### DIFF
--- a/x-pack/plugins/log_explorer/public/state_machines/data_views/src/defaults.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/data_views/src/defaults.ts
@@ -8,7 +8,7 @@
 import { HashedCache } from '../../../../common/hashed_cache';
 import { DefaultDataViewsContext } from './types';
 
-export const DEFAULT_CONTEXT: DefaultDataViewsContext = {
+export const createDefaultContext = (): DefaultDataViewsContext => ({
   cache: new HashedCache(),
   dataViewsSource: null,
   dataViews: null,
@@ -17,4 +17,4 @@ export const DEFAULT_CONTEXT: DefaultDataViewsContext = {
     name: '',
     sortOrder: 'asc',
   },
-};
+});

--- a/x-pack/plugins/log_explorer/public/state_machines/data_views/src/state_machine.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/data_views/src/state_machine.ts
@@ -11,7 +11,7 @@ import { assign, createMachine } from 'xstate';
 import { DiscoverStart } from '@kbn/discover-plugin/public';
 import { parseDataViewListItem } from '../../../utils/parse_data_view_list_item';
 import { createComparatorByField } from '../../../utils/comparator_by_field';
-import { DEFAULT_CONTEXT } from './defaults';
+import { createDefaultContext } from './defaults';
 import type {
   DataViewsContext,
   DataViewsEvent,
@@ -21,7 +21,7 @@ import type {
 } from './types';
 
 export const createPureDataViewsStateMachine = (
-  initialContext: DefaultDataViewsContext = DEFAULT_CONTEXT
+  initialContext: DefaultDataViewsContext = createDefaultContext()
 ) =>
   createMachine<DataViewsContext, DataViewsEvent, DataViewsTypestate>(
     {

--- a/x-pack/plugins/log_explorer/public/state_machines/datasets/src/defaults.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/datasets/src/defaults.ts
@@ -8,7 +8,7 @@
 import { HashedCache } from '../../../../common/hashed_cache';
 import { DefaultDatasetsContext } from './types';
 
-export const DEFAULT_CONTEXT: DefaultDatasetsContext = {
+export const createDefaultContext = (): DefaultDatasetsContext => ({
   cache: new HashedCache(),
   datasets: null,
   error: null,
@@ -16,4 +16,4 @@ export const DEFAULT_CONTEXT: DefaultDatasetsContext = {
     datasetQuery: '',
     sortOrder: 'asc',
   },
-};
+});

--- a/x-pack/plugins/log_explorer/public/state_machines/datasets/src/state_machine.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/datasets/src/state_machine.ts
@@ -9,7 +9,7 @@ import { isEmpty, isError, omitBy } from 'lodash';
 import { assign, createMachine } from 'xstate';
 import { Dataset } from '../../../../common/datasets';
 import { IDatasetsClient } from '../../../services/datasets';
-import { DEFAULT_CONTEXT } from './defaults';
+import { createDefaultContext } from './defaults';
 import type {
   DatasetsContext,
   DatasetsEvent,
@@ -18,7 +18,7 @@ import type {
 } from './types';
 
 export const createPureDatasetsStateMachine = (
-  initialContext: DefaultDatasetsContext = DEFAULT_CONTEXT
+  initialContext: DefaultDatasetsContext = createDefaultContext()
 ) =>
   /** @xstate-layout N4IgpgJg5mDOIC5QBECGAXVsztgOgFcA7AS1PRNQBsSAvSAYgBkB5AQWQH1k2AVNgMoBRXgIDaABgC6iUAAcA9rBIUFRWSAAeiAGwBmAJx4DAdh0BWPXvMAWAIzn9BgDQgAnogAcdvDYP+dACYdfQk9e08AX0jXNExsXDwqBVQIMigGCDUwPDIANwUAaxy4rBx8ZNT0hHyFAGMMEjVJKRaNRWVVdSQtXUNjM0tre0dDVw8EG09A339PHU8wwMWw6NiMMsTKtKIMsAAnfYV9vDkqDAAzY4BbPFKEipSdqBqiAoaulraejpUm7tA2gQdhBMwkEhMJnMjhseh0Ek8nnGiEC5iM5hBJmm+k8BimwTWIHu5SST3SDGEbAASgBhAAS3D4ghE4mk7SUfzUGiBOhMNjwJnC4Vh8J0eJsyOBnnMxjsFmW5m8JjsnhshOJWzJuwpLCpvEZ-GEom+8g5XW5iAMEiMsL5NnhWMChkCksxeB0NkC4MVCz0nj5OnVGwepNSjEptIZPENLJNIF+5p6QLlEl8ljsCvCEjlC0lXr0sosiNhqokapiRODJO24d1+ujzONbJ+Zv+FuB8LTegz0qzOaR7kQVk8AsFgQM03HJitUQrGvwEDAACMFMQ6mABGBUPs6gALdLzilCan0g2N1kyFudNtJxA2cF4QJ2KbdsKQq0uwfA++zfwihxYgigZzlWiSLiua4bluO77rsh6aLAmDoDkqAXMh+wABR6OCACUDDzng4GrkQ66btue4HqBsBxgmN6An0RimBYVi2A4Th5nCvhyrY8yeOEKoEiB8TVlqUAAGKoCQVCMFSQisBwZ5Ghe7LXlyt7AqCeDgpC0IenCCIDhMXpGNmdhmKiegmIEL56NEFZEAoi7wD084qZyAK9AgAC0OiSj5QbCYkxBkH81B0JAbmJvRkwGAWcr3jYJjWjYGJ2C4X7TFp4LgiqIIToKJgBZsjxVLskV0Z5uL8kEfgpYY-o2BKX5PiZBgYiliWNRIHqzusgUlYuEDlWp0WepK5hOlptjTcs07deWfXFYRy7EaR0EUXBVHDR5QKWamQpWW1VndUErptcY-gGPoyp8osfJFSG2zpBJUkRVe7ntnY3YjsqCJTAYcqovMrpingaIYo4V0pXx912UAA */
   createMachine<DatasetsContext, DatasetsEvent, DatasetsTypestate>(

--- a/x-pack/plugins/log_explorer/public/state_machines/integrations/src/defaults.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/integrations/src/defaults.ts
@@ -8,7 +8,7 @@
 import { HashedCache } from '../../../../common/hashed_cache';
 import { DefaultIntegrationsContext } from './types';
 
-export const DEFAULT_CONTEXT: DefaultIntegrationsContext = {
+export const createDefaultContext = (): DefaultIntegrationsContext => ({
   cache: new HashedCache(),
   integrationsSource: null,
   integrations: null,
@@ -17,4 +17,4 @@ export const DEFAULT_CONTEXT: DefaultIntegrationsContext = {
     nameQuery: '',
     sortOrder: 'asc',
   },
-};
+});

--- a/x-pack/plugins/log_explorer/public/state_machines/integrations/src/state_machine.ts
+++ b/x-pack/plugins/log_explorer/public/state_machines/integrations/src/state_machine.ts
@@ -10,7 +10,7 @@ import { isEmpty, isError, omitBy } from 'lodash';
 import { createComparatorByField } from '../../../utils/comparator_by_field';
 import { Dataset, Integration } from '../../../../common/datasets';
 import { IDatasetsClient } from '../../../services/datasets';
-import { DEFAULT_CONTEXT } from './defaults';
+import { createDefaultContext } from './defaults';
 import {
   DefaultIntegrationsContext,
   IntegrationsContext,
@@ -20,7 +20,7 @@ import {
 } from './types';
 
 export const createPureIntegrationsStateMachine = (
-  initialContext: DefaultIntegrationsContext = DEFAULT_CONTEXT
+  initialContext: DefaultIntegrationsContext = createDefaultContext()
 ) =>
   createMachine<IntegrationsContext, IntegrationsEvent, IntegrationTypestate>(
     {


### PR DESCRIPTION
## 📓 Summary

Closes #174538 

This work fixes an issue which prevented newly created data views from being shown in the Log Explorer selector when performing client navigations.

This issue was caused by a globally instantiated cache, which was not recreated when the page was left and revisited later.

It now recreates correctly the initial context, including the cache, to display the correct list of data views. The same fix applies to integrations and datasets, which had their cache created in the same way.

https://github.com/elastic/kibana/assets/34506779/4c53072a-7880-434c-9afc-d585a43610a2

