### PR TITLE
[ES|QL] Fix validation support for `count()`

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/definitions/aggs.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/definitions/aggs.ts
@@ -100,7 +100,13 @@ export const statsAggregationFunctionDefinitions: FunctionDefinition[] = [
       signatures: [
         {
           params: [
-            { name: 'column', type: 'any', noNestingFunctions: true, supportsWildcard: true },
+            {
+              name: 'column',
+              type: 'any',
+              noNestingFunctions: true,
+              supportsWildcard: true,
+              optional: true,
+            },
           ],
           returnType: 'number',
           examples: [`from index | stats result = count(field)`, `from index | stats count(field)`],

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/validation.test.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/validation.test.ts
@@ -1192,7 +1192,9 @@ describe('validation logic', () => {
     ]);
 
     testErrorsAndWarnings('from a | stats count(*)', []);
+    testErrorsAndWarnings('from a | stats count()', []);
     testErrorsAndWarnings('from a | stats var0 = count(*)', []);
+    testErrorsAndWarnings('from a | stats var0 = count()', []);
     testErrorsAndWarnings('from a | stats var0 = avg(numberField), count(*)', []);
 
     for (const { name, alias, signatures, ...defRest } of statsAggregationFunctionDefinitions) {


### PR DESCRIPTION
## Summary

Fix validation on `count()` function with no argument. Added tests.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios