### PR TITLE
[Obs AI Assistant] Increase no of max function calls to 5

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.test.ts
@@ -1267,11 +1267,15 @@ describe('Observability AI Assistant client', () => {
 
       await requestAlertsFunctionCall();
 
+      await requestAlertsFunctionCall();
+
+      await requestAlertsFunctionCall();
+
       await finished(stream);
     });
 
     it('executed the function no more than three times', () => {
-      expect(functionClientMock.executeFunction).toHaveBeenCalledTimes(3);
+      expect(functionClientMock.executeFunction).toHaveBeenCalledTimes(5);
     });
 
     it('does not give the LLM the choice to call a function anymore', () => {

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -147,7 +147,7 @@ export class ObservabilityAIAssistantClient {
 
         let numFunctionsCalled: number = 0;
 
-        const MAX_FUNCTION_CALLS = 3;
+        const MAX_FUNCTION_CALLS = 5;
         const MAX_FUNCTION_RESPONSE_TOKEN_COUNT = 4000;
 
         const next = async (nextMessages: Message[]): Promise<void> => {


### PR DESCRIPTION
The function limit of 3 is too low, it runs into issues w/ ES|QL query generation if the `get_dataset_info` and `execute_query` functions are used.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->