### PR TITLE
Update docs-preview-links.yml

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -12,7 +12,7 @@ jobs:
   doc-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/docs/.github/actions/docs-preview@current
+      - uses: elastic/docs/.github/actions/docs-preview@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
### Summary

The new check added in https://github.com/elastic/kibana/pull/175463 is currently failing:

<img width="941" alt="Screenshot 2024-01-26 at 7 38 06 AM" src="https://github.com/elastic/kibana/assets/5618806/3d196fbb-e462-42d4-89fe-08191378913e">

I think this needs to point to the `@master` branch instead of `@current`. For example: 
1. https://github.com/elastic/stack-docs/blob/main/.github/workflows/docs-preview-links.yml#L15
2. https://github.com/elastic/docs/blob/master/.github/workflows/doc-preview.yml#L17