### PR TITLE
[APM] Limit source map index to 1 replica at most

### DIFF
--- a/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
+++ b/x-pack/plugins/apm/server/routes/source_maps/create_apm_source_map_index_template.ts
@@ -19,7 +19,7 @@ const indexTemplate: IndicesPutIndexTemplateRequest = {
       settings: {
         index: {
           number_of_shards: 1,
-          auto_expand_replicas: '0-2',
+          auto_expand_replicas: '0-1',
           hidden: true,
         },
       },


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/149979 the number of replicas for the source map index was changed from 1 to anything between 0 and 2. This PR changes it to being _at most_ 1 replica.

Documentation for `auto_expand_replicas`: https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html

