### PR TITLE
[ES Archiver][Load Action] Add perf option override to loadIfNeeded

### DIFF
--- a/packages/kbn-es-archiver/src/es_archiver.ts
+++ b/packages/kbn-es-archiver/src/es_archiver.ts
@@ -155,8 +155,8 @@ export class EsArchiver {
    *
    * @param name
    */
-  async loadIfNeeded(name: string) {
-    return await this.load(name, { skipExisting: true });
+  async loadIfNeeded(name: string, performance?: LoadActionPerfOptions) {
+    return await this.load(name, { skipExisting: true, performance });
   }
 
   /**

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
@@ -37,10 +37,7 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('dashboard feature controls security', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional', {
-        batchSize: 300,
-        concurrency: 2,
-      });
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
       await kbnServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/dashboard/feature_controls/security/security.json'
       );

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
@@ -38,8 +38,8 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
   describe('dashboard feature controls security', () => {
     before(async () => {
       await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional', {
-        batchSize: 5000,
-        concurrency: 4,
+        batchSize: 300,
+        concurrency: 2,
       });
       await kbnServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/dashboard/feature_controls/security/security.json'

--- a/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
+++ b/x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts
@@ -37,7 +37,10 @@ export default function ({ getPageObjects, getService }: FtrProviderContext) {
 
   describe('dashboard feature controls security', () => {
     before(async () => {
-      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional');
+      await esArchiver.loadIfNeeded('x-pack/test/functional/es_archives/logstash_functional', {
+        batchSize: 5000,
+        concurrency: 4,
+      });
       await kbnServer.importExport.load(
         'x-pack/test/functional/fixtures/kbn_archiver/dashboard/feature_controls/security/security.json'
       );


### PR DESCRIPTION
## Summary

With the merge of https://github.com/elastic/kibana/pull/174631, we've need of a follow up pr, 
to extend the performance override, to the loadIfNeeded function.

Resolves a ticket within [Appex QA](https://github.com/orgs/elastic/projects/1137)

### More Details

I've taken the liberty to demonstrate the override in use within `x-pack/test/functional/apps/dashboard/group1/feature_controls/dashboard_security.ts`, in this pr.  
We can remove this if need be, but I wanted it here for now, to test this out in ci.

