### PR TITLE
[ci] Bump type check/api docs timeout

### DIFF
--- a/.buildkite/pipelines/pull_request/base.yml
+++ b/.buildkite/pipelines/pull_request/base.yml
@@ -96,7 +96,7 @@ steps:
     agents:
       queue: n2-4-spot
     key: build_api_docs
-    timeout_in_minutes: 60
+    timeout_in_minutes: 90
     retry:
       automatic:
         - exit_status: '-1'


### PR DESCRIPTION
We're seeing occasional timeouts on this step.
We do want keep times below the current one hour timeout, but in the interim this bumps the timeout from 60 minutes to 90 minutes.