### PR TITLE
[Security Solution][Endpoint] Gate responder action item for sentinel one alert with feature flag

### DIFF
--- a/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
@@ -7,6 +7,7 @@
 import type { ReactNode } from 'react';
 import { useCallback, useMemo } from 'react';
 import type { TimelineEventsDetailsItem } from '@kbn/timelines-plugin/common';
+import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
 import { getSentinelOneAgentId } from '../../../common/utils/sentinelone_alert_check';
 import type { ThirdPartyAgentInfo } from '../../../../common/types';
 import type { ResponseActionAgentType } from '../../../../common/endpoint/service/response_actions/constants';
@@ -76,6 +77,9 @@ export const useResponderActionData = ({
   const isEndpointHost = agentType === 'endpoint';
   const showResponseActionsConsole = useWithShowResponder();
 
+  const isSentinelOneV1Enabled = useIsExperimentalFeatureEnabled(
+    'responseActionsSentinelOneV1Enabled'
+  );
   const {
     data: hostInfo,
     isFetching,
@@ -83,8 +87,9 @@ export const useResponderActionData = ({
   } = useGetEndpointDetails(endpointId, { enabled: Boolean(endpointId) });
 
   const [isDisabled, tooltip]: [disabled: boolean, tooltip: ReactNode] = useMemo(() => {
+    // v8.13 disabled for third-party agent alerts if the feature flag is not enabled
     if (!isEndpointHost) {
-      return [false, undefined];
+      return [!isSentinelOneV1Enabled, undefined];
     }
 
     // Still loading host info
@@ -114,7 +119,7 @@ export const useResponderActionData = ({
     }
 
     return [false, undefined];
-  }, [isEndpointHost, isFetching, error, hostInfo?.host_status]);
+  }, [isEndpointHost, isSentinelOneV1Enabled, isFetching, error, hostInfo?.host_status]);
 
   const handleResponseActionsClick = useCallback(() => {
     if (!isEndpointHost) {

--- a/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
@@ -84,7 +84,7 @@ export const useResponderActionData = ({
     data: hostInfo,
     isFetching,
     error,
-  } = useGetEndpointDetails(endpointId, { enabled: Boolean(endpointId) });
+  } = useGetEndpointDetails(endpointId, { enabled: Boolean(endpointId && isEndpointHost) });
 
   const [isDisabled, tooltip]: [disabled: boolean, tooltip: ReactNode] = useMemo(() => {
     // v8.13 disabled for third-party agent alerts if the feature flag is not enabled

--- a/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
+++ b/x-pack/plugins/security_solution/public/detections/components/endpoint_responder/use_responder_action_data.ts
@@ -75,6 +75,7 @@ export const useResponderActionData = ({
   tooltip: ReactNode;
 } => {
   const isEndpointHost = agentType === 'endpoint';
+  const isSentinelOneHost = agentType === 'sentinel_one';
   const showResponseActionsConsole = useWithShowResponder();
 
   const isSentinelOneV1Enabled = useIsExperimentalFeatureEnabled(
@@ -89,7 +90,7 @@ export const useResponderActionData = ({
   const [isDisabled, tooltip]: [disabled: boolean, tooltip: ReactNode] = useMemo(() => {
     // v8.13 disabled for third-party agent alerts if the feature flag is not enabled
     if (!isEndpointHost) {
-      return [!isSentinelOneV1Enabled, undefined];
+      return [isSentinelOneHost ? !isSentinelOneV1Enabled : true, undefined];
     }
 
     // Still loading host info
@@ -119,7 +120,14 @@ export const useResponderActionData = ({
     }
 
     return [false, undefined];
-  }, [isEndpointHost, isSentinelOneV1Enabled, isFetching, error, hostInfo?.host_status]);
+  }, [
+    isEndpointHost,
+    isSentinelOneHost,
+    isSentinelOneV1Enabled,
+    isFetching,
+    error,
+    hostInfo?.host_status,
+  ]);
 
   const handleResponseActionsClick = useCallback(() => {
     if (!isEndpointHost) {


### PR DESCRIPTION
## Summary

Shows responder action item enabled for SentinelOne alerts if feature flag is enabled.

**with `responseActionsSentinelOneV1Enabled` enabled**
<img width="939" alt="Screenshot 2024-02-08 at 9 21 54 AM" src="https://github.com/elastic/kibana/assets/1849116/08cbe00a-850e-4c78-9df2-57ae28e280eb">


Follow up of elastic/kibana/pull/173927

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed