### PR TITLE
[Infra] Add Threads tab tooltip

### DIFF
--- a/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/profiling.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/profiling/profiling.tsx
@@ -114,6 +114,16 @@ export function Profiling() {
           <Threads />
         </>
       ),
+      append: (
+        <Popover iconSize="s" iconColor="subdued" icon="questionInCircle">
+          <EuiText size="xs">
+            <FormattedMessage
+              id="xpack.infra.profiling.threadsInfoPopoverBody"
+              defaultMessage="Visualize profiling stacktraces grouped by process thread names. This view enables you to identify the top threads consuming CPU resources and allows you to drill down into the call stack of each thread, so you can quickly identify resource-intensive lines of code within the thread."
+            />
+          </EuiText>
+        </Popover>
+      ),
     },
   ];
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/175535

## Summary

Adds a tooltip for the Threads tab in Profiling within Infra host details.

![CleanShot 2024-01-25 at 14 30 55@2x](https://github.com/elastic/kibana/assets/793851/f292d0c9-4f82-42df-9f81-ef378d3f56a2)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->