### PR TITLE
[Search] Don't skip ahead if connector doesn't have config items

### DIFF
--- a/x-pack/plugins/serverless_search/public/application/components/connectors/connector_config/connector_configuration.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors/connector_config/connector_configuration.tsx
@@ -36,13 +36,14 @@ export const ConnectorConfiguration: React.FC<ConnectorConfigurationProps> = ({ 
     const step =
       connector.status === ConnectorStatus.CREATED
         ? 'link'
-        : connector.status === ConnectorStatus.NEEDS_CONFIGURATION
+        : connector.status === ConnectorStatus.NEEDS_CONFIGURATION &&
+          Object.keys(connector.configuration || {}).length > 0
         ? 'configure'
         : connector.status === ConnectorStatus.CONFIGURED
         ? 'connect'
         : 'connected';
     setCurrentStep(step);
-  }, [connector.status, setCurrentStep]);
+  }, [connector.status, setCurrentStep, connector.configuration]);
   const steps: EuiStepsHorizontalProps['steps'] = [
     {
       title: i18n.translate('xpack.serverlessSearch.connectors.config.linkToElasticTitle', {


### PR DESCRIPTION
## Summary

This fixes an issue where connectors config would skip ahead on setting a service type.