### PR TITLE
[Fleet] Make datastream rollover lazy (#174790)

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.test.ts
@@ -1673,7 +1673,14 @@ describe('EPM template', () => {
         },
       ]);
 
-      expect(esClient.indices.rollover).toHaveBeenCalled();
+      expect(esClient.transport.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '/test.prefix1-default/_rollover',
+          querystring: {
+            lazy: true,
+          },
+        })
+      );
     });
     it('should skip rollover on expected error when flag is on', async () => {
       const esClient = elasticsearchServiceMock.createElasticsearchClient();

--- a/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
+++ b/x-pack/plugins/fleet/server/services/epm/elasticsearch/template/template.ts
@@ -946,8 +946,12 @@ const getDataStreams = async (
 const rolloverDataStream = (dataStreamName: string, esClient: ElasticsearchClient) => {
   try {
     // Do no wrap rollovers in retryTransientEsErrors since it is not idempotent
-    return esClient.indices.rollover({
-      alias: dataStreamName,
+    return esClient.transport.request({
+      method: 'POST',
+      path: `/${dataStreamName}/_rollover`,
+      querystring: {
+        lazy: true,
+      },
     });
   } catch (error) {
     throw new PackageESError(

--- a/x-pack/test/fleet_api_integration/apis/epm/install_hidden_datastreams.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_hidden_datastreams.ts
@@ -34,46 +34,50 @@ export default function (providerContext: FtrProviderContext) {
         .send({ force: true })
         .expect(200);
 
-      await es.index({
-        index: 'metrics-apm.service_summary.10m-default',
-        document: {
-          '@timestamp': '2023-05-30T07:50:00.000Z',
-          agent: {
-            name: 'go',
-          },
-          data_stream: {
-            dataset: 'apm.service_summary.10m',
-            namespace: 'default',
-            type: 'metrics',
-          },
-          ecs: {
-            version: '8.6.0-dev',
-          },
-          event: {
-            agent_id_status: 'missing',
-            ingested: '2023-05-30T07:57:12Z',
-          },
-          metricset: {
-            interval: '10m',
-            name: 'service_summary',
-          },
-          observer: {
-            hostname: '047e282994fb',
-            type: 'apm-server',
-            version: '8.7.0',
-          },
-          processor: {
-            event: 'metric',
-            name: 'metric',
-          },
-          service: {
-            language: {
+      const writeDoc = () =>
+        es.index({
+          refresh: true,
+          index: 'metrics-apm.service_summary.10m-default',
+          document: {
+            '@timestamp': '2023-05-30T07:50:00.000Z',
+            agent: {
               name: 'go',
             },
-            name: '___main_elastic_cloud_87_ilm_fix',
+            data_stream: {
+              dataset: 'apm.service_summary.10m',
+              namespace: 'default',
+              type: 'metrics',
+            },
+            ecs: {
+              version: '8.6.0-dev',
+            },
+            event: {
+              agent_id_status: 'missing',
+              ingested: '2023-05-30T07:57:12Z',
+            },
+            metricset: {
+              interval: '10m',
+              name: 'service_summary',
+            },
+            observer: {
+              hostname: '047e282994fb',
+              type: 'apm-server',
+              version: '8.7.0',
+            },
+            processor: {
+              event: 'metric',
+              name: 'metric',
+            },
+            service: {
+              language: {
+                name: 'go',
+              },
+              name: '___main_elastic_cloud_87_ilm_fix',
+            },
           },
-        },
-      });
+        });
+
+      await writeDoc();
 
       await supertest
         .post(`/api/fleet/epm/packages/apm/8.8.0`)
@@ -81,6 +85,8 @@ export default function (providerContext: FtrProviderContext) {
         .send({ force: true })
         .expect(200);
 
+      // Rollover are lazy need to write a new doc
+      await writeDoc();
       const ds = await es.indices.get({
         index: 'metrics-apm.service_summary*',
         expand_wildcards: ['open', 'hidden'],


### PR DESCRIPTION
## Summary

Add back changes in https://github.com/elastic/kibana/pull/174790 after https://github.com/elastic/elasticsearch/issues/104732 is fixed

Resolve https://github.com/elastic/kibana/issues/174480
