### PR TITLE
[tests] skip editTags unit tests for being flaky

### DIFF
--- a/x-pack/plugins/cases/public/components/case_view/components/edit_tags.test.tsx
+++ b/x-pack/plugins/cases/public/components/case_view/components/edit_tags.test.tsx
@@ -25,7 +25,15 @@ const defaultProps: EditTagsProps = {
   tags: [],
 };
 
-describe('EditTags ', () => {
+// The suite is skipped for having several flaky tests
+// See:
+// https://github.com/elastic/kibana/issues/175618
+// https://github.com/elastic/kibana/issues/175619
+// https://github.com/elastic/kibana/issues/175621
+// https://github.com/elastic/kibana/issues/175622
+// https://github.com/elastic/kibana/issues/175623
+// https://github.com/elastic/kibana/issues/175655
+describe.skip('EditTags ', () => {
   let appMockRender: AppMockRenderer;
 
   const sampleTags = ['coke', 'pepsi'];


### PR DESCRIPTION
## Summary
The tests started to be flaky recently: https://ops.kibana.dev/s/ci/app/dashboards#/view/cb7380fb-67fe-5c41-873d-003d1a407dad?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-4w,to:now))

https://github.com/elastic/kibana/issues/175618
https://github.com/elastic/kibana/issues/175619
https://github.com/elastic/kibana/issues/175621
https://github.com/elastic/kibana/issues/175622
https://github.com/elastic/kibana/issues/175623
https://github.com/elastic/kibana/issues/175655