### PR TITLE
[Ops/QA] Fix daily coverage job (ep2)

### DIFF
--- a/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
+++ b/.buildkite/scripts/steps/code_coverage/reporting/uploadStaticSite.sh
@@ -13,17 +13,19 @@ uploadPrefixWithTimeStamp="${uploadPrefix}${TIME_STAMP}/"
 
 uploadBase() {
   for x in 'src/dev/code_coverage/www/index.html' 'src/dev/code_coverage/www/404.html'; do
-    gsutil -m -q cp -r -a public-read -z js,css,html "${x}" "${uploadPrefix}"
+    gsutil -m -q cp -r -z js,css,html "${x}" "${uploadPrefix}"
     gsutil -m -q cp -r -a public-read -z js,css,html "${x}" "${uploadPrefix_old}"
   done
 }
 
 uploadRest() {
   for x in "${xs[@]}"; do
-    gsutil -m -q cp -r -a public-read -z js,css,html "target/kibana-coverage/${x}-combined" "${uploadPrefixWithTimeStamp}"
+    gsutil -m -q cp -r -z js,css,html "target/kibana-coverage/${x}-combined" "${uploadPrefixWithTimeStamp}"
     gsutil -m -q cp -r -a public-read -z js,css,html "target/kibana-coverage/${x}-combined" "${uploadPrefixWithTimeStamp_old}"
   done
 }
+
+echo "--- Uploading static site"
 
 uploadBase
 uploadRest


### PR DESCRIPTION
## Summary
Still trying to fix the daily coverage job, that I managed to break while setting up another new target for the uploaded artifacts.

This time, fixing (as seen at: [this build](https://buildkite.com/elastic/kibana-code-coverage-main/builds/1291#018d6830-f9cb-4034-9d23-1686a6218c0f))
```
BadRequestException: 400 Cannot insert legacy ACL for an object when uniform bucket-level access is enabled. Read more at https://cloud.google.com/storage/docs/uniform-bucket-level-access
```

Supposed fix is already applied: https://github.com/elastic/kibana-operations/pull/55