### PR TITLE
[artifacts/package testing] Update apt cache

### DIFF
--- a/test/package/roles/install_kibana_deb/tasks/main.yml
+++ b/test/package/roles/install_kibana_deb/tasks/main.yml
@@ -6,6 +6,7 @@
       - fonts-liberation
       - libfontconfig
     state: latest
+    cache_valid_time: 3600
 
 - name: find deb package
   find:


### PR DESCRIPTION
Fixes an issue where the `fonts-liberation` package could not be found by running the equivalent of `apt-get update`.

https://buildkite.com/elastic/kibana-artifacts-snapshot/builds/3892

<!--ONMERGE {"backportTargets":["7.17","8.12"]} ONMERGE-->