### PR TITLE
[Cases] Optional default values

### DIFF
--- a/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
@@ -12,6 +12,7 @@ import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 import type { CustomFieldFormState } from './form';
 import { CustomFieldsForm } from './form';
+import type { CustomFieldConfiguration } from '../../../common/types/domain';
 import { CustomFieldTypes } from '../../../common/types/domain';
 import * as i18n from './translations';
 import userEvent from '@testing-library/user-event';
@@ -152,24 +153,38 @@ describe('CustomFieldsForm ', () => {
 
     const onChangeState = (state: CustomFieldFormState) => (formState = state);
 
-    appMockRender.render(<CustomFieldsForm onChange={onChangeState} initialValue={null} />);
+    const initialValue = {
+      required: true,
+      type: CustomFieldTypes.TEXT as const,
+      defaultValue: null,
+    };
+
+    appMockRender.render(
+      <CustomFieldsForm
+        onChange={onChangeState}
+        initialValue={
+          {
+            key: 'test_key_1',
+            label: 'Summary',
+            ...initialValue,
+          } as CustomFieldConfiguration
+        }
+      />
+    );
 
     await waitFor(() => {
       expect(formState).not.toBeUndefined();
     });
 
-    userEvent.paste(await screen.findByTestId('custom-field-label-input'), 'Summary');
-    userEvent.click(await screen.findByTestId('text-custom-field-required'));
-    userEvent.paste(await screen.findByTestId('text-custom-field-default-value'), ' ');
+    userEvent.paste(await screen.findByTestId('custom-field-label-input'), ' New');
 
     await act(async () => {
       const { data } = await formState!.submit();
 
       expect(data).toEqual({
         key: expect.anything(),
-        label: 'Summary',
-        required: true,
-        type: 'text',
+        label: 'Summary New',
+        ...initialValue,
       });
     });
   });

--- a/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/form.test.tsx
@@ -94,6 +94,86 @@ describe('CustomFieldsForm ', () => {
     });
   });
 
+  it('serializes the data correctly if required is selected and the text default value is not filled', async () => {
+    let formState: CustomFieldFormState;
+
+    const onChangeState = (state: CustomFieldFormState) => (formState = state);
+
+    appMockRender.render(<CustomFieldsForm onChange={onChangeState} initialValue={null} />);
+
+    await waitFor(() => {
+      expect(formState).not.toBeUndefined();
+    });
+
+    userEvent.paste(await screen.findByTestId('custom-field-label-input'), 'Summary');
+    userEvent.click(await screen.findByTestId('text-custom-field-required'));
+
+    await act(async () => {
+      const { data } = await formState!.submit();
+
+      expect(data).toEqual({
+        key: expect.anything(),
+        label: 'Summary',
+        required: true,
+        type: 'text',
+      });
+    });
+  });
+
+  it('serializes the data correctly if required is selected and the text default value is an empty string', async () => {
+    let formState: CustomFieldFormState;
+
+    const onChangeState = (state: CustomFieldFormState) => (formState = state);
+
+    appMockRender.render(<CustomFieldsForm onChange={onChangeState} initialValue={null} />);
+
+    await waitFor(() => {
+      expect(formState).not.toBeUndefined();
+    });
+
+    userEvent.paste(await screen.findByTestId('custom-field-label-input'), 'Summary');
+    userEvent.click(await screen.findByTestId('text-custom-field-required'));
+    userEvent.paste(await screen.findByTestId('text-custom-field-default-value'), ' ');
+
+    await act(async () => {
+      const { data } = await formState!.submit();
+
+      expect(data).toEqual({
+        key: expect.anything(),
+        label: 'Summary',
+        required: true,
+        type: 'text',
+      });
+    });
+  });
+
+  it('serializes the data correctly if the initial default value is null', async () => {
+    let formState: CustomFieldFormState;
+
+    const onChangeState = (state: CustomFieldFormState) => (formState = state);
+
+    appMockRender.render(<CustomFieldsForm onChange={onChangeState} initialValue={null} />);
+
+    await waitFor(() => {
+      expect(formState).not.toBeUndefined();
+    });
+
+    userEvent.paste(await screen.findByTestId('custom-field-label-input'), 'Summary');
+    userEvent.click(await screen.findByTestId('text-custom-field-required'));
+    userEvent.paste(await screen.findByTestId('text-custom-field-default-value'), ' ');
+
+    await act(async () => {
+      const { data } = await formState!.submit();
+
+      expect(data).toEqual({
+        key: expect.anything(),
+        label: 'Summary',
+        required: true,
+        type: 'text',
+      });
+    });
+  });
+
   it('serializes the data correctly if required is not selected', async () => {
     let formState: CustomFieldFormState;
 

--- a/x-pack/plugins/cases/public/components/custom_fields/form.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/form.tsx
@@ -14,6 +14,7 @@ import { schema } from './schema';
 import { FormFields } from './form_fields';
 import type { CustomFieldConfiguration } from '../../../common/types/domain';
 import { CustomFieldTypes } from '../../../common/types/domain';
+import { customFieldSerializer } from './utils';
 
 export interface CustomFieldFormState {
   isValid: boolean | undefined;
@@ -37,6 +38,7 @@ const FormComponent: React.FC<Props> = ({ onChange, initialValue }) => {
     },
     options: { stripEmptyFields: false },
     schema,
+    serializer: customFieldSerializer,
   });
 
   const { submit, isValid, isSubmitting } = form;

--- a/x-pack/plugins/cases/public/components/custom_fields/schema.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/schema.tsx
@@ -46,10 +46,6 @@ export const schema = {
   },
   defaultValue: {
     label: i18n.DEFAULT_VALUE,
-    validations: [
-      {
-        validator: emptyField(i18n.REQUIRED_FIELD(i18n.DEFAULT_VALUE)),
-      },
-    ],
+    validations: [],
   },
 };

