### PR TITLE
[Logs Explorer] Functional tests: Complete cleanup before continuing with the next tests

### DIFF
--- a/x-pack/test/functional/apps/observability_log_explorer/dataset_selector.ts
+++ b/x-pack/test/functional/apps/observability_log_explorer/dataset_selector.ts
@@ -295,7 +295,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             expect(nodes.length).to.be(20);
           });
 
-          cleanupAdditionalSetup();
+          await cleanupAdditionalSetup();
         });
 
         describe('clicking on integration and moving into the second navigation level', () => {

--- a/x-pack/test_serverless/functional/test_suites/observability/observability_log_explorer/dataset_selector.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/observability_log_explorer/dataset_selector.ts
@@ -296,7 +296,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
             expect(nodes.length).to.be(20);
           });
 
-          cleanupAdditionalSetup();
+          await cleanupAdditionalSetup();
         });
 
         describe('clicking on integration and moving into the second navigation level', () => {


### PR DESCRIPTION
This [functional test](https://github.com/elastic/kibana/blob/b25407edba0bb146c37d74b24e01d8c6367bfa64/x-pack/test/functional/apps/observability_log_explorer/dataset_selector.ts#L311) was failing locally, as it was expecting the integration to be `Apache HTTP Server` but was in fact `1password`. This is because the previous test loads more integrations (than the original 3) and sometimes it doesn’t clean up in time before the next test runs.

This PR adds `await` on the async [cleanupAdditionalSetup](https://github.com/elastic/kibana/blob/main/x-pack/test/functional/apps/observability_log_explorer/dataset_selector.ts#L298) call to complete the cleanup before continuing with other tests.