### PR TITLE
[EDR Workflows] Fix vagrant unzip

### DIFF
--- a/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
+++ b/x-pack/plugins/security_solution/public/management/cypress/e2e/response_actions/response_console/file_operations.cy.ts
@@ -112,7 +112,7 @@ describe('Response console', { tags: ['@ess', '@serverless'] }, () => {
         path: `${homeFilePath}/upload.zip`,
         password: 'elastic',
       }).then((unzippedFileContent) => {
-        expect(unzippedFileContent).to.equal(fileContent);
+        expect(unzippedFileContent).to.contain(fileContent);
       });
     });
 

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
@@ -32,5 +32,6 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: cachedAgentSource, destination: "~/#{cachedAgentFilename}"
   config.vm.provision "shell", inline: "mkdir #{agentDestinationFolder}"
   config.vm.provision "shell", inline: "tar -zxf #{cachedAgentFilename} --directory #{agentDestinationFolder} --strip-components=1 && rm -f #{cachedAgentFilename}"
+  config.vm.provision "shell", inline: "sudo apt update"
   config.vm.provision "shell", inline: "sudo apt-get install unzip"
 end

--- a/x-pack/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
+++ b/x-pack/plugins/security_solution/scripts/endpoint/common/vagrant/Vagrantfile
@@ -32,6 +32,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: cachedAgentSource, destination: "~/#{cachedAgentFilename}"
   config.vm.provision "shell", inline: "mkdir #{agentDestinationFolder}"
   config.vm.provision "shell", inline: "tar -zxf #{cachedAgentFilename} --directory #{agentDestinationFolder} --strip-components=1 && rm -f #{cachedAgentFilename}"
-  config.vm.provision "shell", inline: "sudo apt update"
+  config.vm.provision "shell", inline: "sudo apt-get update"
+  config.vm.provision "shell", inline: "sudo apt-get upgrade"
   config.vm.provision "shell", inline: "sudo apt-get install unzip"
 end


### PR DESCRIPTION
Not sure what happened but `vagrant up` started to fail due to finding unzip package issue. 

<img width="667" alt="Zrzut ekranu 2024-01-27 o 16 37 46" src="https://github.com/elastic/kibana/assets/16632552/45e2fe80-7bc7-4ebc-9b23-0f5b409ef6d0">

This PR fixes this.

However after the `upgrade` - `unzip` package seems to be returning different output. 
<img width="715" alt="Zrzut ekranu 2024-01-27 o 16 54 00" src="https://github.com/elastic/kibana/assets/16632552/776591c3-c444-4c00-96d6-c41cf3f562b3">

That's why I adjusted the test from `equal` to `contain`. 

This is a quick fix done on Saturday (I am off on Monday), so if someone has some time during the working hours and feels that this could be fixed in a better way, please feel free to do so :) 

Thank you!

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->