### PR TITLE
[Serverless Search] index_management: show embedded console in serverless search

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -41,3 +41,6 @@ xpack.ml.ad.enabled: false
 xpack.ml.dfa.enabled: false
 xpack.ml.nlp.enabled: true
 xpack.ml.compatibleModuleType: 'search'
+
+# Enable the embedded dev console for index management pages
+xpack.index_management.enableEmbeddedConsole: true

--- a/src/plugins/console/public/application/index.tsx
+++ b/src/plugins/console/public/application/index.tsx
@@ -27,6 +27,7 @@ import {
   setStorage,
 } from '../services';
 import { createUsageTracker } from '../services/tracker';
+import { loadActiveApi } from '../lib/kb';
 import * as localStorageObjectClient from '../lib/local_storage_object_client';
 import { Main } from './containers';
 import { ServicesContextProvider, EditorContextProvider, RequestContextProvider } from './contexts';
@@ -44,7 +45,7 @@ export interface BootDependencies {
   autocompleteInfo: AutocompleteInfo;
 }
 
-export function renderApp({
+export async function renderApp({
   I18nContext,
   notifications,
   docLinkVersion,
@@ -58,6 +59,7 @@ export function renderApp({
   const trackUiMetric = createUsageTracker(usageCollection);
   trackUiMetric.load('opened_app');
 
+  await loadActiveApi(http);
   const storage = createStorage({
     engine: window.localStorage,
     prefix: 'sense:',

--- a/src/plugins/console/public/application/models/sense_editor/integration.test.js
+++ b/src/plugins/console/public/application/models/sense_editor/integration.test.js
@@ -80,7 +80,7 @@ describe('Integration', () => {
           });
         }
       }
-      kb.setActiveApi(testApi);
+      kb._test.setActiveApi(testApi);
       const { cursor } = testToRun;
       senseEditor.update(editorValue, true).then(() => {
         senseEditor.getCoreEditor().moveCursorToPosition(cursor);

--- a/src/plugins/console/public/lib/kb/kb.js
+++ b/src/plugins/console/public/lib/kb/kb.js
@@ -6,6 +6,8 @@
  * Side Public License, v 1.
  */
 
+import { API_BASE_PATH } from '../../../common/constants';
+
 import {
   IndexAutocompleteComponent,
   FieldAutocompleteComponent,
@@ -16,12 +18,12 @@ import {
   DataStreamAutocompleteComponent,
 } from '../autocomplete/components';
 
-import $ from 'jquery';
 import _ from 'lodash';
 
 import Api from './api';
 
 let ACTIVE_API = new Api();
+let apiLoaded = false;
 const isNotAnIndexName = (name) => name[0] === '_' && name !== '_all';
 
 const parametrizedComponentFactories = {
@@ -113,36 +115,30 @@ function loadApisFromJson(
   }
 }
 
-// TODO: clean up setting up of active API and use of jQuery.
-// This function should be attached to a class that holds the current state, not setup
-// when the file is required. Also, jQuery should not be used to make network requests
-// like this, it looks like a minor security issue.
-export function setActiveApi(api) {
+function setActiveApi(api) {
   if (!api) {
-    $.ajax({
-      url: '../api/console/api_server',
-      dataType: 'json', // disable automatic guessing
-      headers: {
-        'kbn-xsrf': 'kibana',
-        // workaround for serverless
-        'x-elastic-internal-origin': 'Kibana',
-      },
-    }).then(
-      function (data) {
-        setActiveApi(loadApisFromJson(data));
-      },
-      function (jqXHR) {
-        console.log("failed to load API '" + api + "': " + jqXHR.responseText);
-      }
-    );
     return;
   }
 
   ACTIVE_API = api;
 }
 
-setActiveApi();
+export async function loadActiveApi(http) {
+  // Only load the API data once
+  if (apiLoaded) return;
+  apiLoaded = true;
+
+  try {
+    const data = await http.get(`${API_BASE_PATH}/api_server`);
+    setActiveApi(loadApisFromJson(data));
+  } catch (err) {
+    console.log(`failed to load API: ${err.responseText}`);
+    // If we fail to load the API, clear this flag so it can be retried
+    apiLoaded = false;
+  }
+}
 
 export const _test = {
   loadApisFromJson: loadApisFromJson,
+  setActiveApi: setActiveApi,
 };

--- a/src/plugins/console/public/lib/kb/kb.test.js
+++ b/src/plugins/console/public/lib/kb/kb.test.js
@@ -16,13 +16,13 @@ import { AutocompleteInfo, setAutocompleteInfo } from '../../services';
 describe('Knowledge base', () => {
   let autocompleteInfo;
   beforeEach(() => {
-    kb.setActiveApi(kb._test.loadApisFromJson({}));
+    kb._test.setActiveApi(kb._test.loadApisFromJson({}));
     autocompleteInfo = new AutocompleteInfo();
     setAutocompleteInfo(autocompleteInfo);
     autocompleteInfo.mapping.clearMappings();
   });
   afterEach(() => {
-    kb.setActiveApi(kb._test.loadApisFromJson({}));
+    kb._test.setActiveApi(kb._test.loadApisFromJson({}));
     autocompleteInfo = null;
     setAutocompleteInfo(null);
   });
@@ -113,7 +113,7 @@ describe('Knowledge base', () => {
         kb._test.globalUrlComponentFactories
       );
 
-      kb.setActiveApi(testApi);
+      kb._test.setActiveApi(testApi);
 
       autocompleteInfo.mapping.loadMappings(MAPPING);
       testUrlContext(tokenPath, otherTokenValues, expectedContext);

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -20,7 +20,6 @@ import {
   EmbeddableConsoleDependencies,
 } from './types';
 import { AutocompleteInfo, setAutocompleteInfo } from './services';
-import { loadActiveApi } from './lib/kb';
 
 export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDependencies> {
   private readonly autocompleteInfo = new AutocompleteInfo();
@@ -69,7 +68,6 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
             docLinks: { DOC_LINK_VERSION, links },
           } = core;
 
-          await loadActiveApi(core.http);
           const { renderApp } = await import('./application');
 
           return renderApp({

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -20,6 +20,7 @@ import {
   EmbeddableConsoleDependencies,
 } from './types';
 import { AutocompleteInfo, setAutocompleteInfo } from './services';
+import { loadActiveApi } from './lib/kb';
 
 export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDependencies> {
   private readonly autocompleteInfo = new AutocompleteInfo();
@@ -68,6 +69,7 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
             docLinks: { DOC_LINK_VERSION, links },
           } = core;
 
+          await loadActiveApi(core.http);
           const { renderApp } = await import('./application');
 
           return renderApp({

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -270,6 +270,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.index_management.enableIndexStats (any)',
         'xpack.index_management.editableIndexSettings (any)',
         'xpack.index_management.enableDataStreamsStorageColumn (any)',
+        'xpack.index_management.enableEmbeddedConsole (boolean)',
         'xpack.infra.sources.default.fields.message (array)',
         /**
          * Feature flags bellow are conditional based on traditional/serverless offering

--- a/x-pack/plugins/index_management/__jest__/components/index_table.test.js
+++ b/x-pack/plugins/index_management/__jest__/components/index_table.test.js
@@ -167,6 +167,7 @@ describe('index table', () => {
         enableLegacyTemplates: true,
         enableIndexActions: true,
         enableIndexStats: true,
+        enableEmbeddedConsole: false,
       },
     };
 

--- a/x-pack/plugins/index_management/kibana.jsonc
+++ b/x-pack/plugins/index_management/kibana.jsonc
@@ -20,7 +20,8 @@
       "security",
       "usageCollection",
       "fleet",
-      "cloud"
+      "cloud",
+      "console"
     ],
     "requiredBundles": [
       "kibanaReact",

--- a/x-pack/plugins/index_management/public/application/app_context.tsx
+++ b/x-pack/plugins/index_management/public/application/app_context.tsx
@@ -24,6 +24,7 @@ import type { SharePluginStart } from '@kbn/share-plugin/public';
 
 import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { CloudSetup } from '@kbn/cloud-plugin/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import { ExtensionsService } from '../services';
 import { UiMetricService, NotificationService, HttpService } from './services';
 
@@ -42,6 +43,7 @@ export interface AppDependencies {
     isFleetEnabled: boolean;
     share: SharePluginStart;
     cloud?: CloudSetup;
+    console?: ConsolePluginStart;
   };
   services: {
     uiMetricService: UiMetricService;
@@ -55,6 +57,7 @@ export interface AppDependencies {
     enableIndexStats: boolean;
     editableIndexSettings: 'all' | 'limited';
     enableDataStreamsStorageColumn: boolean;
+    enableEmbeddedConsole: boolean;
   };
   history: ScopedHistory;
   setBreadcrumbs: ManagementAppMountParams['setBreadcrumbs'];

--- a/x-pack/plugins/index_management/public/application/mount_management_section.ts
+++ b/x-pack/plugins/index_management/public/application/mount_management_section.ts
@@ -103,6 +103,7 @@ export async function mountManagementSection({
       isFleetEnabled,
       share: startDependencies.share,
       cloud,
+      console: startDependencies.console,
     },
     services: {
       httpService,

--- a/x-pack/plugins/index_management/public/application/sections/home/home.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/home.tsx
@@ -14,6 +14,7 @@ import { EuiButtonEmpty, EuiPageHeader, EuiSpacer } from '@elastic/eui';
 import { Section } from '../../../../common/constants';
 import { documentationService } from '../../services/documentation';
 import { ComponentTemplateList } from '../../components/component_templates';
+import { useAppContext } from '../../app_context';
 import { IndexList } from './index_list';
 import { EnrichPoliciesList } from './enrich_policies_list';
 import { IndexDetailsPage } from './index_list/details_page';
@@ -38,6 +39,10 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
   },
   history,
 }) => {
+  const {
+    config: { enableEmbeddedConsole },
+    plugins: { console: consolePlugin },
+  } = useAppContext();
   const tabs = [
     {
       id: Section.Indices,
@@ -141,6 +146,7 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
         />
         <Route exact path={`/${Section.EnrichPolicies}`} component={EnrichPoliciesList} />
       </Routes>
+      {(enableEmbeddedConsole && consolePlugin?.renderEmbeddableConsole?.()) ?? <></>}
     </>
   );
   return (

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
@@ -90,7 +90,8 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
   navigateToIndicesList,
 }) => {
   const {
-    config: { enableIndexStats },
+    config: { enableIndexStats, enableEmbeddedConsole },
+    plugins: { console: consolePlugin },
     services: { extensionsService },
   } = useAppContext();
 
@@ -178,6 +179,7 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
       >
         <DetailsPageTab tabs={tabs} tab={tab} index={index} />
       </div>
+      {(enableEmbeddedConsole && consolePlugin?.renderEmbeddableConsole?.()) ?? <></>}
     </>
   );
 };

--- a/x-pack/plugins/index_management/public/plugin.ts
+++ b/x-pack/plugins/index_management/public/plugin.ts
@@ -43,6 +43,7 @@ export class IndexMgmtUIPlugin {
       enableIndexStats,
       editableIndexSettings,
       enableDataStreamsStorageColumn,
+      enableEmbeddedConsole,
     } = this.ctx.config.get<ClientConfigType>();
 
     if (isIndexManagementUiEnabled) {
@@ -54,6 +55,7 @@ export class IndexMgmtUIPlugin {
         enableIndexStats: enableIndexStats ?? true,
         editableIndexSettings: editableIndexSettings ?? 'all',
         enableDataStreamsStorageColumn: enableDataStreamsStorageColumn ?? true,
+        enableEmbeddedConsole: enableEmbeddedConsole ?? false,
       };
       management.sections.section.data.registerApp({
         id: PLUGIN.id,

--- a/x-pack/plugins/index_management/public/types.ts
+++ b/x-pack/plugins/index_management/public/types.ts
@@ -9,6 +9,7 @@ import { UsageCollectionSetup } from '@kbn/usage-collection-plugin/public';
 import { ManagementSetup } from '@kbn/management-plugin/public';
 import { SharePluginSetup, SharePluginStart } from '@kbn/share-plugin/public';
 import { CloudSetup } from '@kbn/cloud-plugin/public';
+import { ConsolePluginStart } from '@kbn/console-plugin/public';
 import { ExtensionsSetup, PublicApiServiceSetup } from './services';
 
 export interface IndexManagementPluginSetup {
@@ -29,6 +30,7 @@ export interface SetupDependencies {
 }
 
 export interface StartDependencies {
+  console?: ConsolePluginStart;
   share: SharePluginStart;
 }
 
@@ -41,4 +43,5 @@ export interface ClientConfigType {
   enableIndexStats?: boolean;
   editableIndexSettings?: 'all' | 'limited';
   enableDataStreamsStorageColumn?: boolean;
+  enableEmbeddedConsole?: boolean;
 }

--- a/x-pack/plugins/index_management/server/config.ts
+++ b/x-pack/plugins/index_management/server/config.ts
@@ -52,6 +52,8 @@ const schemaLatest = schema.object(
       // We take this approach in order to have a central place (serverless.yml) for serverless config across Kibana
       serverless: schema.boolean({ defaultValue: true }),
     }),
+    // Embedded Developer Console is disabled by default
+    enableEmbeddedConsole: schema.boolean({ defaultValue: false }),
   },
   { defaultValue: undefined }
 );
@@ -64,6 +66,7 @@ const configLatest: PluginConfigDescriptor<IndexManagementConfig> = {
     enableIndexStats: true,
     editableIndexSettings: true,
     enableDataStreamsStorageColumn: true,
+    enableEmbeddedConsole: true,
   },
   schema: schemaLatest,
   deprecations: ({ unused }) => [unused('dev.enableIndexDetailsPage', { level: 'warning' })],

--- a/x-pack/plugins/index_management/tsconfig.json
+++ b/x-pack/plugins/index_management/tsconfig.json
@@ -43,6 +43,7 @@
     "@kbn/ui-theme",
     "@kbn/core-application-browser",
     "@kbn/code-editor",
+    "@kbn/console-plugin",
   ],
   "exclude": [
     "target/**/*",

--- a/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 import { FtrProviderContext } from '../../../ftr_provider_context';
+import { testHasEmbeddedConsole } from '../embedded_console';
+
 const TEST_CONNECTOR_NAME = 'my-connector';
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects([
@@ -31,12 +33,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
       await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectConnectorOverviewPageComponentsToExist();
     });
     it('has embedded dev console', async () => {
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleControlBarExists();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeOpen();
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
+      await testHasEmbeddedConsole(pageObjects);
     });
     describe('create and configure connector', async () => {
       it('create connector and confirm connector configuration page is loaded', async () => {

--- a/x-pack/test_serverless/functional/test_suites/search/embedded_console.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/embedded_console.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+type PageObjects = Pick<ReturnType<FtrProviderContext['getPageObjects']>, 'svlCommonNavigation'>;
+
+export async function testHasEmbeddedConsole(pageObjects: PageObjects) {
+  await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleControlBarExists();
+  await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
+  await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
+  await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeOpen();
+  await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
+  await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
+}

--- a/x-pack/test_serverless/functional/test_suites/search/index_management.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/index_management.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../ftr_provider_context';
+
+import { testHasEmbeddedConsole } from './embedded_console';
+
+export default function ({ getPageObjects, getService }: FtrProviderContext) {
+  const pageObjects = getPageObjects([
+    'svlCommonPage',
+    'svlCommonNavigation',
+    'common',
+    'header',
+    'indexManagement',
+  ]);
+  const security = getService('security');
+
+  describe('index management', function () {
+    before(async () => {
+      await security.testUser.setRoles(['index_management_user']);
+      // Navigate to the index management page
+      await pageObjects.svlCommonPage.login();
+      await pageObjects.common.navigateToApp('indexManagement');
+      // Navigate to the indices tab
+      await pageObjects.indexManagement.changeTabs('indicesTab');
+      await pageObjects.header.waitUntilLoadingHasFinished();
+    });
+
+    it('has embedded dev console', async () => {
+      await testHasEmbeddedConsole(pageObjects);
+    });
+  });
+}

--- a/x-pack/test_serverless/functional/test_suites/search/landing_page.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/landing_page.ts
@@ -7,6 +7,8 @@
 
 import { FtrProviderContext } from '../../ftr_provider_context';
 
+import { testHasEmbeddedConsole } from './embedded_console';
+
 export default function ({ getPageObjects, getService }: FtrProviderContext) {
   const pageObjects = getPageObjects([
     'svlSearchLandingPage',
@@ -44,12 +46,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
     });
 
     it('has embedded dev console', async () => {
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleControlBarExists();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeOpen();
-      await pageObjects.svlCommonNavigation.devConsole.clickEmbeddedConsoleControlBar();
-      await pageObjects.svlCommonNavigation.devConsole.expectEmbeddedConsoleToBeClosed();
+      await testHasEmbeddedConsole(pageObjects);
     });
 
     describe('API Key creation', async () => {


### PR DESCRIPTION
## Summary

Adding the embedded dev console to Index Management pages for Serverless Search.

### Screenshots
Index Management
![image](https://github.com/elastic/kibana/assets/1972968/49065c9c-7f6d-4baa-a2f1-5b5bad652073)
Index Details Page
![image](https://github.com/elastic/kibana/assets/1972968/8280e387-0278-4ad5-80d4-6bbf8d926423)


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
