### PR TITLE
[Enterprise Search] Display redaction message in pipeline card if model ID is redacted

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
@@ -16,8 +16,8 @@ import { EuiButtonEmpty, EuiPanel, EuiText, EuiTitle } from '@elastic/eui';
 import { InferencePipeline, TrainedModelState } from '../../../../../../common/types/pipelines';
 
 import { InferencePipelineCard, TrainedModelHealthPopover } from './inference_pipeline_card';
-import { MLModelTypeBadge } from './ml_model_type_badge';
 import { MODEL_REDACTED_VALUE } from './ml_inference/utils';
+import { MLModelTypeBadge } from './ml_model_type_badge';
 
 export const DEFAULT_VALUES: InferencePipeline = {
   modelId: 'sample-bert-ner-model',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.test.tsx
@@ -17,6 +17,7 @@ import { InferencePipeline, TrainedModelState } from '../../../../../../common/t
 
 import { InferencePipelineCard, TrainedModelHealthPopover } from './inference_pipeline_card';
 import { MLModelTypeBadge } from './ml_model_type_badge';
+import { MODEL_REDACTED_VALUE } from './ml_inference/utils';
 
 export const DEFAULT_VALUES: InferencePipeline = {
   modelId: 'sample-bert-ner-model',
@@ -61,11 +62,29 @@ describe('InferencePipelineCard', () => {
     const subtitle = wrapper.find(EuiText).at(0).children();
     expect(subtitle.text()).toBe(DEFAULT_VALUES.modelId);
   });
+  it("renders message about redaction instead of model ID if it's redacted", () => {
+    const values = {
+      ...DEFAULT_VALUES,
+      modelId: '',
+    };
+    const wrapper = shallow(<InferencePipelineCard {...values} />);
+    expect(wrapper.find(EuiText)).toHaveLength(1);
+    const subtitle = wrapper.find(EuiText).at(0).children();
+    expect(subtitle.text()).toBe(MODEL_REDACTED_VALUE);
+  });
   it('renders model type as badge', () => {
     const wrapper = shallow(<InferencePipelineCard {...mockValues} />);
     expect(wrapper.find(MLModelTypeBadge)).toHaveLength(1);
     const badge = wrapper.find(MLModelTypeBadge).render();
     expect(badge.text()).toBe('ner');
+  });
+  it('does not render model type if model ID is redacted', () => {
+    const values = {
+      ...DEFAULT_VALUES,
+      modelId: '',
+    };
+    const wrapper = shallow(<InferencePipelineCard {...values} />);
+    expect(wrapper.find(MLModelTypeBadge)).toHaveLength(0);
   });
 });
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -33,10 +33,10 @@ import { IndexNameLogic } from '../index_name_logic';
 import { IndexViewLogic } from '../index_view_logic';
 
 import { DeleteInferencePipelineButton } from './delete_inference_pipeline_button';
+import { MODEL_REDACTED_VALUE } from './ml_inference/utils';
 import { TrainedModelHealth } from './ml_model_health';
 import { MLModelTypeBadge } from './ml_model_type_badge';
 import { PipelinesLogic } from './pipelines_logic';
-import { MODEL_REDACTED_VALUE } from './ml_inference/utils';
 
 export const TrainedModelHealthPopover: React.FC<InferencePipeline> = (pipeline) => {
   const { http } = useValues(HttpLogic);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_pipeline_card.tsx
@@ -36,6 +36,7 @@ import { DeleteInferencePipelineButton } from './delete_inference_pipeline_butto
 import { TrainedModelHealth } from './ml_model_health';
 import { MLModelTypeBadge } from './ml_model_type_badge';
 import { PipelinesLogic } from './pipelines_logic';
+import { MODEL_REDACTED_VALUE } from './ml_inference/utils';
 
 export const TrainedModelHealthPopover: React.FC<InferencePipeline> = (pipeline) => {
   const { http } = useValues(HttpLogic);
@@ -188,6 +189,7 @@ export const TrainedModelHealthPopover: React.FC<InferencePipeline> = (pipeline)
 
 export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => {
   const { modelId, pipelineName, types: modelTypes } = pipeline;
+  const modelIdDisplay = modelId && modelId.length > 0 ? modelId : MODEL_REDACTED_VALUE;
   const modelType = getMLType(modelTypes);
   const modelTitle = getModelDisplayTitle(modelType);
   const isSmallScreen = useIsWithinMaxBreakpoint('s');
@@ -207,14 +209,16 @@ export const InferencePipelineCard: React.FC<InferencePipeline> = (pipeline) => 
                 <EuiFlexGroup gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiText size="s" color="subdued">
-                      {modelId}
+                      {modelIdDisplay}
                     </EuiText>
                   </EuiFlexItem>
-                  <EuiFlexItem>
-                    <span>
-                      <MLModelTypeBadge type={modelType} />
-                    </span>
-                  </EuiFlexItem>
+                  {modelId && modelId.length > 0 && (
+                    <EuiFlexItem>
+                      <span>
+                        <MLModelTypeBadge type={modelType} />
+                      </span>
+                    </EuiFlexItem>
+                  )}
                 </EuiFlexGroup>
               </EuiFlexItem>
             )}


### PR DESCRIPTION
## Summary

Handle redacted model ID (if the model is not available in the current Kibana space) the same way in the inference pipeline cards, as in the selectable existing pipelines list.

<img width="596" alt="Screenshot 2024-01-24 at 12 06 27" src="https://github.com/elastic/kibana/assets/14224983/7f63ab29-ec21-4995-8886-a75f977013af">

<img width="872" alt="Screenshot 2024-01-24 at 12 06 12" src="https://github.com/elastic/kibana/assets/14224983/32ee30d0-0e1d-4d5f-9db3-3c49f546607b">

### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
