### PR TITLE
[Ops] Add debug logging to certain jest error cases

### DIFF
--- a/packages/kbn-test/jest-preset.js
+++ b/packages/kbn-test/jest-preset.js
@@ -130,4 +130,7 @@ module.exports = {
   globals: {
     structuredClone: {},
   },
+
+  testResultsProcessor:
+    '<rootDir>/packages/kbn-test/src/jest/result_processors/logging_result_processor.js',
 };

--- a/packages/kbn-test/src/jest/result_processors/logging_result_processor.js
+++ b/packages/kbn-test/src/jest/result_processors/logging_result_processor.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+const FAILURE_MESSAGE_TRIGGERS = ['but is not defined anymore'];
+const log = (...args) => {
+  const loggable = args.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)));
+  process.stdout.write(`${loggable.join(' ')}\n`);
+};
+/**
+ * This processor looks for specific errors, and logs the result context of test suites where they occur.
+ * @param results
+ * @returns {*}
+ */
+module.exports = (results) => {
+  const resultsThatMatchTriggers = results.testResults.filter(
+    (e) =>
+      e.failureMessage &&
+      FAILURE_MESSAGE_TRIGGERS.some((trigger) => e.failureMessage.includes(trigger))
+  );
+
+  if (resultsThatMatchTriggers.length !== 0) {
+    log('The following test suites failed, with notable errors:');
+    resultsThatMatchTriggers.forEach((e) => {
+      log(` -> ${e.testFilePath}`, 'Details: ', e);
+    });
+  }
+
+  return results;
+};

--- a/packages/kbn-test/src/jest/result_processors/logging_result_processor.js
+++ b/packages/kbn-test/src/jest/result_processors/logging_result_processor.js
@@ -8,8 +8,10 @@
 
 const FAILURE_MESSAGE_TRIGGERS = ['but is not defined anymore'];
 const log = (...args) => {
-  const loggable = args.map((arg) => (typeof arg === 'string' ? arg : JSON.stringify(arg)));
-  process.stdout.write(`${loggable.join(' ')}\n`);
+  const loggable = args.map((arg) =>
+    typeof arg === 'string' ? arg : JSON.stringify(arg, null, 2)
+  );
+  process.stdout.write(`${loggable.join(' ')}\n`, 'utf8');
 };
 /**
  * This processor looks for specific errors, and logs the result context of test suites where they occur.
@@ -26,7 +28,7 @@ module.exports = (results) => {
   if (resultsThatMatchTriggers.length !== 0) {
     log('The following test suites failed, with notable errors:');
     resultsThatMatchTriggers.forEach((e) => {
-      log(` -> ${e.testFilePath}`, 'Details: ', e);
+      log(` -> ${e.testFilePath}`, 'Details: ', e, '\n');
     });
   }
 


### PR DESCRIPTION
## Summary
We see quite frequently this kind of error in Jest unit tests:
```
Error: The `document` global was defined when React was initialized, but is not defined anymore. This can happen in a test environment if a component schedules an update from an asynchronous callback, but the test has already finished running. To solve this, you can either unmount the component at the end of your test (and ensure that any asynchronous operations get canceled in `componentWillUnmount`), or you can change the test itself to be asynchronous.
```

As the test execution stops due to this runtime error, and the console logging is disabled in CI, we don't see a lot of the context of the error. 

This PR adds minimal extra logging when the case of this error happens. 