### PR TITLE
[DO NOT MERGE] add logging for re-running flaky oidc tests

### DIFF
--- a/x-pack/plugins/security/server/routes/authentication/oidc.ts
+++ b/x-pack/plugins/security/server/routes/authentication/oidc.ts
@@ -12,7 +12,7 @@ import { i18n } from '@kbn/i18n';
 import type { RouteDefinitionParams } from '..';
 import { OIDCAuthenticationProvider, OIDCLogin } from '../../authentication';
 import type { ProviderLoginAttempt } from '../../authentication/providers/oidc';
-import { wrapIntoCustomErrorResponse } from '../../errors';
+import { getDetailedErrorMessage, wrapIntoCustomErrorResponse } from '../../errors';
 import { createLicensedRouteHandler } from '../licensed_route_handler';
 import { ROUTE_TAG_AUTH_FLOW, ROUTE_TAG_CAN_REDIRECT } from '../tags';
 
@@ -271,6 +271,7 @@ export function defineOIDCRoutes({
 
       return response.unauthorized({ body: authenticationResult.error });
     } catch (error) {
+      logger.error(`Failed to perform OIDC login: ${getDetailedErrorMessage(error)}`);
       return response.customError(wrapIntoCustomErrorResponse(error));
     }
   }

--- a/x-pack/test/security_api_integration/plugins/oidc_provider/server/index.ts
+++ b/x-pack/test/security_api_integration/plugins/oidc_provider/server/index.ts
@@ -8,8 +8,10 @@
 import type { PluginInitializer, Plugin } from '@kbn/core/server';
 import { initRoutes } from './init_routes';
 
-export const plugin: PluginInitializer<void, void> = async (): Promise<Plugin> => ({
-  setup: (core) => initRoutes(core.http.createRouter()),
+export const plugin: PluginInitializer<void, void> = async (
+  initializerContext
+): Promise<Plugin> => ({
+  setup: (core) => initRoutes(initializerContext, core),
   start: () => {},
   stop: () => {},
 });

--- a/x-pack/test/security_api_integration/plugins/oidc_provider/server/init_routes.ts
+++ b/x-pack/test/security_api_integration/plugins/oidc_provider/server/init_routes.ts
@@ -6,10 +6,12 @@
  */
 
 import { schema } from '@kbn/config-schema';
-import type { IRouter } from '@kbn/core/server';
+import { CoreSetup, PluginInitializerContext } from '@kbn/core/server';
 import { createTokens } from '@kbn/security-api-integration-helpers/oidc/oidc_tools';
 
-export function initRoutes(router: IRouter) {
+export function initRoutes(initializerContext: PluginInitializerContext, core: CoreSetup) {
+  const logger = initializerContext.logger.get();
+  const router = core.http.createRouter();
   let nonce = '';
   router.get(
     {
@@ -69,17 +71,26 @@ export function initRoutes(router: IRouter) {
       options: { authRequired: false, xsrfRequired: false },
     },
     (context, request, response) => {
-      const userId = request.body.code.substring(4);
-      const { accessToken, idToken } = createTokens(userId, nonce);
-      return response.ok({
-        body: {
-          access_token: accessToken,
-          token_type: 'Bearer',
-          refresh_token: `valid-refresh-token${userId}`,
-          expires_in: 3600,
-          id_token: idToken,
-        },
-      });
+      try {
+        const userId = request.body.code.substring(4);
+        logger.info(
+          `Accessing token endpoint for user ${userId} (headers: ${JSON.stringify(request.headers)}`
+        );
+
+        const { accessToken, idToken } = createTokens(userId, nonce);
+        return response.ok({
+          body: {
+            access_token: accessToken,
+            token_type: 'Bearer',
+            refresh_token: `valid-refresh-token${userId}`,
+            expires_in: 3600,
+            id_token: idToken,
+          },
+        });
+      } catch (err) {
+        logger.error(`Failed to create tokens: ${err?.message ?? err}`, err);
+        throw err;
+      }
     }
   );
 


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
