### PR TITLE
[8.12] [Fleet] Fix reserved keys for Elasticsearch output YAML box (#175901)

### DIFF
--- a/x-pack/plugins/fleet/common/constants/output.ts
+++ b/x-pack/plugins/fleet/common/constants/output.ts
@@ -122,12 +122,12 @@ export const kafkaSupportedVersions = [
 
 export const RESERVED_CONFIG_YML_KEYS = [
   'bulk_max_size',
-  'workers',
+  'compression_level',
+  'connection_idle_timeout',
   'queue.mem.events',
-  'flush.min_events',
-  'flush.timeout',
-  'compression',
-  'idle_timeout',
+  'queue.mem.flush.min_events',
+  'queue.mem.flush.timeout',
+  'workers',
 ];
 
 export const OUTPUT_TYPES_WITH_PRESET_SUPPORT: Array<ValueOf<OutputType>> = [

--- a/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
+++ b/x-pack/plugins/fleet/cypress/e2e/fleet_settings_outputs.cy.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { RESERVED_CONFIG_YML_KEYS } from '../../common/constants';
+
 import {
   getSpecificSelectorId,
   SETTINGS_CONFIRM_MODAL_BTN,
@@ -32,8 +34,15 @@ import {
 } from '../screens/fleet_outputs';
 
 import { login } from '../tasks/login';
-
 import { visit } from '../tasks/common';
+
+export const fillYamlConfigBox = (query: string) => {
+  cy.get('[data-test-subj="kibanaCodeEditor"] textarea').type(query, { force: true });
+};
+
+export const clearYamlConfigBox = () => {
+  cy.get('[data-test-subj="kibanaCodeEditor"] textarea').clear({ force: true });
+};
 
 describe('Outputs', () => {
   beforeEach(() => {
@@ -42,16 +51,38 @@ describe('Outputs', () => {
 
   describe('Elasticsearch', () => {
     describe('Preset input', () => {
+      afterEach(() => {
+        clearYamlConfigBox();
+        cy.getBySel(SETTINGS_OUTPUTS.PRESET_INPUT).select('balanced');
+      });
+
       it('is set to balanced by default', () => {
         selectESOutput();
 
         cy.getBySel(SETTINGS_OUTPUTS.PRESET_INPUT).should('have.value', 'balanced');
       });
 
-      it('forces custom when reserved key is included in config YAML box', () => {
+      for (const keyword of RESERVED_CONFIG_YML_KEYS) {
+        it(`forces custom when reserved key ${keyword} is included in config YAML box`, () => {
+          selectESOutput();
+
+          fillYamlConfigBox(`${keyword}: value`);
+
+          cy.getBySel(SETTINGS_OUTPUTS.PRESET_INPUT)
+            .should('have.value', 'custom')
+            .should('be.disabled');
+        });
+      }
+
+      it('handles expanded syntax for reserved keys', () => {
         selectESOutput();
 
-        cy.getBySel('kibanaCodeEditor').click().focused().type('bulk_max_size: 1000');
+        fillYamlConfigBox(`
+queue:
+  mem:
+    flush:
+      min_events: 100
+          `);
 
         cy.getBySel(SETTINGS_OUTPUTS.PRESET_INPUT)
           .should('have.value', 'custom')


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Fleet] Fix reserved keys for Elasticsearch output YAML box (#175901)](https://github.com/elastic/kibana/pull/175901)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Kyle Pollich","email":"kyle.pollich@elastic.co"},"sourceCommit":{"committedDate":"2024-01-30T16:30:36Z","message":"[Fleet] Fix reserved keys for Elasticsearch output YAML box (#175901)\n\n## Summary\r\n\r\nFixes #175892\r\n\r\nUpdates reserved keywords that trigger the `Custom` preset for the\r\nElasticsearch output.\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/6766512/dda60f6c-d77e-4e98-946b-2c389660074b\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c9318043902474f27d4bbf9739de70994e58cf8","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","Team:Fleet","backport:prev-minor","v8.13.0"],"number":175901,"url":"https://github.com/elastic/kibana/pull/175901","mergeCommit":{"message":"[Fleet] Fix reserved keys for Elasticsearch output YAML box (#175901)\n\n## Summary\r\n\r\nFixes #175892\r\n\r\nUpdates reserved keywords that trigger the `Custom` preset for the\r\nElasticsearch output.\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/6766512/dda60f6c-d77e-4e98-946b-2c389660074b\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c9318043902474f27d4bbf9739de70994e58cf8"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/175901","number":175901,"mergeCommit":{"message":"[Fleet] Fix reserved keys for Elasticsearch output YAML box (#175901)\n\n## Summary\r\n\r\nFixes #175892\r\n\r\nUpdates reserved keywords that trigger the `Custom` preset for the\r\nElasticsearch output.\r\n\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/6766512/dda60f6c-d77e-4e98-946b-2c389660074b\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"0c9318043902474f27d4bbf9739de70994e58cf8"}}]}] BACKPORT-->