### PR TITLE
[8.12] [Profiling,Infra,APM] Disable Profiling integration by default (#175201)

### DIFF
--- a/test/plugin_functional/test_suites/core_plugins/rendering.ts
+++ b/test/plugin_functional/test_suites/core_plugins/rendering.ts
@@ -213,6 +213,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.apm.featureFlags.migrationToFleetAvailable (any)',
         'xpack.apm.featureFlags.sourcemapApiAvailable (any)',
         'xpack.apm.featureFlags.storageExplorerAvailable (any)',
+        'xpack.apm.featureFlags.profilingIntegrationAvailable (boolean)',
         'xpack.apm.serverless.enabled (any)', // It's a boolean (any because schema.conditional)
         'xpack.assetManager.alphaEnabled (boolean)',
         'xpack.observability_onboarding.serverless.enabled (any)', // It's a boolean (any because schema.conditional)
@@ -282,7 +283,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
         'xpack.infra.featureFlags.logThresholdAlertRuleEnabled (any)',
         'xpack.infra.featureFlags.logsUIEnabled (any)',
         'xpack.infra.featureFlags.alertsAndRulesDropdownEnabled (any)',
-        'xpack.infra.featureFlags.profilingEnabled (any)',
+        'xpack.infra.featureFlags.profilingEnabled (boolean)',
 
         'xpack.license_management.ui.enabled (boolean)',
         'xpack.maps.preserveDrawingBuffer (boolean)',

--- a/x-pack/plugins/apm/common/apm_feature_flags.ts
+++ b/x-pack/plugins/apm/common/apm_feature_flags.ts
@@ -16,6 +16,7 @@ export enum ApmFeatureFlagName {
   MigrationToFleetAvailable = 'migrationToFleetAvailable',
   SourcemapApiAvailable = 'sourcemapApiAvailable',
   StorageExplorerAvailable = 'storageExplorerAvailable',
+  ProfilingIntegrationAvailable = 'profilingIntegrationAvailable',
 }
 
 const apmFeatureFlagMap = {
@@ -45,6 +46,10 @@ const apmFeatureFlagMap = {
   },
   [ApmFeatureFlagName.StorageExplorerAvailable]: {
     default: true,
+    type: t.boolean,
+  },
+  [ApmFeatureFlagName.ProfilingIntegrationAvailable]: {
+    default: false,
     type: t.boolean,
   },
 };

--- a/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/settings/general_settings/index.tsx
@@ -27,26 +27,39 @@ import {
   useEditableSettings,
   useUiTracker,
 } from '@kbn/observability-shared-plugin/public';
+import { useApmFeatureFlag } from '../../../../hooks/use_apm_feature_flag';
+import { ApmFeatureFlagName } from '../../../../../common/apm_feature_flags';
 import { useApmPluginContext } from '../../../../context/apm_plugin/use_apm_plugin_context';
 import { BottomBarActions } from '../bottom_bar_actions';
 
-const apmSettingsKeys = [
-  enableComparisonByDefault,
-  defaultApmServiceEnvironment,
-  apmServiceGroupMaxNumberOfServices,
-  enableInspectEsQueries,
-  apmLabsButton,
-  apmAWSLambdaPriceFactor,
-  apmAWSLambdaRequestCostPerMillion,
-  apmEnableServiceMetrics,
-  apmEnableContinuousRollups,
-  enableAgentExplorerView,
-  apmEnableProfilingIntegration,
-];
+function getApmSettingsKeys(isProfilingIntegrationEnabled: boolean) {
+  const keys = [
+    enableComparisonByDefault,
+    defaultApmServiceEnvironment,
+    apmServiceGroupMaxNumberOfServices,
+    enableInspectEsQueries,
+    apmLabsButton,
+    apmAWSLambdaPriceFactor,
+    apmAWSLambdaRequestCostPerMillion,
+    apmEnableServiceMetrics,
+    apmEnableContinuousRollups,
+    enableAgentExplorerView,
+  ];
+
+  if (isProfilingIntegrationEnabled) {
+    keys.push(apmEnableProfilingIntegration);
+  }
+
+  return keys;
+}
 
 export function GeneralSettings() {
   const trackApmEvent = useUiTracker({ app: 'apm' });
   const { docLinks, notifications } = useApmPluginContext().core;
+  const isProfilingIntegrationEnabled = useApmFeatureFlag(
+    ApmFeatureFlagName.ProfilingIntegrationAvailable
+  );
+  const apmSettingsKeys = getApmSettingsKeys(isProfilingIntegrationEnabled);
   const {
     handleFieldChange,
     settingsEditableConfig,

--- a/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.test.tsx
+++ b/x-pack/plugins/apm/public/components/app/transaction_details/distribution/index.test.tsx
@@ -25,8 +25,13 @@ import { fromQuery } from '../../../shared/links/url_helpers';
 
 import { TransactionDistribution } from '.';
 
+const coreMock = {
+  settings: { client: { get: () => {} } },
+} as unknown as CoreStart;
+
 function Wrapper({ children }: { children?: ReactNode }) {
   const KibanaReactContext = createKibanaReactContext({
+    ...coreMock,
     usageCollection: { reportUiCounter: () => {} },
   } as Partial<CoreStart>);
 

--- a/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
+++ b/x-pack/plugins/apm/public/components/routing/templates/apm_service_template/index.tsx
@@ -20,6 +20,7 @@ import { enableAwsLambdaMetrics } from '@kbn/observability-plugin/common';
 import { omit } from 'lodash';
 import React from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
+import { useProfilingIntegrationSetting } from '../../../../hooks/use_profiling_integration_setting';
 import {
   isAWSLambdaAgentName,
   isAzureFunctionsAgentName,
@@ -224,6 +225,8 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
     ApmFeatureFlagName.InfrastructureTabAvailable
   );
 
+  const isProfilingIntegrationEnabled = useProfilingIntegrationSetting();
+
   const isAwsLambdaEnabled = core.uiSettings.get<boolean>(
     enableAwsLambdaMetrics,
     true
@@ -404,6 +407,7 @@ function useTabs({ selectedTab }: { selectedTab: Tab['key'] }) {
         defaultMessage: 'Universal Profiling',
       }),
       hidden:
+        !isProfilingIntegrationEnabled ||
         isRumOrMobileAgentName(agentName) ||
         isAWSLambdaAgentName(serverlessType),
       append: (

--- a/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/transaction_action_menu/transaction_action_menu.test.tsx
@@ -31,6 +31,7 @@ import {
 import { TransactionActionMenu } from './transaction_action_menu';
 import * as Transactions from './__fixtures__/mock_data';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { useProfilingIntegrationSetting } from '../../../hooks/use_profiling_integration_setting';
 
 const apmContextMock = {
   ...mockApmPluginContextValue,
@@ -54,6 +55,10 @@ const apmContextMock = {
     },
   },
 } as unknown as ApmPluginContextValue;
+
+jest.mock('../../../hooks/use_profiling_integration_setting', () => ({
+  useProfilingIntegrationSetting: jest.fn().mockReturnValue(false),
+}));
 
 const history = createMemoryHistory();
 history.replace(
@@ -108,9 +113,11 @@ describe('TransactionActionMenu component', () => {
       refetch: jest.fn(),
     });
   });
+
   afterEach(() => {
     jest.clearAllMocks();
   });
+
   it('should always render the discover link', async () => {
     const { queryByText } = await renderTransaction(
       Transactions.transactionWithMinimalData
@@ -278,6 +285,10 @@ describe('TransactionActionMenu component', () => {
   });
 
   describe('Profiling items', () => {
+    beforeEach(() => {
+      (useProfilingIntegrationSetting as jest.Mock).mockReturnValue(true);
+    });
+
     it('renders flamegraph item', async () => {
       const component = await renderTransaction(
         Transactions.transactionWithHostData

--- a/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
+++ b/x-pack/plugins/apm/public/context/apm_plugin/mock_apm_plugin_context.tsx
@@ -80,6 +80,7 @@ const mockConfig: ConfigSchema = {
     migrationToFleetAvailable: true,
     sourcemapApiAvailable: true,
     storageExplorerAvailable: true,
+    profilingIntegrationAvailable: false,
   },
   serverless: { enabled: false },
 };

--- a/x-pack/plugins/apm/public/hooks/use_profiling_integration_setting.ts
+++ b/x-pack/plugins/apm/public/hooks/use_profiling_integration_setting.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useUiSetting } from '@kbn/kibana-react-plugin/public';
+import { apmEnableProfilingIntegration } from '@kbn/observability-plugin/common';
+import { ApmFeatureFlagName } from '../../common/apm_feature_flags';
+import { useApmFeatureFlag } from './use_apm_feature_flag';
+
+export function useProfilingIntegrationSetting() {
+  const isProfilingIntegrationFeatureFlagEnabled = useApmFeatureFlag(
+    ApmFeatureFlagName.ProfilingIntegrationAvailable
+  );
+  const isProfilingIntegrationUiSettingEnabled = useUiSetting<boolean>(
+    apmEnableProfilingIntegration
+  );
+
+  return (
+    isProfilingIntegrationFeatureFlagEnabled &&
+    isProfilingIntegrationUiSettingEnabled
+  );
+}

--- a/x-pack/plugins/apm/public/hooks/use_profiling_plugin.tsx
+++ b/x-pack/plugins/apm/public/hooks/use_profiling_plugin.tsx
@@ -5,16 +5,13 @@
  * 2.0.
  */
 
-import { apmEnableProfilingIntegration } from '@kbn/observability-plugin/common';
 import { useApmPluginContext } from '../context/apm_plugin/use_apm_plugin_context';
 import { isPending, useFetcher } from './use_fetcher';
+import { useProfilingIntegrationSetting } from './use_profiling_integration_setting';
 
 export function useProfilingPlugin() {
-  const { plugins, core } = useApmPluginContext();
-  const isProfilingIntegrationEnabled = core.uiSettings.get<boolean>(
-    apmEnableProfilingIntegration,
-    true
-  );
+  const { plugins } = useApmPluginContext();
+  const isProfilingIntegrationEnabled = useProfilingIntegrationSetting();
 
   const { data, status } = useFetcher((callApmApi) => {
     return callApmApi('GET /internal/apm/profiling/status');

--- a/x-pack/plugins/apm/public/index.ts
+++ b/x-pack/plugins/apm/public/index.ts
@@ -24,6 +24,7 @@ export interface ConfigSchema {
     migrationToFleetAvailable: boolean;
     sourcemapApiAvailable: boolean;
     storageExplorerAvailable: boolean;
+    profilingIntegrationAvailable: boolean;
   };
   serverless: {
     enabled: boolean;

--- a/x-pack/plugins/apm/server/index.ts
+++ b/x-pack/plugins/apm/server/index.ts
@@ -72,6 +72,12 @@ const configSchema = schema.object({
     migrationToFleetAvailable: disabledOnServerless,
     sourcemapApiAvailable: disabledOnServerless,
     storageExplorerAvailable: disabledOnServerless,
+    /**
+     * Depends on optional "profilingDataAccess" and "profiling"
+     * plugins. Enable both with `xpack.profiling.enabled: true` before
+     * enabling this feature flag.
+     */
+    profilingIntegrationAvailable: schema.boolean({ defaultValue: false }),
   }),
   serverless: schema.object({
     enabled: offeringBasedSchema({

--- a/x-pack/plugins/infra/server/plugin.ts
+++ b/x-pack/plugins/infra/server/plugin.ts
@@ -113,14 +113,11 @@ export const config: PluginConfigDescriptor<InfraConfig> = {
         serverless: schema.boolean({ defaultValue: true }),
       }),
       /**
-       * This flag depends on profilingDataAccess optional plugin,
-       * make sure to enable it with `xpack.profiling.enabled: true`
-       * before enabling this flag.
+       * Depends on optional "profilingDataAccess" and "profiling"
+       * plugins. Enable both with `xpack.profiling.enabled: true` before
+       * enabling this feature flag.
        */
-      profilingEnabled: offeringBasedSchema({
-        traditional: schema.boolean({ defaultValue: true }),
-        serverless: schema.boolean({ defaultValue: false }),
-      }),
+      profilingEnabled: schema.boolean({ defaultValue: false }),
     }),
   }),
   exposeToBrowser: publicConfigKeys,

--- a/x-pack/test/functional/apps/infra/config.ts
+++ b/x-pack/test/functional/apps/infra/config.ts
@@ -13,5 +13,12 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
   return {
     ...functionalConfig.getAll(),
     testFiles: [require.resolve('.')],
+    kbnTestServer: {
+      ...functionalConfig.get('kbnTestServer'),
+      serverArgs: [
+        ...functionalConfig.get('kbnTestServer.serverArgs'),
+        `--xpack.infra.featureFlags.profilingEnabled=true`,
+      ],
+    },
   };
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Profiling,Infra,APM] Disable Profiling integration by default (#175201)](https://github.com/elastic/kibana/pull/175201)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Mykola Harmash","email":"mykola.harmash@gmail.com"},"sourceCommit":{"committedDate":"2024-01-24T11:44:26Z","message":"[Profiling,Infra,APM] Disable Profiling integration by default (#175201)\n\nCloses https://github.com/elastic/kibana/issues/175016\r\n\r\n## Summary\r\n\r\nThis PR disables the Profiling integration in Infra and APM by default\r\non the plugin configuration level because this integration require users\r\nto first configure the main `profiling` plugin. On-prem users will have\r\nto manually enable both integrations once they enabled the Universal\r\nProfiling for their hosts. Cloud users will have Infra and APM\r\nintegrations enabled by default because on Cloud instances Universal\r\nProfiling is already configured. A PR for the default Cloud settings\r\nwill follow after this one is merged.\r\n\r\nChanges I've made:\r\n* Disabled the Infra integration be default\r\n* Introduced a new APM feature flag for the Profiling integration\r\n* Made sure all the places in APM that rely on Profiling integration\r\nrespect the new feature flag\r\n* Fixed a bug in APM when Universal Profiling was shown even though the\r\nintegration was disabled in UI settings\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/793851/65dfbb5b-1850-4d18-a92a-6ad59e0436a3\r\n\r\n## How To Test\r\n\r\n1. Checkout locally\r\n2. Make sure you don't have `xpack.infra.featureFlags.profilingEnabled`\r\nalready enabled in `kibana.yml`\r\n3. Open kibana and make sure you don't see \"Universal Profiling\" tab in\r\nHost and Service details\r\n4. Enabled both flags in `kibana.yml`:\r\n`xpack.infra.featureFlags.profilingEnabled` and\r\n`xpack.apm.featureFlags.profilingIntegrationAvailable: true`\r\n5. Check that now you see \"Universal Profiling\" tab in the details\r\nscreens in both Infra and APM\r\n6. Go to Infra settings view and disable the Profiling integration, make\r\nsure the tab disappears\r\n7. 6. Go to APM settings view and disable the Profiling integration,\r\nmake sure the tab disappears\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"abd3515dda40d48bd0c59f7d2861ffa86db133c1","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport missing","Team:obs-ux-infra_services","v8.12.1","v8.13.0"],"number":175201,"url":"https://github.com/elastic/kibana/pull/175201","mergeCommit":{"message":"[Profiling,Infra,APM] Disable Profiling integration by default (#175201)\n\nCloses https://github.com/elastic/kibana/issues/175016\r\n\r\n## Summary\r\n\r\nThis PR disables the Profiling integration in Infra and APM by default\r\non the plugin configuration level because this integration require users\r\nto first configure the main `profiling` plugin. On-prem users will have\r\nto manually enable both integrations once they enabled the Universal\r\nProfiling for their hosts. Cloud users will have Infra and APM\r\nintegrations enabled by default because on Cloud instances Universal\r\nProfiling is already configured. A PR for the default Cloud settings\r\nwill follow after this one is merged.\r\n\r\nChanges I've made:\r\n* Disabled the Infra integration be default\r\n* Introduced a new APM feature flag for the Profiling integration\r\n* Made sure all the places in APM that rely on Profiling integration\r\nrespect the new feature flag\r\n* Fixed a bug in APM when Universal Profiling was shown even though the\r\nintegration was disabled in UI settings\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/793851/65dfbb5b-1850-4d18-a92a-6ad59e0436a3\r\n\r\n## How To Test\r\n\r\n1. Checkout locally\r\n2. Make sure you don't have `xpack.infra.featureFlags.profilingEnabled`\r\nalready enabled in `kibana.yml`\r\n3. Open kibana and make sure you don't see \"Universal Profiling\" tab in\r\nHost and Service details\r\n4. Enabled both flags in `kibana.yml`:\r\n`xpack.infra.featureFlags.profilingEnabled` and\r\n`xpack.apm.featureFlags.profilingIntegrationAvailable: true`\r\n5. Check that now you see \"Universal Profiling\" tab in the details\r\nscreens in both Infra and APM\r\n6. Go to Infra settings view and disable the Profiling integration, make\r\nsure the tab disappears\r\n7. 6. Go to APM settings view and disable the Profiling integration,\r\nmake sure the tab disappears\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"abd3515dda40d48bd0c59f7d2861ffa86db133c1"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"8.12","label":"v8.12.1","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/175201","number":175201,"mergeCommit":{"message":"[Profiling,Infra,APM] Disable Profiling integration by default (#175201)\n\nCloses https://github.com/elastic/kibana/issues/175016\r\n\r\n## Summary\r\n\r\nThis PR disables the Profiling integration in Infra and APM by default\r\non the plugin configuration level because this integration require users\r\nto first configure the main `profiling` plugin. On-prem users will have\r\nto manually enable both integrations once they enabled the Universal\r\nProfiling for their hosts. Cloud users will have Infra and APM\r\nintegrations enabled by default because on Cloud instances Universal\r\nProfiling is already configured. A PR for the default Cloud settings\r\nwill follow after this one is merged.\r\n\r\nChanges I've made:\r\n* Disabled the Infra integration be default\r\n* Introduced a new APM feature flag for the Profiling integration\r\n* Made sure all the places in APM that rely on Profiling integration\r\nrespect the new feature flag\r\n* Fixed a bug in APM when Universal Profiling was shown even though the\r\nintegration was disabled in UI settings\r\n\r\n\r\nhttps://github.com/elastic/kibana/assets/793851/65dfbb5b-1850-4d18-a92a-6ad59e0436a3\r\n\r\n## How To Test\r\n\r\n1. Checkout locally\r\n2. Make sure you don't have `xpack.infra.featureFlags.profilingEnabled`\r\nalready enabled in `kibana.yml`\r\n3. Open kibana and make sure you don't see \"Universal Profiling\" tab in\r\nHost and Service details\r\n4. Enabled both flags in `kibana.yml`:\r\n`xpack.infra.featureFlags.profilingEnabled` and\r\n`xpack.apm.featureFlags.profilingIntegrationAvailable: true`\r\n5. Check that now you see \"Universal Profiling\" tab in the details\r\nscreens in both Infra and APM\r\n6. Go to Infra settings view and disable the Profiling integration, make\r\nsure the tab disappears\r\n7. 6. Go to APM settings view and disable the Profiling integration,\r\nmake sure the tab disappears\r\n\r\n---------\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"abd3515dda40d48bd0c59f7d2861ffa86db133c1"}}]}] BACKPORT-->