### PR TITLE
fix(NA): run script over original cwd for promote manifest pipeline

### DIFF
--- a/.buildkite/scripts/steps/es_snapshots/promote_manifest.ts
+++ b/.buildkite/scripts/steps/es_snapshots/promote_manifest.ts
@@ -18,6 +18,7 @@ import { BASE_BUCKET_DAILY, BASE_BUCKET_PERMANENT } from './bucket_config';
       throw Error('Manifest URL missing');
     }
 
+    const mainCWD = process.cwd();
     const tempDir = fs.mkdtempSync('snapshot-promotion');
     process.chdir(tempDir);
 
@@ -35,13 +36,10 @@ import { BASE_BUCKET_DAILY, BASE_BUCKET_PERMANENT } from './bucket_config';
 
     fs.writeFileSync('manifest-permanent.json', manifestPermanentJson);
 
-    const currentPath = execSync('pwd', { encoding: 'utf-8' }).trim();
-    console.log('Current working directory:', currentPath);
-
     execSync(
       `
       set -euo pipefail
-      .buildkite/scripts/common/activate_service_account.sh ${bucket}
+      ${mainCWD}/.buildkite/scripts/common/activate_service_account.sh ${bucket}
       cp manifest.json manifest-latest-verified.json
       gsutil -h "Cache-Control:no-cache, max-age=0, no-transform" cp manifest-latest-verified.json gs://${BASE_BUCKET_DAILY}/${version}/
       rm manifest.json


### PR DESCRIPTION
This PR solves a problem introduced at https://github.com/elastic/kibana/pull/174756 where the addition into the bash script was not being correctly loaded for the promote manifest pipeline as it was not running in the original main cwd.