### PR TITLE
[Search] Fix multiple radio buttons conflicting in connector config

### DIFF
--- a/packages/kbn-search-connectors/components/configuration/connector_configuration_field.tsx
+++ b/packages/kbn-search-connectors/components/configuration/connector_configuration_field.tsx
@@ -174,7 +174,7 @@ export const ConnectorConfigurationField: React.FC<ConnectorConfigurationFieldPr
         <EuiRadioGroup
           disabled={isLoading}
           idSelected={ensureStringType(value)}
-          name="radio group"
+          name={key}
           options={options.map((option) => ({ id: option.value, label: option.label }))}
           onChange={(id) => {
             validateAndSetConfigValue(id);


### PR DESCRIPTION
## Summary

This fixes an issue where multiple radio groups in a single connector config would conflict leading to UI glitches.

<!--ONMERGE {"backportTargets":["8.12","8.14"]} ONMERGE-->