### PR TITLE
[Security][EuiInMemoryTable] Replace usage of deprecated ref method with controlled `selection.selected` API

### DIFF
--- a/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
@@ -236,13 +236,7 @@ export class RoleMappingsGridPage extends Component<Props, State> {
           {(deleteRoleMappingsPrompt) => {
             return (
               <EuiButton
-                onClick={() =>
-                  deleteRoleMappingsPrompt(
-                    selectedItems,
-                    this.onRoleMappingsDeleted,
-                    this.onRoleMappingsDeleteCancel
-                  )
-                }
+                onClick={() => deleteRoleMappingsPrompt(selectedItems, this.onRoleMappingsDeleted)}
                 color="danger"
                 data-test-subj="bulkDeleteActionButton"
               >
@@ -495,10 +489,6 @@ export class RoleMappingsGridPage extends Component<Props, State> {
     if (roleMappings.length) {
       this.reloadRoleMappings();
     }
-  };
-
-  private onRoleMappingsDeleteCancel = () => {
-    this.setState({ selectedItems: [] });
   };
 
   private async checkPrivileges() {

--- a/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/role_mappings/role_mappings_grid/role_mappings_grid_page.tsx
@@ -74,7 +74,6 @@ export class RoleMappingsGridPage extends Component<Props, State> {
     readOnly: false,
   };
 
-  private tableRef: React.RefObject<EuiInMemoryTable<RoleMapping>>;
   constructor(props: any) {
     super(props);
     this.state = {
@@ -85,7 +84,6 @@ export class RoleMappingsGridPage extends Component<Props, State> {
       selectedItems: [],
       error: undefined,
     };
-    this.tableRef = React.createRef();
   }
 
   public componentDidMount() {
@@ -226,6 +224,7 @@ export class RoleMappingsGridPage extends Component<Props, State> {
           selectedItems: newSelectedItems,
         });
       },
+      selected: selectedItems,
     };
 
     const search = {
@@ -298,7 +297,6 @@ export class RoleMappingsGridPage extends Component<Props, State> {
                 loading={loadState === 'loadingTable'}
                 message={message}
                 isSelectable={true}
-                ref={this.tableRef}
                 rowProps={() => {
                   return {
                     'data-test-subj': 'roleMappingRow',
@@ -500,7 +498,7 @@ export class RoleMappingsGridPage extends Component<Props, State> {
   };
 
   private onRoleMappingsDeleteCancel = () => {
-    this.tableRef.current?.setSelection([]);
+    this.setState({ selectedItems: [] });
   };
 
   private async checkPrivileges() {

--- a/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
@@ -68,7 +68,6 @@ export class RolesGridPage extends Component<Props, State> {
     readOnly: false,
   };
 
-  private tableRef: React.RefObject<EuiInMemoryTable<Role>>;
   constructor(props: Props) {
     super(props);
     this.state = {
@@ -80,7 +79,6 @@ export class RolesGridPage extends Component<Props, State> {
       permissionDenied: false,
       includeReservedRoles: true,
     };
-    this.tableRef = React.createRef();
   }
 
   public componentDidMount() {
@@ -156,6 +154,7 @@ export class RolesGridPage extends Component<Props, State> {
                     selectableMessage: (selectable: boolean) =>
                       !selectable ? 'Role is reserved' : '',
                     onSelectionChange: (selection: Role[]) => this.setState({ selection }),
+                    selected: this.state.selection,
                   }
             }
             pagination={{
@@ -188,7 +187,6 @@ export class RolesGridPage extends Component<Props, State> {
                 direction: 'asc',
               },
             }}
-            ref={this.tableRef}
             rowProps={(role: Role) => {
               return {
                 'data-test-subj': `roleRow`,
@@ -485,6 +483,5 @@ export class RolesGridPage extends Component<Props, State> {
   }
   private onCancelDelete = () => {
     this.setState({ showDeleteConfirmation: false, selection: [] });
-    this.tableRef.current?.setSelection([]);
   };
 }

--- a/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
+++ b/x-pack/plugins/security/public/management/roles/roles_grid/roles_grid_page.tsx
@@ -482,6 +482,6 @@ export class RolesGridPage extends Component<Props, State> {
     );
   }
   private onCancelDelete = () => {
-    this.setState({ showDeleteConfirmation: false, selection: [] });
+    this.setState({ showDeleteConfirmation: false });
   };
 }


### PR DESCRIPTION
Closes #175836

## Summary

**Please help us QA your affected tables to confirm that your plugin's table selection still works as before!**

EUI will shortly be removing this deprecated ref `setSelection` method in favor of the new controlled `selection.selected` prop. This PR converts the Security plugin's basic usages of controlled selection and additionally removes 2 deletion cancellation behaviors on the team's request. There should not be any other UI/UX regressions when selecting rows.

See also: 
- https://github.com/elastic/eui/pull/7321
- https://github.com/elastic/kibana/pull/175722 (examples of basic conversions)