### PR TITLE
[Obs AI Assistant] Handle token limit error

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/common/utils/throw_serialized_chat_completion_errors.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/utils/throw_serialized_chat_completion_errors.ts
@@ -20,10 +20,12 @@ export function throwSerializedChatCompletionErrors() {
   ): Observable<Exclude<T, ChatCompletionErrorEvent>> => {
     return source$.pipe(
       tap((event) => {
+        // de-serialise error
         if (event.type === StreamingChatResponseEventType.ChatCompletionError) {
           const code = event.error.code ?? ChatCompletionErrorCode.InternalError;
           const message = event.error.message;
-          throw new ChatCompletionError(code, message);
+          const meta = event.error.meta;
+          throw new ChatCompletionError(code, message, meta);
         }
       }),
       filter(

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -22,6 +22,7 @@ import {
   createConversationNotFoundError,
   MessageAddEvent,
   StreamingChatResponseEventType,
+  createTokenLimitReachedError,
   type StreamingChatResponseEvent,
 } from '../../../common/conversation_complete';
 import {
@@ -458,6 +459,17 @@ export class ObservabilityAIAssistantClient {
         },
       },
     });
+
+    if (executeResult.status === 'error' && executeResult?.serviceMessage) {
+      const tokenLimitRegex =
+        /This model's maximum context length is (\d+) tokens\. However, your messages resulted in (\d+) tokens/g;
+      const tokenLimitRegexResult = tokenLimitRegex.exec(executeResult.serviceMessage);
+
+      if (tokenLimitRegexResult) {
+        const [, tokenLimit, tokenCount] = tokenLimitRegexResult;
+        throw createTokenLimitReachedError(parseInt(tokenLimit, 10), parseInt(tokenCount, 10));
+      }
+    }
 
     if (executeResult.status === 'error') {
       throw internal(`${executeResult?.message} - ${executeResult?.serviceMessage}`);

--- a/x-pack/plugins/observability_ai_assistant/server/service/util/observable_into_stream.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/util/observable_into_stream.ts
@@ -29,6 +29,7 @@ export function observableIntoStream(
           message: error.message,
           stack: error.stack,
           code: isChatCompletionError(error) ? error.code : undefined,
+          meta: error.meta,
         },
         type: StreamingChatResponseEventType.ChatCompletionError,
       };

--- a/x-pack/test/observability_ai_assistant_api_integration/tests/chat/chat.spec.ts
+++ b/x-pack/test/observability_ai_assistant_api_integration/tests/chat/chat.spec.ts
@@ -170,8 +170,8 @@ export default function ApiTest({ getService }: FtrProviderContext) {
 
       const response = JSON.parse(data);
 
-      expect(response.message).to.contain(
-        `an error occurred while running the action - Status code: 400. Message: API Error: Bad Request - This model's maximum context length is 8192 tokens. However, your messages resulted in 11036 tokens. Please reduce the length of the messages.`
+      expect(response.message).to.be(
+        `Token limit reached. Token limit is 8192, but the current conversation has 11036 tokens.`
       );
     });
 


### PR DESCRIPTION
When the user reaches the token limit they would previously see a generic toast. This PR improves this case by handling the error and showing a more user friendly message.


### Before
<img width="1484" alt="image" src="https://github.com/elastic/kibana/assets/209966/de6559fe-a98b-4c99-8995-8d43d1a56032">


### After
<img width="1502" alt="image" src="https://github.com/elastic/kibana/assets/209966/2a17117f-aa66-45e1-83dd-59c8133814c7">

### Possible additional enhancements

- Disable the prompt to avoid new messages that will fail anyway
- Show an error icon instead of the normal assistant avatar- 