### PR TITLE
[Expressions] Unskips test

### DIFF
--- a/test/examples/expressions_explorer/expressions.ts
+++ b/test/examples/expressions_explorer/expressions.ts
@@ -17,8 +17,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
   const find = getService('find');
   const browser = getService('browser');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/156780
-  describe.skip('', () => {
+  describe('', () => {
     it('runs expression', async () => {
       await retry.try(async () => {
         const text = await testSubjects.getVisibleText('expressionResult');
@@ -54,7 +53,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
       await find.clickByCssSelector(selector);
       await retry.try(async () => {
         const text = await browser.getCurrentUrl();
-        expect(text).to.contain('https://www.google.com/');
+        expect(text).to.contain('https://www.google.com');
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/156780
Unskips the expression tests

Flaky runner (50 times)

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->