--- a/x-pack/plugins/cases/public/components/custom_fields/text/configure.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/text/configure.tsx
@@ -15,7 +15,10 @@ import * as i18n from '../translations';
 
 const ConfigureComponent: CustomFieldType<CaseCustomFieldText>['Configure'] = () => {
   const [{ required }] = useFormData<{ required: boolean }>();
-  const config = getTextFieldConfig({ required, label: i18n.DEFAULT_VALUE.toLocaleLowerCase() });
+  const config = getTextFieldConfig({
+    required: false,
+    label: i18n.DEFAULT_VALUE.toLocaleLowerCase(),
+  });
 
   return (
     <>

--- a/x-pack/plugins/cases/public/components/custom_fields/utils.test.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/utils.test.ts
@@ -5,196 +5,288 @@
  * 2.0.
  */
 
-import { addOrReplaceCustomField } from './utils';
+import { addOrReplaceCustomField, customFieldSerializer } from './utils';
 import { customFieldsConfigurationMock, customFieldsMock } from '../../containers/mock';
+import type { CustomFieldConfiguration } from '../../../common/types/domain';
 import { CustomFieldTypes } from '../../../common/types/domain';
 import type { CaseUICustomField } from '../../../common/ui';
 
-describe('addOrReplaceCustomField ', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
+describe('utils ', () => {
+  describe('addOrReplaceCustomField ', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('adds new custom field correctly', async () => {
+      const fieldToAdd: CaseUICustomField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        value: 'my_test_value',
+      };
+      const res = addOrReplaceCustomField(customFieldsMock, fieldToAdd);
+      expect(res).toMatchInlineSnapshot(
+        [...customFieldsMock, fieldToAdd],
+        `
+              Array [
+                Object {
+                  "key": "test_key_1",
+                  "type": "text",
+                  "value": "My text test value 1",
+                },
+                Object {
+                  "key": "test_key_2",
+                  "type": "toggle",
+                  "value": true,
+                },
+                Object {
+                  "key": "test_key_3",
+                  "type": "text",
+                  "value": null,
+                },
+                Object {
+                  "key": "test_key_4",
+                  "type": "toggle",
+                  "value": null,
+                },
+                Object {
+                  "key": "my_test_key",
+                  "type": "text",
+                  "value": "my_test_value",
+                },
+              ]
+          `
+      );
+    });
+
+    it('updates existing custom field correctly', async () => {
+      const fieldToUpdate = {
+        ...customFieldsMock[0],
+        field: { value: ['My text test value 1!!!'] },
+      };
+
+      const res = addOrReplaceCustomField(customFieldsMock, fieldToUpdate as CaseUICustomField);
+      expect(res).toMatchInlineSnapshot(
+        [
+          { ...fieldToUpdate },
+          { ...customFieldsMock[1] },
+          { ...customFieldsMock[2] },
+          { ...customFieldsMock[3] },
+        ],
+        `
+              Array [
+                Object {
+                  "field": Object {
+                    "value": Array [
+                      "My text test value 1!!!",
+                    ],
+                  },
+                  "key": "test_key_1",
+                  "type": "text",
+                  "value": "My text test value 1",
+                },
+                Object {
+                  "key": "test_key_2",
+                  "type": "toggle",
+                  "value": true,
+                },
+                Object {
+                  "key": "test_key_3",
+                  "type": "text",
+                  "value": null,
+                },
+                Object {
+                  "key": "test_key_4",
+                  "type": "toggle",
+                  "value": null,
+                },
+              ]
+          `
+      );
+    });
+
+    it('adds new custom field configuration correctly', async () => {
+      const fieldToAdd = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'my_test_label',
+        required: true,
+      };
+      const res = addOrReplaceCustomField(customFieldsConfigurationMock, fieldToAdd);
+      expect(res).toMatchInlineSnapshot(
+        [...customFieldsConfigurationMock, fieldToAdd],
+        `
+              Array [
+                Object {
+                  "defaultValue": "My default value",
+                  "key": "test_key_1",
+                  "label": "My test label 1",
+                  "required": true,
+                  "type": "text",
+                },
+                Object {
+                  "defaultValue": true,
+                  "key": "test_key_2",
+                  "label": "My test label 2",
+                  "required": true,
+                  "type": "toggle",
+                },
+                Object {
+                  "key": "test_key_3",
+                  "label": "My test label 3",
+                  "required": false,
+                  "type": "text",
+                },
+                Object {
+                  "key": "test_key_4",
+                  "label": "My test label 4",
+                  "required": false,
+                  "type": "toggle",
+                },
+                Object {
+                  "key": "my_test_key",
+                  "label": "my_test_label",
+                  "required": true,
+                  "type": "text",
+                },
+              ]
+          `
+      );
+    });
+
+    it('updates existing custom field config correctly', async () => {
+      const fieldToUpdate = {
+        ...customFieldsConfigurationMock[0],
+        label: `${customFieldsConfigurationMock[0].label}!!!`,
+      };
+
+      const res = addOrReplaceCustomField(customFieldsConfigurationMock, fieldToUpdate);
+      expect(res).toMatchInlineSnapshot(
+        [
+          { ...fieldToUpdate },
+          { ...customFieldsConfigurationMock[1] },
+          { ...customFieldsConfigurationMock[2] },
+          { ...customFieldsConfigurationMock[3] },
+        ],
+        `
+              Array [
+                Object {
+                  "defaultValue": "My default value",
+                  "key": "test_key_1",
+                  "label": "My test label 1!!!",
+                  "required": true,
+                  "type": "text",
+                },
+                Object {
+                  "defaultValue": true,
+                  "key": "test_key_2",
+                  "label": "My test label 2",
+                  "required": true,
+                  "type": "toggle",
+                },
+                Object {
+                  "key": "test_key_3",
+                  "label": "My test label 3",
+                  "required": false,
+                  "type": "text",
+                },
+                Object {
+                  "key": "test_key_4",
+                  "label": "My test label 4",
+                  "required": false,
+                  "type": "toggle",
+                },
+              ]
+          `
+      );
+    });
   });
 
-  it('adds new custom field correctly', async () => {
-    const fieldToAdd: CaseUICustomField = {
-      key: 'my_test_key',
-      type: CustomFieldTypes.TEXT,
-      value: 'my_test_value',
-    };
-    const res = addOrReplaceCustomField(customFieldsMock, fieldToAdd);
-    expect(res).toMatchInlineSnapshot(
-      [...customFieldsMock, fieldToAdd],
-      `
-      Array [
+  describe('customFieldSerializer ', () => {
+    it('serializes the data correctly if the default value is a normal string', async () => {
+      const customField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        required: true,
+        defaultValue: 'foobar',
+      } as CustomFieldConfiguration;
+
+      expect(customFieldSerializer(customField)).toMatchInlineSnapshot(`
         Object {
-          "key": "test_key_1",
+          "defaultValue": "foobar",
+          "key": "my_test_key",
+          "required": true,
           "type": "text",
-          "value": "My text test value 1",
-        },
-        Object {
-          "key": "test_key_2",
-          "type": "toggle",
-          "value": true,
-        },
-        Object {
-          "key": "test_key_3",
-          "type": "text",
-          "value": null,
-        },
-        Object {
-          "key": "test_key_4",
-          "type": "toggle",
-          "value": null,
-        },
+        }
+      `);
+    });
+
+    it('serializes the data correctly if the default value is undefined', async () => {
+      const customField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        required: true,
+      } as CustomFieldConfiguration;
+
+      expect(customFieldSerializer(customField)).toMatchInlineSnapshot(`
         Object {
           "key": "my_test_key",
-          "type": "text",
-          "value": "my_test_value",
-        },
-      ]
-    `
-    );
-  });
-
-  it('updates existing custom field correctly', async () => {
-    const fieldToUpdate = {
-      ...customFieldsMock[0],
-      field: { value: ['My text test value 1!!!'] },
-    };
-
-    const res = addOrReplaceCustomField(customFieldsMock, fieldToUpdate as CaseUICustomField);
-    expect(res).toMatchInlineSnapshot(
-      [
-        { ...fieldToUpdate },
-        { ...customFieldsMock[1] },
-        { ...customFieldsMock[2] },
-        { ...customFieldsMock[3] },
-      ],
-      `
-      Array [
-        Object {
-          "field": Object {
-            "value": Array [
-              "My text test value 1!!!",
-            ],
-          },
-          "key": "test_key_1",
-          "type": "text",
-          "value": "My text test value 1",
-        },
-        Object {
-          "key": "test_key_2",
-          "type": "toggle",
-          "value": true,
-        },
-        Object {
-          "key": "test_key_3",
-          "type": "text",
-          "value": null,
-        },
-        Object {
-          "key": "test_key_4",
-          "type": "toggle",
-          "value": null,
-        },
-      ]
-    `
-    );
-  });
-
-  it('adds new custom field configuration correctly', async () => {
-    const fieldToAdd = {
-      key: 'my_test_key',
-      type: CustomFieldTypes.TEXT,
-      label: 'my_test_label',
-      required: true,
-    };
-    const res = addOrReplaceCustomField(customFieldsConfigurationMock, fieldToAdd);
-    expect(res).toMatchInlineSnapshot(
-      [...customFieldsConfigurationMock, fieldToAdd],
-      `
-      Array [
-        Object {
-          "defaultValue": "My default value",
-          "key": "test_key_1",
-          "label": "My test label 1",
           "required": true,
           "type": "text",
-        },
+        }
+      `);
+    });
+
+    it('serializes the data correctly if the default value is null', async () => {
+      const customField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        required: true,
+        defaultValue: null,
+      } as CustomFieldConfiguration;
+
+      expect(customFieldSerializer(customField)).toMatchInlineSnapshot(`
         Object {
-          "defaultValue": true,
-          "key": "test_key_2",
-          "label": "My test label 2",
+          "defaultValue": null,
+          "key": "my_test_key",
           "required": true,
-          "type": "toggle",
-        },
-        Object {
-          "key": "test_key_3",
-          "label": "My test label 3",
-          "required": false,
           "type": "text",
-        },
-        Object {
-          "key": "test_key_4",
-          "label": "My test label 4",
-          "required": false,
-          "type": "toggle",
-        },
+        }
+      `);
+    });
+
+    it('serializes the data correctly if the default value is an empty string', async () => {
+      const customField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TEXT,
+        required: true,
+        defaultValue: '   ',
+      } as CustomFieldConfiguration;
+
+      expect(customFieldSerializer(customField)).toMatchInlineSnapshot(`
         Object {
           "key": "my_test_key",
-          "label": "my_test_label",
           "required": true,
           "type": "text",
-        },
-      ]
-    `
-    );
-  });
+        }
+      `);
+    });
 
