### PR TITLE
[ML] Trained models functional tests: ensure inputs are cleared properly when deploying DFA models

### DIFF
--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -181,8 +181,7 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.trainedModelsTable.assertPipelinesTabContent(false);
       });
 
-      // FLAKY: https://github.com/elastic/kibana/issues/165084
-      describe.skip('DFA model deployment', () => {
+      describe('DFA model deployment', () => {
         after(async () => {
           await ml.api.deleteIngestPipeline(modelWithoutPipelineDataExpectedValues.name, false);
           await ml.api.deleteIngestPipeline(
@@ -191,7 +190,7 @@ export default function ({ getService }: FtrProviderContext) {
           );
         });
 
-        it.skip('deploys the trained model with default values', async () => {
+        it('deploys the trained model with default values', async () => {
           await ml.testExecution.logTestStep('should display the trained model in the table');
           await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
           await ml.testExecution.logTestStep(
@@ -248,7 +247,7 @@ export default function ({ getService }: FtrProviderContext) {
           });
         });
 
-        it.skip('deploys the trained model with custom values', async () => {
+        it('deploys the trained model with custom values', async () => {
           await ml.testExecution.logTestStep('should display the trained model in the table');
           await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
           await ml.testExecution.logTestStep(

--- a/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
+++ b/x-pack/test/functional/apps/ml/short_tests/model_management/model_list.ts
@@ -116,6 +116,12 @@ export default function ({ getService }: FtrProviderContext) {
       await ml.testResources.deleteDataViewByTitle(
         modelWithPipelineAndDestIndexExpectedValues.dataViewTitle
       );
+      // Delete pipelines from deploy DFA model tests
+      await ml.api.deleteIngestPipeline(modelWithoutPipelineDataExpectedValues.name, false);
+      await ml.api.deleteIngestPipeline(
+        modelWithoutPipelineDataExpectedValues.duplicateName,
+        false
+      );
     });
 
     describe('for ML user with read-only access', () => {
@@ -181,140 +187,122 @@ export default function ({ getService }: FtrProviderContext) {
         await ml.trainedModelsTable.assertPipelinesTabContent(false);
       });
 
-      describe('DFA model deployment', () => {
-        after(async () => {
-          await ml.api.deleteIngestPipeline(modelWithoutPipelineDataExpectedValues.name, false);
-          await ml.api.deleteIngestPipeline(
-            modelWithoutPipelineDataExpectedValues.duplicateName,
-            false
-          );
+      it('deploys the DFA trained model with default values', async () => {
+        await ml.testExecution.logTestStep('should display the trained model in the table');
+        await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
+        await ml.testExecution.logTestStep(
+          'should show collapsed actions menu for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
+          modelWithoutPipelineData.modelId,
+          true
+        );
+        await ml.testExecution.logTestStep('should show deploy action for the model in the table');
+        await ml.trainedModelsTable.assertModelDeployActionButtonEnabled(
+          modelWithoutPipelineData.modelId,
+          true
+        );
+        await ml.testExecution.logTestStep('should open the deploy model flyout');
+        await ml.trainedModelsTable.clickDeployAction(modelWithoutPipelineData.modelId);
+        await ml.testExecution.logTestStep('should complete the deploy model Details step');
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutDetails({
+          name: modelWithoutPipelineDataExpectedValues.name,
+          description: modelWithoutPipelineDataExpectedValues.description,
+          // If no metadata is provided, the target field will default to empty string
+          targetField: '',
         });
-
-        it('deploys the trained model with default values', async () => {
-          await ml.testExecution.logTestStep('should display the trained model in the table');
-          await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
-          await ml.testExecution.logTestStep(
-            'should show collapsed actions menu for the model in the table'
-          );
-          await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
-            modelWithoutPipelineData.modelId,
-            true
-          );
-          await ml.testExecution.logTestStep(
-            'should show deploy action for the model in the table'
-          );
-          await ml.trainedModelsTable.assertModelDeployActionButtonEnabled(
-            modelWithoutPipelineData.modelId,
-            true
-          );
-          await ml.testExecution.logTestStep('should open the deploy model flyout');
-          await ml.trainedModelsTable.clickDeployAction(modelWithoutPipelineData.modelId);
-          await ml.testExecution.logTestStep('should complete the deploy model Details step');
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutDetails({
-            name: modelWithoutPipelineDataExpectedValues.name,
-            description: modelWithoutPipelineDataExpectedValues.description,
-            // If no metadata is provided, the target field will default to empty string
-            targetField: '',
-          });
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model Pipeline Config step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutPipelineConfig({
-            inferenceConfig: modelWithoutPipelineDataExpectedValues.inferenceConfig,
-            fieldMap: modelWithoutPipelineDataExpectedValues.fieldMap,
-          });
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model pipeline On Failure step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutOnFailure(
-            getDefaultOnFailureConfiguration()
-          );
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model pipeline Create pipeline step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutCreateStep({
-            description: modelWithoutPipelineDataExpectedValues.description,
-            processors: [
-              {
-                inference: {
-                  model_id: modelWithoutPipelineData.modelId,
-                  ignore_failure: false,
-                  inference_config: modelWithoutPipelineDataExpectedValues.inferenceConfig,
-                  on_failure: getDefaultOnFailureConfiguration(),
-                },
+        await ml.testExecution.logTestStep('should complete the deploy model Pipeline Config step');
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutPipelineConfig({
+          inferenceConfig: modelWithoutPipelineDataExpectedValues.inferenceConfig,
+          fieldMap: modelWithoutPipelineDataExpectedValues.fieldMap,
+        });
+        await ml.testExecution.logTestStep(
+          'should complete the deploy model pipeline On Failure step'
+        );
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutOnFailure(
+          getDefaultOnFailureConfiguration()
+        );
+        await ml.testExecution.logTestStep(
+          'should complete the deploy model pipeline Create pipeline step'
+        );
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutCreateStep({
+          description: modelWithoutPipelineDataExpectedValues.description,
+          processors: [
+            {
+              inference: {
+                model_id: modelWithoutPipelineData.modelId,
+                ignore_failure: false,
+                inference_config: modelWithoutPipelineDataExpectedValues.inferenceConfig,
+                on_failure: getDefaultOnFailureConfiguration(),
               },
-            ],
-          });
+            },
+          ],
         });
+      });
 
-        it('deploys the trained model with custom values', async () => {
-          await ml.testExecution.logTestStep('should display the trained model in the table');
-          await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
-          await ml.testExecution.logTestStep(
-            'should not show collapsed actions menu for the model in the table'
-          );
-          await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
-            modelWithoutPipelineData.modelId,
-            true
-          );
-          await ml.testExecution.logTestStep(
-            'should show deploy action for the model in the table'
-          );
-          await ml.trainedModelsTable.assertModelDeployActionButtonExists(
-            modelWithoutPipelineData.modelId,
-            false
-          );
-          await ml.testExecution.logTestStep('should open the deploy model flyout');
-          await ml.trainedModelsTable.clickDeployAction(modelWithoutPipelineData.modelId);
-          await ml.testExecution.logTestStep('should complete the deploy model Details step');
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutDetails(
-            {
-              name: modelWithoutPipelineDataExpectedValues.duplicateName,
-              description: modelWithoutPipelineDataExpectedValues.duplicateDescription,
-              targetField: 'myTargetField',
-            },
-            true
-          );
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model Pipeline Config step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutPipelineConfig(
-            {
-              inferenceConfig: modelWithoutPipelineDataExpectedValues.inferenceConfig,
-              editedInferenceConfig: modelWithoutPipelineDataExpectedValues.editedInferenceConfig,
-              fieldMap: modelWithoutPipelineDataExpectedValues.fieldMap,
-              editedFieldMap: modelWithoutPipelineDataExpectedValues.editedFieldMap,
-            },
-            true
-          );
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model pipeline On Failure step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutOnFailure(
-            getDefaultOnFailureConfiguration(),
-            true
-          );
-          await ml.testExecution.logTestStep(
-            'should complete the deploy model pipeline Create pipeline step'
-          );
-          await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutCreateStep({
+      it('deploys the DFA trained model with custom values', async () => {
+        await ml.testExecution.logTestStep('should display the trained model in the table');
+        await ml.trainedModelsTable.filterWithSearchString(modelWithoutPipelineData.modelId, 1);
+        await ml.testExecution.logTestStep(
+          'should not show collapsed actions menu for the model in the table'
+        );
+        await ml.trainedModelsTable.assertModelCollapsedActionsButtonExists(
+          modelWithoutPipelineData.modelId,
+          true
+        );
+        await ml.testExecution.logTestStep('should show deploy action for the model in the table');
+        await ml.trainedModelsTable.assertModelDeployActionButtonExists(
+          modelWithoutPipelineData.modelId,
+          false
+        );
+        await ml.testExecution.logTestStep('should open the deploy model flyout');
+        await ml.trainedModelsTable.clickDeployAction(modelWithoutPipelineData.modelId);
+        await ml.testExecution.logTestStep('should complete the deploy model Details step');
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutDetails(
+          {
+            name: modelWithoutPipelineDataExpectedValues.duplicateName,
             description: modelWithoutPipelineDataExpectedValues.duplicateDescription,
-            processors: [
-              {
-                inference: {
-                  field_map: {
-                    incoming_field: 'old_field',
-                  },
-                  ignore_failure: true,
-                  if: "ctx?.network?.name == 'Guest'",
-                  model_id: modelWithoutPipelineData.modelId,
-                  inference_config: modelWithoutPipelineDataExpectedValues.inferenceConfigDuplicate,
-                  tag: 'tag',
-                  target_field: 'myTargetField',
+            targetField: 'myTargetField',
+          },
+          true
+        );
+        await ml.testExecution.logTestStep('should complete the deploy model Pipeline Config step');
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutPipelineConfig(
+          {
+            inferenceConfig: modelWithoutPipelineDataExpectedValues.inferenceConfig,
+            editedInferenceConfig: modelWithoutPipelineDataExpectedValues.editedInferenceConfig,
+            fieldMap: modelWithoutPipelineDataExpectedValues.fieldMap,
+            editedFieldMap: modelWithoutPipelineDataExpectedValues.editedFieldMap,
+          },
+          true
+        );
+        await ml.testExecution.logTestStep(
+          'should complete the deploy model pipeline On Failure step'
+        );
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutOnFailure(
+          getDefaultOnFailureConfiguration(),
+          true
+        );
+        await ml.testExecution.logTestStep(
+          'should complete the deploy model pipeline Create pipeline step'
+        );
+        await ml.deployDFAModelFlyout.completeTrainedModelsInferenceFlyoutCreateStep({
+          description: modelWithoutPipelineDataExpectedValues.duplicateDescription,
+          processors: [
+            {
+              inference: {
+                field_map: {
+                  incoming_field: 'old_field',
                 },
+                ignore_failure: true,
+                if: "ctx?.network?.name == 'Guest'",
+                model_id: modelWithoutPipelineData.modelId,
+                inference_config: modelWithoutPipelineDataExpectedValues.inferenceConfigDuplicate,
+                tag: 'tag',
+                target_field: 'myTargetField',
               },
-            ],
-          });
+            },
+          ],
         });
       });
 

--- a/x-pack/test/functional/services/ml/deploy_models_flyout.ts
+++ b/x-pack/test/functional/services/ml/deploy_models_flyout.ts
@@ -100,6 +100,25 @@ export function DeployDFAModelFlyoutProvider(
       await saveChangesButton.click();
     }
 
+    public async clearTrainedModelsInferenceFlyoutCustomEditorValues(
+      selector: string,
+      defaultValue?: string
+    ) {
+      const configElement = await testSubjects.find(selector);
+      const editor = await configElement.findByClassName('kibanaCodeEditor');
+      await editor.click();
+      const input = await find.activeElement();
+      // check default value then clear
+      const editorContent = await input.getAttribute('value');
+      if (defaultValue !== undefined) {
+        expect(editorContent).to.contain(defaultValue);
+      }
+      await input.clearValueWithKeyboard();
+      // Ensure the editor is cleared
+      const editorContentAfterClearing = await input.getAttribute('value');
+      expect(editorContentAfterClearing).to.eql('');
+    }
+
     public async setTrainedModelsInferenceFlyoutCustomEditorValues(
       selector: string,
       value: string
@@ -108,10 +127,6 @@ export function DeployDFAModelFlyoutProvider(
       const editor = await configElement.findByClassName('kibanaCodeEditor');
       await editor.click();
       const input = await find.activeElement();
-      await input.clearValueWithKeyboard();
-      // Ensure the editor is cleared before adding input
-      const editorContentAfterClearing = await input.getAttribute('value');
-      expect(editorContentAfterClearing).to.eql('');
 
       for (const chr of value) {
         await retry.tryForTime(5000, async () => {
@@ -131,6 +146,9 @@ export function DeployDFAModelFlyoutProvider(
         'mlTrainedModelsInferencePipelineInferenceConfigEditButton'
       );
       await editInferenceConfigButton.click();
+      await this.clearTrainedModelsInferenceFlyoutCustomEditorValues(
+        'mlTrainedModelsInferencePipelineInferenceConfigEditor'
+      );
       await this.setTrainedModelsInferenceFlyoutCustomEditorValues(
         'mlTrainedModelsInferencePipelineInferenceConfigEditor',
         JSON.stringify(values.editedInferenceConfig)
@@ -141,6 +159,10 @@ export function DeployDFAModelFlyoutProvider(
         'mlTrainedModelsInferencePipelineFieldMapEditButton'
       );
       await editFieldMapButton.click();
+      await this.clearTrainedModelsInferenceFlyoutCustomEditorValues(
+        'mlTrainedModelsInferencePipelineFieldMapEdit',
+        '{\n  "field_map": {\n    "incoming_field": "field_the_model_expects"\n  }\n'
+      );
 
       await this.setTrainedModelsInferenceFlyoutCustomEditorValues(
         'mlTrainedModelsInferencePipelineFieldMapEdit',


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/165084

For DFA trained model deployments functional tests, adds a function to ensure inputs are cleared of default values before attempting to fill in inputs.

Flaky test runner: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5155


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


