### PR TITLE
[APM] Fix and unskip alert failing tests

### DIFF
--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_duration.spec.ts
@@ -45,7 +45,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   };
 
   registry.when('transaction duration alert', { config: 'basic', archives: [] }, () => {
-    before(async () => {
+    before(() => {
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -68,7 +68,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               .success(),
           ];
         });
-      await synthtraceEsClient.index(events);
+      return synthtraceEsClient.index(events);
     });
 
     after(async () => {

--- a/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
+++ b/x-pack/test/apm_api_integration/tests/alerts/transaction_error_rate.spec.ts
@@ -33,7 +33,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
   const synthtraceEsClient = getService('synthtraceEsClient');
 
   registry.when('transaction error rate alert', { config: 'basic', archives: [] }, () => {
-    before(async () => {
+    before(() => {
       const opbeansJava = apm
         .service({ name: 'opbeans-java', environment: 'production', agentName: 'java' })
         .instance('instance');
@@ -66,7 +66,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
               .success(),
           ];
         });
-      await synthtraceEsClient.index(events);
+      return synthtraceEsClient.index(events);
     });
 
     after(async () => {
@@ -200,7 +200,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
       let ruleId: string;
       let alerts: ApmAlertFields[];
 
-      before(async () => {
+      beforeEach(async () => {
         const createdRule = await createApmRule({
           supertest,
           ruleTypeId: ApmRuleType.TransactionErrorRate,
@@ -232,7 +232,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         alerts = await waitForAlertsForRule({ es, ruleId });
       });
 
-      after(async () => {
+      afterEach(async () => {
         await cleanupRuleAndAlertState({ es, supertest, logger });
       });
 
@@ -249,8 +249,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         );
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/173419
-      it.skip('shows alert count=1 for opbeans-node on service inventory', async () => {
+      it('shows alert count=1 for opbeans-node on service inventory', async () => {
         const serviceInventoryAlertCounts = await fetchServiceInventoryAlertCounts(apmApiClient);
         expect(serviceInventoryAlertCounts).to.eql({
           'opbeans-node': 1,
@@ -258,8 +257,7 @@ export default function ApiTest({ getService }: FtrProviderContext) {
         });
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/173439
-      it.skip('shows alert count=0 in opbeans-java service', async () => {
+      it('shows alert count=0 in opbeans-java service', async () => {
         const serviceTabAlertCount = await fetchServiceTabAlertCount({
           apmApiClient,
           serviceName: 'opbeans-java',


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/173419 and https://github.com/elastic/kibana/issues/173439

### Summary

Test were likely failing because the opbeans-java alert was not deleted from previous tests. To prevent that from happening again, I've changed the test to make sure the rules are cleaned before each test.
Also, we follow a similar approach to https://github.com/elastic/kibana/pull/174327, to prevent the tests from running without the necessary synthtrace data.

https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/4896

