### PR TITLE
[ResponseOps][Connectors] Fix bug in PagerDuty Connector

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
@@ -84,7 +84,7 @@ describe('pagerduty action params validation', () => {
     });
   });
 
-  test('action params validation fails when customDetails are not valid JSON', async () => {
+  test('action params validation fails when customDetails are not valid JSON object', async () => {
     const actionParams = {
       eventAction: 'trigger',
       dedupKey: 'test',
@@ -105,12 +105,38 @@ describe('pagerduty action params validation', () => {
         summary: [],
         timestamp: [],
         links: [],
-        customDetails: ['Custom details must be a valid JSON.'],
+        customDetails: ['Custom details must be a valid JSON object.'],
       },
     });
   });
 
-  test('action params validation does not fail when customDetails are JSON', async () => {
+  test('action params validation fails when customDetails are a valid JSON but not an object', async () => {
+    const actionParams = {
+      eventAction: 'trigger',
+      dedupKey: 'test',
+      summary: '2323',
+      source: 'source',
+      severity: 'critical',
+      timestamp: new Date().toISOString(),
+      component: 'test',
+      group: 'group',
+      class: 'test class',
+      customDetails: '1234',
+      links: [],
+    };
+
+    expect(await connectorTypeModel.validateParams(actionParams)).toEqual({
+      errors: {
+        dedupKey: [],
+        summary: [],
+        timestamp: [],
+        links: [],
+        customDetails: ['Custom details must be a valid JSON object.'],
+      },
+    });
+  });
+
+  test('action params validation does not fail when customDetails are a valid JSON object', async () => {
     const actionParams = {
       eventAction: 'trigger',
       dedupKey: 'test',

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
@@ -95,7 +95,7 @@ describe('pagerduty action params validation', () => {
       component: 'test',
       group: 'group',
       class: 'test class',
-      customDetails: '{foo:bar}',
+      customDetails: '{foo:bar, "customFields": "{{contex.foo}}"}',
       links: [],
     };
 
@@ -110,7 +110,7 @@ describe('pagerduty action params validation', () => {
     });
   });
 
-  test('action params validation does not fail when customDetails are not JSON but have mustache templates inside', async () => {
+  test('action params validation does not fail when customDetails are JSON', async () => {
     const actionParams = {
       eventAction: 'trigger',
       dedupKey: 'test',
@@ -121,7 +121,7 @@ describe('pagerduty action params validation', () => {
       component: 'test',
       group: 'group',
       class: 'test class',
-      customDetails: '{"details": {{alert.flapping}}}',
+      customDetails: '{"details": "{{alert.flapping}}"}',
       links: [],
     };
 

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.test.tsx
@@ -136,6 +136,32 @@ describe('pagerduty action params validation', () => {
     });
   });
 
+  test('action params validation fails when customDetails are an array of objects', async () => {
+    const actionParams = {
+      eventAction: 'trigger',
+      dedupKey: 'test',
+      summary: '2323',
+      source: 'source',
+      severity: 'critical',
+      timestamp: new Date().toISOString(),
+      component: 'test',
+      group: 'group',
+      class: 'test class',
+      customDetails: '[{"details": "Foo Bar"}, {"details": "{{alert.flapping}}"}]',
+      links: [],
+    };
+
+    expect(await connectorTypeModel.validateParams(actionParams)).toEqual({
+      errors: {
+        dedupKey: [],
+        summary: [],
+        timestamp: [],
+        links: [],
+        customDetails: ['Custom details must be a valid JSON object.'],
+      },
+    });
+  });
+
   test('action params validation does not fail when customDetails are a valid JSON object', async () => {
     const actionParams = {
       eventAction: 'trigger',

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
@@ -16,6 +16,7 @@ import {
   AlertProvidedActionVariables,
   hasMustacheTokens,
 } from '@kbn/triggers-actions-ui-plugin/public';
+import { isPlainObject } from 'lodash';
 import {
   PagerDutyConfig,
   PagerDutySecrets,
@@ -103,7 +104,7 @@ export function getConnectorType(): ConnectorTypeModel<
         try {
           const parsedJSON = JSON.parse(actionParams.customDetails);
 
-          if (typeof parsedJSON !== 'object') {
+          if (!isPlainObject(parsedJSON)) {
             errors.customDetails.push(errorMessage);
           }
         } catch {

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
@@ -93,17 +93,21 @@ export function getConnectorType(): ConnectorTypeModel<
         });
       }
       if (actionParams.customDetails?.length) {
+        const errorMessage = i18n.translate(
+          'xpack.stackConnectors.components.pagerDuty.error.invalidCustomDetails',
+          {
+            defaultMessage: 'Custom details must be a valid JSON object.',
+          }
+        );
+
         try {
-          JSON.parse(actionParams.customDetails);
+          const parsedJSON = JSON.parse(actionParams.customDetails);
+
+          if (typeof parsedJSON !== 'object') {
+            errors.customDetails.push(errorMessage);
+          }
         } catch {
-          errors.customDetails.push(
-            i18n.translate(
-              'xpack.stackConnectors.components.pagerDuty.error.invalidCustomDetails',
-              {
-                defaultMessage: 'Custom details must be a valid JSON.',
-              }
-            )
-          );
+          errors.customDetails.push(errorMessage);
         }
       }
       return validationResult;

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty.tsx
@@ -92,7 +92,7 @@ export function getConnectorType(): ConnectorTypeModel<
           }
         });
       }
-      if (actionParams.customDetails?.length && !hasMustacheTokens(actionParams.customDetails)) {
+      if (actionParams.customDetails?.length) {
         try {
           JSON.parse(actionParams.customDetails);
         } catch {

--- a/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty_params.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/pagerduty/pagerduty_params.tsx
@@ -370,7 +370,7 @@ const PagerDutyParamsFields: React.FunctionComponent<ActionParamsProps<PagerDuty
               }}
               onBlur={() => {
                 if (!customDetails) {
-                  editAction('customDetails', '', index);
+                  editAction('customDetails', '{}', index);
                 }
               }}
               dataTestSubj="customDetailsJsonEditor"


### PR DESCRIPTION
Fixes #175342 

## Summary

The Pagerduty action UI does not allow users to save when there are linting errors in the `Custom Details` field.

Previously the validation was skipped if there were Mustache templates in the field.




<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->