### PR TITLE
[ES|QL] Add support for mv_first, mv_last, to_geoshape, to_cartesianshape

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/definitions/functions.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/definitions/functions.ts
@@ -268,6 +268,19 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
     ],
   },
   {
+    name: 'to_cartesianshape',
+    description: i18n.translate('monaco.esql.definitions.toCartesianshapeDoc', {
+      defaultMessage: 'Converts an input value to a cartesian_shape value.',
+    }),
+    signatures: [
+      {
+        params: [{ name: 'field', type: 'any' }],
+        returnType: 'cartesian_shape',
+        examples: [`from index | EVAL cartesianshape = to_cartesianshape(field)`],
+      },
+    ],
+  },
+  {
     name: 'to_datetime',
     alias: ['to_dt'],
     description: i18n.translate('monaco.esql.definitions.toDateTimeDoc', {
@@ -318,6 +331,19 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
         params: [{ name: 'field', type: 'any' }],
         returnType: 'geo_point',
         examples: [`from index | EVAL geopoint = to_geopoint(field)`],
+      },
+    ],
+  },
+  {
+    name: 'to_geoshape',
+    description: i18n.translate('monaco.esql.definitions.toGeoshapeDoc', {
+      defaultMessage: 'Converts an input value to a geo_shape value.',
+    }),
+    signatures: [
+      {
+        params: [{ name: 'field', type: 'any' }],
+        returnType: 'geo_shape',
+        examples: [`from index | EVAL geoshape = to_geoshape(field)`],
       },
     ],
   },
@@ -849,7 +875,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
       {
         params: [{ name: 'multivalue', type: 'number[]' }],
         returnType: 'number',
-        examples: ['row a = [1, 2, 3] | mv_avg(a)'],
+        examples: ['row a = [1, 2, 3] | eval mv_avg(a)'],
       },
     ],
   },
@@ -866,7 +892,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           { name: 'delimeter', type: 'string' },
         ],
         returnType: 'string',
-        examples: ['row a = ["1", "2", "3"] | mv_concat(a, ", ")'],
+        examples: ['row a = ["1", "2", "3"] | eval mv_concat(a, ", ")'],
       },
     ],
   },
@@ -894,6 +920,34 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
         params: [{ name: 'multivalue', type: 'any[]' }],
         returnType: 'any[]',
         examples: ['row a = [2, 2, 3] | eval mv_dedupe(a)'],
+      },
+    ],
+  },
+  {
+    name: 'mv_first',
+    description: i18n.translate('monaco.esql.definitions.mvFirstDoc', {
+      defaultMessage:
+        'Reduce a multivalued field to a single valued field containing the first value.',
+    }),
+    signatures: [
+      {
+        params: [{ name: 'multivalue', type: 'any' }],
+        returnType: 'any',
+        examples: ['row a = [1, 2, 3] | eval one = mv_first(a)'],
+      },
+    ],
+  },
+  {
+    name: 'mv_last',
+    description: i18n.translate('monaco.esql.definitions.mvLastDoc', {
+      defaultMessage:
+        'Reduce a multivalued field to a single valued field containing the last value.',
+    }),
+    signatures: [
+      {
+        params: [{ name: 'multivalue', type: 'any' }],
+        returnType: 'any',
+        examples: ['row a = [1, 2, 3] | eval three = mv_last(a)'],
       },
     ],
   },


### PR DESCRIPTION
## Summary

Add missing functions to ES|QL validation/autocomplete support.


### Checklist

- [x] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios