### PR TITLE
[Search] Remove search prefix from connector and api indices

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/index/index_exists_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/index/index_exists_api_logic.ts
@@ -20,6 +20,10 @@ export interface IndexExistsApiResponse {
 export const fetchIndexExists = async ({
   indexName,
 }: IndexExistsApiParams): Promise<IndexExistsApiResponse> => {
+  if (!indexName) {
+    return { exists: false, indexName };
+  }
+
   const route = `/internal/enterprise_search/indices/${indexName}/exists`;
 
   const { exists } = await HttpLogic.values.http.get<{ exists: boolean }>(route);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.test.ts
@@ -25,6 +25,7 @@ const DEFAULT_VALUES: NewSearchIndexValues = {
   fullIndexName: 'search-',
   fullIndexNameExists: false,
   fullIndexNameIsValid: true,
+  hasPrefix: true,
   language: null,
   languageSelectValue: UNIVERSAL_LANGUAGE_VALUE,
   rawName: '',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_logic.ts
@@ -43,6 +43,7 @@ export interface NewSearchIndexValues {
   fullIndexName: string;
   fullIndexNameExists: boolean;
   fullIndexNameIsValid: boolean;
+  hasPrefix: boolean;
   language: LanguageForOptimization;
   languageSelectValue: string;
   rawName: string;
@@ -61,12 +62,14 @@ type NewSearchIndexActions = Pick<
     AddConnectorApiLogicResponse
   >['apiSuccess'];
   crawlerIndexCreated: Actions<CreateCrawlerIndexArgs, CreateCrawlerIndexResponse>['apiSuccess'];
+  setHasPrefix(hasPrefix: boolean): { hasPrefix: boolean };
   setLanguageSelectValue(language: string): { language: string };
   setRawName(rawName: string): { rawName: string };
 };
 
 export const NewSearchIndexLogic = kea<MakeLogicType<NewSearchIndexValues, NewSearchIndexActions>>({
   actions: {
+    setHasPrefix: (hasPrefix) => ({ hasPrefix }),
     setLanguageSelectValue: (language) => ({ language }),
     setRawName: (rawName) => ({ rawName }),
   },
@@ -103,6 +106,12 @@ export const NewSearchIndexLogic = kea<MakeLogicType<NewSearchIndexValues, NewSe
   }),
   path: ['enterprise_search', 'content', 'new_search_index'],
   reducers: {
+    hasPrefix: [
+      true,
+      {
+        setHasPrefix: (_, { hasPrefix }) => hasPrefix,
+      },
+    ],
     languageSelectValue: [
       UNIVERSAL_LANGUAGE_VALUE,
       {
@@ -117,7 +126,10 @@ export const NewSearchIndexLogic = kea<MakeLogicType<NewSearchIndexValues, NewSe
     ],
   },
   selectors: ({ selectors }) => ({
-    fullIndexName: [() => [selectors.rawName], (name: string) => `search-${name}`],
+    fullIndexName: [
+      () => [selectors.rawName, selectors.hasPrefix],
+      (name: string, hasPrefix: boolean) => (hasPrefix ? `search-${name}` : name),
+    ],
     fullIndexNameExists: [
       () => [selectors.data, selectors.fullIndexName],
       (data: IndexExistsApiResponse | undefined, fullIndexName: string) =>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.test.tsx
@@ -26,12 +26,17 @@ describe('NewSearchIndexTemplate', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setMockValues({
+      hasPrefix: false,
       language: null,
       languageSelectValue: UNIVERSAL_LANGUAGE_VALUE,
       name: 'my-name',
       rawName: 'MY$_RAW_$NAME',
     });
-    setMockActions({ makeRequest: jest.fn(), setLanguageSelectValue: jest.fn() });
+    setMockActions({
+      makeRequest: jest.fn(),
+      setHasPrefix: jest.fn(),
+      setLanguageSelectValue: jest.fn(),
+    });
   });
 
   it('renders', () => {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -61,11 +61,13 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
     fullIndexName,
     fullIndexNameExists,
     fullIndexNameIsValid,
+    hasPrefix,
     language,
     rawName,
     languageSelectValue,
   } = useValues(NewSearchIndexLogic);
-  const { setRawName, setLanguageSelectValue } = useActions(NewSearchIndexLogic);
+  const { setRawName, setLanguageSelectValue, setHasPrefix } = useActions(NewSearchIndexLogic);
+  setHasPrefix(type === INGESTION_METHOD_IDS.CRAWLER);
 
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setRawName(e.target.value);
@@ -195,12 +197,12 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                     value={rawName}
                     onChange={handleNameChange}
                     autoFocus
-                    prepend="search-"
+                    prepend={hasPrefix ? 'search-' : ''}
                   />
                 </EuiFormRow>
                 <EuiText size="xs" color="subdued">
                   {i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineTwo',
+                    'xpack.enterprisecrawlerIndexName.content.newIndex.newcrawlerIndexNameIndexTemplate.nameInputHelpText.lineTwo',
                     {
                       defaultMessage:
                         'Names should be lowercase and cannot contain spaces or special characters.',
@@ -212,7 +214,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 <EuiFormRow
                   isDisabled={disabled}
                   label={i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputLabel',
+                    'xpack.enterprisecrawlerIndexName.content.newIndex.newSearchIndexTemplate.languageInputLabel',
                     {
                       defaultMessage: 'Language analyzer',
                     }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -202,7 +202,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 </EuiFormRow>
                 <EuiText size="xs" color="subdued">
                   {i18n.translate(
-                    'xpack.enterprisecrawlerIndexName.content.newIndex.newcrawlerIndexNameIndexTemplate.nameInputHelpText.lineTwo',
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineTwo',
                     {
                       defaultMessage:
                         'Names should be lowercase and cannot contain spaces or special characters.',
@@ -214,7 +214,7 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                 <EuiFormRow
                   isDisabled={disabled}
                   label={i18n.translate(
-                    'xpack.enterprisecrawlerIndexName.content.newIndex.newSearchIndexTemplate.languageInputLabel',
+                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.languageInputLabel',
                     {
                       defaultMessage: 'Language analyzer',
                     }


### PR DESCRIPTION
## Summary

Remove the `search-` prefix requirements for Connectors and API indices in Search.
The prefix requirement remains for Crawlers.

### Example new Connector creation page (gif)

![out](https://github.com/elastic/kibana/assets/13634519/ef548c6d-01ed-4132-8e45-e4e08e943724)

### Example unchanged Crawler creation page (screenshot)

![Screenshot 2024-02-07 at 16 46 01](https://github.com/elastic/kibana/assets/13634519/e1bbf414-35fa-4cac-a6c4-bf8c2625503d)
