### PR TITLE
console: introduce config to enable/disable embedded console

### DIFF
--- a/config/serverless.es.yml
+++ b/config/serverless.es.yml
@@ -41,6 +41,3 @@ xpack.ml.ad.enabled: false
 xpack.ml.dfa.enabled: false
 xpack.ml.nlp.enabled: true
 xpack.ml.compatibleModuleType: 'search'
-
-# Enable the embedded dev console for index management pages
-xpack.index_management.enableEmbeddedConsole: true

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -86,3 +86,6 @@ xpack.ml.ad.enabled: true
 xpack.ml.dfa.enabled: false
 xpack.ml.nlp.enabled: false
 xpack.ml.compatibleModuleType: 'observability'
+
+// Disable the embedded Dev Console
+console.ui.embeddedEnabled: false

--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -87,5 +87,5 @@ xpack.ml.dfa.enabled: false
 xpack.ml.nlp.enabled: false
 xpack.ml.compatibleModuleType: 'observability'
 
-// Disable the embedded Dev Console
+# Disable the embedded Dev Console
 console.ui.embeddedEnabled: false

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -66,3 +66,6 @@ xpack.ml.ad.enabled: true
 xpack.ml.dfa.enabled: true
 xpack.ml.nlp.enabled: false
 xpack.ml.compatibleModuleType: 'security'
+
+// Disable the embedded Dev Console
+console.ui.embeddedEnabled: false

--- a/config/serverless.security.yml
+++ b/config/serverless.security.yml
@@ -67,5 +67,5 @@ xpack.ml.dfa.enabled: true
 xpack.ml.nlp.enabled: false
 xpack.ml.compatibleModuleType: 'security'
 
-// Disable the embedded Dev Console
+# Disable the embedded Dev Console
 console.ui.embeddedEnabled: false

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -15,6 +15,7 @@ import {
   AppStartUIPluginDependencies,
   ClientConfigType,
   ConsolePluginSetup,
+  ConsolePluginStart,
   ConsoleUILocatorParams,
   EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
@@ -101,22 +102,27 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
     return {};
   }
 
