### PR TITLE
[Cases] Apply circuit breakers to the case action

### DIFF
--- a/x-pack/plugins/cases/server/connectors/cases/constants.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/constants.ts
@@ -8,6 +8,7 @@
 export const CASES_CONNECTOR_ID = '.cases';
 export const CASES_CONNECTOR_TITLE = 'Cases';
 export const MAX_CONCURRENT_ES_REQUEST = 5;
+export const MAX_OPEN_CASES = 10;
 
 export enum CASES_CONNECTOR_SUB_ACTION {
   RUN = 'run',

--- a/x-pack/plugins/cases/server/connectors/cases/schema.test.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/schema.test.ts
@@ -28,7 +28,7 @@ describe('CasesConnectorRunParamsSchema', () => {
         "groupingBy": Array [
           "host.name",
         ],
-        "maxOpenCases": 5,
+        "maximumCasesToOpen": 5,
         "owner": "cases",
         "reopenClosedCases": false,
         "rule": Object {
@@ -181,20 +181,37 @@ describe('CasesConnectorRunParamsSchema', () => {
     });
   });
 
-  describe('maxOpenCases', () => {
-    it('defaults the maxOpenCases to 5', () => {
-      expect(CasesConnectorRunParamsSchema.validate(getParams()).maxOpenCases).toBe(5);
+  describe('maximumCasesToOpen', () => {
+    it('defaults the maximumCasesToOpen to 5', () => {
+      expect(CasesConnectorRunParamsSchema.validate(getParams()).maximumCasesToOpen).toBe(5);
     });
 
-    it('throws if the maxOpenCases > 10', () => {
+    it('sets the maximumCasesToOpen correctly', () => {
+      expect(
+        CasesConnectorRunParamsSchema.validate(getParams({ maximumCasesToOpen: 3 }))
+          .maximumCasesToOpen
+      ).toBe(3);
+    });
+
+    it('does not accept maximumCasesToOpen to be zero', () => {
+      const params = getParams();
+
       expect(() =>
-        CasesConnectorRunParamsSchema.validate(getParams({ maxOpenCases: 11 }))
+        CasesConnectorRunParamsSchema.validate({
+          ...params,
+          maximumCasesToOpen: 0,
+        })
       ).toThrow();
     });
 
-    it('throws if the maxOpenCases < 1', () => {
+    it('does not accept maximumCasesToOpen to be more than 10', () => {
+      const params = getParams();
+
       expect(() =>
-        CasesConnectorRunParamsSchema.validate(getParams({ maxOpenCases: 0 }))
+        CasesConnectorRunParamsSchema.validate({
+          ...params,
+          maximumCasesToOpen: 11,
+        })
       ).toThrow();
     });
   });

--- a/x-pack/plugins/cases/server/connectors/cases/schema.test.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/schema.test.ts
@@ -28,6 +28,7 @@ describe('CasesConnectorRunParamsSchema', () => {
         "groupingBy": Array [
           "host.name",
         ],
+        "maxOpenCases": 5,
         "owner": "cases",
         "reopenClosedCases": false,
         "rule": Object {
@@ -177,6 +178,24 @@ describe('CasesConnectorRunParamsSchema', () => {
   describe('reopenClosedCases', () => {
     it('defaults the reopenClosedCases to false', () => {
       expect(CasesConnectorRunParamsSchema.validate(getParams()).reopenClosedCases).toBe(false);
+    });
+  });
+
+  describe('maxOpenCases', () => {
+    it('defaults the maxOpenCases to 5', () => {
+      expect(CasesConnectorRunParamsSchema.validate(getParams()).maxOpenCases).toBe(5);
+    });
+
+    it('throws if the maxOpenCases > 10', () => {
+      expect(() =>
+        CasesConnectorRunParamsSchema.validate(getParams({ maxOpenCases: 11 }))
+      ).toThrow();
+    });
+
+    it('throws if the maxOpenCases < 1', () => {
+      expect(() =>
+        CasesConnectorRunParamsSchema.validate(getParams({ maxOpenCases: 0 }))
+      ).toThrow();
     });
   });
 });

--- a/x-pack/plugins/cases/server/connectors/cases/schema.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/schema.ts
@@ -7,6 +7,7 @@
 
 import { schema } from '@kbn/config-schema';
 import dateMath from '@kbn/datemath';
+import { MAX_OPEN_CASES } from './constants';
 
 const AlertSchema = schema.recordOf(schema.string(), schema.any(), {
   validate: (value) => {
@@ -72,5 +73,5 @@ export const CasesConnectorRunParamsSchema = schema.object({
     },
   }),
   reopenClosedCases: schema.boolean({ defaultValue: false }),
-  maximumCasesToOpen: schema.number({ defaultValue: 5, min: 1, max: 10 }),
+  maximumCasesToOpen: schema.number({ defaultValue: 5, min: 1, max: MAX_OPEN_CASES }),
 });

--- a/x-pack/plugins/cases/server/connectors/cases/schema.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/schema.ts
@@ -72,4 +72,5 @@ export const CasesConnectorRunParamsSchema = schema.object({
     },
   }),
   reopenClosedCases: schema.boolean({ defaultValue: false }),
+  maxOpenCases: schema.number({ defaultValue: 5, min: 1, max: 10 }),
 });

--- a/x-pack/plugins/cases/server/connectors/cases/schema.ts
+++ b/x-pack/plugins/cases/server/connectors/cases/schema.ts
@@ -72,5 +72,5 @@ export const CasesConnectorRunParamsSchema = schema.object({
     },
   }),
   reopenClosedCases: schema.boolean({ defaultValue: false }),
-  maxOpenCases: schema.number({ defaultValue: 5, min: 1, max: 10 }),
+  maximumCasesToOpen: schema.number({ defaultValue: 5, min: 1, max: 10 }),
 });


### PR DESCRIPTION
## Summary

This PR applies certain circuit breakers to the case action. Specifically, if the number of produced cases is bigger than `maximumCasesToOpen` param provided by the user or bigger than the hard limit of ten cases, all alerts will be attached to the case that represents the rule.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
