### PR TITLE
Rename `contexts` to `categories`

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.test.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.test.tsx
@@ -39,7 +39,7 @@ describe('<ChatBody>', () => {
           role: 'assistant',
           function_call: {
             name: 'recall',
-            arguments: '{"queries":[],"contexts":[]}',
+            arguments: '{"queries":[],"categories":[]}',
             trigger: 'assistant',
           },
           content: '',
@@ -87,7 +87,7 @@ describe('<ChatBody>', () => {
           role: 'assistant',
           function_call: {
             name: 'recall',
-            arguments: '{"queries":[],"contexts":[]}',
+            arguments: '{"queries":[],"categories":[]}',
             trigger: 'assistant',
           },
           content: '',

--- a/x-pack/plugins/observability_ai_assistant/public/utils/get_timeline_items_from_conversation.test.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/utils/get_timeline_items_from_conversation.test.tsx
@@ -115,7 +115,7 @@ describe('getTimelineItemsFromConversation', () => {
               role: MessageRole.Assistant,
               function_call: {
                 name: 'recall',
-                arguments: JSON.stringify({ queries: [], contexts: [] }),
+                arguments: JSON.stringify({ queries: [], categories: [] }),
                 trigger: MessageRole.Assistant,
               },
             },
@@ -454,7 +454,7 @@ describe('getTimelineItemsFromConversation', () => {
               role: MessageRole.Assistant,
               function_call: {
                 name: 'recall',
-                arguments: JSON.stringify({ queries: [], contexts: [] }),
+                arguments: JSON.stringify({ queries: [], categories: [] }),
                 trigger: MessageRole.User,
               },
             },

--- a/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
@@ -61,22 +61,22 @@ export function registerRecallFunction({
               type: 'string',
             },
           },
-          contexts: {
+          categories: {
             type: 'array',
             additionalItems: false,
             additionalProperties: false,
             description:
-              'Contexts or categories of internal documentation that you want to search for. By default internal documentation will be excluded. Use `apm` to get internal APM documentation, `lens` to get internal Lens documentation, or both.',
+              'Categories of internal documentation that you want to search for. By default internal documentation will be excluded. Use `apm` to get internal APM documentation, `lens` to get internal Lens documentation, or both.',
             items: {
               type: 'string',
               enum: ['apm', 'lens'],
             },
           },
         },
-        required: ['queries', 'contexts'],
+        required: ['queries', 'categories'],
       } as const,
     },
-    async ({ arguments: { queries, contexts }, messages, connectorId }, signal) => {
+    async ({ arguments: { queries, categories }, messages, connectorId }, signal) => {
       const systemMessage = messages.find((message) => message.message.role === MessageRole.System);
 
       if (!systemMessage) {
@@ -91,7 +91,7 @@ export function registerRecallFunction({
         userMessage,
         client,
         signal,
-        contexts,
+        categories,
         queries,
       });
 
@@ -129,13 +129,13 @@ async function retrieveSuggestions({
   userMessage,
   queries,
   client,
-  contexts,
+  categories,
   signal,
 }: {
   userMessage?: Message;
   queries: string[];
   client: ObservabilityAIAssistantClient;
-  contexts: Array<'apm' | 'lens'>;
+  categories: Array<'apm' | 'lens'>;
   signal: AbortSignal;
 }) {
   const queriesWithUserPrompt =
@@ -145,7 +145,7 @@ async function retrieveSuggestions({
 
   const recallResponse = await client.recall({
     queries: queriesWithUserPrompt,
-    contexts,
+    categories,
   });
 
   return recallResponse.entries.map((entry) => omit(entry, 'labels', 'is_correction', 'score'));

--- a/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
@@ -42,7 +42,7 @@ export function registerRecallFunction({
           "lens function usage",
           "get_apm_timeseries function usage"    
         ],
-        "contexts": [
+        "categories": [
           "lens",
           "apm"
         ]

--- a/x-pack/plugins/observability_ai_assistant/server/routes/functions/route.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/routes/functions/route.ts
@@ -56,7 +56,7 @@ const functionRecallRoute = createObservabilityAIAssistantServerRoute({
         queries: t.array(nonEmptyStringRt),
       }),
       t.partial({
-        contexts: t.array(t.string),
+        categories: t.array(t.string),
       }),
     ]),
   }),
@@ -71,14 +71,14 @@ const functionRecallRoute = createObservabilityAIAssistantServerRoute({
     const client = await resources.service.getClient({ request: resources.request });
 
     const {
-      body: { queries, contexts },
+      body: { queries, categories },
     } = resources.params;
 
     if (!client) {
       throw notImplemented();
     }
 
-    return client.recall({ queries, contexts });
+    return client.recall({ queries, categories });
   },
 });
 

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.test.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.test.ts
@@ -1130,7 +1130,7 @@ describe('Observability AI Assistant client', () => {
             role: MessageRole.Assistant,
             function_call: {
               name: 'recall',
-              arguments: JSON.stringify({ queries: [], contexts: [] }),
+              arguments: JSON.stringify({ queries: [], categories: [] }),
               trigger: MessageRole.Assistant,
             },
           },

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -625,16 +625,16 @@ export class ObservabilityAIAssistantClient {
 
   recall = async ({
     queries,
-    contexts,
+    categories,
   }: {
     queries: string[];
-    contexts?: string[];
+    categories?: string[];
   }): Promise<{ entries: RecalledEntry[] }> => {
     return this.dependencies.knowledgeBaseService.recall({
       namespace: this.dependencies.namespace,
       user: this.dependencies.user,
       queries,
-      contexts,
+      categories,
       asCurrentUser: this.dependencies.esClient.asCurrentUser,
     });
   };

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -175,7 +175,7 @@ export class ObservabilityAIAssistantClient {
                   name: 'recall',
                   arguments: JSON.stringify({
                     queries: [],
-                    contexts: [],
+                    categories: [],
                   }),
                   trigger: MessageRole.Assistant as const,
                 },

--- a/x-pack/plugins/observability_ai_assistant/server/service/knowledge_base_service/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/knowledge_base_service/index.ts
@@ -295,13 +295,13 @@ export class KnowledgeBaseService {
 
   private async recallFromKnowledgeBase({
     queries,
-    contexts,
+    categories,
     namespace,
     user,
     modelId,
   }: {
     queries: string[];
-    contexts?: string[];
+    categories?: string[];
     namespace: string;
     user: { name: string };
     modelId: string;
@@ -321,7 +321,7 @@ export class KnowledgeBaseService {
             user,
             namespace,
           }),
-          ...getCategoryQuery({ contexts }),
+          ...getCategoryQuery({ categories }),
         ],
       },
     };
@@ -424,12 +424,12 @@ export class KnowledgeBaseService {
   recall = async ({
     user,
     queries,
-    contexts,
+    categories,
     namespace,
     asCurrentUser,
   }: {
     queries: string[];
-    contexts?: string[];
+    categories?: string[];
     user: { name: string };
     namespace: string;
     asCurrentUser: ElasticsearchClient;
@@ -442,7 +442,7 @@ export class KnowledgeBaseService {
       this.recallFromKnowledgeBase({
         user,
         queries,
-        contexts,
+        categories,
         namespace,
         modelId,
       }).catch((error) => {

--- a/x-pack/plugins/observability_ai_assistant/server/service/util/get_category_query.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/util/get_category_query.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-export function getCategoryQuery({ contexts }: { contexts?: string[] }) {
+export function getCategoryQuery({ categories }: { categories?: string[] }) {
   const noCategoryFilter = {
     bool: {
       must_not: {
@@ -16,7 +16,7 @@ export function getCategoryQuery({ contexts }: { contexts?: string[] }) {
     },
   };
 
-  if (!contexts) {
+  if (!categories) {
     return [noCategoryFilter];
   }
 
@@ -27,7 +27,7 @@ export function getCategoryQuery({ contexts }: { contexts?: string[] }) {
           noCategoryFilter,
           {
             terms: {
-              'labels.category': contexts,
+              'labels.category': categories,
             },
           },
         ],


### PR DESCRIPTION
This might have breaking changes that I'm unaware of.

The term `contexts` is slightly overused. In this case it looks like it maps directly to the field `labels.category` in which case `categories` is a better (and more unique) term. 