### PR TITLE
[Search] Allow connector syncs when errored

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/connectors/connector_config/connector_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/connector_config/connector_overview.tsx
@@ -64,9 +64,9 @@ export const ConnectorOverview: React.FC<ConnectorOverviewProps> = ({ connector 
         <EuiButton
           data-test-subj="serverlessSearchConnectorOverviewSyncButton"
           color="primary"
-          disabled={
-            ![ConnectorStatus.CONFIGURED, ConnectorStatus.CONNECTED].includes(connector.status)
-          }
+          disabled={[ConnectorStatus.CREATED, ConnectorStatus.NEEDS_CONFIGURATION].includes(
+            connector.status
+          )}
           fill
           isLoading={isLoading}
           onClick={() => mutate()}


### PR DESCRIPTION
## Summary

This enables the sync button when the connector is in an error state.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->