### PR TITLE
Updates test file wrapper to deterministically detect file write completion

### DIFF
--- a/x-pack/test/security_api_integration/tests/anonymous/login.ts
+++ b/x-pack/test/security_api_integration/tests/anonymous/login.ts
@@ -245,7 +245,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(302);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(2);

--- a/x-pack/test/security_api_integration/tests/audit/audit_log.ts
+++ b/x-pack/test/security_api_integration/tests/audit/audit_log.ts
@@ -25,7 +25,7 @@ export default function ({ getService }: FtrProviderContext) {
 
     it('logs audit events when reading and writing saved objects', async () => {
       await supertest.get('/audit_log?query=param').set('kbn-xsrf', 'foo').expect(204);
-      await retry.waitFor('logs event in the dest file', async () => await logFile.isNotEmpty());
+      await logFile.isWritten();
       const content = await logFile.readJSON();
 
       const httpEvent = content.find((c) => c.event.action === 'http_request');
@@ -68,7 +68,7 @@ export default function ({ getService }: FtrProviderContext) {
           params: { username, password },
         })
         .expect(200);
-      await retry.waitFor('logs event in the dest file', async () => await logFile.isNotEmpty());
+      await logFile.isWritten();
       const content = await logFile.readJSON();
 
       const loginEvent = content.find((c) => c.event.action === 'user_login');
@@ -92,7 +92,7 @@ export default function ({ getService }: FtrProviderContext) {
           params: { username, password: 'invalid_password' },
         })
         .expect(401);
-      await retry.waitFor('logs event in the dest file', async () => await logFile.isNotEmpty());
+      await logFile.isWritten();
       const content = await logFile.readJSON();
 
       const loginEvent = content.find((c) => c.event.action === 'user_login');

--- a/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
+++ b/x-pack/test/security_api_integration/tests/kerberos/kerberos_login.ts
@@ -519,7 +519,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(302);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(2);
@@ -545,7 +545,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Authorization', `Negotiate ${Buffer.from('Hello').toString('base64')}`)
           .expect(401);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(1);

--- a/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
+++ b/x-pack/test/security_api_integration/tests/oidc/authorization_code_flow/oidc_auth.ts
@@ -714,7 +714,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(302);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(2);
@@ -739,7 +739,7 @@ export default function ({ getService }: FtrProviderContext) {
           .get(`/api/security/oidc/callback?code=thisisthecode&state=someothervalue`)
           .expect(401);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(1);

--- a/x-pack/test/security_api_integration/tests/pki/pki_auth.ts
+++ b/x-pack/test/security_api_integration/tests/pki/pki_auth.ts
@@ -505,7 +505,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(302);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(2);
@@ -528,7 +528,7 @@ export default function ({ getService }: FtrProviderContext) {
       it('should log authentication failure correctly', async () => {
         await supertest.get('/security/account').ca(CA_CERT).pfx(UNTRUSTED_CLIENT_CERT).expect(401);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(1);

--- a/x-pack/test/security_api_integration/tests/saml/saml_login.ts
+++ b/x-pack/test/security_api_integration/tests/saml/saml_login.ts
@@ -843,7 +843,7 @@ export default function ({ getService }: FtrProviderContext) {
           .set('Cookie', sessionCookie.cookieString())
           .expect(302);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(2);
@@ -881,7 +881,7 @@ export default function ({ getService }: FtrProviderContext) {
           })
           .expect(401);
 
-        await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+        await logFile.isWritten();
         const auditEvents = await logFile.readJSON();
 
         expect(auditEvents).to.have.length(1);

--- a/x-pack/test/security_api_integration/tests/token/audit.ts
+++ b/x-pack/test/security_api_integration/tests/token/audit.ts
@@ -53,7 +53,7 @@ export default function ({ getService }: FtrProviderContext) {
         .set('Cookie', sessionCookie.cookieString())
         .expect(302);
 
-      await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+      await logFile.isWritten();
       const auditEvents = await logFile.readJSON();
 
       expect(auditEvents).to.have.length(2);
@@ -85,7 +85,7 @@ export default function ({ getService }: FtrProviderContext) {
         })
         .expect(401);
 
-      await retry.waitFor('audit events in dest file', () => logFile.isNotEmpty());
+      await logFile.isWritten();
       const auditEvents = await logFile.readJSON();
 
       expect(auditEvents).to.have.length(1);


### PR DESCRIPTION
Closes #119267

## Summary

Attempts to deterministically detect when a file is written in entirety in order to resolve flaky test issues where parsed JSON is incomplete.

Flaky Test Runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5015

<!--ONMERGE {"backportTargets":["7.17","8.12"]} ONMERGE-->