-  public start(core: CoreStart, deps: AppStartUIPluginDependencies) {
+  public start(core: CoreStart, deps: AppStartUIPluginDependencies): ConsolePluginStart {
     const {
-      ui: { enabled: isConsoleUiEnabled },
+      ui: { enabled: isConsoleUiEnabled, embeddedEnabled: isEmbeddedConsoleEnabled },
     } = this.ctx.config.get<ClientConfigType>();
 
-    if (isConsoleUiEnabled && core.application.capabilities?.dev_tools?.show === true) {
-      return {
-        renderEmbeddableConsole: (props: EmbeddableConsoleProps) => {
-          const consoleDeps: EmbeddableConsoleDependencies = {
-            core,
-            usageCollection: deps.usageCollection,
-          };
-          return renderEmbeddableConsole(props, consoleDeps);
-        },
+    const consoleStart: ConsolePluginStart = {};
+    const embeddedConsoleAvailable =
+      isConsoleUiEnabled &&
+      isEmbeddedConsoleEnabled &&
+      core.application.capabilities?.dev_tools?.show === true;
+
+    if (embeddedConsoleAvailable) {
+      consoleStart.renderEmbeddableConsole = (props?: EmbeddableConsoleProps) => {
+        const consoleDeps: EmbeddableConsoleDependencies = {
+          core,
+          usageCollection: deps.usageCollection,
+        };
+        return renderEmbeddableConsole(props, consoleDeps);
       };
     }
-    return {};
+
+    return consoleStart;
   }
 }

--- a/src/plugins/console/public/types/config.ts
+++ b/src/plugins/console/public/types/config.ts
@@ -9,5 +9,6 @@
 export interface ClientConfigType {
   ui: {
     enabled: boolean;
+    embeddedEnabled: boolean;
   };
 }

--- a/src/plugins/console/server/config.ts
+++ b/src/plugins/console/server/config.ts
@@ -23,6 +23,7 @@ const schemaLatest = schema.object(
   {
     ui: schema.object({
       enabled: schema.boolean({ defaultValue: true }),
+      embeddedEnabled: schema.boolean({ defaultValue: true }),
     }),
     autocompleteDefinitions: schema.object({
       // Only displays the endpoints that are available in the specified environment

--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -102,6 +102,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         // Ensure that your change does not unintentionally expose any sensitive values!
         'console.autocompleteDefinitions.endpointsAvailability (alternatives)',
         'console.ui.enabled (boolean)',
+        'console.ui.embeddedEnabled (boolean)',
         'dashboard.allowByValueEmbeddables (boolean)',
         'unifiedSearch.autocomplete.querySuggestions.enabled (boolean)',
         'unifiedSearch.autocomplete.valueSuggestions.enabled (boolean)',
@@ -270,7 +271,6 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.index_management.enableIndexStats (any)',
         'xpack.index_management.editableIndexSettings (any)',
         'xpack.index_management.enableDataStreamsStorageColumn (any)',
-        'xpack.index_management.enableEmbeddedConsole (boolean)',
         'xpack.infra.sources.default.fields.message (array)',
         /**
          * Feature flags bellow are conditional based on traditional/serverless offering

--- a/x-pack/plugins/index_management/__jest__/components/index_table.test.js
+++ b/x-pack/plugins/index_management/__jest__/components/index_table.test.js
@@ -167,7 +167,6 @@ describe('index table', () => {
         enableLegacyTemplates: true,
         enableIndexActions: true,
         enableIndexStats: true,
-        enableEmbeddedConsole: false,
       },
     };
 

--- a/x-pack/plugins/index_management/public/application/app_context.tsx
+++ b/x-pack/plugins/index_management/public/application/app_context.tsx
@@ -57,7 +57,6 @@ export interface AppDependencies {
     enableIndexStats: boolean;
     editableIndexSettings: 'all' | 'limited';
     enableDataStreamsStorageColumn: boolean;
-    enableEmbeddedConsole: boolean;
   };
   history: ScopedHistory;
   setBreadcrumbs: ManagementAppMountParams['setBreadcrumbs'];

--- a/x-pack/plugins/index_management/public/application/sections/home/home.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/home.tsx
@@ -40,7 +40,6 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
   history,
 }) => {
   const {
-    config: { enableEmbeddedConsole },
     plugins: { console: consolePlugin },
   } = useAppContext();
   const tabs = [
@@ -146,7 +145,7 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
         />
         <Route exact path={`/${Section.EnrichPolicies}`} component={EnrichPoliciesList} />
       </Routes>
-      {(enableEmbeddedConsole && consolePlugin?.renderEmbeddableConsole?.()) ?? <></>}
+      {consolePlugin?.renderEmbeddableConsole?.() ?? <></>}
     </>
   );
   return (

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
@@ -91,7 +91,7 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
   navigateToIndicesList,
 }) => {
   const {
-    config: { enableIndexStats, enableEmbeddedConsole },
+    config: { enableIndexStats },
     plugins: { console: consolePlugin },
     services: { extensionsService },
   } = useAppContext();
@@ -180,7 +180,7 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
       >
         <DetailsPageTab tabs={tabs} tab={tab} index={index} />
       </div>
-      {(enableEmbeddedConsole && consolePlugin?.renderEmbeddableConsole?.()) ?? <></>}
+      {consolePlugin?.renderEmbeddableConsole?.() ?? <></>}
     </>
   );
 };

--- a/x-pack/plugins/index_management/public/plugin.ts
+++ b/x-pack/plugins/index_management/public/plugin.ts
@@ -43,7 +43,6 @@ export class IndexMgmtUIPlugin {
       enableIndexStats,
       editableIndexSettings,
       enableDataStreamsStorageColumn,
-      enableEmbeddedConsole,
     } = this.ctx.config.get<ClientConfigType>();
 
     if (isIndexManagementUiEnabled) {
@@ -55,7 +54,6 @@ export class IndexMgmtUIPlugin {
         enableIndexStats: enableIndexStats ?? true,
         editableIndexSettings: editableIndexSettings ?? 'all',
         enableDataStreamsStorageColumn: enableDataStreamsStorageColumn ?? true,
-        enableEmbeddedConsole: enableEmbeddedConsole ?? false,
       };
       management.sections.section.data.registerApp({
         id: PLUGIN.id,

--- a/x-pack/plugins/index_management/public/types.ts
+++ b/x-pack/plugins/index_management/public/types.ts
@@ -43,5 +43,4 @@ export interface ClientConfigType {
   enableIndexStats?: boolean;
   editableIndexSettings?: 'all' | 'limited';
   enableDataStreamsStorageColumn?: boolean;
-  enableEmbeddedConsole?: boolean;
 }

--- a/x-pack/plugins/index_management/server/config.ts
+++ b/x-pack/plugins/index_management/server/config.ts
@@ -52,8 +52,6 @@ const schemaLatest = schema.object(
       // We take this approach in order to have a central place (serverless.yml) for serverless config across Kibana
       serverless: schema.boolean({ defaultValue: true }),
     }),
-    // Embedded Developer Console is disabled by default
-    enableEmbeddedConsole: schema.boolean({ defaultValue: false }),
   },
   { defaultValue: undefined }
 );
@@ -66,7 +64,6 @@ const configLatest: PluginConfigDescriptor<IndexManagementConfig> = {
     enableIndexStats: true,
     editableIndexSettings: true,
     enableDataStreamsStorageColumn: true,
-    enableEmbeddedConsole: true,
   },
   schema: schemaLatest,
   deprecations: ({ unused }) => [unused('dev.enableIndexDetailsPage', { level: 'warning' })],


### PR DESCRIPTION
## Summary

Introduced the console.ui.embeddedEnabled (boolean) value to allow disabling the embedded console in serverless security and observability projects.

This also replaces an index management specific config value to do that same thing which is removed here as well. Adding this console configuration will allow us to have one value to set instead of N which was the pattern I had started to use, but then decided against.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)