### PR TITLE
[Observability Shared] Fix layout issue due to wrapping node

### DIFF
--- a/x-pack/plugins/observability_shared/public/components/page_template/page_template.tsx
+++ b/x-pack/plugins/observability_shared/public/components/page_template/page_template.tsx
@@ -110,7 +110,6 @@ export function ObservabilityPageTemplate({
   const sections = useObservable(navigationSections$, []);
   const currentAppId = useObservable(currentAppId$, undefined);
   const { pathname: currentPath } = useLocation();
-  const containerRef = React.useRef<HTMLDivElement>(null);
 
   const { services } = useKibana();
 
@@ -198,45 +197,39 @@ export function ObservabilityPageTemplate({
       >
         {({ isTourVisible }) => {
           return (
-            <div ref={containerRef}>
-              <KibanaPageTemplate
-                restrictWidth={false}
-                {...pageTemplateProps}
-                solutionNav={
-                  showSolutionNav
-                    ? {
-                        icon: 'logoObservability',
-                        items: sideNavItems,
-                        name: sideNavTitle,
-                        // Only false if tour is active
-                        canBeCollapsed: isTourVisible === false,
-                      }
-                    : undefined
-                }
-              >
-                <KibanaErrorBoundaryProvider analytics={services.analytics}>
-                  <KibanaErrorBoundary>
-                    <KibanaPageTemplate.Section
-                      component="div"
-                      alignment={pageTemplateProps.isEmptyState ? 'center' : 'top'}
-                      {...pageSectionProps}
-                    >
-                      {topSearchBar && (
-                        <SearchBarPortal containerRef={containerRef}>
-                          {topSearchBar}
-                        </SearchBarPortal>
-                      )}
-                      {children}
-                    </KibanaPageTemplate.Section>
-                  </KibanaErrorBoundary>
-                </KibanaErrorBoundaryProvider>
-                {bottomBar && (
-                  <KibanaPageTemplate.BottomBar {...bottomBarProps}>
-                    {bottomBar}
-                  </KibanaPageTemplate.BottomBar>
-                )}
-              </KibanaPageTemplate>
-            </div>
+            <KibanaPageTemplate
+              restrictWidth={false}
+              {...pageTemplateProps}
+              solutionNav={
+                showSolutionNav
+                  ? {
+                      icon: 'logoObservability',
+                      items: sideNavItems,
+                      name: sideNavTitle,
+                      // Only false if tour is active
+                      canBeCollapsed: isTourVisible === false,
+                    }
+                  : undefined
+              }
+            >
+              <KibanaErrorBoundaryProvider analytics={services.analytics}>
+                <KibanaErrorBoundary>
+                  <KibanaPageTemplate.Section
+                    component="div"
+                    alignment={pageTemplateProps.isEmptyState ? 'center' : 'top'}
+                    {...pageSectionProps}
+                  >
+                    {topSearchBar && <SearchBarPortal>{topSearchBar}</SearchBarPortal>}
+                    {children}
+                  </KibanaPageTemplate.Section>
+                </KibanaErrorBoundary>
+              </KibanaErrorBoundaryProvider>
+              {bottomBar && (
+                <KibanaPageTemplate.BottomBar {...bottomBarProps}>
+                  {bottomBar}
+                </KibanaPageTemplate.BottomBar>
+              )}
+            </KibanaPageTemplate>
           );
         }}
       </ObservabilityTour>

--- a/x-pack/plugins/observability_shared/public/components/page_template/search_bar_portal.tsx
+++ b/x-pack/plugins/observability_shared/public/components/page_template/search_bar_portal.tsx
@@ -11,30 +11,27 @@ import { EuiPanel, EuiSpacer } from '@elastic/eui';
 import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
 export interface Props {
   children: ReactNode;
-  containerRef: React.RefObject<HTMLDivElement>;
 }
 
-export function SearchBarPortal({ children, containerRef }: Props) {
+export function SearchBarPortal({ children }: Props) {
   const portalNode = useMemo(() => createHtmlPortalNode(), []);
 
   useEffect(() => {
-    if (containerRef?.current) {
-      setTimeout(() => {
-        const mainContent = containerRef?.current?.querySelector('main');
-        if (!mainContent) return;
-        const element = document.createElement('div');
-        element.setAttribute('id', 'searchBarContainer');
-        ReactDOM.render(<OutPortal node={portalNode} />, element);
-        if (mainContent.childNodes?.[0]) {
-          mainContent.insertBefore(element, mainContent.childNodes?.[0]);
-        }
-      }, 10);
-    }
+    setTimeout(() => {
+      const mainContent = globalThis.document.querySelector('main');
+      if (!mainContent) return;
+      const element = document.createElement('div');
+      element.setAttribute('id', 'searchBarContainer');
+      ReactDOM.render(<OutPortal node={portalNode} />, element);
+      if (mainContent.childNodes?.[0]) {
+        mainContent.insertBefore(element, mainContent.childNodes?.[0]);
+      }
+    }, 10);
 
     return () => {
       portalNode.unmount();
     };
-  }, [portalNode, containerRef]);
+  }, [portalNode]);
 
   return (
     <InPortal node={portalNode}>


### PR DESCRIPTION
## 📓 Summary

Fixes a layout issue introduced with an extra wrapping div block around the Observability Page Layout.

To keep the same feature it was introduced for, we don't rely anymore on a wrapping element referenced, but use the `globalThis` root element to query for the `main`node.

| Before | After |
|---|---|
| <img width="3007" alt="Screenshot 2024-02-02 at 12 13 13" src="https://github.com/elastic/kibana/assets/34506779/ea403d11-29f0-4ded-8b92-51145e3fa5ae"> | <img width="3006" alt="Screenshot 2024-02-02 at 12 50 24" src="https://github.com/elastic/kibana/assets/34506779/1c544e06-15ae-4371-bf04-4a6b58f06f40"> |