### PR TITLE
[Cases] Update custom field error toast message

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
@@ -1019,7 +1019,7 @@ describe('bulkCreate', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: The following custom fields have the wrong type in the request: first_key,second_key"`
+        `"Failed to bulk create cases: Error: The following custom fields have the wrong type in the request: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -729,7 +729,7 @@ describe('create', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: The following custom fields have the wrong type in the request: first_key,second_key"`
+        `"Failed to create case: Error: The following custom fields have the wrong type in the request: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -1338,7 +1338,7 @@ describe('update', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: The following custom fields have the wrong type in the request: first_key,second_key"`
+        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: The following custom fields have the wrong type in the request: \\"missing field 1\\", \\"foo\\""`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -100,7 +100,7 @@ describe('validators', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'first label',
               required: false,
             },
             {
@@ -112,7 +112,7 @@ describe('validators', () => {
           ] as CustomFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following custom fields have the wrong type in the request: first_key"`
+        `"The following custom fields have the wrong type in the request: \\"first label\\""`
       );
     });
 
@@ -141,25 +141,25 @@ describe('validators', () => {
             {
               key: 'first_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'first label',
               required: false,
             },
             {
               key: 'second_key',
               type: CustomFieldTypes.TEXT,
-              label: 'foo',
+              label: 'second label',
               required: false,
             },
             {
               key: 'third_key',
               type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
+              label: 'third label',
               required: false,
             },
           ] as CustomFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following custom fields have the wrong type in the request: first_key,second_key,third_key"`
+        `"The following custom fields have the wrong type in the request: \\"first label\\", \\"second label\\", \\"third label\\""`
       );
     });
 
