### PR TITLE
[Security Solution][Timeline] refactor timeline modal open timeline button

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/action_menu/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/action_menu/index.tsx
@@ -16,7 +16,7 @@ import { InputsModelId } from '../../../../common/store/inputs/constants';
 import { AddToCaseButton } from '../add_to_case_button';
 import { NewTimelineAction } from './new_timeline';
 import { SaveTimelineButton } from './save_timeline_button';
-import { OpenTimelineAction } from './open_timeline';
+import { OpenTimelineButton } from '../../modal/actions/open_timeline_button';
 import { TIMELINE_TOUR_CONFIG_ANCHORS } from '../../timeline/tour/step_config';
 
 interface TimelineActionMenuProps {
@@ -54,7 +54,7 @@ const TimelineActionMenuComponent = ({
         <NewTimelineAction timelineId={timelineId} />
       </EuiFlexItem>
       <EuiFlexItem data-test-subj="open-timeline-action">
-        <OpenTimelineAction />
+        <OpenTimelineButton />
       </EuiFlexItem>
       <EuiFlexItem data-test-subj="inspect-timeline-action">
         <InspectButton

--- a/x-pack/plugins/security_solution/public/timelines/components/flyout/action_menu/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/flyout/action_menu/translations.ts
@@ -23,34 +23,6 @@ export const NEW_TIMELINE = i18n.translate(
   }
 );
 
-export const OPEN_TIMELINE_BTN = i18n.translate(
-  'xpack.securitySolution.flyout.timeline.actionMenu.openTimelineBtn',
-  {
-    defaultMessage: 'Open',
-  }
-);
-
-export const OPEN_TIMELINE_BTN_LABEL = i18n.translate(
-  'xpack.securitySolution.flyout.timeline.actionMenu.openTimelineBtnLabel',
-  {
-    defaultMessage: 'Open Existing Timeline',
-  }
-);
-
-export const SAVE_TIMELINE_BTN = i18n.translate(
-  'xpack.securitySolution.flyout.timeline.actionMenu.saveTimelineBtn',
-  {
-    defaultMessage: 'Save',
-  }
-);
-
-export const SAVE_TIMELINE_BTN_LABEL = i18n.translate(
-  'xpack.securitySolution.flyout.timeline.actionMenu.saveTimelineBtnLabel',
-  {
-    defaultMessage: 'Save currently opened Timeline',
-  }
-);
-
 export const NEW_TEMPLATE_TIMELINE = i18n.translate(
   'xpack.securitySolution.flyout.timeline.actionMenu.newTimelineTemplate',
   {
@@ -63,14 +35,6 @@ export const CALL_OUT_UNAUTHORIZED_MSG = i18n.translate(
   {
     defaultMessage:
       'You can use Timeline to investigate events, but you do not have the required permissions to save timelines for future use. If you need to save timelines, contact your Kibana administrator.',
-  }
-);
-
-export const CALL_OUT_IMMUTABLE = i18n.translate(
-  'xpack.securitySolution.timeline.callOut.immutable.message.description',
-  {
-    defaultMessage:
-      'This prebuilt timeline template cannot be modified. To make changes, please duplicate this template and make modifications to the duplicate template.',
   }
 );
 
@@ -149,23 +113,9 @@ export const OPTIONAL = i18n.translate(
   }
 );
 
-export const SAVE_TOUR_CLOSE = i18n.translate(
-  'xpack.securitySolution.timeline.flyout.saveTour.closeButton',
-  {
-    defaultMessage: 'Close',
-  }
-);
-
 export const TITLE = i18n.translate('xpack.securitySolution.timeline.saveTimeline.modal.title', {
   defaultMessage: 'Title',
 });
-
-export const SAVE_TOUR_TITLE = i18n.translate(
-  'xpack.securitySolution.timeline.flyout.saveTour.title',
-  {
-    defaultMessage: 'Timeline changes now require manual saves',
-  }
-);
 
 export const SAVE_AS_NEW = i18n.translate(
   'xpack.securitySolution.timeline.saveTimeline.modal.saveAsNew',

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { OpenTimelineButton } from './open_timeline_button';
+import { TestProviders } from '../../../../common/mock/test_providers';
+import { useParams } from 'react-router-dom';
+import { TimelineType } from '../../../../../common/api/timeline';
+import { useStartTransaction } from '../../../../common/lib/apm/use_start_transaction';
+import { useSourcererDataView } from '../../../../common/containers/sourcerer';
+import { useTimelineStatus } from '../../open_timeline/use_timeline_status';
+
+jest.mock('../../../../common/lib/apm/use_start_transaction');
+jest.mock('../../../../common/containers/sourcerer');
+jest.mock('../../open_timeline/use_timeline_status');
+jest.mock('react-redux', () => {
+  const origin = jest.requireActual('react-redux');
+  return {
+    ...origin,
+    useDispatch: jest.fn(),
+  };
+});
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: jest.fn(),
+  };
+});
+jest.mock('../../../../common/lib/kibana', () => {
+  const actual = jest.requireActual('../../../../common/lib/kibana');
+  return {
+    ...actual,
+    useNavigation: () => ({
+      navigateTo: jest.fn(),
+    }),
+  };
+});
+
+const renderOpenTimelineButton = () =>
+  render(
+    <TestProviders>
+      <OpenTimelineButton />
+    </TestProviders>
+  );
+
+describe('OpenTimelineButton', () => {
+  it('should render the button', () => {
+    const { getByTestId, queryByTestId } = renderOpenTimelineButton();
+
+    expect(getByTestId('timeline-modal-open-timeline-button')).toBeInTheDocument();
+    expect(getByTestId('timeline-modal-open-timeline-button')).toHaveTextContent('Open');
+
+    expect(queryByTestId('open-timeline-modal')).not.toBeInTheDocument();
+  });
+
+  it('should open the modal after clicking on the button', async () => {
+    (useParams as jest.Mock).mockReturnValue({ tabName: TimelineType.template });
+    (useStartTransaction as jest.Mock).mockReturnValue({ startTransaction: jest.fn() });
+    (useSourcererDataView as jest.Mock).mockReturnValue({ dataViewId: '', selectedPatterns: [] });
+    (useTimelineStatus as jest.Mock).mockReturnValue({
+      timelineStatus: 'active',
+      templateTimelineFilter: null,
+      installPrepackagedTimelines: jest.fn(),
+    });
+
+    const { getByTestId } = renderOpenTimelineButton();
+
+    getByTestId('timeline-modal-open-timeline-button').click();
+
+    await waitFor(() => {
+      expect(getByTestId('open-timeline-modal')).toBeInTheDocument();
+    });
+  });
+});

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/open_timeline_button.tsx
@@ -13,28 +13,28 @@ import * as i18n from './translations';
 
 const actionTimelineToHide: ActionTimelineToShow[] = ['createFrom'];
 
-export const OpenTimelineAction = React.memo(() => {
+/**
+ * Renders a button that opens the `OpenTimelineModal` to allow users to select a saved timeline to open
+ */
+export const OpenTimelineButton = React.memo(() => {
   const [showTimelineModal, setShowTimelineModal] = useState(false);
-  const onCloseTimelineModal = useCallback(() => setShowTimelineModal(false), []);
-  const onOpenTimelineModal = useCallback(() => {
-    setShowTimelineModal(true);
-  }, []);
+  const toggleTimelineModal = useCallback(() => setShowTimelineModal((prev) => !prev), []);
 
   return (
     <>
       <EuiButtonEmpty
-        data-test-subj="open-timeline-button"
-        onClick={onOpenTimelineModal}
+        data-test-subj="timeline-modal-open-timeline-button"
+        onClick={toggleTimelineModal}
         aria-label={i18n.OPEN_TIMELINE_BTN_LABEL}
       >
         {i18n.OPEN_TIMELINE_BTN}
       </EuiButtonEmpty>
 
       {showTimelineModal ? (
-        <OpenTimelineModal onClose={onCloseTimelineModal} hideActions={actionTimelineToHide} />
+        <OpenTimelineModal onClose={toggleTimelineModal} hideActions={actionTimelineToHide} />
       ) : null}
     </>
   );
 });
 
-OpenTimelineAction.displayName = 'OpenTimelineAction';
+OpenTimelineButton.displayName = 'OpenTimelineButton';

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/actions/translations.ts
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/actions/translations.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+
+export const OPEN_TIMELINE_BTN = i18n.translate(
+  'xpack.securitySolution.timeline.modal.openTimelineBtn',
+  {
+    defaultMessage: 'Open',
+  }
+);
+
+export const OPEN_TIMELINE_BTN_LABEL = i18n.translate(
+  'xpack.securitySolution.timeline.modal.openTimelineBtnLabel',
+  {
+    defaultMessage: 'Open Existing Timeline',
+  }
+);

--- a/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
+++ b/x-pack/test/security_solution_cypress/cypress/screens/timeline.ts
@@ -81,7 +81,7 @@ export const DELETE_NOTE = '[data-test-subj="delete-note"]';
 export const MARKDOWN_INVESTIGATE_BUTTON =
   '[data-test-subj="insight-investigate-in-timeline-button"]';
 
-export const OPEN_TIMELINE_ICON = '[data-test-subj="open-timeline-button"]';
+export const OPEN_TIMELINE_ICON = '[data-test-subj="timeline-modal-open-timeline-button"]';
 
 export const OPEN_TIMELINE_MODAL = '[data-test-subj="open-timeline-modal"]';
 


### PR DESCRIPTION
## Summary

This PR is part of a set of 3-4 small PRs that aim at cleaning up the flyout folder under timeline. It focuses on refactoring and cleaning the `open_timeline` component, renamed to `open_timeline_button` and moved to a new `modal` folder (timeline is not a flyout anymore).

The next PRs will concentrate on the other action components (new, attach to case, save...)

**No UI or behavior changes should be introduced by the PR!**

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios