### PR TITLE
[FTR] Fix URL checks in navigateToApp

### DIFF
--- a/test/functional/page_objects/common_page.ts
+++ b/test/functional/page_objects/common_page.ts
@@ -332,14 +332,16 @@ export class CommonPageObject extends FtrService {
         }
 
         currentUrl = (await this.browser.getCurrentUrl()).replace(/\/\/\w+:\w+@/, '//');
+        const decodedAppUrl = decodeURIComponent(appUrl);
+        const decodedCurrentUrl = decodeURIComponent(currentUrl);
 
-        const navSuccessful = currentUrl
+        const navSuccessful = decodedCurrentUrl
           .replace(':80/', '/')
           .replace(':443/', '/')
-          .startsWith(appUrl.replace(':80/', '/').replace(':443/', '/'));
+          .startsWith(decodedAppUrl.replace(':80/', '/').replace(':443/', '/'));
 
         if (!navSuccessful) {
-          const msg = `App failed to load: ${appName} in ${this.defaultFindTimeout}ms appUrl=${appUrl} currentUrl=${currentUrl}`;
+          const msg = `App failed to load: ${appName} in ${this.defaultFindTimeout}ms appUrl=${decodedAppUrl} currentUrl=${decodedCurrentUrl}`;
           this.log.debug(msg);
           throw new Error(msg);
         }


### PR DESCRIPTION
## Summary

This PR fixes the URL check for successful navigation in the `common` PageObject `navigateToApp` method.

This check failed if it was comparing an URL containing escaped characters with the same URL w/o escaping (happened e.g. in #175237). The fix is to decode both URLs before comparing them.


<!--ONMERGE {"backportTargets":["8.12"]} ONMERGE-->