### PR TITLE
[APM] Hide Table search on Service Inventory

### DIFF
--- a/x-pack/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
+++ b/x-pack/plugins/apm/ftr_e2e/cypress/e2e/service_inventory/service_inventory.cy.ts
@@ -115,7 +115,8 @@ describe('Service inventory', () => {
     });
   });
 
-  describe('Table search', () => {
+  // Skipping this until we enable the table search on the Service inventory view
+  describe.skip('Table search', () => {
     beforeEach(() => {
       cy.updateAdvancedSettings({
         'observability:apmEnableTableSearchBar': true,

--- a/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_inventory/service_list/index.tsx
@@ -357,6 +357,7 @@ export function ServiceList({
 
   const tableSearchBar: TableSearchBar<ServiceListItem> = useMemo(() => {
     return {
+      isEnabled: false,
       fieldsToSearch: ['serviceName'],
       maxCountExceeded,
       onChangeSearchQuery,

--- a/x-pack/plugins/apm/public/components/shared/managed_table/index.tsx
+++ b/x-pack/plugins/apm/public/components/shared/managed_table/index.tsx
@@ -111,7 +111,7 @@ function UnoptimizedManagedTable<T extends object>(props: {
   const { core } = useApmPluginContext();
   const isTableSearchBarEnabled = core.uiSettings.get<boolean>(
     apmEnableTableSearchBar,
-    false
+    true
   );
 
   const {


### PR DESCRIPTION
Hide the Table search on the Service Inventory page and enable the feature by default.
<img width="1354" alt="Screenshot 2024-02-08 at 13 22 06" src="https://github.com/elastic/kibana/assets/55978943/702930b8-d04a-4546-9fcd-10053c9d6b29">
<img width="957" alt="Screenshot 2024-02-08 at 13 22 13" src="https://github.com/elastic/kibana/assets/55978943/93842868-b726-4701-8d21-3e518b21c885">
<img width="1349" alt="Screenshot 2024-02-08 at 13 22 20" src="https://github.com/elastic/kibana/assets/55978943/13a31bf2-177e-47ce-a6fc-1d05cdd0e38b">