-  it('updates existing custom field config correctly', async () => {
-    const fieldToUpdate = {
-      ...customFieldsConfigurationMock[0],
-      label: `${customFieldsConfigurationMock[0].label}!!!`,
-    };
+    it('serializes the data correctly if the default value is false', async () => {
+      const customField = {
+        key: 'my_test_key',
+        type: CustomFieldTypes.TOGGLE,
+        required: true,
+        defaultValue: false,
+      } as CustomFieldConfiguration;
 
-    const res = addOrReplaceCustomField(customFieldsConfigurationMock, fieldToUpdate);
-    expect(res).toMatchInlineSnapshot(
-      [
-        { ...fieldToUpdate },
-        { ...customFieldsConfigurationMock[1] },
-        { ...customFieldsConfigurationMock[2] },
-        { ...customFieldsConfigurationMock[3] },
-      ],
-      `
-      Array [
+      expect(customFieldSerializer(customField)).toMatchInlineSnapshot(`
         Object {
-          "defaultValue": "My default value",
-          "key": "test_key_1",
-          "label": "My test label 1!!!",
-          "required": true,
-          "type": "text",
-        },
-        Object {
-          "defaultValue": true,
-          "key": "test_key_2",
-          "label": "My test label 2",
+          "defaultValue": false,
+          "key": "my_test_key",
           "required": true,
           "type": "toggle",
-        },
-        Object {
-          "key": "test_key_3",
-          "label": "My test label 3",
-          "required": false,
-          "type": "text",
-        },
-        Object {
-          "key": "test_key_4",
-          "label": "My test label 4",
-          "required": false,
-          "type": "toggle",
-        },
-      ]
-    `
-    );
+        }
+      `);
+    });
   });
 });

