### PR TITLE
Fallback to using api key id when name is not defined

### DIFF
--- a/x-pack/plugins/security/server/routes/api_keys/get.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.test.ts
@@ -65,8 +65,12 @@ describe('Get API Keys route', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload.apiKeys).toContainEqual({ id: '123', name: '', invalidated: false });
-    expect(response.payload.apiKeys).not.toContainEqual({ id: '456', name: '', invalidated: true });
+    expect(response.payload.apiKeys).toContainEqual({ id: '123', name: '123', invalidated: false });
+    expect(response.payload.apiKeys).not.toContainEqual({
+      id: '456',
+      name: '456',
+      invalidated: true,
+    });
   });
 
   it('should substitute an empty string for keys with `null` names', async () => {
@@ -94,12 +98,12 @@ describe('Get API Keys route', () => {
       },
       {
         id: 'undefined_name',
-        name: '',
+        name: 'undefined_name',
         invalidated: false,
       },
       {
         id: 'null_name',
-        name: '',
+        name: 'null_name',
         invalidated: false,
       },
     ]);

--- a/x-pack/plugins/security/server/routes/api_keys/get.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.test.ts
@@ -73,7 +73,7 @@ describe('Get API Keys route', () => {
     });
   });
 
-  it('should substitute an empty string for keys with `null` names', async () => {
+  it('should substitute the API key id for keys with `null` names', async () => {
     esClientMock.asCurrentUser.security.getApiKey.mockRestore();
     esClientMock.asCurrentUser.security.getApiKey.mockResponse({
       api_keys: [

--- a/x-pack/plugins/security/server/routes/api_keys/get.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.ts
@@ -70,7 +70,7 @@ export function defineGetApiKeysRoutes({
           .filter(({ invalidated }) => !invalidated)
           .map((key) => {
             if (!key.name) {
-              key.name = '';
+              key.name = key.id;
             }
             return key;
           });


### PR DESCRIPTION
Followup to https://github.com/elastic/kibana/pull/175721.

Prefer using the key's `id` when `name` is not defined.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->