@@ -568,9 +568,7 @@ describe('validators', () => {
           customFieldsConfiguration,
           customFields: customFieldsMax,
         })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"Maximum ${MAX_CUSTOM_FIELDS_PER_CASE} customFields are allowed."`
-      );
+      ).toThrowErrorMatchingInlineSnapshot(`"Maximum 10 customFields are allowed."`);
     });
   });
 });

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -163,6 +163,40 @@ describe('validators', () => {
       );
     });
 
+    it('throws with label unknown for missing custom field labels', () => {
+      expect(() =>
+        validateCustomFieldTypesInRequest({
+          requestCustomFields: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TOGGLE,
+              value: true,
+            },
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TEXT,
+              value: 'foobar',
+            },
+          ],
+
+          customFieldsConfiguration: [
+            {
+              key: 'first_key',
+              type: CustomFieldTypes.TEXT,
+              required: false,
+            },
+            {
+              key: 'second_key',
+              type: CustomFieldTypes.TEXT,
+              required: false,
+            },
+          ] as CustomFieldsConfiguration,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"The following custom fields have the wrong type in the request: \\"Unknown\\""`
+      );
+    });
+
     it('throws if configuration is missing and request has custom fields', () => {
       expect(() =>
         validateCustomFieldTypesInRequest({

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -59,8 +59,20 @@ export function validateCustomFieldTypesInRequest({
   }
 
   if (invalidCustomFieldKeys.length) {
+    const invalidCustomFieldLabels: string[] = [];
+
+    invalidCustomFieldKeys.forEach((invalidFieldKey) => {
+      const configuration = customFieldsConfiguration.find((item) => item.key === invalidFieldKey);
+
+      if (configuration !== undefined) {
+        invalidCustomFieldLabels.push(`"${configuration.label}"`);
+      }
+    });
+
     throw Boom.badRequest(
-      `The following custom fields have the wrong type in the request: ${invalidCustomFieldKeys}`
+      `The following custom fields have the wrong type in the request: ${invalidCustomFieldLabels.join(
+        ', '
+      )}`
     );
   }
 }

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -65,7 +65,8 @@ export function validateCustomFieldTypesInRequest({
       const configuration = customFieldsConfiguration.find((item) => item.key === invalidFieldKey);
 
       if (configuration !== undefined) {
-        invalidCustomFieldLabels.push(`"${configuration.label}"`);
+        const invalidLabel = configuration.label ? configuration.label : 'Unknown';
+        invalidCustomFieldLabels.push(`"${invalidLabel}"`);
       }
     });
 

--- a/x-pack/plugins/cases/server/client/configure/client.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.test.ts
@@ -333,7 +333,7 @@ describe('client', () => {
             customFields: [
               {
                 key: 'wrong_type_key',
-                label: 'text',
+                label: 'text label',
                 type: CustomFieldTypes.TEXT,
                 required: false,
               },
@@ -343,7 +343,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        'Failed to get patch configure in route: Error: Invalid custom field types in request for the following keys: wrong_type_key'
+        "Failed to get patch configure in route: Error: Invalid custom field types in request for the following keys: 'text label'"
       );
     });
 
@@ -356,7 +356,7 @@ describe('client', () => {
             customFields: [
               {
                 key: 'missing_default',
-                label: 'text',
+                label: 'text label',
                 type: CustomFieldTypes.TEXT,
                 required: true,
               },
@@ -366,7 +366,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        'Failed to get patch configure in route: Error: The following required custom fields are missing the default value: missing_default'
+        "Failed to get patch configure in route: Error: The following required custom fields are missing the default value: 'text label'"
       );
     });
 
@@ -379,7 +379,7 @@ describe('client', () => {
             customFields: [
               {
                 key: 'extra_default',
-                label: 'text',
+                label: 'text label',
                 type: CustomFieldTypes.TEXT,
                 required: false,
                 defaultValue: 'foobar',
@@ -390,7 +390,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        'Failed to get patch configure in route: Error: The following optional custom fields try to define a default value: extra_default'
+        "Failed to get patch configure in route: Error: The following optional custom fields try to define a default value: 'text label'"
       );
     });
   });
@@ -463,7 +463,7 @@ describe('client', () => {
             customFields: [
               {
                 key: 'missing_default',
-                label: 'text',
+                label: 'text label',
                 type: CustomFieldTypes.TEXT,
                 required: true,
               },
@@ -473,7 +473,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        'Failed to create case configuration: Error: The following required custom fields are missing the default value: missing_default'
+        "Failed to create case configuration: Error: The following required custom fields are missing the default value: 'text label'"
       );
     });
 
@@ -485,7 +485,7 @@ describe('client', () => {
             customFields: [
               {
                 key: 'extra_default',
-                label: 'text',
+                label: 'text label',
                 type: CustomFieldTypes.TEXT,
                 required: false,
                 defaultValue: 'foobar',
@@ -496,7 +496,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        'Failed to create case configuration: Error: The following optional custom fields try to define a default value: extra_default'
+        "Failed to create case configuration: Error: The following optional custom fields try to define a default value: 'text label'"
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/configure/client.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.test.ts
@@ -343,7 +343,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        "Failed to get patch configure in route: Error: Invalid custom field types in request for the following keys: 'text label'"
+        'Failed to get patch configure in route: Error: Invalid custom field types in request for the following keys: "text label"'
       );
     });
 
@@ -366,7 +366,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        "Failed to get patch configure in route: Error: The following required custom fields are missing the default value: 'text label'"
+        'Failed to get patch configure in route: Error: The following required custom fields are missing the default value: "text label"'
       );
     });
 
@@ -390,7 +390,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        "Failed to get patch configure in route: Error: The following optional custom fields try to define a default value: 'text label'"
+        'Failed to get patch configure in route: Error: The following optional custom fields try to define a default value: "text label"'
       );
     });
   });
@@ -473,7 +473,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        "Failed to create case configuration: Error: The following required custom fields are missing the default value: 'text label'"
+        'Failed to create case configuration: Error: The following required custom fields are missing the default value: "text label"'
       );
     });
 