--- a/x-pack/plugins/cases/public/components/custom_fields/utils.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { isEmptyString } from '@kbn/es-ui-shared-plugin/static/validators/string';
+import { isString } from 'lodash';
 import type { CustomFieldConfiguration } from '../../../common/types/domain';
 
 export const addOrReplaceCustomField = <T extends { key: string }>(
@@ -34,11 +35,9 @@ export const customFieldSerializer = (
 ): CustomFieldConfiguration => {
   const { defaultValue, ...otherProperties } = field;
 
-  return {
-    ...otherProperties,
-    ...(!isEmptyString(String(defaultValue)) &&
-      defaultValue !== undefined && {
-        defaultValue,
-      }),
-  } as CustomFieldConfiguration;
+  if (defaultValue === undefined || (isString(defaultValue) && isEmptyString(defaultValue))) {
+    return otherProperties;
+  }
+
+  return field;
 };

--- a/x-pack/plugins/cases/public/components/custom_fields/utils.ts
+++ b/x-pack/plugins/cases/public/components/custom_fields/utils.ts
@@ -5,6 +5,9 @@
  * 2.0.
  */
 
+import { isEmptyString } from '@kbn/es-ui-shared-plugin/static/validators/string';
+import type { CustomFieldConfiguration } from '../../../common/types/domain';
+
 export const addOrReplaceCustomField = <T extends { key: string }>(
   customFields: T[],
   customFieldToAdd: T
@@ -24,4 +27,18 @@ export const addOrReplaceCustomField = <T extends { key: string }>(
 
     return customFieldToAdd;
   });
+};
+
+export const customFieldSerializer = (
+  field: CustomFieldConfiguration
+): CustomFieldConfiguration => {
+  const { defaultValue, ...otherProperties } = field;
+
+  return {
+    ...otherProperties,
+    ...(!isEmptyString(String(defaultValue)) &&
+      defaultValue !== undefined && {
+        defaultValue,
+      }),
+  } as CustomFieldConfiguration;
 };

