### PR TITLE
[Dev Tools] Introduce UI setting for Docked Console

### DIFF
--- a/packages/kbn-management/settings/utilities/category/const.ts
+++ b/packages/kbn-management/settings/utilities/category/const.ts
@@ -22,6 +22,7 @@ export const SECURITY_SOLUTION_CATEGORY = 'securitySolution';
 export const TIMELION_CATEGORY = 'timelion';
 export const VISUALIZATION_CATEGORY = 'visualization';
 export const ENTERPRISE_SEARCH_CATEGORY = 'enterpriseSearch';
+export const DEV_TOOLS_CATEGORY = 'devTools';
 
 export const CATEGORY_ORDER = [
   GENERAL_CATEGORY,
@@ -39,4 +40,5 @@ export const CATEGORY_ORDER = [
   SECURITY_SOLUTION_CATEGORY,
   TIMELION_CATEGORY,
   VISUALIZATION_CATEGORY,
+  DEV_TOOLS_CATEGORY,
 ];

--- a/packages/kbn-management/settings/utilities/category/get_category_name.ts
+++ b/packages/kbn-management/settings/utilities/category/get_category_name.ts
@@ -11,6 +11,7 @@ import {
   ACCESSIBILITY_CATEGORY,
   AUTOCOMPLETE_CATEGORY,
   BANNER_CATEGORY,
+  DEV_TOOLS_CATEGORY,
   DISCOVER_CATEGORY,
   ENTERPRISE_SEARCH_CATEGORY,
   GENERAL_CATEGORY,
@@ -91,6 +92,9 @@ const names: Record<string, string> = {
   }),
   [ROLLUPS_CATEGORY]: i18n.translate('management.settings.categoryNames.rollupsLabel', {
     defaultMessage: 'Rollups',
+  }),
+  [DEV_TOOLS_CATEGORY]: i18n.translate('management.settings.categoryNames.devToolsLabel', {
+    defaultMessage: 'Developer Tools',
   }),
 };
 