@@ -496,7 +496,7 @@ describe('client', () => {
           casesClientInternal
         )
       ).rejects.toThrow(
-        "Failed to create case configuration: Error: The following optional custom fields try to define a default value: 'text label'"
+        'Failed to create case configuration: Error: The following optional custom fields try to define a default value: "text label"'
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/configure/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.test.ts
@@ -18,16 +18,17 @@ describe('validators', () => {
       expect(() =>
         validateCustomFieldTypesInRequest({
           requestCustomFields: [
-            { key: '1', type: CustomFieldTypes.TOGGLE },
-            { key: '2', type: CustomFieldTypes.TEXT },
+            { key: '1', type: CustomFieldTypes.TOGGLE, label: 'label 1' },
+            { key: '2', type: CustomFieldTypes.TEXT, label: 'label 2' },
           ],
+
           originalCustomFields: [
             { key: '1', type: CustomFieldTypes.TEXT },
             { key: '2', type: CustomFieldTypes.TOGGLE },
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid custom field types in request for the following keys: 1,2"`
+        `"Invalid custom field types in request for the following keys: 'label 1','label 2'"`
       );
     });
 
@@ -35,16 +36,17 @@ describe('validators', () => {
       expect(() =>
         validateCustomFieldTypesInRequest({
           requestCustomFields: [
-            { key: '1', type: CustomFieldTypes.TOGGLE },
-            { key: '2', type: CustomFieldTypes.TOGGLE },
+            { key: '1', type: CustomFieldTypes.TOGGLE, label: 'label 1' },
+            { key: '2', type: CustomFieldTypes.TOGGLE, label: 'label 2' },
           ],
+
           originalCustomFields: [
             { key: '1', type: CustomFieldTypes.TEXT },
             { key: '2', type: CustomFieldTypes.TOGGLE },
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid custom field types in request for the following keys: 1"`
+        `"Invalid custom field types in request for the following keys: 'label 1'"`
       );
     });
 
@@ -63,8 +65,8 @@ describe('validators', () => {
       expect(() =>
         validateCustomFieldTypesInRequest({
           requestCustomFields: [
-            { key: '1', type: CustomFieldTypes.TOGGLE },
-            { key: '2', type: CustomFieldTypes.TEXT },
+            { key: '1', type: CustomFieldTypes.TOGGLE, label: 'label 1' },
+            { key: '2', type: CustomFieldTypes.TEXT, label: 'label 2' },
           ],
           originalCustomFields: [],
         })
@@ -77,8 +79,8 @@ describe('validators', () => {
       expect(() =>
         validateRequiredCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: false },
-            { key: '2', required: false },
+            { key: '1', required: false, label: 'label 1' },
+            { key: '2', required: false, label: 'label 2' },
           ],
         })
       ).not.toThrow();
@@ -88,8 +90,8 @@ describe('validators', () => {
       expect(() =>
         validateRequiredCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: true, defaultValue: false },
-            { key: '2', required: true, defaultValue: 'foobar' },
+            { key: '1', required: true, defaultValue: false, label: 'label 1' },
+            { key: '2', required: true, defaultValue: 'foobar', label: 'label 2' },
           ],
         })
       ).not.toThrow();
@@ -107,7 +109,7 @@ describe('validators', () => {
     it('does not throw an error for other falsy defaultValues (empty string)', () => {
       expect(() =>
         validateRequiredCustomFieldsInRequest({
-          requestCustomFields: [{ key: '1', required: true, defaultValue: '' }],
+          requestCustomFields: [{ key: '1', required: true, defaultValue: '', label: 'label' }],
         })
       ).not.toThrow();
     });
@@ -116,13 +118,13 @@ describe('validators', () => {
       expect(() =>
         validateRequiredCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: true, defaultValue: null },
-            { key: '2', required: true },
-            { key: '3', required: false },
+            { key: '1', required: true, defaultValue: null, label: 'label 1' },
+            { key: '2', required: true, label: 'label 2' },
+            { key: '3', required: false, label: 'label 3' },
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following required custom fields are missing the default value: 1,2"`
+        `"The following required custom fields are missing the default value: 'label 1','label 2'"`
       );
     });
   });
@@ -132,8 +134,8 @@ describe('validators', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: false },
-            { key: '2', required: false },
+            { key: '1', required: false, label: 'label 1' },
+            { key: '2', required: false, label: 'label 2' },
           ],
         })
       ).not.toThrow();
@@ -143,8 +145,8 @@ describe('validators', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: true, defaultValue: false },
-            { key: '2', required: true, defaultValue: 'foobar' },
+            { key: '1', required: true, defaultValue: false, label: 'label 1' },
+            { key: '2', required: true, defaultValue: 'foobar', label: 'label 2' },
           ],
         })
       ).not.toThrow();
