### PR TITLE
[ci] Stop pull request build if Checks step fails

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -19,6 +19,18 @@ steps:
         - exit_status: '-1'
           limit: 3
 
+  - command: .buildkite/scripts/steps/checks.sh
+    label: 'Checks'
+    agents:
+      queue: n2-2-spot
+    timeout_in_minutes: 60
+    retry:
+      automatic:
+        - exit_status: '-1'
+          limit: 3
+
+  - wait
+
   - command: .buildkite/scripts/steps/build_api_docs.sh
     label: 'Check Types and Build API Docs'
     agents:
@@ -74,16 +86,6 @@ steps:
       queue: n2-16-spot
     key: linting_with_types
     timeout_in_minutes: 90
-    retry:
-      automatic:
-        - exit_status: '-1'
-          limit: 3
-
-  - command: .buildkite/scripts/steps/checks.sh
-    label: 'Checks'
-    agents:
-      queue: n2-2-spot
-    timeout_in_minutes: 60
     retry:
       automatic:
         - exit_status: '-1'

--- a/scripts/es.js
+++ b/scripts/es.js
@@ -25,4 +25,4 @@ kbnEs
   .catch(function (e) {
     console.error(e);
     process.exitCode = 1;
-  });
+  })

--- a/scripts/es.js
+++ b/scripts/es.js
@@ -25,4 +25,4 @@ kbnEs
   .catch(function (e) {
     console.error(e);
     process.exitCode = 1;
-  })
+  });


### PR DESCRIPTION
This adds a new block containing the `Checks` and `Build Kibana Distribution and Plugins` steps.  If either fails the build will be aborted before tests run.

Running `Checks` in parallel with `Build Kibana Distribution and Plugins` step should minimize the increase in time for the pipeline to finish (est +5 minutes vs +15 minutes).

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->