### PR TITLE
[EDR Workflows][Fleet] Improve uninstall token validation in Fleet setup

### DIFF
--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -583,6 +583,9 @@ export class FleetPlugin
           }
         );
 
+        // Validate Unintall Tokens asynchronously, showing errors in Kibana logs
+        this.validateUninstallTokens();
+
         this.fleetStatus$.next({
           level: ServiceStatusLevels.available,
           summary: 'Fleet is available',
@@ -697,5 +700,26 @@ export class FleetPlugin
     }
 
     return this.logger;
+  }
+
+  private validateUninstallTokens() {
+    const logger = appContextService.getLogger();
+    const uninstallTokenService = appContextService.getUninstallTokenService();
+
+    logger.debug('Validating uninstall tokens');
+    uninstallTokenService
+      ?.checkTokenValidityForAllPolicies()
+      .catch((error) => {
+        logger.warn('Error happened during uninstall token validation.', {
+          error: { message: error },
+        });
+      })
+      .then((unintallTokenValidationError) => {
+        if (unintallTokenValidationError) {
+          logger.warn(unintallTokenValidationError.error);
+        } else {
+          logger.debug('Uninstall tokens validation successful.');
+        }
+      });
   }
 }

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -732,7 +732,7 @@ export class FleetPlugin
     uninstallTokenService
       ?.checkTokenValidityForAllPolicies()
       .catch((error) => {
-        logger.warn('Error happened during uninstall token validation.', {
+        logger.error('Error happened during uninstall token validation.', {
           error: { message: error },
         });
       })

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -583,10 +583,8 @@ export class FleetPlugin
           }
         );
 
