### PR TITLE
[ES|QL] Fixes the mapping of ES fields

### DIFF
--- a/packages/kbn-field-types/src/kbn_field_types.ts
+++ b/packages/kbn-field-types/src/kbn_field_types.ts
@@ -52,8 +52,6 @@ export const getFilterableKbnTypeNames = (): string[] =>
 export function esFieldTypeToKibanaFieldType(type: string) {
   switch (type) {
     case ES_FIELD_TYPES._INDEX:
-    case ES_FIELD_TYPES.GEO_POINT:
-    case ES_FIELD_TYPES.IP:
       return KBN_FIELD_TYPES.STRING;
     case '_version':
       return KBN_FIELD_TYPES.NUMBER;

--- a/src/plugins/data/common/search/expressions/esql.ts
+++ b/src/plugins/data/common/search/expressions/esql.ts
@@ -7,13 +7,9 @@
  */
 
 import type { KibanaRequest } from '@kbn/core/server';
-import { castEsToKbnFieldTypeName, ES_FIELD_TYPES, KBN_FIELD_TYPES } from '@kbn/field-types';
+import { esFieldTypeToKibanaFieldType } from '@kbn/field-types';
 import { i18n } from '@kbn/i18n';
-import type {
-  Datatable,
-  DatatableColumnType,
-  ExpressionFunctionDefinition,
-} from '@kbn/expressions-plugin/common';
+import type { Datatable, ExpressionFunctionDefinition } from '@kbn/expressions-plugin/common';
 import { RequestAdapter } from '@kbn/inspector-plugin/common';
 
 import { zipObject } from 'lodash';
@@ -59,21 +55,6 @@ interface EsqlFnArguments {
 interface EsqlStartDependencies {
   search: ISearchGeneric;
   uiSettings: UiSettingsCommon;
-}
-
-function normalizeType(type: string): DatatableColumnType {
-  switch (type) {
-    case ES_FIELD_TYPES._INDEX:
-    case ES_FIELD_TYPES.GEO_POINT:
-    case ES_FIELD_TYPES.IP:
-      return KBN_FIELD_TYPES.STRING;
-    case '_version':
-      return KBN_FIELD_TYPES.NUMBER;
-    case 'datetime':
-      return KBN_FIELD_TYPES.DATE;
-    default:
-      return castEsToKbnFieldTypeName(type) as DatatableColumnType;
-  }
 }
 
 function extractTypeAndReason(attributes: any): { type?: string; reason?: string } {
@@ -252,7 +233,7 @@ export const getEsqlFn = ({ getStartDependencies }: EsqlFnArguments) => {
             (body.all_columns ?? body.columns)?.map(({ name, type }) => ({
               id: name,
               name,
-              meta: { type: normalizeType(type) },
+              meta: { type: esFieldTypeToKibanaFieldType(type) },
               isNull: hasEmptyColumns ? !lookup.has(name) : false,
             })) ?? [];
 

--- a/test/functional/apps/discover/group2/_data_grid_field_tokens.ts
+++ b/test/functional/apps/discover/group2/_data_grid_field_tokens.ts
@@ -130,7 +130,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       await PageObjects.unifiedFieldList.clickFieldListItemAdd('ip');
       await PageObjects.unifiedFieldList.clickFieldListItemAdd('geo.coordinates');
 
-      expect(await findFirstColumnTokens()).to.eql(['Number', 'String', 'String', 'String']);
+      expect(await findFirstColumnTokens()).to.eql(['Number', 'String', 'IP address', 'Geo point']);
 
       expect(await findFirstDocViewerTokens()).to.eql([
         'String',
@@ -138,9 +138,9 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         'Date',
         'String',
         'Number',
+        'IP address',
         'String',
-        'String',
-        'String',
+        'Geo point',
         'String',
         'String',
       ]);

--- a/test/functional/apps/discover/group3/_sidebar.ts
+++ b/test/functional/apps/discover/group3/_sidebar.ts
@@ -114,7 +114,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         await PageObjects.unifiedFieldList.waitUntilSidebarHasLoaded();
         await PageObjects.unifiedFieldList.openSidebarFieldFilter();
         options = await find.allByCssSelector('[data-test-subj*="typeFilter"]');
-        expect(options).to.have.length(3);
+        expect(options).to.have.length(5);
 
         expect(await PageObjects.unifiedFieldList.getSidebarAriaDescription()).to.be(
           '82 available fields.'


### PR DESCRIPTION
## Summary

When we created the ESQL strategy we used the same logic with SQL. But this is not 100% correct. For example it converts the ip type fields to strings, same as geo_points. This PR is fixing it.

So now if you run for example

```
from kibana_sample_data_logs | WHERE CIDR_MATCH(ip, "153.189.234.161/32", "127.0.0.3/32") | stats count(*)
```

the client side validation won't fail.