### PR TITLE
serverless.oblt.yml: don't install apm integration

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -63,10 +63,8 @@ xpack.fleet.internal.registry.excludePackages: [
     'profiler_agent',
   ]
 
-## Required for force installation of APM Package
+## Required for force installation of integration packages
 xpack.fleet.packages:
-  - name: apm
-    version: latest
   # fleet_server package installed to publish agent metrics
   - name: fleet_server
     version: latest


### PR DESCRIPTION
## Summary

We will depend on the apm-data Elasticsearch plugin for setting up index templates and ingest pipelines. We have been testing this in serverless dev and QA with config overrides -- this is just final step to roll it out to all environments.

See https://github.com/elastic/apm-server/issues/11529