### PR TITLE
[Security Solution] Fix date fields not formatted on the new user expandable flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user_items.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user_items.test.ts
@@ -28,14 +28,12 @@ describe('useManagedUserItems', () => {
         getValues: expect.any(Function),
       },
       {
-        field: '@timestamp',
         label: 'First seen',
-        getValues: expect.any(Function),
+        render: expect.any(Function),
       },
       {
-        field: '@timestamp',
         label: 'Last seen',
-        getValues: expect.any(Function),
+        render: expect.any(Function),
       },
       {
         field: 'host.os.name',
@@ -65,8 +63,8 @@ describe('useManagedUserItems', () => {
       [
         ['1234', '321'], // id
         ['test domain', 'another test domain'], // domain
-        ['2023-02-23T20:03:17.489Z'], // First seen
-        ['2023-02-23T20:03:17.489Z'], // Last seen
+        undefined, // First seen doesn't implement getValues
+        undefined, // Last seen doesn't implement getValues
         ['testOs'], // OS name
         ['testFamily'], // os family
         ['10.0.0.1', '127.0.0.1'], // IP addresses

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user_items.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_right/hooks/use_observed_user_items.tsx
@@ -5,13 +5,15 @@
  * 2.0.
  */
 
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
+import { FormattedRelativePreferenceDate } from '../../../../common/components/formatted_date';
 import type { UserItem } from '../../../../../common/search_strategy';
 import { useMlCapabilities } from '../../../../common/components/ml/hooks/use_ml_capabilities';
 import { getAnomaliesFields } from '../../shared/common';
 import * as i18n from './translations';
 import type { ObservedEntityData } from '../../shared/components/observed_entity/types';
 import type { EntityTableRows } from '../../shared/components/entity_table/types';
+import { getEmptyTagValue } from '../../../../common/components/empty_value';
 
 const basicUserFields: EntityTableRows<ObservedEntityData<UserItem>> = [
   {
@@ -26,15 +28,21 @@ const basicUserFields: EntityTableRows<ObservedEntityData<UserItem>> = [
   },
   {
     label: i18n.FIRST_SEEN,
-    getValues: (userData: ObservedEntityData<UserItem>) =>
-      userData.firstSeen.date ? [userData.firstSeen.date] : undefined,
-    field: '@timestamp',
+    render: (userData: ObservedEntityData<UserItem>) =>
+      userData.firstSeen.date ? (
+        <FormattedRelativePreferenceDate value={userData.firstSeen.date} />
+      ) : (
+        getEmptyTagValue()
+      ),
   },
   {
     label: i18n.LAST_SEEN,
-    getValues: (userData: ObservedEntityData<UserItem>) =>
-      userData.lastSeen.date ? [userData.lastSeen.date] : undefined,
-    field: '@timestamp',
+    render: (userData: ObservedEntityData<UserItem>) =>
+      userData.lastSeen.date ? (
+        <FormattedRelativePreferenceDate value={userData.lastSeen.date} />
+      ) : (
+        getEmptyTagValue()
+      ),
   },
   {
     label: i18n.OPERATING_SYSTEM_TITLE,


### PR DESCRIPTION
## Summary

Fix first-seen and last-seen fields not properly formatted on the new user expandable flyout.

**Before**
<img width="400" src="https://github.com/elastic/kibana/assets/1490444/00140a86-1b2a-42ea-8ecd-6a27c9f6bd59" />



**After**
<img width="400" src="https://github.com/elastic/kibana/assets/1490444/b841dfb2-e2b8-4fcf-8e7e-e51d831059b7" />


### How to test
* Enable the experimental flag `newUserDetailsFlyout`
* Open the alerts page populated with data
* Click on the user name
* It should display the new user flyout with formatted dates

### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
