### PR TITLE
[Fleet] Fix categories labels in integration overview

### DIFF
--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
@@ -29,6 +29,7 @@ import type {
   AssetTypeToParts,
   KibanaAssetType,
   RegistryPolicyTemplate,
+  RegistryPolicyIntegrationTemplate,
 } from '../../../../../types';
 import { entries } from '../../../../../types';
 import { useGetCategoriesQuery } from '../../../../../hooks';
@@ -66,17 +67,20 @@ const Replacements = euiStyled(EuiFlexItem)`
 export const Details: React.FC<Props> = memo(({ packageInfo, integrationInfo }) => {
   const { data: categoriesData, isLoading: isLoadingCategories } = useGetCategoriesQuery();
 
-  const mergedCategories: string[] = useMemo(() => {
-    let allCategories: string[] = [];
+  const mergedCategories: Array<string | undefined> = useMemo(() => {
+    let allCategories: Array<string | undefined> = [];
 
     if (packageInfo?.categories) {
-      allCategories = packageInfo?.categories;
+      allCategories = packageInfo.categories;
     }
-    if (integrationInfo?.categories as any as RegistryPolicyTemplate) {
-      allCategories = uniq([...allCategories, ...integrationInfo.categories]);
+    if ((integrationInfo as RegistryPolicyIntegrationTemplate)?.categories) {
+      allCategories = uniq([
+        ...allCategories,
+        ...((integrationInfo as RegistryPolicyIntegrationTemplate)?.categories || []),
+      ]);
     }
     return allCategories;
-  }, [integrationInfo?.categories, packageInfo?.categories]);
+  }, [integrationInfo, packageInfo?.categories]);
 
   const packageCategories: string[] = useMemo(() => {
     if (!isLoadingCategories && categoriesData?.items) {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/details.tsx
@@ -21,12 +21,14 @@ import {
 import { euiStyled } from '@kbn/kibana-react-plugin/common';
 
 import { withSuspense, LazyReplacementCard } from '@kbn/custom-integrations-plugin/public';
+import { uniq } from 'lodash';
 
 import type {
   PackageInfo,
   PackageSpecCategory,
   AssetTypeToParts,
   KibanaAssetType,
+  RegistryPolicyTemplate,
 } from '../../../../../types';
 import { entries } from '../../../../../types';
 import { useGetCategoriesQuery } from '../../../../../hooks';
@@ -41,6 +43,7 @@ const ReplacementCard = withSuspense(LazyReplacementCard);
 
 interface Props {
   packageInfo: PackageInfo;
+  integrationInfo?: RegistryPolicyTemplate;
 }
 
 const Replacements = euiStyled(EuiFlexItem)`
@@ -60,16 +63,29 @@ const Replacements = euiStyled(EuiFlexItem)`
   }
 `;
 
-export const Details: React.FC<Props> = memo(({ packageInfo }) => {
+export const Details: React.FC<Props> = memo(({ packageInfo, integrationInfo }) => {
   const { data: categoriesData, isLoading: isLoadingCategories } = useGetCategoriesQuery();
+
+  const mergedCategories: string[] = useMemo(() => {
+    let allCategories: string[] = [];
+
+    if (packageInfo?.categories) {
+      allCategories = packageInfo?.categories;
+    }
+    if (integrationInfo?.categories as any as RegistryPolicyTemplate) {
+      allCategories = uniq([...allCategories, ...integrationInfo.categories]);
+    }
+    return allCategories;
+  }, [integrationInfo?.categories, packageInfo?.categories]);
+
   const packageCategories: string[] = useMemo(() => {
     if (!isLoadingCategories && categoriesData?.items) {
       return categoriesData.items
-        .filter((category) => packageInfo.categories?.includes(category.id as PackageSpecCategory))
+        .filter((category) => mergedCategories?.includes(category.id as PackageSpecCategory))
         .map((category) => category.title);
     }
     return [];
-  }, [categoriesData, isLoadingCategories, packageInfo.categories]);
+  }, [categoriesData, isLoadingCategories, mergedCategories]);
 
   const [isNoticeModalOpen, setIsNoticeModalOpen] = useState(false);
   const toggleNoticeModal = useCallback(() => {

--- a/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
+++ b/x-pack/plugins/fleet/public/applications/integrations/sections/epm/screens/detail/overview/overview.tsx
@@ -328,7 +328,7 @@ export const OverviewPage: React.FC<Props> = memo(
               </EuiFlexItem>
             ) : null}
             <EuiFlexItem className="eui-textBreakWord">
-              <Details packageInfo={packageInfo} />
+              <Details packageInfo={packageInfo} integrationInfo={integrationInfo} />
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>

--- a/x-pack/plugins/fleet/public/types/index.ts
+++ b/x-pack/plugins/fleet/public/types/index.ts
@@ -138,6 +138,7 @@ export type {
   GetInputsTemplatesRequest,
   GetInputsTemplatesResponse,
   BulkGetAgentPoliciesResponse,
+  RegistryPolicyIntegrationTemplate,
 } from '../../common/types';
 export {
   entries,


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/176031

## Summary

Fixing missing category label in Integration overwiew page for subintegrations. The category label was just showing the parent Integration label but not the own category. To fix it, I'm adding the categories in `integrationInfo` as well.

### Before
![Screenshot 2024-02-02 at 12 37 01](https://github.com/elastic/kibana/assets/16084106/5170bb5d-fce3-400c-b6a5-3e39003f4158)


### After
![Screenshot 2024-02-02 at 12 33 06](https://github.com/elastic/kibana/assets/16084106/14d475c8-ab02-4d50-883f-80924cd96b93)




<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->