--- a/packages/serverless/settings/search_project/tsconfig.json
+++ b/packages/serverless/settings/search_project/tsconfig.json
@@ -15,5 +15,6 @@
   ],
   "kbn_references": [
     "@kbn/management-settings-ids",
+    "@kbn/dev-tools-plugin",
   ]
 }

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -8,7 +8,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
-import { enableDockedConsoleUiSetting } from '@kbn/dev-tools-plugin/common/constants';
+import { enableDockedConsoleUiSetting } from '@kbn/dev-tools-plugin/public';
 
 import { renderEmbeddableConsole } from './application/containers/embeddable';
 import {

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -8,7 +8,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
-import { enableDockedConsoleUiSetting } from '@kbn/dev-tools-plugin/public';
+import { ENABLE_DOCKED_CONSOLE_UI_SETTING_ID } from '@kbn/dev-tools-plugin/public';
 
 import { renderEmbeddableConsole } from './application/containers/embeddable';
 import {
@@ -109,7 +109,9 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
     } = this.ctx.config.get<ClientConfigType>();
 
     const consoleStart: ConsolePluginStart = {};
-    const embeddedConsoleUiSetting = core.uiSettings.get<boolean>(enableDockedConsoleUiSetting);
+    const embeddedConsoleUiSetting = core.uiSettings.get<boolean>(
+      ENABLE_DOCKED_CONSOLE_UI_SETTING_ID
+    );
     const embeddedConsoleAvailable =
       isConsoleUiEnabled &&
       isEmbeddedConsoleEnabled &&

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -8,6 +8,7 @@
 
 import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
+import { enableDockedConsoleUiSetting } from '@kbn/dev-tools-plugin/common/constants';
 
 import { renderEmbeddableConsole } from './application/containers/embeddable';
 import {
@@ -108,10 +109,12 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
     } = this.ctx.config.get<ClientConfigType>();
 
     const consoleStart: ConsolePluginStart = {};
+    const embeddedConsoleUiSetting = core.uiSettings.get<boolean>(enableDockedConsoleUiSetting);
     const embeddedConsoleAvailable =
       isConsoleUiEnabled &&
       isEmbeddedConsoleEnabled &&
-      core.application.capabilities?.dev_tools?.show === true;
+      core.application.capabilities?.dev_tools?.show === true &&
+      embeddedConsoleUiSetting;
 
     if (embeddedConsoleAvailable) {
       consoleStart.renderEmbeddableConsole = (props?: EmbeddableConsoleProps) => {

--- a/src/plugins/dev_tools/common/constants.ts
+++ b/src/plugins/dev_tools/common/constants.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+export const devToolsFeatureId = 'devTools';
+export const enableDockedConsoleUiSetting = 'devTools:enableDockedConsole';

--- a/src/plugins/dev_tools/common/constants.ts
+++ b/src/plugins/dev_tools/common/constants.ts
@@ -6,5 +6,11 @@
  * Side Public License, v 1.
  */
 
+/**
+ * The UI Setting prefix and category for dev tools UI Settings
+ */
 export const DEV_TOOLS_FEATURE_ID = 'devTools';
+/**
+ * UI Setting ID for enabling / disabling the docked console in Kibana
+ */
 export const ENABLE_DOCKED_CONSOLE_UI_SETTING_ID = 'devTools:enableDockedConsole';

--- a/src/plugins/dev_tools/common/constants.ts
+++ b/src/plugins/dev_tools/common/constants.ts
@@ -6,5 +6,5 @@
  * Side Public License, v 1.
  */
 
-export const devToolsFeatureId = 'devTools';
-export const enableDockedConsoleUiSetting = 'devTools:enableDockedConsole';
+export const DEV_TOOLS_FEATURE_ID = 'devTools';
+export const ENABLE_DOCKED_CONSOLE_UI_SETTING_ID = 'devTools:enableDockedConsole';

--- a/src/plugins/dev_tools/common/index.ts
+++ b/src/plugins/dev_tools/common/index.ts
@@ -6,10 +6,4 @@
  * Side Public License, v 1.
  */
 
-import { COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX_ID } from '@kbn/management-settings-ids';
-import { ENABLE_DOCKED_CONSOLE_UI_SETTING_ID } from '@kbn/dev-tools-plugin/common';
-
-export const SEARCH_PROJECT_SETTINGS = [
-  COURIER_IGNORE_FILTER_IF_FIELD_NOT_IN_INDEX_ID,
-  ENABLE_DOCKED_CONSOLE_UI_SETTING_ID,
-];
+export { DEV_TOOLS_FEATURE_ID, ENABLE_DOCKED_CONSOLE_UI_SETTING_ID } from './constants';

--- a/src/plugins/dev_tools/public/index.ts
+++ b/src/plugins/dev_tools/public/index.ts
@@ -12,6 +12,7 @@
 import { PluginInitializerContext } from '@kbn/core/public';
 import { DevToolsPlugin } from './plugin';
 export * from './plugin';
+export * from '../common/constants';
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new DevToolsPlugin(initializerContext);

--- a/src/plugins/dev_tools/server/plugin.ts
+++ b/src/plugins/dev_tools/server/plugin.ts
@@ -6,12 +6,17 @@
  * Side Public License, v 1.
  */
 
-import { PluginInitializerContext, Plugin } from '@kbn/core/server';
+import { PluginInitializerContext, Plugin, CoreSetup } from '@kbn/core/server';
 
+import { uiSettings } from './ui_settings';
 export class DevToolsServerPlugin implements Plugin<object, object> {
   constructor(initializerContext: PluginInitializerContext) {}
 
-  public setup() {
+  public setup(core: CoreSetup<object>) {
+    /**
+     * Register Dev Tools UI Settings
+     */
+    core.uiSettings.register(uiSettings);
     return {};
   }
 

--- a/src/plugins/dev_tools/server/ui_settings.ts
+++ b/src/plugins/dev_tools/server/ui_settings.ts
@@ -10,14 +10,14 @@ import { schema } from '@kbn/config-schema';
 import { UiSettingsParams } from '@kbn/core/types';
 import { i18n } from '@kbn/i18n';
 
-import { devToolsFeatureId, enableDockedConsoleUiSetting } from '../common/constants';
+import { DEV_TOOLS_FEATURE_ID, ENABLE_DOCKED_CONSOLE_UI_SETTING_ID } from '../common/constants';
 
 /**
  * uiSettings definitions for Dev Tools
  */
 export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
-  [enableDockedConsoleUiSetting]: {
-    category: [devToolsFeatureId],
+  [ENABLE_DOCKED_CONSOLE_UI_SETTING_ID]: {
+    category: [DEV_TOOLS_FEATURE_ID],
     description: i18n.translate('devTools.uiSettings.dockedConsole.description', {
       defaultMessage:
         'Docks the Console in the Kibana UI. This setting does not affect the standard Console in Dev Tools.',

--- a/src/plugins/dev_tools/server/ui_settings.ts
+++ b/src/plugins/dev_tools/server/ui_settings.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import { schema } from '@kbn/config-schema';
+import { UiSettingsParams } from '@kbn/core/types';
+import { i18n } from '@kbn/i18n';
+
+import { devToolsFeatureId, enableDockedConsoleUiSetting } from '../common/constants';
+
+/**
+ * uiSettings definitions for Dev Tools
+ */
+export const uiSettings: Record<string, UiSettingsParams<boolean>> = {
+  [enableDockedConsoleUiSetting]: {
+    category: [devToolsFeatureId],
+    description: i18n.translate('devTools.uiSettings.dockedConsole.description', {
+      defaultMessage:
+        'Docks the Console in the Kibana UI. This setting does not affect the standard Console in Dev Tools.',
+    }),
+    name: i18n.translate('devTools.uiSettings.dockedConsole.name', {
+      defaultMessage: 'Docked Console',
+    }),
+    requiresPageReload: true,
+    schema: schema.boolean(),
+    value: true,
+  },
+};

--- a/src/plugins/dev_tools/tsconfig.json
+++ b/src/plugins/dev_tools/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "target/types",
   },
-  "include": ["public/**/*", "server/**/*"],
+  "include": ["common/*", "public/**/*", "server/**/*"],
   "kbn_references": [
     "@kbn/core",
     "@kbn/url-forwarding-plugin",

--- a/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/schema.ts
@@ -628,4 +628,8 @@ export const stackManagementSchema: MakeSchemaFrom<UsageStats> = {
     type: 'keyword',
     _meta: { description: 'Non-default value of setting.' },
   },
+  'devTools:enableDockedConsole': {
+    type: 'boolean',
+    _meta: { description: 'Non-default value of setting.' },
+  },
 };

--- a/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
+++ b/src/plugins/kibana_usage_collection/server/collectors/management/types.ts
@@ -166,4 +166,5 @@ export interface UsageStats {
   'observability:profilingCostPervCPUPerHour': number;
   'observability:profilingAWSCostDiscountRate': number;
   'data_views:fields_excluded_data_tiers': string;
+  'devTools:enableDockedConsole': boolean;
 }

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -10257,7 +10257,13 @@
           "_meta": {
             "description": "Non-default value of setting."
           }
-        }
+        },
+        "devTools:enableDockedConsole": {
+          "type": "boolean",
+          "_meta": {
+            "description": "Non-default value of setting."
+          }
+        },
       }
     },
     "static_telemetry": {

--- a/src/plugins/telemetry/schema/oss_plugins.json
+++ b/src/plugins/telemetry/schema/oss_plugins.json
@@ -10263,7 +10263,7 @@
           "_meta": {
             "description": "Non-default value of setting."
           }
-        },
+        }
       }
     },
     "static_telemetry": {


### PR DESCRIPTION
## Summary

Introduce a new UI setting to allow users to disable the "Docked Console" aka the EmbeddableConsole from the console plugin. This console is currently used on Search pages and Index Management pages for 8.13, and will be added to more pages in future releases.

### Screenshots
![image](https://github.com/elastic/kibana/assets/1972968/c8b7ed8a-8695-486d-aef5-d403ea4d4547)

### Checklist

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials