### PR TITLE
[Infra] Kubernetes form - update survey link for correct cluster version

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/survey_kubernetes.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/inventory_view/components/survey_kubernetes.tsx
@@ -35,6 +35,9 @@ export const SurveyKubernetes = () => {
             defaultMessage="Tell us what you think! (K8s)"
           />
         }
+        formConfig={{
+          kibanaVersionQueryParam: 'entry.184582718',
+        }}
       />
       {!isToastSeen && (
         <EuiGlobalToastList

--- a/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
+++ b/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
@@ -23,13 +23,19 @@ const getDeploymentType = (isCloudEnv?: boolean, isServerlessEnv?: boolean): str
   return 'Self-Managed (you manage)';
 };
 
-const getSurveyFeedbackURL = (
-  formUrl: string,
-  formConfig?: FormConfig,
-  kibanaVersion?: string,
-  deploymentType?: string,
-  sanitizedPath?: string
-) => {
+const getSurveyFeedbackURL = ({
+  formUrl,
+  formConfig,
+  kibanaVersion,
+  deploymentType,
+  sanitizedPath,
+}: {
+  formUrl: string;
+  formConfig?: FormConfig;
+  kibanaVersion?: string;
+  deploymentType?: string;
+  sanitizedPath?: string;
+}) => {
   const url = new URL(formUrl);
   if (kibanaVersion) {
     url.searchParams.append(
@@ -96,7 +102,13 @@ export const FeatureFeedbackButton = ({
 
   return (
     <EuiButton
-      href={getSurveyFeedbackURL(formUrl, formConfig, kibanaVersion, deploymentType, sanitizedPath)}
+      href={getSurveyFeedbackURL({
+        formUrl,
+        formConfig,
+        kibanaVersion,
+        deploymentType,
+        sanitizedPath,
+      })}
       target="_blank"
       color={defaultButton ? undefined : 'warning'}
       iconType={defaultButton ? undefined : 'editorComment'}

--- a/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
+++ b/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
@@ -39,19 +39,19 @@ const getSurveyFeedbackURL = ({
   const url = new URL(formUrl);
   if (kibanaVersion) {
     url.searchParams.append(
-      formConfig?.kibanaVersionQueryParam ?? KIBANA_VERSION_QUERY_PARAM,
+      formConfig?.kibanaVersionQueryParam || KIBANA_VERSION_QUERY_PARAM,
       kibanaVersion
     );
   }
   if (deploymentType) {
     url.searchParams.append(
-      formConfig?.kibanaDeploymentTypeQueryParam ?? KIBANA_DEPLOYMENT_TYPE_PARAM,
+      formConfig?.kibanaDeploymentTypeQueryParam || KIBANA_DEPLOYMENT_TYPE_PARAM,
       deploymentType
     );
   }
   if (sanitizedPath) {
     url.searchParams.append(
-      formConfig?.sanitizedPathQueryParam ?? SANITIZED_PATH_PARAM,
+      formConfig?.sanitizedPathQueryParam || SANITIZED_PATH_PARAM,
       sanitizedPath
     );
   }

--- a/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
+++ b/x-pack/plugins/observability_shared/public/components/feature_feedback_button/feature_feedback_button.tsx
@@ -25,23 +25,39 @@ const getDeploymentType = (isCloudEnv?: boolean, isServerlessEnv?: boolean): str
 
 const getSurveyFeedbackURL = (
   formUrl: string,
+  formConfig?: FormConfig,
   kibanaVersion?: string,
   deploymentType?: string,
   sanitizedPath?: string
 ) => {
   const url = new URL(formUrl);
   if (kibanaVersion) {
-    url.searchParams.append(KIBANA_VERSION_QUERY_PARAM, kibanaVersion);
+    url.searchParams.append(
+      formConfig?.kibanaVersionQueryParam ?? KIBANA_VERSION_QUERY_PARAM,
+      kibanaVersion
+    );
   }
   if (deploymentType) {
-    url.searchParams.append(KIBANA_DEPLOYMENT_TYPE_PARAM, deploymentType);
+    url.searchParams.append(
+      formConfig?.kibanaDeploymentTypeQueryParam ?? KIBANA_DEPLOYMENT_TYPE_PARAM,
+      deploymentType
+    );
   }
   if (sanitizedPath) {
-    url.searchParams.append(SANITIZED_PATH_PARAM, sanitizedPath);
+    url.searchParams.append(
+      formConfig?.sanitizedPathQueryParam ?? SANITIZED_PATH_PARAM,
+      sanitizedPath
+    );
   }
 
   return url.href;
 };
+
+interface FormConfig {
+  kibanaVersionQueryParam?: string;
+  kibanaDeploymentTypeQueryParam?: string;
+  sanitizedPathQueryParam?: string;
+}
 
 interface FeatureFeedbackButtonProps {
   formUrl: string;
@@ -53,10 +69,12 @@ interface FeatureFeedbackButtonProps {
   isCloudEnv?: boolean;
   isServerlessEnv?: boolean;
   sanitizedPath?: string;
+  formConfig?: FormConfig;
 }
 
 export const FeatureFeedbackButton = ({
   formUrl,
+  formConfig,
   'data-test-subj': dts,
   onClickCapture,
   defaultButton,
@@ -78,7 +96,7 @@ export const FeatureFeedbackButton = ({
 
   return (
     <EuiButton
-      href={getSurveyFeedbackURL(formUrl, kibanaVersion, deploymentType, sanitizedPath)}
+      href={getSurveyFeedbackURL(formUrl, formConfig, kibanaVersion, deploymentType, sanitizedPath)}
       target="_blank"
       color={defaultButton ? undefined : 'warning'}
       iconType={defaultButton ? undefined : 'editorComment'}


### PR DESCRIPTION
Closes #174347 

## Summary

This PR changes the Kibana version query parameter in the k8s feedback URL to fix the issue with prefilling the form and adds an option to have more flexibility in the feedback button regarding the form parameter names.

## Testing
- Open Inventory view and select Kubernetes Pods from the `Show` menu
- Click on the feedback button
- Check if the Kibana version is prefilled correctly in the form


https://github.com/elastic/kibana/assets/14139027/b62edb51-d990-49dc-9214-764dbbf6f47c

