### PR TITLE
[Ops] Increase step timeout for storybook build

### DIFF
--- a/.buildkite/pipelines/on_merge.yml
+++ b/.buildkite/pipelines/on_merge.yml
@@ -372,7 +372,7 @@ steps:
     agents:
       queue: n2-8-spot
     key: storybooks
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80
     retry:
       automatic:
         - exit_status: '-1'

--- a/.buildkite/pipelines/pull_request/storybooks.yml
+++ b/.buildkite/pipelines/pull_request/storybooks.yml
@@ -4,4 +4,4 @@ steps:
     agents:
       queue: n2-8-spot
     key: storybooks
-    timeout_in_minutes: 60
+    timeout_in_minutes: 80


### PR DESCRIPTION
## Summary
Several instances of post-merge build failed on the storybook build and upload, as it just finished briefly within limit, the step altogether timed out.

This PR increases the timeout by 20m (a generous increment) while taking note on ideally speeding up storybook builds: 
https://github.com/elastic/kibana/issues/176500