### PR TITLE
[Fleet] allow upgrade agent to newer patch version than fleet-server

### DIFF
--- a/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import { checkKibanaVersion } from './upgrade_handler';
+import { checkFleetServerVersion, checkKibanaVersion } from './upgrade_handler';
 
 describe('upgrade handler', () => {
   describe('checkKibanaVersion', () => {
@@ -40,6 +40,27 @@ describe('upgrade handler', () => {
     it('should not throw if force is specified and major and minor is newer', () => {
       expect(() => checkKibanaVersion('7.5.0', '8.4.0', true)).not.toThrowError();
       expect(() => checkKibanaVersion('8.4.0', '8.4.0', true)).not.toThrowError();
+    });
+  });
+
+  describe('checkFleetServerVersion', () => {
+    it('should not throw if no force is specified and patch is newer', () => {
+      const fleetServers = [
+        { local_metadata: { elastic: { agent: { version: '8.3.0' } } } },
+        { local_metadata: { elastic: { agent: { version: '8.4.0' } } } },
+      ] as any;
+      expect(() => checkFleetServerVersion('8.4.1', fleetServers, false)).not.toThrowError();
+      expect(() =>
+        checkFleetServerVersion('8.4.1-SNAPSHOT', fleetServers, false)
+      ).not.toThrowError();
+    });
+
+    it('should throw if no force is specified and minor is newer', () => {
+      const fleetServers = [
+        { local_metadata: { elastic: { agent: { version: '8.3.0' } } } },
+        { local_metadata: { elastic: { agent: { version: '8.4.0' } } } },
+      ] as any;
+      expect(() => checkFleetServerVersion('8.5.1', fleetServers, false)).toThrowError();
     });
   });
 });

--- a/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
+++ b/x-pack/plugins/fleet/server/routes/agent/upgrade_handler.ts
@@ -223,7 +223,7 @@ export const checkKibanaVersion = (version: string, kibanaVersion: string, force
 };
 
 // Check the installed fleet server version
-const checkFleetServerVersion = (
+export const checkFleetServerVersion = (
   versionToUpgradeNumber: string,
   fleetServerAgents: Agent[],
   force = false
@@ -238,9 +238,13 @@ const checkFleetServerVersion = (
     return;
   }
 
-  if (!force && semverGt(versionToUpgradeNumber, maxFleetServerVersion)) {
-    throw new AgentRequestInvalidError(
-      `Cannot upgrade agent to ${versionToUpgradeNumber} because it is higher than the latest fleet server version ${maxFleetServerVersion}`
+  if (
+    !force &&
+    semverGt(versionToUpgradeNumber, maxFleetServerVersion) &&
+    !differsOnlyInPatch(versionToUpgradeNumber, maxFleetServerVersion)
+  ) {
+    throw new Error(
+      `cannot upgrade agent to ${versionToUpgradeNumber} because it is higher than the latest fleet server version ${maxFleetServerVersion}`
     );
   }
 

--- a/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
+++ b/x-pack/test/fleet_api_integration/apis/agents/upgrade.ts
@@ -1309,7 +1309,7 @@ export default function (providerContext: FtrProviderContext) {
       });
 
       it('should respond 400 if trying to bulk upgrade to a version that is higher than the latest fleet server version', async () => {
-        const higherVersion = semver.inc(fleetServerVersion, 'patch');
+        const higherVersion = '7.17.0';
         await es.update({
           id: 'agent1',
           refresh: 'wait_for',


### PR DESCRIPTION
## Summary

Adding the fix in https://github.com/elastic/kibana/pull/175765 to main too.

To verify:
- add a fleet-server version 8.12.0
- enroll an agent version 8.12.0-SNAPSHOT
- take the agent id and in console run this API request
```
POST kbn:/api/fleet/agents/6a56f865-a611-4921-9f24-87757259223e/upgrade
  {
    "version": "8.12.1-SNAPSHOT"
  }
```
- verify that the API returns 200 

Relates https://github.com/elastic/kibana/issues/168502