### PR TITLE
[Fleet] make deprecated paths public

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/index.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/index.ts
@@ -6,7 +6,7 @@
  */
 
 import type { FleetAuthz } from '../../../common';
-import { API_VERSIONS, INTERNAL_API_ACCESS } from '../../../common/constants';
+import { API_VERSIONS } from '../../../common/constants';
 
 import { getRouteRequiredAuthz, type FleetAuthzRouter } from '../../services/security';
 
@@ -351,7 +351,6 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     );
   router.versioned
     .get({
-      access: INTERNAL_API_ACCESS,
       path: AGENT_API_ROUTES.STATUS_PATTERN_DEPRECATED,
       fleetAuthz: {
         fleet: { all: true },
@@ -359,7 +358,7 @@ export const registerAPIRoutes = (router: FleetAuthzRouter, config: FleetConfigT
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: GetAgentStatusRequestSchema },
       },
       getAgentStatusForAgentPolicyHandler

--- a/x-pack/plugins/fleet/server/routes/app/index.ts
+++ b/x-pack/plugins/fleet/server/routes/app/index.ts
@@ -11,7 +11,7 @@ import type { TypeOf } from '@kbn/config-schema';
 import type { FleetAuthzRouter } from '../../services/security';
 
 import { APP_API_ROUTES } from '../../constants';
-import { API_VERSIONS, INTERNAL_API_ACCESS } from '../../../common/constants';
+import { API_VERSIONS } from '../../../common/constants';
 
 import { appContextService } from '../../services';
 import type { CheckPermissionsResponse, GenerateServiceTokenResponse } from '../../../common/types';
@@ -141,11 +141,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: {},
       },
       generateServiceTokenHandler

--- a/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
+++ b/x-pack/plugins/fleet/server/routes/enrollment_api_key/index.ts
@@ -8,7 +8,7 @@
 import type { FleetAuthzRouter } from '../../services/security';
 
 import { ENROLLMENT_API_KEY_ROUTES } from '../../constants';
-import { API_VERSIONS, INTERNAL_API_ACCESS } from '../../../common/constants';
+import { API_VERSIONS } from '../../../common/constants';
 
 import {
   GetEnrollmentAPIKeysRequestSchema,
@@ -91,11 +91,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readEnrollmentTokens: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: GetOneEnrollmentAPIKeyRequestSchema },
       },
       getOneEnrollmentApiKeyHandler
@@ -107,11 +106,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: DeleteEnrollmentAPIKeyRequestSchema },
       },
       deleteEnrollmentApiKeyHandler
@@ -123,11 +121,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { readEnrollmentTokens: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: GetEnrollmentAPIKeysRequestSchema },
       },
       getEnrollmentApiKeysHandler
@@ -139,11 +136,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         fleet: { all: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: PostEnrollmentAPIKeyRequestSchema },
       },
       postEnrollmentApiKeyHandler

--- a/x-pack/plugins/fleet/server/routes/epm/index.ts
+++ b/x-pack/plugins/fleet/server/routes/epm/index.ts
@@ -7,7 +7,7 @@
 
 import type { IKibanaResponse } from '@kbn/core/server';
 
-import { API_VERSIONS, INTERNAL_API_ACCESS } from '../../../common/constants';
+import { API_VERSIONS } from '../../../common/constants';
 
 import type { FleetAuthz } from '../../../common';
 
