### PR TITLE
[Response Ops][DOCS] Removing ESS icon from `xpack.alerting.rules.maxScheduledPerMinute`

### DIFF
--- a/docs/settings/alert-action-settings.asciidoc
+++ b/docs/settings/alert-action-settings.asciidoc
@@ -581,7 +581,7 @@ Specifies whether to skip writing alerts and scheduling actions if rule
 processing was cancelled due to a timeout. Default: `true`. This setting can be
 overridden by individual rule types.
 
-`xpack.alerting.rules.maxScheduledPerMinute` {ess-icon}::
+`xpack.alerting.rules.maxScheduledPerMinute`::
 Specifies the maximum number of rules to run per minute. Default: 10000
 
 `xpack.alerting.rules.minimumScheduleInterval.value` {ess-icon}::


### PR DESCRIPTION
## Summary

User reported that this setting has an ESS icon indicating it's available in cloud but it's actually not available in cloud. In the future, if we want to create a cloud PR to add this setting, the icon can be added back at that time.


<!--ONMERGE {"backportTargets":["8.11","8.12"]} ONMERGE-->