### PR TITLE
[Synthetics] Require write access for all non-GET routes on Synthetics server

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createSyntheticsRouteWithAuth } from './create_route_with_auth';
+
+describe('createSyntheticsRouteWithAuth', () => {
+  it('should create a route with auth', () => {
+    const route = createSyntheticsRouteWithAuth(() => ({
+      method: 'GET',
+      path: '/foo',
+      validate: {},
+      handler: async () => {
+        return { success: true };
+      },
+    }));
+
+    expect(route).toEqual({
+      method: 'GET',
+      path: '/foo',
+      validate: {},
+      handler: expect.any(Function),
+      writeAccess: false,
+    });
+  });
+
+  it.each([['POST'], ['PUT'], ['DELETE']])(
+    'requires write permissions for %s requests',
+    (method) => {
+      if (method !== 'POST' && method !== 'PUT' && method !== 'DELETE')
+        throw Error('Invalid method');
+      const route = createSyntheticsRouteWithAuth(() => ({
+        method,
+        path: '/foo',
+        validate: {},
+        handler: async () => {
+          return { success: true };
+        },
+      }));
+
+      expect(route).toEqual({
+        method,
+        path: '/foo',
+        validate: {},
+        handler: expect.any(Function),
+        writeAccess: true,
+      });
+    }
+  );
+
+  it.each([['POST'], ['PUT'], ['DELETE']])(
+    'allows write access override for %s requests',
+    (method) => {
+      if (method !== 'POST' && method !== 'PUT' && method !== 'DELETE')
+        throw Error('Invalid method');
+      const route = createSyntheticsRouteWithAuth(() => ({
+        method,
+        path: '/foo',
+        validate: {},
+        handler: async () => {
+          return { success: true };
+        },
+        writeAccessOverride: true,
+      }));
+
+      expect(route).toEqual({
+        method,
+        path: '/foo',
+        validate: {},
+        handler: expect.any(Function),
+        writeAccess: undefined,
+      });
+    }
+  );
+});

--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
@@ -13,6 +13,13 @@ import {
 } from '../../common/constants';
 import { SyntheticsRestApiRouteFactory, SyntheticsRoute, SyntheticsRouteHandler } from './types';
 
+function getWriteAccessFlag(method: string, writeAccessOverride?: boolean, writeAccess?: boolean) {
+  // if route includes an override, skip write-only access with `undefined`
+  // otherwise, if route is not a GET, require write access
+  // if route is get, use writeAccess value with `false` as default
+  return writeAccessOverride === true ? undefined : method !== 'GET' ? true : writeAccess ?? false;
+}
+
 export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
   routeCreator: SyntheticsRestApiRouteFactory
 ): SyntheticsRoute<ClientContract> => {
@@ -49,11 +56,7 @@ export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
     options,
     handler: licenseCheckHandler,
     ...rest,
-    writeAccess:
-      // if route includes an override, skip write-only access with `undefined`
-      // otherwise, if route is not a GET, require write access
-      // if route is get, use writeAccess value with `false` as default
-      writeAccessOverride === true ? undefined : method !== 'GET' ? true : writeAccess ?? false,
+    writeAccess: getWriteAccessFlag(method, writeAccessOverride, writeAccess),
   };
 };
 

