### PR TITLE
[Docs] Remove broken weak links fix plan

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -5732,7 +5732,7 @@ conditions are true:
 
 In 8.0.0 and later, weak links break because <<saved-object-ids-impact-when-using-import-and-copy,saved object IDs can change during import or copy>>.
 This applies to both the UI and the API.
-This issue will be fixed 8.0.1 and 8.1.0. For more information, refer to {kibana-issue}123550[#123550].
+For more information, refer to {kibana-issue}123550[#123550].
 
 *Impact* +
 Saved objects in 7.x that are migrated during upgrade are **not** impacted.


### PR DESCRIPTION
## Summary

The broken weak links problem wasn't fixed in 8.1, so this statement is now confusing.

An aliasing workaround [was added](https://github.com/elastic/kibana/pull/149021) in 8.8 for those customers who need it.

Better solutions
- use the [new links panel](https://www.elastic.co/guide/en/kibana/current/dashboard-links.html) for navigation between dashboards
- use [shareable dashboards](https://github.com/elastic/kibana/issues/167901) to make analytics stuff available in multiple spaces instead of copying (not yet available)
