### PR TITLE
[Console] Docked Console page spacer fix

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
@@ -1,3 +1,8 @@
+.kbnBody--hasEmbeddableConsole .euiPageTemplate main {
+  // Ensure page content is not overlapped by console control bar
+  padding-bottom: $embeddableConsoleInitialHeight;
+}
+
 .embeddableConsole {
   background: $embeddableConsoleBackground;
   color: $embeddableConsoleText;

--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -31,6 +31,8 @@ import { setLoadFromParameter, removeLoadFromParameter } from '../../lib/load_fr
 import { ConsoleWrapper } from './console_wrapper';
 import './_index.scss';
 
+const KBN_BODY_CONSOLE_CLASS = 'kbnBody--hasEmbeddableConsole';
+
 const landmarkHeading = i18n.translate('console.embeddableConsole.landmarkHeading', {
   defaultMessage: 'Developer console',
 });
@@ -58,6 +60,10 @@ export const EmbeddableConsole = ({
       removeLoadFromParameter();
     }
   }, [consoleState.isOpen, consoleState.loadFromContent]);
+  useEffect(() => {
+    document.body.classList.add(KBN_BODY_CONSOLE_CLASS);
+    return () => document.body.classList.remove(KBN_BODY_CONSOLE_CLASS);
+  }, []);
 
   const isConsoleOpen = consoleState.isOpen;
   const setIsConsoleOpen = (value: boolean) => {


### PR DESCRIPTION
## Summary

Updated the embeddable console to add a class to the body element for
the kbnBody main element that ensures there is adequate padding at the
bottom of the page when the console control bar is rendered.

### Screenshots
Index Management Page
Before:
![image](https://github.com/elastic/kibana/assets/1972968/f4d169ce-f997-4d80-afaa-513c8b2b514f)
After:
![image](https://github.com/elastic/kibana/assets/1972968/a4033395-ccd3-4574-a323-c2fe54441138)
