### PR TITLE
Fix connectors overview tests for serverless search project

### DIFF
--- a/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/connectors/connectors_overview.ts
@@ -62,58 +62,60 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
         await pageObjects.svlCommonNavigation.sidenav.clickLink({
           deepLinkId: 'serverlessConnectors',
         });
-        browser.refresh();
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectConnectorTableToExist();
+        await browser.refresh();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectConnectorTableToExist();
       });
     });
     describe('connector table', async () => {
       it('confirm searchBar to exist', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectSearchBarToExist();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectSearchBarToExist();
       });
 
       it('searchBar and select, filters connector table', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.getConnectorFromConnectorTable(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.getConnectorFromConnectorTable(
           TEST_CONNECTOR_NAME
         );
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.setSearchBarValue(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.setSearchBarValue(
           TEST_CONNECTOR_NAME
         );
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.connectorNameExists(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.connectorNameExists(
           TEST_CONNECTOR_NAME
         );
 
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.changeSearchBarTableSelectValue(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.changeSearchBarTableSelectValue(
           'Type'
         );
 
         await testSubjects.click('clearSearchButton');
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.setSearchBarValue('confluence');
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectConnectorTableToHaveNoItems();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.setSearchBarValue(
+          'confluence'
+        );
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectConnectorTableToHaveNoItems();
         await testSubjects.click('clearSearchButton');
       });
     });
     describe('delete connector', async () => {
       it('delete connector button exist in table', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectDeleteConnectorButtonExist();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.expectDeleteConnectorButtonExist();
       });
       it('open delete connector modal', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.openDeleteConnectorModal();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.openDeleteConnectorModal();
       });
       it('delete connector button open modal', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.confirmDeleteConnectorModalComponentsExists();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.confirmDeleteConnectorModalComponentsExists();
       });
       it('delete connector field is disabled if field name does not match connector name', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.deleteConnectorIncorrectName(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.deleteConnectorIncorrectName(
           'invalid'
         );
       });
       it('delete connector button deletes connector', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.deleteConnectorWithCorrectName(
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.deleteConnectorWithCorrectName(
           TEST_CONNECTOR_NAME
         );
       });
       it('confirm connector table is disappeared after delete ', async () => {
-        pageObjects.svlSearchConnectorsPage.connectorOverviewPage.confirmConnectorTableIsDisappearedAfterDelete();
+        await pageObjects.svlSearchConnectorsPage.connectorOverviewPage.confirmConnectorTableIsDisappearedAfterDelete();
       });
     });
   });


### PR DESCRIPTION
## Summary

This PR fixes some connectors overview tests for the serverless search project by adding missing `await`'s.

### Additional information

The tests have been introduced with missing `await`'s in December (#173561), but it didn't fail until recently. Here's my suspicion:
- the CI runs just happened to have good timing, so this issues didn't occur
- with #175067, new tests have been added to the suite, which changed the timing
- the timing still works for the "local" CI runs, but no longer for MKI