### PR TITLE
Fix API Key table sorting

### DIFF
--- a/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/api_keys/api_keys_grid/api_keys_grid_page.tsx
@@ -353,12 +353,9 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
     },
     {
       field: 'type',
-      name: (
-        <FormattedMessage
-          id="xpack.security.management.apiKeys.table.typeColumnName"
-          defaultMessage="Type"
-        />
-      ),
+      name: i18n.translate('xpack.security.management.apiKeys.table.typeColumnName', {
+        defaultMessage: 'Type',
+      }),
       sortable: true,
       render: (type: CategorizedApiKey['type']) => <ApiKeyBadge type={type} />,
     }
@@ -367,12 +364,9 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
   if (canManageApiKeys || usernameFilters.length > 1) {
     columns.push({
       field: 'username',
-      name: (
-        <FormattedMessage
-          id="xpack.security.management.apiKeys.table.ownerColumnName"
-          defaultMessage="Owner"
-        />
-      ),
+      name: i18n.translate('xpack.security.management.apiKeys.table.ownerColumnName', {
+        defaultMessage: 'Owner',
+      }),
       sortable: true,
       render: (username: CategorizedApiKey['username']) => <UsernameWithIcon username={username} />,
     });
@@ -381,12 +375,9 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
   columns.push(
     {
       field: 'creation',
-      name: (
-        <FormattedMessage
-          id="xpack.security.management.apiKeys.table.createdColumnName"
-          defaultMessage="Created"
-        />
-      ),
+      name: i18n.translate('xpack.security.management.apiKeys.table.createdColumnName', {
+        defaultMessage: 'Created',
+      }),
       sortable: true,
       mobileOptions: {
         show: false,
@@ -406,12 +397,9 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
     },
     {
       field: 'expiration',
-      name: (
-        <FormattedMessage
-          id="xpack.security.management.apiKeys.table.statusColumnName"
-          defaultMessage="Status"
-        />
-      ),
+      name: i18n.translate('xpack.security.management.apiKeys.table.statusColumnName', {
+        defaultMessage: 'Status',
+      }),
       sortable: true,
       render: (expiration: number) => <ApiKeyStatus expiration={expiration} />,
     }
@@ -422,12 +410,9 @@ export const ApiKeysTable: FunctionComponent<ApiKeysTableProps> = ({
       width: `${24 + 2 * 8}px`,
       actions: [
         {
-          name: (
-            <FormattedMessage
-              id="xpack.security.management.apiKeys.table.deleteAction"
-              defaultMessage="Delete"
-            />
-          ),
+          name: i18n.translate('xpack.security.management.apiKeys.table.deleteAction', {
+            defaultMessage: 'Delete',
+          }),
           description: i18n.translate('xpack.security.management.apiKeys.table.deleteDescription', {
             defaultMessage: 'Delete this API key',
           }),


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/173862.

EUI's [documentation](https://eui.elastic.co/#/tabular-content/in-memory-tables) for the `EuiInMemoryTable` component states:

> EuiMemoryTable relies on referential equality of a column's name
> 
> EuiMemoryTable relies on referential equality of a column's name field when sorting by that column. For example, if a JSX element is created for the name every render it appears different to the table and prevents sorting. Instead, that value needs to be lifted outside of the render method and preserved between renders. 


Our column names had a mix of strings and `FormattedMessage` components. This PR updates the column definitions to always use strings, in order to support the aforementioned referential equality checks.

https://github.com/elastic/kibana/assets/3493255/79071373-33ff-4d3b-8857-f4ee49022869





<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->