### PR TITLE
[Ops] More resilient test failure collection

### DIFF
--- a/.buildkite/scripts/lifecycle/post_command.sh
+++ b/.buildkite/scripts/lifecycle/post_command.sh
@@ -39,14 +39,14 @@ if [[ "$IS_TEST_EXECUTION_STEP" == "true" ]]; then
   if [[ $BUILDKITE_COMMAND_EXIT_STATUS -ne 0 ]]; then
     echo "--- Run Failed Test Reporter"
     node scripts/report_failed_tests --build-url="${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}" 'target/junit/**/*.xml'
-    TEST_REPORT_EXIT_CODE=$TEST_REPORT_EXIT_CODE || TEST_REPORT_EXIT_CODE=$?
+    TEST_REPORT_EXIT_CODE=$((TEST_REPORT_EXIT_CODE || $?))
   fi
 
   if [[ -d 'target/test_failures' ]]; then
     buildkite-agent artifact upload 'target/test_failures/**/*'
-    TEST_REPORT_EXIT_CODE=$TEST_REPORT_EXIT_CODE || TEST_REPORT_EXIT_CODE=$?
+    TEST_REPORT_EXIT_CODE=$((TEST_REPORT_EXIT_CODE || $?))
     ts-node .buildkite/scripts/lifecycle/annotate_test_failures.ts
-    TEST_REPORT_EXIT_CODE=$TEST_REPORT_EXIT_CODE || TEST_REPORT_EXIT_CODE=$?
+    TEST_REPORT_EXIT_CODE=$((TEST_REPORT_EXIT_CODE || $?))
   fi
   set -e
 


### PR DESCRIPTION
## Summary
See:  https://buildkite.com/elastic/kibana-on-merge/builds/40574#018d3ab8-240d-44b2-975a-9cbfa09d3177

If I interpret the results right, some FTR runs fail on the JUnit result collection step, thus not allowing any further steps to run from the post-command actions, this prevents the annotation and screenshot uploading from happening.

This PR adds a more resilient execution of post-command actions, collecting the resulting exit code from several steps before exiting. 