### PR TITLE
[Cloud Security] [Findings] Set misconfiguration tab as default and Fix non matching groups data

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
+++ b/x-pack/plugins/cloud_security_posture/public/pages/configurations/latest_findings/use_latest_findings.ts
@@ -74,7 +74,7 @@ export const getFindingsQuery = (
             },
           },
         ],
-        must_not: mutedRulesFilterQuery,
+        must_not: [...(query?.bool?.must_not ?? []), ...mutedRulesFilterQuery],
       },
     },
     ...(pageParam ? { from: pageParam } : {}),

--- a/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/pages/findings/findings.tsx
@@ -47,9 +47,11 @@ const FindingsTabRedirecter = ({ lastTabSelected }: { lastTabSelected?: Findings
     );
   }
 
-  // otherwise stay on the vulnerabilities tab, since it's the first one.
+  // otherwise stay on the misconfigurations tab, since it's the first one.
   return (
-    <Redirect to={{ search: location.search, pathname: findingsNavigation.vulnerabilities.path }} />
+    <Redirect
+      to={{ search: location.search, pathname: findingsNavigation.findings_default.path }}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

It fixes #176750 
It fixes #176751

This PR addresses the following issues in the Findings -> Misconfigurations page:

- Updated Misconfigurations to be the Default selected tab in the Findings page on the initial load (when LocalStorage is not set yet)

https://github.com/elastic/kibana/assets/19270322/dc3f071e-f64f-4cf4-8d63-fb481ea98d6b



- Fixed an issue with the Non-Matching group that wasn't combining the must_not filter from the grouping with the Benchmark Rules.


https://github.com/elastic/kibana/assets/19270322/b428070d-f237-40f9-8249-28fdb0fcddf4

