### PR TITLE
[ResponseOps] Failing ES Promotion: FTR Configs #77 / Alerting builtin alertTypes es_query rule runs correctly: threshold on ungrouped hit count < >

### DIFF
--- a/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.test.ts
+++ b/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.test.ts
@@ -19,7 +19,7 @@ const eqlQuery = {
 };
 const esqlQueryRequest = {
   method: 'POST',
-  path: '/_esql',
+  path: '/_query',
   body: {
     query: 'from .kibana_task_manager',
   },
@@ -291,7 +291,7 @@ describe('wrapScopedClusterClient', () => {
         }).client();
 
         await expect(
-          wrappedSearchClient.asInternalUser.transport.request({ method: 'POST', path: '/_esql' })
+          wrappedSearchClient.asInternalUser.transport.request({ method: 'POST', path: '/_query' })
         ).rejects.toThrowErrorMatchingInlineSnapshot(`"something went wrong!"`);
       });
 
@@ -322,7 +322,7 @@ describe('wrapScopedClusterClient', () => {
         expect(stats.totalSearchDurationMs).toBeGreaterThan(-1);
 
         expect(logger.debug).toHaveBeenCalledWith(
-          `executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {\"method\":\"POST\",\"path\":\"/_esql\",\"body\":{\"query\":\"from .kibana_task_manager\"}} - with options {}`
+          `executing ES|QL query for rule .test-rule-type:abcdefg in space my-space - {\"method\":\"POST\",\"path\":\"/_query\",\"body\":{\"query\":\"from .kibana_task_manager\"}} - with options {}`
         );
       });
 
@@ -342,7 +342,10 @@ describe('wrapScopedClusterClient', () => {
         }).client();
 
         await expect(
-          abortableSearchClient.asInternalUser.transport.request({ method: 'POST', path: '/_esql' })
+          abortableSearchClient.asInternalUser.transport.request({
+            method: 'POST',
+            path: '/_query',
+          })
         ).rejects.toThrowErrorMatchingInlineSnapshot(
           `"ES|QL search has been aborted due to cancelled execution"`
         );

--- a/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
+++ b/x-pack/plugins/alerting/server/lib/wrap_scoped_cluster_client.ts
@@ -124,7 +124,7 @@ function getWrappedTransportRequestFn(opts: WrapEsClientOpts) {
     options?: TransportRequestOptions
   ): Promise<TResponse | TransportResult<TResponse, TContext>> {
     // Wrap ES|QL requests with an abort signal
-    if (params.method === 'POST' && params.path === '/_esql') {
+    if (params.method === 'POST' && params.path === '/_query') {
       try {
         const requestOptions = options ?? {};
         const start = Date.now();

--- a/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
+++ b/x-pack/plugins/stack_alerts/server/rule_types/es_query/lib/fetch_esql_query.ts
@@ -44,7 +44,7 @@ export async function fetchEsqlQuery({
 
   const response = await esClient.transport.request<EsqlTable>({
     method: 'POST',
-    path: '/_esql',
+    path: '/_query',
     body: query,
   });
 

--- a/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
+++ b/x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/builtin_alert_types/es_query/esql_only.ts
@@ -45,8 +45,7 @@ export default function ruleTests({ getService }: FtrProviderContext) {
     { label: 'host.name', searchPath: 'host.name' },
   ];
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176116
-  describe.skip('rule', async () => {
+  describe('rule', async () => {
     let endDate: string;
     let connectorId: string;
     const objectRemover = new ObjectRemover(supertest);


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/176116

## Summary

The test was failing with the following error, `Incorrect HTTP method for uri [/_esql] and method [POST], allowed: [HEAD, PUT, DELETE, GET]","status":405`.

This pr updates the ES|QL query request, for es query rule, to use` /_query`. Security solution also uses `/_query` for their ES|QL rule here:
`x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/esql/esql_request.ts`.

### To verify

- Run this command to start the functional test server, and verify that the tests work properly
```
ES_SNAPSHOT_MANIFEST="https://storage.googleapis.com/kibana-ci-es-snapshots-daily/8.13.0/archives/20240201-212246_98a37c7b/manifest.json" node scripts/functional_tests_server.js --config x-pack/test/alerting_api_integration/spaces_only/tests/alerting/group3/config.ts
```