### PR TITLE
[Security Solution] update Threat Intelligence codeowners to Threat Hunting Investigations team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -806,7 +806,7 @@ packages/kbn-text-based-editor @elastic/kibana-visualizations
 src/plugins/text_based_languages @elastic/kibana-visualizations
 x-pack/examples/third_party_lens_navigation_prompt @elastic/kibana-visualizations
 x-pack/examples/third_party_vis_lens_example @elastic/kibana-visualizations
-x-pack/plugins/threat_intelligence @elastic/protections-experience
+x-pack/plugins/threat_intelligence @elastic/security-threat-hunting-investigations
 x-pack/plugins/timelines @elastic/security-threat-hunting-investigations
 packages/kbn-timelion-grammar @elastic/kibana-visualizations
 packages/kbn-tinymath @elastic/kibana-visualizations

--- a/x-pack/plugins/threat_intelligence/kibana.jsonc
+++ b/x-pack/plugins/threat_intelligence/kibana.jsonc
@@ -1,7 +1,7 @@
 {
   "type": "plugin",
   "id": "@kbn/threat-intelligence-plugin",
-  "owner": "@elastic/protections-experience",
+  "owner": "@elastic/security-threat-hunting-investigations",
   "description": "Elastic threat intelligence helps you see if you are open to or have been subject to current or historical known threats",
   "plugin": {
     "id": "threatIntelligence",


### PR DESCRIPTION
## Summary

This PR makes the codeowners change from the [Protections Experience team](https://github.com/orgs/elastic/teams/protections-experience) (which we should probably remove to avoid confusion) to the [Threat Hunting Investigations team](https://github.com/orgs/elastic/teams/security-threat-hunting-investigations) which now owns Threat Intelligence.

This previous [PR](https://github.com/elastic/kibana/pull/174658) forgot to modify one entry in the CODEOWNERS file.
