### PR TITLE
[ResizableLayout] Implement workaround for `onResizeEnd` stale closure issue in `EuiResizableContainer`

### DIFF
--- a/packages/kbn-resizable-layout/src/panels_resizable.tsx
+++ b/packages/kbn-resizable-layout/src/panels_resizable.tsx
@@ -172,7 +172,7 @@ export const PanelsResizable = ({
 
   // EUI will call an outdated version of this callback when the resize ends,
   // so we need to make sure on our end that the latest version is called.
-  const onResizeEnd = useLatest(() => {
+  const onResizeEndStable = useLatest(() => {
     if (!resizeWithPortalsHackIsResizing) {
       return;
     }
@@ -190,6 +190,10 @@ export const PanelsResizable = ({
     disableResizeWithPortalsHack();
   });
 
+  const onResizeEnd = useCallback(() => {
+    onResizeEndStable.current();
+  }, [onResizeEndStable]);
+
   // Don't render EuiResizableContainer until we have have valid
   // panel sizes or it can cause the resize functionality to break.
   if (!panelSizes.fixedPanelSizePct && !panelSizes.flexPanelSizePct) {
@@ -202,9 +206,7 @@ export const PanelsResizable = ({
       direction={direction}
       onPanelWidthChange={onPanelSizeChange}
       onResizeStart={onResizeStart}
-      onResizeEnd={() => {
-        onResizeEnd.current();
-      }}
+      onResizeEnd={onResizeEnd}
       data-test-subj={`${dataTestSubj}ResizableContainer`}
       css={css`
         height: 100%;

--- a/packages/kbn-resizable-layout/src/panels_resizable.tsx
+++ b/packages/kbn-resizable-layout/src/panels_resizable.tsx
@@ -12,6 +12,7 @@ import { css } from '@emotion/react';
 import { isEqual, round } from 'lodash';
 import type { ReactElement } from 'react';
 import React, { useCallback, useEffect, useState } from 'react';
+import useLatest from 'react-use/lib/useLatest';
 import { ResizableLayoutDirection } from '../types';
 import { getContainerSize, percentToPixels, pixelsToPercent } from './utils';
 
@@ -169,7 +170,9 @@ export const PanelsResizable = ({
     [enableResizeWithPortalsHack]
   );
 
-  const onResizeEnd = useCallback(() => {
+  // EUI will call an outdated version of this callback when the resize ends,
+  // so we need to make sure on our end that the latest version is called.
+  const onResizeEnd = useLatest(() => {
     if (!resizeWithPortalsHackIsResizing) {
       return;
     }
@@ -185,7 +188,7 @@ export const PanelsResizable = ({
     }
 
     disableResizeWithPortalsHack();
-  }, [disableResizeWithPortalsHack, resizeWithPortalsHackIsResizing]);
+  });
 
   // Don't render EuiResizableContainer until we have have valid
   // panel sizes or it can cause the resize functionality to break.
@@ -199,7 +202,9 @@ export const PanelsResizable = ({
       direction={direction}
       onPanelWidthChange={onPanelSizeChange}
       onResizeStart={onResizeStart}
-      onResizeEnd={onResizeEnd}
+      onResizeEnd={() => {
+        onResizeEnd.current();
+      }}
       data-test-subj={`${dataTestSubj}ResizableContainer`}
       css={css`
         height: 100%;


### PR DESCRIPTION
## Summary

This PR implements a workaround in `ResizableLayout` for an issue where `EuiResizableContainer` will call an outdated version of the `onResizeEnd` callback on resize end.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)