### PR TITLE
[8.12] Fallback to using api key id when name is not defined (#175733)

### DIFF
--- a/x-pack/plugins/security/server/routes/api_keys/get.test.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.test.ts
@@ -65,11 +65,15 @@ describe('Get API Keys route', () => {
     );
 
     expect(response.status).toBe(200);
-    expect(response.payload.apiKeys).toContainEqual({ id: '123', name: '', invalidated: false });
-    expect(response.payload.apiKeys).not.toContainEqual({ id: '456', name: '', invalidated: true });
+    expect(response.payload.apiKeys).toContainEqual({ id: '123', name: '123', invalidated: false });
+    expect(response.payload.apiKeys).not.toContainEqual({
+      id: '456',
+      name: '456',
+      invalidated: true,
+    });
   });
 
-  it('should substitute an empty string for keys with `null` names', async () => {
+  it('should substitute the API key id for keys with `null` names', async () => {
     esClientMock.asCurrentUser.security.getApiKey.mockRestore();
     esClientMock.asCurrentUser.security.getApiKey.mockResponse({
       api_keys: [
@@ -94,12 +98,12 @@ describe('Get API Keys route', () => {
       },
       {
         id: 'undefined_name',
-        name: '',
+        name: 'undefined_name',
         invalidated: false,
       },
       {
         id: 'null_name',
-        name: '',
+        name: 'null_name',
         invalidated: false,
       },
     ]);

--- a/x-pack/plugins/security/server/routes/api_keys/get.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.ts
@@ -70,7 +70,7 @@ export function defineGetApiKeysRoutes({
           .filter(({ invalidated }) => !invalidated)
           .map((key) => {
             if (!key.name) {
-              key.name = '';
+              key.name = key.id;
             }
             return key;
           });


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [Fallback to using api key id when name is not defined (#175733)](https://github.com/elastic/kibana/pull/175733)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Larry Gregory","email":"larry.gregory@elastic.co"},"sourceCommit":{"committedDate":"2024-01-26T22:34:05Z","message":"Fallback to using api key id when name is not defined (#175733)\n\nFollowup to https://github.com/elastic/kibana/pull/175721.\r\n\r\nPrefer using the key's `id` when `name` is not defined.","sha":"2cf9668d5d84448046154e0a070b587385b6fc35","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Security","Feature:Users/Roles/API Keys","release_note:skip","backport:prev-minor","v8.13.0"],"number":175733,"url":"https://github.com/elastic/kibana/pull/175733","mergeCommit":{"message":"Fallback to using api key id when name is not defined (#175733)\n\nFollowup to https://github.com/elastic/kibana/pull/175721.\r\n\r\nPrefer using the key's `id` when `name` is not defined.","sha":"2cf9668d5d84448046154e0a070b587385b6fc35"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/175733","number":175733,"mergeCommit":{"message":"Fallback to using api key id when name is not defined (#175733)\n\nFollowup to https://github.com/elastic/kibana/pull/175721.\r\n\r\nPrefer using the key's `id` when `name` is not defined.","sha":"2cf9668d5d84448046154e0a070b587385b6fc35"}}]}] BACKPORT-->