--- a/x-pack/plugins/cases/server/client/configure/client.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.test.ts
@@ -347,29 +347,6 @@ describe('client', () => {
       );
     });
 
-    it('throws when a required custom field is missing the default value', async () => {
-      await expect(
-        update(
-          'test-id',
-          {
-            version: 'test-version',
-            customFields: [
-              {
-                key: 'missing_default',
-                label: 'text label',
-                type: CustomFieldTypes.TEXT,
-                required: true,
-              },
-            ],
-          },
-          clientArgs,
-          casesClientInternal
-        )
-      ).rejects.toThrow(
-        'Failed to get patch configure in route: Error: The following required custom fields are missing the default value: "text label"'
-      );
-    });
-
     it('throws when an optional custom field has a default value', async () => {
       await expect(
         update(
@@ -452,28 +429,6 @@ describe('client', () => {
         )
       ).rejects.toThrow(
         'Failed to create case configuration: Error: Invalid duplicated custom field keys in request: duplicated_key'
-      );
-    });
-
-    it('throws when a required custom field is missing the default value', async () => {
-      await expect(
-        create(
-          {
-            ...baseRequest,
-            customFields: [
-              {
-                key: 'missing_default',
-                label: 'text label',
-                type: CustomFieldTypes.TEXT,
-                required: true,
-              },
-            ],
-          },
-          clientArgs,
-          casesClientInternal
-        )
-      ).rejects.toThrow(
-        'Failed to create case configuration: Error: The following required custom fields are missing the default value: "text label"'
       );
     });
 

--- a/x-pack/plugins/cases/server/client/configure/client.ts
+++ b/x-pack/plugins/cases/server/client/configure/client.ts
@@ -52,7 +52,6 @@ import { validateDuplicatedCustomFieldKeysInRequest } from '../validators';
 import {
   validateCustomFieldTypesInRequest,
   validateOptionalCustomFieldsInRequest,
-  validateRequiredCustomFieldsInRequest,
 } from './validators';
 
 /**
@@ -257,7 +256,6 @@ export async function update(
     const request = decodeWithExcessOrThrow(ConfigurationPatchRequestRt)(req);
 
     validateDuplicatedCustomFieldKeysInRequest({ requestCustomFields: request.customFields });
-    validateRequiredCustomFieldsInRequest({ requestCustomFields: request.customFields });
     validateOptionalCustomFieldsInRequest({ requestCustomFields: request.customFields });
 
     const { version, ...queryWithoutVersion } = request;
@@ -372,9 +370,6 @@ export async function create(
       decodeWithExcessOrThrow(ConfigurationRequestRt)(configRequest);
 
     validateDuplicatedCustomFieldKeysInRequest({
-      requestCustomFields: validatedConfigurationRequest.customFields,
-    });
-    validateRequiredCustomFieldsInRequest({
       requestCustomFields: validatedConfigurationRequest.customFields,
     });
     validateOptionalCustomFieldsInRequest({

--- a/x-pack/plugins/cases/server/client/configure/validators.test.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.test.ts
@@ -9,7 +9,6 @@ import { CustomFieldTypes } from '../../../common/types/domain';
 import {
   validateCustomFieldTypesInRequest,
   validateOptionalCustomFieldsInRequest,
-  validateRequiredCustomFieldsInRequest,
 } from './validators';
 
 describe('validators', () => {
@@ -71,61 +70,6 @@ describe('validators', () => {
           originalCustomFields: [],
         })
       ).not.toThrow();
-    });
-  });
-
-  describe('validateRequiredCustomFieldsInRequest', () => {
-    it('does not throw an error for not required custom fields', () => {
-      expect(() =>
-        validateRequiredCustomFieldsInRequest({
-          requestCustomFields: [
-            { key: '1', required: false, label: 'label 1' },
-            { key: '2', required: false, label: 'label 2' },
-          ],
-        })
-      ).not.toThrow();
-    });
-
-    it('does not throw an error for required custom fields with default values', () => {
-      expect(() =>
-        validateRequiredCustomFieldsInRequest({
-          requestCustomFields: [
-            { key: '1', required: true, defaultValue: false, label: 'label 1' },
-            { key: '2', required: true, defaultValue: 'foobar', label: 'label 2' },
-          ],
-        })
-      ).not.toThrow();
-    });
-
-    it('does not throw an error for other falsy defaultValues (0)', () => {
-      expect(() =>
-        validateRequiredCustomFieldsInRequest({
-          // @ts-ignore intended
-          requestCustomFields: [{ key: '1', required: true, defaultValue: 0 }],
-        })
-      ).not.toThrow();
-    });
-
-    it('does not throw an error for other falsy defaultValues (empty string)', () => {
-      expect(() =>
-        validateRequiredCustomFieldsInRequest({
-          requestCustomFields: [{ key: '1', required: true, defaultValue: '', label: 'label' }],
-        })
-      ).not.toThrow();
-    });
-
-    it('throws an error with the keys of required customFields missing a default value', () => {
-      expect(() =>
-        validateRequiredCustomFieldsInRequest({
-          requestCustomFields: [
-            { key: '1', required: true, defaultValue: null, label: 'label 1' },
-            { key: '2', required: true, label: 'label 2' },
-            { key: '3', required: false, label: 'label 3' },
-          ],
-        })
-      ).toThrowErrorMatchingInlineSnapshot(
-        `"The following required custom fields are missing the default value: \\"label 1\\", \\"label 2\\""`
-      );
     });
   });
 

--- a/x-pack/plugins/cases/server/client/configure/validators.ts
+++ b/x-pack/plugins/cases/server/client/configure/validators.ts
@@ -40,43 +40,6 @@ export const validateCustomFieldTypesInRequest = ({
 };
 
 /**
- * Throws an error if any required custom field is missing the default value.
- */
-export const validateRequiredCustomFieldsInRequest = ({
-  requestCustomFields,
-}: {
-  requestCustomFields?: Array<{
-    key: string;
-    required: boolean;
-    defaultValue?: string | boolean | null;
-    label: string;
-  }>;
-}) => {
-  if (!Array.isArray(requestCustomFields)) {
-    return;
-  }
-
-  const invalidFields: string[] = [];
-
-  requestCustomFields.forEach((requestField) => {
-    if (
-      requestField.required &&
-      (requestField.defaultValue === undefined || requestField.defaultValue === null)
-    ) {
-      invalidFields.push(`"${requestField.label}"`);
-    }
-  });
-
-  if (invalidFields.length > 0) {
-    throw Boom.badRequest(
-      `The following required custom fields are missing the default value: ${invalidFields.join(
-        ', '
-      )}`
-    );
-  }
-};
-
-/**
  * Throws an error if any optional custom field defines a default value.
  */
 export const validateOptionalCustomFieldsInRequest = ({

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/patch_configure.ts
@@ -60,7 +60,7 @@ export default ({ getService }: FtrProviderContext): void => {
           key: 'text_field',
           label: '#1',
           type: CustomFieldTypes.TEXT,
-          required: false,
+          required: true,
         },
         {
           key: 'toggle_field',

--- a/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
+++ b/x-pack/test/cases_api_integration/security_and_spaces/tests/common/configure/post_configure.ts
@@ -71,6 +71,12 @@ export default ({ getService }: FtrProviderContext): void => {
             required: true,
             defaultValue: false,
           },
+          {
+            key: 'hello_again',
+            label: 'text',
+            type: CustomFieldTypes.TEXT,
+            required: true,
+          },
         ],
       };
 


### PR DESCRIPTION
## Summary

Setting a default value is now optional for required custom fields.

This means:
1. Removed the required custom field validation from PATCH configuration
1. Removed the required custom field validation from POST configuration
2. Removed the schema that validated empty default values for the forms/UI in the cases settings page

The UI will:
1. Send the initial defaultValue if it exists(`undefined | null | non_empty_string`)
  - Applies mostly to the edit custom field form
2. Not send the `defaultValue` property if the user sets it to an empty `string` in the form.

With this PR we will no longer have the bug described(and fixed) in https://github.com/elastic/kibana/pull/175825