### PR TITLE
[ML] add embedded console to ml trained models page

### DIFF
--- a/x-pack/plugins/ml/kibana.jsonc
+++ b/x-pack/plugins/ml/kibana.jsonc
@@ -42,7 +42,8 @@
       "security",
       "spaces",
       "usageCollection",
-      "cases"
+      "cases",
+      "console"
     ],
     "requiredBundles": [
       "cases",

--- a/x-pack/plugins/ml/public/application/app.tsx
+++ b/x-pack/plugins/ml/public/application/app.tsx
@@ -83,6 +83,7 @@ const App: FC<AppProps> = ({ coreStart, deps, appMountParams, isServerless, mlFe
     return {
       cases: deps.cases,
       charts: deps.charts,
+      console: deps.console,
       contentManagement: deps.contentManagement,
       dashboard: deps.dashboard,
       data: deps.data,

--- a/x-pack/plugins/ml/public/application/contexts/kibana/kibana_context.ts
+++ b/x-pack/plugins/ml/public/application/contexts/kibana/kibana_context.ts
@@ -31,11 +31,13 @@ import type { PresentationUtilPluginStart } from '@kbn/presentation-util-plugin/
 import type { DataViewEditorStart } from '@kbn/data-view-editor-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import type { FieldFormatsRegistry } from '@kbn/field-formats-plugin/common';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { MlServicesContext } from '../../app';
 
 interface StartPlugins {
   cases?: CasesUiStart;
   charts: ChartsPluginStart;
+  console?: ConsolePluginStart;
   contentManagement: ContentManagementPublicStart;
   dashboard: DashboardStart;
   data: DataPublicPluginStart;

--- a/x-pack/plugins/ml/public/application/model_management/models_list.tsx
+++ b/x-pack/plugins/ml/public/application/model_management/models_list.tsx
@@ -125,6 +125,7 @@ export const ModelsList: FC<Props> = ({
   const {
     services: {
       application: { capabilities },
+      console: consolePlugin,
       docLinks,
     },
   } = useMlKibana();
@@ -848,6 +849,7 @@ export const ModelsList: FC<Props> = ({
           }}
         />
       ) : null}
+      {consolePlugin?.renderEmbeddableConsole?.() ?? null}
     </>
   );
 };

--- a/x-pack/plugins/ml/public/plugin.ts
+++ b/x-pack/plugins/ml/public/plugin.ts
@@ -24,6 +24,7 @@ import type { HomePublicPluginSetup } from '@kbn/home-plugin/public';
 import type { EmbeddableSetup, EmbeddableStart } from '@kbn/embeddable-plugin/public';
 import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 
 import { AppStatus, type AppUpdater, DEFAULT_APP_CATEGORIES } from '@kbn/core/public';
 import type { UiActionsSetup, UiActionsStart } from '@kbn/ui-actions-plugin/public';
@@ -74,6 +75,7 @@ import type { MlApiServices } from './application/services/ml_api_service';
 export interface MlStartDependencies {
   cases?: CasesUiStart;
   charts: ChartsPluginStart;
+  console?: ConsolePluginStart;
   contentManagement: ContentManagementPublicStart;
   dashboard: DashboardStart;
   data: DataPublicPluginStart;
@@ -158,6 +160,7 @@ export class MlPlugin implements Plugin<MlPluginSetup, MlPluginStart> {
           {
             cases: pluginsStart.cases,
             charts: pluginsStart.charts,
+            console: pluginsStart.console,
             contentManagement: pluginsStart.contentManagement,
             dashboard: pluginsStart.dashboard,
             data: pluginsStart.data,

--- a/x-pack/plugins/ml/tsconfig.json
+++ b/x-pack/plugins/ml/tsconfig.json
@@ -115,5 +115,6 @@
     "@kbn/ml-creation-wizard-utils",
     "@kbn/deeplinks-management",
     "@kbn/code-editor",
+    "@kbn/console-plugin",
   ],
 }


### PR DESCRIPTION
## Summary

Adding the embedded dev console to the ML trained models pages, if it's available.

### Screenshots
![image](https://github.com/elastic/kibana/assets/1972968/0fb3968c-886b-45ef-9b5c-04eeed5f1177)
![image](https://github.com/elastic/kibana/assets/1972968/11a90487-897b-48ef-a347-ef14631e5904)

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

## Note

This should not be merged before #175736 since that will ensure the embedded console is only available in Dedicated and Serverless Search.