### PR TITLE
[Search] Extract pipeline select logic from ML inference logic

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select.tsx
@@ -11,17 +11,17 @@ import { useActions, useValues } from 'kea';
 
 import { EuiSelectable, useEuiTheme, useIsWithinMaxBreakpoint } from '@elastic/eui';
 
-import { MLInferenceLogic, MLInferencePipelineOption } from './ml_inference_logic';
+import { MLInferencePipelineOption, PipelineSelectLogic } from './pipeline_select_logic';
 import { PipelineSelectOption, PipelineSelectOptionProps } from './pipeline_select_option';
 
 export const PipelineSelect: React.FC = () => {
   const {
-    addInferencePipelineModal: { configuration },
+    addInferencePipelineModal: {
+      configuration: { pipelineName },
+    },
     existingInferencePipelines,
-  } = useValues(MLInferenceLogic);
-  const { selectExistingPipeline } = useActions(MLInferenceLogic);
-
-  const { pipelineName } = configuration;
+  } = useValues(PipelineSelectLogic);
+  const { selectExistingPipeline } = useActions(PipelineSelectLogic);
 
   const { euiTheme } = useEuiTheme();
   const largeScreenRowHeight = euiTheme.base * 6;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_logic.test.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LogicMounter } from '../../../../../__mocks__/kea_logic';
