### PR TITLE
[8.11] [DOCS] Manually adding 8.11.4 release notes (#174849)

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -10,6 +10,7 @@
 
 Review important information about the {kib} 8.x releases.
 
+* <<release-notes-8.11.4>>
 * <<release-notes-8.11.3>>
 * <<release-notes-8.11.2>>
 * <<release-notes-8.11.1>>
@@ -57,6 +58,14 @@ Review important information about the {kib} 8.x releases.
 * <<release-notes-8.0.0-alpha1>>
 
 --
+[[release-notes-8.11.4]]
+== {kib} 8.11.4
+
+[float]
+[[fixes-v8.11.4]]
+=== Bug fixes and enhancements
+There are no user-facing changes in the 8.11.4 release.
+
 [[release-notes-8.11.3]]
 == {kib} 8.11.3
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.11`:
 - [[DOCS] Manually adding 8.11.4 release notes (#174849)](https://github.com/elastic/kibana/pull/174849)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"amyjtechwriter","email":"61687663+amyjtechwriter@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-16T13:59:40Z","message":"[DOCS] Manually adding 8.11.4 release notes (#174849)\n\nAdds the 8.11.4 release notes to 8.11.0. In the original release notes\r\nPR I used the wrong label so the changes were not backported. The\r\nbackport tool kept getting stuck in the cherry-picking state.\r\n\r\nOriginal PR: #174636","sha":"565cd99d60378cd1c9d35b3144ec05ce99a0621c","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Docs","backport","release_note:skip","docs","v8.11.0","v8.13.0"],"number":174849,"url":"https://github.com/elastic/kibana/pull/174849","mergeCommit":{"message":"[DOCS] Manually adding 8.11.4 release notes (#174849)\n\nAdds the 8.11.4 release notes to 8.11.0. In the original release notes\r\nPR I used the wrong label so the changes were not backported. The\r\nbackport tool kept getting stuck in the cherry-picking state.\r\n\r\nOriginal PR: #174636","sha":"565cd99d60378cd1c9d35b3144ec05ce99a0621c"}},"sourceBranch":"main","suggestedTargetBranches":["8.11"],"targetPullRequestStates":[{"branch":"8.11","label":"v8.11.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174849","number":174849,"mergeCommit":{"message":"[DOCS] Manually adding 8.11.4 release notes (#174849)\n\nAdds the 8.11.4 release notes to 8.11.0. In the original release notes\r\nPR I used the wrong label so the changes were not backported. The\r\nbackport tool kept getting stuck in the cherry-picking state.\r\n\r\nOriginal PR: #174636","sha":"565cd99d60378cd1c9d35b3144ec05ce99a0621c"}}]}] BACKPORT-->