### PR TITLE
[Index Management] Small fixes

### DIFF
--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/create_index/create_index_modal.tsx
@@ -156,7 +156,10 @@ export const CreateIndexModal = ({ closeModal, loadIndices }: CreateIndexModalPr
           data-test-subj="createIndexSaveButton"
           data-telemetry-id="idxMgmt-indexList-createIndex-saveButton"
         >
-          <FormattedMessage id="xpack.idxMgmt.createIndex.modal.saveButton" defaultMessage="Save" />
+          <FormattedMessage
+            id="xpack.idxMgmt.createIndex.modal.saveButton"
+            defaultMessage="Create"
+          />
         </EuiButton>
       </EuiModalFooter>
     </EuiModal>

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/index_table/index_table.js
@@ -334,6 +334,9 @@ export class IndexTable extends Component {
 
   areAllItemsSelected = () => {
     const { indices } = this.props;
+    if (indices.length <= 0) {
+      return false;
+    }
     const indexOfUnselectedItem = indices.findIndex((index) => !this.isItemSelected(index.name));
     return indexOfUnselectedItem === -1;
   };


### PR DESCRIPTION
## Summary
Fixes https://github.com/elastic/kibana/issues/175633
Fixes https://github.com/elastic/kibana/issues/175630

This PR fixes the "all indices" checkbox being checked when there are no indices and updates the copy of the button in the Create index modal.

### Screenshots 
<img width="1186" alt="Screenshot 2024-01-26 at 16 56 59" src="https://github.com/elastic/kibana/assets/6585477/36c9dc3f-5d39-4740-becd-eedcdc5055bd">

<img width="428" alt="Screenshot 2024-01-26 at 16 56 36" src="https://github.com/elastic/kibana/assets/6585477/6c25319b-b72e-405e-850c-c39455fdeb6f">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
