### PR TITLE
[Security Solution][Timeline] add telemetry to full screen buttons

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/header_actions/header_actions.tsx
@@ -78,7 +78,7 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = ({
   timelineId,
   fieldBrowserOptions,
 }) => {
-  const { triggersActionsUi } = useKibana().services;
+  const { triggersActionsUi, telemetry } = useKibana().services;
   const { globalFullScreen, setGlobalFullScreen } = useGlobalFullScreen();
   const { timelineFullScreen, setTimelineFullScreen } = useTimelineFullScreen();
   const dispatch = useDispatch();
@@ -88,12 +88,15 @@ const HeaderActionsComponent: React.FC<HeaderActionProps> = ({
 
   const toggleFullScreen = useCallback(() => {
     if (timelineId === TimelineId.active) {
+      telemetry.reportTimelineFullScreenClicked({ timelineId, tab: tabType });
       setTimelineFullScreen(!timelineFullScreen);
     } else {
       setGlobalFullScreen(!globalFullScreen);
     }
   }, [
+    tabType,
     timelineId,
+    telemetry,
     setTimelineFullScreen,
     timelineFullScreen,
     setGlobalFullScreen,

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/constants.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/constants.ts
@@ -56,6 +56,7 @@ export enum TelemetryEventTypes {
   AnomaliesCountClicked = 'Anomalies Count Clicked',
   DataQualityIndexChecked = 'Data Quality Index Checked',
   DataQualityCheckAllCompleted = 'Data Quality Check All Completed',
+  TimelineFullScreenClicked = 'Timeline Full Screen Clicked',
 }
 
 export enum ML_JOB_TELEMETRY_STATUS {

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/telemetry_events.ts
@@ -4,6 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
+import { timelineFullScreenClickedEvent } from './timeline';
 import type { TelemetryEvent } from '../types';
 import { TelemetryEventTypes } from '../constants';
 import {
@@ -155,4 +156,5 @@ export const telemetryEvents = [
   dataQualityIndexCheckedEvent,
   dataQualityCheckAllClickedEvent,
   breadCrumbClickedEvent,
+  timelineFullScreenClickedEvent,
 ];

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/timeline/index.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/timeline/index.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { TelemetryEvent } from '../../types';
+import { TelemetryEventTypes } from '../../constants';
+
+export const timelineFullScreenClickedEvent: TelemetryEvent = {
+  eventType: TelemetryEventTypes.TimelineFullScreenClicked,
+  schema: {
+    timelineId: {
+      type: 'keyword',
+      _meta: {
+        description: 'Timeline id (active, case or test)',
+        optional: false,
+      },
+    },
+    tab: {
+      type: 'keyword',
+      _meta: {
+        description: 'Timeline tab (query, esql, pinned...)',
+        optional: false,
+      },
+    },
+  },
+};

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/events/timeline/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/events/timeline/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RootSchema } from '@kbn/analytics-client';
+import type { TelemetryEventTypes } from '../../constants';
+
+export interface TimelineFullScreenClickedParams {
+  timelineId: string;
+  tab: string;
+}
+
+export type TimelineTelemetryEventParams = TimelineFullScreenClickedParams;
+
+export interface TimelineTelemetryEvent {
+  eventType: TelemetryEventTypes.TimelineFullScreenClicked;
+  schema: RootSchema<TimelineFullScreenClickedParams>;
+}

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/telemetry_client.mock.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/telemetry_client.mock.ts
@@ -27,4 +27,5 @@ export const createTelemetryClientMock = (): jest.Mocked<TelemetryClientStart> =
   reportToggleRiskSummaryClicked: jest.fn(),
   reportRiskInputsExpandedFlyoutOpened: jest.fn(),
   reportAddRiskInputToTimelineClicked: jest.fn(),
+  reportTimelineFullScreenClicked: jest.fn(),
 });

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/telemetry_client.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/telemetry_client.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AnalyticsServiceSetup } from '@kbn/core-analytics-server';
+import type { TimelineFullScreenClickedParams } from './events/timeline/types';
 import type {
   TelemetryClientStart,
   ReportAlertsGroupingChangedParams,
@@ -142,5 +143,9 @@ export class TelemetryClient implements TelemetryClientStart {
     this.analytics.reportEvent(TelemetryEventTypes.BreadcrumbClicked, {
       title,
     });
+  };
+
+  public reportTimelineFullScreenClicked = (params: TimelineFullScreenClickedParams) => {
+    this.analytics.reportEvent(TelemetryEventTypes.TimelineFullScreenClicked, params);
   };
 }

--- a/x-pack/plugins/security_solution/public/common/lib/telemetry/types.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/telemetry/types.ts
@@ -7,6 +7,11 @@
 
 import type { RootSchema } from '@kbn/analytics-client';
 import type { AnalyticsServiceSetup } from '@kbn/core/public';
+import type {
+  TimelineFullScreenClickedParams,
+  TimelineTelemetryEvent,
+  TimelineTelemetryEventParams,
+} from './events/timeline/types';
 import type { SecurityMetadata } from '../../../actions/types';
 import type { ML_JOB_TELEMETRY_STATUS, TelemetryEventTypes } from './constants';
 import type {
@@ -89,7 +94,8 @@ export type TelemetryEventParams =
   | ReportAnomaliesCountClickedParams
   | ReportDataQualityIndexCheckedParams
   | ReportDataQualityCheckAllCompletedParams
-  | ReportBreadcrumbClickedParams;
+  | ReportBreadcrumbClickedParams
+  | TimelineTelemetryEventParams;
 
 export interface TelemetryClientStart {
   reportAlertsGroupingChanged(params: ReportAlertsGroupingChangedParams): void;
@@ -117,6 +123,8 @@ export interface TelemetryClientStart {
   reportDataQualityIndexChecked(params: ReportDataQualityIndexCheckedParams): void;
   reportDataQualityCheckAllCompleted(params: ReportDataQualityCheckAllCompletedParams): void;
   reportBreadcrumbClicked(params: ReportBreadcrumbClickedParams): void;
+
+  reportTimelineFullScreenClicked(params: TimelineFullScreenClickedParams): void;
 }
 
 export type TelemetryEvent =
@@ -139,4 +147,5 @@ export type TelemetryEvent =
   | {
       eventType: TelemetryEventTypes.BreadcrumbClicked;
       schema: RootSchema<ReportBreadcrumbClickedParams>;
-    };
+    }
+  | TimelineTelemetryEvent;


### PR DESCRIPTION
## Summary

This PR adds telemetry to the full screen zoom buttons in timeline. The goal is to see if we can [remove that functionality](https://github.com/elastic/security-team/issues/8495) now that the header in timeline is more compact.

### Steps to verify:

- add `telemetry.optIn: true` to `kibana.dev.yml`
- open timeline and click on the full screen zoom button under the query, correlation or pinned tabs
- usually the event would be sent every hour to [staging](https://telemetry-v2-staging.elastic.dev/s/securitysolution/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d%2Fd,to:now))&_a=(columns:!(),filters:!(),index:'55889f4f-cd1b-5b27-97f6-7244e9199ecc',interval:auto,query:(language:kuery,query:''),sort:!(!(telemetry.processed_timestamp,desc)))), if not, visit staging again on the next day.

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