--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
@@ -17,7 +17,7 @@ export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
   routeCreator: SyntheticsRestApiRouteFactory
 ): SyntheticsRoute<ClientContract> => {
   const restRoute = routeCreator();
-  const { handler, method, path, options, ...rest } = restRoute;
+  const { handler, method, path, options, writeAccess, writeAccessOverride, ...rest } = restRoute;
   const licenseCheckHandler: SyntheticsRouteHandler<ClientContract> = async ({
     context,
     response,
@@ -49,6 +49,11 @@ export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
     options,
     handler: licenseCheckHandler,
     ...rest,
+    writeAccess:
+      // if route includes an override, skip write-only access with `undefined`
+      // otherwise, if route is not a GET, require write access
+      // if route is get, use writeAccess value with `false` as default
+      writeAccessOverride === true ? undefined : method !== 'GET' ? true : writeAccess ?? false,
   };
 };
 

--- a/x-pack/plugins/synthetics/server/routes/default_alerts/enable_default_alert.ts
+++ b/x-pack/plugins/synthetics/server/routes/default_alerts/enable_default_alert.ts
@@ -13,7 +13,6 @@ export const enableDefaultAlertingRoute: SyntheticsRestApiRouteFactory = () => (
   method: 'POST',
   path: SYNTHETICS_API_URLS.ENABLE_DEFAULT_ALERTING,
   validate: {},
-  writeAccess: true,
   handler: async ({ context, server, savedObjectsClient }): Promise<any> => {
     const defaultAlertService = new DefaultAlertService(context, server, savedObjectsClient);
 

--- a/x-pack/plugins/synthetics/server/routes/default_alerts/update_default_alert.ts
+++ b/x-pack/plugins/synthetics/server/routes/default_alerts/update_default_alert.ts
@@ -13,7 +13,6 @@ export const updateDefaultAlertingRoute: SyntheticsRestApiRouteFactory = () => (
   method: 'PUT',
   path: SYNTHETICS_API_URLS.ENABLE_DEFAULT_ALERTING,
   validate: {},
-  writeAccess: true,
   handler: async ({ context, server, savedObjectsClient }): Promise<any> => {
     const defaultAlertService = new DefaultAlertService(context, server, savedObjectsClient);
 

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor.ts
@@ -50,7 +50,6 @@ export const addSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => ({
       gettingStarted: schema.maybe(schema.boolean()),
     }),
   },
-  writeAccess: true,
   handler: async (routeContext): Promise<any> => {
     const { request, response, savedObjectsClient, server } = routeContext;
     // usually id is auto generated, but this is useful for testing

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor_project.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/add_monitor_project.ts
@@ -31,7 +31,6 @@ export const addSyntheticsProjectMonitorRoute: SyntheticsRestApiRouteFactory = (
       maxBytes: MAX_PAYLOAD_SIZE,
     },
   },
-  writeAccess: true,
   handler: async (routeContext): Promise<any> => {
     const { request, response, server } = routeContext;
     const { projectName } = request.params;

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/delete_monitor.ts
@@ -34,7 +34,6 @@ export const deleteSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =>
       monitorId: schema.string({ minLength: 1, maxLength: 1024 }),
     }),
   },
-  writeAccess: true,
   handler: async (routeContext): Promise<any> => {
     const { request, response } = routeContext;
     const { monitorId } = request.params;

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/edit_monitor.ts
@@ -42,7 +42,6 @@ export const editSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () => (
     }),
     body: schema.any(),
   },
-  writeAccess: true,
   handler: async (routeContext): Promise<any> => {
     const { request, response, savedObjectsClient, server } = routeContext;
     const { logger } = server;

--- a/x-pack/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/monitor_cruds/inspect_monitor.ts
@@ -25,7 +25,6 @@ export const inspectSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
       hideParams: schema.maybe(schema.boolean()),
     }),
   },
-  writeAccess: true,
   handler: async (routeContext): Promise<any> => {
     const { savedObjectsClient, server, syntheticsMonitorClient, request, spaceId, response } =
       routeContext;

--- a/x-pack/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
@@ -22,6 +22,7 @@ export const createJourneyScreenshotBlocksRoute: SyntheticsRestApiRouteFactory =
       hashes: schema.arrayOf(schema.string()),
     }),
   },
+  writeAccessOverride: true,
   handler: async (routeProps) => {
     return await journeyScreenshotBlocksHandler(routeProps);
   },

--- a/x-pack/plugins/synthetics/server/routes/settings/params/add_param.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/params/add_param.ts
@@ -37,7 +37,6 @@ export const addSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       body: schema.oneOf([ParamsObjectSchema, schema.arrayOf(ParamsObjectSchema)]),
     },
   },
-  writeAccess: true,
   handler: async ({ request, response, server, savedObjectsClient }) => {
     try {
       const { id: spaceId } = (await server.spaces?.spacesService.getActiveSpace(request)) ?? {

--- a/x-pack/plugins/synthetics/server/routes/settings/params/delete_param.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/params/delete_param.ts
@@ -27,7 +27,6 @@ export const deleteSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       }),
     },
   },
