### PR TITLE
[Infra] Make k8s section collapsible

### DIFF
--- a/x-pack/plugins/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/overview/metrics/metrics_section.tsx
@@ -58,7 +58,11 @@ export const MetricsSection = ({ assetName, metricsDataView, logsDataView, dateR
           filterFieldName={model.fields.name}
         />
       </Section>
-      <Section dependsOn={dashboards?.kubernetes?.dependsOn} title={KubernetesMetricsSectionTitle}>
+      <Section
+        dependsOn={dashboards?.kubernetes?.dependsOn}
+        title={KubernetesMetricsSectionTitle}
+        collapsible
+      >
         <MetricsGrid
           assetName={assetName}
           dateRange={dateRange}


### PR DESCRIPTION
Closes #176733

## Summary
This PR makes the Kubernetes Overview section on the Asset details page collapsible

## Testing
- Open the asset details page
- Check the metrics section (the Kubernetes Overview section should be collapsible)

https://github.com/elastic/kibana/assets/14139027/61fe91e4-1cd0-4dd8-b81f-402a04e47fcc

