### PR TITLE
[Console] Add support to remotely open Embeddable Console

### DIFF
--- a/packages/kbn-search-api-panels/components/code_box.tsx
+++ b/packages/kbn-search-api-panels/components/code_box.tsx
@@ -23,6 +23,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 
 import { LanguageDefinition } from '../types';
@@ -38,6 +39,7 @@ interface CodeBoxProps {
   setSelectedLanguage: (language: LanguageDefinition) => void;
   assetBasePath: string;
   application?: ApplicationStart;
+  consolePlugin?: ConsolePluginStart;
   sharePlugin: SharePluginStart;
   consoleRequest?: string;
 }
@@ -45,6 +47,7 @@ interface CodeBoxProps {
 export const CodeBox: React.FC<CodeBoxProps> = ({
   application,
   codeSnippet,
+  consolePlugin,
   languageType,
   languages,
   assetBasePath,
@@ -117,6 +120,7 @@ export const CodeBox: React.FC<CodeBoxProps> = ({
               <TryInConsoleButton
                 request={consoleRequest}
                 application={application}
+                consolePlugin={consolePlugin}
                 sharePlugin={sharePlugin}
               />
             </EuiFlexItem>

--- a/packages/kbn-search-api-panels/components/ingest_data.tsx
+++ b/packages/kbn-search-api-panels/components/ingest_data.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { EuiSpacer, EuiTitle } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { ApplicationStart } from '@kbn/core-application-browser';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import { CodeBox } from './code_box';
 import { LanguageDefinition } from '../types';
@@ -26,6 +27,7 @@ interface IngestDataProps {
   };
   assetBasePath: string;
   application?: ApplicationStart;
+  consolePlugin?: ConsolePluginStart;
   sharePlugin: SharePluginStart;
   languages: LanguageDefinition[];
   consoleRequest?: string;
@@ -39,6 +41,7 @@ export const IngestData: React.FC<IngestDataProps> = ({
   docLinks,
   assetBasePath,
   application,
+  consolePlugin,
   sharePlugin,
   languages,
   consoleRequest,
@@ -58,6 +61,7 @@ export const IngestData: React.FC<IngestDataProps> = ({
           setSelectedLanguage={setSelectedLanguage}
           assetBasePath={assetBasePath}
           application={application}
+          consolePlugin={consolePlugin}
           sharePlugin={sharePlugin}
         />
       }

--- a/packages/kbn-search-api-panels/components/try_in_console_button.tsx
+++ b/packages/kbn-search-api-panels/components/try_in_console_button.tsx
@@ -36,7 +36,7 @@ export const TryInConsoleButton = ({
       <EuiButtonEmpty
         iconType="popout"
         size="s"
-        onClick={() => consolePlugin?.openEmbeddedConsole?.()}
+        onClick={() => consolePlugin?.openEmbeddedConsole?.(request)}
       >
         <FormattedMessage
           id="searchApiPanels.welcomeBanner.tryInConsoleButton"

--- a/packages/kbn-search-api-panels/components/try_in_console_button.tsx
+++ b/packages/kbn-search-api-panels/components/try_in_console_button.tsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 
 import { FormattedMessage } from '@kbn/i18n-react';
 import { compressToEncodedURIComponent } from 'lz-string';
@@ -18,16 +19,32 @@ import { compressToEncodedURIComponent } from 'lz-string';
 export interface TryInConsoleButtonProps {
   request: string;
   application?: ApplicationStart;
+  consolePlugin?: ConsolePluginStart;
   sharePlugin: SharePluginStart;
 }
 export const TryInConsoleButton = ({
   request,
   application,
+  consolePlugin,
   sharePlugin,
 }: TryInConsoleButtonProps) => {
   const { url } = sharePlugin;
   const canShowDevtools = !!application?.capabilities?.dev_tools?.show;
   if (!canShowDevtools || !url) return null;
+  if (consolePlugin && consolePlugin?.isEmbeddedConsoleAvailable?.()) {
+    return (
+      <EuiButtonEmpty
+        iconType="popout"
+        size="s"
+        onClick={() => consolePlugin?.openEmbeddedConsole?.()}
+      >
+        <FormattedMessage
+          id="searchApiPanels.welcomeBanner.tryInConsoleButton"
+          defaultMessage="Try in Console"
+        />
+      </EuiButtonEmpty>
+    );
+  }
 
   const devToolsDataUri = compressToEncodedURIComponent(request);
   const consolePreviewLink = url.locators.get('CONSOLE_APP_LOCATOR')?.useUrl(

--- a/packages/kbn-search-api-panels/components/try_in_console_button.tsx
+++ b/packages/kbn-search-api-panels/components/try_in_console_button.tsx
@@ -31,20 +31,6 @@ export const TryInConsoleButton = ({
   const { url } = sharePlugin;
   const canShowDevtools = !!application?.capabilities?.dev_tools?.show;
   if (!canShowDevtools || !url) return null;
-  if (consolePlugin && consolePlugin?.isEmbeddedConsoleAvailable?.()) {
-    return (
-      <EuiButtonEmpty
-        iconType="popout"
-        size="s"
-        onClick={() => consolePlugin?.openEmbeddedConsole?.(request)}
-      >
-        <FormattedMessage
-          id="searchApiPanels.welcomeBanner.tryInConsoleButton"
-          defaultMessage="Try in Console"
-        />
-      </EuiButtonEmpty>
-    );
-  }
 
   const devToolsDataUri = compressToEncodedURIComponent(request);
   const consolePreviewLink = url.locators.get('CONSOLE_APP_LOCATOR')?.useUrl(
@@ -56,8 +42,20 @@ export const TryInConsoleButton = ({
   );
   if (!consolePreviewLink) return null;
 
+  const onClick = () => {
+    const embeddedConsoleAvailable =
+      (consolePlugin?.openEmbeddedConsole !== undefined &&
+        consolePlugin?.isEmbeddedConsoleAvailable?.()) ??
+      false;
+    if (embeddedConsoleAvailable) {
+      consolePlugin!.openEmbeddedConsole!(request);
+    } else {
+      window.open(consolePreviewLink, '_blank', 'noreferrer');
+    }
+  };
+
   return (
-    <EuiButtonEmpty href={consolePreviewLink} iconType="popout" target="_blank" size="s">
+    <EuiButtonEmpty onClick={onClick} iconType="popout" size="s">
       <FormattedMessage
         id="searchApiPanels.welcomeBanner.tryInConsoleButton"
         defaultMessage="Try in Console"

--- a/packages/kbn-search-api-panels/tsconfig.json
+++ b/packages/kbn-search-api-panels/tsconfig.json
@@ -21,6 +21,7 @@
     "@kbn/core-application-browser",
     "@kbn/share-plugin",
     "@kbn/i18n-react",
-    "@kbn/security-plugin"
+    "@kbn/security-plugin",
+    "@kbn/console-plugin"
   ]
 }

--- a/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
+++ b/src/plugins/console/public/application/containers/editor/legacy/console_editor/editor.tsx
@@ -108,7 +108,7 @@ function EditorUI({ initialTextValue, setEditorInstance }: EditorProps) {
     }
 
     const readQueryParams = () => {
-      const [, queryString] = (window.location.hash || '').split('?');
+      const [, queryString] = (window.location.hash || window.location.search || '').split('?');
 
       return parse(queryString || '', { sort: false }) as Required<QueryParams>;
     };

--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -14,8 +14,10 @@ import {
   I18nStart,
   CoreTheme,
   DocLinksStart,
+  CoreStart,
 } from '@kbn/core/public';
 import { KibanaThemeProvider } from '@kbn/react-kibana-context-theme';
+import { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
 
 import { ObjectStorageClient } from '../../../../common/types';
 
@@ -62,10 +64,10 @@ interface ConsoleDependencies {
   trackUiMetric: MetricsTracker;
 }
 
-const loadDependencies = async ({
-  core,
-  usageCollection,
-}: EmbeddableConsoleDependencies): Promise<ConsoleDependencies> => {
+const loadDependencies = async (
+  core: CoreStart,
+  usageCollection?: UsageCollectionStart
+): Promise<ConsoleDependencies> => {
   const {
     docLinks: { DOC_LINK_VERSION, links },
     http,
@@ -107,10 +109,12 @@ const loadDependencies = async ({
   };
 };
 
-export const ConsoleWrapper = (props: EmbeddableConsoleDependencies): React.ReactElement => {
+type ConsoleWrapperProps = Omit<EmbeddableConsoleDependencies, 'setDispatch'>;
+
+export const ConsoleWrapper: React.FunctionComponent<ConsoleWrapperProps> = (props) => {
   const [dependencies, setDependencies] = useState<ConsoleDependencies | null>(null);
   useEffect(() => {
-    loadDependencies(props).then(setDependencies);
+    loadDependencies(props.core, props.usageCollection).then(setDependencies);
   }, [setDependencies, props]);
   useEffect(() => {
     return () => {

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { useState } from 'react';
+import React, { useReducer, useEffect } from 'react';
 import classNames from 'classnames';
 import useObservable from 'react-use/lib/useObservable';
 import {
@@ -25,6 +25,8 @@ import {
   EmbeddableConsoleDependencies,
 } from '../../../types/embeddable_console';
 
+import * as store from '../../stores/embeddable_console';
+
 import { ConsoleWrapper } from './console_wrapper';
 import './_index.scss';
 
@@ -36,10 +38,24 @@ export const EmbeddableConsole = ({
   size = 'm',
   core,
   usageCollection,
+  setDispatch,
 }: EmbeddableConsoleProps & EmbeddableConsoleDependencies) => {
-  const [isConsoleOpen, setIsConsoleOpen] = useState<boolean>(false);
-  const toggleConsole = () => setIsConsoleOpen(!isConsoleOpen);
+  const [consoleState, consoleDispatch] = useReducer(
+    store.reducer,
+    store.initialValue,
+    (value) => ({ ...value })
+  );
   const chromeStyle = useObservable(core.chrome.getChromeStyle$());
+  useEffect(() => {
+    setDispatch(consoleDispatch);
+    return () => setDispatch(null);
+  }, [setDispatch, consoleDispatch]);
+
+  const isConsoleOpen = consoleState.isOpen;
+  const setIsConsoleOpen = (value: boolean) => {
+    consoleDispatch(value ? { type: 'open' } : { type: 'close' });
+  };
+  const toggleConsole = () => setIsConsoleOpen(!isConsoleOpen);
 
   const onKeyDown = (event: any) => {
     if (event.key === keys.ESCAPE) {

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -26,6 +26,7 @@ import {
 } from '../../../types/embeddable_console';
 
 import * as store from '../../stores/embeddable_console';
+import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_from';
 
 import { ConsoleWrapper } from './console_wrapper';
 import './_index.scss';
@@ -50,6 +51,13 @@ export const EmbeddableConsole = ({
     setDispatch(consoleDispatch);
     return () => setDispatch(null);
   }, [setDispatch, consoleDispatch]);
+  useEffect(() => {
+    if (consoleState.isOpen && consoleState.loadFromContent) {
+      setLoadFromParameter(consoleState.loadFromContent);
+    } else if (!consoleState.isOpen) {
+      removeLoadFromParameter();
+    }
+  }, [consoleState.isOpen, consoleState.loadFromContent]);
 
   const isConsoleOpen = consoleState.isOpen;
   const setIsConsoleOpen = (value: boolean) => {

--- a/src/plugins/console/public/application/lib/load_from.test.ts
+++ b/src/plugins/console/public/application/lib/load_from.test.ts
@@ -17,7 +17,7 @@ const baseMockWindow = () => {
     location: {
       host: 'my-kibana.elastic.co',
       pathname: '',
-      protocol: 'https',
+      protocol: 'https:',
       search: '',
       hash: '',
     },

--- a/src/plugins/console/public/application/lib/load_from.test.ts
+++ b/src/plugins/console/public/application/lib/load_from.test.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { compressToEncodedURIComponent } from 'lz-string';
+import { setLoadFromParameter, removeLoadFromParameter } from './load_from';
+
+const baseMockWindow = () => {
+  return {
+    history: {
+      pushState: jest.fn(),
+    },
+    location: {
+      host: 'my-kibana.elastic.co',
+      pathname: '',
+      protocol: 'https',
+      search: '',
+      hash: '',
+    },
+  };
+};
+let windowSpy: jest.SpyInstance;
+let mockWindow = baseMockWindow();
+
+describe('load from lib', () => {
+  beforeEach(() => {
+    mockWindow = baseMockWindow();
+    windowSpy = jest.spyOn(globalThis, 'window', 'get');
+    windowSpy.mockImplementation(() => mockWindow);
+  });
+
+  afterEach(() => {
+    windowSpy.mockRestore();
+  });
+
+  describe('setLoadFromParameter', () => {
+    it('adds load_from as expected', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: '#/console',
+      };
+      const codeSnippet = 'GET /_stats';
+      const expectedUrl =
+        'https://my-kibana.elastic.co/foo/app/dev_tools#/console?load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgzgFwIYLkA';
+
+      setLoadFromParameter(codeSnippet);
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('can replace an existing value', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: `#/console?load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgxgQwC5QJYDsAmq4FMDOQA`,
+      };
+      const codeSnippet = 'GET /_stats';
+      const expectedUrl =
+        'https://my-kibana.elastic.co/foo/app/dev_tools#/console?load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgzgFwIYLkA';
+
+      setLoadFromParameter(codeSnippet);
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('works with other query params', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: '#/console?foo=bar',
+      };
+      const codeSnippet = 'GET /_stats';
+      const expectedUrl =
+        'https://my-kibana.elastic.co/foo/app/dev_tools#/console?foo=bar&load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgzgFwIYLkA';
+
+      setLoadFromParameter(codeSnippet);
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('works with a non-hash route', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/enterprise_search/overview',
+      };
+      const codeSnippet = 'GET /_stats';
+      const expectedUrl =
+        'https://my-kibana.elastic.co/foo/app/enterprise_search/overview?load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgzgFwIYLkA';
+
+      setLoadFromParameter(codeSnippet);
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('works with a non-hash route and other params', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/enterprise_search/overview',
+        search: '?foo=bar',
+      };
+      const codeSnippet = 'GET /_stats';
+      const expectedUrl =
+        'https://my-kibana.elastic.co/foo/app/enterprise_search/overview?foo=bar&load_from=data%3Atext%2Fplain%2COIUQKgBA9A%2BgzgFwIYLkA';
+
+      setLoadFromParameter(codeSnippet);
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+  });
+
+  describe('removeLoadFromParameter', () => {
+    it('leaves other params in place', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        search: `?foo=bar&load_from=data:text/plain,${compressToEncodedURIComponent(
+          'GET /_cat/indices'
+        )}`,
+      };
+
+      const expectedUrl = 'https://my-kibana.elastic.co/foo/app/dev_tools?foo=bar';
+
+      removeLoadFromParameter();
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('leaves other params with a hashroute', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: `#/console?foo=bar&load_from=data:text/plain,${compressToEncodedURIComponent(
+          'GET /_cat/indices'
+        )}`,
+      };
+
+      const expectedUrl = 'https://my-kibana.elastic.co/foo/app/dev_tools#/console?foo=bar';
+
+      removeLoadFromParameter();
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('removes ? if load_from was the only param', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        search: `?load_from=data:text/plain,${compressToEncodedURIComponent('GET /_cat/indices')}`,
+      };
+
+      const expectedUrl = 'https://my-kibana.elastic.co/foo/app/dev_tools';
+
+      removeLoadFromParameter();
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('removes ? if load_from was the only param in a hashroute', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: `#/console?load_from=data:text/plain,${compressToEncodedURIComponent(
+          'GET /_cat/indices'
+        )}`,
+      };
+
+      const expectedUrl = 'https://my-kibana.elastic.co/foo/app/dev_tools#/console';
+
+      removeLoadFromParameter();
+      expect(mockWindow.history.pushState).toHaveBeenCalledTimes(1);
+      expect(mockWindow.history.pushState).toHaveBeenCalledWith(
+        {
+          path: expectedUrl,
+        },
+        '',
+        expectedUrl
+      );
+    });
+    it('noop if load_from not currently defined on QS', () => {
+      mockWindow.location = {
+        ...mockWindow.location,
+        pathname: '/foo/app/dev_tools',
+        hash: `#/console?foo=bar`,
+      };
+
+      removeLoadFromParameter();
+      expect(mockWindow.history.pushState).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/plugins/console/public/application/lib/load_from.ts
+++ b/src/plugins/console/public/application/lib/load_from.ts
@@ -10,7 +10,7 @@ import qs from 'query-string';
 import { compressToEncodedURIComponent } from 'lz-string';
 
 function getBaseUrl() {
-  return `${window.location.protocol}://${window.location.host}${window.location.pathname}`;
+  return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
 }
 function parseQueryString() {
   const [hashRoute, queryString] = (window.location.hash || window.location.search || '').split(

--- a/src/plugins/console/public/application/lib/load_from.ts
+++ b/src/plugins/console/public/application/lib/load_from.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import qs from 'query-string';
+import { compressToEncodedURIComponent } from 'lz-string';
+
+function getBaseUrl() {
+  return `${window.location.protocol}://${window.location.host}${window.location.pathname}`;
+}
+function parseQueryString() {
+  const [hashRoute, queryString] = (window.location.hash || window.location.search || '').split(
+    '?'
+  );
+
+  const parsedQueryString = qs.parse(queryString || '', { sort: false });
+  return {
+    hasHash: !!window.location.hash,
+    hashRoute,
+    queryString: parsedQueryString,
+  };
+}
+
+export const setLoadFromParameter = (value: string) => {
+  const baseUrl = getBaseUrl();
+  const { hasHash, hashRoute, queryString } = parseQueryString();
+  const consoleDataUri = compressToEncodedURIComponent(value);
+  queryString.load_from = `data:text/plain,${consoleDataUri}`;
+  const params = `?${qs.stringify(queryString)}`;
+  const newUrl = hasHash ? `${baseUrl}${hashRoute}${params}` : `${baseUrl}${params}`;
+
+  window.history.pushState({ path: newUrl }, '', newUrl);
+};
+
+export const removeLoadFromParameter = () => {
+  const baseUrl = getBaseUrl();
+  const { hasHash, hashRoute, queryString } = parseQueryString();
+  if (queryString.load_from) {
+    delete queryString.load_from;
+
+    const params = Object.keys(queryString).length ? `?${qs.stringify(queryString)}` : '';
+    const newUrl = hasHash ? `${baseUrl}${hashRoute}${params}` : `${baseUrl}${params}`;
+    window.history.pushState({ path: newUrl }, '', newUrl);
+  }
+};

--- a/src/plugins/console/public/application/stores/embeddable_console.ts
+++ b/src/plugins/console/public/application/stores/embeddable_console.ts
@@ -25,12 +25,14 @@ export const reducer: Reducer<EmbeddedConsoleStore, EmbeddedConsoleAction> = (st
       case 'open':
         if (!state.isOpen) {
           draft.isOpen = true;
+          draft.loadFromContent = action.payload?.content;
           return;
         }
         break;
       case 'close':
         if (state.isOpen) {
           draft.isOpen = false;
+          draft.loadFromContent = undefined;
           return;
         }
         break;

--- a/src/plugins/console/public/application/stores/embeddable_console.ts
+++ b/src/plugins/console/public/application/stores/embeddable_console.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { Reducer } from 'react';
+import { produce } from 'immer';
+import { identity } from 'fp-ts/lib/function';
+
+import { EmbeddedConsoleAction, EmbeddedConsoleStore } from '../../types/embeddable_console';
+
+export const initialValue: EmbeddedConsoleStore = produce<EmbeddedConsoleStore>(
+  {
+    isOpen: false,
+  },
+  identity
+);
+
+export const reducer: Reducer<EmbeddedConsoleStore, EmbeddedConsoleAction> = (state, action) =>
+  produce<EmbeddedConsoleStore>(state, (draft) => {
+    switch (action.type) {
+      case 'open':
+        if (!state.isOpen) {
+          draft.isOpen = true;
+          return;
+        }
+        break;
+      case 'close':
+        if (state.isOpen) {
+          draft.isOpen = false;
+          return;
+        }
+        break;
+    }
+    return draft;
+  });

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -127,7 +127,8 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
       };
       consoleStart.isEmbeddedConsoleAvailable = () =>
         this._embeddableConsole.isEmbeddedConsoleAvailable();
-      consoleStart.openEmbeddedConsole = () => this._embeddableConsole.openEmbeddedConsole();
+      consoleStart.openEmbeddedConsole = (content?: string) =>
+        this._embeddableConsole.openEmbeddedConsole(content);
     }
 
     return consoleStart;

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -5,7 +5,6 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
 import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
 
@@ -20,10 +19,12 @@ import {
   EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
 } from './types';
-import { AutocompleteInfo, setAutocompleteInfo } from './services';
+import { AutocompleteInfo, setAutocompleteInfo, EmbeddableConsoleInfo } from './services';
 
 export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDependencies> {
   private readonly autocompleteInfo = new AutocompleteInfo();
+  private _embeddableConsole: EmbeddableConsoleInfo = new EmbeddableConsoleInfo();
+
   constructor(private ctx: PluginInitializerContext) {}
 
   public setup(
@@ -118,9 +119,15 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
         const consoleDeps: EmbeddableConsoleDependencies = {
           core,
           usageCollection: deps.usageCollection,
+          setDispatch: (d) => {
+            this._embeddableConsole.setDispatch(d);
+          },
         };
         return renderEmbeddableConsole(props, consoleDeps);
       };
+      consoleStart.isEmbeddedConsoleAvailable = () =>
+        this._embeddableConsole.isEmbeddedConsoleAvailable();
+      consoleStart.openEmbeddedConsole = () => this._embeddableConsole.openEmbeddedConsole();
     }
 
     return consoleStart;

--- a/src/plugins/console/public/services/embeddable_console.test.ts
+++ b/src/plugins/console/public/services/embeddable_console.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { EmbeddableConsoleInfo } from './embeddable_console';
+
+describe('EmbeddableConsoleInfo', () => {
+  let eConsole: EmbeddableConsoleInfo;
+  beforeEach(() => {
+    eConsole = new EmbeddableConsoleInfo();
+  });
+  describe('isEmbeddedConsoleAvailable', () => {
+    it('returns true if dispatch has been set', () => {
+      eConsole.setDispatch(jest.fn());
+      expect(eConsole.isEmbeddedConsoleAvailable()).toBe(true);
+    });
+    it('returns false if dispatch has not been set', () => {
+      expect(eConsole.isEmbeddedConsoleAvailable()).toBe(false);
+    });
+    it('returns false if dispatch has been cleared', () => {
+      eConsole.setDispatch(jest.fn());
+      eConsole.setDispatch(null);
+      expect(eConsole.isEmbeddedConsoleAvailable()).toBe(false);
+    });
+  });
+  describe('openEmbeddedConsole', () => {
+    const mockDispatch = jest.fn();
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      eConsole.setDispatch(mockDispatch);
+    });
+    it('dispatches open action', () => {
+      eConsole.openEmbeddedConsole();
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({ type: 'open' });
+    });
+    it('can set content', () => {
+      eConsole.openEmbeddedConsole('GET /_cat/_indices');
+
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'open',
+        payload: { content: 'GET /_cat/_indices' },
+      });
+    });
+  });
+});

--- a/src/plugins/console/public/services/embeddable_console.ts
+++ b/src/plugins/console/public/services/embeddable_console.ts
@@ -20,10 +20,10 @@ export class EmbeddableConsoleInfo {
     return this._dispatch !== null;
   }
 
-  public openEmbeddedConsole() {
+  public openEmbeddedConsole(content?: string) {
     // Embedded Console is not rendered on the page, nothing to do
     if (!this._dispatch) return;
 
-    this._dispatch({ type: 'open' });
+    this._dispatch({ type: 'open', payload: content ? { content } : undefined });
   }
 }

--- a/src/plugins/console/public/services/embeddable_console.ts
+++ b/src/plugins/console/public/services/embeddable_console.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+import type { Dispatch } from 'react';
+
+import { EmbeddedConsoleAction as EmbeddableConsoleAction } from '../types/embeddable_console';
+
+export class EmbeddableConsoleInfo {
+  private _dispatch: Dispatch<EmbeddableConsoleAction> | null = null;
+
+  public setDispatch(d: Dispatch<EmbeddableConsoleAction> | null) {
+    this._dispatch = d;
+  }
+
+  public isEmbeddedConsoleAvailable(): boolean {
+    return this._dispatch !== null;
+  }
+
+  public openEmbeddedConsole() {
+    // Embedded Console is not rendered on the page, nothing to do
+    if (!this._dispatch) return;
+
+    this._dispatch({ type: 'open' });
+  }
+}

--- a/src/plugins/console/public/services/index.ts
+++ b/src/plugins/console/public/services/index.ts
@@ -16,3 +16,4 @@ export {
   setAutocompleteInfo,
   ENTITIES,
 } from './autocomplete';
+export { EmbeddableConsoleInfo } from './embeddable_console';

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -7,6 +7,7 @@
  */
 import type { CoreStart } from '@kbn/core/public';
 import type { UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
+import type { Dispatch } from 'react';
 
 /**
  * EmbeddableConsoleProps are optional props used when rendering the embeddable developer console.
@@ -21,4 +22,10 @@ export interface EmbeddableConsoleProps {
 export interface EmbeddableConsoleDependencies {
   core: CoreStart;
   usageCollection?: UsageCollectionStart;
+  setDispatch: (dispatch: Dispatch<EmbeddedConsoleAction> | null) => void;
+}
+
+export type EmbeddedConsoleAction = { type: 'open' } | { type: 'close' };
+export interface EmbeddedConsoleStore {
+  isOpen: boolean;
 }

--- a/src/plugins/console/public/types/embeddable_console.ts
+++ b/src/plugins/console/public/types/embeddable_console.ts
@@ -25,7 +25,11 @@ export interface EmbeddableConsoleDependencies {
   setDispatch: (dispatch: Dispatch<EmbeddedConsoleAction> | null) => void;
 }
 
-export type EmbeddedConsoleAction = { type: 'open' } | { type: 'close' };
+export type EmbeddedConsoleAction =
+  | { type: 'open'; payload?: { content?: string } }
+  | { type: 'close' };
+
 export interface EmbeddedConsoleStore {
   isOpen: boolean;
+  loadFromContent?: string;
 }

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -56,5 +56,5 @@ export interface ConsolePluginStart {
    * openEmbeddedConsole is available if the embedded console can be rendered. Calling
    * this function will open the embedded console on the page if it is currently rendered.
    */
-  openEmbeddedConsole?: () => void;
+  openEmbeddedConsole?: (content?: string) => void;
 }

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -47,4 +47,14 @@ export interface ConsolePluginStart {
    * render an embeddable version of the developer console on the page.
    */
   renderEmbeddableConsole?: (props?: EmbeddableConsoleProps) => ReactElement | null;
+  /**
+   * isEmbeddedConsoleAvailable is available if the embedded console can be rendered. Returns true when
+   * called if the Embedded Console is currently rendered.
+   */
+  isEmbeddedConsoleAvailable?: () => boolean;
+  /**
+   * openEmbeddedConsole is available if the embedded console can be rendered. Calling
+   * this function will open the embedded console on the page if it is currently rendered.
+   */
+  openEmbeddedConsole?: () => void;
 }

--- a/x-pack/plugins/enterprise_search/common/types/kibana_deps.ts
+++ b/x-pack/plugins/enterprise_search/common/types/kibana_deps.ts
@@ -7,6 +7,7 @@
 
 import type { ChartsPluginStart } from '@kbn/charts-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
+import type { ConsolePluginStart } from '@kbn/console-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DiscoverStart } from '@kbn/discover-plugin/public';
 import type { FeaturesPluginStart } from '@kbn/features-plugin/public';
@@ -19,6 +20,7 @@ import type { SpacesPluginStart } from '@kbn/spaces-plugin/public';
 export interface KibanaDeps {
   charts: ChartsPluginStart;
   cloud: CloudStart;
+  console?: ConsolePluginStart;
   data: DataPublicPluginStart;
   discover: DiscoverStart;
   features: FeaturesPluginStart;

--- a/x-pack/plugins/enterprise_search/public/applications/shared/getting_started/panels/add_data_panel_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/getting_started/panels/add_data_panel_content.tsx
@@ -43,6 +43,7 @@ export const AddDataPanelContent: React.FC<AddDataPanelContentProps> = ({
       setSelectedLanguage={setSelectedLanguage}
       assetBasePath={assetBasePath}
       application={services.application}
+      consolePlugin={services.console}
       sharePlugin={services.share}
     />
   );

--- a/x-pack/plugins/enterprise_search/public/applications/shared/getting_started/panels/search_query_panel_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/getting_started/panels/search_query_panel_content.tsx
@@ -47,6 +47,7 @@ export const SearchQueryPanelContent: React.FC<SearchQueryPanelContentProps> = (
       setSelectedLanguage={setSelectedLanguage}
       assetBasePath={assetBasePath}
       application={services.application}
+      consolePlugin={services.console}
       sharePlugin={services.share}
     />
   );

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -250,6 +250,7 @@ export const ElasticsearchOverview = () => {
           assetBasePath={assetBasePath}
           docLinks={docLinks}
           application={application}
+          consolePlugin={consolePlugin}
           sharePlugin={share}
           additionalIngestionPanel={<ConnectorIngestionPanel assetBasePath={assetBasePath} />}
         />
@@ -277,6 +278,7 @@ export const ElasticsearchOverview = () => {
               setSelectedLanguage={setSelectedLanguage}
               assetBasePath={assetBasePath}
               application={application}
+              consolePlugin={consolePlugin}
               sharePlugin={share}
             />
           }


### PR DESCRIPTION
## Summary

Updated the embeddable console and console start to allow triggering the Console open from the ConsolePluginStart object with or without specific content to be pre-loaded.

### Checklist

- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
