### PR TITLE
Add listConnectors function

### DIFF
--- a/packages/kbn-search-connectors/lib/fetch_connectors.test.ts
+++ b/packages/kbn-search-connectors/lib/fetch_connectors.test.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { CONNECTORS_INDEX } from '..';
+import { CONNECTORS_INDEX, listConnectors } from '..';
 
 import { fetchConnectorById, fetchConnectorByIndexName, fetchConnectors } from './fetch_connectors';
 
@@ -34,6 +34,9 @@ describe('fetchConnectors lib', () => {
   const mockClient = {
     get: jest.fn(),
     search: jest.fn(),
+    transport: {
+      request: jest.fn(),
+    },
   };
 
   beforeEach(() => {
@@ -186,6 +189,30 @@ describe('fetchConnectors lib', () => {
         index: CONNECTORS_INDEX,
         query: { match_all: {} },
         size: 1000,
+      });
+    });
+  });
+  describe('list connectors', () => {
+    it('should list connectors', async () => {
+      mockClient.transport.request.mockImplementationOnce(() => ({
+        count: 22,
+        results: [],
+      }));
+      await expect(listConnectors(mockClient as any, 0, 10)).resolves.toEqual({
+        _meta: {
+          page: {
+            from: 0,
+            has_more_hits_than_total: true,
+            size: 10,
+            total: 22,
+          },
+        },
+        data: [],
+      });
+      expect(mockClient.transport.request).toHaveBeenCalledWith({
+        method: 'GET',
+        path: '/_connector',
+        querystring: 'from=0&size=10',
       });
     });
   });

--- a/packages/kbn-search-connectors/types/connectors_api.ts
+++ b/packages/kbn-search-connectors/types/connectors_api.ts
@@ -8,7 +8,7 @@
 
 // TODO: delete this once ES client can be used for Connectors API
 
-import { ConnectorSyncJob } from './connectors';
+import { Connector, ConnectorSyncJob } from './connectors';
 
 enum Result {
   created = 'created',
@@ -29,4 +29,9 @@ export interface ConnectorsAPISyncJobResponse {
 
 export interface ConnectorSecretCreateResponse {
   id: string;
+}
+
+export interface ConnectorsAPIConnectorResponse {
+  count: number;
+  results: Connector[];
 }


### PR DESCRIPTION
## Summary

Add a `listConnectors` to use [List connectors API](https://www.elastic.co/guide/en/elasticsearch/reference/current/list-connector-api.html) instead of calling ES index directly.

### Checklist

- [ x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
