### PR TITLE
[Serverless Search] Add home button in left nav

### DIFF
--- a/x-pack/plugins/serverless_search/public/navigation_tree.ts
+++ b/x-pack/plugins/serverless_search/public/navigation_tree.ts
@@ -22,6 +22,14 @@ export const navigationTree: NavigationTreeDefinition = {
       breadcrumbStatus: 'hidden',
       children: [
         {
+          id: 'home',
+          title: i18n.translate('xpack.serverlessSearch.nav.home', {
+            defaultMessage: 'Home',
+          }),
+          link: 'serverlessElasticsearch',
+          spaceBefore: 'm',
+        },
+        {
           id: 'dev_tools',
           title: i18n.translate('xpack.serverlessSearch.nav.devTools', {
             defaultMessage: 'Dev Tools',
@@ -30,7 +38,7 @@ export const navigationTree: NavigationTreeDefinition = {
           getIsActive: ({ pathNameSerialized, prepend }) => {
             return pathNameSerialized.startsWith(prepend('/app/dev_tools'));
           },
-          spaceBefore: 'l',
+          spaceBefore: 'm',
         },
         {
           link: 'discover',

--- a/x-pack/test_serverless/functional/test_suites/search/navigation.ts
+++ b/x-pack/test_serverless/functional/test_suites/search/navigation.ts
@@ -64,7 +64,7 @@ export default function ({ getPageObject, getService }: FtrProviderContext) {
       await svlCommonNavigation.sidenav.expectLinkActive({
         deepLinkId: 'serverlessElasticsearch',
       });
-      await svlCommonNavigation.breadcrumbs.expectBreadcrumbExists({ text: `Get started` });
+      await svlCommonNavigation.breadcrumbs.expectBreadcrumbExists({ text: `Home` });
       await testSubjects.existOrFail(`svlSearchOverviewPage`);
 
       await expectNoPageReload();


### PR DESCRIPTION
## Summary

This PR adds "Home" button in Serverless Search left side nav. This button redirects to` /app/elasticsearch` same as getting started button. 

https://github.com/elastic/kibana/assets/55930906/75599fdb-f289-40a5-86af-57e630e6cd3e



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)

