### PR TITLE
[infra] telemetry can be undefined

### DIFF
--- a/x-pack/plugins/infra/public/containers/metrics_source/source.tsx
+++ b/x-pack/plugins/infra/public/containers/metrics_source/source.tsx
@@ -57,7 +57,7 @@ export const useSource = ({ sourceId }: { sourceId: string }) => {
         const response = await fetchService.fetch<MetricsSourceConfigurationResponse>(API_URL, {
           method: 'GET',
         });
-        telemetry.reportPerformanceMetricEvent(
+        telemetry?.reportPerformanceMetricEvent(
           'infra_source_load',
           performance.now() - start,
           {},

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/hooks/use_hosts_view.ts
@@ -72,7 +72,7 @@ export const useHostsView = () => {
         }
       );
       const duration = performance.now() - start;
-      telemetry.reportPerformanceMetricEvent(
+      telemetry?.reportPerformanceMetricEvent(
         'infra_hosts_table_load',
         duration,
         { key1: 'data_load', value1: duration },

--- a/x-pack/plugins/infra/public/types.ts
+++ b/x-pack/plugins/infra/public/types.ts
@@ -102,7 +102,7 @@ export interface InfraClientStartDeps {
   uiActions: UiActionsStart;
   unifiedSearch: UnifiedSearchPublicPluginStart;
   usageCollection: UsageCollectionStart;
-  telemetry: ITelemetryClient;
+  telemetry?: ITelemetryClient;
   fieldFormats: FieldFormatsStart;
   licensing: LicensingPluginStart;
 }


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/175026

Telemetry service can be undefined when source is loaded from non-infra plugin context

### Testing
- create a metric rule
- fields can be loaded and preview graph is showing in the metric creation panel
