### PR TITLE
fix(embeddable_console): use header offset to calculate max height

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_variables.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_variables.scss
@@ -2,7 +2,7 @@ $embeddableConsoleBackground: lightOrDarkTheme($euiColorDarkestShade, $euiColorI
 $embeddableConsoleText: lighten(makeHighContrastColor($euiColorLightestShade, $embeddableConsoleBackground), 20%);
 $embeddableConsoleBorderColor: transparentize($euiColorGhost, .8);
 $embeddableConsoleInitialHeight: $euiSizeXXL;
-$embeddableConsoleMaxHeight: calc(100vh - #{$euiSize * 5});
+$embeddableConsoleMaxHeight: calc(100vh - var(--euiFixedHeadersOffset, 0));
 
 // Pixel heights ensure no blurriness caused by half pixel offsets
 $embeddableConsoleHeights: (


### PR DESCRIPTION
## Summary

Update the docked console max height to use the euiFixedHeadersOffset CSS variable instead of #{$euiSize * 5}

### Screenshot
![image](https://github.com/elastic/kibana/assets/1972968/610f02bf-ca90-4af2-878c-c85de681d87b)