@@ -361,11 +361,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { upgradePackages: true, writePackageSettings: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: UpdatePackageRequestSchemaDeprecated },
       },
       async (context, request, response) => {
@@ -415,11 +414,10 @@ export const registerRoutes = (router: FleetAuthzRouter) => {
       fleetAuthz: {
         integrations: { removePackages: true },
       },
-      access: INTERNAL_API_ACCESS,
     })
     .addVersion(
       {
-        version: API_VERSIONS.internal.v1,
+        version: API_VERSIONS.public.v1,
         validate: { request: DeletePackageRequestSchemaDeprecated },
       },
       async (context, request, response) => {

--- a/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/support/commands.ts
@@ -144,7 +144,7 @@ Cypress.Commands.add('deleteIntegration', (integrationName: string) => {
         },
         headers: {
           'kbn-xsrf': 'e2e_test',
-          'Elastic-Api-Version': '1',
+          'Elastic-Api-Version': '2023-10-31',
         },
         auth: { user: 'editor', pass: 'changeme' },
       });

--- a/x-pack/test/fleet_api_integration/apis/agents/status.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/status.ts
@@ -8,7 +8,6 @@
 import expect from '@kbn/expect';
 
 import { INGEST_SAVED_OBJECT_INDEX } from '@kbn/core-saved-objects-server';
-import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 
 import { AGENTS_INDEX } from '@kbn/fleet-plugin/common';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
@@ -232,11 +231,7 @@ export default function ({ getService }: FtrProviderContext) {
     });
 
     it('should work with deprecated api', async () => {
-      await supertest
-        .get(`/api/fleet/agent-status`)
-        .set('kbn-xsrf', 'xxxx')
-        .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
-        .expect(200);
+      await supertest.get(`/api/fleet/agent-status`).set('kbn-xsrf', 'xxxx').expect(200);
     });
 
     it('should work with adequate package privileges', async () => {

--- a/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
+++ b/x-pack/test/fleet_api_integration/apis/enrollment_api_keys/crud.ts
@@ -7,7 +7,6 @@
 
 import expect from '@kbn/expect';
 
-import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import { FtrProviderContext } from '../../../api_integration/ftr_provider_context';
 import { setupFleetAndAgents, getEsClientForAPIKey } from '../agents/services';
 import { skipIfNoDockerRegistry } from '../../helpers';
@@ -325,7 +324,6 @@ export default function (providerContext: FtrProviderContext) {
         const { body: apiResponse } = await supertest
           .post(`/api/fleet/enrollment-api-keys`)
           .set('kbn-xsrf', 'xxx')
-          .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
           .send({
             policy_id: 'policy1',
           })
@@ -334,20 +332,14 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should get and delete with deprecated API', async () => {
-        await supertest
-          .get(`/api/fleet/enrollment-api-keys`)
-          .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
-          .set('kbn-xsrf', 'xxx')
-          .expect(200);
+        await supertest.get(`/api/fleet/enrollment-api-keys`).set('kbn-xsrf', 'xxx').expect(200);
         await supertest
           .get(`/api/fleet/enrollment-api-keys/${ENROLLMENT_KEY_ID}`)
-          .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
           .set('kbn-xsrf', 'xxx')
           .expect(200);
 
         await supertest
           .delete(`/api/fleet/enrollment-api-keys/${keyId}`)
-          .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
           .set('kbn-xsrf', 'xxx')
           .expect(200);
       });

--- a/x-pack/test/fleet_api_integration/apis/service_tokens.ts
+++ b/x-pack/test/fleet_api_integration/apis/service_tokens.ts
@@ -6,7 +6,6 @@
  */
 
 import expect from '@kbn/expect';
-import { API_VERSIONS } from '@kbn/fleet-plugin/common/constants';
 import { FtrProviderContext } from '../../api_integration/ftr_provider_context';
 
 export default function (providerContext: FtrProviderContext) {
@@ -47,11 +46,7 @@ export default function (providerContext: FtrProviderContext) {
     });
 
     it('should work with deprecated api', async () => {
-      await supertest
-        .post(`/api/fleet/service-tokens`)
-        .set('kbn-xsrf', 'xxxx')
-        .set('Elastic-Api-Version', `${API_VERSIONS.internal.v1}`)
-        .expect(200);
+      await supertest.post(`/api/fleet/service-tokens`).set('kbn-xsrf', 'xxxx').expect(200);
     });
 
     it('should create a valid remote service account token', async () => {


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/175031

Made deprecated APIs public instead of internal, to fix the accidental breaking change for customers who called these APIs before (internal APIs don't have a default version resolution yet, so require a version header)

One caveat of this change is if someone already changed their deprecated API call to use 'elastic-api-version: 1' in 8.11, as it would have to be changed again to use the public version or remove the header. Though I don't think we have many usages like that, since the version usage is not very well documented and we only got one support question about it.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->