### PR TITLE
[SecuritySolutions] Fix Risk score visualization uses max aggregation instead of latest

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
@@ -80,7 +80,7 @@ export const getRiskScoreSummaryAttributes: (
                 [columnIds[0]]: {
                   label: 'Risk',
                   dataType: 'number',
-                  operationType: 'max',
+                  operationType: 'last_value',
                   isBucketed: false,
                   scale: 'ratio',
                   sourceField,


### PR DESCRIPTION
## Summary

Update the lens config to use `latest` aggregation.


### Steps to reproduce
* Generate an alert for a host or user with a high alert risk score
* Allow entity risk scoring to run (for example, by turning off/on the risk engine)
* Navigate to the flyout for that host/user to ensure that it has a risk score
  <img src="https://github.com/elastic/kibana/assets/1490444/330e8c8c-cea3-47c8-9ed1-bb65c1c6840b" width="400">

* Perform some action that will reduce that entity's risk score (for example, assigning a "Not Important" asset criticality to that host/user)
* Allow entity risk scoring to run again (for example, by turning off/on the risk engine)
* Navigate to the flyout for that host/user to ensure that it has a risk score, and notice that the visualization shows the higher risk score, not necessarily the "current" risk score
  <img src="https://github.com/elastic/kibana/assets/1490444/727e7d1a-8955-43d0-b403-1a05bd5d6bc7" width="400">







