### PR TITLE
[OBS-UX-MNGMT] - Fix flaky test - Failing test: X-Pack Alerting API Integration Tests.x-pack/test/alerting_api_integration/observability/custom_threshold_rule/rate_bytes_fired·ts - Observability Rules Rules Endpoints Custom Threshold rule RATE - GROUP_BY - BYTES - FIRED Rule creation should set correct action variables

### DIFF
--- a/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/p99_pct_fired.ts
+++ b/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/p99_pct_fired.ts
@@ -67,7 +67,12 @@ export default function ({ getService }: FtrProviderContext) {
             metrics: [{ name: 'system.cpu.user.pct', method: 'linear', start: 2.5, end: 2.5 }],
           },
         ],
-        indexing: { dataset: 'fake_hosts' as Dataset, eventsPerCycle: 1, interval: 10000 },
+        indexing: {
+          dataset: 'fake_hosts' as Dataset,
+          eventsPerCycle: 1,
+          interval: 10000,
+          alignEventsToInterval: true,
+        },
       };
       dataForgeIndices = await generate({ client: esClient, config: dataForgeConfig, logger });
       logger.info(JSON.stringify(dataForgeIndices.join(',')));

--- a/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/rate_bytes_fired.ts
+++ b/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/rate_bytes_fired.ts
@@ -258,9 +258,9 @@ export default function ({ getService }: FtrProviderContext) {
           `https://localhost:5601/app/observability/alerts?_a=(kuery:%27kibana.alert.uuid:%20%22${alertId}%22%27%2CrangeFrom:%27${rangeFrom}%27%2CrangeTo:now%2Cstatus:all)`
         );
         expect(resp.hits.hits[0]._source?.reason).eql(
-          `Rate of system.network.in.bytes is 0.2 B/s, above or equal the threshold of 0.2 B/s. (duration: 1 min, data view: kbn-data-forge-fake_hosts.fake_hosts-*, group: host-0,container-0)`
+          `Rate of system.network.in.bytes is 0.3 B/s, above or equal the threshold of 0.2 B/s. (duration: 1 min, data view: kbn-data-forge-fake_hosts.fake_hosts-*, group: host-0,container-0)`
         );
-        expect(resp.hits.hits[0]._source?.value).eql('0.2 B/s');
+        expect(resp.hits.hits[0]._source?.value).eql('0.3 B/s');
         expect(resp.hits.hits[0]._source?.host).eql(
           '{"name":"host-0","mac":["00-00-5E-00-53-23","00-00-5E-00-53-24"]}'
         );

--- a/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/rate_bytes_fired.ts
+++ b/x-pack/test/alerting_api_integration/observability/custom_threshold_rule/rate_bytes_fired.ts
@@ -53,7 +53,12 @@ export default function ({ getService }: FtrProviderContext) {
             metrics: [{ name: 'system.network.in.bytes', method: 'exp', start: 10, end: 100 }],
           },
         ],
-        indexing: { dataset: 'fake_hosts' as Dataset, eventsPerCycle: 1, interval: 10000 },
+        indexing: {
+          dataset: 'fake_hosts' as Dataset,
+          eventsPerCycle: 1,
+          interval: 10000,
+          alignEventsToInterval: true,
+        },
       };
       dataForgeIndices = await generate({ client: esClient, config: dataForgeConfig, logger });
       await waitForDocumentInIndex({


### PR DESCRIPTION
## Summary

It fixes https://github.com/elastic/kibana/issues/176393 
Related to https://github.com/elastic/kibana/pull/173728
