### PR TITLE
[Data Views] Use spec to create data view id

### DIFF
--- a/src/plugins/data_views/common/data_views/data_views.ts
+++ b/src/plugins/data_views/common/data_views/data_views.ts
@@ -11,7 +11,6 @@ import type { PublicMethodsOf } from '@kbn/utility-types';
 import { castEsToKbnFieldTypeName } from '@kbn/field-types';
 import { FieldFormatsStartCommon, FORMATS_UI_SETTINGS } from '@kbn/field-formats-plugin/common';
 import { v4 as uuidv4 } from 'uuid';
-import { createSHA256Hash } from '@kbn/crypto';
 import { PersistenceAPI } from '../types';
 
 import { createDataViewCache } from '.';
@@ -956,7 +955,6 @@ export class DataViewsService {
     displayErrors = true,
     generateIdBySpec = true
   ): Promise<DataView> {
-    console.log('createFromSpec', restOfSpec);
     const shortDotsEnable = await this.config.get<boolean>(FORMATS_UI_SETTINGS.SHORT_DOTS_ENABLE);
     const metaFields = await this.config.get<string[] | undefined>(META_FIELDS);
 
@@ -974,11 +972,7 @@ export class DataViewsService {
       metaFields,
     });
     if (!id && generateIdBySpec) {
-      const newSpec = dataView.toSpec(false);
-      delete newSpec.id;
-      const specId = createSHA256Hash(JSON.stringify(newSpec));
-      dataView.id = specId;
-      console.log('create', spec, generateIdBySpec, id);
+      dataView.id = dataView.toSpecId();
     }
 
     if (!skipFetchFields) {

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -21,7 +21,6 @@ import {
 } from '@kbn/data-plugin/public';
 import { DataView, DataViewSpec, DataViewType } from '@kbn/data-views-plugin/public';
 import type { SavedSearch } from '@kbn/saved-search-plugin/public';
-import { v4 as uuidv4 } from 'uuid';
 import { merge } from 'rxjs';
 import { AggregateQuery, Query, TimeRange } from '@kbn/es-query';
 import { loadSavedSearch as loadSavedSearchFn } from './load_saved_search';
@@ -298,7 +297,10 @@ export function getDiscoverStateContainer({
   const updateAdHocDataViewId = async () => {
     const prevDataView = internalStateContainer.getState().dataView;
     if (!prevDataView || prevDataView.isPersisted()) return;
-    const newDataView = await services.dataViews.create({ ...prevDataView.toSpec(), id: uuidv4() });
+    const newDataView = await services.dataViews.create({
+      ...prevDataView.toSpec(false),
+      id: undefined,
+    });
     services.dataViews.clearInstanceCache(prevDataView.id);
 
     updateFiltersReferences(prevDataView, newDataView);


### PR DESCRIPTION
## Summary

Experiment figuring out what breaks if a data view id is generated by spec. While generating a id by a given spec would resolve issues described in 
https://github.com/elastic/kibana/discussions/174862
* It would be currently not applicable to the ad hoc data view generation, because every time the spec would be extended, this would change the id. 
* What's more we e.g. do not provide a `timefield` everywhere we generate ad-hoc data views, but when the data view is being edited, a timefield is assigned ... this would change the id.
* It seems could optimize the spec to not contain default values or empty  objects / array
* We generate several custom ids for an ad-hoc data view in Kibana (easy fixable, but just wanted to mention)

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
