### PR TITLE
Add `build_flavor` to `/api/status` response

### DIFF
--- a/packages/core/apps/core-apps-browser-internal/src/status/components/version_header.test.tsx
+++ b/packages/core/apps/core-apps-browser-internal/src/status/components/version_header.test.tsx
@@ -17,6 +17,7 @@ const buildServerVersion = (parts: Partial<ServerVersion> = {}): ServerVersion =
   build_number: 9000,
   build_snapshot: false,
   build_date: '2023-05-15T23:12:09.000Z',
+  build_flavor: 'traditional',
   ...parts,
 });
 

--- a/packages/core/apps/core-apps-browser-internal/src/status/lib/load_status.test.ts
+++ b/packages/core/apps/core-apps-browser-internal/src/status/lib/load_status.test.ts
@@ -21,6 +21,7 @@ const mockedResponse: StatusResponse = {
     build_number: 12,
     build_snapshot: false,
     build_date: '2023-05-15T23:12:09.000Z',
+    build_flavor: 'traditional',
   },
   status: {
     overall: {

--- a/packages/core/status/core-status-common-internal/src/status.ts
+++ b/packages/core/status/core-status-common-internal/src/status.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import type { BuildFlavor } from '@kbn/config';
 import type { ServiceStatusLevelId, ServiceStatus, CoreStatus } from '@kbn/core-status-common';
 import type { OpsMetrics } from '@kbn/core-metrics-server';
 
@@ -34,6 +35,7 @@ export interface ServerVersion {
   build_hash: string;
   build_number: number;
   build_snapshot: boolean;
+  build_flavor: BuildFlavor;
   build_date: string;
 }
 

--- a/packages/core/status/core-status-common-internal/tsconfig.json
+++ b/packages/core/status/core-status-common-internal/tsconfig.json
@@ -13,7 +13,8 @@
   ],
   "kbn_references": [
     "@kbn/core-status-common",
-    "@kbn/core-metrics-server"
+    "@kbn/core-metrics-server",
+    "@kbn/config"
   ],
   "exclude": [
     "target/**/*",

--- a/packages/core/status/core-status-server-internal/src/routes/status.ts
+++ b/packages/core/status/core-status-server-internal/src/routes/status.ts
@@ -156,7 +156,7 @@ const getFullStatusResponse = async ({
   };
   query: { v8format?: boolean; v7format?: boolean };
 }): Promise<StatusHttpBody> => {
-  const { version, buildSha, buildNum, buildDate } = config.packageInfo;
+  const { version, buildSha, buildNum, buildDate, buildFlavor } = config.packageInfo;
   const versionWithoutSnapshot = version.replace(SNAPSHOT_POSTFIX, '');
 
   let statusInfo: StatusInfo | LegacyStatusInfo;
@@ -186,6 +186,7 @@ const getFullStatusResponse = async ({
       build_hash: buildSha,
       build_number: buildNum,
       build_snapshot: SNAPSHOT_POSTFIX.test(version),
+      build_flavor: buildFlavor,
       build_date: buildDate.toISOString(),
     },
     status: statusInfo,

--- a/src/core/server/integration_tests/status/routes/status.test.ts
+++ b/src/core/server/integration_tests/status/routes/status.test.ts
@@ -210,6 +210,7 @@ describe('GET /api/status', () => {
         build_number: 1234,
         build_snapshot: true,
         build_date: new Date('2023-05-15T23:12:09.000Z').toISOString(),
+        build_flavor: 'traditional',
       });
       const metricsMockValue = await firstValueFrom(metrics.getOpsMetrics$());
       expect(result.body.metrics).toEqual({


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/176475

Add the `version.build_flavor` field to the response of the status API 

<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->