### PR TITLE
[Cases ] Fill missing default values in configuration requests

### DIFF
--- a/x-pack/plugins/cases/common/types/api/configure/v1.ts
+++ b/x-pack/plugins/cases/common/types/api/configure/v1.ts
@@ -114,6 +114,7 @@ export const ConfigurationPatchRequestRt = rt.intersection([
 export type ConfigurationRequest = rt.TypeOf<typeof ConfigurationRequestRt>;
 export type ConfigurationPatchRequest = rt.TypeOf<typeof ConfigurationPatchRequestRt>;
 export type GetConfigurationFindRequest = rt.TypeOf<typeof GetConfigurationFindRequestRt>;
+export type CustomFieldsConfigurationRequest = rt.TypeOf<typeof CustomFieldsConfigurationRt>;
 export type GetConfigureResponse = Configurations;
 export type CreateConfigureResponse = Configuration;
 export type UpdateConfigureResponse = Configuration;

--- a/x-pack/plugins/cases/server/client/configure/client.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.test.ts
@@ -347,29 +347,6 @@ describe('client', () => {
       );
     });
 
-    it('throws when a required custom field is missing the default value', async () => {
-      await expect(
-        update(
-          'test-id',
-          {
-            version: 'test-version',
-            customFields: [
-              {
-                key: 'missing_default',
-                label: 'text label',
-                type: CustomFieldTypes.TEXT,
-                required: true,
-              },
-            ],
-          },
-          clientArgs,
-          casesClientInternal
-        )
-      ).rejects.toThrow(
-        'Failed to get patch configure in route: Error: The following required custom fields are missing the default value: "text label"'
-      );
-    });
-
     it('throws when an optional custom field has a default value', async () => {
       await expect(
         update(

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -54,6 +54,7 @@ import {
   validateOptionalCustomFieldsInRequest,
   validateRequiredCustomFieldsInRequest,
 } from './validators';
+import { fillMissingDefaultValues } from './utils';
 
 /**
  * Defines the internal helper functions.
@@ -257,7 +258,6 @@ export async function update(
     const request = decodeWithExcessOrThrow(ConfigurationPatchRequestRt)(req);
 
     validateDuplicatedCustomFieldKeysInRequest({ requestCustomFields: request.customFields });
-    validateRequiredCustomFieldsInRequest({ requestCustomFields: request.customFields });
     validateOptionalCustomFieldsInRequest({ requestCustomFields: request.customFields });
 
     const { version, ...queryWithoutVersion } = request;
@@ -330,6 +330,9 @@ export async function update(
         ...(connector != null && { connector }),
         updated_at: updateDate,
         updated_by: user,
+        customFields: fillMissingDefaultValues({
+          customFields: queryWithoutVersionAndConnector.customFields,
+        }),
       },
       originalConfiguration: configuration,
     });

--- a/x-pack/plugins/cases/server/client/configure/utils.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/utils.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { fillMissingDefaultValues } from './utils';
+import { CustomFieldTypes } from '../../../common/types/domain';
+import type { CustomFieldsConfigurationRequest } from '../../../common/types/api';
+import { DEFAULT_VALUE_TEXT, DEFAULT_VALUE_TOGGLE } from '../../common/constants';
+
+describe('utils', () => {
+  describe('fillMissingDefaultValues', () => {
+    const customFields = [
+      {
+        key: 'first_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'label 1',
+        required: true,
+      },
+      {
+        key: 'second_key',
+        type: CustomFieldTypes.TOGGLE,
+        label: 'label 2',
+        required: true,
+      },
+    ];
+
+    it('adds missing default values correctly', () => {
+      expect(
+        fillMissingDefaultValues({
+          customFields,
+        })
+      ).toEqual([
+        {
+          ...customFields[0],
+          defaultValue: DEFAULT_VALUE_TEXT,
+        },
+        {
+          ...customFields[1],
+          defaultValue: DEFAULT_VALUE_TOGGLE,
+        },
+      ]);
+    });
+
+    it('adds missing default values if defaultValue: null', () => {
+      expect(
+        fillMissingDefaultValues({
+          customFields: [
+            {
+              ...customFields[0],
+              defaultValue: null,
+            },
+            {
+              ...customFields[1],
+              defaultValue: null,
+            },
+          ],
+        })
+      ).toEqual([
+        {
+          ...customFields[0],
+          defaultValue: DEFAULT_VALUE_TEXT,
+        },
+        {
+          ...customFields[1],
+          defaultValue: DEFAULT_VALUE_TOGGLE,
+        },
+      ]);
+    });
+
+    it('does not add default values when they already exist', () => {
+      const customFieldsWithDefaultValues = [
+        {
+          ...customFields[0],
+          defaultValue: 'default value',
+        },
+        {
+          ...customFields[1],
+          defaultValue: true,
+        },
+      ] as CustomFieldsConfigurationRequest;
+
+      expect(
+        fillMissingDefaultValues({
+          customFields: customFieldsWithDefaultValues,
+        })
+      ).toEqual(customFieldsWithDefaultValues);
+    });
+
+    it('only adds missing default values', () => {
+      const additionalCustomFields = [
+        {
+          key: 'third_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'label 3',
+          required: true,
+          defaultValue: 'default value',
+        },
+        {
+          key: 'fourth_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'label 4',
+          required: true,
+          defaultValue: true,
+        },
+      ];
+      expect(
+        fillMissingDefaultValues({
+          customFields: [...customFields, ...additionalCustomFields],
+        })
+      ).toEqual([
+        {
+          ...customFields[0],
+          defaultValue: DEFAULT_VALUE_TEXT,
+        },
+        {
+          ...customFields[1],
+          defaultValue: DEFAULT_VALUE_TOGGLE,
+        },
+        ...additionalCustomFields,
+      ]);
+    });
+
+    it('does not change optional custom fields', () => {
+      const optionalCustomFields = [
+        {
+          key: 'third_key',
+          type: CustomFieldTypes.TEXT,
+          label: 'label 3',
+          required: false,
+        },
+        {
+          key: 'fourth_key',
+          type: CustomFieldTypes.TOGGLE,
+          label: 'label 4',
+          required: false,
+        },
+      ];
+      expect(
+        fillMissingDefaultValues({
+          customFields: [...customFields, ...optionalCustomFields],
+        })
+      ).toEqual([
+        {
+          ...customFields[0],
+          defaultValue: DEFAULT_VALUE_TEXT,
+        },
+        {
+          ...customFields[1],
+          defaultValue: DEFAULT_VALUE_TOGGLE,
+        },
+        ...optionalCustomFields,
+      ]);
+    });
+  });
+});

--- a/x-pack/plugins/cases/server/client/configure/utils.ts
+++ b/x-pack/plugins/cases/server/client/configure/utils.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { CustomFieldTypes } from '../../../common/types/domain';
+import type { CustomFieldsConfigurationRequest } from '../../../common/types/api';
+import { DEFAULT_VALUE_TEXT, DEFAULT_VALUE_TOGGLE } from '../../common/constants';
+
+export const fillMissingDefaultValues = ({
+  customFields = [],
+}: {
+  customFields?: CustomFieldsConfigurationRequest;
+}): CustomFieldsConfigurationRequest => {
+  return customFields.map((customField) => {
+    if (
+      customField.required &&
+      (customField.defaultValue === undefined || customField.defaultValue === null)
+    ) {
+      return {
+        ...customField,
+        defaultValue:
+          customField.type === CustomFieldTypes.TEXT ? DEFAULT_VALUE_TEXT : DEFAULT_VALUE_TOGGLE,
+      } as CustomFieldsConfigurationRequest[number];
+    }
+
+    return customField;
+  });
+};

--- a/x-pack/plugins/cases/server/common/constants.ts
+++ b/x-pack/plugins/cases/server/common/constants.ts
@@ -65,3 +65,9 @@ export const STATUS_ESMODEL_TO_EXTERNAL: Record<CasePersistedStatus, CaseStatuse
   [CasePersistedStatus.IN_PROGRESS]: CaseStatuses['in-progress'],
   [CasePersistedStatus.CLOSED]: CaseStatuses.closed,
 };
+
+/**
+ * The placeholder values used to fill missing default values in configuration requests
+ */
+export const DEFAULT_VALUE_TEXT = 'N/A';
+export const DEFAULT_VALUE_TOGGLE = false;


### PR DESCRIPTION
See https://github.com/elastic/kibana/issues/171747 for context.

## Summary

**Merging into a feature branch.**

This PR handled an issue found by @cnasikas and mentioned for the first time [in this comment in a previous PR](https://github.com/elastic/kibana/pull/174628#pullrequestreview-1821776691).

> On certain configurations, I can get stuck on an "infinite loop" where I cannot edit any custom field nor add a new one. This could happen if I have two custom fields with required fields created before the PR. If I try to set the default value in any of them add a new custom field or edit any of the others I get an error regarding missing default values.

The reason was that we put all the custom fields on the request, but I can edit only one per time in the UI. Some of them would then be missing the mandatory `defaultValue`.

To solve this problem, exclusively in this scenario, we populate the default values with `N/A` for `text` custom fields, and with `false` for `toggle` custom fields.