+
+import { MlModel, MlModelDeploymentState } from '../../../../../../../common/types/ml';
+import { TrainedModelState } from '../../../../../../../common/types/pipelines';
+
+import { MappingsApiLogic } from '../../../../api/mappings/mappings_logic';
+import { CachedFetchModelsApiLogic } from '../../../../api/ml_models/cached_fetch_models_api_logic';
+import { FetchMlInferencePipelineProcessorsApiLogic } from '../../../../api/pipelines/fetch_ml_inference_pipeline_processors';
+import {
+  FetchMlInferencePipelinesApiLogic,
+  FetchMlInferencePipelinesResponse,
+} from '../../../../api/pipelines/fetch_ml_inference_pipelines';
+
+import { PipelineSelectLogic, PipelineSelectValues } from './pipeline_select_logic';
+import { AddInferencePipelineSteps } from './types';
+
+const DEFAULT_VALUES: PipelineSelectValues = {
+  addInferencePipelineModal: {
+    configuration: {
+      modelID: '',
+      pipelineName: '',
+      targetField: '',
+    },
+    indexName: '',
+    step: AddInferencePipelineSteps.Configuration,
+  },
+  existingInferencePipelines: [],
+  mlInferencePipelineProcessors: undefined,
+  mlInferencePipelinesData: undefined,
+  selectableModels: [],
+  sourceFields: undefined,
+};
+
+const DEFAULT_MODELS: MlModel[] = [
+  {
+    modelId: 'model_1',
+    type: 'ner',
+    title: 'Model 1',
+    description: 'Model 1 description',
+    licenseType: 'elastic',
+    modelDetailsPageUrl: 'https://my-model.ai',
+    deploymentState: MlModelDeploymentState.NotDeployed,
+    startTime: 0,
+    targetAllocationCount: 0,
+    nodeAllocationCount: 0,
+    threadsPerAllocation: 0,
+    isPlaceholder: false,
+    hasStats: false,
+    types: ['pytorch', 'ner'],
+    inputFieldNames: ['title'],
+    version: '1',
+  },
+];
+
+const DEFAULT_PIPELINES: FetchMlInferencePipelinesResponse = {
+  'my-pipeline': {
+    processors: [
+      {
+        inference: {
+          field_map: {
+            body: 'text_field',
+          },
+          model_id: DEFAULT_MODELS[0].modelId,
+          target_field: 'ml.inference.body',
+        },
+      },
+    ],
+    version: 1,
+  },
+};
+
+describe('PipelineSelectLogic', () => {
+  const { mount } = new LogicMounter(PipelineSelectLogic);
+  const { mount: mountFetchMlInferencePipelineProcessorsApiLogic } = new LogicMounter(
+    FetchMlInferencePipelineProcessorsApiLogic
+  );
+  const { mount: mountFetchMlInferencePipelinesApiLogic } = new LogicMounter(
+    FetchMlInferencePipelinesApiLogic
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mountFetchMlInferencePipelineProcessorsApiLogic();
+    mountFetchMlInferencePipelinesApiLogic();
+    mount();
+  });
+
+  describe('actions', () => {
+    describe('selectExistingPipeline', () => {
+      it('updates inference pipeline configuration', () => {
+        mount(DEFAULT_VALUES);
+        jest.spyOn(PipelineSelectLogic.actions, 'setInferencePipelineConfiguration');
+
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess(DEFAULT_PIPELINES);
+        PipelineSelectLogic.actions.selectExistingPipeline('my-pipeline');
+
+        expect(PipelineSelectLogic.actions.setInferencePipelineConfiguration).toHaveBeenCalledWith({
+          existingPipeline: true,
+          modelID: DEFAULT_MODELS[0].modelId,
+          pipelineName: 'my-pipeline',
+          fieldMappings: [
+            {
+              sourceField: 'body',
+              targetField: 'ml.inference.body',
+            },
+          ],
+          targetField: '',
+        });
+      });
+      it('does not update inference pipeline configuration if pipeline name is not in list of fetched pipelines', () => {
+        mount(DEFAULT_VALUES);
+        jest.spyOn(PipelineSelectLogic.actions, 'setInferencePipelineConfiguration');
+
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess(DEFAULT_PIPELINES);
+        PipelineSelectLogic.actions.selectExistingPipeline('nonexistent-pipeline');
+
+        expect(
+          PipelineSelectLogic.actions.setInferencePipelineConfiguration
+        ).not.toHaveBeenCalled();
+      });
+      it('does not update inference pipeline configuration if inference processor cannot be parsed from fetched pipeline', () => {
+        mount(DEFAULT_VALUES);
+        jest.spyOn(PipelineSelectLogic.actions, 'setInferencePipelineConfiguration');
+
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess({
+          'my-pipeline': {
+            processors: [
+              {
+                set: {
+                  // No inference processor
+                  field: 'some-field',
+                },
+              },
+            ],
+            version: 1,
+          },
+        });
+        PipelineSelectLogic.actions.selectExistingPipeline('my-pipeline');
+
+        expect(
+          PipelineSelectLogic.actions.setInferencePipelineConfiguration
+        ).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('selectors', () => {
+    describe('existingInferencePipelines', () => {
+      beforeEach(() => {
+        CachedFetchModelsApiLogic.actions.apiSuccess(DEFAULT_MODELS);
+        MappingsApiLogic.actions.apiSuccess({
+          mappings: {
+            properties: {
+              body: {
+                type: 'text',
+              },
+            },
+          },
+        });
+      });
+      it('returns empty list when there are no existing pipelines available', () => {
+        expect(PipelineSelectLogic.values.existingInferencePipelines).toEqual([]);
+      });
+      it('returns existing pipeline option', () => {
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess(DEFAULT_PIPELINES);
+
+        expect(PipelineSelectLogic.values.existingInferencePipelines).toEqual([
+          {
+            disabled: false,
+            modelId: DEFAULT_MODELS[0].modelId,
+            modelType: 'ner',
+            pipelineName: 'my-pipeline',
+            sourceFields: ['body'],
+            indexFields: ['body'],
+          },
+        ]);
+      });
+      it('returns disabled pipeline option if missing source fields', () => {
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess({
+          'my-pipeline': {
+            processors: [
+              {
+                inference: {
+                  field_map: {
+                    title: 'text_field', // Does not exist in index
+                  },
+                  model_id: DEFAULT_MODELS[0].modelId,
+                  target_field: 'ml.inference.title',
+                },
+              },
+              {
+                inference: {
+                  field_map: {
+                    body: 'text_field', // Exists in index
+                  },
+                  model_id: DEFAULT_MODELS[0].modelId,
+                  target_field: 'ml.inference.body',
+                },
+              },
+              {
+                inference: {
+                  field_map: {
+                    body_content: 'text_field', // Does not exist in index
+                  },
+                  model_id: DEFAULT_MODELS[0].modelId,
+                  target_field: 'ml.inference.body_content',
+                },
+              },
+            ],
+            version: 1,
+          },
+        });
+
+        expect(PipelineSelectLogic.values.existingInferencePipelines).toEqual([
+          {
+            disabled: true,
+            disabledReason: expect.stringContaining('title, body_content'),
+            modelId: DEFAULT_MODELS[0].modelId,
+            modelType: 'ner',
+            pipelineName: 'my-pipeline',
+            sourceFields: ['title', 'body', 'body_content'],
+            indexFields: ['body'],
+          },
+        ]);
+      });
+      it('returns enabled pipeline option if model is redacted', () => {
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess({
+          'my-pipeline': {
+            processors: [
+              {
+                inference: {
+                  field_map: {
+                    body: 'text_field',
+                  },
+                  model_id: '', // Redacted
+                  target_field: 'ml.inference.body',
+                },
+              },
+            ],
+            version: 1,
+          },
+        });
+
+        expect(PipelineSelectLogic.values.existingInferencePipelines).toEqual([
+          {
+            disabled: false,
+            pipelineName: 'my-pipeline',
+            modelType: '',
+            modelId: '',
+            sourceFields: ['body'],
+            indexFields: ['body'],
+          },
+        ]);
+      });
+      it('filters pipeline if pipeline already attached', () => {
+        FetchMlInferencePipelineProcessorsApiLogic.actions.apiSuccess([
+          {
+            modelId: DEFAULT_MODELS[0].modelId,
+            modelState: TrainedModelState.Started,
+            pipelineName: 'my-pipeline',
+            pipelineReferences: ['test@ml-inference'],
+            types: ['ner', 'pytorch'],
+          },
+        ]);
+        FetchMlInferencePipelinesApiLogic.actions.apiSuccess(DEFAULT_PIPELINES);
+
+        expect(PipelineSelectLogic.values.existingInferencePipelines).toEqual([]);
+      });
+    });
+  });
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_logic.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { parseMlInferenceParametersFromPipeline } from '../../../../../../../common/ml_inference_pipeline';
+
+import { getMLType } from '../../../shared/ml_inference/utils';
+
+import {
+  MLInferenceLogic,
+  MLInferenceProcessorsActions,
+  MLInferenceProcessorsValues,
+} from './ml_inference_logic';
+import { EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS } from './utils';
+
+export interface MLInferencePipelineOption {
+  disabled: boolean;
+  disabledReason?: string;
+  modelId: string;
+  modelType: string;
+  pipelineName: string;
+  sourceFields: string[];
+  indexFields: string[];
+}
+
+export interface PipelineSelectActions {
+  selectExistingPipeline: (pipelineName: string) => {
+    pipelineName: string;
+  };
+  setInferencePipelineConfiguration: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
+}
+
+export interface PipelineSelectValues {
+  addInferencePipelineModal: MLInferenceProcessorsValues['addInferencePipelineModal'];
+  existingInferencePipelines: MLInferencePipelineOption[];
+  mlInferencePipelineProcessors: MLInferenceProcessorsValues['mlInferencePipelineProcessors'];
+  mlInferencePipelinesData: MLInferenceProcessorsValues['mlInferencePipelinesData'];
+  selectableModels: MLInferenceProcessorsValues['selectableModels'];
+  sourceFields: MLInferenceProcessorsValues['sourceFields'];
+}
+
+export const PipelineSelectLogic = kea<MakeLogicType<PipelineSelectValues, PipelineSelectActions>>({
+  actions: {
+    selectExistingPipeline: (pipelineName: string) => ({ pipelineName }),
+  },
+  connect: {
+    actions: [MLInferenceLogic, ['setInferencePipelineConfiguration']],
+    values: [
+      MLInferenceLogic,
+      [
+        'addInferencePipelineModal',
+        'mlInferencePipelineProcessors',
+        'mlInferencePipelinesData',
+        'selectableModels',
+        'selectedModel',
+        'sourceFields',
+      ],
+    ],
+  },
+  path: ['enterprise_search', 'content', 'pipeline_select_logic'],
+  listeners: ({ actions, values }) => ({
+    selectExistingPipeline: ({ pipelineName }) => {
+      const pipeline = values.mlInferencePipelinesData?.[pipelineName];
+      if (!pipeline) return;
+      const params = parseMlInferenceParametersFromPipeline(pipelineName, pipeline);
+      if (params === null) return;
+      actions.setInferencePipelineConfiguration({
+        existingPipeline: true,
+        modelID: params.model_id,
+        pipelineName,
+        fieldMappings: params.field_mappings,
+        targetField: '',
+      });
+    },
+  }),
+  selectors: ({ selectors }) => ({
+    existingInferencePipelines: [
+      () => [
+        selectors.mlInferencePipelinesData,
+        selectors.sourceFields,
+        selectors.selectableModels,
+        selectors.mlInferencePipelineProcessors,
+      ],
+      (
+        mlInferencePipelinesData: MLInferenceProcessorsValues['mlInferencePipelinesData'],
+        indexFields: MLInferenceProcessorsValues['sourceFields'],
+        selectableModels: MLInferenceProcessorsValues['selectableModels'],
+        mlInferencePipelineProcessors: MLInferenceProcessorsValues['mlInferencePipelineProcessors']
+      ) => {
+        if (!mlInferencePipelinesData) {
+          return [];
+        }
+        const indexProcessorNames =
+          mlInferencePipelineProcessors?.map((processor) => processor.pipelineName) ?? [];
+
+        const existingPipelines: MLInferencePipelineOption[] = Object.entries(
+          mlInferencePipelinesData
+        )
+          .map(([pipelineName, pipeline]): MLInferencePipelineOption | undefined => {
+            if (!pipeline || indexProcessorNames.includes(pipelineName)) return undefined;
+
+            // Parse configuration from pipeline definition
+            const pipelineParams = parseMlInferenceParametersFromPipeline(pipelineName, pipeline);
+            if (!pipelineParams) return undefined;
+            const { model_id: modelId, field_mappings: fieldMappings } = pipelineParams;
+
+            const sourceFields = fieldMappings?.map((m) => m.sourceField) ?? [];
+            const missingSourceFields = sourceFields.filter((f) => !indexFields?.includes(f)) ?? [];
+            const mlModel = selectableModels.find((model) => model.modelId === modelId);
+            const modelType = mlModel ? getMLType(mlModel.types) : '';
+            const disabledReason =
+              missingSourceFields.length > 0
+                ? EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS(missingSourceFields.join(', '))
+                : undefined;
+
+            return {
+              disabled: disabledReason !== undefined,
+              disabledReason,
+              modelId,
+              modelType,
+              pipelineName,
+              sourceFields,
+              indexFields: indexFields ?? [],
+            };
+          })
+          .filter((p): p is MLInferencePipelineOption => p !== undefined);
+
+        return existingPipelines;
+      },
+    ],
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.test.tsx
@@ -13,7 +13,7 @@ import { EuiText, EuiTitle } from '@elastic/eui';
 
 import { MLModelTypeBadge } from '../ml_model_type_badge';
 
-import { MLInferencePipelineOption } from './ml_inference_logic';
+import { MLInferencePipelineOption } from './pipeline_select_logic';
 import { PipelineSelectOption, PipelineSelectOptionDisabled } from './pipeline_select_option';
 
 import { MODEL_REDACTED_VALUE } from './utils';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/pipeline_select_option.tsx
@@ -11,7 +11,7 @@ import { EuiFlexGroup, EuiFlexItem, EuiIcon, EuiText, EuiTextColor, EuiTitle } f
 
 import { MLModelTypeBadge } from '../ml_model_type_badge';
 
-import { MLInferencePipelineOption } from './ml_inference_logic';
+import { MLInferencePipelineOption } from './pipeline_select_logic';
 import { EXISTING_PIPELINE_DISABLED_MISSING_SOURCE_FIELDS, MODEL_REDACTED_VALUE } from './utils';
 
 export interface PipelineSelectOptionProps {


### PR DESCRIPTION
## Summary

This PR extracts the inference pipeline selection logic from `ml_inference_logic.ts` into a more cohesive logic file. There are no functional changes. Referenced values and actions (like pipeline and index data, config update action) are pulled in from `ml_inference_logic.ts`.


### Checklist
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
