### PR TITLE
[Security Solution][Entity Analytics] Change display labels for Asset criticality

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality/asset_criticality_badge.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality/asset_criticality_badge.tsx
@@ -73,7 +73,7 @@ export const AssetCriticalityBadgeAllowMissing: React.FC<{
     <EuiHealth color="subdued" data-test-subj={dataTestSubj}>
       <FormattedMessage
         id="xpack.securitySolution.entityAnalytics.assetCriticality.noCriticality"
-        defaultMessage="No criticality assigned"
+        defaultMessage="Criticality Unassigned"
       />
     </EuiHealth>
   );

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality/asset_criticality_selector.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/asset_criticality/asset_criticality_selector.tsx
@@ -104,7 +104,7 @@ const AssetCriticalityComponent: React.FC<Props> = ({ entity }) => {
                   ) : (
                     <FormattedMessage
                       id="xpack.securitySolution.entityAnalytics.assetCriticality.createButton"
-                      defaultMessage="Create"
+                      defaultMessage="Assign"
                     />
                   )}
                 </EuiButtonEmpty>

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/contexts_table.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/contexts_table.test.tsx
@@ -74,6 +74,6 @@ describe('ContextsTable', () => {
 
     expect(screen.getByText('Asset Criticality Level')).toBeInTheDocument();
     expect(screen.getByTestId('risk-inputs-asset-criticality-badge')).toBeInTheDocument();
-    expect(screen.getByText('No criticality assigned')).toBeInTheDocument();
+    expect(screen.getByText('Criticality Unassigned')).toBeInTheDocument();
   });
 });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/new_entity_flyout.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/entity_analytics/new_entity_flyout.cy.ts
@@ -112,7 +112,7 @@ describe(
             'Asset Criticality'
           );
 
-          cy.get(ENTITY_DETAILS_FLYOUT_ASSET_CRITICALITY_BUTTON).should('have.text', 'Create');
+          cy.get(ENTITY_DETAILS_FLYOUT_ASSET_CRITICALITY_BUTTON).should('have.text', 'Assign');
         });
 
         it('should display asset criticality modal', () => {
@@ -193,7 +193,7 @@ describe(
           'Asset Criticality'
         );
 
-        cy.get(ENTITY_DETAILS_FLYOUT_ASSET_CRITICALITY_BUTTON).should('have.text', 'Create');
+        cy.get(ENTITY_DETAILS_FLYOUT_ASSET_CRITICALITY_BUTTON).should('have.text', 'Assign');
       });
 
       it('should display asset criticality modal', () => {


### PR DESCRIPTION
This PR changes the labels in the asset criticality selector from

![image](https://github.com/elastic/security-team/assets/147995946/299de79b-cee4-4d9e-ba2c-08286d8f8512)


to 

![Screenshot 2024-02-09 at 10 49 28](https://github.com/elastic/kibana/assets/2423976/8ae0910f-44ab-4dda-ab6f-bdf12ec66ed4)

