### PR TITLE
[Links] Set empty default title for Links saved to library

### DIFF
--- a/src/plugins/links/public/content_management/save_to_library.tsx
+++ b/src/plugins/links/public/content_management/save_to_library.tsx
@@ -75,7 +75,7 @@ export const runSaveToLibrary = async (
       <SavedObjectSaveModal
         onSave={onSave}
         onClose={() => resolve(undefined)}
-        title={newAttributes.title}
+        title={newAttributes.title ?? ''}
         customModalTitle={modalTitle}
         description={newAttributes.description}
         showDescription


### PR DESCRIPTION
Fixes #176016 

## Summary

Fixes form validation when saving Links to library.


