### PR TITLE
[Fleet] Fix max agent for agent activity

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/agent_activity_flyout.tsx
@@ -58,7 +58,7 @@ const FlyoutFooterWPadding = styled(EuiFlyoutFooter)`
   padding: 16px 24px !important;
 `;
 
-const MAX_VIEW_AGENTS_COUNT = 2000;
+const MAX_VIEW_AGENTS_COUNT = 1000;
 
 export const AgentActivityFlyout: React.FunctionComponent<{
   onClose: () => void;


### PR DESCRIPTION
## Description 

Resolve #157678

Fix max agent we display for the agent activity link 

2000 seems is still too high, I tried locally with 1000 and it seems to work well, so let change that

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->