### PR TITLE
[Ops] Remove -e from node.conf (in Kibana docker images)

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -137,7 +137,7 @@ RUN set -e ; \
  chown -R 1000:0 /usr/share/kibana/openssl-3.0.8
 
 # Enable FIPS for Kibana only. In the future we can override OS wide with ENV OPENSSL_CONF
-RUN echo -e '\n--enable-fips' >> config/node.options
+RUN echo '\n--enable-fips' >> config/node.options
 RUN echo '--openssl-config=/usr/share/kibana/openssl-3.0.8/nodejs.cnf' >> config/node.options
 COPY --chown=1000:0 openssl/nodejs.cnf /usr/share/kibana/openssl-3.0.8/nodejs.cnf
 ENV OPENSSL_MODULES=/usr/local/lib64/ossl-modules
@@ -158,7 +158,7 @@ COPY --chown=1000:0 config/serverless.es.yml /usr/share/kibana/config/serverless
 COPY --chown=1000:0 config/serverless.oblt.yml /usr/share/kibana/config/serverless.oblt.yml
 COPY --chown=1000:0 config/serverless.security.yml /usr/share/kibana/config/serverless.security.yml
 # Supportability enhancement: enable capturing heap snapshots. See https://nodejs.org/api/cli.html#--heapsnapshot-signalsignal
-RUN echo -e '\n--heapsnapshot-signal=SIGUSR2' >> config/node.options
+RUN echo '\n--heapsnapshot-signal=SIGUSR2' >> config/node.options
 RUN echo '--diagnostic-dir=./data' >> config/node.options
 {{/serverless}}
 {{^opensslLegacyProvider}}

--- a/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
+++ b/src/dev/build/tasks/os_packages/docker_generator/templates/base/Dockerfile
@@ -137,8 +137,8 @@ RUN set -e ; \
  chown -R 1000:0 /usr/share/kibana/openssl-3.0.8
 
 # Enable FIPS for Kibana only. In the future we can override OS wide with ENV OPENSSL_CONF
-RUN echo '\n--enable-fips' >> config/node.options
-RUN echo '--openssl-config=/usr/share/kibana/openssl-3.0.8/nodejs.cnf' >> config/node.options
+RUN /usr/bin/echo -e '\n--enable-fips' >> config/node.options
+RUN /usr/bin/echo '--openssl-config=/usr/share/kibana/openssl-3.0.8/nodejs.cnf' >> config/node.options
 COPY --chown=1000:0 openssl/nodejs.cnf /usr/share/kibana/openssl-3.0.8/nodejs.cnf
 ENV OPENSSL_MODULES=/usr/local/lib64/ossl-modules
 
@@ -158,8 +158,8 @@ COPY --chown=1000:0 config/serverless.es.yml /usr/share/kibana/config/serverless
 COPY --chown=1000:0 config/serverless.oblt.yml /usr/share/kibana/config/serverless.oblt.yml
 COPY --chown=1000:0 config/serverless.security.yml /usr/share/kibana/config/serverless.security.yml
 # Supportability enhancement: enable capturing heap snapshots. See https://nodejs.org/api/cli.html#--heapsnapshot-signalsignal
-RUN echo '\n--heapsnapshot-signal=SIGUSR2' >> config/node.options
-RUN echo '--diagnostic-dir=./data' >> config/node.options
+RUN /usr/bin/echo -e '\n--heapsnapshot-signal=SIGUSR2' >> config/node.options
+RUN /usr/bin/echo '--diagnostic-dir=./data' >> config/node.options
 {{/serverless}}
 {{^opensslLegacyProvider}}
 RUN sed 's/\(--openssl-legacy-provider\)/#\1/' -i config/node.options
@@ -221,7 +221,7 @@ ENTRYPOINT ["/bin/tini", "--"]
 CMD ["/app/kibana.sh"]
 # Generate a stub command that will be overwritten at runtime
 RUN mkdir /app && \
-    echo -e '#!/bin/bash\nexec /usr/local/bin/kibana-docker' > /app/kibana.sh && \
+    /usr/bin/echo -e '#!/bin/bash\nexec /usr/local/bin/kibana-docker' > /app/kibana.sh && \
     chmod 0555 /app/kibana.sh
 {{/cloud}}
 


### PR DESCRIPTION
## Summary
There seems to be an issue with the kibana docker image, and the error is the following: 
```
/usr/share/kibana/bin/../node/bin/node: -e is not allowed in NODE_OPTIONS
```

See thread for details: https://elastic.slack.com/archives/C0574PUV998/p1707483034202249

### Changes
- chore(FIPS): remove -e flags from echo - they're emitted to the output, the newline seems to work without the flags (source: https://stackoverflow.com/questions/45532467/run-echo-e-deb-http-prepares-a-wrong-contents-of-the-target-file)
