### PR TITLE
[ES|QL] Remove CCS validation

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/validation/errors.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/errors.ts
@@ -172,15 +172,6 @@ function getMessageAndTypeFromId<K extends ErrorTypes>({
           },
         }),
       };
-    case 'ccsNotSupportedForCommand':
-      return {
-        message: i18n.translate('monaco.esql.validation.ccsNotSupportedForCommand', {
-          defaultMessage: 'ES|QL does not yet support querying remote indices [{value}]',
-          values: {
-            value: out.value,
-          },
-        }),
-      };
     case 'unsupportedFieldType':
       return {
         message: i18n.translate('monaco.esql.validation.unsupportedFieldType', {

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/types.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/types.ts
@@ -108,10 +108,6 @@ export interface ValidationErrors {
     message: string;
     type: { name: string };
   };
-  ccsNotSupportedForCommand: {
-    message: string;
-    type: { value: string };
-  };
   unsupportedFieldType: {
     message: string;
     type: { field: string };

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/validation.test.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/validation.test.ts
@@ -272,24 +272,12 @@ describe('validation logic', () => {
     testErrorsAndWarnings(`from ind*ex`, []);
     testErrorsAndWarnings(`from indexes*`, ['Unknown index [indexes*]']);
 
-    testErrorsAndWarnings(`from remote-*:indexes*`, [
-      'ES|QL does not yet support querying remote indices [remote-*:indexes*]',
-    ]);
-    testErrorsAndWarnings(`from remote-*:indexes`, [
-      'ES|QL does not yet support querying remote indices [remote-*:indexes]',
-    ]);
-    testErrorsAndWarnings(`from remote-ccs:indexes`, [
-      'ES|QL does not yet support querying remote indices [remote-ccs:indexes]',
-    ]);
-    testErrorsAndWarnings(`from a, remote-ccs:indexes`, [
-      'ES|QL does not yet support querying remote indices [remote-ccs:indexes]',
-    ]);
-    testErrorsAndWarnings(`from remote-ccs:indexes [METADATA _id]`, [
-      'ES|QL does not yet support querying remote indices [remote-ccs:indexes]',
-    ]);
-    testErrorsAndWarnings(`from *:indexes [METADATA _id]`, [
-      'ES|QL does not yet support querying remote indices [*:indexes]',
-    ]);
+    testErrorsAndWarnings(`from remote-*:indexes*`, []);
+    testErrorsAndWarnings(`from remote-*:indexes`, []);
+    testErrorsAndWarnings(`from remote-ccs:indexes`, []);
+    testErrorsAndWarnings(`from a, remote-ccs:indexes`, []);
+    testErrorsAndWarnings(`from remote-ccs:indexes [METADATA _id]`, []);
+    testErrorsAndWarnings(`from *:indexes [METADATA _id]`, []);
     testErrorsAndWarnings('from .secretIndex', []);
     testErrorsAndWarnings('from my-index', []);
   });

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/validation.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/validation.ts
@@ -482,16 +482,9 @@ function validateSource(
       })
     );
   } else {
+    // give up on validate if CCS for now
     const hasCCS = hasCCSSource(source.name);
-    if (hasCCS) {
-      messages.push(
-        getMessageFromId({
-          messageId: 'ccsNotSupportedForCommand',
-          values: { value: source.name },
-          locations: source.location,
-        })
-      );
-    } else {
+    if (!hasCCS) {
       const isWildcardAndNotSupported =
         hasWildcard(source.name) && !commandDef.signature.params.some(({ wildcards }) => wildcards);
       if (isWildcardAndNotSupported) {


### PR DESCRIPTION
## Summary

Remove validation errors on CCS in ES|QL.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
