### PR TITLE
[Fleet] Fix deleteFleetServerPoliciesForPolicyId with large number of .fleet-policies

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -24,7 +24,7 @@ import type {
 } from '../types';
 import { AGENT_POLICY_SAVED_OBJECT_TYPE } from '../constants';
 
-import { AGENT_POLICY_INDEX } from '../../common';
+import { AGENT_POLICY_INDEX, SO_SEARCH_LIMIT } from '../../common';
 
 import { agentPolicyService } from './agent_policy';
 import { agentPolicyUpdateEventHandler } from './agent_policy_update';
@@ -1005,6 +1005,21 @@ describe('agent policy', () => {
       expect(mockedAuditLoggingService.writeCustomAuditLog).toHaveBeenCalledWith({
         message: 'User deleting policy [id=test-agent-policy]',
       });
+    });
+
+    it('should call deleteByQuery multiple time if there is more than 10000 .fleet-policies', async () => {
+      const esClient = elasticsearchServiceMock.createClusterClient().asInternalUser;
+
+      esClient.deleteByQuery.mockResolvedValueOnce({
+        deleted: SO_SEARCH_LIMIT,
+      });
+      esClient.deleteByQuery.mockResolvedValueOnce({
+        deleted: 10,
+      });
+
+      await agentPolicyService.deleteFleetServerPoliciesForPolicyId(esClient, 'test-agent-policy');
+
+      expect(esClient.deleteByQuery).toBeCalledTimes(2);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -1033,17 +1033,21 @@ class AgentPolicyService {
       message: `User deleting policy [id=${agentPolicyId}]`,
     });
 
-    await esClient.deleteByQuery({
-      index: AGENT_POLICY_INDEX,
-      ignore_unavailable: true,
-      body: {
+    let hasMore = true;
+    while (hasMore) {
+      const res = await esClient.deleteByQuery({
+        index: AGENT_POLICY_INDEX,
+        ignore_unavailable: true,
+        scroll_size: SO_SEARCH_LIMIT,
+        refresh: true,
         query: {
           term: {
             policy_id: agentPolicyId,
           },
         },
-      },
-    });
+      });
+      hasMore = (res.deleted ?? 0) === SO_SEARCH_LIMIT;
+    }
   }
 
   public async getLatestFleetPolicy(esClient: ElasticsearchClient, agentPolicyId: string) {


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/kibana/issues/171995 https://github.com/elastic/ingest-dev/issues/2120

When resetting preconfigured agent policies it was sometime necessary to clean `.fleet-policies`. It seems this was happening as the es delete by query by default only delete 1000 documents. 

That PR should fix that by using a larger `scroll_size` and doing multiple queries if there is more documents to delete than the `scroll_size`.

## How to tests


1. Create a preconfigured policy
2. Create more than 10k .fleet-policies for that policy
<img width="1512" alt="Screenshot 2024-01-22 at 1 43 09 PM" src="https://github.com/elastic/kibana/assets/1336873/71dd06a4-51f6-4de3-8f74-11232295634d">
3. call the reset api 

```
curl -u elastic:changeme -XPOST "http://localhost:5601/internal/fleet/reset_preconfigured_agent_policies/test-policy" -H "kbn-xsrf: reporting" -H 'elastic-api-version: 1'
```

4.  check you only have the new `.fleet-policies` 
<img width="1507" alt="Screenshot 2024-01-22 at 1 43 23 PM" src="https://github.com/elastic/kibana/assets/1336873/6e39f38c-14b1-4663-ae3f-49170978000d">



