### PR TITLE
[Security Solution][Timeline] fix wrong add to favorite within timeline guided tour

### DIFF
--- a/x-pack/plugins/security_solution/public/timelines/components/add_to_favorites/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/add_to_favorites/index.test.tsx
@@ -30,10 +30,10 @@ jest.mock('react-redux', () => {
   };
 });
 
-const renderAddFavoritesButton = () =>
+const renderAddFavoritesButton = (isPartOfGuidedTour = false) =>
   render(
     <TestProviders>
-      <AddToFavoritesButton timelineId="timeline-1" />
+      <AddToFavoritesButton timelineId="timeline-1" isPartOfGuidedTour={isPartOfGuidedTour} />
     </TestProviders>
   );
 
@@ -49,6 +49,7 @@ describe('AddToFavoritesButton', () => {
     const button = getByTestId('timeline-favorite-empty-star');
 
     expect(button).toBeInTheDocument();
+    expect(button).toHaveProperty('id', '');
     expect(button.firstChild).toHaveAttribute('data-euiicon-type', 'starEmpty');
     expect(queryByTestId('timeline-favorite-filled-star')).not.toBeInTheDocument();
   });
@@ -85,5 +86,18 @@ describe('AddToFavoritesButton', () => {
 
     expect(getByTestId('timeline-favorite-filled-star')).toBeInTheDocument();
     expect(queryByTestId('timeline-favorite-empty-star')).not.toBeInTheDocument();
+  });
+
+  it('should use id for guided tour if prop is true', () => {
+    mockGetState.mockReturnValue({
+      ...mockTimelineModel,
+      status: TimelineStatus.active,
+    });
+
+    const { getByTestId } = renderAddFavoritesButton(true);
+
+    const button = getByTestId('timeline-favorite-empty-star');
+
+    expect(button).toHaveProperty('id', 'add-to-favorites');
   });
 });

--- a/x-pack/plugins/security_solution/public/timelines/components/add_to_favorites/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/add_to_favorites/index.tsx
@@ -34,40 +34,46 @@ interface AddToFavoritesButtonProps {
    * Id of the timeline to be displayed in the bottom bar and within the modal
    */
   timelineId: string;
+  /**
+   * Whether the button is a step in the timeline guided tour
+   */
+  isPartOfGuidedTour?: boolean;
 }
 
 /**
  * This component renders the add to favorites button for timeline.
  * It is used in the bottom bar as well as in the timeline modal's header.
  */
-export const AddToFavoritesButton = React.memo<AddToFavoritesButtonProps>(({ timelineId }) => {
-  const dispatch = useDispatch();
-  const { isFavorite, status } = useSelector((state: State) =>
-    selectTimelineById(state, timelineId)
-  );
+export const AddToFavoritesButton = React.memo<AddToFavoritesButtonProps>(
+  ({ timelineId, isPartOfGuidedTour = false }) => {
+    const dispatch = useDispatch();
+    const { isFavorite, status } = useSelector((state: State) =>
+      selectTimelineById(state, timelineId)
+    );
 
-  const isTimelineDraftOrImmutable = status !== TimelineStatus.active;
-  const label = isFavorite ? REMOVE_FROM_FAVORITES : ADD_TO_FAVORITES;
+    const isTimelineDraftOrImmutable = status !== TimelineStatus.active;
+    const label = isFavorite ? REMOVE_FROM_FAVORITES : ADD_TO_FAVORITES;
 
-  const handleClick = useCallback(
-    () => dispatch(timelineActions.updateIsFavorite({ id: timelineId, isFavorite: !isFavorite })),
-    [dispatch, timelineId, isFavorite]
-  );
+    const handleClick = useCallback(
+      () => dispatch(timelineActions.updateIsFavorite({ id: timelineId, isFavorite: !isFavorite })),
+      [dispatch, timelineId, isFavorite]
+    );
 
-  return (
-    <EuiButtonIcon
-      id={TIMELINE_TOUR_CONFIG_ANCHORS.ADD_TO_FAVORITES}
-      iconType={isFavorite ? 'starFilled' : 'starEmpty'}
-      isSelected={isFavorite}
-      disabled={isTimelineDraftOrImmutable}
-      aria-label={label}
-      title={label}
-      data-test-subj={`timeline-favorite-${isFavorite ? 'filled' : 'empty'}-star`}
-      onClick={handleClick}
-    >
-      {label}
-    </EuiButtonIcon>
-  );
-});
+    return (
+      <EuiButtonIcon
+        id={isPartOfGuidedTour ? TIMELINE_TOUR_CONFIG_ANCHORS.ADD_TO_FAVORITES : undefined}
+        iconType={isFavorite ? 'starFilled' : 'starEmpty'}
+        isSelected={isFavorite}
+        disabled={isTimelineDraftOrImmutable}
+        aria-label={label}
+        title={label}
+        data-test-subj={`timeline-favorite-${isFavorite ? 'filled' : 'empty'}-star`}
+        onClick={handleClick}
+      >
+        {label}
+      </EuiButtonIcon>
+    );
+  }
+);
 
 AddToFavoritesButton.displayName = 'AddToFavoritesButton';

--- a/x-pack/plugins/security_solution/public/timelines/components/bottom_bar/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/bottom_bar/index.test.tsx
@@ -32,6 +32,7 @@ describe('TimelineBottomBar', () => {
     expect(getByTestId('timeline-event-count-badge')).toBeInTheDocument();
     expect(getByTestId('timeline-save-status')).toBeInTheDocument();
     expect(getByTestId('timeline-favorite-empty-star')).toBeInTheDocument();
+    expect(getByTestId('timeline-favorite-empty-star')).toHaveProperty('id', '');
   });
 
   test('should not render the event count badge if timeline is open', () => {

--- a/x-pack/plugins/security_solution/public/timelines/components/modal/header/index.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/modal/header/index.tsx
@@ -120,7 +120,7 @@ export const TimelineModalHeader = React.memo<FlyoutHeaderPanelProps>(({ timelin
         <EuiFlexItem grow={false}>
           <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
             <EuiFlexItem grow={false}>
-              <AddToFavoritesButton timelineId={timelineId} />
+              <AddToFavoritesButton timelineId={timelineId} isPartOfGuidedTour />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <EuiText


### PR DESCRIPTION
## Summary

This PR fixes the timeline guided tour. The bug must have been introduced in this refactor [PR](https://github.com/elastic/kibana/pull/175161), but looking at the prior code, I'm not sure how things were correctly working before. We already had the favorite button shared and both had the same id...

The code is now working correctly

https://github.com/elastic/kibana/assets/17276605/2a66a10b-4c08-4c26-92d8-482af47c36fc

_Notes: I decided to use a `isPartOfGuidedTour: boolean` prop but originally had a different idea: using something like `guidedTourId: string` (`guidedTourId` would be the actual tour id). I didn't like the fact that the parent component had to know about that information though, so decided against it. If you think this would be better I'll make the change!_

https://github.com/elastic/kibana/issues/175952

### TODO:
- [x] add unit test to verify for guided tour

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
