### PR TITLE
[Search] Fix connector config resetting without changes

### DIFF
--- a/packages/kbn-search-connectors/components/configuration/connector_configuration.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useEffect, useRef, useState } from 'react';
 
 import {
   EuiButton,
@@ -20,8 +20,15 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
+import { isDeepEqual } from 'react-use/lib/util';
 import { sortAndFilterConnectorConfiguration } from '../../utils/connector_configuration_utils';
-import { Connector, ConnectorConfigProperties, ConnectorStatus, FeatureName } from '../..';
+import {
+  Connector,
+  ConnectorConfigProperties,
+  ConnectorConfiguration,
+  ConnectorStatus,
+  FeatureName,
+} from '../..';
 
 import { ConnectorConfigurationForm } from './connector_configuration_form';
 
@@ -82,6 +89,7 @@ export const ConnectorConfigurationComponent: React.FC<ConnectorConfigurationPro
   subscriptionLink,
   stackManagementLink,
 }) => {
+  const configurationRef = useRef<ConnectorConfiguration>({});
   const {
     configuration,
     error,
@@ -95,7 +103,10 @@ export const ConnectorConfigurationComponent: React.FC<ConnectorConfigurationPro
   const [isEditing, setIsEditing] = useState(false);
 
   useEffect(() => {
-    setIsEditing(false);
+    if (!isDeepEqual(configuration, configurationRef.current)) {
+      configurationRef.current = configuration;
+      setIsEditing(false);
+    }
   }, [configuration]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

This fixes an issue in the connector configuration where the config would keep resetting without config changes.

<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->