### PR TITLE
[Dashboard] Make the ES|QL panel more prominent

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/top_nav/editor_menu.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/editor_menu.tsx
@@ -255,6 +255,7 @@ export const EditorMenu = ({
   const getEditorMenuPanels = (closePopover: () => void) => {
     const initialPanelItems = [
       ...visTypeAliases.map(getVisTypeAliasMenuItem),
+      ...getAddPanelActionMenuItems(api, addPanelActions, closePopover),
       ...toolVisTypes.map(getVisTypeMenuItem),
       ...ungroupedFactories.map((factory) => {
         return getEmbeddableFactoryMenuItem(factory, closePopover);
@@ -265,9 +266,7 @@ export const EditorMenu = ({
         panel: panelId,
         'data-test-subj': `dashboardEditorMenu-${id}Group`,
       })),
-
       ...promotedVisTypes.map(getVisTypeMenuItem),
-      ...getAddPanelActionMenuItems(api, addPanelActions, closePopover),
     ];
     if (aggsBasedVisTypes.length > 0) {
       initialPanelItems.push({


### PR DESCRIPTION
## Summary

ES|QL panel was not so prominent so I was asked to move it higher in the hierarchy.

![image (18)](https://github.com/elastic/kibana/assets/17003240/53ceb80a-0c8b-4b64-888e-da2fc74f8385)
