### PR TITLE
[8.12] [Obs AI Assistant] Improve recall speed (#176428)

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/recall.ts
@@ -9,7 +9,7 @@ import { decodeOrThrow, jsonRt } from '@kbn/io-ts-utils';
 import type { Serializable } from '@kbn/utility-types';
 import dedent from 'dedent';
 import * as t from 'io-ts';
-import { last, omit } from 'lodash';
+import { compact, last, omit } from 'lodash';
 import { lastValueFrom } from 'rxjs';
 import { FunctionRegistrationParameters } from '.';
 import { MessageRole, type Message } from '../../common/types';
@@ -89,12 +89,17 @@ export function registerRecallFunction({
         messages.filter((message) => message.message.role === MessageRole.User)
       );
 
+      const nonEmptyQueries = compact(queries);
+
+      const queriesOrUserPrompt = nonEmptyQueries.length
+        ? nonEmptyQueries
+        : compact([userMessage?.message.content]);
+
       const suggestions = await retrieveSuggestions({
         userMessage,
         client,
-        signal,
         contexts,
-        queries,
+        queries: queriesOrUserPrompt,
       });
 
       resources.logger.debug(`Received ${suggestions.length} suggestions`);
@@ -109,9 +114,8 @@ export function registerRecallFunction({
 
       const relevantDocuments = await scoreSuggestions({
         suggestions,
-        systemMessage,
-        userMessage,
-        queries,
+        queries: queriesOrUserPrompt,
+        messages,
         client,
         connectorId,
         signal,
@@ -128,25 +132,17 @@ export function registerRecallFunction({
 }
 
 async function retrieveSuggestions({
-  userMessage,
   queries,
   client,
   contexts,
-  signal,
 }: {
   userMessage?: Message;
   queries: string[];
   client: ObservabilityAIAssistantClient;
   contexts: Array<'apm' | 'lens'>;
-  signal: AbortSignal;
 }) {
-  const queriesWithUserPrompt =
-    userMessage && userMessage.message.content
-      ? [userMessage.message.content, ...queries]
-      : queries;
-
   const recallResponse = await client.recall({
-    queries: queriesWithUserPrompt,
+    queries,
     contexts,
   });
 
@@ -163,50 +159,42 @@ const scoreFunctionRequestRt = t.type({
 });
 
 const scoreFunctionArgumentsRt = t.type({
-  scores: t.array(
-    t.type({
-      id: t.string,
-      score: t.number,
-    })
-  ),
+  scores: t.string,
 });
 
 async function scoreSuggestions({
   suggestions,
-  systemMessage,
-  userMessage,
+  messages,
   queries,
   client,
   connectorId,
   signal,
 }: {
   suggestions: Awaited<ReturnType<typeof retrieveSuggestions>>;
-  systemMessage: Message;
-  userMessage?: Message;
+  messages: Message[];
   queries: string[];
   client: ObservabilityAIAssistantClient;
   connectorId: string;
   signal: AbortSignal;
 }) {
-  const systemMessageExtension =
-    dedent(`You have the function called score available to help you inform the user about how relevant you think a given document is to the conversation.
-    Please give a score between 1 and 7, fractions are allowed.
-    A higher score means it is more relevant.`);
-  const extendedSystemMessage = {
-    ...systemMessage,
-    message: {
-      ...systemMessage.message,
-      content: `${systemMessage.message.content}\n\n${systemMessageExtension}`,
-    },
-  };
-
-  const userMessageOrQueries =
-    userMessage && userMessage.message.content ? userMessage.message.content : queries.join(',');
+  const indexedSuggestions = suggestions.map((suggestion, index) => ({ ...suggestion, id: index }));
 
   const newUserMessageContent =
-    dedent(`Given the question "${userMessageOrQueries}", can you give me a score for how relevant the following documents are?
+    dedent(`Given the following question, score the documents that are relevant to the question. on a scale from 0 to 7,
+    0 being completely relevant, and 7 being extremely relevant. Information is relevant to the question if it helps in
+    answering the question. Judge it according to the following criteria:
 
-  ${JSON.stringify(suggestions, null, 2)}`);
+    - The document is relevant to the question, and the rest of the conversation
+    - The document has information relevant to the question that is not mentioned,
+      or more detailed than what is available in the conversation
+    - The document has a high amount of information relevant to the question compared to other documents
+    - The document contains new information not mentioned before in the conversation
+
+    Question:
+    ${queries.join('\n')}
+
+    Documents:
+    ${JSON.stringify(indexedSuggestions, null, 2)}`);
 
   const newUserMessage: Message = {
     '@timestamp': new Date().toISOString(),
@@ -225,22 +213,13 @@ async function scoreSuggestions({
       additionalProperties: false,
       properties: {
         scores: {
-          description: 'The document IDs and their scores',
-          type: 'array',
-          items: {
-            type: 'object',
-            additionalProperties: false,
-            properties: {
-              id: {
-                description: 'The ID of the document',
-                type: 'string',
-              },
-              score: {
-                description: 'The score for the document',
-                type: 'number',
-              },
-            },
-          },
+          description: `The document IDs and their scores, as CSV. Example:
+          
+            my_id,7
+            my_other_id,3
+            my_third_id,4
+          `,
+          type: 'string',
         },
       },
       required: ['score'],
@@ -252,7 +231,7 @@ async function scoreSuggestions({
     streamIntoObservable(
       await client.chat({
         connectorId,
-        messages: [extendedSystemMessage, newUserMessage],
+        messages: [...messages.slice(0, -1), newUserMessage],
         functions: [scoreFunction],
         functionCall: 'score',
         signal,
@@ -260,9 +239,18 @@ async function scoreSuggestions({
     ).pipe(processOpenAiStream(), concatenateOpenAiChunks())
   );
   const scoreFunctionRequest = decodeOrThrow(scoreFunctionRequestRt)(response);
-  const { scores } = decodeOrThrow(jsonRt.pipe(scoreFunctionArgumentsRt))(
+  const { scores: scoresAsString } = decodeOrThrow(jsonRt.pipe(scoreFunctionArgumentsRt))(
     scoreFunctionRequest.message.function_call.arguments
   );
+
+  const scores = scoresAsString.split('\n').map((line) => {
+    const [index, score] = line
+      .split(',')
+      .map((value) => value.trim())
+      .map(Number);
+
+    return { id: suggestions[index].id, score };
+  });
 
   if (scores.length === 0) {
     return [];

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -451,8 +451,6 @@ export class ObservabilityAIAssistantClient {
     this.dependencies.logger.debug(`Sending conversation to connector`);
     this.dependencies.logger.trace(JSON.stringify(request, null, 2));
 
-    const now = performance.now();
-
     const executeResult = await this.dependencies.actionsClient.execute({
       actionId: connectorId,
       params: {

--- a/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/client/index.ts
@@ -451,6 +451,8 @@ export class ObservabilityAIAssistantClient {
     this.dependencies.logger.debug(`Sending conversation to connector`);
     this.dependencies.logger.trace(JSON.stringify(request, null, 2));
 
+    const now = performance.now();
+
     const executeResult = await this.dependencies.actionsClient.execute({
       actionId: connectorId,
       params: {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.12`:
 - [[Obs AI Assistant] Improve recall speed (#176428)](https://github.com/elastic/kibana/pull/176428)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dario Gieselaar","email":"dario.gieselaar@elastic.co"},"sourceCommit":{"committedDate":"2024-02-08T16:27:24Z","message":"[Obs AI Assistant] Improve recall speed (#176428)\n\nImproves recall speed by outputting as CSV with zero-indexed document\r\n\"ids\". Previously, it was a JSON object, with the real document ids.\r\nThis causes the LLM to \"think\" for longer, for whatever reason. I didn't\r\nactually see a difference in completion speed, but emitting the first\r\nvalue took significantly less time when using the CSV output. I also\r\ntried sending a single document per request using the old format, and\r\nwhile that certainly improves things, the slowest request becomes the\r\nbottleneck. These are results from about 10 tries per strategy (I'd love\r\nto see others reproduce at least the `batch` vs `csv` strategy results):\r\n\r\n`batch`: 24.7s\r\n`chunk`: 10s\r\n`csv`: 4.9s\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fc58a0d3a71dd946fb24a75050930030c002d2a4","branchLabelMapping":{"^v8.13.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v8.13.0","v8.12.2"],"number":176428,"url":"https://github.com/elastic/kibana/pull/176428","mergeCommit":{"message":"[Obs AI Assistant] Improve recall speed (#176428)\n\nImproves recall speed by outputting as CSV with zero-indexed document\r\n\"ids\". Previously, it was a JSON object, with the real document ids.\r\nThis causes the LLM to \"think\" for longer, for whatever reason. I didn't\r\nactually see a difference in completion speed, but emitting the first\r\nvalue took significantly less time when using the CSV output. I also\r\ntried sending a single document per request using the old format, and\r\nwhile that certainly improves things, the slowest request becomes the\r\nbottleneck. These are results from about 10 tries per strategy (I'd love\r\nto see others reproduce at least the `batch` vs `csv` strategy results):\r\n\r\n`batch`: 24.7s\r\n`chunk`: 10s\r\n`csv`: 4.9s\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fc58a0d3a71dd946fb24a75050930030c002d2a4"}},"sourceBranch":"main","suggestedTargetBranches":["8.12"],"targetPullRequestStates":[{"branch":"main","label":"v8.13.0","labelRegex":"^v8.13.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/176428","number":176428,"mergeCommit":{"message":"[Obs AI Assistant] Improve recall speed (#176428)\n\nImproves recall speed by outputting as CSV with zero-indexed document\r\n\"ids\". Previously, it was a JSON object, with the real document ids.\r\nThis causes the LLM to \"think\" for longer, for whatever reason. I didn't\r\nactually see a difference in completion speed, but emitting the first\r\nvalue took significantly less time when using the CSV output. I also\r\ntried sending a single document per request using the old format, and\r\nwhile that certainly improves things, the slowest request becomes the\r\nbottleneck. These are results from about 10 tries per strategy (I'd love\r\nto see others reproduce at least the `batch` vs `csv` strategy results):\r\n\r\n`batch`: 24.7s\r\n`chunk`: 10s\r\n`csv`: 4.9s\r\n\r\n---------\r\n\r\nCo-authored-by: Søren Louv-Jansen <sorenlouv@gmail.com>\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>","sha":"fc58a0d3a71dd946fb24a75050930030c002d2a4"}},{"branch":"8.12","label":"v8.12.2","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->