### PR TITLE
[Fleet] added output validation when creating package policy

### DIFF
--- a/x-pack/plugins/fleet/common/services/output_helpers.ts
+++ b/x-pack/plugins/fleet/common/services/output_helpers.ts
@@ -19,6 +19,12 @@ import {
   RESERVED_CONFIG_YML_KEYS,
 } from '../constants';
 
+const sameClusterRestrictedPackages = [
+  FLEET_SERVER_PACKAGE,
+  FLEET_SYNTHETICS_PACKAGE,
+  FLEET_APM_PACKAGE,
+];
+
 /**
  * Return allowed output type for a given agent policy,
  * Fleet Server and APM cannot use anything else than same cluster ES
@@ -27,11 +33,18 @@ export function getAllowedOutputTypeForPolicy(agentPolicy: AgentPolicy) {
   const isRestrictedToSameClusterES =
     agentPolicy.package_policies &&
     agentPolicy.package_policies.some(
-      (p) =>
-        p.package?.name === FLEET_SERVER_PACKAGE ||
-        p.package?.name === FLEET_SYNTHETICS_PACKAGE ||
-        p.package?.name === FLEET_APM_PACKAGE
+      (p) => p.package?.name && sameClusterRestrictedPackages.includes(p.package?.name)
     );
+
+  if (isRestrictedToSameClusterES) {
+    return [outputType.Elasticsearch];
+  }
+
+  return Object.values(outputType);
+}
+
+export function getAllowedOutputTypesForIntegration(packageName: string) {
+  const isRestrictedToSameClusterES = sameClusterRestrictedPackages.includes(packageName);
 
   if (isRestrictedToSameClusterES) {
     return [outputType.Elasticsearch];

--- a/x-pack/plugins/fleet/common/services/output_helpers.ts
+++ b/x-pack/plugins/fleet/common/services/output_helpers.ts
@@ -29,7 +29,7 @@ const sameClusterRestrictedPackages = [
  * Return allowed output type for a given agent policy,
  * Fleet Server and APM cannot use anything else than same cluster ES
  */
