### PR TITLE
[Fleet] Fix flaky serverless API integration tests

### DIFF
--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.test.ts
@@ -33,14 +33,10 @@ describe('fleet server hosts handler', () => {
     jest
       .spyOn(fleetServerService, 'updateFleetServerHost')
       .mockResolvedValue({ id: 'host1' } as any);
-    jest.spyOn(fleetServerService, 'listFleetServerHosts').mockResolvedValue({
-      items: [
-        { id: SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID, host_urls: ['http://elasticsearch:9200'] },
-      ] as any,
-      total: 1,
-      page: 1,
-      perPage: 1,
-    });
+    jest.spyOn(fleetServerService, 'getFleetServerHost').mockResolvedValue({
+      id: SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID,
+      host_urls: ['http://elasticsearch:9200'],
+    } as any);
     jest
       .spyOn(agentPolicyService, 'bumpAllAgentPoliciesForFleetServerHosts')
       .mockResolvedValue({} as any);
@@ -118,17 +114,29 @@ describe('fleet server hosts handler', () => {
     expect(res).toEqual({ body: { item: { id: 'host1' } } });
   });
 
-  // it('should return ok on put in stateful if host url is different from default', async () => {
-  //   jest
-  //     .spyOn(appContextService, 'getCloud')
-  //     .mockReturnValue({ isServerlessEnabled: false } as any);
+  it('should return ok on put in serverless if host urls are not passed', async () => {
+    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isServerlessEnabled: true } as any);
 
-  //   const res = await putFleetServerHostHandler(
-  //     mockContext,
-  //     { body: { host_urls: ['http://localhost:8080'] }, params: { outputId: 'host1' } } as any,
-  //     mockResponse as any
-  //   );
+    const res = await putFleetServerHostHandler(
+      mockContext,
+      { body: { name: ['Renamed'] }, params: { outputId: 'host1' } } as any,
+      mockResponse as any
+    );
 
-  //   expect(res).toEqual({ body: { item: { id: 'host1' } } });
-  // });
+    expect(res).toEqual({ body: { item: { id: 'host1' } } });
+  });
+
+  it('should return ok on put in stateful if host url is different from default', async () => {
+    jest
+      .spyOn(appContextService, 'getCloud')
+      .mockReturnValue({ isServerlessEnabled: false } as any);
+
+    const res = await putFleetServerHostHandler(
+      mockContext,
+      { body: { host_urls: ['http://localhost:8080'] }, params: { outputId: 'host1' } } as any,
+      mockResponse as any
+    );
+
+    expect(res).toEqual({ body: { item: { id: 'host1' } } });
+  });
 });

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.test.ts
@@ -114,18 +114,6 @@ describe('fleet server hosts handler', () => {
     expect(res).toEqual({ body: { item: { id: 'host1' } } });
   });
 