@@ -154,42 +156,44 @@ describe('validators', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
           requestCustomFields: [
-            { key: '1', required: false, defaultValue: false },
-            { key: '2', required: false, defaultValue: 'foobar' },
+            { key: '1', required: false, defaultValue: false, label: 'label 1' },
+            { key: '2', required: false, defaultValue: 'foobar', label: 'label 2' },
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 1,2"`
+        `"The following optional custom fields try to define a default value: 'label 1','label 2'"`
       );
     });
 
     it('throws an error for other falsy defaultValues (null)', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
-          requestCustomFields: [{ key: '1', required: false, defaultValue: null }],
+          requestCustomFields: [
+            { key: '1', required: false, defaultValue: null, label: 'label 1' },
+          ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 1"`
+        `"The following optional custom fields try to define a default value: 'label 1'"`
       );
     });
 
     it('throws an error for other falsy defaultValues (0)', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
-          requestCustomFields: [{ key: '1', required: false, defaultValue: 0 }],
+          requestCustomFields: [{ key: '1', required: false, defaultValue: 0, label: 'label 1' }],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 1"`
+        `"The following optional custom fields try to define a default value: 'label 1'"`
       );
     });
 
     it('throws an error for other falsy defaultValues (empty string)', () => {
       expect(() =>
         validateOptionalCustomFieldsInRequest({
-          requestCustomFields: [{ key: '1', required: false, defaultValue: '' }],
+          requestCustomFields: [{ key: '1', required: false, defaultValue: '', label: 'label 1' }],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 1"`
+        `"The following optional custom fields try to define a default value: 'label 1'"`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/configure/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.test.ts
@@ -28,7 +28,7 @@ describe('validators', () => {
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid custom field types in request for the following keys: 'label 1','label 2'"`
+        `"Invalid custom field types in request for the following keys: \\"label 1\\", \\"label 2\\""`
       );
     });
 
@@ -46,7 +46,7 @@ describe('validators', () => {
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Invalid custom field types in request for the following keys: 'label 1'"`
+        `"Invalid custom field types in request for the following keys: \\"label 1\\""`
       );
     });
 
@@ -124,7 +124,7 @@ describe('validators', () => {
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following required custom fields are missing the default value: 'label 1','label 2'"`
+        `"The following required custom fields are missing the default value: \\"label 1\\", \\"label 2\\""`
       );
     });
   });
@@ -161,7 +161,7 @@ describe('validators', () => {
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 'label 1','label 2'"`
+        `"The following optional custom fields try to define a default value: \\"label 1\\", \\"label 2\\""`
       );
     });
 
@@ -173,7 +173,7 @@ describe('validators', () => {
           ],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 'label 1'"`
+        `"The following optional custom fields try to define a default value: \\"label 1\\""`
       );
     });
 
@@ -183,7 +183,7 @@ describe('validators', () => {
           requestCustomFields: [{ key: '1', required: false, defaultValue: 0, label: 'label 1' }],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 'label 1'"`
+        `"The following optional custom fields try to define a default value: \\"label 1\\""`
       );
     });
 