-  writeAccess: true,
   handler: async ({ savedObjectsClient, request }) => {
     const { ids } = request.body;
 

--- a/x-pack/plugins/synthetics/server/routes/settings/params/edit_param.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/params/edit_param.ts
@@ -38,7 +38,6 @@ export const editSyntheticsParamsRoute: SyntheticsRestApiRouteFactory<
       }),
     },
   },
-  writeAccess: true,
   handler: async ({ savedObjectsClient, request, server, response }) => {
     try {
       const { id: _spaceId } = (await server.spaces?.spacesService.getActiveSpace(request)) ?? {

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/add_private_location.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/add_private_location.ts
@@ -40,7 +40,6 @@ export const addPrivateLocationRoute: SyntheticsRestApiRouteFactory<PrivateLocat
       body: PrivateLocationSchema,
     },
   },
-  writeAccess: true,
   handler: async ({ response, request, savedObjectsClient, syntheticsMonitorClient }) => {
     const location = request.body as PrivateLocationObject;
 

--- a/x-pack/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/private_locations/delete_private_location.ts
@@ -28,7 +28,6 @@ export const deletePrivateLocationRoute: SyntheticsRestApiRouteFactory<undefined
       }),
     },
   },
-  writeAccess: true,
   handler: async ({ response, savedObjectsClient, syntheticsMonitorClient, request, server }) => {
     const { locationId } = request.params as { locationId: string };
 

--- a/x-pack/plugins/synthetics/server/routes/settings/sync_global_params.ts
+++ b/x-pack/plugins/synthetics/server/routes/settings/sync_global_params.ts
@@ -14,7 +14,6 @@ export const syncParamsSyntheticsParamsRoute: SyntheticsRestApiRouteFactory = ()
   method: 'GET',
   path: SYNTHETICS_API_URLS.SYNC_GLOBAL_PARAMS,
   validate: {},
-  writeAccess: true,
   handler: async ({
     savedObjectsClient,
     syntheticsMonitorClient,

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
@@ -16,6 +16,7 @@ import {
 export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
   path: SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT,
+  writeAccessOverride: true,
   validate: {},
   handler: async ({ savedObjectsClient, request, server }): Promise<any> => {
     try {

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/run_once_monitor.ts
@@ -22,7 +22,6 @@ export const runOnceSyntheticsMonitorRoute: SyntheticsRestApiRouteFactory = () =
       monitorId: schema.string({ minLength: 1, maxLength: 1024 }),
     }),
   },
-  writeAccess: true,
   handler: async ({
     request,
     response,

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -23,7 +23,6 @@ export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse>
       monitorId: schema.string({ minLength: 1, maxLength: 1024 }),
     }),
   },
-  writeAccess: true,
   handler: async (routeContext) => {
     const { monitorId } = routeContext.request.params;
     return triggerTestNow(monitorId, routeContext);

--- a/x-pack/plugins/synthetics/server/routes/types.ts
+++ b/x-pack/plugins/synthetics/server/routes/types.ts
@@ -32,6 +32,7 @@ export type SyntheticsRequest = KibanaRequest<
 export interface UMServerRoute<T> {
   method: 'GET' | 'PUT' | 'POST' | 'DELETE';
   writeAccess?: boolean;
+  writeAccessOverride?: boolean;
   handler: T;
   validation?: FullValidationConfig<any, any, any>;
   streamHandler?: (


### PR DESCRIPTION
## Summary

Resolves #175333.

Introduces a notion of `writeAccessOverride` when creating routes. This allows non-GET routes to permit readonly users to consume the API. This is necessary for a few routes that are "read-like" but have a non GET method for implementation reasons, like the screenshot blocks endpoint.

Write access is implicitly required for all non-GETs without specifying the override flag in the route definition.

### Testing this PR

You can test these changes by hitting a non-GET route as a readonly user.

1. Set up a Synthetics deployment and run this branch against it with some monitors
1. Create a role with read access to uptime and index privs for synthetics*
1. Create a user and assign that role to it
1. `curl` some requests to non-read endpoints. Example:

```bash
curl -X POST http://localhost:5601/internal/synthetics/service/monitors/run_once/{monitorID} \
-u testuser:testuser \
-H "kbn-xsrf: true"
```

You should receive a 403 error. You can contrast this by checking out `main` and doing the same thing, you should receive any response code other than 403.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->