### PR TITLE
[Ops] Fix an error that might occur when VAULT_ADDR is not defined

### DIFF
--- a/.buildkite/scripts/common/util.sh
+++ b/.buildkite/scripts/common/util.sh
@@ -172,7 +172,7 @@ download_artifact() {
 }
 
 # TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
-if [[ "$VAULT_ADDR" == *"secrets.elastic.co"* ]]; then
+if [[ "${VAULT_ADDR:-}" == *"secrets.elastic.co"* ]]; then
   VAULT_PATH_PREFIX="secret/kibana-issues/dev"
   VAULT_KV_PREFIX="secret/kibana-issues/dev"
   IS_LEGACY_VAULT_ADDR=true


### PR DESCRIPTION
## Summary
In some scenarios, the VAULT_ADDR is not defined, or at least not at the time when `util.sh` is loaded.

Follow up to #174915 - fixes: https://buildkite.com/elastic/kibana-agent-packer-cache/builds/539#018d31d6-86bf-4f30-98fc-a82f42d16a4d