### PR TITLE
[Search] Remove API keys when deleting connectors

### DIFF
--- a/packages/kbn-search-connectors/lib/delete_connector_secret.test.ts
+++ b/packages/kbn-search-connectors/lib/delete_connector_secret.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+
+import { deleteConnectorSecret } from './delete_connector_secret';
+
+describe('deleteConnectorSecret lib function', () => {
+  const mockClient = {
+    transport: {
+      request: jest.fn(),
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  it('should delete a connector secret', async () => {
+    mockClient.transport.request.mockImplementation(() => ({
+      result: 'deleted',
+    }));
+
+    await expect(
+      deleteConnectorSecret(mockClient as unknown as ElasticsearchClient, 'secret-id')
+    ).resolves.toEqual({ result: 'deleted' });
+    expect(mockClient.transport.request).toHaveBeenCalledWith({
+      method: 'DELETE',
+      path: '/_connector/_secret/secret-id',
+    });
+    jest.useRealTimers();
+  });
+});

--- a/packages/kbn-search-connectors/lib/delete_connector_secret.ts
+++ b/packages/kbn-search-connectors/lib/delete_connector_secret.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { ElasticsearchClient } from '@kbn/core-elasticsearch-server';
+import { ConnectorsAPIUpdateResponse } from '../types/connectors_api';
+
+export const deleteConnectorSecret = async (client: ElasticsearchClient, id: string) => {
+  return await client.transport.request<ConnectorsAPIUpdateResponse>({
+    method: 'DELETE',
+    path: `/_connector/_secret/${id}`,
+  });
+};

--- a/packages/kbn-search-connectors/lib/index.ts
+++ b/packages/kbn-search-connectors/lib/index.ts
@@ -11,6 +11,7 @@ export * from './create_connector';
 export * from './create_connector_document';
 export * from './create_connector_secret';
 export * from './delete_connector';
+export * from './delete_connector_secret';
 export * from './fetch_connectors';
 export * from './fetch_sync_jobs';
 export * from './update_filtering';

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -9,6 +9,7 @@ import { schema } from '@kbn/config-schema';
 import { i18n } from '@kbn/i18n';
 import {
   deleteConnectorById,
+  deleteConnectorSecret,
   fetchConnectorById,
   fetchConnectors,
   fetchSyncJobs,
@@ -589,17 +590,24 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
       const { shouldDeleteIndex } = request.query;
 
       let connectorResponse;
-      let indexNameToDelete;
       try {
-        if (shouldDeleteIndex) {
-          const connector = await fetchConnectorById(client.asCurrentUser, connectorId);
-          indexNameToDelete = connector?.value.index_name;
-        }
+        const connector = await fetchConnectorById(client.asCurrentUser, connectorId);
+        const indexNameToDelete = shouldDeleteIndex ? connector?.value.index_name : null;
+        const apiKeyId = connector?.value.api_key_id;
+        const secretId = connector?.value.api_key_secret_id;
+
         connectorResponse = await deleteConnectorById(client.asCurrentUser, connectorId);
+
         if (indexNameToDelete) {
           await deleteIndexPipelines(client, indexNameToDelete);
           await deleteAccessControlIndex(client, indexNameToDelete);
           await client.asCurrentUser.indices.delete({ index: indexNameToDelete });
+        }
+        if (apiKeyId) {
+          await client.asCurrentUser.security.invalidateApiKey({ ids: [apiKeyId] });
+        }
+        if (secretId) {
+          await deleteConnectorSecret(client.asCurrentUser, secretId);
         }
       } catch (error) {
         if (isResourceNotFoundException(error)) {

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -14,7 +14,7 @@ import { schema } from '@kbn/config-schema';
 
 import { i18n } from '@kbn/i18n';
 
-import { deleteConnectorById } from '@kbn/search-connectors';
+import { deleteConnectorById, deleteConnectorSecret } from '@kbn/search-connectors';
 import {
   fetchConnectorByIndexName,
   fetchConnectors,
@@ -204,6 +204,12 @@ export function registerIndexRoutes({
 
         if (connector) {
           await deleteConnectorById(client.asCurrentUser, connector.id);
+          if (connector.api_key_id) {
+            await client.asCurrentUser.security.invalidateApiKey({ ids: [connector.api_key_id] });
+          }
+          if (connector.api_key_secret_id) {
+            await deleteConnectorSecret(client.asCurrentUser, connector.api_key_secret_id);
+          }
         }
 
         await deleteIndexPipelines(client, indexName);


### PR DESCRIPTION
## Summary

When deleting connectors or indices in Search:

- Invalidate the API key if a connector has an `api_key_id` value
- Delete the connector secret if a connector has an `api_key_secret_id` value
