### PR TITLE
[Lens] stop gap solution for invalid formula and math columns

### DIFF
--- a/x-pack/plugins/lens/public/datasources/form_based/utils.test.tsx
+++ b/x-pack/plugins/lens/public/datasources/form_based/utils.test.tsx
@@ -435,5 +435,68 @@ describe('indexpattern_datasource utils', () => {
       );
       expect(warnings).toHaveLength(2);
     });
+
+    // formula columns should never have a source field
+    // but it has been observed in the wild (https://github.com/elastic/kibana/issues/168561)
+    it('should ignore formula column with source field', () => {
+      const state = {
+        layers: {
+          '08ae29be-2717-4320-a908-a50ca73ee558': {
+            indexPatternId: '0',
+            columnOrder: [
+              '62f73507-09c4-4bf9-9e6f-a9692e348d94',
+              '1a027207-98b3-4a57-a97f-4c67e95eebc1',
+            ],
+            columns: {
+              '1a027207-98b3-4a57-a97f-4c67e95eebc1': {
+                customLabel: true,
+                dataType: 'number',
+                filter: {
+                  language: 'kuery',
+                  query: 'my:field',
+                },
+                isBucketed: false,
+                label: 'Failures',
+                operationType: 'count',
+                params: {
+                  emptyAsNull: true,
+                },
+                scale: 'ratio',
+                sourceField: '___records___',
+              },
+              '62f73507-09c4-4bf9-9e6f-a9692e348d94': {
+                customLabel: true,
+                dataType: 'number',
+                filter: {
+                  language: 'kuery',
+                  query: 'my:field',
+                },
+                isBucketed: false,
+                label: 'Success',
+                operationType: 'formula',
+                params: {
+                  emptyAsNull: true,
+                  formula: 'count(kql=\'message:"some message" AND message:"SUCCESS"\')',
+                  isFormulaBroken: false,
+                },
+                references: ['62f73507-09c4-4bf9-9e6f-a9692e348d94X0'],
+                scale: 'ratio',
+                // here's the issue - this should not be here
+                sourceField: '___records___',
+              },
+            },
+            incompleteColumns: {},
+          },
+        },
+      } as unknown as FormBasedPrivateState;
+
+      expect(() => {
+        getUnsupportedOperationsWarningMessage(
+          state,
+          createFramePublic(createMockedIndexPatternWithAdditionalFields([])),
+          docLinks
+        );
+      }).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## Summary

A stop-gap solution for https://github.com/elastic/kibana/issues/168561

This visualization can be used to test.

```
{"attributes":{"fieldFormatMap":"{\"hour_of_day\":{}}","name":"Kibana Sample Data Logs","runtimeFieldMap":"{\"hour_of_day\":{\"type\":\"long\",\"script\":{\"source\":\"emit(doc['timestamp'].value.getHour());\"}}}","timeFieldName":"timestamp","title":"kibana_sample_data_logs"},"coreMigrationVersion":"8.8.0","created_at":"2024-01-24T19:57:34.193Z","id":"90943e30-9a47-11e8-b64d-95841ca0b247","managed":false,"references":[],"type":"index-pattern","typeMigrationVersion":"8.0.0","updated_at":"2024-01-24T19:57:34.193Z","version":"WzM1LDFd"}
{"attributes":{"description":"","state":{"adHocDataViews":{},"datasourceStates":{"formBased":{"layers":{"7945fa55-b9ea-4b10-a498-e265ef192d7d":{"columnOrder":["207508ea-7433-494f-9925-70d55831c74c","36d445ea-dd2a-4b13-96e2-d51d07d98f70","36d445ea-dd2a-4b13-96e2-d51d07d98f70X0"],"columns":{"207508ea-7433-494f-9925-70d55831c74c":{"dataType":"date","isBucketed":true,"label":"timestamp","operationType":"date_histogram","params":{"dropPartials":false,"includeEmptyRows":true,"interval":"auto"},"scale":"interval","sourceField":"timestamp"},"36d445ea-dd2a-4b13-96e2-d51d07d98f70":{"dataType":"number","isBucketed":false,"label":"median(bytes)","operationType":"formula","sourceField":"___records___","params":{"formula":"median(bytes)","isFormulaBroken":false},"references":["36d445ea-dd2a-4b13-96e2-d51d07d98f70X0"],"scale":"ratio"},"36d445ea-dd2a-4b13-96e2-d51d07d98f70X0":{"customLabel":true,"dataType":"number","isBucketed":false,"label":"Part of median(bytes)","operationType":"median","params":{"emptyAsNull":false},"scale":"ratio","sourceField":"bytes"}},"incompleteColumns":{},"sampling":1}}},"indexpattern":{"layers":{}},"textBased":{"layers":{}}},"filters":[],"internalReferences":[],"query":{"language":"kuery","query":""},"visualization":{"axisTitlesVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"fittingFunction":"None","gridlinesVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"labelsOrientation":{"x":0,"yLeft":0,"yRight":0},"layers":[{"accessors":["36d445ea-dd2a-4b13-96e2-d51d07d98f70"],"layerId":"7945fa55-b9ea-4b10-a498-e265ef192d7d","layerType":"data","position":"top","seriesType":"bar_stacked","showGridlines":false,"xAccessor":"207508ea-7433-494f-9925-70d55831c74c"}],"legend":{"isVisible":true,"position":"right"},"preferredSeriesType":"bar_stacked","tickLabelsVisibilitySettings":{"x":true,"yLeft":true,"yRight":true},"valueLabels":"hide"}},"title":"Vis with formula","visualizationType":"lnsXY"},"coreMigrationVersion":"8.8.0","created_at":"2024-01-25T21:12:58.923Z","id":"2139b4e8-ee7c-41dc-9564-74b7c1e54216","managed":false,"references":[{"id":"90943e30-9a47-11e8-b64d-95841ca0b247","name":"indexpattern-datasource-layer-7945fa55-b9ea-4b10-a498-e265ef192d7d","type":"index-pattern"}],"type":"lens","typeMigrationVersion":"8.9.0","updated_at":"2024-01-25T21:12:58.923Z","version":"WzgwLDFd"}
{"excludedObjects":[],"excludedObjectsCount":0,"exportedCount":2,"missingRefCount":0,"missingReferences":[]}
```

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->