### PR TITLE
[Reporting/Deprecations: ILM] ensure error is logged

### DIFF
--- a/x-pack/plugins/reporting/server/lib/deprecations/check_ilm_migration_status.ts
+++ b/x-pack/plugins/reporting/server/lib/deprecations/check_ilm_migration_status.ts
@@ -13,8 +13,9 @@ import type { DeprecationsDependencies } from './types';
 export const checkIlmMigrationStatus = async ({
   reportingCore,
   elasticsearchClient,
+  logger,
 }: DeprecationsDependencies): Promise<IlmPolicyMigrationStatus> => {
-  const ilmPolicyManager = IlmPolicyManager.create({ client: elasticsearchClient });
+  const ilmPolicyManager = IlmPolicyManager.create({ client: elasticsearchClient, logger });
   if (!(await ilmPolicyManager.doesIlmPolicyExist())) {
     return 'policy-not-found';
   }

--- a/x-pack/plugins/reporting/server/lib/deprecations/types.ts
+++ b/x-pack/plugins/reporting/server/lib/deprecations/types.ts
@@ -5,10 +5,11 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient } from '@kbn/core/server';
+import type { ElasticsearchClient, Logger } from '@kbn/core/server';
 import type { ReportingCore } from '../../core';
 
 export interface DeprecationsDependencies {
   reportingCore: ReportingCore;
   elasticsearchClient: ElasticsearchClient;
+  logger: Logger;
 }

--- a/x-pack/plugins/reporting/server/lib/store/store.ts
+++ b/x-pack/plugins/reporting/server/lib/store/store.ts
@@ -125,7 +125,7 @@ export class ReportingStore {
 
   private async getIlmPolicyManager() {
     const client = await this.getClient();
-    return IlmPolicyManager.create({ client });
+    return IlmPolicyManager.create({ client, logger: this.logger });
   }
 
   private async createIndex(indexName: string) {

--- a/x-pack/plugins/reporting/server/routes/internal/deprecations/deprecations.ts
+++ b/x-pack/plugins/reporting/server/routes/internal/deprecations/deprecations.ts
@@ -74,6 +74,7 @@ export const registerDeprecationsRoutes = (reporting: ReportingCore, logger: Log
           reportingCore: reporting,
           // We want to make the current status visible to all reporting users
           elasticsearchClient: scopedClient.asInternalUser,
+          logger,
         });
       };
 
@@ -114,6 +115,7 @@ export const registerDeprecationsRoutes = (reporting: ReportingCore, logger: Log
 
       const scopedIlmPolicyManager = IlmPolicyManager.create({
         client,
+        logger,
       });
 
       // First we ensure that the reporting ILM policy exists in the cluster


### PR DESCRIPTION
## Summary

This PR resolves an un-logged error. If an error occurs when retrieving ILM deprecations for the Reporting indices, we need to make sure the Kibana server logs display meaningful error message(s).