### PR TITLE
[Fleet] add retry logic for transform uninstall

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/transform/remove.ts
@@ -13,6 +13,8 @@ import type { EsAssetReference } from '../../../../types';
 import { PACKAGES_SAVED_OBJECT_TYPE } from '../../../../../common/constants';
 import { appContextService } from '../../../app_context';
 
+import { retryTransientEsErrors } from '../retry';
+
 export const stopTransforms = async (transformIds: string[], esClient: ElasticsearchClient) => {
   for (const transformId of transformIds) {
     await esClient.transform.stopTransform(
@@ -35,14 +37,16 @@ export const deleteTransforms = async (
   await Promise.all(
     transformIds.map(async (transformId) => {
       await stopTransforms([transformId], esClient);
-      await esClient.transform.deleteTransform(
-        {
-          force: true,
-          transform_id: transformId,
-          // @ts-expect-error ES type needs to be updated
-          delete_dest_index: deleteDestinationIndices,
-        },
-        { ...(secondaryAuth ? secondaryAuth : {}), ignore: [404] }
+      await retryTransientEsErrors(() =>
+        esClient.transform.deleteTransform(
+          {
+            force: true,
+            transform_id: transformId,
+            // @ts-expect-error ES type needs to be updated
+            delete_dest_index: deleteDestinationIndices,
+          },
+          { ...(secondaryAuth ? secondaryAuth : {}), ignore: [404] }
+        )
       );
       logger.info(`Deleted: ${transformId}`);
     })


### PR DESCRIPTION
## Summary

Adds retry logic to transform uninstall. This is to address potential situations in which the transform doesn't get uninstalled due to transient ES errors: https://github.com/elastic/kibana/issues/173688.


### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
