### PR TITLE
[Console] disable access to embedded console without dev tools capability

### DIFF
--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -105,7 +105,8 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
     const {
       ui: { enabled: isConsoleUiEnabled },
     } = this.ctx.config.get<ClientConfigType>();
-    if (isConsoleUiEnabled) {
+
+    if (isConsoleUiEnabled && core.application.capabilities?.dev_tools?.show === true) {
       return {
         renderEmbeddableConsole: (props: EmbeddableConsoleProps) => {
           const consoleDeps: EmbeddableConsoleDependencies = {


### PR DESCRIPTION
## Summary

Added a check for the dev tools capability in kibana before making the render of the embedded console available to other plugins.