### PR TITLE
[ES|QL] Use the border indicator in the resizable button

### DIFF
--- a/packages/kbn-text-based-editor/src/resizable_button.tsx
+++ b/packages/kbn-text-based-editor/src/resizable_button.tsx
@@ -27,6 +27,7 @@ export function ResizableButton({
       onMouseDown={onMouseDownResizeHandler}
       onKeyDown={onKeyDownResizeHandler}
       onTouchStart={onMouseDownResizeHandler}
+      indicator="border"
       css={css`
         position: ${editorIsInline ? 'relative' : 'absolute'};
         bottom: 0;


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/171379

Uses the new border indicator in the editor

![image (19)](https://github.com/elastic/kibana/assets/17003240/d4f8a8ba-6686-454b-bafc-8d286bda3c1b)
