### PR TITLE
Revert "[Fleet] Make datastream rollover lazy"

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -1611,14 +1611,7 @@ describe('EPM template', () => {
         },
       ]);
 
-      expect(esClient.transport.request).toHaveBeenCalledWith(
-        expect.objectContaining({
-          path: '/test.prefix1-default/_rollover',
-          querystring: {
-            lazy: true,
-          },
-        })
-      );
+      expect(esClient.indices.rollover).toHaveBeenCalled();
     });
     it('should skip rollover on expected error when flag is on', async () => {
       const esClient = elasticsearchServiceMock.createElasticsearchClient();

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -933,12 +933,8 @@ const getDataStreams = async (
 const rolloverDataStream = (dataStreamName: string, esClient: ElasticsearchClient) => {
   try {
     // Do no wrap rollovers in retryTransientEsErrors since it is not idempotent
-    return esClient.transport.request({
-      method: 'POST',
-      path: `/${dataStreamName}/_rollover`,
-      querystring: {
-        lazy: true,
-      },
+    return esClient.indices.rollover({
+      alias: dataStreamName,
     });
   } catch (error) {
     throw new PackageESError(

--- a/x-pack/test/fleet_api_integration/apis/epm/data_stream.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/data_stream.ts
@@ -41,46 +41,43 @@ export default function (providerContext: FtrProviderContext) {
       skipIfNoDockerRegistry(providerContext);
       setupFleetAndAgents(providerContext);
 
-      const writeMetricsDoc = (namespace: string) =>
-        es.transport.request(
-          {
-            method: 'POST',
-            path: `/${metricsTemplateName}-${namespace}/_doc?refresh=true`,
-            body: {
-              '@timestamp': new Date().toISOString(),
-              logs_test_name: 'test',
-              data_stream: {
-                dataset: `${pkgName}.test_metrics`,
-                namespace,
-                type: 'metrics',
-              },
-            },
-          },
-          { meta: true }
-        );
-
-      const writeLogsDoc = (namespace: string) =>
-        es.transport.request(
-          {
-            method: 'POST',
-            path: `/${logsTemplateName}-${namespace}/_doc?refresh=true`,
-            body: {
-              '@timestamp': new Date().toISOString(),
-              logs_test_name: 'test',
-              data_stream: {
-                dataset: `${pkgName}.test_logs`,
-                namespace,
-                type: 'logs',
-              },
-            },
-          },
-          { meta: true }
-        );
       beforeEach(async () => {
         await installPackage(pkgName, pkgVersion);
         await Promise.all(
           namespaces.map(async (namespace) => {
-            return Promise.all([writeLogsDoc(namespace), writeMetricsDoc(namespace)]);
+            const createLogsRequest = es.transport.request(
+              {
+                method: 'POST',
+                path: `/${logsTemplateName}-${namespace}/_doc`,
+                body: {
+                  '@timestamp': '2015-01-01',
+                  logs_test_name: 'test',
+                  data_stream: {
+                    dataset: `${pkgName}.test_logs`,
+                    namespace,
+                    type: 'logs',
+                  },
+                },
+              },
+              { meta: true }
+            );
+            const createMetricsRequest = es.transport.request(
+              {
+                method: 'POST',
+                path: `/${metricsTemplateName}-${namespace}/_doc`,
+                body: {
+                  '@timestamp': '2015-01-01',
+                  logs_test_name: 'test',
+                  data_stream: {
+                    dataset: `${pkgName}.test_metrics`,
+                    namespace,
+                    type: 'metrics',
+                  },
+                },
+              },
+              { meta: true }
+            );
+            return Promise.all([createLogsRequest, createMetricsRequest]);
           })
         );
       });
@@ -144,11 +141,7 @@ export default function (providerContext: FtrProviderContext) {
 
       it('after update, it should have rolled over logs datastream because mappings are not compatible and not metrics', async function () {
         await installPackage(pkgName, pkgUpdateVersion);
-
         await asyncForEach(namespaces, async (namespace) => {
-          // write doc as rollover is lazy
-          await writeLogsDoc(namespace);
-          await writeMetricsDoc(namespace);
           const resLogsDatastream = await es.transport.request<any>(
             {
               method: 'GET',
@@ -273,8 +266,6 @@ export default function (providerContext: FtrProviderContext) {
             })
             .expect(200);
 
-          // Write a doc to trigger lazy rollover
-          await writeLogsDoc('default');
           // Datastream should have been rolled over
           expect(await getLogsDefaultBackingIndicesLength()).to.be(2);
         });
@@ -312,29 +303,26 @@ export default function (providerContext: FtrProviderContext) {
       skipIfNoDockerRegistry(providerContext);
       setupFleetAndAgents(providerContext);
 
-      const writeMetricDoc = (body: any = {}) =>
-        es.transport.request(
+      beforeEach(async () => {
+        await installPackage(pkgName, pkgVersion);
+
+        // Create a sample document so the data stream is created
+        await es.transport.request(
           {
             method: 'POST',
-            path: `/${metricsTemplateName}-${namespace}/_doc?refresh=true`,
+            path: `/${metricsTemplateName}-${namespace}/_doc`,
             body: {
-              '@timestamp': new Date().toISOString(),
+              '@timestamp': '2015-01-01',
               logs_test_name: 'test',
               data_stream: {
                 dataset: `${pkgName}.test_logs`,
                 namespace,
                 type: 'logs',
               },
-              ...body,
             },
           },
           { meta: true }
         );
-      beforeEach(async () => {
-        await installPackage(pkgName, pkgVersion);
-
-        // Create a sample document so the data stream is created
-        await writeMetricDoc();
       });
 
       afterEach(async () => {
@@ -352,10 +340,6 @@ export default function (providerContext: FtrProviderContext) {
       it('rolls over data stream when index_mode: time_series is set in the updated package version', async () => {
         await installPackage(pkgName, pkgUpdateVersion);
 
-        // Write a doc so lazy rollover can happen
-        await writeMetricDoc({
-          some_field: 'test',
-        });
         const resMetricsDatastream = await es.transport.request<any>(
           {
             method: 'GET',

--- a/x-pack/test/fleet_api_integration/apis/epm/install_hidden_datastreams.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_hidden_datastreams.ts
@@ -34,50 +34,46 @@ export default function (providerContext: FtrProviderContext) {
         .send({ force: true })
         .expect(200);
 
-      const writeDoc = () =>
-        es.index({
-          refresh: true,
-          index: 'metrics-apm.service_summary.10m-default',
-          document: {
-            '@timestamp': '2023-05-30T07:50:00.000Z',
-            agent: {
+      await es.index({
+        index: 'metrics-apm.service_summary.10m-default',
+        document: {
+          '@timestamp': '2023-05-30T07:50:00.000Z',
+          agent: {
+            name: 'go',
+          },
+          data_stream: {
+            dataset: 'apm.service_summary.10m',
+            namespace: 'default',
+            type: 'metrics',
+          },
+          ecs: {
+            version: '8.6.0-dev',
+          },
+          event: {
+            agent_id_status: 'missing',
+            ingested: '2023-05-30T07:57:12Z',
+          },
+          metricset: {
+            interval: '10m',
+            name: 'service_summary',
+          },
+          observer: {
+            hostname: '047e282994fb',
+            type: 'apm-server',
+            version: '8.7.0',
+          },
+          processor: {
+            event: 'metric',
+            name: 'metric',
+          },
+          service: {
+            language: {
               name: 'go',
             },
-            data_stream: {
-              dataset: 'apm.service_summary.10m',
-              namespace: 'default',
-              type: 'metrics',
-            },
-            ecs: {
-              version: '8.6.0-dev',
-            },
-            event: {
-              agent_id_status: 'missing',
-              ingested: '2023-05-30T07:57:12Z',
-            },
-            metricset: {
-              interval: '10m',
-              name: 'service_summary',
-            },
-            observer: {
-              hostname: '047e282994fb',
-              type: 'apm-server',
-              version: '8.7.0',
-            },
-            processor: {
-              event: 'metric',
-              name: 'metric',
-            },
-            service: {
-              language: {
-                name: 'go',
-              },
-              name: '___main_elastic_cloud_87_ilm_fix',
-            },
+            name: '___main_elastic_cloud_87_ilm_fix',
           },
-        });
-
-      await writeDoc();
+        },
+      });
 
       await supertest
         .post(`/api/fleet/epm/packages/apm/8.8.0`)
@@ -85,8 +81,6 @@ export default function (providerContext: FtrProviderContext) {
         .send({ force: true })
         .expect(200);
 
-      // Rollover are lazy need to write a new doc
-      await writeDoc();
       const ds = await es.indices.get({
         index: 'metrics-apm.service_summary*',
         expand_wildcards: ['open', 'hidden'],


### PR DESCRIPTION
Reverts elastic/kibana#174790 as it causes problems with checking privileges on write.
Reverting this while we work on a long term fix.