### PR TITLE
Ensure all API Keys have a defined name

### DIFF
--- a/x-pack/plugins/security/server/routes/api_keys/get.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.test.ts
@@ -65,8 +65,44 @@ describe('Get API Keys route', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload.apiKeys).toContainEqual({ id: '123', invalidated: false });
-    expect(response.payload.apiKeys).not.toContainEqual({ id: '456', invalidated: true });
+    expect(response.payload.apiKeys).toContainEqual({ id: '123', name: '', invalidated: false });
+    expect(response.payload.apiKeys).not.toContainEqual({ id: '456', name: '', invalidated: true });
+  });
+
+  it('should substitute an empty string for keys with `null` names', async () => {
+    esClientMock.asCurrentUser.security.getApiKey.mockRestore();
+    esClientMock.asCurrentUser.security.getApiKey.mockResponse({
+      api_keys: [
+        { id: 'with_name', name: 'foo', invalidated: false },
+        { id: 'undefined_name', invalidated: false },
+        { id: 'null_name', name: null, invalidated: false },
+      ],
+    } as any);
+
+    const response = await routeHandler(
+      mockContext,
+      httpServerMock.createKibanaRequest(),
+      kibanaResponseFactory
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.payload.apiKeys).toEqual([
+      {
+        id: 'with_name',
+        name: 'foo',
+        invalidated: false,
+      },
+      {
+        id: 'undefined_name',
+        name: '',
+        invalidated: false,
+      },
+      {
+        id: 'null_name',
+        name: '',
+        invalidated: false,
+      },
+    ]);
   });
 
   it('should return `404` if API keys are disabled', async () => {

--- a/x-pack/plugins/security/server/routes/api_keys/get.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.ts
@@ -66,7 +66,14 @@ export function defineGetApiKeysRoutes({
           owner: !clusterPrivileges.manage_api_key && !clusterPrivileges.read_security,
         });
 
-        const validKeys = apiResponse.api_keys.filter(({ invalidated }) => !invalidated);
+        const validKeys = apiResponse.api_keys
+          .filter(({ invalidated }) => !invalidated)
+          .map((key) => {
+            if (!key.name) {
+              key.name = '';
+            }
+            return key;
+          });
 
         return response.ok<GetAPIKeysResult>({
           body: {


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/173890.

API Keys created in the 7.x era did not require a `name` (https://www.elastic.co/guide/en/elasticsearch/reference/7.5/security-api-create-api-key.html#security-api-create-api-key-request-body). The `name` is no longer an optional field, but our UIs have come to assume that a `name` will always be available. This updates our `GET /internal/security/api_key` API to ensure that a `name` will always exist.

**Update** The behavior of this has changed slightly via https://github.com/elastic/kibana/pull/175733. Instead of returning an empty `name`, the `name` will fallback to the key's `id`.


<!--ONMERGE {"backportTargets":["7.17","8.12"]} ONMERGE-->

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->