### PR TITLE
[Observability AI Assistant] [KB] Allow documents to not have `labels`

### DIFF
--- a/src/plugins/ai_assistant_management/observability/public/helpers/categorize_entries.ts
+++ b/src/plugins/ai_assistant_management/observability/public/helpers/categorize_entries.ts
@@ -16,7 +16,7 @@ export interface KnowledgeBaseEntryCategory {
 
 export function categorizeEntries({ entries }: { entries: KnowledgeBaseEntry[] }) {
   return entries.reduce((acc, entry) => {
-    const categoryName = entry.labels.category ?? entry.id;
+    const categoryName = entry.labels?.category ?? entry.id;
 
     const index = acc.findIndex((item) => item.categoryName === categoryName);
 

--- a/x-pack/plugins/observability_ai_assistant/common/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/types.ts
@@ -86,7 +86,7 @@ export interface KnowledgeBaseEntry {
   confidence: 'low' | 'medium' | 'high';
   is_correction: boolean;
   public: boolean;
-  labels: Record<string, string>;
+  labels?: Record<string, string>;
   role: KnowledgeBaseEntryRole;
 }
 


### PR DESCRIPTION
## Summary

A helper function assumed all ingested documents would have a `labels` key in them. As there are multiple ways to ingest documents, it is possible that a user ingests docs in such a way that they would not have `labels`. This would result in the KB interface not being rendered. This takes care of that scenario.