### PR TITLE
[Response Ops][Alerting] Removing unnecessary error log when getting the rules setting saved object

### DIFF
--- a/x-pack/plugins/alerting/server/rules_settings_client.mock.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client.mock.ts
@@ -23,14 +23,10 @@ const createRulesSettingsClientMock = () => {
   const flappingMocked: RulesSettingsFlappingClientMock = {
     get: jest.fn().mockReturnValue(DEFAULT_FLAPPING_SETTINGS),
     update: jest.fn(),
-    getSettings: jest.fn(),
-    createSettings: jest.fn(),
   };
   const queryDelayMocked: RulesSettingsQueryDelayClientMock = {
     get: jest.fn().mockReturnValue(DEFAULT_QUERY_DELAY_SETTINGS),
     update: jest.fn(),
-    getSettings: jest.fn(),
-    createSettings: jest.fn(),
   };
   const mocked: RulesSettingsClientMock = {
     flapping: jest.fn().mockReturnValue(flappingMocked),

--- a/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.test.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.test.ts
@@ -215,6 +215,7 @@ describe('RulesSettingsFlappingClient', () => {
       references: [],
     });
 
+    // @ts-expect-error access private method
     const result = await client.createSettings();
 
     expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
@@ -249,6 +250,7 @@ describe('RulesSettingsFlappingClient', () => {
       attributes: mockAttributes,
       references: [],
     });
+    // @ts-expect-error access private method
     const result = await client.getSettings();
     expect(result.attributes).toEqual(mockAttributes);
   });
@@ -262,6 +264,7 @@ describe('RulesSettingsFlappingClient', () => {
         RULES_SETTINGS_FLAPPING_SAVED_OBJECT_ID
       )
     );
+    // @ts-expect-error access private method
     await expect(client.getSettings()).rejects.toThrowError();
   });
 

--- a/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/flapping/rules_settings_flapping_client.ts
@@ -130,19 +130,14 @@ export class RulesSettingsFlappingClient {
     }
   }
 
-  public async getSettings(): Promise<SavedObject<RulesSettings>> {
-    try {
-      return await this.savedObjectsClient.get<RulesSettings>(
-        RULES_SETTINGS_SAVED_OBJECT_TYPE,
-        RULES_SETTINGS_FLAPPING_SAVED_OBJECT_ID
-      );
-    } catch (e) {
-      this.logger.error(`Failed to get flapping rules setting for current space. Error: ${e}`);
-      throw e;
-    }
+  private async getSettings(): Promise<SavedObject<RulesSettings>> {
+    return await this.savedObjectsClient.get<RulesSettings>(
+      RULES_SETTINGS_SAVED_OBJECT_TYPE,
+      RULES_SETTINGS_FLAPPING_SAVED_OBJECT_ID
+    );
   }
 
-  public async createSettings(): Promise<SavedObject<RulesSettings>> {
+  private async createSettings(): Promise<SavedObject<RulesSettings>> {
     const modificationMetadata = await this.getModificationMetadata();
     try {
       return await this.savedObjectsClient.create<RulesSettings>(

--- a/x-pack/plugins/alerting/server/rules_settings_client/query_delay/rules_settings_query_delay_client.test.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/query_delay/rules_settings_query_delay_client.test.ts
@@ -179,7 +179,7 @@ describe('RulesSettingsQueryDelayClient', () => {
       attributes: mockAttributes,
       references: [],
     });
-
+    // @ts-expect-error access private method
     const result = await client.createSettings();
 
     expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
@@ -221,7 +221,7 @@ describe('RulesSettingsQueryDelayClient', () => {
       attributes: mockAttributes,
       references: [],
     });
-
+    // @ts-expect-error access private method
     const result = await client.createSettings();
 
     expect(savedObjectsClient.create).toHaveBeenCalledTimes(1);
@@ -254,6 +254,7 @@ describe('RulesSettingsQueryDelayClient', () => {
       attributes: mockAttributes,
       references: [],
     });
+    // @ts-expect-error access private method
     const result = await client.getSettings();
     expect(result.attributes).toEqual(mockAttributes);
   });

--- a/x-pack/plugins/alerting/server/rules_settings_client/query_delay/rules_settings_query_delay_client.ts
+++ b/x-pack/plugins/alerting/server/rules_settings_client/query_delay/rules_settings_query_delay_client.ts
@@ -121,19 +121,14 @@ export class RulesSettingsQueryDelayClient {
     }
   }
 
-  public async getSettings(): Promise<SavedObject<RulesSettings>> {
-    try {
-      return await this.savedObjectsClient.get<RulesSettings>(
-        RULES_SETTINGS_SAVED_OBJECT_TYPE,
-        RULES_SETTINGS_QUERY_DELAY_SAVED_OBJECT_ID
-      );
-    } catch (e) {
-      this.logger.error(`Failed to get query delay rules setting for current space. Error: ${e}`);
-      throw e;
-    }
+  private async getSettings(): Promise<SavedObject<RulesSettings>> {
+    return await this.savedObjectsClient.get<RulesSettings>(
+      RULES_SETTINGS_SAVED_OBJECT_TYPE,
+      RULES_SETTINGS_QUERY_DELAY_SAVED_OBJECT_ID
+    );
   }
 
-  public async createSettings(): Promise<SavedObject<RulesSettings>> {
+  private async createSettings(): Promise<SavedObject<RulesSettings>> {
     const modificationMetadata = await this.getModificationMetadata();
     const defaultQueryDelaySettings = this.isServerless
       ? DEFAULT_SERVERLESS_QUERY_DELAY_SETTINGS


### PR DESCRIPTION
Resolves https://github.com/elastic/kibana/issues/174534

## Summary

Removing extra error log that was unneeded and did not check for a saved object not found error before logging. Since the `getSettings` function is only used internally by the client, I removed the logger altogether and let the calling function catch and handle the error.

## To Verify
Start up ES and Kibana and create a rule. On the first run, you should see 2 INFO logs for creating the settings but no error logs.

```
[2024-02-08T12:53:44.327-05:00][INFO ][plugins.alerting] Creating new default flapping rules settings for current space.
[2024-02-08T12:49:41.780-05:00][INFO ][plugins.alerting] Creating new default query delay rules settings for current space.
```