### PR TITLE
[ML] Anomaly Detection: Fixes color of markers in Single Metric Viewer when there is sparse data

### DIFF
--- a/x-pack/plugins/ml/public/application/timeseriesexplorer/_timeseriesexplorer.scss
+++ b/x-pack/plugins/ml/public/application/timeseriesexplorer/_timeseriesexplorer.scss
@@ -74,6 +74,11 @@
       pointer-events: none;
     }
 
+    .values-dots circle {
+      fill: $euiColorPrimary;
+      stroke-width: 0;
+    }
+
     .metric-value {
       opacity: 1;
       fill: transparent;


### PR DESCRIPTION
## Summary

Fixes the colors of "value dots", the dots that are shown in the Single Metric Viewer when there's sparse data and not a continuous line.

Before:

<img width="1112" alt="image" src="https://github.com/elastic/kibana/assets/230104/7844bfa0-3a50-4088-869a-5a6fc366c0cd">

After:

<img width="1112" alt="image" src="https://github.com/elastic/kibana/assets/230104/28fcaa1e-eed9-497b-8c1a-c824effd7c31">

### Checklist

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->