### PR TITLE
[8.12] [Fleet] Use correctly space scoped SO client when tagging saved objects (#173860)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.test.ts
@@ -28,6 +28,11 @@ import * as obj from '.';
 
 jest.mock('../../app_context', () => {
   const logger = { error: jest.fn(), debug: jest.fn(), warn: jest.fn(), info: jest.fn() };
+  const mockedSavedObjectTagging = {
+    createInternalAssignmentService: jest.fn(),
+    createTagClient: jest.fn(),
+  };
+
   return {
     appContextService: {
       getLogger: jest.fn(() => {
@@ -38,13 +43,12 @@ jest.mock('../../app_context', () => {
         createImporter: jest.fn(),
       })),
       getConfig: jest.fn(() => ({})),
-      getSavedObjectsTagging: jest.fn(() => ({
-        createInternalAssignmentService: jest.fn(),
-        createTagClient: jest.fn(),
-      })),
+      getSavedObjectsTagging: jest.fn(() => mockedSavedObjectTagging),
+      getInternalUserSOClientForSpaceId: jest.fn(),
     },
   };
 });
+
 jest.mock('.');
 jest.mock('../registry', () => {
   return {
@@ -145,6 +149,7 @@ describe('install', () => {
 
     mockGetBundledPackageByPkgKey.mockReset();
     (install._installPackage as jest.Mock).mockClear();
+    jest.mocked(appContextService.getInternalUserSOClientForSpaceId).mockReset();
   });
 
   describe('registry', () => {
@@ -347,6 +352,38 @@ describe('install', () => {
       });
 
       expect(response.status).toEqual('installed');
+    });
+
+    it('should use a scopped to package space soClient for tagging', async () => {
+      const mockedTaggingSo = savedObjectsClientMock.create();
+      jest
+        .mocked(appContextService.getInternalUserSOClientForSpaceId)
+        .mockReturnValue(mockedTaggingSo);
+      jest
+        .spyOn(obj, 'getInstallationObject')
+        .mockImplementationOnce(() => Promise.resolve({ attributes: { version: '1.2.0' } } as any));
+      jest.spyOn(licenseService, 'hasAtLeast').mockReturnValue(true);
+      await installPackage({
+        spaceId: 'test',
+        installSource: 'registry',
+        pkgkey: 'apache-1.3.0',
+        savedObjectsClient: savedObjectsClientMock.create(),
+        esClient: {} as ElasticsearchClient,
+      });
+
+      expect(appContextService.getInternalUserSOClientForSpaceId).toBeCalledWith('test');
+      expect(appContextService.getSavedObjectsTagging().createTagClient).toBeCalledWith(
+        expect.objectContaining({
+          client: mockedTaggingSo,
+        })
+      );
+      expect(
+        appContextService.getSavedObjectsTagging().createInternalAssignmentService
+      ).toBeCalledWith(
+        expect.objectContaining({
+          client: mockedTaggingSo,
+        })
+      );
     });
   });
 

--- a/x-pack/plugins/fleet/server/services/epm/packages/install.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/install.ts
@@ -576,13 +576,16 @@ async function installPackageCommon(options: {
       .getSavedObjects()
       .createImporter(savedObjectsClient, { importSizeLimit: 15_000 });
 
+    // Saved object client need to be scopped with the package space for saved object tagging
+    const savedObjectClientWithSpace = appContextService.getInternalUserSOClientForSpaceId(spaceId);
+
     const savedObjectTagAssignmentService = appContextService
       .getSavedObjectsTagging()
-      .createInternalAssignmentService({ client: savedObjectsClient });
+      .createInternalAssignmentService({ client: savedObjectClientWithSpace });
 
     const savedObjectTagClient = appContextService
       .getSavedObjectsTagging()
-      .createTagClient({ client: savedObjectsClient });
+      .createTagClient({ client: savedObjectClientWithSpace });
 
     // try installing the package, if there was an error, call error handler and rethrow
     // @ts-expect-error status is string instead of InstallResult.status 'installed' | 'already_installed'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Fleet] Use correctly space scoped SO client when tagging saved objects (#173860)](https://github.com/elastic/kibana/pull/173860)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2024-01-02T13:56:27Z","message":"[Fleet] Use correctly space scoped SO client when tagging saved objects (#173860)","sha":"274134120a27fc8273c35c440c819ea1e2e1d5a7","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Fleet","v8.13.0"],"number":173860,"url":"https://github.com/elastic/kibana/pull/173860","mergeCommit":{"message":"[Fleet] Use correctly space scoped SO client when tagging saved objects (#173860)","sha":"274134120a27fc8273c35c440c819ea1e2e1d5a7"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/173860","number":173860,"mergeCommit":{"message":"[Fleet] Use correctly space scoped SO client when tagging saved objects (#173860)","sha":"274134120a27fc8273c35c440c819ea1e2e1d5a7"}}]}] BACKPORT-->