### PR TITLE
Partially revert yarn upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "engines": {
     "node": "20.10.0",
-    "yarn": "^1.22.21"
+    "yarn": "^1.22.19"
   },
   "resolutions": {
     "**/@hello-pangea/dnd": "16.2.0",


### PR DESCRIPTION
We upgraded bazel and the corepack version to 1.22.21.  We're seeing some issues upgrading the global version, and there isn't a strict need yet.  This sets engines.yarn back to ^1.22.19 to unblock areas having issues.

<!--ONMERGE {"backportTargets":["7.17","8.12"]} ONMERGE-->