### PR TITLE
[Lens] Cleanups the veil flag from the ExpressionWrapper

### DIFF
--- a/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
+++ b/x-pack/plugins/lens/public/embeddable/expression_wrapper.tsx
@@ -46,7 +46,6 @@ export interface ExpressionWrapperProps {
   executionContext?: KibanaExecutionContext;
   lensInspector: LensInspector;
   noPadding?: boolean;
-  shouldUseSizeTransitionVeil?: boolean;
   abortController?: AbortController;
 }
 
@@ -73,7 +72,6 @@ export function ExpressionWrapper({
   executionContext,
   lensInspector,
   noPadding,
-  shouldUseSizeTransitionVeil,
   abortController,
 }: ExpressionWrapperProps) {
   if (!expression) return null;
@@ -97,7 +95,6 @@ export function ExpressionWrapper({
           syncCursor={syncCursor}
           executionContext={executionContext}
           abortController={abortController}
-          shouldUseSizeTransitionVeil={shouldUseSizeTransitionVeil ?? true}
           renderError={(errorMessage, error) => {
             const messages = getOriginalRequestErrorMessages(error || null);
             addUserMessages(messages);


### PR DESCRIPTION
## Summary

Cleanups the unused shouldUseSizeTransitionVeil from the ExpressionWrapper. This true default value can cause bugs in embeddables.