### PR TITLE
[8.12] Tweaks to prompt editor (#174030)

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
@@ -27,7 +27,7 @@ import type { UseGenAIConnectorsResult } from '../../hooks/use_genai_connectors'
 import type { UseKnowledgeBaseResult } from '../../hooks/use_knowledge_base';
 import { type Conversation, type Message, MessageRole } from '../../../common/types';
 import { ChatHeader } from './chat_header';
-import { ChatPromptEditor } from './chat_prompt_editor';
+import { PromptEditor } from '../prompt_editor/prompt_editor';
 import { ChatTimeline } from './chat_timeline';
 import { Feedback } from '../feedback_buttons';
 import { IncorrectLicensePanel } from './incorrect_license_panel';
@@ -210,7 +210,7 @@ export function ChatBody({
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
           <EuiPanel hasBorder={false} hasShadow={false} paddingSize="m">
-            <ChatPromptEditor
+            <PromptEditor
               hidden={connectors.loading || connectors.connectors?.length === 0}
               loading={isLoading}
               disabled
@@ -253,6 +253,7 @@ export function ChatBody({
                   chatState={state}
                   hasConnector={!!connectors.connectors?.length}
                   onEdit={(editedMessage, newMessage) => {
+                    setStickToBottom(true);
                     const indexOf = messages.indexOf(editedMessage);
                     next(messages.slice(0, indexOf).concat(newMessage));
                   }}
@@ -308,14 +309,14 @@ export function ChatBody({
             color="subdued"
             className={promptEditorContainerClassName}
           >
-            <ChatPromptEditor
+            <PromptEditor
               disabled={!connectors.selectedConnector || !hasCorrectLicense}
               hidden={connectors.loading || connectors.connectors?.length === 0}
               loading={isLoading}
+              onChangeHeight={handleChangeHeight}
               onSendTelemetry={(eventWithPayload) =>
                 sendEvent(chatService.analytics, eventWithPayload)
               }
-              onChangeHeight={handleChangeHeight}
               onSubmit={(message) => {
                 setStickToBottom(true);
                 return next(messages.concat(message));

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_item.tsx
@@ -127,6 +127,7 @@ export function ChatItem({
 
   const handleInlineEditSubmit = (newMessage: Message) => {
     handleToggleEdit();
+
     return onEditSubmit(newMessage);
   };
 

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_item_content_inline_prompt_editor.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_item_content_inline_prompt_editor.tsx
@@ -6,10 +6,11 @@
  */
 
 import React from 'react';
-import { EuiPanel } from '@elastic/eui';
+import { noop } from 'lodash';
 import { css } from '@emotion/css';
+import { EuiPanel } from '@elastic/eui';
 import { MessageText } from '../message_panel/message_text';
-import { ChatPromptEditor } from './chat_prompt_editor';
+import { PromptEditor } from '../prompt_editor/prompt_editor';
 import type { Message } from '../../../common';
 import type { ChatActionClickHandler } from './types';
 import type { TelemetryEventTypeWithPayload } from '../../analytics';
@@ -59,14 +60,14 @@ export function ChatItemContentInlinePromptEditor({
       hasShadow={false}
       className={editorContainerClassName}
     >
-      <ChatPromptEditor
+      <PromptEditor
         disabled={false}
         hidden={false}
         loading={false}
         initialFunctionCall={functionCall}
         initialContent={content}
         initialRole={role}
-        onChangeHeight={() => {}}
+        onChangeHeight={noop}
         onSubmit={onSubmit}
         onSendTelemetry={onSendTelemetry}
       />

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_timeline.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_timeline.tsx
@@ -120,9 +120,9 @@ export function ChatTimeline({
             key={index}
             consolidatedItem={item}
             onActionClick={onActionClick}
+            onEditSubmit={onEdit}
             onFeedback={onFeedback}
             onRegenerate={onRegenerate}
-            onEditSubmit={onEdit}
             onSendTelemetry={onSendTelemetry}
             onStopGenerating={onStopGenerating}
           />

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/function_list_popover.tsx
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   EuiBetaBadge,
   EuiButtonIcon,
@@ -42,8 +42,6 @@ export function FunctionListPopover({
   const { getFunctions } = useObservabilityAIAssistantChatService();
   const functions = getFunctions();
 
-  const filterRef = useRef<HTMLInputElement | null>(null);
-
   const [functionOptions, setFunctionOptions] = useState<
     Array<EuiSelectableOption<FunctionListOption>>
   >(mapFunctions({ functions, selectedFunctionName }));
@@ -66,68 +64,18 @@ export function FunctionListPopover({
   };
 
   useEffect(() => {
-    const keyboardListener = (event: KeyboardEvent) => {
-      if (event.shiftKey && event.code === 'Digit4') {
-        setIsFunctionListOpen(true);
-      }
-    };
-
-    window.addEventListener('keyup', keyboardListener);
-
-    return () => {
-      window.removeEventListener('keyup', keyboardListener);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isFunctionListOpen && filterRef.current) {
-      filterRef.current.focus();
-    }
-  }, [isFunctionListOpen]);
-
-  useEffect(() => {
     const options = mapFunctions({ functions, selectedFunctionName });
     if (options.length !== functionOptions.length) {
       setFunctionOptions(options);
     }
   }, [functionOptions.length, functions, selectedFunctionName]);
 
-  const renderFunctionOption = (
-    option: EuiSelectableOption<FunctionListOption>,
-    searchValue: string
-  ) => {
-    return (
-      <EuiFlexGroup gutterSize="xs" direction="column">
-        <EuiFlexItem grow={false}>
-          <EuiFlexGroup gutterSize="xs">
-            <EuiFlexItem grow={false}>
-              <EuiText size="s">
-                <strong>
-                  <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>{' '}
-                  <EuiBetaBadge label="beta" size="s" style={{ verticalAlign: 'middle' }} />
-                </strong>
-              </EuiText>
-            </EuiFlexItem>
-            <EuiFlexItem grow={false} />
-          </EuiFlexGroup>
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiText
-            size="xs"
-            style={{ textOverflow: 'ellipsis', overflow: 'hidden', marginBottom: 4 }}
-          >
-            <EuiHighlight search={searchValue}>{option.searchableLabel || ''}</EuiHighlight>
-          </EuiText>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    );
-  };
-
   return (
     <EuiPopover
       anchorPosition="downLeft"
       button={
         <EuiToolTip
+          key={mode} // this is added to prevent the tooltip from flickering when the mode stays the same
           content={
             mode === 'prompt'
               ? i18n.translate(
@@ -144,6 +92,10 @@ export function FunctionListPopover({
           display="block"
         >
           <EuiButtonIcon
+            aria-label={i18n.translate(
+              'xpack.observabilityAiAssistant.functionListPopover.euiButtonIcon.selectAFunctionLabel',
+              { defaultMessage: 'Select function' }
+            )}
             data-test-subj="observabilityAiAssistantFunctionListPopoverButton"
             disabled={disabled}
             iconType={selectedFunctionName ? 'cross' : 'plusInCircle'}
@@ -154,6 +106,7 @@ export function FunctionListPopover({
       }
       closePopover={handleClickFunctionList}
       css={{ maxWidth: 400 }}
+      initialFocus="#searchFilterList"
       panelPaddingSize="none"
       isOpen={isFunctionListOpen}
     >
@@ -173,7 +126,7 @@ export function FunctionListPopover({
         searchable
         searchProps={{
           'data-test-subj': 'searchFiltersList',
-          inputRef: (node) => (filterRef.current = node),
+          id: 'searchFilterList',
           placeholder: i18n.translate('xpack.observabilityAiAssistant.prompt.functionList.filter', {
             defaultMessage: 'Filter',
           }),
@@ -214,4 +167,35 @@ function mapFunctions({
           ? ('on' as EuiSelectableOptionCheckedType)
           : ('off' as EuiSelectableOptionCheckedType),
     }));
+}
+
+function renderFunctionOption(
+  option: EuiSelectableOption<FunctionListOption>,
+  searchValue: string
+) {
+  return (
+    <EuiFlexGroup gutterSize="xs" direction="column">
+      <EuiFlexItem grow={false}>
+        <EuiFlexGroup gutterSize="xs">
+          <EuiFlexItem grow={false}>
+            <EuiText size="s">
+              <strong>
+                <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>{' '}
+                <EuiBetaBadge label="beta" size="s" style={{ verticalAlign: 'middle' }} />
+              </strong>
+            </EuiText>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false} />
+        </EuiFlexGroup>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiText
+          size="xs"
+          style={{ textOverflow: 'ellipsis', overflow: 'hidden', marginBottom: 4 }}
+        >
+          <EuiHighlight search={searchValue}>{option.searchableLabel || ''}</EuiHighlight>
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
 }

--- a/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor.stories.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor.stories.tsx
@@ -7,17 +7,17 @@
 
 import React from 'react';
 import { ComponentStory } from '@storybook/react';
-import { ChatPromptEditor as Component, ChatPromptEditorProps } from './chat_prompt_editor';
+import { PromptEditor as Component, PromptEditorProps } from './prompt_editor';
 import { KibanaReactStorybookDecorator } from '../../utils/storybook_decorator';
 
 /*
-  JSON Schema validation in the ChatPromptEditor compponent does not work
+  JSON Schema validation in the PromptEditor compponent does not work
   when rendering the component from within Storybook.
   
 */
 export default {
   component: Component,
-  title: 'app/Molecules/ChatPromptEditor',
+  title: 'app/Molecules/PromptEditor',
   argTypes: {},
   parameters: {
     backgrounds: {
@@ -28,11 +28,11 @@ export default {
   decorators: [KibanaReactStorybookDecorator],
 };
 
-const Template: ComponentStory<typeof Component> = (props: ChatPromptEditorProps) => {
+const Template: ComponentStory<typeof Component> = (props: PromptEditorProps) => {
   return <Component {...props} />;
 };
 
 const defaultProps = {};
 
-export const ChatPromptEditor = Template.bind({});
-ChatPromptEditor.args = defaultProps;
+export const PromptEditor = Template.bind({});
+PromptEditor.args = defaultProps;

--- a/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_function.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_function.tsx
@@ -4,12 +4,13 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React, { useCallback, useEffect, useState } from 'react';
-import { CodeEditor } from '@kbn/kibana-react-plugin/public';
-import { i18n } from '@kbn/i18n';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import usePrevious from 'react-use/lib/usePrevious';
-import { EuiCode, EuiPanel } from '@elastic/eui';
 import { css } from '@emotion/css';
+import { CodeEditor } from '@kbn/code-editor';
+import { monaco } from '@kbn/monaco';
+import { i18n } from '@kbn/i18n';
+import { EuiCode, EuiPanel } from '@elastic/eui';
 import { useJsonEditorModel } from '../../hooks/use_json_editor_model';
 import { type Message, MessageRole } from '../../../common';
 
@@ -17,13 +18,22 @@ export interface Props {
   functionName: string;
   functionPayload?: string;
   onChange: (message: Message['message']) => void;
+  onFocus: () => void;
+  onBlur: () => void;
 }
 
 const functionNameClassName = css`
   display: inline-block;
 `;
 
-export function ChatPromptEditorFunction({ functionName, functionPayload, onChange }: Props) {
+export function PromptEditorFunction({
+  functionName,
+  functionPayload,
+  onChange,
+  onFocus,
+  onBlur,
+}: Props) {
+  const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const [functionEditorLineCount, setFunctionEditorLineCount] = useState<number>(0);
 
   const previousPayload = usePrevious(functionPayload);
@@ -33,8 +43,8 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
     initialJson: functionPayload,
   });
 
-  const handleChangeFunctionPayload = (params: string) => {
-    recalculateFunctionEditorLineCount();
+  const handleChangePayload = (args: string) => {
+    recalculateLineCount();
 
     onChange({
       role: MessageRole.Assistant,
@@ -42,12 +52,12 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
       function_call: {
         name: functionName,
         trigger: MessageRole.User,
-        arguments: params,
+        arguments: args,
       },
     });
   };
 
-  const recalculateFunctionEditorLineCount = useCallback(() => {
+  const recalculateLineCount = useCallback(() => {
     const newLineCount = model?.getLineCount() || 0;
     if (newLineCount !== functionEditorLineCount) {
       setFunctionEditorLineCount(newLineCount + 1);
@@ -55,8 +65,8 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
   }, [functionEditorLineCount, model]);
 
   useEffect(() => {
-    recalculateFunctionEditorLineCount();
-  }, [model, recalculateFunctionEditorLineCount]);
+    recalculateLineCount();
+  }, [model, recalculateLineCount]);
 
   useEffect(() => {
     if (previousPayload === undefined && initialJsonString) {
@@ -72,6 +82,10 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
     }
   }, [functionName, functionPayload, initialJsonString, onChange, previousPayload]);
 
+  editorRef.current?.onDidBlurEditorWidget(() => {
+    onBlur();
+  });
+
   return (
     <EuiPanel paddingSize="none" hasShadow={false} hasBorder>
       <EuiCode className={functionNameClassName}>{functionName}</EuiCode>
@@ -81,10 +95,15 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
           { defaultMessage: 'payloadEditor' }
         )}
         data-test-subj="observabilityAiAssistantChatPromptEditorCodeEditor"
+        editorDidMount={(editor) => {
+          editorRef.current = editor;
+          editor.focus();
+          onFocus();
+        }}
         fullWidth
         height={'180px'}
-        languageId="json"
         isCopyable
+        languageId="json"
         languageConfiguration={{
           autoClosingPairs: [
             {
@@ -92,9 +111,6 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
               close: '}',
             },
           ],
-        }}
-        editorDidMount={(editor) => {
-          editor.focus();
         }}
         options={{
           accessibilitySupport: 'off',
@@ -121,7 +137,7 @@ export function ChatPromptEditorFunction({ functionName, functionPayload, onChan
         }}
         transparentBackground
         value={functionPayload || ''}
-        onChange={handleChangeFunctionPayload}
+        onChange={handleChangePayload}
       />
     </EuiPanel>
   );

--- a/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_natural_language.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_natural_language.tsx
@@ -53,7 +53,6 @@ export function PromptEditorNaturalLanguage({
 
     if (textarea) {
       textarea.focus();
-      textarea.select();
     }
   }, [handleResizeTextArea]);
 

--- a/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_natural_language.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/prompt_editor/prompt_editor_natural_language.tsx
@@ -14,9 +14,18 @@ interface Props {
   prompt: string | undefined;
   onChange: (message: Message['message']) => void;
   onChangeHeight: (height: number) => void;
+  onFocus: () => void;
+  onBlur: () => void;
 }
 
-export function ChatPromptEditorPrompt({ disabled, prompt, onChange, onChangeHeight }: Props) {
+export function PromptEditorNaturalLanguage({
+  disabled,
+  prompt,
+  onChange,
+  onChangeHeight,
+  onFocus,
+  onBlur,
+}: Props) {
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   const handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -44,6 +53,7 @@ export function ChatPromptEditorPrompt({ disabled, prompt, onChange, onChangeHei
 
     if (textarea) {
       textarea.focus();
+      textarea.select();
     }
   }, [handleResizeTextArea]);
 
@@ -65,6 +75,8 @@ export function ChatPromptEditorPrompt({ disabled, prompt, onChange, onChangeHei
       rows={1}
       value={prompt || ''}
       onChange={handleChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   );
 }

--- a/x-pack/plugins/observability_ai_assistant/public/hooks/use_json_editor_model.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/hooks/use_json_editor_model.ts
@@ -12,9 +12,6 @@ import { safeJsonParse } from '../utils/safe_json_parse';
 
 const { editor, languages, Uri } = monaco;
 
-const SCHEMA_URI = 'http://elastic.co/foo.json';
-const modelUri = Uri.parse(SCHEMA_URI);
-
 export const useJsonEditorModel = ({
   functionName,
   initialJson,
@@ -28,13 +25,17 @@ export const useJsonEditorModel = ({
 
   const [initialJsonValue, setInitialJsonValue] = useState<string | undefined>(initialJson);
 
+  const SCHEMA_URI = `http://elastic.co/${functionName}.json`;
+
+  const modelUri = useMemo(() => Uri.parse(SCHEMA_URI), [SCHEMA_URI]);
+
   useEffect(() => {
     setInitialJsonValue(initialJson);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [functionName]);
 
   return useMemo(() => {
-    if (!functionDefinition) {
+    if (!functionDefinition || !modelUri) {
       return {};
     }
 
@@ -66,5 +67,5 @@ export const useJsonEditorModel = ({
     }
 
     return { model, initialJsonString };
-  }, [functionDefinition, initialJsonValue]);
+  }, [SCHEMA_URI, functionDefinition, initialJsonValue, modelUri]);
 };

--- a/x-pack/plugins/observability_ai_assistant/tsconfig.json
+++ b/x-pack/plugins/observability_ai_assistant/tsconfig.json
@@ -59,7 +59,8 @@
     "@kbn/ml-plugin",
     "@kbn/expect",
     "@kbn/apm-synthtrace-client",
-    "@kbn/apm-synthtrace"
+    "@kbn/apm-synthtrace",
+    "@kbn/code-editor"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Tweaks to prompt editor (#174030)](https://github.com/elastic/kibana/pull/174030)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Coen Warmer","email":"coen.warmer@gmail.com"},"sourceCommit":{"committedDate":"2024-01-08T15:59:07Z","message":"Tweaks to prompt editor (#174030)\n\n## Summary\r\n\r\nThis fixes the following edge case when using the chat interface:\r\n\r\n* When the main editor has a value in the text area, and the user edits\r\nan existing message, and presses `<enter>` on the keyboard, the value\r\nthat was in the main editor is appended as a new message, instead of\r\nediting the existing message.\r\n\r\nIt also does a bit of cleanup (moving of ChatPromptEditor components to\r\n`/components/prompt_editor`, and renaming to `PromptEditor`.)\r\n\r\n### Additional fixes\r\n* [Don't stick to bottom when changing to edit mode, re-stick to bottom\r\nwhen done\r\nediting](https://github.com/elastic/kibana/pull/174030/commits/e8a01c1d4ddd449fdf85f0fef11de3d7cc9b2637)\r\n\r\n* [Autofocus function popover list search box upon\r\nopening](https://github.com/elastic/kibana/pull/174030/commits/2329d1c0a791716bf192b5e567c49336853edbd4)\r\n\r\n* [Remove focus trap as it wasn't doing anything\r\nanymore](https://github.com/elastic/kibana/pull/174030/commits/7fcb4e0b775a768c07b79c9c362f030c8f6036cb)\r\n\r\n* [Move constants used when creating monaco model inside function scope\r\nto avoid sharing of model between multiple editor\r\ninstances](https://github.com/elastic/kibana/pull/174030/commits/c9cab2c15566a01f21342dcef66964c13574939d)\r\n\r\n* [Disable submitting function editor when json is not\r\nvalid](https://github.com/elastic/kibana/pull/174030/commits/2a6f1e1cfb2ee5f917ac4862b68aff02813341be)","sha":"f4265ca731be471481518a24794a3664a46774ff","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","backport:prev-minor","v8.12.0","v8.13.0"],"number":174030,"url":"https://github.com/elastic/kibana/pull/174030","mergeCommit":{"message":"Tweaks to prompt editor (#174030)\n\n## Summary\r\n\r\nThis fixes the following edge case when using the chat interface:\r\n\r\n* When the main editor has a value in the text area, and the user edits\r\nan existing message, and presses `<enter>` on the keyboard, the value\r\nthat was in the main editor is appended as a new message, instead of\r\nediting the existing message.\r\n\r\nIt also does a bit of cleanup (moving of ChatPromptEditor components to\r\n`/components/prompt_editor`, and renaming to `PromptEditor`.)\r\n\r\n### Additional fixes\r\n* [Don't stick to bottom when changing to edit mode, re-stick to bottom\r\nwhen done\r\nediting](https://github.com/elastic/kibana/pull/174030/commits/e8a01c1d4ddd449fdf85f0fef11de3d7cc9b2637)\r\n\r\n* [Autofocus function popover list search box upon\r\nopening](https://github.com/elastic/kibana/pull/174030/commits/2329d1c0a791716bf192b5e567c49336853edbd4)\r\n\r\n* [Remove focus trap as it wasn't doing anything\r\nanymore](https://github.com/elastic/kibana/pull/174030/commits/7fcb4e0b775a768c07b79c9c362f030c8f6036cb)\r\n\r\n* [Move constants used when creating monaco model inside function scope\r\nto avoid sharing of model between multiple editor\r\ninstances](https://github.com/elastic/kibana/pull/174030/commits/c9cab2c15566a01f21342dcef66964c13574939d)\r\n\r\n* [Disable submitting function editor when json is not\r\nvalid](https://github.com/elastic/kibana/pull/174030/commits/2a6f1e1cfb2ee5f917ac4862b68aff02813341be)","sha":"f4265ca731be471481518a24794a3664a46774ff"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174030","number":174030,"mergeCommit":{"message":"Tweaks to prompt editor (#174030)\n\n## Summary\r\n\r\nThis fixes the following edge case when using the chat interface:\r\n\r\n* When the main editor has a value in the text area, and the user edits\r\nan existing message, and presses `<enter>` on the keyboard, the value\r\nthat was in the main editor is appended as a new message, instead of\r\nediting the existing message.\r\n\r\nIt also does a bit of cleanup (moving of ChatPromptEditor components to\r\n`/components/prompt_editor`, and renaming to `PromptEditor`.)\r\n\r\n### Additional fixes\r\n* [Don't stick to bottom when changing to edit mode, re-stick to bottom\r\nwhen done\r\nediting](https://github.com/elastic/kibana/pull/174030/commits/e8a01c1d4ddd449fdf85f0fef11de3d7cc9b2637)\r\n\r\n* [Autofocus function popover list search box upon\r\nopening](https://github.com/elastic/kibana/pull/174030/commits/2329d1c0a791716bf192b5e567c49336853edbd4)\r\n\r\n* [Remove focus trap as it wasn't doing anything\r\nanymore](https://github.com/elastic/kibana/pull/174030/commits/7fcb4e0b775a768c07b79c9c362f030c8f6036cb)\r\n\r\n* [Move constants used when creating monaco model inside function scope\r\nto avoid sharing of model between multiple editor\r\ninstances](https://github.com/elastic/kibana/pull/174030/commits/c9cab2c15566a01f21342dcef66964c13574939d)\r\n\r\n* [Disable submitting function editor when json is not\r\nvalid](https://github.com/elastic/kibana/pull/174030/commits/2a6f1e1cfb2ee5f917ac4862b68aff02813341be)","sha":"f4265ca731be471481518a24794a3664a46774ff"}}]}] BACKPORT-->