### PR TITLE
[maps][ESQL] fix esql layers do not support spatial filters drawn on map

### DIFF
--- a/x-pack/plugins/maps/common/descriptor_types/source_descriptor_types.ts
+++ b/x-pack/plugins/maps/common/descriptor_types/source_descriptor_types.ts
@@ -51,9 +51,9 @@ export type ESQLSourceDescriptor = AbstractSourceDescriptor & {
    */
   dateField?: string;
   /*
-   * Geo field used to
-   * 1. narrow ES|QL requests by visible map area
-   * 2. narrow by spatial filters drawn on map
+   * Geo field used to narrow ES|QL requests by
+   * 1. by visible map area
+   * 2. spatial filters drawn on map
    */
   geoField?: string;
   narrowByGlobalSearch: boolean;

--- a/x-pack/plugins/maps/common/descriptor_types/source_descriptor_types.ts
+++ b/x-pack/plugins/maps/common/descriptor_types/source_descriptor_types.ts
@@ -51,7 +51,9 @@ export type ESQLSourceDescriptor = AbstractSourceDescriptor & {
    */
   dateField?: string;
   /*
-   * Geo field used to narrow ES|QL requests by visible map area
+   * Geo field used to
+   * 1. narrow ES|QL requests by visible map area
+   * 2. narrow by spatial filters drawn on map
    */
   geoField?: string;
   narrowByGlobalSearch: boolean;

--- a/x-pack/plugins/maps/public/classes/layers/layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/layer.tsx
@@ -577,7 +577,11 @@ export class AbstractLayer implements ILayer {
 
   getGeoFieldNames(): string[] {
     const source = this.getSource();
-    return hasESSourceMethod(source, 'getGeoFieldName') ? [source.getGeoFieldName()] : [];
+    if (!hasESSourceMethod(source, 'getGeoFieldName')) {
+      return [];
+    }
+    const geoFieldName = source.getGeoFieldName();
+    return geoFieldName ? [geoFieldName] : [];
   }
 
   async getStyleMetaDescriptorFromLocalFeatures(): Promise<StyleMetaDescriptor | null> {

--- a/x-pack/plugins/maps/public/classes/layers/layer.tsx
+++ b/x-pack/plugins/maps/public/classes/layers/layer.tsx
@@ -577,10 +577,9 @@ export class AbstractLayer implements ILayer {
 
   getGeoFieldNames(): string[] {
     const source = this.getSource();
-    if (!hasESSourceMethod(source, 'getGeoFieldName')) {
-      return [];
-    }
-    const geoFieldName = source.getGeoFieldName();
+    const geoFieldName = hasESSourceMethod(source, 'getGeoFieldName')
+      ? source.getGeoFieldName()
+      : undefined;
     return geoFieldName ? [geoFieldName] : [];
   }
 

--- a/x-pack/plugins/maps/public/classes/sources/es_source/types.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_source/types.ts
@@ -49,7 +49,7 @@ export interface IESSource extends IVectorSource {
 
   getIndexPatternId(): string;
 
-  getGeoFieldName(): string;
+  getGeoFieldName(): string | undefined;
 
   loadStylePropsMeta({
     layerName,

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -45,7 +45,10 @@ export const sourceTitle = i18n.translate('xpack.maps.source.esqlSearchTitle', {
   defaultMessage: 'ES|QL',
 });
 
-export class ESQLSource extends AbstractVectorSource implements IVectorSource, Pick<IESSource, 'getIndexPatternId' | 'getGeoFieldName'> {
+export class ESQLSource
+  extends AbstractVectorSource
+  implements IVectorSource, Pick<IESSource, 'getIndexPatternId' | 'getGeoFieldName'>
+{
   readonly _descriptor: ESQLSourceDescriptor;
 
   static createDescriptor(descriptor: Partial<ESQLSourceDescriptor>): ESQLSourceDescriptor {

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/esql_source.tsx
@@ -28,6 +28,7 @@ import { isValidStringConfig } from '../../util/valid_string_config';
 import type { SourceEditorArgs } from '../source';
 import { AbstractVectorSource, getLayerFeaturesRequestName } from '../vector_source';
 import type { IVectorSource, GeoJsonWithMeta, SourceStatus } from '../vector_source';
+import type { IESSource } from '../es_source';
 import type { IField } from '../../fields/field';
 import { InlineField } from '../../fields/inline_field';
 import { getData, getUiSettings } from '../../../kibana_services';
@@ -44,7 +45,7 @@ export const sourceTitle = i18n.translate('xpack.maps.source.esqlSearchTitle', {
   defaultMessage: 'ES|QL',
 });
 
-export class ESQLSource extends AbstractVectorSource implements IVectorSource {
+export class ESQLSource extends AbstractVectorSource implements IVectorSource, Pick<IESSource, 'getIndexPatternId' | 'getGeoFieldName'> {
   readonly _descriptor: ESQLSourceDescriptor;
 
   static createDescriptor(descriptor: Partial<ESQLSourceDescriptor>): ESQLSourceDescriptor {
@@ -324,5 +325,9 @@ export class ESQLSource extends AbstractVectorSource implements IVectorSource {
 
   getIndexPatternId() {
     return this._descriptor.dataViewId;
+  }
+
+  getGeoFieldName() {
+    return this._descriptor.geoField;
   }
 }


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/176752

### test instructions
1. install sample web logs 
2. create new map
3. add "ES|QL" layer
4. verify drawing tools are enable on map and drawing a filter narrows ES|QL layer.
    <img width="600" alt="Screenshot 2024-02-12 at 12 38 03 PM" src="https://github.com/elastic/kibana/assets/373691/fffb77de-f2fd-43f0-9a87-a5f44ff68ee2">
