### PR TITLE
Add ignore_empty_value to generated set processor

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/pipelines/create_pipeline_definitions.ts
@@ -78,6 +78,7 @@ export const createIndexPipelineDefinitions = async (
           set: {
             field: 'body',
             if: 'ctx?._extract_binary_content == true',
+            ignore_empty_value: true,
             on_failure: [
               {
                 append: {


### PR DESCRIPTION
## Summary

The `ent-search-generic-ingestion` pipeline has this, see:
https://github.com/elastic/elasticsearch/blob/317f365390825f070164e0966879545006076772/x-pack/plugin/core/template-resources/src/main/resources/entsearch/generic_ingestion_pipeline.json#L35

but the dynamically generated pipeline definitions that Kibana creates that are index-specific were missing the `ignore_empty_value`, which meant that resulting docs always had a `"body": ""` in the output.


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
