### PR TITLE
Update copy for API Key management

### DIFF
--- a/docs/CHANGELOG.asciidoc
+++ b/docs/CHANGELOG.asciidoc
@@ -980,7 +980,7 @@ Alerting::
 APM::
 * Adds KQL filtering in APM rules ({kibana-pull}163825[#163825]).
 * Make service group saved objects exportable ({kibana-pull}163569[#163569]).
-* Added ability to manage Cross-Cluster API keys ({kibana-pull}162363[#162363]).
+* Added ability to manage cross-cluster API keys ({kibana-pull}162363[#162363]).
 * Enable Trace Explorer by default ({kibana-pull}162308[#162308]).
 * Adds error.grouping_name to group alerts in Error Count rule ({kibana-pull}161810[#161810]).
 * Adds query to check for overflow bucket in service groups ({kibana-pull}159990[#159990]).

--- a/docs/user/security/api-keys/index.asciidoc
+++ b/docs/user/security/api-keys/index.asciidoc
@@ -9,9 +9,9 @@ For example, if you extract data from an {es} cluster on a daily basis, you migh
 
 You can use {kib} to manage your different API keys:
 
-* Personal API key: allows external services to access the Elastic Stack on behalf of a user.
-* Cross-Cluster API key: allows remote clusters to connect to your local cluster.
-* Managed API key: created and managed by Kibana to correctly run background tasks.
+* User API key: allows external services to access the Elastic Stack on behalf of a user.
+* Cross-cluster API key: allows other clusters to connect to this cluster.
+* Managed API key: created and managed by Kibana to run background tasks.
 
 To manage API keys, open the main menu, then click *Stack Management > Security > API Keys*.
 
@@ -24,7 +24,7 @@ image:images/api-keys.png["API Keys UI"]
 
 * To use API keys in {kib}, you must have the `manage_security`, `manage_api_key`, or the `manage_own_api_key` cluster privileges.
 * To delete API keys, you must have the `manage_api_key` or `manage_own_api_key` privileges.
-* To create or update a *personal API key*, you must have the `manage_api_key` or the `manage_own_api_key` privilege.
+* To create or update a *user API key*, you must have the `manage_api_key` or the `manage_own_api_key` privilege.
 * To create or update a *cross-cluster API key*, you must have the `manage_security` privilege and an Enterprise license.
 * To have a read-only view on the API keys, you must have access to the page and the `read_security` cluster privilege.
 
@@ -40,7 +40,7 @@ To create an API key, open the main menu, then click *Stack Management > Securit
 image:images/create-ccr-api-key.png["Create API Key UI"]
 
 
-Refer to the {ref}/security-api-create-api-key.html[create API key] documentation to learn more about creating personal API keys.
+Refer to the {ref}/security-api-create-api-key.html[create API key] documentation to learn more about creating user API keys.
 
 Refer to the {ref}/security-api-create-cross-cluster-api-key.html[create cross-cluster API key] documentation to learn more about creating cross-cluster API keys.
 
@@ -50,7 +50,7 @@ Refer to the {ref}/security-api-create-cross-cluster-api-key.html[create cross-c
 
 To update an API key, open the main menu, click *Stack Management > Security > API Keys*, and then click on the name of the key. You cannot update the name or the type of API key.
 
-Refer to the {ref}/security-api-update-api-key.html[update API key] documentation to learn more about updating personal API keys.
+Refer to the {ref}/security-api-update-api-key.html[update API key] documentation to learn more about updating user API keys.
 
 Refer to the {ref}/security-api-update-cross-cluster-api-key.html[update cross-cluster API key] documentation to learn more about updating cross-cluster API keys.
 

--- a/x-pack/plugins/security/common/model/api_key.ts
+++ b/x-pack/plugins/security/common/model/api_key.ts
@@ -22,7 +22,7 @@ export interface RestApiKey extends BaseApiKey {
 }
 
 /**
- * Interface representing a Cross-Cluster API key the way it is returned by Elasticsearch GET endpoint.
+ * Interface representing a cross-cluster API key the way it is returned by Elasticsearch GET endpoint.
  *
  * TODO: Remove this type when `@elastic/elasticsearch` has been updated.
  */

--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_key_flyout.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_key_flyout.tsx
@@ -282,7 +282,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                       title={
                         <FormattedMessage
                           id="xpack.security.accountManagement.apiKeyFlyout.readonlyOwnedByOtherUserWarning"
-                          defaultMessage="You cannot update this API key, since it is owned by another user."
+                          defaultMessage="You can’t update this API key. It belongs to another user."
                         />
                       }
                     />
@@ -295,7 +295,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                       title={
                         <FormattedMessage
                           id="xpack.security.accountManagement.apiKeyFlyout.readonlyExpiredWarning"
-                          defaultMessage="You cannot update this API key, since it has already expired."
+                          defaultMessage="This API key has expired. You can no longer update it."
                         />
                       }
                     />
@@ -451,7 +451,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                                     <h2>
                                       <FormattedMessage
                                         id="xpack.security.accountManagement.apiKeyFlyout.restTypeLabel"
-                                        defaultMessage="Personal API key"
+                                        defaultMessage="User API key"
                                       />
                                     </h2>
                                   </EuiTitle>
@@ -477,7 +477,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                                     <h2>
                                       <FormattedMessage
                                         id="xpack.security.accountManagement.apiKeyFlyout.crossClusterTypeLabel"
-                                        defaultMessage="Cross-Cluster API key"
+                                        defaultMessage="Cross-cluster API key"
                                       />
                                     </h2>
                                   </EuiTitle>
@@ -485,7 +485,7 @@ export const ApiKeyFlyout: FunctionComponent<ApiKeyFlyoutProps> = ({
                                   <EuiText size="s">
                                     <FormattedMessage
                                       id="xpack.security.accountManagement.apiKeyFlyout.crossClusterTypeDescription"
-                                      defaultMessage="Allow remote clusters to connect to your local cluster."
+                                      defaultMessage="Allow other clusters to connect to this cluster."
                                     />
                                   </EuiText>
                                 </>

--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -159,7 +159,7 @@ export const APIKeysGridPage: FunctionComponent = () => {
             description={
               <FormattedMessage
                 id="xpack.security.management.apiKeys.table.apiKeysAllDescription"
-                defaultMessage="Allow external services to access the Elastic Stack on behalf of a user."
+                defaultMessage="Allow external services to access your Elastic Stack."
               />
             }
             rightSideItems={
@@ -571,7 +571,7 @@ export const TypesFilterButton: FunctionComponent<TypesFilterButtonProps> = ({
         >
           <FormattedMessage
             id="xpack.security.accountManagement.apiKeyBadge.restTitle"
-            defaultMessage="Personal"
+            defaultMessage="User"
           />
         </EuiFilterButton>
       ) : null}
@@ -593,7 +593,7 @@ export const TypesFilterButton: FunctionComponent<TypesFilterButtonProps> = ({
         >
           <FormattedMessage
             id="xpack.security.accountManagement.apiKeyBadge.crossClusterLabel"
-            defaultMessage="Cross-Cluster"
+            defaultMessage="Cross-cluster"
           />
         </EuiFilterButton>
       ) : null}
@@ -786,7 +786,7 @@ export const ApiKeyBadge: FunctionComponent<ApiKeyBadgeProps> = ({ type }) => {
       <EuiBadge color="hollow" iconType="cluster">
         <FormattedMessage
           id="xpack.security.accountManagement.apiKeyBadge.crossClusterLabel"
-          defaultMessage="Cross-Cluster"
+          defaultMessage="Cross-cluster"
         />
       </EuiBadge>
     </EuiToolTip>
@@ -818,7 +818,7 @@ export const ApiKeyBadge: FunctionComponent<ApiKeyBadgeProps> = ({ type }) => {
       <EuiBadge color="hollow" iconType="user">
         <FormattedMessage
           id="xpack.security.accountManagement.apiKeyBadge.restTitle"
-          defaultMessage="Personal"
+          defaultMessage="User"
         />
       </EuiBadge>
     </EuiToolTip>

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.test.ts
@@ -259,7 +259,7 @@ describe('API Keys', () => {
       });
     });
 
-    it('creates Cross-Cluster API key when type is `cross_cluster`', async () => {
+    it('creates cross-cluster API key when type is `cross_cluster`', async () => {
       mockLicense.isEnabled.mockReturnValue(true);
 
       mockScopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({
@@ -388,7 +388,7 @@ describe('API Keys', () => {
       });
     });
 
-    it('updates Cross-Cluster API key when type is `cross_cluster`', async () => {
+    it('updates cross-cluster API key when type is `cross_cluster`', async () => {
       mockLicense.isEnabled.mockReturnValue(true);
 
       mockScopedClusterClient.asCurrentUser.transport.request.mockResolvedValueOnce({

--- a/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
+++ b/x-pack/plugins/security/server/authentication/api_keys/api_keys.ts
@@ -113,7 +113,7 @@ export class APIKeys implements APIKeysType {
   }
 
   /**
-   * Determines if Cross-Cluster API Keys are enabled in Elasticsearch.
+   * Determines if cross-cluster API Keys are enabled in Elasticsearch.
    */
   async areCrossClusterAPIKeysEnabled(): Promise<boolean> {
     if (!this.license.isEnabled()) {
@@ -123,14 +123,14 @@ export class APIKeys implements APIKeysType {
     const id = 'kibana-api-key-service-test';
 
     this.logger.debug(
-      `Testing if Cross-Cluster API Keys are enabled by attempting to update a non-existant key: ${id}`
+      `Testing if cross-cluster API Keys are enabled by attempting to update a non-existant key: ${id}`
     );
 
     try {
       await this.clusterClient.asInternalUser.transport.request({
         method: 'PUT',
         path: `/_security/cross_cluster/api_key/${id}`,
-        body: {}, // We are sending an empty request body and expect a validation error if Update Cross-Cluster API key endpoint is available.
+        body: {}, // We are sending an empty request body and expect a validation error if Update cross-cluster API key endpoint is available.
       });
       return false;
     } catch (error) {
@@ -143,7 +143,7 @@ export class APIKeys implements APIKeysType {
    *
    * Returns newly created API key or `null` if API keys are disabled.
    *
-   * User needs `manage_api_key` privilege to create REST API keys and `manage_security` for Cross-Cluster API keys.
+   * User needs `manage_api_key` privilege to create REST API keys and `manage_security` for cross-cluster API keys.
    *
    * @param request Request instance.
    * @param createParams The params to create an API key
@@ -199,7 +199,7 @@ export class APIKeys implements APIKeysType {
    *
    * Returns `updated`, `true` if the update was successful, `false` if there was nothing to update
    *
-   * User needs `manage_api_key` privilege to update REST API keys and `manage_security` for Cross-Cluster API keys.
+   * User needs `manage_api_key` privilege to update REST API keys and `manage_security` for cross-cluster API keys.
    *
    * @param request Request instance.
    * @param updateParams The params to edit an API key

--- a/x-pack/plugins/security/server/routes/api_keys/get.ts
+++ b/x-pack/plugins/security/server/routes/api_keys/get.ts
@@ -77,7 +77,7 @@ export function defineGetApiKeysRoutes({
 
         return response.ok<GetAPIKeysResult>({
           body: {
-            // @ts-expect-error Elasticsearch client types do not know about Cross-Cluster API keys yet.
+            // @ts-expect-error Elasticsearch client types do not know about cross-cluster API keys yet.
             apiKeys: validKeys,
             canManageCrossClusterApiKeys:
               clusterPrivileges.manage_security && areCrossClusterApiKeysEnabled,


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/166095.

This updates the API Key management screen to reflect the copy adjustments described in #166095:

1. Change `Cross-Cluster` to `Cross-cluster`, unless it is mid-sentence in which case `cross-cluster` should be used.
2. Updated ownership & expiry warnings to use the active voice.
3. Renamed `Personal` API Keys to `User` API Keys.


![Larry Gregory 2024-01-29 at 10 12 45@2x](https://github.com/elastic/kibana/assets/3493255/8df4e279-5d68-4353-87aa-e40e6949f528)

![Larry Gregory 2024-01-29 at 10 14 02@2x](https://github.com/elastic/kibana/assets/3493255/290166ea-51a3-43ae-bed4-7278865b1bdc)

![Larry Gregory 2024-01-29 at 10 15 03@2x](https://github.com/elastic/kibana/assets/3493255/97bb6426-e8ce-4bc1-b5ae-44944683978f)


![Larry Gregory 2024-01-29 at 10 15 27@2x](https://github.com/elastic/kibana/assets/3493255/61adfece-05eb-4fbc-bf68-265d5cfaa987)


View docs changes here: https://kibana_bk_175809.docs-preview.app.elstc.co/diff

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->