### PR TITLE
[8.12] [Index Management] Keep the filters value in the url for the indices list (#174515)

### DIFF
--- a/x-pack/plugins/index_management/__jest__/client_integration/helpers/test_subjects.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/helpers/test_subjects.ts
@@ -30,7 +30,7 @@ export type TestSubjects =
   | 'indexContextMenu'
   | 'indexManagementHeaderContent'
   | 'indexTable'
-  | 'indexTableIncludeHiddenIndicesToggle'
+  | 'checkboxToggles-includeHiddenIndices'
   | 'indexTableIndexNameLink'
   | 'indicesList'
   | 'indicesTab'

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/home.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/home.helpers.ts
@@ -44,7 +44,7 @@ export const setup = async (httpSetup: HttpSetup): Promise<HomeTestBed> => {
   };
 
   const toggleHiddenIndices = async function () {
-    find('indexTableIncludeHiddenIndicesToggle').simulate('click');
+    find('checkboxToggles-includeHiddenIndices').simulate('click');
   };
 
   return {

--- a/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
+++ b/x-pack/plugins/index_management/__jest__/client_integration/home/indices_tab.helpers.ts
@@ -74,7 +74,7 @@ export const setup = async (
 
   const clickIncludeHiddenIndicesToggle = () => {
     const { find } = testBed;
-    find('indexTableIncludeHiddenIndicesToggle').simulate('click');
+    find('checkboxToggles-includeHiddenIndices').simulate('click');
   };
 
   const clickManageContextMenuButton = async () => {
@@ -88,7 +88,7 @@ export const setup = async (
 
   const getIncludeHiddenIndicesToggleStatus = () => {
     const { find } = testBed;
-    const props = find('indexTableIncludeHiddenIndicesToggle').props();
+    const props = find('checkboxToggles-includeHiddenIndices').props();
     return Boolean(props['aria-checked']);
   };
 

--- a/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
+++ b/x-pack/plugins/index_management/__jest__/client_integration/index_details_page/index_details_page.test.tsx
@@ -650,11 +650,31 @@ describe('<IndexDetailsPage />', () => {
     });
   });
 
-  it('navigates back to indices', async () => {
-    jest.spyOn(testBed.routerMock.history, 'push');
-    await testBed.actions.clickBackToIndicesButton();
-    expect(testBed.routerMock.history.push).toHaveBeenCalledTimes(1);
-    expect(testBed.routerMock.history.push).toHaveBeenCalledWith('/indices');
+  describe('navigates back to the indices list', () => {
+    it('without indices list params', async () => {
+      jest.spyOn(testBed.routerMock.history, 'push');
+      await testBed.actions.clickBackToIndicesButton();
+      expect(testBed.routerMock.history.push).toHaveBeenCalledTimes(1);
+      expect(testBed.routerMock.history.push).toHaveBeenCalledWith('/indices');
+    });
+    it('with indices list params', async () => {
+      const filter = 'isFollower:true';
+      await act(async () => {
+        testBed = await setup({
+          httpSetup,
+          initialEntry: `/indices/index_details?indexName=${testIndexName}&filter=${encodeURIComponent(
+            filter
+          )}&includeHiddenIndices=true`,
+        });
+      });
+      testBed.component.update();
+      jest.spyOn(testBed.routerMock.history, 'push');
+      await testBed.actions.clickBackToIndicesButton();
+      expect(testBed.routerMock.history.push).toHaveBeenCalledTimes(1);
+      expect(testBed.routerMock.history.push).toHaveBeenCalledWith(
+        `/indices?filter=${encodeURIComponent(filter)}&includeHiddenIndices=true`
+      );
+    });
   });
 
   it('renders a link to discover', () => {

--- a/x-pack/plugins/index_management/__jest__/components/index_table.test.js
+++ b/x-pack/plugins/index_management/__jest__/components/index_table.test.js
@@ -277,7 +277,7 @@ describe('index table', () => {
     snapshot(indicesInTable);
 
     // Enable "Show hidden indices"
-    const switchControl = findTestSubject(rendered, 'indexTableIncludeHiddenIndicesToggle');
+    const switchControl = findTestSubject(rendered, 'checkboxToggles-includeHiddenIndices');
     switchControl.simulate('click');
 
     // We do expect now the `.admin1` and `.admin3` indices to be in the list

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page.tsx
@@ -6,12 +6,17 @@
  */
 
 import React, { useCallback, useEffect, useMemo, useState, FunctionComponent } from 'react';
+import qs from 'query-string';
 import { RouteComponentProps } from 'react-router-dom';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { EuiPageTemplate, EuiText, EuiCode } from '@elastic/eui';
 import { SectionLoading } from '@kbn/es-ui-shared-plugin/public';
 
-import { IndexDetailsSection, IndexDetailsTabId } from '../../../../../../common/constants';
+import {
+  IndexDetailsSection,
+  IndexDetailsTabId,
+  Section,
+} from '../../../../../../common/constants';
 import { Index } from '../../../../../../common';
 import { Error } from '../../../../../shared_imports';
 import { loadIndex } from '../../../../services';
@@ -28,6 +33,14 @@ export const DetailsPage: FunctionComponent<
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const [index, setIndex] = useState<Index | null>();
+
+  const navigateToIndicesList = useCallback(() => {
+    const indicesListParams = qs.parse(search);
+    delete indicesListParams.indexName;
+    delete indicesListParams.tab;
+    const paramsString = qs.stringify(indicesListParams);
+    history.push(`/${Section.Indices}${paramsString ? '?' : ''}${paramsString}`);
+  }, [history, search]);
 
   const fetchIndexDetails = useCallback(async () => {
     if (indexName) {
@@ -95,6 +108,8 @@ export const DetailsPage: FunctionComponent<
       tab={tab}
       fetchIndexDetails={fetchIndexDetails}
       history={history}
+      search={search}
+      navigateToIndicesList={navigateToIndicesList}
     />
   );
 };

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
@@ -78,12 +78,14 @@ interface Props {
   index: Index;
   tab: IndexDetailsTabId;
   history: RouteComponentProps['history'];
+  search: string;
   fetchIndexDetails: () => Promise<void>;
 }
 export const DetailsPageContent: FunctionComponent<Props> = ({
   index,
   tab,
   history,
+  search,
   fetchIndexDetails,
 }) => {
   const {
@@ -110,9 +112,9 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
 
   const onSectionChange = useCallback(
     (newSection: IndexDetailsTabId) => {
-      return history.push(getIndexDetailsLink(index.name, newSection));
+      return history.push(getIndexDetailsLink(index.name, search, newSection));
     },
-    [history, index]
+    [history, index.name, search]
   );
 
   const navigateToAllIndices = useCallback(() => {

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_overview/aliases_details.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_overview/aliases_details.tsx
@@ -37,6 +37,7 @@ export const AliasesDetails: FunctionComponent<{ aliases: Index['aliases'] }> = 
   }
   const aliasesBadges = aliases.slice(0, MAX_VISIBLE_ALIASES).map((alias) => (
     <EuiBadge
+      key={alias}
       css={css`
         max-width: 250px;
       `}

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_actions_context_menu/index_actions_context_menu.js
@@ -68,6 +68,7 @@ export class IndexActionsContextMenu extends Component {
       indices,
       reloadIndices,
       unfreezeIndices,
+      indicesListURLParams,
     } = this.props;
     const allOpen = every(indexNames, (indexName) => {
       return indexStatusByName[indexName] === INDEX_OPEN;
@@ -82,7 +83,9 @@ export class IndexActionsContextMenu extends Component {
           defaultMessage: 'Show index overview',
         }),
         onClick: () => {
-          history.push(getIndexDetailsLink(indexNames[0], IndexDetailsSection.Overview));
+          history.push(
+            getIndexDetailsLink(indexNames[0], indicesListURLParams, IndexDetailsSection.Overview)
+          );
         },
       });
       items.push({
@@ -91,7 +94,9 @@ export class IndexActionsContextMenu extends Component {
           defaultMessage: 'Show index settings',
         }),
         onClick: () => {
-          history.push(getIndexDetailsLink(indexNames[0], IndexDetailsSection.Settings));
+          history.push(
+            getIndexDetailsLink(indexNames[0], indicesListURLParams, IndexDetailsSection.Settings)
+          );
         },
       });
       items.push({
@@ -100,7 +105,9 @@ export class IndexActionsContextMenu extends Component {
           defaultMessage: 'Show index mapping',
         }),
         onClick: () => {
-          history.push(getIndexDetailsLink(indexNames[0], IndexDetailsSection.Mappings));
+          history.push(
+            getIndexDetailsLink(indexNames[0], indicesListURLParams, IndexDetailsSection.Mappings)
+          );
         },
       });
       if (allOpen && enableIndexActions) {
@@ -110,7 +117,9 @@ export class IndexActionsContextMenu extends Component {
             defaultMessage: 'Show index stats',
           }),
           onClick: () => {
-            history.push(getIndexDetailsLink(indexNames[0], IndexDetailsSection.Stats));
+            history.push(
+              getIndexDetailsLink(indexNames[0], indicesListURLParams, IndexDetailsSection.Stats)
+            );
           },
         });
       }

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
@@ -50,6 +50,8 @@ import { NoMatch, DataHealth } from '../../../../components';
 import { IndexActionsContextMenu } from '../index_actions_context_menu';
 import { CreateIndexButton } from '../create_index/create_index_button';
 
+const PAGE_SIZE_OPTIONS = [10, 50, 100];
+
 const getHeaders = ({ showIndexStats }) => {
   const headers = {};
 
@@ -127,16 +129,28 @@ export class IndexTable extends Component {
         ),
       REFRESH_RATE_INDEX_LIST
     );
-    const { location, filterChanged } = this.props;
-    const { filter } = qs.parse((location && location.search) || '');
+    const { filterChanged, pageSizeChanged, pageChanged, toggleNameToVisibleMap, toggleChanged } =
+      this.props;
+    const { filter, pageSize, pageIndex, ...rest } = this.readURLParams();
     if (filter) {
-      const decodedFilter = attemptToURIDecode(filter);
-
       try {
-        const filter = EuiSearchBar.Query.parse(decodedFilter);
-        filterChanged(filter);
+        const parsedFilter = EuiSearchBar.Query.parse(filter);
+        filterChanged(parsedFilter);
       } catch (e) {
         this.setState({ filterError: e });
+      }
+    }
+    if (pageSize && PAGE_SIZE_OPTIONS.includes(pageSize)) {
+      pageSizeChanged(pageSize);
+    }
+    if (pageIndex && pageIndex > -1) {
+      pageChanged(pageIndex);
+    }
+    const toggleParams = Object.keys(rest);
+    const toggles = Object.keys(toggleNameToVisibleMap);
+    for (const toggleParam of toggleParams) {
+      if (toggles.includes(toggleParam)) {
+        toggleChanged(toggleParam, rest[toggleParam] === 'true');
       }
     }
   }
@@ -152,21 +166,25 @@ export class IndexTable extends Component {
 
   readURLParams() {
     const { location } = this.props;
-    const { includeHiddenIndices } = qs.parse((location && location.search) || '');
+    const { filter, pageSize, pageIndex, ...rest } = qs.parse((location && location.search) || '');
     return {
-      includeHiddenIndices: includeHiddenIndices === 'true',
+      filter: filter ? attemptToURIDecode(String(filter)) : undefined,
+      pageSize: pageSize ? Number(String(pageSize)) : undefined,
+      pageIndex: pageIndex ? Number(String(pageIndex)) : undefined,
+      ...rest,
     };
   }
 
-  setIncludeHiddenParam(hidden) {
-    const { pathname, search } = this.props.location;
+  setURLParam(paramName, value) {
+    const { location, history } = this.props;
+    const { pathname, search } = location;
     const params = qs.parse(search);
-    if (hidden) {
-      params.includeHiddenIndices = 'true';
+    if (value) {
+      params[paramName] = value;
     } else {
-      delete params.includeHiddenIndices;
+      delete params[paramName];
     }
-    this.props.history.push(pathname + '?' + qs.stringify(params));
+    history.push(pathname + '?' + qs.stringify(params));
   }
 
   onSort = (column) => {
@@ -206,6 +224,7 @@ export class IndexTable extends Component {
     if (error) {
       this.setState({ filterError: error });
     } else {
+      this.setURLParam('filter', encodeURIComponent(query.text));
       this.props.filterChanged(query);
       this.setState({ filterError: null });
     }
@@ -282,7 +301,7 @@ export class IndexTable extends Component {
   }
 
   buildRowCell(fieldName, value, index, appServices) {
-    const { filterChanged, history } = this.props;
+    const { filterChanged, history, location } = this.props;
 
     if (fieldName === 'health') {
       return <DataHealth health={value} />;
@@ -291,7 +310,7 @@ export class IndexTable extends Component {
         <Fragment>
           <EuiLink
             data-test-subj="indexTableIndexNameLink"
-            onClick={() => history.push(getIndexDetailsLink(value))}
+            onClick={() => history.push(getIndexDetailsLink(value, location.search || ''))}
           >
             {value}
           </EuiLink>
@@ -416,10 +435,16 @@ export class IndexTable extends Component {
       <EuiTablePagination
         activePage={pager.getCurrentPageIndex()}
         itemsPerPage={pager.itemsPerPage}
-        itemsPerPageOptions={[10, 50, 100]}
+        itemsPerPageOptions={PAGE_SIZE_OPTIONS}
         pageCount={pager.getTotalPages()}
-        onChangeItemsPerPage={pageSizeChanged}
-        onChangePage={pageChanged}
+        onChangeItemsPerPage={(pageSize) => {
+          this.setURLParam('pageSize', pageSize);
+          pageSizeChanged(pageSize);
+        }}
+        onChangePage={(pageIndex) => {
+          this.setURLParam('pageIndex', pageIndex);
+          pageChanged(pageIndex);
+        }}
       />
     );
   }
@@ -436,7 +461,10 @@ export class IndexTable extends Component {
           id={`checkboxToggles-${name}`}
           data-test-subj={`checkboxToggles-${name}`}
           checked={toggleNameToVisibleMap[name]}
-          onChange={(event) => toggleChanged(name, event.target.checked)}
+          onChange={(event) => {
+            this.setURLParam(name, event.target.checked);
+            toggleChanged(name, event.target.checked);
+          }}
           label={label}
         />
       </EuiFlexItem>
@@ -444,10 +472,18 @@ export class IndexTable extends Component {
   }
 
   render() {
-    const { filter, indices, loadIndices, indicesLoading, indicesError, allIndices, pager } =
-      this.props;
+    const {
+      filter,
+      filterChanged,
+      indices,
+      loadIndices,
+      indicesLoading,
+      indicesError,
+      allIndices,
+      pager,
+      location,
+    } = this.props;
 
-    const { includeHiddenIndices } = this.readURLParams();
     const hasContent = !indicesLoading && !indicesError;
 
     if (!hasContent) {
@@ -532,21 +568,6 @@ export class IndexTable extends Component {
                       {extensionsService.toggles.map((toggle) => {
                         return this.renderToggleControl(toggle);
                       })}
-
-                      <EuiFlexItem grow={false}>
-                        <EuiSwitch
-                          id="checkboxShowHiddenIndices"
-                          data-test-subj="indexTableIncludeHiddenIndicesToggle"
-                          checked={includeHiddenIndices}
-                          onChange={(event) => this.setIncludeHiddenParam(event.target.checked)}
-                          label={
-                            <FormattedMessage
-                              id="xpack.idxMgmt.indexTable.hiddenIndicesSwitchLabel"
-                              defaultMessage="Include hidden indices"
-                            />
-                          }
-                        />
-                      </EuiFlexItem>
                     </EuiFlexGroup>
                   )}
                 </EuiFlexItem>
@@ -565,6 +586,7 @@ export class IndexTable extends Component {
                         <IndexActionsContextMenu
                           indexNames={Object.keys(selectedIndicesMap)}
                           isOnListView={true}
+                          indicesListURLParams={location.search || ''}
                           resetSelection={() => {
                             this.setState({ selectedIndicesMap: {} });
                           }}

--- a/x-pack/plugins/index_management/public/application/services/routing.test.ts
+++ b/x-pack/plugins/index_management/public/application/services/routing.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { getIndexDetailsLink, getIndexListUri } from './routing';
+
+describe('routing', () => {
+  describe('index details link', () => {
+    it('adds the index name to the url', () => {
+      const indexName = 'testIndex';
+      const url = getIndexDetailsLink(indexName, '');
+      expect(url).toContain(`indexName=${indexName}`);
+    });
+
+    it('adds the indices table parameters to the url', () => {
+      const filter = 'isFollower:true';
+      const url = getIndexDetailsLink('testIndex', `?filter=${encodeURIComponent(filter)}`);
+      expect(url).toContain(`&filter=${encodeURIComponent(filter)}`);
+    });
+
+    it('adds an optional index details tab to the url', () => {
+      const tab = 'dynamic-tab';
+      const url = getIndexDetailsLink('testIndex', '', tab);
+      expect(url).toContain(`tab=${tab}`);
+    });
+  });
+
+  describe('indices list link', () => {
+    it('adds filter to the url', () => {
+      const filter = 'isFollower:true';
+      const url = getIndexListUri(filter);
+      expect(url).toContain(`?filter=${encodeURIComponent(filter)}`);
+    });
+
+    it('adds includeHiddenIndices param to the url', () => {
+      const url = getIndexListUri('', true);
+      expect(url).toContain(`?includeHiddenIndices=true`);
+    });
+  });
+});

--- a/x-pack/plugins/index_management/public/application/services/routing.ts
+++ b/x-pack/plugins/index_management/public/application/services/routing.ts
@@ -35,27 +35,35 @@ export const getTemplateCloneLink = (name: string, isLegacy?: boolean) => {
 };
 
 export const getIndexListUri = (filter?: string, includeHiddenIndices?: boolean) => {
+  let url = `/${Section.Indices}`;
   const hiddenIndicesParam =
     typeof includeHiddenIndices !== 'undefined' ? includeHiddenIndices : false;
-  if (filter) {
+  if (hiddenIndicesParam) {
+    url = `${url}?includeHiddenIndices=${hiddenIndicesParam}`;
+  }
+  if (filter && filter !== 'undefined') {
     // React router tries to decode url params but it can't because the browser partially
     // decodes them. So we have to encode both the URL and the filter to get it all to
     // work correctly for filters with URL unsafe characters in them.
-    return encodeURI(
-      `/indices?includeHiddenIndices=${hiddenIndicesParam}&filter=${encodeURIComponent(filter)}`
-    );
+    url = `${url}${hiddenIndicesParam ? '&' : '?'}filter=${encodeURIComponent(filter)}`;
   }
 
-  // If no filter, URI is already safe so no need to encode.
-  return '/indices';
+  return url;
 };
 
 export const getDataStreamDetailsLink = (name: string) => {
   return encodeURI(`/data_streams/${encodeURIComponent(name)}`);
 };
 
-export const getIndexDetailsLink = (indexName: string, tab?: IndexDetailsTabId) => {
+export const getIndexDetailsLink = (
+  indexName: string,
+  indicesListURLParams: string,
+  tab?: IndexDetailsTabId
+) => {
   let link = `/${Section.Indices}/index_details?indexName=${encodeURIComponent(indexName)}`;
+  if (indicesListURLParams) {
+    link = `${link}&${indicesListURLParams.replace('?', '')}`;
+  }
   if (tab) {
     link = `${link}&tab=${tab}`;
   }

--- a/x-pack/plugins/index_management/public/application/store/reducers/table_state.js
+++ b/x-pack/plugins/index_management/public/application/store/reducers/table_state.js
@@ -20,6 +20,7 @@ export const defaultTableState = {
   currentPage: 0,
   sortField: 'index.name',
   isSortAscending: true,
+  toggleNameToVisibleMap: {},
 };
 
 export const tableState = handleActions(

--- a/x-pack/plugins/index_management/public/application/store/selectors/index.d.ts
+++ b/x-pack/plugins/index_management/public/application/store/selectors/index.d.ts
@@ -9,4 +9,4 @@ import { ExtensionsService } from '../../../services';
 
 export declare function setExtensionsService(extensionsService: ExtensionsService): any;
 
-export const getFilteredIndices: (state: any, props: any) => any;
+export const getFilteredIndices: (state: any) => any;

--- a/x-pack/plugins/index_management/public/application/store/selectors/index.js
+++ b/x-pack/plugins/index_management/public/application/store/selectors/index.js
@@ -8,9 +8,7 @@
 import { Pager, EuiSearchBar } from '@elastic/eui';
 
 import { createSelector } from 'reselect';
-import * as qs from 'query-string';
 import { indexStatusLabels } from '../../lib/index_status_labels';
-import { isHiddenIndex } from '../../lib/indices';
 import { sortTable } from '../../services';
 import { extensionsService } from './extension_service';
 
@@ -50,16 +48,15 @@ const filterByToggles = (indices, toggleNameToVisibleMap) => {
   if (!toggleNames.length) {
     return indices;
   }
-  // An index is visible if ANY applicable toggle is visible.
   return indices.filter((index) => {
-    return toggleNames.some((toggleName) => {
-      if (!togglesByName[toggleName].matchIndex(index)) {
-        return true;
+    return toggleNames.every((toggleName) => {
+      // if an index matches a toggle, it's only shown if the toggle is set to "enabled"
+      // for example, a hidden index is only shown when the "include hidden" toggle is "enabled"
+      if (togglesByName[toggleName].matchIndex(index)) {
+        return toggleNameToVisibleMap[toggleName] === true;
       }
-
-      const isVisible = toggleNameToVisibleMap[toggleName] === true;
-
-      return isVisible;
+      // otherwise the index is shown by default
+      return true;
     });
   });
 };
@@ -68,17 +65,11 @@ export const getFilteredIndices = createSelector(
   getIndices,
   getAllIds,
   getTableState,
-  getTableLocationProp,
-  (indices, allIds, tableState, tableLocation) => {
+  (indices, allIds, tableState) => {
     let indexArray = allIds.map((indexName) => indices[indexName]);
     indexArray = filterByToggles(indexArray, tableState.toggleNameToVisibleMap);
-    const { includeHiddenIndices: includeHiddenParam } = qs.parse(tableLocation.search);
-    const includeHidden = includeHiddenParam === 'true';
-    const filteredIndices = includeHidden
-      ? indexArray
-      : indexArray.filter((index) => !isHiddenIndex(index));
     const filter = tableState.filter || EuiSearchBar.Query.MATCH_ALL;
-    return EuiSearchBar.Query.execute(filter, filteredIndices, {
+    return EuiSearchBar.Query.execute(filter, indexArray, {
       defaultFields: defaultFilterFields,
     });
   }

--- a/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
+++ b/x-pack/plugins/index_management/public/application/store/selectors/indices_filter.test.ts
@@ -4,16 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import SemVer from 'semver/classes/semver';
 
-import { MAJOR_VERSION } from '../../../../common';
 import { ExtensionsService } from '../../../services';
 import { getFilteredIndices } from '.';
 // @ts-ignore
 import { defaultTableState } from '../reducers/table_state';
 import { setExtensionsService } from './extension_service';
-
-const kibanaVersion = new SemVer(MAJOR_VERSION);
 
 describe('getFilteredIndices selector', () => {
   let extensionService: ExtensionsService;
@@ -37,19 +33,20 @@ describe('getFilteredIndices selector', () => {
   };
 
   it('filters out hidden indices', () => {
-    let expected = [{ name: 'index2', hidden: false }, { name: 'index3' }, { name: '.index4' }];
+    const expected = [{ name: 'index2', hidden: false }, { name: 'index3' }, { name: '.index4' }];
 
-    if (kibanaVersion.major < 8) {
-      // In 7.x index name starting with a dot are considered hidden indices
-      expected = [{ name: 'index2', hidden: false }, { name: 'index3' }];
-    }
-
-    expect(getFilteredIndices(state, { location: { search: '' } })).toEqual(expected);
+    expect(getFilteredIndices(state)).toEqual(expected);
   });
 
   it('includes hidden indices', () => {
     expect(
-      getFilteredIndices(state, { location: { search: '?includeHiddenIndices=true' } })
+      getFilteredIndices({
+        ...state,
+        tableState: {
+          ...defaultTableState,
+          toggleNameToVisibleMap: { includeHiddenIndices: true },
+        },
+      })
     ).toEqual([
       { name: 'index1', hidden: true },
       { name: 'index2', hidden: false },

--- a/x-pack/plugins/index_management/public/services/extensions_service.ts
+++ b/x-pack/plugins/index_management/public/services/extensions_service.ts
@@ -19,6 +19,11 @@ export interface IndexContent {
   }) => ReturnType<FunctionComponent>;
 }
 
+export interface IndexToggle {
+  matchIndex: (index: Index) => boolean;
+  label: string;
+  name: string;
+}
 export interface IndexBadge {
   matchIndex: (index: Index) => boolean;
   label: string;
@@ -37,7 +42,8 @@ export interface ExtensionsSetup {
   // adds a badge to the index name
   addBadge(badge: IndexBadge): void;
   // adds a toggle to the indices list
-  addToggle(toggle: any): void;
+  addToggle(toggle: IndexToggle): void;
+  // set the content to render when the indices list is empty
   // adds a tab to the index details page
   addIndexDetailsTab(tab: IndexDetailsTab): void;
   // sets content to render instead of the code block on the overview tab of the index page
@@ -52,7 +58,7 @@ export class ExtensionsService {
   private _filters: any[] = [];
   private _badges: IndexBadge[] = [
     {
-      matchIndex: (index: { isFrozen: boolean }) => {
+      matchIndex: (index) => {
         return index.isFrozen;
       },
       label: i18n.translate('xpack.idxMgmt.frozenBadgeLabel', {
@@ -62,7 +68,17 @@ export class ExtensionsService {
       color: 'primary',
     },
   ];
-  private _toggles: any[] = [];
+  private _toggles: IndexToggle[] = [
+    {
+      matchIndex: (index) => {
+        return index.hidden;
+      },
+      label: i18n.translate('xpack.idxMgmt.indexTable.hiddenIndicesSwitchLabel', {
+        defaultMessage: 'Include hidden indices',
+      }),
+      name: 'includeHiddenIndices',
+    },
+  ];
   private _indexDetailsTabs: IndexDetailsTab[] = [];
   private _indexOverviewContent: IndexContent | null = null;
   private _indexMappingsContent: IndexContent | null = null;

--- a/x-pack/plugins/rollup/public/extend_index_management/index.ts
+++ b/x-pack/plugins/rollup/public/extend_index_management/index.ts
@@ -7,12 +7,10 @@
 
 import { i18n } from '@kbn/i18n';
 import { Index } from '@kbn/index-management-plugin/common';
-import { get } from 'lodash';
 
-const propertyPath = 'isRollupIndex';
 export const rollupToggleExtension = {
-  matchIndex: (index: { isRollupIndex: boolean }) => {
-    return get(index, propertyPath);
+  matchIndex: (index: Index) => {
+    return Boolean(index.isRollupIndex);
   },
   label: i18n.translate('xpack.rollupJobs.indexMgmtToggle.toggleLabel', {
     defaultMessage: 'Include rollup indices',
@@ -22,7 +20,7 @@ export const rollupToggleExtension = {
 
 export const rollupBadgeExtension = {
   matchIndex: (index: Index) => {
-    return !!get(index, propertyPath);
+    return Boolean(index.isRollupIndex);
   },
   label: i18n.translate('xpack.rollupJobs.indexMgmtBadge.rollupLabel', {
     defaultMessage: 'Rollup',

--- a/x-pack/test/functional/page_objects/index_management_page.ts
+++ b/x-pack/test/functional/page_objects/index_management_page.ts
@@ -26,7 +26,7 @@ export function IndexManagementPageProvider({ getService }: FtrProviderContext) 
       await testSubjects.click('checkboxToggles-rollupToggle');
     },
     async toggleHiddenIndices() {
-      await testSubjects.click('indexTableIncludeHiddenIndicesToggle');
+      await testSubjects.click('checkboxToggles-includeHiddenIndices');
     },
 
     async clickEnrichPolicyAt(indexOfRow: number): Promise<void> {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Index Management] Keep the filters value in the url for the indices list (#174515)](https://github.com/elastic/kibana/pull/174515)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Yulia Čech","email":"6585477+yuliacech@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-01-18T16:04:11Z","message":"[Index Management] Keep the filters value in the url for the indices list (#174515)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/173637 \r\n\r\nThis PR fixes a UX regression introduced in 8.11 by adding a new index\r\ndetails page: the search value is lost when the user clicks the index\r\nname and the index details page is opened. When they click the \"back to\r\nall indices\" button, the search in the indices list is cleared.\r\nTo fix this issue, we need to store the data of the users' search,\r\ntoggles and pagination before opening the index details page so that\r\nwhen going back to the indices list, these parameters could be restored\r\nin the table. This PR adds these parameters to the url when the index\r\npage is opened and when navigating back, the indices list is initialized\r\nwith this data.\r\nSince the toggles of the indices list can be added dynamically via the\r\nextensions service, there logic for storing this data needs to be\r\ndynamic as well. For a cleaner solution, I decided to move the \"include\r\nhidden indices\" toggle to the extensions service as well, since the\r\nlogic of this toggle is exactly the same as the one for \"include rollup\r\nindices\" toggle for example. This caused a minor change in the UI: the\r\nrollup and hidden indices toggles are now displayed in the reversed\r\norder.\r\n\r\n### Screenshot \r\n<img width=\"916\" alt=\"Screenshot 2024-01-11 at 14 38 22\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6585477/e7174909-0a68-4041-94a2-2d1646eae0fe\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"953c92f4cb09453b2890909ca5e3493376778c1f","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Feature:Index Management","Team:Deployment Management","backport:prev-minor","v8.13.0"],"number":174515,"url":"https://github.com/elastic/kibana/pull/174515","mergeCommit":{"message":"[Index Management] Keep the filters value in the url for the indices list (#174515)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/173637 \r\n\r\nThis PR fixes a UX regression introduced in 8.11 by adding a new index\r\ndetails page: the search value is lost when the user clicks the index\r\nname and the index details page is opened. When they click the \"back to\r\nall indices\" button, the search in the indices list is cleared.\r\nTo fix this issue, we need to store the data of the users' search,\r\ntoggles and pagination before opening the index details page so that\r\nwhen going back to the indices list, these parameters could be restored\r\nin the table. This PR adds these parameters to the url when the index\r\npage is opened and when navigating back, the indices list is initialized\r\nwith this data.\r\nSince the toggles of the indices list can be added dynamically via the\r\nextensions service, there logic for storing this data needs to be\r\ndynamic as well. For a cleaner solution, I decided to move the \"include\r\nhidden indices\" toggle to the extensions service as well, since the\r\nlogic of this toggle is exactly the same as the one for \"include rollup\r\nindices\" toggle for example. This caused a minor change in the UI: the\r\nrollup and hidden indices toggles are now displayed in the reversed\r\norder.\r\n\r\n### Screenshot \r\n<img width=\"916\" alt=\"Screenshot 2024-01-11 at 14 38 22\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6585477/e7174909-0a68-4041-94a2-2d1646eae0fe\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"953c92f4cb09453b2890909ca5e3493376778c1f"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/174515","number":174515,"mergeCommit":{"message":"[Index Management] Keep the filters value in the url for the indices list (#174515)\n\n## Summary\r\n\r\nFixes https://github.com/elastic/kibana/issues/173637 \r\n\r\nThis PR fixes a UX regression introduced in 8.11 by adding a new index\r\ndetails page: the search value is lost when the user clicks the index\r\nname and the index details page is opened. When they click the \"back to\r\nall indices\" button, the search in the indices list is cleared.\r\nTo fix this issue, we need to store the data of the users' search,\r\ntoggles and pagination before opening the index details page so that\r\nwhen going back to the indices list, these parameters could be restored\r\nin the table. This PR adds these parameters to the url when the index\r\npage is opened and when navigating back, the indices list is initialized\r\nwith this data.\r\nSince the toggles of the indices list can be added dynamically via the\r\nextensions service, there logic for storing this data needs to be\r\ndynamic as well. For a cleaner solution, I decided to move the \"include\r\nhidden indices\" toggle to the extensions service as well, since the\r\nlogic of this toggle is exactly the same as the one for \"include rollup\r\nindices\" toggle for example. This caused a minor change in the UI: the\r\nrollup and hidden indices toggles are now displayed in the reversed\r\norder.\r\n\r\n### Screenshot \r\n<img width=\"916\" alt=\"Screenshot 2024-01-11 at 14 38 22\"\r\nsrc=\"https://github.com/elastic/kibana/assets/6585477/e7174909-0a68-4041-94a2-2d1646eae0fe\">\r\n\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [ ] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios\r\n- [ ] [Flaky Test\r\nRunner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was\r\nused on any tests changed\r\n- [ ] Any UI touched in this PR is usable by keyboard only (learn more\r\nabout [keyboard accessibility](https://webaim.org/techniques/keyboard/))\r\n- [ ] Any UI touched in this PR does not create any new axe failures\r\n(run axe in browser:\r\n[FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/),\r\n[Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))\r\n- [ ] If a plugin configuration key changed, check if it needs to be\r\nallowlisted in the cloud and added to the [docker\r\nlist](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)\r\n- [ ] This renders correctly on smaller devices using a responsive\r\nlayout. (You can test this [in your\r\nbrowser](https://www.browserstack.com/guide/responsive-testing-on-local-server))\r\n- [ ] This was checked for [cross-browser\r\ncompatibility](https://www.elastic.co/support/matrix#matrix_browsers)\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"953c92f4cb09453b2890909ca5e3493376778c1f"}}]}] BACKPORT-->