### PR TITLE
[Reporting/Deprecations: ILM] ensure error is logged

### DIFF
--- a/x-pack/plugins/reporting/server/lib/deprecations/check_ilm_migration_status.ts
+++ b/x-pack/plugins/reporting/server/lib/deprecations/check_ilm_migration_status.ts
@@ -16,8 +16,9 @@ import type { DeprecationsDependencies } from './types';
 export const checkIlmMigrationStatus = async ({
   reportingCore,
   elasticsearchClient,
+  logger,
 }: DeprecationsDependencies): Promise<IlmPolicyMigrationStatus> => {
-  const ilmPolicyManager = IlmPolicyManager.create({ client: elasticsearchClient });
+  const ilmPolicyManager = IlmPolicyManager.create({ client: elasticsearchClient, logger });
   if (!(await ilmPolicyManager.doesIlmPolicyExist())) {
     return 'policy-not-found';
   }

--- a/x-pack/plugins/reporting/server/lib/deprecations/types.ts
+++ b/x-pack/plugins/reporting/server/lib/deprecations/types.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from 'src/core/server';
+import type { ElasticsearchClient, Logger } from 'src/core/server';
 import type { ReportingCore } from '../../core';
 
 export interface DeprecationsDependencies {
   reportingCore: ReportingCore;
   elasticsearchClient: ElasticsearchClient;
+  logger: Logger
 }

--- a/x-pack/plugins/reporting/server/lib/store/ilm_policy_manager/ilm_policy_manager.ts
+++ b/x-pack/plugins/reporting/server/lib/store/ilm_policy_manager/ilm_policy_manager.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from 'src/core/server';
+import type { ElasticsearchClient, Logger } from 'src/core/server';
 import { ILM_POLICY_NAME } from '../../../../common/constants';
 
 import { reportingIlmPolicy } from './constants';
@@ -16,10 +16,11 @@ import { reportingIlmPolicy } from './constants';
  * Uses the provided {@link ElasticsearchClient} to scope request privileges.
  */
 export class IlmPolicyManager {
-  constructor(private readonly client: ElasticsearchClient) {}
+  constructor(private readonly client: ElasticsearchClient, private readonly logger: Logger) {}
 
-  public static create(opts: { client: ElasticsearchClient }) {
-    return new IlmPolicyManager(opts.client);
+  public static create(opts: { client: ElasticsearchClient, logger: Logger }) {
+    const logger = opts.logger.get('ilm-policy-manager');
+    return new IlmPolicyManager(opts.client, logger);
   }
 
   public async doesIlmPolicyExist(): Promise<boolean> {
@@ -30,6 +31,7 @@ export class IlmPolicyManager {
       if (e.statusCode === 404) {
         return false;
       }
+      this.logger.error(e);
       throw e;
     }
   }

--- a/x-pack/plugins/reporting/server/lib/store/store.ts
+++ b/x-pack/plugins/reporting/server/lib/store/store.ts
@@ -103,7 +103,7 @@ export class ReportingStore {
   private async getIlmPolicyManager() {
     if (!this.ilmPolicyManager) {
       const client = await this.getClient();
-      this.ilmPolicyManager = IlmPolicyManager.create({ client });
+      this.ilmPolicyManager = IlmPolicyManager.create({ client, logger: this.logger });
     }
 
     return this.ilmPolicyManager;

--- a/x-pack/plugins/reporting/server/routes/deprecations.ts
+++ b/x-pack/plugins/reporting/server/routes/deprecations.ts
@@ -104,7 +104,7 @@ export const registerDeprecationsRoutes = (reporting: ReportingCore, logger: Log
       } = elasticsearch;
 
       const scopedIlmPolicyManager = IlmPolicyManager.create({
-        client,
+        client, logger
       });
 
       // First we ensure that the reporting ILM policy exists in the cluster


### PR DESCRIPTION
## Summary

This PR resolves an un-logged error. If an error occurs when retrieving ILM deprecations for the Reporting indices, we need to make sure the Kibana server logs display meaningful error message(s).

This is a manual backport of https://github.com/elastic/kibana/pull/175950 for 7.17
