### PR TITLE
[Search] Typography fixes to get consistency within Web Crawlers and Connectors sections

### DIFF
--- a/packages/kbn-search-index-documents/components/documents_overview.tsx
+++ b/packages/kbn-search-index-documents/components/documents_overview.tsx
@@ -36,7 +36,7 @@ export const DocumentsOverview: React.FC<DocumentsProps> = ({
         <EuiFlexItem>
           <EuiFlexGroup direction="row" alignItems="center">
             <EuiFlexItem className="enterpriseSearchDocumentsHeader" grow={false}>
-              <EuiTitle>
+              <EuiTitle size="s">
                 <h2>
                   {i18n.translate('searchIndexDocuments.documents.title', {
                     defaultMessage: 'Browse documents',

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -111,14 +111,14 @@ export const CrawlRequestsTable: React.FC = () => {
         <EuiEmptyPrompt
           iconType="tableDensityExpanded"
           title={
-            <h3>
+            <h4>
               {i18n.translate(
                 'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
                 {
                   defaultMessage: 'No recent crawl requests',
                 }
               )}
-            </h3>
+            </h4>
           }
           body={
             <p>

--- a/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/app_search/components/crawler/components/crawl_requests_table.tsx
@@ -110,15 +110,16 @@ export const CrawlRequestsTable: React.FC = () => {
       noItemsMessage={
         <EuiEmptyPrompt
           iconType="tableDensityExpanded"
+          titleSize="s"
           title={
-            <h4>
+            <h3>
               {i18n.translate(
                 'xpack.enterpriseSearch.appSearch.crawler.crawlRequestsTable.emptyPrompt.title',
                 {
                   defaultMessage: 'No recent crawl requests',
                 }
               )}
-            </h4>
+            </h3>
           }
           body={
             <p>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { useValues } from 'kea';
 
@@ -29,9 +29,9 @@ import { NewIndexCard } from './new_index_card';
 
 const getAvailableMethodOptions = (productFeatures: ProductFeatures): INGESTION_METHOD_IDS[] => {
   return [
+    INGESTION_METHOD_IDS.API,
     ...(productFeatures.hasWebCrawler ? [INGESTION_METHOD_IDS.CRAWLER] : []),
     ...(productFeatures.hasConnectors ? [INGESTION_METHOD_IDS.CONNECTOR] : []),
-    INGESTION_METHOD_IDS.API,
   ];
 };
 
@@ -40,7 +40,6 @@ export const NewIndex: React.FC = () => {
   const availableIngestionMethodOptions = getAvailableMethodOptions(productFeatures);
   const { errorConnectingMessage } = useValues(HttpLogic);
 
-  const [selectedMethod, setSelectedMethod] = useState<string>('');
   return (
     <EnterpriseSearchContentPageTemplate
       pageChrome={[
@@ -75,7 +74,6 @@ export const NewIndex: React.FC = () => {
                     )}
                     type={type}
                     onSelect={() => {
-                      setSelectedMethod(type);
                       if (type === INGESTION_METHOD_IDS.CONNECTOR) {
                         KibanaLogic.values.navigateToUrl(NEW_INDEX_SELECT_CONNECTOR_PATH);
                       } else {
@@ -84,7 +82,6 @@ export const NewIndex: React.FC = () => {
                         );
                       }
                     }}
-                    isSelected={selectedMethod === type}
                   />
                 </EuiFlexItem>
               ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_index.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 
 import { useValues } from 'kea';
 
@@ -29,9 +29,9 @@ import { NewIndexCard } from './new_index_card';
 
 const getAvailableMethodOptions = (productFeatures: ProductFeatures): INGESTION_METHOD_IDS[] => {
   return [
-    INGESTION_METHOD_IDS.API,
     ...(productFeatures.hasWebCrawler ? [INGESTION_METHOD_IDS.CRAWLER] : []),
     ...(productFeatures.hasConnectors ? [INGESTION_METHOD_IDS.CONNECTOR] : []),
+    INGESTION_METHOD_IDS.API,
   ];
 };
 
@@ -40,6 +40,7 @@ export const NewIndex: React.FC = () => {
   const availableIngestionMethodOptions = getAvailableMethodOptions(productFeatures);
   const { errorConnectingMessage } = useValues(HttpLogic);
 
+  const [selectedMethod, setSelectedMethod] = useState<string>('');
   return (
     <EnterpriseSearchContentPageTemplate
       pageChrome={[
@@ -74,6 +75,7 @@ export const NewIndex: React.FC = () => {
                     )}
                     type={type}
                     onSelect={() => {
+                      setSelectedMethod(type);
                       if (type === INGESTION_METHOD_IDS.CONNECTOR) {
                         KibanaLogic.values.navigateToUrl(NEW_INDEX_SELECT_CONNECTOR_PATH);
                       } else {
@@ -82,6 +84,7 @@ export const NewIndex: React.FC = () => {
                         );
                       }
                     }}
+                    isSelected={selectedMethod === type}
                   />
                 </EuiFlexItem>
               ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_overview_panels.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_overview_panels.tsx
@@ -31,7 +31,7 @@ import { SearchIndexTabId } from '../search_index';
 const StatusPanel: React.FC<{ ingestionStatus: IngestionStatus }> = ({ ingestionStatus }) => (
   <EuiPanel color={ingestionStatusToColor(ingestionStatus)} hasShadow={false} paddingSize="l">
     <EuiStat
-      titleSize="m"
+      titleSize="s"
       description={i18n.translate('xpack.enterpriseSearch.connector.ingestionStatus.title', {
         defaultMessage: 'Ingestion status',
       })}
@@ -49,7 +49,7 @@ export const ConnectorOverviewPanels: React.FC = () => {
         <EuiPanel color="primary" hasShadow={false} paddingSize="l">
           <EuiStat
             data-test-subj="entSearchContent-indexOverview-totalStats-documentCount"
-            titleSize="m"
+            titleSize="s"
             description={i18n.translate(
               'xpack.enterpriseSearch.content.searchIndex.totalStats.documentCountCardLabel',
               {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector.tsx
@@ -36,20 +36,20 @@ export const ConvertConnector: React.FC = () => {
   return (
     <>
       {isModalVisible && <ConvertConnectorModal />}
-      <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs">
+      <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiIcon type="wrench" />
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiTitle size="xxs">
-            <h4>
+          <EuiTitle size="xs">
+            <h3>
               {i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.convertConnector.title',
                 {
                   defaultMessage: 'Self-manage this connector',
                 }
               )}
-            </h4>
+            </h3>
           </EuiTitle>
         </EuiFlexItem>
       </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -187,20 +187,20 @@ export const NativeConnectorConfiguration: React.FC = () => {
           <EuiFlexGroup direction="column">
             <EuiFlexItem grow={false}>
               <EuiPanel hasBorder hasShadow={false}>
-                <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs">
+                <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiIcon type="clock" />
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiTitle size="xxs">
-                      <h4>
+                    <EuiTitle size="xs">
+                      <h3>
                         {i18n.translate(
                           'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.schedulingReminder.title',
                           {
                             defaultMessage: 'Configurable sync schedule',
                           }
                         )}
-                      </h4>
+                      </h3>
                     </EuiTitle>
                   </EuiFlexItem>
                 </EuiFlexGroup>
@@ -218,20 +218,20 @@ export const NativeConnectorConfiguration: React.FC = () => {
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiPanel hasBorder hasShadow={false}>
-                <EuiFlexGroup direction="row" alignItems="center" gutterSize="xs">
+                <EuiFlexGroup direction="row" alignItems="center" gutterSize="s">
                   <EuiFlexItem grow={false}>
                     <EuiIcon type="globe" />
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiTitle size="xxs">
-                      <h4>
+                    <EuiTitle size="xs">
+                      <h3>
                         {i18n.translate(
                           'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.securityReminder.title',
                           {
                             defaultMessage: 'Document level security',
                           }
                         )}
-                      </h4>
+                      </h3>
                     </EuiTitle>
                   </EuiFlexItem>
                 </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -94,8 +94,8 @@ export const NativeConnectorConfiguration: React.FC = () => {
                 </EuiFlexItem>
               )}
               <EuiFlexItem grow={false}>
-                <EuiTitle size="m">
-                  <h3>{nativeConnector?.name ?? index.connector.name}</h3>
+                <EuiTitle size="s">
+                  <h2>{nativeConnector?.name ?? index.connector.name}</h2>
                 </EuiTitle>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/sync_rules/connector_rules.tsx
@@ -72,11 +72,11 @@ export const ConnectorSyncRules: React.FC = () => {
               <EuiFlexGroup alignItems="center" justifyContent="flexStart" gutterSize="s">
                 <EuiFlexItem grow={false}>
                   <EuiTitle size="s">
-                    <h3>
+                    <h2>
                       {i18n.translate('xpack.enterpriseSearch.index.connector.syncRules.title', {
                         defaultMessage: 'Sync rules ',
                       })}
-                    </h3>
+                    </h2>
                   </EuiTitle>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector_total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector_total_stats.tsx
@@ -87,7 +87,7 @@ export const ConnectorTotalStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color="primary" hasShadow={false} paddingSize="l">
-              <EuiStat titleSize="m" {...item} />
+              <EuiStat titleSize="s" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/automatic_crawl_scheduler/automatic_crawl_scheduler.tsx
@@ -60,7 +60,7 @@ export const AutomaticCrawlScheduler: React.FC = () => {
   return (
     <>
       <EuiSpacer />
-      <EuiTitle size="m">
+      <EuiTitle size="s">
         <h2>
           {i18n.translate('xpack.enterpriseSearch.automaticCrawlSchedule.title', {
             defaultMessage: 'Crawl frequency',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawl_requests_panel/crawl_requests_table.tsx
@@ -97,6 +97,7 @@ export const CrawlRequestsTable: React.FC = () => {
       noItemsMessage={
         <EuiEmptyPrompt
           iconType="tableDensityExpanded"
+          titleSize="s"
           title={
             <h3>
               {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler/crawler_configuration/crawler_configuration.tsx
@@ -39,12 +39,12 @@ export const CrawlerConfiguration: React.FC = () => {
       <EuiSplitPanel.Outer hasBorder hasShadow={false}>
         <EuiSplitPanel.Inner>
           <EuiTitle size="s">
-            <h3>
+            <h2>
               {i18n.translate(
                 'xpack.enterpriseSearch.content.crawler.crawlerConfiguration.extractHTML.title',
                 { defaultMessage: 'Store full HTML' }
               )}
-            </h3>
+            </h2>
           </EuiTitle>
           <EuiSpacer />
           <EuiText size="s">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler_total_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/crawler_total_stats.tsx
@@ -77,7 +77,7 @@ export const CrawlerTotalStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color={index === 0 ? 'primary' : 'subdued'} hasShadow={false} paddingSize="l">
-              <EuiStat titleSize="m" {...item} />
+              <EuiStat titleSize="s" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/name_and_description_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/name_and_description_stats.tsx
@@ -72,7 +72,7 @@ export const NameAndDescriptionStats: React.FC = () => {
         {stats.map((item, index) => (
           <EuiFlexItem key={index}>
             <EuiPanel color={'subdued'} hasShadow={false} paddingSize="l">
-              <EuiStat titleSize="m" {...item} />
+              <EuiStat titleSize="s" {...item} />
             </EuiPanel>
           </EuiFlexItem>
         ))}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_errors.tsx
@@ -63,12 +63,12 @@ export const InferenceErrors: React.FC = () => {
         hasBorder
         iconType="documents"
         title={
-          <h2>
+          <h3>
             {i18n.translate(
               'xpack.enterpriseSearch.content.indices.pipelines.tabs.pipelineInferenceLogs.title',
               { defaultMessage: 'Inference errors' }
             )}
-          </h2>
+          </h3>
         }
       >
         {isLoading ? (

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_history.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/inference_history.tsx
@@ -51,12 +51,12 @@ export const InferenceHistory: React.FC = () => {
         hasBorder
         iconType="compute"
         title={
-          <h2>
+          <h3>
             {i18n.translate(
               'xpack.enterpriseSearch.content.indices.pipelines.tabs.inferenceHistory.title',
               { defaultMessage: 'Historical inference processors' }
             )}
-          </h2>
+          </h3>
         }
         subtitle={i18n.translate(
           'xpack.enterpriseSearch.content.indices.pipelines.tabs.inferenceHistory.subtitle',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/pipelines.tsx
@@ -135,14 +135,14 @@ export const SearchIndexPipelines: React.FC = () => {
               </EuiLink>
             }
             title={
-              <h2>
+              <h3>
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.indices.pipelines.ingestionPipeline.title',
                   {
                     defaultMessage: 'Ingest Pipelines',
                   }
                 )}
-              </h2>
+              </h3>
             }
             subtitle={
               apiIndex
@@ -203,14 +203,14 @@ export const SearchIndexPipelines: React.FC = () => {
               </EuiLink>
             }
             title={
-              <h2>
+              <h3>
                 {i18n.translate(
                   'xpack.enterpriseSearch.content.indices.pipelines.mlInferencePipelines.title',
                   {
                     defaultMessage: 'Machine Learning Inference Pipelines',
                   }
                 )}
-              </h2>
+              </h3>
             }
             subtitle={
               apiIndex && hasIndexIngestionPipeline


### PR DESCRIPTION
## Summary

Getting typography consistency and better hierarchy throughout Connectors and Web Crawlers sections:

- Now all panels have the same title size and gutter:

<img width="421" alt="Screenshot 2024-01-25 at 15 13 27" src="https://github.com/elastic/kibana/assets/3108788/e98a99e1-b928-4a9e-9004-98fee32e58a5">

<img width="434" alt="Screenshot 2024-01-25 at 15 08 53" src="https://github.com/elastic/kibana/assets/3108788/d9d14415-a2a4-4778-8b9c-444110024a90">

<img width="1223" alt="Screenshot 2024-01-25 at 15 09 16" src="https://github.com/elastic/kibana/assets/3108788/79ee934d-278d-4324-8a23-8d5184e2dd82">

- All titles have the same treatment and size:

<img width="1247" alt="Screenshot 2024-01-25 at 15 14 30" src="https://github.com/elastic/kibana/assets/3108788/e5d52c80-c569-4916-a50b-e09a18002e34">
<img width="1238" alt="Screenshot 2024-01-25 at 15 14 45" src="https://github.com/elastic/kibana/assets/3108788/6ff3ea2f-195a-4109-96f2-9fd6b826c49b">
<img width="1234" alt="Screenshot 2024-01-25 at 15 14 52" src="https://github.com/elastic/kibana/assets/3108788/03bf49ea-a268-49ad-9e90-75f6a7e79761">
<img width="1235" alt="Screenshot 2024-01-25 at 15 15 15" src="https://github.com/elastic/kibana/assets/3108788/b3ed1031-eaaf-4d92-8a7e-c3d7eb124dee">
<img width="1238" alt="Screenshot 2024-01-25 at 15 15 21" src="https://github.com/elastic/kibana/assets/3108788/809e08a9-a2c2-4a3f-aea2-d97f009e1311">
<img width="1242" alt="Screenshot 2024-01-25 at 15 15 30" src="https://github.com/elastic/kibana/assets/3108788/a35d7485-45b1-4d98-a131-0d6abce4d87f">


- Overview panels using small size for better font hierarchy 

<img width="1227" alt="Screenshot 2024-01-25 at 15 17 45" src="https://github.com/elastic/kibana/assets/3108788/81227d4e-bf8b-4b39-9918-92b8b8ed554a">
<img width="1228" alt="Screenshot 2024-01-25 at 15 17 54" src="https://github.com/elastic/kibana/assets/3108788/042925f0-6ca5-483f-8c7f-8972f458f283">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)