### PR TITLE
[Profiling] Add basic support for error frames

### DIFF
--- a/packages/kbn-profiling-utils/common/profiling.test.ts
+++ b/packages/kbn-profiling-utils/common/profiling.test.ts
@@ -14,6 +14,7 @@ import {
   getCalleeSource,
   getFrameSymbolStatus,
   getLanguageType,
+  normalizeFrameType,
 } from './profiling';
 
 describe('Stack frame metadata operations', () => {
@@ -80,6 +81,14 @@ describe('Stack frame metadata operations', () => {
     });
     expect(getCalleeSource(metadata)).toEqual('runtime/malloc.go');
   });
+
+  test('metadata indicates an error frame', () => {
+    const metadata = createStackFrameMetadata({
+      FrameType: FrameType.Error,
+      AddressOrLine: 1234,
+    });
+    expect(getCalleeSource(metadata)).toEqual('unwinding error code #1234');
+  });
 });
 
 describe('getFrameSymbolStatus', () => {
@@ -98,6 +107,20 @@ describe('getFrameSymbolStatus', () => {
     expect(getFrameSymbolStatus({ sourceFilename: 'foo', sourceLine: 10 })).toEqual(
       FrameSymbolStatus.SYMBOLIZED
     );
+  });
+});
+
+describe('normalizeFrameType', () => {
+  it('rewrites any frame with error bit to the generic error variant', () => {
+    expect(normalizeFrameType(0x83 as FrameType)).toEqual(FrameType.Error);
+  });
+  it('rewrites unknown frame types to "unsymbolized" variant', () => {
+    expect(normalizeFrameType(0x123 as FrameType)).toEqual(FrameType.Unsymbolized);
+  });
+  it('passes regular known frame types through untouched', () => {
+    expect(normalizeFrameType(FrameType.JVM)).toEqual(FrameType.JVM);
+    expect(normalizeFrameType(FrameType.Native)).toEqual(FrameType.Native);
+    expect(normalizeFrameType(FrameType.JavaScript)).toEqual(FrameType.JavaScript);
   });
 });
 

--- a/packages/kbn-profiling-utils/index.ts
+++ b/packages/kbn-profiling-utils/index.ts
@@ -12,6 +12,7 @@ export { ProfilingESField } from './common/elasticsearch';
 export {
   groupStackFrameMetadataByStackTrace,
   describeFrameType,
+  normalizeFrameType,
   FrameType,
   getCalleeFunction,
   getCalleeSource,

--- a/x-pack/plugins/profiling/common/frame_type_colors.ts
+++ b/x-pack/plugins/profiling/common/frame_type_colors.ts
@@ -5,22 +5,23 @@
  * 2.0.
  */
 
-import { FrameType } from '@kbn/profiling-utils';
+import { FrameType, normalizeFrameType } from '@kbn/profiling-utils';
 
 /*
  * Helper to calculate the color of a given block to be drawn. The desirable outcomes of this are:
  * Each of the following frame types should get a different set of color hues:
  *
- *   0 = Unsymbolized frame
- *   1 = Python
- *   2 = PHP
- *   3 = Native
- *   4 = Kernel
- *   5 = JVM/Hotspot
- *   6 = Ruby
- *   7 = Perl
- *   8 = JavaScript
- *   9 = PHP JIT
+ *   0x00 = Unsymbolized frame
+ *   0x01 = Python
+ *   0x02 = PHP
+ *   0x03 = Native
+ *   0x04 = Kernel
+ *   0x05 = JVM/Hotspot
+ *   0x06 = Ruby
+ *   0x07 = Perl
+ *   0x08 = JavaScript
+ *   0x09 = PHP JIT
+ *   0xFF = Error frame
  *
  * This is most easily achieved by mapping frame types to different color variations, using
  * the x-position we can use different colors for adjacent blocks while keeping a similar hue
@@ -38,10 +39,11 @@ export const FRAME_TYPE_COLOR_MAP = {
   [FrameType.Perl]: [0xf98bb9, 0xfaa2c7, 0xfbb9d5, 0xfdd1e3],
   [FrameType.JavaScript]: [0xcbc3e3, 0xd5cfe8, 0xdfdbee, 0xeae7f3],
   [FrameType.PHPJIT]: [0xccfc82, 0xd1fc8e, 0xd6fc9b, 0xdbfca7],
+  [FrameType.Error]: [0xfd8484, 0xfd9d9d, 0xfeb5b5, 0xfecece],
 };
 
 export function frameTypeToRGB(frameType: FrameType, x: number): number {
-  return FRAME_TYPE_COLOR_MAP[frameType][x % 4];
+  return FRAME_TYPE_COLOR_MAP[normalizeFrameType(frameType)][x % 4];
 }
 
 export function rgbToRGBA(rgb: number): number[] {


### PR DESCRIPTION
## Summary

We added a new, internal frame types for errors a while ago. We currently only send `0xFF` as a critical error ("unwinding was aborted"), but we also plan to add non-critical error frames that each interpreter unwinder can generate by setting the generic error bit `0x80` soon. It is currently not ever generated by regular profiling host agent builds and must be explicitly enabled with a command-line option that is not available on public builds.

The presence of these error frames would previously crash Kibana because the lookup tables didn't contain an appropriate entry. This PR:

- adds support for the aforementioned error frames
- adds graceful handling for unknown frame types to avoid similar crashes in the future

### Screenshots

<img width="1853" alt="Screenshot 2024-02-08 at 10 00 21" src="https://github.com/elastic/kibana/assets/6553158/851d60d9-2aff-4e4e-a16f-ba2429355ab4">

<img width="931" alt="Screenshot 2024-02-08 at 10 00 40" src="https://github.com/elastic/kibana/assets/6553158/679139e9-de0b-4296-ac69-d284f8d43dfa">

### Checklist

Delete any items that are not applicable to this PR.

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
