### PR TITLE
[Search] Remove pass-through values/actions from model select logic

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.test.ts
@@ -56,13 +56,13 @@ describe('ModelSelectLogic', () => {
         expect(ModelSelectLogic.actions.startPollingModels).toHaveBeenCalled();
       });
       it('sets selected model as non-placeholder', () => {
-        jest.spyOn(ModelSelectLogic.actions, 'clearModelPlaceholderFlagFromMLInferenceLogic');
+        jest.spyOn(ModelSelectLogic.actions, 'clearModelPlaceholderFlag');
 
         ModelSelectLogic.actions.createModelSuccess(CREATE_MODEL_API_RESPONSE);
 
-        expect(
-          ModelSelectLogic.actions.clearModelPlaceholderFlagFromMLInferenceLogic
-        ).toHaveBeenCalledWith(CREATE_MODEL_API_RESPONSE.modelId);
+        expect(ModelSelectLogic.actions.clearModelPlaceholderFlag).toHaveBeenCalledWith(
+          CREATE_MODEL_API_RESPONSE.modelId
+        );
       });
     });
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/pipelines/ml_inference/model_select_logic.ts
@@ -8,7 +8,6 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { HttpError, Status } from '../../../../../../../common/types/api';
-import { MlModel } from '../../../../../../../common/types/ml';
 import { getErrorsFromHttpResponse } from '../../../../../shared/flash_messages/handle_api_errors';
 import {
   CreateModelApiLogic,
@@ -27,13 +26,12 @@ import {
 } from './ml_inference_logic';
 
 export interface ModelSelectActions {
-  clearModelPlaceholderFlagFromMLInferenceLogic: MLInferenceProcessorsActions['clearModelPlaceholderFlag'];
+  clearModelPlaceholderFlag: MLInferenceProcessorsActions['clearModelPlaceholderFlag'];
   createModel: (modelId: string) => { modelId: string };
   createModelError: CreateModelApiLogicActions['apiError'];
   createModelMakeRequest: CreateModelApiLogicActions['makeRequest'];
   createModelSuccess: CreateModelApiLogicActions['apiSuccess'];
   setInferencePipelineConfiguration: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
-  setInferencePipelineConfigurationFromMLInferenceLogic: MLInferenceProcessorsActions['setInferencePipelineConfiguration'];
   startModel: (modelId: string) => { modelId: string };
   startModelError: CreateModelApiLogicActions['apiError'];
   startModelMakeRequest: StartModelApiLogicActions['makeRequest'];
@@ -43,19 +41,14 @@ export interface ModelSelectActions {
 
 export interface ModelSelectValues {
   addInferencePipelineModal: MLInferenceProcessorsValues['addInferencePipelineModal'];
-  addInferencePipelineModalFromMLInferenceLogic: MLInferenceProcessorsValues['addInferencePipelineModal'];
   areActionButtonsDisabled: boolean;
   createModelError: HttpError | undefined;
   createModelStatus: Status;
   ingestionMethod: string;
-  ingestionMethodFromIndexViewLogic: string;
   isLoading: boolean;
-  isModelsInitialLoadingFromMLInferenceLogic: boolean;
   modelStateChangeError: string | undefined;
-  selectableModels: MlModel[];
-  selectableModelsFromMLInferenceLogic: MlModel[];
-  selectedModel: MlModel | undefined;
-  selectedModelFromMLInferenceLogic: MlModel | undefined;
+  selectableModels: MLInferenceProcessorsValues['selectableModels'];
+  selectedModel: MLInferenceProcessorsValues['selectedModel'];
   startModelError: HttpError | undefined;
   startModelStatus: Status;
 }
@@ -63,7 +56,6 @@ export interface ModelSelectValues {
 export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelectActions>>({
   actions: {
     createModel: (modelId: string) => ({ modelId }),
-    setInferencePipelineConfiguration: (configuration) => ({ configuration }),
     startModel: (modelId: string) => ({ modelId }),
   },
   connect: {
@@ -75,11 +67,7 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
         'apiError as createModelError',
       ],
       MLInferenceLogic,
-      [
-        'clearModelPlaceholderFlag as clearModelPlaceholderFlagFromMLInferenceLogic',
-        'setInferencePipelineConfiguration as setInferencePipelineConfigurationFromMLInferenceLogic',
-        'startPollingModels',
-      ],
+      ['clearModelPlaceholderFlag', 'setInferencePipelineConfiguration', 'startPollingModels'],
       StartModelApiLogic,
       [
         'makeRequest as startModelMakeRequest',
@@ -91,13 +79,13 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
       CreateModelApiLogic,
       ['status as createModelStatus', 'error as createModelError'],
       IndexViewLogic,
-      ['ingestionMethod as ingestionMethodFromIndexViewLogic'],
+      ['ingestionMethod'],
       MLInferenceLogic,
       [
-        'addInferencePipelineModal as addInferencePipelineModalFromMLInferenceLogic',
-        'isModelsInitialLoading as isModelsInitialLoadingFromMLInferenceLogic',
-        'selectableModels as selectableModelsFromMLInferenceLogic',
-        'selectedModel as selectedModelFromMLInferenceLogic',
+        'addInferencePipelineModal',
+        'isModelsInitialLoading as isLoading',
+        'selectableModels',
+        'selectedModel',
       ],
       StartModelApiLogic,
       ['status as startModelStatus', 'error as startModelError'],
@@ -110,10 +98,7 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
     createModelSuccess: (response) => {
       actions.startPollingModels();
       // The create action succeeded, so the model is no longer a placeholder
-      actions.clearModelPlaceholderFlagFromMLInferenceLogic(response.modelId);
-    },
-    setInferencePipelineConfiguration: ({ configuration }) => {
-      actions.setInferencePipelineConfigurationFromMLInferenceLogic(configuration);
+      actions.clearModelPlaceholderFlag(response.modelId);
     },
     startModel: ({ modelId }) => {
       actions.startModelMakeRequest({ modelId });
@@ -124,18 +109,10 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
   }),
   path: ['enterprise_search', 'content', 'model_select_logic'],
   selectors: ({ selectors }) => ({
-    addInferencePipelineModal: [
-      () => [selectors.addInferencePipelineModalFromMLInferenceLogic],
-      (modal) => modal, // Pass-through
-    ],
     areActionButtonsDisabled: [
       () => [selectors.createModelStatus, selectors.startModelStatus],
       (createModelStatus: Status, startModelStatus: Status) =>
         createModelStatus === Status.LOADING || startModelStatus === Status.LOADING,
-    ],
-    ingestionMethod: [
-      () => [selectors.ingestionMethodFromIndexViewLogic],
-      (ingestionMethod) => ingestionMethod, // Pass-through
     ],
     modelStateChangeError: [
       () => [selectors.createModelError, selectors.startModelError],
@@ -144,18 +121,6 @@ export const ModelSelectLogic = kea<MakeLogicType<ModelSelectValues, ModelSelect
 
         return getErrorsFromHttpResponse(createModelError ?? startModelError!)[0];
       },
-    ],
-    selectableModels: [
-      () => [selectors.selectableModelsFromMLInferenceLogic],
-      (selectableModels) => selectableModels, // Pass-through
-    ],
-    selectedModel: [
-      () => [selectors.selectedModelFromMLInferenceLogic],
-      (selectedModel) => selectedModel, // Pass-through
-    ],
-    isLoading: [
-      () => [selectors.isModelsInitialLoadingFromMLInferenceLogic],
-      (isModelsInitialLoading) => isModelsInitialLoading, // Pass-through
     ],
   }),
 });


### PR DESCRIPTION
## Summary

Remove pure pass-through actions and selectors from `model_select_logic.ts`. No functional changes.