@@ -193,7 +193,7 @@ describe('validators', () => {
           requestCustomFields: [{ key: '1', required: false, defaultValue: '', label: 'label 1' }],
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"The following optional custom fields try to define a default value: 'label 1'"`
+        `"The following optional custom fields try to define a default value: \\"label 1\\""`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/configure/validators.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.ts
@@ -15,7 +15,7 @@ export const validateCustomFieldTypesInRequest = ({
   requestCustomFields,
   originalCustomFields,
 }: {
-  requestCustomFields?: Array<{ key: string; type: CustomFieldTypes }>;
+  requestCustomFields?: Array<{ key: string; type: CustomFieldTypes; label: string }>;
   originalCustomFields: Array<{ key: string; type: CustomFieldTypes }>;
 }) => {
   if (!Array.isArray(requestCustomFields) || !originalCustomFields.length) {
@@ -28,7 +28,7 @@ export const validateCustomFieldTypesInRequest = ({
     const originalField = originalCustomFields.find((item) => item.key === requestField.key);
 
     if (originalField && originalField.type !== requestField.type) {
-      invalidFields.push(requestField.key);
+      invalidFields.push(`'${requestField.label}'`);
     }
   });
 
@@ -49,6 +49,7 @@ export const validateRequiredCustomFieldsInRequest = ({
     key: string;
     required: boolean;
     defaultValue?: string | boolean | null;
+    label: string;
   }>;
 }) => {
   if (!Array.isArray(requestCustomFields)) {
@@ -62,7 +63,7 @@ export const validateRequiredCustomFieldsInRequest = ({
       requestField.required &&
       (requestField.defaultValue === undefined || requestField.defaultValue === null)
     ) {
-      invalidFields.push(requestField.key);
+      invalidFields.push(`'${requestField.label}'`);
     }
   });
 
@@ -83,6 +84,7 @@ export const validateOptionalCustomFieldsInRequest = ({
     key: string;
     required: boolean;
     defaultValue?: unknown;
+    label: string;
   }>;
 }) => {
   if (!Array.isArray(requestCustomFields)) {
@@ -93,7 +95,7 @@ export const validateOptionalCustomFieldsInRequest = ({
 
   requestCustomFields.forEach((requestField) => {
     if (!requestField.required && requestField.defaultValue !== undefined) {
-      invalidFields.push(requestField.key);
+      invalidFields.push(`'${requestField.label}'`);
     }
   });
 

--- a/x-pack/plugins/cases/server/client/configure/validators.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.ts
@@ -28,13 +28,13 @@ export const validateCustomFieldTypesInRequest = ({
     const originalField = originalCustomFields.find((item) => item.key === requestField.key);
 
     if (originalField && originalField.type !== requestField.type) {
-      invalidFields.push(`'${requestField.label}'`);
+      invalidFields.push(`"${requestField.label}"`);
     }
   });
 
   if (invalidFields.length > 0) {
     throw Boom.badRequest(
-      `Invalid custom field types in request for the following keys: ${invalidFields}`
+      `Invalid custom field types in request for the following keys: ${invalidFields.join(', ')}`
     );
   }
 };
@@ -63,13 +63,15 @@ export const validateRequiredCustomFieldsInRequest = ({
       requestField.required &&
       (requestField.defaultValue === undefined || requestField.defaultValue === null)
     ) {
-      invalidFields.push(`'${requestField.label}'`);
+      invalidFields.push(`"${requestField.label}"`);
     }
   });
 
   if (invalidFields.length > 0) {
     throw Boom.badRequest(
-      `The following required custom fields are missing the default value: ${invalidFields}`
+      `The following required custom fields are missing the default value: ${invalidFields.join(
+        ', '
+      )}`
     );
   }
 };
@@ -95,13 +97,15 @@ export const validateOptionalCustomFieldsInRequest = ({
 
   requestCustomFields.forEach((requestField) => {
     if (!requestField.required && requestField.defaultValue !== undefined) {
-      invalidFields.push(`'${requestField.label}'`);
+      invalidFields.push(`"${requestField.label}"`);
     }
   });
 
   if (invalidFields.length > 0) {
     throw Boom.badRequest(
-      `The following optional custom fields try to define a default value: ${invalidFields}`
+      `The following optional custom fields try to define a default value: ${invalidFields.join(
+        ', '
+      )}`
     );
   }
 };


### PR DESCRIPTION
## Summary

**Merging into a feature branch.**

Custom field error messages in the case configuration page now list the custom field `label`s instead of `key`s.

The message was updated for the following errors:
1. Custom field type error (trying to change a custom field type)
2. Missing default value from required custom field
3. Trying to define a default value for an optional custom field

Additionally, the error message for custom field type errors in the cases API was also updated.

This PR fixes a bug discussed [in a previous comment](https://github.com/elastic/kibana/pull/174628#pullrequestreview-1821776691).

> For another PR, should we change the IDs in the toaster to the labels to make it easier to understand which field needs fixing?

<details><summary>Screenshot</summary>
<img width="1955" alt="Screenshot 2024-01-22 at 12 03 30" src="https://github.com/elastic/kibana/assets/1533137/c4a2b83e-b40f-420d-9b74-575f3f92d819"></details>