-        // Generate/encrypt uninstall tokens asynchronously
-        this.generateUninstallTokens();
-        // Validate Unintall Tokens asynchronously, showing errors in Kibana logs
-        this.validateUninstallTokens();
+        // initialize (generate/encrypt/validate) Uninstall Tokens asynchronously
+        this.initializeUninstallTokens();
 
         this.fleetStatus$.next({
           level: ServiceStatusLevels.available,
@@ -702,6 +700,11 @@ export class FleetPlugin
     }
 
     return this.logger;
+  }
+
+  private async initializeUninstallTokens() {
+    await this.generateUninstallTokens();
+    this.validateUninstallTokens();
   }
 
   private async generateUninstallTokens() {

--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -746,7 +746,7 @@ export class FleetPlugin
       ?.checkTokenValidityForAllPolicies();
 
     if (unintallTokenValidationError) {
-      logger.warn(unintallTokenValidationError.error);
+      logger.warn(unintallTokenValidationError.error.message);
     } else {
       logger.debug('Uninstall tokens validation successful.');
     }

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.test.ts
@@ -31,6 +31,16 @@ import { agentPolicyService } from '../../agent_policy';
 
 import { UninstallTokenService, type UninstallTokenServiceInterface } from '.';
 
+interface TokenSO {
+  id: string;
+  attributes: {
+    policy_id: string;
+    token?: string;
+    token_plain?: string;
+  };
+  created_at: string;
+}
+
 describe('UninstallTokenService', () => {
   const now = new Date().toISOString();
   const aDayAgo = new Date(Date.now() - 24 * 3600 * 1000).toISOString();
@@ -41,7 +51,7 @@ describe('UninstallTokenService', () => {
   let mockBuckets: any[] = [];
   let uninstallTokenService: UninstallTokenServiceInterface;
 
-  function getDefaultSO(encrypted: boolean = true) {
+  function getDefaultSO(encrypted: boolean = true): TokenSO {
     return encrypted
       ? {
           id: 'test-so-id',
@@ -61,7 +71,7 @@ describe('UninstallTokenService', () => {
         };
   }
 
-  function getDefaultSO2(encrypted: boolean = true) {
+  function getDefaultSO2(encrypted: boolean = true): TokenSO {
     return encrypted
       ? {
           id: 'test-so-id-two',
@@ -80,6 +90,20 @@ describe('UninstallTokenService', () => {
           created_at: aDayAgo,
         };
   }
+
+  const decorateSOWithError = (so: TokenSO) => ({
+    ...so,
+    error: new Error('error reason'),
+  });
+
+  const decorateSOWithMissingToken = (so: TokenSO) => ({
+    ...so,
+    attributes: {
+      ...so.attributes,
+      token: undefined,
+      token_plain: undefined,
+    },
+  });
 
   function getDefaultBuckets(encrypted: boolean = true) {
     const defaultSO = getDefaultSO(encrypted);
@@ -225,6 +249,26 @@ describe('UninstallTokenService', () => {
               filter: `${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.id: "${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}:${so.id}"`,
               perPage: SO_SEARCH_LIMIT,
             }
+          );
+        });
+
+        it('throws error if token is missing', async () => {
+          const so = decorateSOWithMissingToken(getDefaultSO(canEncrypt));
+          mockCreatePointInTimeFinderAsInternalUser([so]);
+
+          await expect(uninstallTokenService.getToken(so.id)).rejects.toThrowError(
+            new UninstallTokenError(
+              'Invalid uninstall token: Saved object is missing the token attribute.'
+            )
+          );
+        });
+
+        it("throws error if there's a depcryption error", async () => {
+          const so = decorateSOWithError(getDefaultSO2(canEncrypt));
+          mockCreatePointInTimeFinderAsInternalUser([so]);
+
+          await expect(uninstallTokenService.getToken(so.id)).rejects.toThrowError(
+            new UninstallTokenError("Error when reading Uninstall Token with id 'test-so-id-two'.")
           );
         });
       });
@@ -507,18 +551,8 @@ describe('UninstallTokenService', () => {
     describe('check validity of tokens', () => {
       const okaySO = getDefaultSO(canEncrypt);
 
-      const errorWithDecryptionSO2 = {
-        ...getDefaultSO2(canEncrypt),
-        error: new Error('error reason'),
-      };
-      const missingTokenSO2 = {
-        ...getDefaultSO2(canEncrypt),
-        attributes: {
-          ...getDefaultSO2(canEncrypt).attributes,
-          token: undefined,
-          token_plain: undefined,
-        },
-      };
+      const errorWithDecryptionSO2 = decorateSOWithError(getDefaultSO2(canEncrypt));
+      const missingTokenSO2 = decorateSOWithMissingToken(getDefaultSO2(canEncrypt));
 
       describe('checkTokenValidityForAllPolicies', () => {
         it('returns null if all of the tokens are available', async () => {

--- a/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
+++ b/x-pack/plugins/fleet/server/services/security/uninstall_token_service/index.ts
@@ -169,9 +169,9 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   public async getToken(id: string): Promise<UninstallToken | null> {
     const filter = `${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.id: "${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}:${id}"`;
 
-    const uninstallTokens = await this.getDecryptedTokens({ filter });
+    const tokenObjects = await this.getDecryptedTokenObjects({ filter });
 
-    return uninstallTokens.length === 1 ? uninstallTokens[0] : null;
+    return tokenObjects.length === 1 ? this.convertTokenObjectToToken(tokenObjects[0]) : null;
   }
 
   public async getTokenMetadata(
@@ -201,6 +201,14 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
   }
 
   private async getDecryptedTokensForPolicyIds(policyIds: string[]): Promise<UninstallToken[]> {
+    const tokenObjects = await this.getDecryptedTokenObjectsForPolicyIds(policyIds);
+
+    return tokenObjects.map(this.convertTokenObjectToToken);
+  }
+
+  private async getDecryptedTokenObjectsForPolicyIds(
+    policyIds: string[]
+  ): Promise<Array<SavedObjectsFindResult<UninstallTokenSOAttributes>>> {
     const tokenObjectHits = await this.getTokenObjectsByIncludeFilter(policyIds);
 
     if (tokenObjectHits.length === 0) {
@@ -211,15 +219,16 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
       ({ _id }) => `${UNINSTALL_TOKENS_SAVED_OBJECT_TYPE}.id: "${_id}"`
     );
 
-    const uninstallTokenChunks: UninstallToken[][] = await asyncMap(
-      chunk(filterEntries, this.getUninstallTokenVerificationBatchSize()),
-      (entries) => {
-        const filter = entries.join(' or ');
-        return this.getDecryptedTokens({ filter });
-      }
-    );
+    const tokenObjectChunks: Array<Array<SavedObjectsFindResult<UninstallTokenSOAttributes>>> =
+      await asyncMap(
+        chunk(filterEntries, this.getUninstallTokenVerificationBatchSize()),
+        async (entries) => {
+          const filter = entries.join(' or ');
+          return this.getDecryptedTokenObjects({ filter });
+        }
+      );
 
-    return uninstallTokenChunks.flat();
+    return tokenObjectChunks.flat();
   }
 
   private getUninstallTokenVerificationBatchSize = () => {
@@ -232,9 +241,9 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     return config?.setup?.uninstallTokenVerificationBatchSize ?? 500;
   };
 
-  private getDecryptedTokens = async (
+  private async getDecryptedTokenObjects(
     options: Partial<SavedObjectsCreatePointInTimeFinderOptions>
-  ): Promise<UninstallToken[]> => {
+  ): Promise<Array<SavedObjectsFindResult<UninstallTokenSOAttributes>>> {
     const tokensFinder =
       await this.esoClient.createPointInTimeFinderDecryptedAsInternalUser<UninstallTokenSOAttributes>(
         {
@@ -243,34 +252,37 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
           ...options,
         }
       );
-    let tokenObject: Array<SavedObjectsFindResult<UninstallTokenSOAttributes>> = [];
+    let tokenObjects: Array<SavedObjectsFindResult<UninstallTokenSOAttributes>> = [];
 
     for await (const result of tokensFinder.find()) {
-      tokenObject = result.saved_objects;
+      tokenObjects = result.saved_objects;
       break;
     }
     tokensFinder.close();
 
-    const uninstallTokens: UninstallToken[] = tokenObject.map(
-      ({ id: _id, attributes, created_at: createdAt, error }) => {
-        if (error) {
-          throw new UninstallTokenError(`Error when reading Uninstall Token with id '${_id}'.`);
-        }
+    return tokenObjects;
+  }
 
-        this.assertPolicyId(attributes);
-        this.assertToken(attributes);
-        this.assertCreatedAt(createdAt);
+  private convertTokenObjectToToken = ({
+    id: _id,
+    attributes,
+    created_at: createdAt,
+    error,
+  }: SavedObjectsFindResult<UninstallTokenSOAttributes>): UninstallToken => {
+    if (error) {
+      throw new UninstallTokenError(`Error when reading Uninstall Token with id '${_id}'.`);
+    }
 
-        return {
-          id: _id,
-          policy_id: attributes.policy_id,
-          token: attributes.token || attributes.token_plain,
-          created_at: createdAt,
-        };
-      }
-    );
+    this.assertPolicyId(attributes);
+    this.assertToken(attributes);
+    this.assertCreatedAt(createdAt);
 
-    return uninstallTokens;
+    return {
+      id: _id,
+      policy_id: attributes.policy_id,
+      token: attributes.token || attributes.token_plain,
+      created_at: createdAt,
+    };
   };
 
   private async getTokenObjectsByIncludeFilter(
@@ -533,7 +545,28 @@ export class UninstallTokenService implements UninstallTokenServiceInterface {
     policyIds: string[]
   ): Promise<UninstallTokenInvalidError | null> {
     try {
-      await this.getDecryptedTokensForPolicyIds(policyIds);
+      const tokenObjects = await this.getDecryptedTokenObjectsForPolicyIds(policyIds);
+
+      const numberOfDecryptionErrors = tokenObjects.filter(({ error }) => error).length;
+      if (numberOfDecryptionErrors > 0) {
+        return {
+          error: new UninstallTokenError(
+            `Failed to decrypt ${numberOfDecryptionErrors} of ${tokenObjects.length} Uninstall Token(s)`
+          ),
+        };
+      }
+
+      const numberOfTokensWithMissingData = tokenObjects.filter(
+        ({ attributes, created_at: createdAt }) =>
+          !createdAt || !attributes.policy_id || (!attributes.token && !attributes.token_plain)
+      ).length;
+      if (numberOfTokensWithMissingData > 0) {
+        return {
+          error: new UninstallTokenError(
+            `Failed to validate Uninstall Tokens: ${numberOfTokensWithMissingData} of ${tokenObjects.length} tokens are invalid`
+          ),
+        };
+      }
     } catch (error) {
       if (error instanceof UninstallTokenError) {
         // known errors are considered non-fatal

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -197,19 +197,6 @@ async function createSetupSideEffects(
       throw error;
     }
   }
-
-  logger.debug('Generating Agent uninstall tokens');
-  if (!appContextService.getEncryptedSavedObjectsSetup()?.canEncrypt) {
-    logger.warn(
-      'xpack.encryptedSavedObjects.encryptionKey is not configured, agent uninstall tokens are being stored in plain text'
-    );
-  }
-  await appContextService.getUninstallTokenService()?.generateTokensForAllPolicies();
-
-  if (appContextService.getEncryptedSavedObjectsSetup()?.canEncrypt) {
-    logger.debug('Checking for and encrypting plain text uninstall tokens');
-    await appContextService.getUninstallTokenService()?.encryptTokens();
-  }
   stepSpan?.end();
 
   stepSpan = apm.startSpan('Upgrade agent policy schema', 'preconfiguration');

--- a/x-pack/plugins/fleet/server/services/setup.ts
+++ b/x-pack/plugins/fleet/server/services/setup.ts
@@ -210,11 +210,6 @@ async function createSetupSideEffects(
     logger.debug('Checking for and encrypting plain text uninstall tokens');
     await appContextService.getUninstallTokenService()?.encryptTokens();
   }
-
-  logger.debug('Checking validity of Uninstall Tokens');
-  const uninstallTokenError = await appContextService
-    .getUninstallTokenService()
-    ?.checkTokenValidityForAllPolicies();
   stepSpan?.end();
 
   stepSpan = apm.startSpan('Upgrade agent policy schema', 'preconfiguration');
@@ -234,7 +229,6 @@ async function createSetupSideEffects(
     ...preconfiguredPackagesNonFatalErrors,
     ...packagePolicyUpgradeErrors,
     ...(messageSigningServiceNonFatalError ? [messageSigningServiceNonFatalError] : []),
-    ...(uninstallTokenError ? [uninstallTokenError] : []),
   ];
 
   if (nonFatalErrors.length > 0) {


### PR DESCRIPTION
## Summary

This PR is a proposal for improving Uninstall Token validation inside Fleet. Any feedback from @elastic/fleet team is very welcome 🙌 

What it does:
- moves Uninstall Token generation and validation from Fleet Setup to Fleet plugin start in order to not perform these steps every time `POST api/fleet/setup` is called
- adds a summary to issues with uninstall tokens to Kibana logs
e.g.
```
[2024-01-30T12:53:31.803+01:00][ERROR][plugins.encryptedSavedObjects] Failed to decrypt attribute "token" of saved object "fleet-uninstall-tokens,fb652173-7e07-47c1-8f42-e469d789d7ca": Unsupported state or unable to authenticate data
[2024-01-30T12:53:31.885+01:00][ERROR][plugins.encryptedSavedObjects] Failed to decrypt attribute "token" of saved object "fleet-uninstall-tokens,2c34c587-f81c-4534-80e3-f45fb0d0c3f9": Unsupported state or unable to authenticate data
[2024-01-30T12:53:31.886+01:00][ERROR][plugins.encryptedSavedObjects] Failed to decrypt attribute "token" of saved object "fleet-uninstall-tokens,e4d8cf22-0d8d-43c6-b21a-e11e7aea9932": Unsupported state or unable to authenticate data
[2024-01-30T12:53:32.522+01:00][WARN ][plugins.fleet] Failed to decrypt 3 of 1130 Uninstall Token(s)
```

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
