### PR TITLE
[Fleet] Add the uptime capability to observability projects

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -39,7 +39,11 @@ xpack.uptime.service.tls.certificate: /mnt/elastic-internal/http-certs/tls.crt
 xpack.uptime.service.tls.key: /mnt/elastic-internal/http-certs/tls.key
 
 # Fleet specific configuration
-xpack.fleet.internal.registry.capabilities: ['apm', 'observability']
+xpack.fleet.internal.registry.capabilities: [
+  'apm',
+  'observability',
+  'uptime',
+]
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 xpack.fleet.internal.registry.spec.max: '3.0'
 # Temporary until all packages implement new spec https://github.com/elastic/kibana/issues/166742


### PR DESCRIPTION
## Summary

Add an specific capability for uptime for packages filtering.

Relates to https://github.com/elastic/integrations/pull/9066.

Before merging let's clarify if we need different capabilities for `uptime`/`synthetics` (see https://github.com/elastic/integrations/pull/9066/files#r1479623917).