### PR TITLE
[Ops/QA] Migrate coverage data to elastic's bucket

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# TODO: Safe to remove this after 2024-03-01
+# TODO: Safe to remove this after 2024-03-01 (https://github.com/elastic/kibana/issues/175904)
 gsutil -m cp -r gs://elastic-bekitzur-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
 
 # TODO: Activate after the above is removed

--- a/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-gsutil -m cp -r gs://elastic-bekitzur-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
+gsutil -m cp -r gs://elastic-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
 
 if [ -e ./previous.txt ]; then
     mv previous.txt downloaded_previous.txt

--- a/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/downloadPrevSha.sh
@@ -2,7 +2,11 @@
 
 set -euo pipefail
 
-gsutil -m cp -r gs://elastic-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
+# TODO: Safe to remove this after 2024-03-01
+gsutil -m cp -r gs://elastic-bekitzur-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
+
+# TODO: Activate after the above is removed
+#gsutil -m cp -r gs://elastic-kibana-coverage-live/previous_pointer/previous.txt . || echo "### Previous Pointer NOT FOUND?"
 
 if [ -e ./previous.txt ]; then
     mv previous.txt downloaded_previous.txt

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
@@ -9,4 +9,4 @@ collectPrevious() {
 }
 collectPrevious
 
-gsutil cp previous.txt gs://elastic-bekitzur-kibana-coverage-live/previous_pointer/
+gsutil cp previous.txt gs://elastic-kibana-coverage-live/previous_pointer/

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
@@ -9,7 +9,7 @@ collectPrevious() {
 }
 collectPrevious
 
-# TODO: Safe to remove this after 2024-03-01
-gsutil cp previous.txt gs://elastic-kibana-coverage-live/previous_pointer/
+# TODO: Safe to remove this after 2024-03-01 (https://github.com/elastic/kibana/issues/175904)
+gsutil cp previous.txt gs://elastic-bekitzur-kibana-coverage-live/previous_pointer/
 
 gsutil cp previous.txt gs://elastic-kibana-coverage-live/previous_pointer/

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadPrevSha.sh
@@ -9,4 +9,7 @@ collectPrevious() {
 }
 collectPrevious
 
+# TODO: Safe to remove this after 2024-03-01
+gsutil cp previous.txt gs://elastic-kibana-coverage-live/previous_pointer/
+
 gsutil cp previous.txt gs://elastic-kibana-coverage-live/previous_pointer/

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
@@ -4,18 +4,24 @@ set -euo pipefail
 
 xs=("$@")
 
+# TODO: Safe to remove this after 2024-03-01 (and usages below)
+uploadPrefix_old="gs://elastic-bekitzur-kibana-coverage-live/"
+uploadPrefixWithTimeStamp_old="${uploadPrefix}${TIME_STAMP}/"
+
 uploadPrefix="gs://elastic-kibana-coverage-live/"
 uploadPrefixWithTimeStamp="${uploadPrefix}${TIME_STAMP}/"
 
 uploadBase() {
   for x in 'src/dev/code_coverage/www/index.html' 'src/dev/code_coverage/www/404.html'; do
     gsutil -m -q cp -r -a public-read -z js,css,html "${x}" "${uploadPrefix}"
+    gsutil -m -q cp -r -a public-read -z js,css,html "${x}" "${uploadPrefix_old}"
   done
 }
 
 uploadRest() {
   for x in "${xs[@]}"; do
     gsutil -m -q cp -r -a public-read -z js,css,html "target/kibana-coverage/${x}-combined" "${uploadPrefixWithTimeStamp}"
+    gsutil -m -q cp -r -a public-read -z js,css,html "target/kibana-coverage/${x}-combined" "${uploadPrefixWithTimeStamp_old}"
   done
 }
 

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 xs=("$@")
 
-# TODO: Safe to remove this after 2024-03-01 (and usages below)
+# TODO: Safe to remove this after 2024-03-01 (https://github.com/elastic/kibana/issues/175904) - also clean up usages
 uploadPrefix_old="gs://elastic-bekitzur-kibana-coverage-live/"
 uploadPrefixWithTimeStamp_old="${uploadPrefix}${TIME_STAMP}/"
 

--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 xs=("$@")
 
-uploadPrefix="gs://elastic-bekitzur-kibana-coverage-live/"
+uploadPrefix="gs://elastic-kibana-coverage-live/"
 uploadPrefixWithTimeStamp="${uploadPrefix}${TIME_STAMP}/"
 
 uploadBase() {


### PR DESCRIPTION
## Summary
The currently used bucket for https://kibana-coverage.elastic.dev/ is `gs://elastic-bekitzur-kibana-coverage-live/` - this is probably belonging to an ex-elastician, now outside the company, we can't adjust access rights to it, won't be able to set up proper IAM access on it in the future. 

We're migrating to this bucket: `gs://elastic-kibana-coverage-live/`. 

To avoid having to copy over 6G of old coverage data, we're setting up the pipeline that populates this bucket (https://buildkite.com/elastic/kibana-code-coverage-main) to copy to both for some time, then we shut down the old one, while the new has some recent coverage data.