### PR TITLE
[Discover] Removes project command from our code

### DIFF
--- a/src/plugins/discover/public/application/main/hooks/use_text_based_query_language.ts
+++ b/src/plugins/discover/public/application/main/hooks/use_text_based_query_language.ts
@@ -18,7 +18,7 @@ import { FetchStatus } from '../../types';
 
 const MAX_NUM_OF_COLUMNS = 50;
 // For ES|QL we want in case of the following commands to display a table view, otherwise display a document view
-const TRANSFORMATIONAL_COMMANDS = ['stats', 'project', 'keep'];
+const TRANSFORMATIONAL_COMMANDS = ['stats', 'keep'];
 
 /**
  * Hook to take care of text based query language state transformations when a new result is returned

--- a/src/plugins/unified_histogram/public/layout/helpers.ts
+++ b/src/plugins/unified_histogram/public/layout/helpers.ts
@@ -8,7 +8,7 @@
 
 import { AggregateQuery } from '@kbn/es-query';
 
-const TRANSFORMATIONAL_COMMANDS = ['stats', 'project', 'keep'];
+const TRANSFORMATIONAL_COMMANDS = ['stats', 'keep'];
 
 export const shouldDisplayHistogram = (query: AggregateQuery) => {
   let queryHasTransformationalCommands = false;


### PR DESCRIPTION
## Summary

This is a cleanup, no need to check for the project command as it is being removed in 8.13 https://github.com/elastic/elasticsearch/pull/105064

The project command was deprecated even on the first release and we were showing a warning in the users to use keep instead. As we are still in tech preview, the ES team decided to remove it (now it will fail) so we are aligning here and also remove this from our code.