### PR TITLE
chore(NA): temporarily enable screenshot failures for artifacts pipeline

### DIFF
--- a/.buildkite/scripts/steps/package_testing/test.sh
+++ b/.buildkite/scripts/steps/package_testing/test.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 source "$(dirname "$0")/../../common/util.sh"
 .buildkite/scripts/bootstrap.sh
 
+# temporary adding this to get screenshots
+is_test_execution_step
+
 echo "--- Package Testing for $TEST_PACKAGE"
 
 mkdir -p target


### PR DESCRIPTION
This PR temporarily changes the artifacts pipeline to upload screenshot failures so we can debug a smoke test problem we're having there