### PR TITLE
[Saved object] prevent deleting managed content from UI

### DIFF
--- a/src/plugins/saved_objects_management/common/types/v1.ts
+++ b/src/plugins/saved_objects_management/common/types/v1.ts
@@ -46,6 +46,7 @@ export interface SavedObjectWithMetadata<T = unknown> {
   error?: SavedObjectError;
   created_at?: string;
   updated_at?: string;
+  managed?: boolean;
   attributes: T;
   namespaces?: string[];
   references: SavedObjectReference[];

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.test.tsx
@@ -15,17 +15,20 @@ import { DeleteConfirmModal } from './delete_confirm_modal';
 interface CreateObjectOptions {
   namespaces?: string[];
   hiddenType?: boolean;
+  managed?: boolean;
 }
 
 const createObject = ({
   namespaces,
   hiddenType = false,
+  managed = false,
 }: CreateObjectOptions = {}): SavedObjectWithMetadata => ({
   id: 'foo',
   type: 'bar',
   attributes: {},
   references: [],
   namespaces,
+  managed,
   meta: {
     hiddenType,
   },
@@ -195,6 +198,33 @@ describe('DeleteConfirmModal', () => {
         wrapper.find('button[data-test-subj="confirmModalConfirmButton"]').getDOMNode()
       ).toBeDisabled();
     });
+  });
+
+  it('excludes the managed objects from the table and displays a callout', () => {
+    const objs = [
+      createObject({ managed: true }),
+      createObject({ managed: false }),
+      createObject({ managed: true }),
+    ];
+
+    const wrapper = mountWithIntl(
+      <DeleteConfirmModal
+        isDeleting={false}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+        selectedObjects={objs}
+        allowedTypes={allowedTypes}
+      />
+    );
+
+    expect(wrapper.find('.euiTableRow')).toHaveLength(1);
+
+    const callout = findTestSubject(wrapper, 'cannotDeleteObjectsConfirmWarning');
+    expect(callout).toHaveLength(1);
+
+    expect(callout.text()).toMatchInlineSnapshot(
+      `"Some objects cannot be deleted2 objects are managed by Elastic and cannot be deleted."`
+    );
   });
 
   describe('shared objects warning', () => {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.test.tsx
@@ -205,6 +205,7 @@ describe('DeleteConfirmModal', () => {
       createObject({ managed: true }),
       createObject({ managed: false }),
       createObject({ managed: true }),
+      createObject({ hiddenType: true }),
     ];
 
     const wrapper = mountWithIntl(
@@ -223,7 +224,7 @@ describe('DeleteConfirmModal', () => {
     expect(callout).toHaveLength(1);
 
     expect(callout.text()).toMatchInlineSnapshot(
-      `"Some objects cannot be deleted2 objects are managed by Elastic and cannot be deleted."`
+      `"Some objects have been excluded1 object is hidden and cannot be deleted.2 objects are managed by Elastic and cannot be deleted."`
     );
   });
 

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
@@ -48,12 +48,15 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
   allowedTypes,
   showPlainSpinner,
 }) => {
-  const undeletableObjects = useMemo(() => {
+  const hiddenObjects = useMemo(() => {
     return selectedObjects.filter((obj) => obj.meta.hiddenType);
+  }, [selectedObjects]);
+  const managedObjects = useMemo(() => {
+    return selectedObjects.filter((obj) => obj.managed);
   }, [selectedObjects]);
   const deletableObjects = useMemo(() => {
     return selectedObjects
-      .filter((obj) => !obj.meta.hiddenType)
+      .filter((obj) => !obj.meta.hiddenType && !obj.managed)
       .map(({ type, id, meta, namespaces = [] }) => {
         const { title = '', icon = 'apps' } = meta;
         const isShared = namespaces.length > 1 || namespaces.includes('*');
@@ -84,7 +87,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
         </EuiModalHeaderTitle>
       </EuiModalHeader>
       <EuiModalBody>
-        {undeletableObjects.length > 0 && (
+        {hiddenObjects.length + managedObjects.length > 0 && (
           <>
             <EuiCallOut
               data-test-subj="cannotDeleteObjectsConfirmWarning"
@@ -97,13 +100,25 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
               iconType="warning"
               color="warning"
             >
-              <p>
-                <FormattedMessage
-                  id="savedObjectsManagement.objectsTable.deleteConfirmModal.cannotDeleteCallout.content"
-                  defaultMessage="{objectCount, plural, one {# object is} other {# objects are}} hidden and cannot be deleted. {objectCount, plural, one {It was} other {They were}} excluded from the table summary."
-                  values={{ objectCount: undeletableObjects.length }}
-                />
-              </p>
+              {hiddenObjects.length > 0 && (
+                <p>
+                  <FormattedMessage
+                    id="savedObjectsManagement.objectsTable.deleteConfirmModal.cannotDeleteCallout.content"
+                    defaultMessage="{objectCount, plural, one {# object is} other {# objects are}} hidden and cannot be deleted. {objectCount, plural, one {It was} other {They were}} excluded from the table summary."
+                    values={{ objectCount: hiddenObjects.length }}
+                  />
+                </p>
+              )}
+
+              {managedObjects.length > 0 && (
+                <p>
+                  <FormattedMessage
+                    id="savedObjectsManagement.objectsTable.deleteConfirmModal.cannotDeleteCallout.managedContent"
+                    defaultMessage="{objectCount, plural, one {# object is} other {# objects are}} managed by Elastic and cannot be deleted."
+                    values={{ objectCount: managedObjects.length }}
+                  />
+                </p>
+              )}
             </EuiCallOut>
             <EuiSpacer size="s" />
           </>
@@ -159,7 +174,7 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
               field: 'id',
               name: i18n.translate(
                 'savedObjectsManagement.objectsTable.deleteSavedObjectsConfirmModal.idColumnName',
-                { defaultMessage: 'Id' }
+                { defaultMessage: 'ID' }
               ),
             },
             {

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/delete_confirm_modal.tsx
@@ -28,6 +28,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { css } from '@emotion/react';
 import type { SavedObjectWithMetadata, SavedObjectManagementTypeInfo } from '../../../../common';
 import { getSavedObjectLabel } from '../../../lib';
 
@@ -94,17 +95,21 @@ export const DeleteConfirmModal: FC<DeleteConfirmModalProps> = ({
               title={
                 <FormattedMessage
                   id="savedObjectsManagement.objectsTable.deleteConfirmModal.cannotDeleteCallout.title"
-                  defaultMessage="Some objects cannot be deleted"
+                  defaultMessage="Some objects have been excluded"
                 />
               }
               iconType="warning"
               color="warning"
             >
               {hiddenObjects.length > 0 && (
-                <p>
+                <p
+                  css={css`
+                    margin-block-end: 0 !important;
+                  `}
+                >
                   <FormattedMessage
                     id="savedObjectsManagement.objectsTable.deleteConfirmModal.cannotDeleteCallout.content"
-                    defaultMessage="{objectCount, plural, one {# object is} other {# objects are}} hidden and cannot be deleted. {objectCount, plural, one {It was} other {They were}} excluded from the table summary."
+                    defaultMessage="{objectCount, plural, one {# object is} other {# objects are}} hidden and cannot be deleted."
                     values={{ objectCount: hiddenObjects.length }}
                   />
                 </p>

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -402,7 +402,8 @@ export class Table extends PureComponent<TableProps, TableState> {
               color="danger"
               onClick={onDelete}
               isDisabled={
-                selectedSavedObjects.length === 0 || !capabilities.savedObjectsManagement.delete
+                selectedSavedObjects.filter(({ managed }) => !managed).length === 0 ||
+                !capabilities.savedObjectsManagement.delete
               }
               title={
                 capabilities.savedObjectsManagement.delete

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/components/table.tsx
@@ -402,8 +402,9 @@ export class Table extends PureComponent<TableProps, TableState> {
               color="danger"
               onClick={onDelete}
               isDisabled={
-                selectedSavedObjects.filter(({ managed }) => !managed).length === 0 ||
-                !capabilities.savedObjectsManagement.delete
+                selectedSavedObjects.filter(
+                  ({ managed, meta: { hiddenType } }) => !managed && !hiddenType
+                ).length === 0 || !capabilities.savedObjectsManagement.delete
               }
               title={
                 capabilities.savedObjectsManagement.delete

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.test.tsx
@@ -538,6 +538,7 @@ describe('SavedObjectsTable', () => {
         { id: '1', type: 'index-pattern', meta: {} },
         { id: '3', type: 'dashboard', meta: {} },
         { id: '4', type: 'dashboard', meta: { hiddenType: false } },
+        { id: '5', type: 'dashboard', managed: true, meta: {} },
       ] as SavedObjectWithMetadata[];
 
       const mockSavedObjects = mockSelectedSavedObjects.map((obj) => ({

--- a/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
+++ b/src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx
@@ -528,7 +528,7 @@ export class SavedObjectsTable extends Component<SavedObjectsTableProps, SavedOb
     const deleteStatus = await bulkDeleteObjects(
       http,
       selectedSavedObjects
-        .filter((object) => !object.meta.hiddenType)
+        .filter((object) => !object.meta.hiddenType && !object.managed)
         .map(({ id, type }) => ({ id, type }))
     );
 

--- a/src/plugins/saved_objects_management/server/lib/to_saved_object_with_meta.ts
+++ b/src/plugins/saved_objects_management/server/lib/to_saved_object_with_meta.ts
@@ -16,6 +16,7 @@ export function toSavedObjectWithMeta(so: SavedObject): SavedObjectWithMetadata 
     namespaces: so.namespaces,
     references: so.references,
     updated_at: so.updated_at,
+    managed: so.managed,
     attributes: so.attributes,
     created_at: so.created_at,
     error: so.error,


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/172391

This change stops users from deleting managed content from the SO management page by
- keeping the delete action disabled when the selection contains only managed content
- excluding managed content from the list in the delete modal

https://github.com/elastic/kibana/assets/315764/5bfa974e-823e-4c35-b6b9-71fcd08bf5e8

<img width="1673" alt="Screenshot 2024-02-07 at 12 53 29 PM" src="https://github.com/elastic/kibana/assets/315764/645238ec-dfe7-4f10-b468-df40e4fcb698">


### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials — will be done in https://github.com/elastic/kibana/issues/175150
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