-export function getAllowedOutputTypeForPolicy(agentPolicy: AgentPolicy) {
+export function getAllowedOutputTypeForPolicy(agentPolicy: AgentPolicy): string[] {
   const isRestrictedToSameClusterES =
     agentPolicy.package_policies &&
     agentPolicy.package_policies.some(
@@ -43,7 +43,7 @@ export function getAllowedOutputTypeForPolicy(agentPolicy: AgentPolicy) {
   return Object.values(outputType);
 }
 
-export function getAllowedOutputTypesForIntegration(packageName: string) {
+export function getAllowedOutputTypesForIntegration(packageName: string): string[] {
   const isRestrictedToSameClusterES = sameClusterRestrictedPackages.includes(packageName);
 
   if (isRestrictedToSameClusterES) {

--- a/x-pack/plugins/fleet/server/services/agent_policies/outputs_helpers.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/outputs_helpers.ts
@@ -7,6 +7,8 @@
 
 import type { SavedObjectsClientContract } from '@kbn/core/server';
 
+import { getAllowedOutputTypesForIntegration } from '../../../common/services/output_helpers';
+
 import type { AgentPolicySOAttributes, AgentPolicy } from '../../types';
 import { LICENCE_FOR_PER_POLICY_OUTPUT, outputType } from '../../../common/constants';
 import { policyHasFleetServer, policyHasSyntheticsIntegration } from '../../../common/services';
@@ -91,5 +93,25 @@ export async function validateOutputForPolicy(
     throw new OutputLicenceError(
       `Invalid licence to set per policy output, you need ${LICENCE_FOR_PER_POLICY_OUTPUT} licence`
     );
+  }
+}
+
+export async function validateOutputForNewPackagePolicy(
+  soClient: SavedObjectsClientContract,
+  agentPolicy: AgentPolicy,
+  packageName: string
+) {
+  const allowedOutputTypeForPolicy = getAllowedOutputTypesForIntegration(packageName);
+
+  const isOutputTypeRestricted =
+    allowedOutputTypeForPolicy.length !== Object.values(outputType).length;
+
+  if (isOutputTypeRestricted) {
+    const dataOutput = await getDataOutputForAgentPolicy(soClient, agentPolicy);
+    if (!allowedOutputTypeForPolicy.includes(dataOutput.type)) {
+      throw new OutputInvalidError(
+        `Integration "${packageName}" cannot be added to agent policy "${agentPolicy.name}" because it uses output type "${dataOutput.type}".`
+      );
+    }
   }
 }

--- a/x-pack/plugins/fleet/server/services/agent_policies/outputs_helpers.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policies/outputs_helpers.ts
@@ -48,7 +48,7 @@ export async function validateOutputForPolicy(
   soClient: SavedObjectsClientContract,
   newData: Partial<AgentPolicySOAttributes>,
   existingData: Partial<AgentPolicySOAttributes> = {},
-  allowedOutputTypeForPolicy = Object.values(outputType)
+  allowedOutputTypeForPolicy: string[] = Object.values(outputType)
 ) {
   if (
     newData.data_output_id === existingData.data_output_id &&

--- a/x-pack/plugins/fleet/server/services/package_policy.ts
+++ b/x-pack/plugins/fleet/server/services/package_policy.ts
@@ -46,8 +46,6 @@ import {
 } from '../../common/services';
 import {
   SO_SEARCH_LIMIT,
-  FLEET_APM_PACKAGE,
-  outputType,
   PACKAGES_SAVED_OBJECT_TYPE,
   DATASET_VAR_NAME,
 } from '../../common/constants';
@@ -103,7 +101,6 @@ import { getAuthzFromRequest, doesNotHaveRequiredFleetAuthz } from './security';
 
 import { storedPackagePolicyToAgentInputs } from './agent_policies';
 import { agentPolicyService } from './agent_policy';
-import { getDataOutputForAgentPolicy } from './agent_policies';
 import { getPackageInfo, getInstallation, ensureInstalledPackage } from './epm/packages';
 import { getAssetsDataFromAssetsMap } from './epm/packages/assets';
 import { compileTemplate } from './epm/agent/agent';
@@ -124,6 +121,7 @@ import {
   isSecretStorageEnabled,
 } from './secrets';
 import { getPackageAssetsMap } from './epm/packages/get';
+import { validateOutputForNewPackagePolicy } from './agent_policies/outputs_helpers';
 
 export type InputsOverride = Partial<NewPackagePolicyInput> & {
   vars?: Array<NewPackagePolicyInput['vars'] & { name: string }>;
@@ -225,11 +223,12 @@ class PackagePolicyClientImpl implements PackagePolicyClient {
       true
     );
 
-    if (agentPolicy && enrichedPackagePolicy.package?.name === FLEET_APM_PACKAGE) {
-      const dataOutput = await getDataOutputForAgentPolicy(soClient, agentPolicy);
-      if (dataOutput.type === outputType.Logstash) {
-        throw new FleetError('You cannot add APM to a policy using a logstash output');
-      }
+    if (agentPolicy && enrichedPackagePolicy.package?.name) {
+      await validateOutputForNewPackagePolicy(
+        soClient,
+        agentPolicy,
+        enrichedPackagePolicy.package?.name
+      );
     }
     await validateIsNotHostedPolicy(soClient, enrichedPackagePolicy.policy_id, options?.force);
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/165816

Added validation to prevent adding an integration to an agent policy that uses an output different than `elasticsearch`.

To verify:
1. Create a logstash output and make it default output by enabling the toggles.
2. Navigate to Integrations and search Fleet Server integration.
3. Add this fleet server integration to a new or existing policy.
4. There should be an error popup saying that this integration can't be added to the agent policy.

<img width="1439" alt="image" src="https://github.com/elastic/kibana/assets/90178898/13f39bfc-8af1-4fa7-95e8-7ff41c6439a4">


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
