### PR TITLE
feat(slo): create SLO health endpoint

### DIFF
--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -245,6 +245,10 @@ const getSLOInstancesResponseSchema = t.type({
   instances: t.array(t.string),
 });
 
+const getSLOHealthParamsSchema = t.type({
+  path: t.type({ id: t.string }),
+});
+
 type SLOResponse = t.OutputOf<typeof sloResponseSchema>;
 type SLOWithSummaryResponse = t.OutputOf<typeof sloWithSummaryResponseSchema>;
 
@@ -323,6 +327,7 @@ export {
   getSLOBurnRatesResponseSchema,
   getSLOInstancesParamsSchema,
   getSLOInstancesResponseSchema,
+  getSLOHealthParamsSchema,
 };
 export type {
   BudgetingMethod,

--- a/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
+++ b/x-pack/packages/kbn-slo-schema/src/rest_specs/slo.ts
@@ -249,6 +249,21 @@ const getSLOHealthParamsSchema = t.type({
   path: t.type({ id: t.string }),
 });
 
+const greenHealthSchema = t.literal('green');
+const redHealthSchema = t.literal('red');
+const healthSchema = t.union([greenHealthSchema, redHealthSchema]);
+
+const getSLOHealthResponseSchema = t.type({
+  health: healthSchema,
+  details: t.type({
+    rollupTransformHealth: healthSchema,
+    summaryTransformHealth: healthSchema,
+    summaryIngestPipelineHealth: healthSchema,
+    summaryDocumentUpdatedAt: healthSchema,
+    lastRollupDocumentIngestedAt: healthSchema,
+  }),
+});
+
 type SLOResponse = t.OutputOf<typeof sloResponseSchema>;
 type SLOWithSummaryResponse = t.OutputOf<typeof sloWithSummaryResponseSchema>;
 
@@ -302,6 +317,8 @@ type TimesclieMetricPercentileMetric = t.OutputOf<typeof timesliceMetricPercenti
 type HistogramIndicator = t.OutputOf<typeof histogramIndicatorSchema>;
 type KQLCustomIndicator = t.OutputOf<typeof kqlCustomIndicatorSchema>;
 
+type GetSLOHealthResponse = t.OutputOf<typeof getSLOHealthResponseSchema>;
+
 export {
   createSLOParamsSchema,
   deleteSLOParamsSchema,
@@ -328,6 +345,7 @@ export {
   getSLOInstancesParamsSchema,
   getSLOInstancesResponseSchema,
   getSLOHealthParamsSchema,
+  getSLOHealthResponseSchema,
 };
 export type {
   BudgetingMethod,
@@ -370,4 +388,5 @@ export type {
   HistogramIndicator,
   KQLCustomIndicator,
   TimeWindow,
+  GetSLOHealthResponse,
 };

--- a/x-pack/plugins/observability/common/slo/constants.ts
+++ b/x-pack/plugins/observability/common/slo/constants.ts
@@ -32,9 +32,10 @@ export const SLO_SUMMARY_DESTINATION_INDEX_PATTERN = `.slo-observability.summary
 export const getSLOTransformId = (sloId: string, sloRevision: number) =>
   `slo-${sloId}-${sloRevision}`;
 
-export const DEFAULT_SLO_PAGE_SIZE = 25;
 export const getSLOSummaryTransformId = (sloId: string, sloRevision: number) =>
   `slo-summary-${sloId}-${sloRevision}`;
 
 export const getSLOSummaryPipelineId = (sloId: string, sloRevision: number) =>
   `.slo-observability.summary.pipeline-${sloId}-${sloRevision}`;
+
+export const DEFAULT_SLO_PAGE_SIZE = 25;

--- a/x-pack/plugins/observability/server/services/slo/get_slo_health.ts
+++ b/x-pack/plugins/observability/server/services/slo/get_slo_health.ts
@@ -1,0 +1,110 @@
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import {
+  getSLOSummaryPipelineId,
+  getSLOSummaryTransformId,
+  getSLOTransformId,
+  SLO_DESTINATION_INDEX_PATTERN,
+  SLO_RESOURCES_VERSION,
+  SLO_SUMMARY_INDEX_TEMPLATE_PATTERN,
+} from '@kbn/observability-plugin/common/slo/constants';
+import { SLO } from '../../domain/models';
+import { SLORepository } from './slo_repository';
+
+const GREEN = 'green';
+const RED = 'red';
+
+export class GetSloHealth {
+  constructor(private esClient: ElasticsearchClient, private sloRepository: SLORepository) {}
+
+  public async execute(sloId: string) {
+    const slo = await this.sloRepository.findById(sloId);
+
+    const transformHealth = await this.getRollupTransformHealth(slo);
+    const summaryTransformHealth = await this.getSummaryTransformHealth(slo);
+    const summaryIngestPipelineHealth = await this.getIngestPipelineHealth(slo);
+    const overallHealth =
+      transformHealth === GREEN &&
+      summaryTransformHealth === GREEN &&
+      summaryIngestPipelineHealth === GREEN
+        ? GREEN
+        : RED;
+
+    const summaryDoc = await this.esClient.search({
+      index: SLO_SUMMARY_INDEX_TEMPLATE_PATTERN,
+      query: {
+        bool: {
+          filter: [{ term: { 'slo.id': slo.id } }, { term: { 'slo.revision': slo.revision } }],
+        },
+      },
+      size: 1,
+    });
+    // @ts-ignore
+    const summaryUpdatedAt = summaryDoc.hits.hits[0]?._source?.summaryUpdatedAt;
+
+    const rollupDocument = await this.esClient.search({
+      index: SLO_DESTINATION_INDEX_PATTERN,
+      query: {
+        bool: {
+          filter: [{ term: { 'slo.id': slo.id } }, { term: { 'slo.revision': slo.revision } }],
+        },
+      },
+      sort: {
+        'event.ingested': {
+          order: 'desc',
+        },
+      },
+      size: 1,
+    });
+
+    // @ts-ignore
+    const lastRollupDocumentIngestedAt = rollupDocument.hits.hits[0]?._source?.event.ingested;
+
+    return {
+      health: overallHealth,
+      details: {
+        rollupTransform: transformHealth,
+        summaryTransform: summaryTransformHealth,
+        summaryIngestPipeline: summaryIngestPipelineHealth,
+        summaryDocumentUpdatedAt: summaryUpdatedAt,
+        lastRollupDocumentIngestedAt,
+      },
+    };
+  }
+
+  private async getSummaryTransformHealth(slo: SLO) {
+    const summaryTransformResponse = await this.esClient.transform.getTransformStats(
+      { transform_id: getSLOSummaryTransformId(slo.id, slo.revision) },
+      { ignore: [404] }
+    );
+
+    return ['green', 'GREEN'].includes(
+      summaryTransformResponse.transforms[0]?.health?.status ?? 'red'
+    )
+      ? GREEN
+      : RED;
+  }
+
+  private async getRollupTransformHealth(slo: SLO) {
+    const transformResponse = await this.esClient.transform.getTransformStats(
+      { transform_id: getSLOTransformId(slo.id, slo.revision) },
+      { ignore: [404] }
+    );
+
+    return ['green', 'GREEN'].includes(transformResponse.transforms[0]?.health?.status ?? 'red')
+      ? GREEN
+      : RED;
+  }
+
+  private async getIngestPipelineHealth(slo: SLO) {
+    const summaryIngestPipelineId = getSLOSummaryPipelineId(slo.id, slo.revision);
+    const ingestResponse = await this.esClient.ingest.getPipeline(
+      { id: summaryIngestPipelineId },
+      { ignore: [404] }
+    );
+
+    // @ts-ignore _meta not typed
+    return ingestResponse?.[summaryIngestPipelineId]?._meta?.version === SLO_RESOURCES_VERSION
+      ? GREEN
+      : RED;
+  }
+}

--- a/x-pack/plugins/observability/server/services/slo/index.ts
+++ b/x-pack/plugins/observability/server/services/slo/index.ts
@@ -21,3 +21,4 @@ export * from './summay_transform_manager';
 export * from './update_slo';
 export * from './summary_client';
 export * from './get_slo_instances';
+export * from './get_slo_health';


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/176088

## Summary

This PR adds a `slos/id/_health` API for getting an overall SLO health.
The SLO health is calculated based on the health of the related rollup and summary transform, summary ingest pipeline. We also include in the details the last ingested rollup document timestamp and the summary document's last updated timestamp.

Based on the health of the related resources we can take or give user some directive directly from the SLO UI:
The summary transform is red: 
- "Try restarting the summary transform from the Stack Management > transform page"
- "Recreate the SLO to trigger reinstallation of resources"

We can imagine other remediation strategies.


@maciejforcone Where would you place this health status? Would we place this under the Action dropdown on the SLO details page?

## Manual testing

Create an SLO and call the API: 

`GET http://localhost:5601/kibana/internal/observability/slos/d0d4f6cd-2ca0-48f9-bd8e-8781fcb208a7/_health`
```
{
	"health": "green",
	"details": {
		"rollupTransformHealth": "green",
		"summaryTransformHealth": "green",
		"summaryIngestPipelineHealth": "green",
		"summaryDocumentUpdatedAt": "2024-02-01T16:29:45.068922Z",
		"lastRollupDocumentIngestedAt": "2024-02-01T16:29:40.039048Z"
	}
}
```
