### PR TITLE
test: add missing await for connector table disappearance

### DIFF
--- a/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
@@ -86,7 +86,7 @@ export function SvlSearchConnectorsPageProvider({ getService }: FtrProviderConte
             .catch(() => false)
         );
         browser.refresh();
-        this.expectConnectorTableToHaveNoItems();
+        await this.expectConnectorTableToHaveNoItems();
       },
       async expectConnectorOverviewPageComponentsToExist() {
         await testSubjects.existOrFail('serverlessSearchConnectorsTitle');

--- a/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
+++ b/x-pack/test_serverless/functional/page_objects/svl_search_connectors_page.ts
@@ -85,7 +85,7 @@ export function SvlSearchConnectorsPageProvider({ getService }: FtrProviderConte
             .then(() => true)
             .catch(() => false)
         );
-        browser.refresh();
+        await browser.refresh();
         await this.expectConnectorTableToHaveNoItems();
       },
       async expectConnectorOverviewPageComponentsToExist() {


### PR DESCRIPTION
## Summary
There's been a few recent failures in this test:
https://buildkite.com/elastic/kibana-on-merge/builds/40574#018d3a8b-fe46-410e-a2b9-51eff916ddcd
https://buildkite.com/elastic/kibana-on-merge/builds/40576#018d3b7a-1be4-499d-9b42-e10d860ee637

I don't know if this small addition will make any difference in the test timing out, but it will probably avoid the `Unhandled Promise rejection detected:` kind of errors, since we'll now wait for the expression.

cc: @saarikabhasi 