-  it('should return ok on put in serverless if host urls are not passed', async () => {
-    jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isServerlessEnabled: true } as any);
-
-    const res = await putFleetServerHostHandler(
-      mockContext,
-      { body: { name: ['Renamed'] }, params: { outputId: 'host1' } } as any,
-      mockResponse as any
-    );
-
-    expect(res).toEqual({ body: { item: { id: 'host1' } } });
-  });
-
   it('should return ok on put in stateful if host url is different from default', async () => {
     jest
       .spyOn(appContextService, 'getCloud')

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -42,7 +42,7 @@ async function checkFleetServerHostsWriteAPIsAllowed(
   );
   if (!isEqual(hostUrls, serverlessDefaultFleetServerHost.host_urls)) {
     throw new FleetServerHostUnauthorizedError(
-      `Fleet server host must have default URL in serverless${serverlessDefaultFleetServerHost.host_urls}`
+      `Fleet server host must have default URL in serverless: ${serverlessDefaultFleetServerHost.host_urls}`
     );
   }
 }

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -40,30 +40,12 @@ async function checkFleetServerHostsWriteAPIsAllowed(
     soClient,
     SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
   );
-  console.log('----> serverlessDefaultFleetServerHost', serverlessDefaultFleetServerHost);
-  console.log(
-    '----> serverlessDefaultFleetServerHost.host_urls',
-    serverlessDefaultFleetServerHost.host_urls
-  );
-  if (
-    serverlessDefaultFleetServerHost === undefined ||
-    !isEqual(hostUrls, serverlessDefaultFleetServerHost.host_urls)
-  ) {
+  if (!isEqual(hostUrls, serverlessDefaultFleetServerHost.host_urls)) {
     throw new FleetServerHostUnauthorizedError(
-      `Fleet server host must have default URL in serverless${
-        serverlessDefaultFleetServerHost ? ': ' + serverlessDefaultFleetServerHost.host_urls : ''
-      }`
+      `Fleet server host must have default URL in serverless${serverlessDefaultFleetServerHost.host_urls}`
     );
   }
 }
-
-// async function getServerlessDefaultFleetServerHost(soClient: SavedObjectsClientContract) {
-//   const res = await listFleetServerHosts(soClient);
-//   const fleetServerHosts = res.items;
-//   return fleetServerHosts.find(
-//     (fleetServerHost) => fleetServerHost.id === SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
-//   );
-// }
 
 export const postFleetServerHost: RequestHandler<
   undefined,

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -36,26 +36,34 @@ async function checkFleetServerHostsWriteAPIsAllowed(
     return;
   }
 
-  const defaultFleetServerHost = await getDefaultFleetServerHost(soClient);
+  const serverlessDefaultFleetServerHost = await getFleetServerHost(
+    soClient,
+    SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
+  );
+  console.log('----> serverlessDefaultFleetServerHost', serverlessDefaultFleetServerHost);
+  console.log(
+    '----> serverlessDefaultFleetServerHost.host_urls',
+    serverlessDefaultFleetServerHost.host_urls
+  );
   if (
-    defaultFleetServerHost === undefined ||
-    !isEqual(hostUrls, defaultFleetServerHost.host_urls)
+    serverlessDefaultFleetServerHost === undefined ||
+    !isEqual(hostUrls, serverlessDefaultFleetServerHost.host_urls)
   ) {
     throw new FleetServerHostUnauthorizedError(
       `Fleet server host must have default URL in serverless${
-        defaultFleetServerHost ? ': ' + defaultFleetServerHost.host_urls : ''
+        serverlessDefaultFleetServerHost ? ': ' + serverlessDefaultFleetServerHost.host_urls : ''
       }`
     );
   }
 }
 
-async function getDefaultFleetServerHost(soClient: SavedObjectsClientContract) {
-  const res = await listFleetServerHosts(soClient);
-  const fleetServerHosts = res.items;
-  return fleetServerHosts.find(
-    (fleetServerHost) => fleetServerHost.id === SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
-  );
-}
+// async function getServerlessDefaultFleetServerHost(soClient: SavedObjectsClientContract) {
+//   const res = await listFleetServerHosts(soClient);
+//   const fleetServerHosts = res.items;
+//   return fleetServerHosts.find(
+//     (fleetServerHost) => fleetServerHost.id === SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID
+//   );
+// }
 
 export const postFleetServerHost: RequestHandler<
   undefined,

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
@@ -12,8 +12,7 @@ export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
 
-  // Failing: See https://github.com/elastic/kibana/issues/176352
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
@@ -12,8 +12,7 @@ export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176399
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/176352
Closes https://github.com/elastic/kibana/issues/176399

https://github.com/elastic/kibana/pull/175315 added the possibility to configure new Fleet Server hosts in serverless, with the constraint that the host URL must match the default URL. The API integration tests written to test this have been flaky, probably due to request timeout when fetching all Fleet Server hosts. This PR improves this by directly retrieving the default Fleet Server host by id.

This fix has been tested using the Flaky Test Runner Pipeline, with 25 test runs for observability and security project types: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5140

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
