### PR TITLE
[Cases] Use custom field defaults on create/update case APIs

### DIFF
--- a/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
@@ -807,7 +807,7 @@ describe('bulkCreate', () => {
       expect(customFields).toEqual(theCustomFields);
     });
 
-    it('should not throw an error and fill out missing customFields when they are undefined', async () => {
+    it('fills out missing required custom fields', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
@@ -835,86 +835,20 @@ describe('bulkCreate', () => {
       ]);
     });
 
-    it('should not throw an error and fill out missing customFields when they are null', async () => {
-      casesClient.configure.get = jest.fn().mockResolvedValue([
-        {
-          owner: theCase.owner,
-          customFields: [
-            defaultCustomFieldsConfiguration[0],
-            {
-              ...defaultCustomFieldsConfiguration[1],
-              required: true,
-              defaultValue: true,
-            },
-          ],
-        },
-      ]);
-
-      await expect(
-        bulkCreate(
-          {
-            cases: getCases({
-              customFields: [
-                { ...theCustomFields[0], value: null },
-                { ...theCustomFields[1], value: null },
-              ],
-            }),
-          },
-          clientArgs,
-          casesClient
-        )
-      ).resolves.not.toThrow();
-
-      const customFields =
-        clientArgs.services.caseService.bulkCreateCases.mock.calls[0][0].cases[0].customFields;
-
-      expect(customFields).toEqual([
-        { key: 'first_key', type: 'text', value: 'default value' },
-        { key: 'second_key', type: 'toggle', value: true },
-      ]);
-    });
-
-    it('should throw an error when required customFields are undefined and missing a default value', async () => {
+    it('throws error when required customFields are null', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
           customFields: [
             {
               ...defaultCustomFieldsConfiguration[0],
-              required: true,
-              defaultValue: undefined,
+              label: 'missing field 1',
             },
             {
               ...defaultCustomFieldsConfiguration[1],
-              required: true,
-            },
-          ],
-        },
-      ]);
-
-      await expect(
-        bulkCreate({ cases: getCases() }, clientArgs, casesClient)
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"label 1\\", \\"label 2\\""`
-      );
-    });
-
-    it('should throw an error when required customFields are null and missing a default value', async () => {
-      casesClient.configure.get = jest.fn().mockResolvedValue([
-        {
-          owner: theCase.owner,
-          customFields: [
-            {
-              key: 'first_key',
-              type: CustomFieldTypes.TEXT,
-              label: 'missing field 1',
-              required: true,
-            },
-            {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
               label: 'missing field 2',
               required: true,
+              defaultValue: true,
             },
           ],
         },
@@ -943,6 +877,31 @@ describe('bulkCreate', () => {
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
         `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
+      );
+    });
+
+    it('throws error when required customFields are undefined and missing a default value', async () => {
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: theCase.owner,
+          customFields: [
+            {
+              ...defaultCustomFieldsConfiguration[0],
+              required: true,
+              defaultValue: undefined,
+            },
+            {
+              ...defaultCustomFieldsConfiguration[1],
+              required: true,
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        bulkCreate({ cases: getCases() }, clientArgs, casesClient)
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"label 1\\", \\"label 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
@@ -752,29 +752,23 @@ describe('bulkCreate', () => {
 
   describe('Custom Fields', () => {
     const clientArgs = createCasesClientMockArgs();
-    clientArgs.services.caseService.bulkCreateCases.mockResolvedValue({ saved_objects: [caseSO] });
     const theCase = getCases()[0];
-
     const casesClient = createCasesClientMock();
-    casesClient.configure.get = jest.fn().mockResolvedValue([
+    const defaultCustomFieldsConfiguration = [
       {
-        owner: theCase.owner,
-        customFields: [
-          {
-            key: 'first_key',
-            type: CustomFieldTypes.TEXT,
-            label: 'foo',
-            required: true,
-          },
-          {
-            key: 'second_key',
-            type: CustomFieldTypes.TOGGLE,
-            label: 'foo',
-            required: false,
-          },
-        ],
+        key: 'first_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'label 1',
+        required: true,
+        defaultValue: 'default value',
       },
-    ]);
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        label: 'label 2',
+        required: false,
+      },
+    ];
 
     const theCustomFields: CaseCustomFields = [
       {
@@ -788,6 +782,19 @@ describe('bulkCreate', () => {
         value: true,
       },
     ];
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      clientArgs.services.caseService.bulkCreateCases.mockResolvedValue({
+        saved_objects: [caseSO],
+      });
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: theCase.owner,
+          customFields: defaultCustomFieldsConfiguration,
+        },
+      ]);
+    });
 
     it('should bulkCreate customFields correctly', async () => {
       await expect(
@@ -805,17 +812,11 @@ describe('bulkCreate', () => {
         {
           owner: theCase.owner,
           customFields: [
+            defaultCustomFieldsConfiguration[0],
             {
-              key: 'first_key',
-              type: CustomFieldTypes.TEXT,
-              label: 'foo',
-              required: false,
-            },
-            {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
-              required: false,
+              ...defaultCustomFieldsConfiguration[1],
+              required: true,
+              defaultValue: true,
             },
           ],
         },
@@ -829,27 +830,63 @@ describe('bulkCreate', () => {
         clientArgs.services.caseService.bulkCreateCases.mock.calls[0][0].cases[0].customFields;
 
       expect(customFields).toEqual([
-        { key: 'first_key', type: 'text', value: null },
-        { key: 'second_key', type: 'toggle', value: null },
+        { key: 'first_key', type: 'text', value: 'default value' },
+        { key: 'second_key', type: 'toggle', value: true },
       ]);
     });
 
-    it('should throw an error when required customFields are undefined', async () => {
+    it('should not throw an error and fill out missing customFields when they are null', async () => {
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: theCase.owner,
+          customFields: [
+            defaultCustomFieldsConfiguration[0],
+            {
+              ...defaultCustomFieldsConfiguration[1],
+              required: true,
+              defaultValue: true,
+            },
+          ],
+        },
+      ]);
+
+      await expect(
+        bulkCreate(
+          {
+            cases: getCases({
+              customFields: [
+                { ...theCustomFields[0], value: null },
+                { ...theCustomFields[1], value: null },
+              ],
+            }),
+          },
+          clientArgs,
+          casesClient
+        )
+      ).resolves.not.toThrow();
+
+      const customFields =
+        clientArgs.services.caseService.bulkCreateCases.mock.calls[0][0].cases[0].customFields;
+
+      expect(customFields).toEqual([
+        { key: 'first_key', type: 'text', value: 'default value' },
+        { key: 'second_key', type: 'toggle', value: true },
+      ]);
+    });
+
+    it('should throw an error when required customFields are undefined and missing a default value', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
           customFields: [
             {
-              key: 'first_key',
-              type: CustomFieldTypes.TEXT,
-              label: 'missing field 1',
+              ...defaultCustomFieldsConfiguration[0],
               required: true,
+              defaultValue: undefined,
             },
             {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
-              required: false,
+              ...defaultCustomFieldsConfiguration[1],
+              required: true,
             },
           ],
         },
@@ -858,11 +895,11 @@ describe('bulkCreate', () => {
       await expect(
         bulkCreate({ cases: getCases() }, clientArgs, casesClient)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields: \\"missing field 1\\""`
+        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"label 1\\", \\"label 2\\""`
       );
     });
 
-    it('should throw an error when required customFields are null', async () => {
+    it('should throw an error when required customFields are null and missing a default value', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
@@ -905,7 +942,7 @@ describe('bulkCreate', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 
@@ -925,7 +962,7 @@ describe('bulkCreate', () => {
       );
     });
 
-    it('throws with duplicated customFields keys', async () => {
+    it('throws error with duplicated customFields keys', async () => {
       await expect(
         bulkCreate(
           {
@@ -974,28 +1011,6 @@ describe('bulkCreate', () => {
       );
     });
 
-    it('throws error when required custom fields are missing', async () => {
-      await expect(
-        bulkCreate(
-          {
-            cases: getCases({
-              customFields: [
-                {
-                  key: 'second_key',
-                  type: CustomFieldTypes.TEXT,
-                  value: 'this is a text field value',
-                },
-              ],
-            }),
-          },
-          clientArgs,
-          casesClient
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields: \\"missing field 1\\""`
-      );
-    });
-
     it('throws when the customField types do not match the configuration', async () => {
       await expect(
         bulkCreate(
@@ -1019,7 +1034,7 @@ describe('bulkCreate', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: The following custom fields have the wrong type in the request: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to bulk create cases: Error: The following custom fields have the wrong type in the request: \\"label 1\\", \\"label 2\\""`
       );
     });
 
@@ -1062,7 +1077,7 @@ describe('bulkCreate', () => {
       await expect(
         bulkCreate({ cases: casesWithDifferentOwners }, clientArgs, casesClient)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields: \\"stack cases custom field\\""`
+        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"stack cases custom field\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/bulk_create.test.ts
@@ -876,7 +876,7 @@ describe('bulkCreate', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to bulk create cases: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to bulk create cases: Error: Invalid value \\"null\\" supplied for the following required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -432,25 +432,21 @@ describe('create', () => {
     clientArgs.services.caseService.createCase.mockResolvedValue(caseSO);
 
     const casesClient = createCasesClientMock();
-    casesClient.configure.get = jest.fn().mockResolvedValue([
+    const defaultCustomFieldsConfiguration = [
       {
-        owner: theCase.owner,
-        customFields: [
-          {
-            key: 'first_key',
-            type: CustomFieldTypes.TEXT,
-            label: 'foo',
-            required: true,
-          },
-          {
-            key: 'second_key',
-            type: CustomFieldTypes.TOGGLE,
-            label: 'foo',
-            required: false,
-          },
-        ],
+        key: 'first_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'label 1',
+        required: true,
+        defaultValue: 'default value',
       },
-    ]);
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        label: 'label 2',
+        required: false,
+      },
+    ];
 
     const theCustomFields: CaseCustomFields = [
       {
@@ -467,6 +463,12 @@ describe('create', () => {
 
     beforeEach(() => {
       jest.clearAllMocks();
+      casesClient.configure.get = jest.fn().mockResolvedValue([
+        {
+          owner: theCase.owner,
+          customFields: defaultCustomFieldsConfiguration,
+        },
+      ]);
     });
 
     it('should create customFields correctly', async () => {
@@ -504,25 +506,6 @@ describe('create', () => {
     });
 
     it('should not throw an error and fill out missing customFields when they are undefined', async () => {
-      casesClient.configure.get = jest.fn().mockResolvedValue([
-        {
-          owner: theCase.owner,
-          customFields: [
-            {
-              key: 'first_key',
-              type: CustomFieldTypes.TEXT,
-              label: 'foo',
-              required: false,
-            },
-            {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
-              required: false,
-            },
-          ],
-        },
-      ]);
       await expect(create({ ...theCase }, clientArgs, casesClient)).resolves.not.toThrow();
 
       expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
@@ -540,7 +523,7 @@ describe('create', () => {
             duration: null,
             status: CaseStatuses.open,
             customFields: [
-              { key: 'first_key', type: 'text', value: null },
+              { key: 'first_key', type: 'text', value: 'default value' },
               { key: 'second_key', type: 'toggle', value: null },
             ],
           },
@@ -550,22 +533,60 @@ describe('create', () => {
       );
     });
 
-    it('should throw an error when required customFields are undefined', async () => {
+    it('should not throw an error and fill out missing customFields when they are null', async () => {
+      await expect(
+        create(
+          {
+            ...theCase,
+            customFields: [
+              { ...theCustomFields[0], value: null },
+              { ...theCustomFields[1], value: null },
+            ],
+          },
+          clientArgs,
+          casesClient
+        )
+      ).resolves.not.toThrow();
+
+      expect(clientArgs.services.caseService.createCase).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attributes: {
+            ...theCase,
+            closed_by: null,
+            closed_at: null,
+            category: null,
+            created_at: expect.any(String),
+            created_by: expect.any(Object),
+            updated_at: null,
+            updated_by: null,
+            external_service: null,
+            duration: null,
+            status: CaseStatuses.open,
+            customFields: [
+              { key: 'first_key', type: 'text', value: 'default value' },
+              { key: 'second_key', type: 'toggle', value: null },
+            ],
+          },
+          id: expect.any(String),
+          refresh: false,
+        })
+      );
+    });
+
+    it('should throw an error when required customFields are undefined and missing a default value', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
           customFields: [
             {
-              key: 'first_key',
-              type: CustomFieldTypes.TEXT,
+              ...defaultCustomFieldsConfiguration[0],
               label: 'missing field 1',
-              required: true,
+              defaultValue: undefined,
             },
             {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
-              label: 'foo',
-              required: false,
+              ...defaultCustomFieldsConfiguration[1],
+              label: 'missing field 2',
+              required: true,
             },
           ],
         },
@@ -574,11 +595,11 @@ describe('create', () => {
       await expect(
         create({ ...theCase }, clientArgs, casesClient)
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\""`
+        `"Failed to create case: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 
-    it('should throw an error when required customFields are null', async () => {
+    it('should throw an error when required customFields are null and missing a default value', async () => {
       casesClient.configure.get = jest.fn().mockResolvedValue([
         {
           owner: theCase.owner,
@@ -604,23 +625,15 @@ describe('create', () => {
           {
             ...theCase,
             customFields: [
-              {
-                key: 'first_key',
-                type: CustomFieldTypes.TEXT,
-                value: null,
-              },
-              {
-                key: 'second_key',
-                type: CustomFieldTypes.TOGGLE,
-                value: null,
-              },
+              { ...theCustomFields[0], value: null },
+              { ...theCustomFields[1], value: null },
             ],
           },
           clientArgs,
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to create case: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 
@@ -686,27 +699,6 @@ describe('create', () => {
       );
     });
 
-    it('throws error when required custom fields are missing', async () => {
-      await expect(
-        create(
-          {
-            ...theCase,
-            customFields: [
-              {
-                key: 'second_key',
-                type: CustomFieldTypes.TEXT,
-                value: 'this is a text field value',
-              },
-            ],
-          },
-          clientArgs,
-          casesClient
-        )
-      ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields: \\"missing field 1\\""`
-      );
-    });
-
     it('throws when the customField types do not match the configuration', async () => {
       await expect(
         create(
@@ -729,7 +721,7 @@ describe('create', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: The following custom fields have the wrong type in the request: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to create case: Error: The following custom fields have the wrong type in the request: \\"label 1\\", \\"label 2\\""`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/cases/create.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/create.test.ts
@@ -565,7 +565,7 @@ describe('create', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to create case: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to create case: Error: Invalid value \\"null\\" supplied for the following required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/update.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/update.test.ts
@@ -1393,7 +1393,7 @@ describe('update', () => {
           casesClient
         )
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: Missing required custom fields without default value configured: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Failed to update case, ids: [{\\"id\\":\\"mock-id-1\\",\\"version\\":\\"WzAsMV0=\\"}]: Error: Invalid value \\"null\\" supplied for the following required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -1460,27 +1460,8 @@ describe('utils', () => {
       ).toEqual(customFieldsToTest);
     });
 
-    it('updates null required custom fields to their default value', () => {
-      expect(
-        fillMissingCustomFields({
-          customFields: [
-            customFields[0],
-            customFields[1],
-            { ...customFields[2], value: null },
-            { ...customFields[3], value: null },
-          ],
-          customFieldsConfiguration,
-        })
-      ).toEqual(customFields);
-    });
-
-    it('does not update null required custom fields if default value is null', () => {
-      const customFieldsToTest = [
-        customFields[0],
-        customFields[1],
-        { ...customFields[2], value: null },
-        { ...customFields[3], value: null },
-      ] as CaseCustomFields;
+    it('does not insert missing required custom fields if default value is null', () => {
+      const customFieldsToTest = [customFields[0], customFields[1]] as CaseCustomFields;
 
       expect(
         fillMissingCustomFields({
@@ -1495,13 +1476,8 @@ describe('utils', () => {
       ).toEqual(customFieldsToTest);
     });
 
-    it('does not update null required custom fields if default value is undefined', () => {
-      const customFieldsToTest = [
-        customFields[0],
-        customFields[1],
-        { ...customFields[2], value: null },
-        { ...customFields[3], value: null },
-      ] as CaseCustomFields;
+    it('does not insert missing required custom fields if default value is undefined', () => {
+      const customFieldsToTest = [customFields[0], customFields[1]] as CaseCustomFields;
 
       expect(
         fillMissingCustomFields({

--- a/x-pack/plugins/cases/server/client/cases/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.test.ts
@@ -32,7 +32,7 @@ import {
   fillMissingCustomFields,
   normalizeCreateCaseRequest,
 } from './utils';
-import type { CaseCustomFields } from '../../../common/types/domain';
+import type { CaseCustomFields, CustomFieldsConfiguration } from '../../../common/types/domain';
 import {
   CaseStatuses,
   CustomFieldTypes,
@@ -1363,9 +1363,24 @@ describe('utils', () => {
         type: CustomFieldTypes.TEXT,
         value: 'this is a text field value',
       },
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        value: null,
+      },
+      {
+        key: 'third_key',
+        type: CustomFieldTypes.TEXT,
+        value: 'default value',
+      },
+      {
+        key: 'fourth_key',
+        type: CustomFieldTypes.TOGGLE,
+        value: false,
+      },
     ];
 
-    const customFieldsConfiguration = [
+    const customFieldsConfiguration: CustomFieldsConfiguration = [
       {
         key: 'first_key',
         type: CustomFieldTypes.TEXT,
@@ -1378,59 +1393,141 @@ describe('utils', () => {
         label: 'foo',
         required: false,
       },
+      {
+        key: 'third_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'foo',
+        required: true,
+        defaultValue: 'default value',
+      },
+      {
+        key: 'fourth_key',
+        type: CustomFieldTypes.TOGGLE,
+        label: 'foo',
+        required: true,
+        defaultValue: false,
+      },
     ];
 
     it('adds missing custom fields correctly', () => {
       expect(
         fillMissingCustomFields({
-          customFields,
+          customFields: [customFields[0]],
           customFieldsConfiguration,
         })
+      ).toEqual(customFields);
+    });
+
+    it('does not use default value for optional custom fields', () => {
+      expect(
+        fillMissingCustomFields({
+          customFields: [],
+          customFieldsConfiguration: [
+            // @ts-ignore: expected
+            { ...customFieldsConfiguration[0], defaultValue: 'default value' },
+            // @ts-ignore: expected
+            { ...customFieldsConfiguration[1], defaultValue: true },
+          ],
+        })
       ).toEqual([
-        customFields[0],
-        {
-          key: 'second_key',
-          type: CustomFieldTypes.TOGGLE,
-          value: null,
-        },
+        { ...customFields[0], value: null },
+        { ...customFields[1], value: null },
       ]);
     });
 
-    it('does not set to null custom fields that exists', () => {
+    it('does not set to null custom fields that exist', () => {
+      expect(
+        fillMissingCustomFields({
+          customFields: [customFields[0], customFields[1]],
+          customFieldsConfiguration,
+        })
+      ).toEqual(customFields);
+    });
+
+    it('does not update existing required custom fields to their default value', () => {
+      const customFieldsToTest = [
+        customFields[0],
+        customFields[1],
+        { ...customFields[2], value: 'not the default' },
+        { ...customFields[3], value: true },
+      ] as CaseCustomFields;
+
+      expect(
+        fillMissingCustomFields({
+          customFields: customFieldsToTest,
+          customFieldsConfiguration,
+        })
+      ).toEqual(customFieldsToTest);
+    });
+
+    it('updates null required custom fields to their default value', () => {
       expect(
         fillMissingCustomFields({
           customFields: [
             customFields[0],
-            {
-              key: 'second_key',
-              type: CustomFieldTypes.TOGGLE,
-              value: true,
-            },
+            customFields[1],
+            { ...customFields[2], value: null },
+            { ...customFields[3], value: null },
           ],
           customFieldsConfiguration,
         })
-      ).toEqual([
+      ).toEqual(customFields);
+    });
+
+    it('does not update null required custom fields if default value is null', () => {
+      const customFieldsToTest = [
         customFields[0],
-        {
-          key: 'second_key',
-          type: CustomFieldTypes.TOGGLE,
-          value: true,
-        },
-      ]);
+        customFields[1],
+        { ...customFields[2], value: null },
+        { ...customFields[3], value: null },
+      ] as CaseCustomFields;
+
+      expect(
+        fillMissingCustomFields({
+          customFields: customFieldsToTest,
+          customFieldsConfiguration: [
+            customFieldsConfiguration[0],
+            customFieldsConfiguration[1],
+            { ...customFieldsConfiguration[2], defaultValue: null },
+            { ...customFieldsConfiguration[3], defaultValue: null },
+          ],
+        })
+      ).toEqual(customFieldsToTest);
+    });
+
+    it('does not update null required custom fields if default value is undefined', () => {
+      const customFieldsToTest = [
+        customFields[0],
+        customFields[1],
+        { ...customFields[2], value: null },
+        { ...customFields[3], value: null },
+      ] as CaseCustomFields;
+
+      expect(
+        fillMissingCustomFields({
+          customFields: customFieldsToTest,
+          customFieldsConfiguration: [
+            customFieldsConfiguration[0],
+            customFieldsConfiguration[1],
+            { ...customFieldsConfiguration[2], defaultValue: undefined },
+            { ...customFieldsConfiguration[3], defaultValue: undefined },
+          ],
+        })
+      ).toEqual(customFieldsToTest);
     });
 
     it('returns all custom fields if they are more than the configuration', () => {
       expect(
         fillMissingCustomFields({
           customFields: [
-            customFields[0],
+            ...customFields,
             {
-              key: 'second_key',
+              key: 'extra 1',
               type: CustomFieldTypes.TOGGLE,
               value: true,
             },
             {
-              key: 'third_key',
+              key: 'extra 2',
               type: CustomFieldTypes.TOGGLE,
               value: true,
             },
@@ -1438,21 +1535,21 @@ describe('utils', () => {
           customFieldsConfiguration,
         })
       ).toEqual([
-        customFields[0],
+        ...customFields,
         {
-          key: 'second_key',
+          key: 'extra 1',
           type: CustomFieldTypes.TOGGLE,
           value: true,
         },
         {
-          key: 'third_key',
+          key: 'extra 2',
           type: CustomFieldTypes.TOGGLE,
           value: true,
         },
       ]);
     });
 
-    it('adds missing custom fields if the customFields is undefined', () => {
+    it('adds missing custom fields if they are undefined', () => {
       expect(
         fillMissingCustomFields({
           customFieldsConfiguration,
@@ -1468,6 +1565,8 @@ describe('utils', () => {
           type: CustomFieldTypes.TOGGLE,
           value: null,
         },
+        customFields[2],
+        customFields[3],
       ]);
     });
 

--- a/x-pack/plugins/cases/server/client/cases/utils.ts
+++ b/x-pack/plugins/cases/server/client/cases/utils.ts
@@ -470,44 +470,30 @@ export const fillMissingCustomFields = ({
   const customFieldsKeys = new Set(customFields.map((customField) => customField.key));
   const missingCustomFields: CaseRequestCustomFields = [];
 
-  // update required custom fields that have value: null and a defaultValue
-  const updatedCustomFields = customFields.map((customField) => {
-    const customFieldConfiguration = customFieldsConfiguration.find(
-      (config) => config.key === customField.key
-    );
-    if (
-      customFieldConfiguration &&
-      customFieldConfiguration.required &&
-      customFieldConfiguration.defaultValue !== null &&
-      customFieldConfiguration.defaultValue !== undefined &&
-      customField.value === null
-    ) {
-      return {
-        key: customField.key,
-        type: customField.type,
-        value: customFieldConfiguration.defaultValue,
-      } as CaseCustomField;
-    }
-    return customField;
-  });
-
-  // add missing custom fields
+  // only populate with the default value required custom fields missing from the request
   for (const confCustomField of customFieldsConfiguration) {
     if (!customFieldsKeys.has(confCustomField.key)) {
-      missingCustomFields.push({
-        key: confCustomField.key,
-        type: confCustomField.type,
-        value:
-          confCustomField.required &&
-          confCustomField?.defaultValue !== null &&
-          confCustomField?.defaultValue !== undefined
-            ? confCustomField.defaultValue
-            : null,
-      } as CaseCustomField);
+      if (
+        confCustomField.required &&
+        confCustomField?.defaultValue !== null &&
+        confCustomField?.defaultValue !== undefined
+      ) {
+        missingCustomFields.push({
+          key: confCustomField.key,
+          type: confCustomField.type,
+          value: confCustomField.defaultValue,
+        } as CaseCustomField);
+      } else if (!confCustomField.required) {
+        missingCustomFields.push({
+          key: confCustomField.key,
+          type: confCustomField.type,
+          value: null,
+        } as CaseCustomField);
+      } // else, missing required custom fields without default are not touched
     }
   }
 
-  return [...updatedCustomFields, ...missingCustomFields];
+  return [...customFields, ...missingCustomFields];
 };
 
 export const normalizeCreateCaseRequest = (

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -469,7 +469,7 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields without default value configured: \\"missing field 2\\""`
+        `"Invalid value \\"null\\" supplied for the following required custom fields: \\"missing field 2\\""`
       );
     });
 
@@ -495,7 +495,7 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields without default value configured: \\"missing field 2\\""`
+        `"Invalid value \\"null\\" supplied for the following required custom fields: \\"missing field 2\\""`
       );
     });
 

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -353,6 +353,32 @@ describe('validators', () => {
       ).not.toThrow();
     });
 
+    it('does not throw if all missing required custom fields have default values', () => {
+      const customFieldsConfiguration: CustomFieldsConfiguration = [
+        {
+          key: 'first_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'foo',
+          required: true,
+          defaultValue: 'default value',
+        },
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'foo',
+          required: true,
+          defaultValue: false,
+        },
+      ];
+
+      expect(() =>
+        validateRequiredCustomFields({
+          requestCustomFields: [],
+          customFieldsConfiguration,
+        })
+      ).not.toThrow();
+    });
+
     it('does not throw if there are only optional custom fields in configuration', () => {
       const customFieldsConfiguration: CustomFieldsConfiguration = [
         {
@@ -380,7 +406,7 @@ describe('validators', () => {
       expect(() => validateRequiredCustomFields({})).not.toThrow();
     });
 
-    it('throws if there are missing required custom fields', () => {
+    it('throws if there are missing required custom fields without a default value', () => {
       const requestCustomFields: CaseCustomFields = [
         {
           key: 'second_key',
@@ -401,6 +427,13 @@ describe('validators', () => {
           label: 'foo',
           required: true,
         },
+        {
+          key: 'third_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'foo',
+          required: true,
+          defaultValue: 'default value',
+        },
       ];
       expect(() =>
         validateRequiredCustomFields({
@@ -408,11 +441,11 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields: \\"missing field 1\\""`
+        `"Missing required custom fields without default value configured: \\"missing field 1\\""`
       );
     });
 
-    it('throws if required custom fields have null value', () => {
+    it('throws if required custom fields(without default) have null value', () => {
       const requestCustomFields: CaseCustomFields = [
         {
           key: 'second_key',
@@ -421,12 +454,6 @@ describe('validators', () => {
         },
       ];
       const customFieldsConfiguration: CustomFieldsConfiguration = [
-        {
-          key: 'first_key',
-          type: CustomFieldTypes.TEXT,
-          label: 'missing field 1',
-          required: true,
-        },
         {
           key: 'second_key',
           type: CustomFieldTypes.TOGGLE,
@@ -440,7 +467,7 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields: \\"missing field 1\\", \\"missing field 2\\""`
+        `"Missing required custom fields without default value configured: \\"missing field 2\\""`
       );
     });
 
@@ -459,12 +486,18 @@ describe('validators', () => {
       ).toThrowErrorMatchingInlineSnapshot(`"No custom fields configured."`);
     });
 
-    it('throws if configuration has required fields but request has no custom fields', () => {
+    it('throws if all missing required custom fields do not have default values', () => {
       const customFieldsConfiguration: CustomFieldsConfiguration = [
         {
           key: 'first_key',
           type: CustomFieldTypes.TEXT,
           label: 'missing field 1',
+          required: true,
+        },
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'foo',
           required: true,
         },
       ];
@@ -473,7 +506,32 @@ describe('validators', () => {
           customFieldsConfiguration,
         })
       ).toThrowErrorMatchingInlineSnapshot(
-        `"Missing required custom fields: \\"missing field 1\\""`
+        `"Missing required custom fields without default value configured: \\"missing field 1\\", \\"foo\\""`
+      );
+    });
+
+    it('throws if some missing required custom fields do not have default values', () => {
+      const customFieldsConfiguration: CustomFieldsConfiguration = [
+        {
+          key: 'first_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'missing field 1',
+          required: true,
+          defaultValue: 'default value',
+        },
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'foo',
+          required: true,
+        },
+      ];
+      expect(() =>
+        validateRequiredCustomFields({
+          customFieldsConfiguration,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Missing required custom fields without default value configured: \\"foo\\""`
       );
     });
   });

--- a/x-pack/plugins/cases/server/client/cases/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.test.ts
@@ -426,6 +426,7 @@ describe('validators', () => {
           type: CustomFieldTypes.TOGGLE,
           label: 'foo',
           required: true,
+          defaultValue: null,
         },
         {
           key: 'third_key',
@@ -445,7 +446,34 @@ describe('validators', () => {
       );
     });
 
-    it('throws if required custom fields(without default) have null value', () => {
+    it('throws if required custom fields with default have null value', () => {
+      const requestCustomFields: CaseCustomFields = [
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          value: null,
+        },
+      ];
+      const customFieldsConfiguration: CustomFieldsConfiguration = [
+        {
+          key: 'second_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'missing field 2',
+          required: true,
+          defaultValue: true,
+        },
+      ];
+      expect(() =>
+        validateRequiredCustomFields({
+          requestCustomFields,
+          customFieldsConfiguration,
+        })
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"Missing required custom fields without default value configured: \\"missing field 2\\""`
+      );
+    });
+
+    it('throws if required custom fields without default have null value', () => {
       const requestCustomFields: CaseCustomFields = [
         {
           key: 'second_key',
@@ -493,6 +521,7 @@ describe('validators', () => {
           type: CustomFieldTypes.TEXT,
           label: 'missing field 1',
           required: true,
+          defaultValue: null,
         },
         {
           key: 'second_key',

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -121,9 +121,7 @@ export const validateRequiredCustomFields = ({
   }
 
   const requiredCustomFields = customFieldsConfiguration.filter(
-    (customField) =>
-      customField.required &&
-      (customField.defaultValue === undefined || customField.defaultValue === null)
+    (customField) => customField.required
   );
 
   if (!requiredCustomFields.length) {
@@ -133,14 +131,19 @@ export const validateRequiredCustomFields = ({
   const missingRequiredCustomFields = differenceWith(
     requiredCustomFields,
     requestCustomFields ?? [],
-    (requiredVal, requestedVal) => requiredVal.key === requestedVal.key
-  ).map((e) => `"${e.label}"`);
+    (configuration, request) => configuration.key === request.key
+  ) // missing custom field and missing defaultValue -> error
+    .filter(
+      (customField) => customField.defaultValue === undefined || customField.defaultValue === null
+    )
+    .map((e) => `"${e.label}"`);
 
   requiredCustomFields.forEach((requiredField) => {
     const found = requestCustomFields?.find(
       (requestField) => requestField.key === requiredField.key
     );
 
+    // required custom fields cannot be set to null
     if (found && found.value === null) {
       missingRequiredCustomFields.push(`"${requiredField.label}"`);
     }

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -106,6 +106,7 @@ export const validateCustomFieldKeysAgainstConfiguration = ({
 
 /**
  * Returns a list of required custom fields missing from the request
+ * that don't have a default value configured.
  */
 export const validateRequiredCustomFields = ({
   requestCustomFields,
@@ -120,7 +121,9 @@ export const validateRequiredCustomFields = ({
   }
 
   const requiredCustomFields = customFieldsConfiguration.filter(
-    (customField) => customField.required
+    (customField) =>
+      customField.required &&
+      (customField.defaultValue === undefined || customField.defaultValue === null)
   );
 
   if (!requiredCustomFields.length) {
@@ -145,7 +148,9 @@ export const validateRequiredCustomFields = ({
 
   if (missingRequiredCustomFields.length) {
     throw Boom.badRequest(
-      `Missing required custom fields: ${missingRequiredCustomFields.join(', ')}`
+      `Missing required custom fields without default value configured: ${missingRequiredCustomFields.join(
+        ', '
+      )}`
     );
   }
 };

--- a/x-pack/plugins/cases/server/client/cases/validators.ts
+++ b/x-pack/plugins/cases/server/client/cases/validators.ts
@@ -138,20 +138,28 @@ export const validateRequiredCustomFields = ({
     )
     .map((e) => `"${e.label}"`);
 
-  requiredCustomFields.forEach((requiredField) => {
-    const found = requestCustomFields?.find(
-      (requestField) => requestField.key === requiredField.key
-    );
-
-    // required custom fields cannot be set to null
-    if (found && found.value === null) {
-      missingRequiredCustomFields.push(`"${requiredField.label}"`);
-    }
-  });
-
   if (missingRequiredCustomFields.length) {
     throw Boom.badRequest(
       `Missing required custom fields without default value configured: ${missingRequiredCustomFields.join(
+        ', '
+      )}`
+    );
+  }
+
+  const nullRequiredCustomFields = requiredCustomFields
+    .filter((requiredField) => {
+      const found = requestCustomFields?.find(
+        (requestField) => requestField.key === requiredField.key
+      );
+
+      // required custom fields cannot be set to null
+      return found && found.value === null;
+    })
+    .map((e) => `"${e.label}"`);
+
+  if (nullRequiredCustomFields.length) {
+    throw Boom.badRequest(
+      `Invalid value "null" supplied for the following required custom fields: ${nullRequiredCustomFields.join(
         ', '
       )}`
     );

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -1217,7 +1217,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it('patches required custom fields with null using the default value', async () => {
+        it('400s trying to patch required custom fields with value: null', async () => {
           await createConfiguration(
             supertest,
             getConfigurationRequest({
@@ -1271,7 +1271,7 @@ export default ({ getService }: FtrProviderContext): void => {
             },
           ];
 
-          const patchedCases = await updateCase({
+          await updateCase({
             supertest,
             params: {
               cases: [
@@ -1282,12 +1282,8 @@ export default ({ getService }: FtrProviderContext): void => {
                 },
               ],
             },
+            expectedHttpCode: 400,
           });
-
-          expect(patchedCases[0].customFields).to.eql([
-            { ...patchedCustomFields[0], value: 'default value' },
-            { ...patchedCustomFields[1], value: false },
-          ]);
         });
 
         it('400s when trying to patch a case with a custom field with the wrong type', async () => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/patch_cases.ts
@@ -11,6 +11,7 @@ import { ALERT_WORKFLOW_STATUS } from '@kbn/rule-data-utils';
 import { DETECTION_ENGINE_QUERY_SIGNALS_URL } from '@kbn/security-solution-plugin/common/constants';
 import {
   AttachmentType,
+  CaseCustomFields,
   Cases,
   CaseSeverity,
   CaseStatuses,
@@ -1154,17 +1155,24 @@ export default ({ getService }: FtrProviderContext): void => {
           });
         });
 
-        it('400s when trying to patch a case with a missing required custom field', async () => {
+        it('patches a case with missing required custom fields to their default values', async () => {
           await createConfiguration(
             supertest,
             getConfigurationRequest({
               overrides: {
                 customFields: [
                   {
-                    key: 'test_custom_field',
+                    key: 'text_custom_field',
                     label: 'text',
                     type: CustomFieldTypes.TEXT,
-                    defaultValue: 'foobar',
+                    defaultValue: 'default value',
+                    required: true,
+                  },
+                  {
+                    key: 'toggle_custom_field',
+                    label: 'toggle',
+                    type: CustomFieldTypes.TOGGLE,
+                    defaultValue: false,
                     required: true,
                   },
                 ],
@@ -1172,18 +1180,25 @@ export default ({ getService }: FtrProviderContext): void => {
             })
           );
 
+          const originalValues = [
+            {
+              key: 'text_custom_field',
+              type: CustomFieldTypes.TEXT,
+              value: 'hello',
+            },
+            {
+              key: 'toggle_custom_field',
+              type: CustomFieldTypes.TOGGLE,
+              value: true,
+            },
+          ] as CaseCustomFields;
+
           const postedCase = await createCase(supertest, {
             ...postCaseReq,
-            customFields: [
-              {
-                key: 'test_custom_field',
-                type: CustomFieldTypes.TEXT,
-                value: 'hello',
-              },
-            ],
+            customFields: originalValues,
           });
 
-          await updateCase({
+          const patchedCases = await updateCase({
             supertest,
             params: {
               cases: [
@@ -1194,22 +1209,33 @@ export default ({ getService }: FtrProviderContext): void => {
                 },
               ],
             },
-            expectedHttpCode: 400,
           });
+
+          expect(patchedCases[0].customFields).to.eql([
+            { ...originalValues[0], value: 'default value' },
+            { ...originalValues[1], value: false },
+          ]);
         });
 
-        it('400s when trying to patch a case with a required custom field with null value', async () => {
+        it('patches required custom fields with null using the default value', async () => {
           await createConfiguration(
             supertest,
             getConfigurationRequest({
               overrides: {
                 customFields: [
                   {
-                    key: 'test_custom_field',
+                    key: 'text_custom_field',
                     label: 'text',
                     type: CustomFieldTypes.TEXT,
-                    defaultValue: 'foobar',
                     required: true,
+                    defaultValue: 'default value',
+                  },
+                  {
+                    key: 'toggle_custom_field',
+                    label: 'toggle',
+                    type: CustomFieldTypes.TOGGLE,
+                    required: true,
+                    defaultValue: false,
                   },
                 ],
               },
@@ -1220,33 +1246,50 @@ export default ({ getService }: FtrProviderContext): void => {
             ...postCaseReq,
             customFields: [
               {
-                key: 'test_custom_field',
+                key: 'text_custom_field',
                 type: CustomFieldTypes.TEXT,
-                value: 'hello',
+                value: 'not default',
+              },
+              {
+                key: 'toggle_custom_field',
+                type: CustomFieldTypes.TOGGLE,
+                value: true,
               },
             ],
           });
 
-          await updateCase({
+          const patchedCustomFields = [
+            {
+              key: 'text_custom_field',
+              type: CustomFieldTypes.TEXT,
+              value: null,
+            },
+            {
+              key: 'toggle_custom_field',
+              type: CustomFieldTypes.TOGGLE,
+              value: null,
+            },
+          ];
+
+          const patchedCases = await updateCase({
             supertest,
             params: {
               cases: [
                 {
                   id: postedCase.id,
                   version: postedCase.version,
-                  customFields: [
-                    {
-                      key: 'test_custom_field',
-                      type: CustomFieldTypes.TEXT,
-                      value: null,
-                    },
-                  ],
+                  customFields: patchedCustomFields,
                 },
               ],
             },
-            expectedHttpCode: 400,
           });
+
+          expect(patchedCases[0].customFields).to.eql([
+            { ...patchedCustomFields[0], value: 'default value' },
+            { ...patchedCustomFields[1], value: false },
+          ]);
         });
+
         it('400s when trying to patch a case with a custom field with the wrong type', async () => {
           await createConfiguration(
             supertest,

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -531,7 +531,7 @@ export default ({ getService }: FtrProviderContext): void => {
           ]);
         });
 
-        it('creates a case with required custom fields set to null and default values', async () => {
+        it('400s trying to create a case with required custom fields set to null', async () => {
           const customFieldsConfiguration = [
             {
               key: 'text_custom_field',
@@ -558,7 +558,7 @@ export default ({ getService }: FtrProviderContext): void => {
             })
           );
 
-          const createdCase = await createCase(
+          await createCase(
             supertest,
             getPostCaseRequest({
               customFields: [
@@ -573,21 +573,9 @@ export default ({ getService }: FtrProviderContext): void => {
                   value: null,
                 },
               ],
-            })
+            }),
+            400
           );
-
-          expect(createdCase.customFields).to.eql([
-            {
-              key: customFieldsConfiguration[0].key,
-              type: customFieldsConfiguration[0].type,
-              value: 'default value',
-            },
-            {
-              key: customFieldsConfiguration[1].key,
-              type: customFieldsConfiguration[1].type,
-              value: false,
-            },
-          ]);
         });
 
         it('400s when trying to create case with a custom field with the wrong type', async () => {

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/cases/post_case.ts
@@ -484,62 +484,81 @@ export default ({ getService }: FtrProviderContext): void => {
           );
         });
 
-        it('400s when creating a case with a missing required custom field', async () => {
+        it('creates a case with missing required custom fields and default values', async () => {
+          const customFieldsConfiguration = [
+            {
+              key: 'text_custom_field',
+              label: 'text',
+              type: CustomFieldTypes.TEXT,
+              required: true,
+              defaultValue: 'default value',
+            },
+            {
+              key: 'toggle_custom_field',
+              label: 'toggle',
+              type: CustomFieldTypes.TOGGLE,
+              defaultValue: false,
+              required: true,
+            },
+          ];
+
           await createConfiguration(
             supertest,
             getConfigurationRequest({
               overrides: {
-                customFields: [
-                  {
-                    key: 'text_custom_field',
-                    label: 'text',
-                    type: CustomFieldTypes.TEXT,
-                    required: false,
-                  },
-                  {
-                    key: 'toggle_custom_field',
-                    label: 'toggle',
-                    type: CustomFieldTypes.TOGGLE,
-                    defaultValue: false,
-                    required: true,
-                  },
-                ],
+                customFields: customFieldsConfiguration,
               },
             })
           );
-          await createCase(
+          const createdCase = await createCase(
             supertest,
             getPostCaseRequest({
-              customFields: [
-                {
-                  key: 'text_custom_field',
-                  type: CustomFieldTypes.TEXT,
-                  value: 'a',
-                },
-              ],
-            }),
-            400
+              customFields: [],
+            })
           );
+
+          expect(createdCase.customFields).to.eql([
+            {
+              key: customFieldsConfiguration[0].key,
+              type: customFieldsConfiguration[0].type,
+              value: 'default value',
+            },
+            {
+              key: customFieldsConfiguration[1].key,
+              type: customFieldsConfiguration[1].type,
+              value: false,
+            },
+          ]);
         });
 
-        it('400s when trying to create case with a required custom field as null', async () => {
+        it('creates a case with required custom fields set to null and default values', async () => {
+          const customFieldsConfiguration = [
+            {
+              key: 'text_custom_field',
+              label: 'text',
+              type: CustomFieldTypes.TEXT,
+              required: true,
+              defaultValue: 'default value',
+            },
+            {
+              key: 'toggle_custom_field',
+              label: 'toggle',
+              type: CustomFieldTypes.TOGGLE,
+              defaultValue: false,
+              required: true,
+            },
+          ];
+
           await createConfiguration(
             supertest,
             getConfigurationRequest({
               overrides: {
-                customFields: [
-                  {
-                    key: 'text_custom_field',
-                    label: 'text',
-                    type: CustomFieldTypes.TEXT,
-                    defaultValue: 'foobar',
-                    required: true,
-                  },
-                ],
+                customFields: customFieldsConfiguration,
               },
             })
           );
-          await createCase(
+
+          const createdCase = await createCase(
             supertest,
             getPostCaseRequest({
               customFields: [
@@ -548,10 +567,27 @@ export default ({ getService }: FtrProviderContext): void => {
                   type: CustomFieldTypes.TEXT,
                   value: null,
                 },
+                {
+                  key: 'toggle_custom_field',
+                  type: CustomFieldTypes.TOGGLE,
+                  value: null,
+                },
               ],
-            }),
-            400
+            })
           );
+
+          expect(createdCase.customFields).to.eql([
+            {
+              key: customFieldsConfiguration[0].key,
+              type: customFieldsConfiguration[0].type,
+              value: 'default value',
+            },
+            {
+              key: customFieldsConfiguration[1].key,
+              type: customFieldsConfiguration[1].type,
+              value: false,
+            },
+          ]);
         });
 
         it('400s when trying to create case with a custom field with the wrong type', async () => {


### PR DESCRIPTION
See https://github.com/elastic/kibana/issues/171747 for context.

## Summary

**Merging into a feature branch.**

Since the default value is now optional, this PR changed a bit.

### New logic for Create and Update case API

- `required` custom field missing from the request:
  - `default value` exists -> set custom field to the `default value`
  - `default value` missing from the configuration -> throws an error
- creating `required` custom fields with `value: null` -> always throws an error
- custom fields sent in the request will be populated as expected and are not affected by these logic changes