### PR TITLE
[Fleet] Add retry logic to serverless API check

### DIFF
--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -47,15 +47,13 @@ async function checkFleetServerHostsWriteAPIsAllowed(
     try {
       return await getFleetServerHost(soClient, SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID);
     } catch (e) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
-        if (nAttempts > 0) {
-          await new Promise((r) => setTimeout(r, 1000));
-          await attempt(nAttempts - 1);
-        } else {
-          throw new FleetNotFoundError(
-            `Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} not found in saved objects: ${e.message}`
-          );
-        }
+      if (nAttempts > 0) {
+        await new Promise((r) => setTimeout(r, 1000));
+        await attempt(nAttempts - 1);
+      } else {
+        throw new FleetNotFoundError(
+          `Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} not found in saved objects: ${e.message}`
+        );
       }
     }
   }

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -44,13 +44,26 @@ async function checkFleetServerHostsWriteAPIsAllowed(
   // API integration tests have been flaky due to the request to get the default
   // Fleet server host failing, this function adds retry logic.
   async function attempt(nAttempts: number) {
+    const logger = appContextService.getLogger();
     try {
       return await getFleetServerHost(soClient, SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID);
     } catch (e) {
       if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
         if (nAttempts > 0) {
-          setTimeout(async () => await attempt(nAttempts - 1), 1000);
+          logger.warn(
+            `----> Retrying retrieving Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} from saved objects (${
+              4 - nAttempts
+            }/3)`
+          );
+          await new Promise((r) => setTimeout(r, 1000));
+          await attempt(nAttempts - 1);
         } else {
+          const res = await listFleetServerHosts(soClient);
+          logger.warn(
+            `----> Could not retrieve Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} from saved objects; found host ids: ${res.items.map(
+              (fs) => [fs.id, fs.host_urls]
+            )}`
+          );
           throw new FleetNotFoundError(
             `Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} not found in saved objects: ${e.message}`
           );

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -40,13 +40,16 @@ async function checkFleetServerHostsWriteAPIsAllowed(
     return;
   }
 
+  // Elasticsearch outputs must have the default host URL in serverless.
+  // API integration tests have been flaky due to the request to get the default
+  // Fleet server host failing, this function adds retry logic.
   async function attempt(nAttempts: number) {
     try {
       return await getFleetServerHost(soClient, SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID);
     } catch (e) {
       if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
         if (nAttempts > 0) {
-          attempt(nAttempts - 1);
+          await attempt(nAttempts - 1);
         } else {
           throw new FleetNotFoundError(e.message);
         }

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -49,7 +49,7 @@ async function checkFleetServerHostsWriteAPIsAllowed(
     } catch (e) {
       if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
         if (nAttempts > 0) {
-          await attempt(nAttempts - 1);
+          setTimeout(async () => await attempt(nAttempts - 1), 1000);
         } else {
           throw new FleetNotFoundError(
             `Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} not found in saved objects: ${e.message}`

--- a/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/fleet_server_hosts/handler.ts
@@ -51,7 +51,9 @@ async function checkFleetServerHostsWriteAPIsAllowed(
         if (nAttempts > 0) {
           await attempt(nAttempts - 1);
         } else {
-          throw new FleetNotFoundError(e.message);
+          throw new FleetNotFoundError(
+            `Fleet Server host id ${SERVERLESS_DEFAULT_FLEET_SERVER_HOST_ID} not found in saved objects: ${e.message}`
+          );
         }
       }
     }

--- a/x-pack/plugins/fleet/server/routes/output/handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.test.ts
@@ -32,7 +32,7 @@ describe('output handler', () => {
       if (id === SERVERLESS_DEFAULT_OUTPUT_ID) {
         return { hosts: ['http://elasticsearch:9200'] } as any;
       } else {
-        return { id: 'output1' } as any;
+        return { type: 'elasticsearch', id: 'output1' } as any;
       }
     });
     jest.spyOn(agentPolicyService, 'bumpAllAgentPoliciesForOutput').mockResolvedValue({} as any);
@@ -148,7 +148,7 @@ describe('output handler', () => {
     const res = await putOutputHandler(
       mockContext,
       {
-        body: { type: 'elasticsearch', hosts: ['http://localhost:8080'] },
+        body: { hosts: ['http://localhost:8080'] },
         params: { outputId: 'output1' },
       } as any,
       mockResponse as any
@@ -169,7 +169,7 @@ describe('output handler', () => {
     const res = await putOutputHandler(
       mockContext,
       {
-        body: { type: 'elasticsearch', hosts: ['http://elasticsearch:9200'] },
+        body: { hosts: ['http://elasticsearch:9200'] },
         params: { outputId: 'output1' },
       } as any,
       mockResponse as any
@@ -184,7 +184,7 @@ describe('output handler', () => {
     const res = await putOutputHandler(
       mockContext,
       {
-        body: { type: 'elasticsearch', name: 'Renamed output' },
+        body: { name: 'Renamed output' },
         params: { outputId: 'output1' },
       } as any,
       mockResponse as any
@@ -201,7 +201,7 @@ describe('output handler', () => {
     const res = await putOutputHandler(
       mockContext,
       {
-        body: { type: 'elasticsearch', hosts: ['http://localhost:8080'] },
+        body: { hosts: ['http://localhost:8080'] },
         params: { outputId: 'output1' },
       } as any,
       mockResponse as any

--- a/x-pack/plugins/fleet/server/routes/output/handler.test.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.test.ts
@@ -32,7 +32,7 @@ describe('output handler', () => {
       if (id === SERVERLESS_DEFAULT_OUTPUT_ID) {
         return { hosts: ['http://elasticsearch:9200'] } as any;
       } else {
-        return { type: 'elasticsearch', id: 'output1' } as any;
+        return { id: 'output1' } as any;
       }
     });
     jest.spyOn(agentPolicyService, 'bumpAllAgentPoliciesForOutput').mockResolvedValue({} as any);
@@ -144,6 +144,14 @@ describe('output handler', () => {
 
   it('should return error on put elasticsearch output in serverless if host url is different from default', async () => {
     jest.spyOn(appContextService, 'getCloud').mockReturnValue({ isServerlessEnabled: true } as any);
+    // The original output should provide the output type
+    jest.spyOn(outputService, 'get').mockImplementation((_, id: string) => {
+      if (id === SERVERLESS_DEFAULT_OUTPUT_ID) {
+        return { hosts: ['http://elasticsearch:9200'] } as any;
+      } else {
+        return { id: 'output1', type: 'elasticsearch' } as any;
+      }
+    });
 
     const res = await putOutputHandler(
       mockContext,

--- a/x-pack/plugins/fleet/server/routes/output/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.ts
@@ -186,7 +186,9 @@ async function validateOutputServerless(
         if (nAttempts > 0) {
           await attempt(nAttempts - 1);
         } else {
-          throw Boom.badRequest(e.message);
+          throw Boom.badRequest(
+            `Output id ${SERVERLESS_DEFAULT_OUTPUT_ID} not found in saved objects: ${e.message}`
+          );
         }
       }
     }

--- a/x-pack/plugins/fleet/server/routes/output/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.ts
@@ -6,6 +6,7 @@
  */
 
 import type { RequestHandler, SavedObjectsClientContract } from '@kbn/core/server';
+import { SavedObjectsErrorHelpers } from '@kbn/core/server';
 import type { TypeOf } from '@kbn/config-schema';
 
 import Boom from '@hapi/boom';
@@ -189,18 +190,29 @@ async function validateOutputServerless(
     }
   }
 
-  // API integration tests have been flaky due to the request to get the default
-  // output, this function adds retry logic.
+  const logger = appContextService.getLogger();
+
   async function attempt(nAttempts: number) {
     try {
       return await outputService.get(soClient, SERVERLESS_DEFAULT_OUTPUT_ID);
     } catch (e) {
-      if (nAttempts > 0) {
-        await new Promise((r) => setTimeout(r, 1000));
-        await attempt(nAttempts - 1);
+      if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
+        if (nAttempts > 0) {
+          logger.warn(
+            `Retrying retrieving default Fleet ES output id ${SERVERLESS_DEFAULT_OUTPUT_ID} (${
+              4 - nAttempts
+            }/3)`
+          );
+          await new Promise((r) => setTimeout(r, 1000));
+          await attempt(nAttempts - 1);
+        } else {
+          throw Boom.badRequest(
+            `Output id ${SERVERLESS_DEFAULT_OUTPUT_ID} not found in saved objects: ${e.message}`
+          );
+        }
       } else {
-        throw Boom.badRequest(
-          `Output id ${SERVERLESS_DEFAULT_OUTPUT_ID} not found in saved objects: ${e.message}`
+        throw new Error(
+          `Error retrieving default ES output id ${SERVERLESS_DEFAULT_OUTPUT_ID}: ${e.message}`
         );
       }
     }
@@ -209,8 +221,6 @@ async function validateOutputServerless(
   const defaultOutput = await attempt(3);
   if (!defaultOutput) {
     throw Boom.badRequest('Default ES output not found');
-  } else if (!defaultOutput?.hosts) {
-    throw Boom.badRequest(`Missing default ES output hosts: ${defaultOutput}`);
   } else if (!isEqual(output.hosts, defaultOutput?.hosts)) {
     throw Boom.badRequest(
       `Elasticsearch output host must have default URL in serverless: ${defaultOutput?.hosts}`

--- a/x-pack/plugins/fleet/server/routes/output/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.ts
@@ -179,13 +179,26 @@ async function validateOutputServerless(
   // API integration tests have been flaky due to the request to get the default
   // output, this function adds retry logic.
   async function attempt(nAttempts: number) {
+    const logger = appContextService.getLogger();
     try {
       return await outputService.get(soClient, SERVERLESS_DEFAULT_OUTPUT_ID);
     } catch (e) {
       if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
         if (nAttempts > 0) {
-          setTimeout(async () => await attempt(nAttempts - 1), 1000);
+          logger.warn(
+            `----> Retrying retrieving output id ${SERVERLESS_DEFAULT_OUTPUT_ID} from saved objects (${
+              4 - nAttempts
+            }/3)`
+          );
+          await new Promise((r) => setTimeout(r, 1000));
+          await attempt(nAttempts - 1);
         } else {
+          const res = await outputService.list(soClient);
+          logger.warn(
+            `----> Could not retrieve output id ${SERVERLESS_DEFAULT_OUTPUT_ID} from saved objects; found: ${res.items.map(
+              (o) => [o.id, o.hosts]
+            )}`
+          );
           throw Boom.badRequest(
             `Output id ${SERVERLESS_DEFAULT_OUTPUT_ID} not found in saved objects: ${e.message}`
           );

--- a/x-pack/plugins/fleet/server/routes/output/handler.ts
+++ b/x-pack/plugins/fleet/server/routes/output/handler.ts
@@ -184,7 +184,7 @@ async function validateOutputServerless(
     } catch (e) {
       if (SavedObjectsErrorHelpers.isNotFoundError(e)) {
         if (nAttempts > 0) {
-          await attempt(nAttempts - 1);
+          setTimeout(async () => await attempt(nAttempts - 1), 1000);
         } else {
           throw Boom.badRequest(
             `Output id ${SERVERLESS_DEFAULT_OUTPUT_ID} not found in saved objects: ${e.message}`

--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FtrProviderContext } from '../../../ftr_provider_context';
+
+const defaultFleetServerHostId = 'default-fleet-server';
+const defaultFleetServerHostUrl = 'https://localhost:8220';
+const defaultElasticsearchOutputId = 'es-default-output';
+const defaultElasticsearchOutputHostUrl = 'https://localhost:9200';
+
+export async function expectDefaultFleetServer({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+
+  await retry.waitForWithTimeout('get default fleet server', 30_000, async () => {
+    const { body, status } = await supertest.get(
+      `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
+    );
+    if (status === 200 && body.item.host_urls.includes(defaultFleetServerHostUrl)) {
+      return true;
+    } else {
+      throw new Error(`Expected default Fleet Server id ${defaultFleetServerHostId} to exist`);
+    }
+  });
+}
+
+export async function expectDefaultElasticsearchOutput({ getService }: FtrProviderContext) {
+  const supertest = getService('supertest');
+  const retry = getService('retry');
+
+  await retry.waitForWithTimeout('get default Elasticsearch output', 30_000, async () => {
+    const { body, status } = await supertest.get(
+      `/api/fleet/outputs/${defaultElasticsearchOutputId}`
+    );
+    if (status === 200 && body.item.hosts.includes(defaultElasticsearchOutputHostUrl)) {
+      return true;
+    } else {
+      throw new Error(
+        `Expected default Elasticsearch output id ${defaultElasticsearchOutputId} to exist`
+      );
+    }
+  });
+}
+
+export const kbnServerArgs = [
+  '--xpack.cloud.serverless.project_id=ftr_fake_project_id',
+  `--xpack.fleet.fleetServerHosts=[${JSON.stringify({
+    id: defaultFleetServerHostId,
+    name: 'Default Fleet Server',
+    is_default: true,
+    host_urls: [defaultFleetServerHostUrl],
+  })}]`,
+  `--xpack.fleet.outputs=[${JSON.stringify({
+    id: defaultElasticsearchOutputId,
+    name: 'Default Output',
+    type: 'elasticsearch',
+    is_default: true,
+    is_default_monitoring: true,
+    hosts: [defaultElasticsearchOutputHostUrl],
+  })}]`,
+];

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts
@@ -7,6 +7,7 @@
 
 import { createTestConfig } from '../../../config.base';
 import { services } from '../apm_api_integration/common/services';
+import { kbnServerArgs } from '../../common/fleet/default_setup';
 
 export default createTestConfig({
   serverlessProject: 'oblt',
@@ -21,21 +22,5 @@ export default createTestConfig({
   // https://github.com/elastic/project-controller/blob/main/internal/project/observability/config/elasticsearch.yml
   esServerArgs: ['xpack.ml.dfa.enabled=false', 'xpack.ml.nlp.enabled=false'],
 
-  kbnServerArgs: [
-    '--xpack.cloud.serverless.project_id=ftr_fake_project_id',
-    `--xpack.fleet.fleetServerHosts=[${JSON.stringify({
-      id: 'default-fleet-server',
-      name: 'Default Fleet Server',
-      is_default: true,
-      host_urls: ['https://localhost:8220'],
-    })}]`,
-    `--xpack.fleet.outputs=[${JSON.stringify({
-      id: 'es-default-output',
-      name: 'Default Output',
-      type: 'elasticsearch',
-      is_default: true,
-      is_default_monitoring: true,
-      hosts: ['https://localhost:9200'],
-    })}]`,
-  ],
+  kbnServerArgs,
 });

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
@@ -11,9 +11,45 @@ import { FtrProviderContext } from '../../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
+  const retry = getService('retry');
+
+  const defaultFleetServerHostId = 'default-fleet-server';
+  const defaultFleetServerHostUrl = 'https://localhost:8220';
+  const defaultElasticsearchOutputId = 'es-default-output';
+  const defaultElasticsearchOutputHostUrl = 'https://localhost:9200';
+
+  async function expectDefaultFleetServer() {
+    await retry.waitForWithTimeout('get default fleet server', 30_000, async () => {
+      const { body, status } = await supertest.get(
+        `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
+      );
+      if (status === 200 && body.item.host_urls.includes(defaultFleetServerHostUrl)) {
+        return true;
+      } else {
+        throw new Error(`Expected default Fleet Server id ${defaultFleetServerHostId} to exist`);
+      }
+    });
+  }
+
+  async function expectDefaultElasticsearchOutput() {
+    await retry.waitForWithTimeout('get default Elasticsearch output', 30_000, async () => {
+      const { body, status } = await supertest.get(
+        `/api/fleet/outputs/${defaultElasticsearchOutputId}`
+      );
+      if (status === 200 && body.item.hosts.includes(defaultElasticsearchOutputHostUrl)) {
+        return true;
+      } else {
+        throw new Error(
+          `Expected default Elasticsearch output id ${defaultElasticsearchOutputId} to exist`
+        );
+      }
+    });
+  }
 
   describe('fleet', function () {
     it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
+      await expectDefaultFleetServer();
+
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -26,12 +62,14 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         statusCode: 403,
         error: 'Forbidden',
-        message: 'Fleet server host must have default URL in serverless: https://localhost:8220',
+        message: `Fleet server host must have default URL in serverless: ${defaultFleetServerHostUrl}`,
       });
       expect(status).toBe(403);
     });
 
     it('accepts request to create a new fleet server hosts if host url is same as default', async () => {
+      await expectDefaultFleetServer();
+
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -43,13 +81,15 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         item: expect.objectContaining({
           name: 'Test Fleet server host',
-          host_urls: ['https://localhost:8220'],
+          host_urls: [defaultFleetServerHostUrl],
         }),
       });
       expect(status).toBe(200);
     });
 
     it('rejects request to create a new elasticsearch output if host is different from default', async () => {
+      await expectDefaultElasticsearchOutput();
+
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -63,13 +103,14 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         statusCode: 400,
         error: 'Bad Request',
-        message:
-          'Elasticsearch output host must have default URL in serverless: https://localhost:9200',
+        message: `Elasticsearch output host must have default URL in serverless: ${defaultElasticsearchOutputHostUrl}`,
       });
       expect(status).toBe(400);
     });
 
     it('accepts request to create a new elasticsearch output if host url is same as default', async () => {
+      await expectDefaultElasticsearchOutput();
+
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -82,7 +123,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         item: expect.objectContaining({
           name: 'Test output',
-          hosts: ['https://localhost:9200'],
+          hosts: [defaultElasticsearchOutputHostUrl],
         }),
       });
       expect(status).toBe(200);

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
@@ -12,8 +12,7 @@ export default function ({ getService }: FtrProviderContext) {
   const svlCommonApi = getService('svlCommonApi');
   const supertest = getService('supertest');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176858
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts
@@ -6,6 +6,7 @@
  */
 
 import { createTestConfig } from '../../../config.base';
+import { kbnServerArgs } from '../../common/fleet/default_setup';
 
 export default createTestConfig({
   serverlessProject: 'security',
@@ -19,21 +20,5 @@ export default createTestConfig({
   // https://github.com/elastic/project-controller/blob/main/internal/project/security/config/elasticsearch.yml
   esServerArgs: ['xpack.ml.nlp.enabled=false'],
 
-  kbnServerArgs: [
-    '--xpack.cloud.serverless.project_id=ftr_fake_project_id',
-    `--xpack.fleet.fleetServerHosts=[${JSON.stringify({
-      id: 'default-fleet-server',
-      name: 'Default Fleet Server',
-      is_default: true,
-      host_urls: ['https://localhost:8220'],
-    })}]`,
-    `--xpack.fleet.outputs=[${JSON.stringify({
-      id: 'es-default-output',
-      name: 'Default Output',
-      type: 'elasticsearch',
-      is_default: true,
-      is_default_monitoring: true,
-      hosts: ['https://localhost:9200'],
-    })}]`,
-  ],
+  kbnServerArgs,
 });

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
@@ -7,49 +7,18 @@
 
 import expect from 'expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
+import {
+  expectDefaultElasticsearchOutput,
+  expectDefaultFleetServer,
+} from '../../common/fleet/default_setup';
 
-export default function ({ getService }: FtrProviderContext) {
-  const svlCommonApi = getService('svlCommonApi');
-  const supertest = getService('supertest');
-  const retry = getService('retry');
+export default function (ctx: FtrProviderContext) {
+  const svlCommonApi = ctx.getService('svlCommonApi');
+  const supertest = ctx.getService('supertest');
 
-  const defaultFleetServerHostId = 'default-fleet-server';
-  const defaultFleetServerHostUrl = 'https://localhost:8220';
-  const defaultElasticsearchOutputId = 'es-default-output';
-  const defaultElasticsearchOutputHostUrl = 'https://localhost:9200';
-
-  async function expectDefaultFleetServer() {
-    await retry.waitForWithTimeout('get default fleet server', 30_000, async () => {
-      const { body, status } = await supertest.get(
-        `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
-      );
-      if (status === 200 && body.item.host_urls.includes(defaultFleetServerHostUrl)) {
-        return true;
-      } else {
-        throw new Error(`Expected default Fleet Server id ${defaultFleetServerHostId} to exist`);
-      }
-    });
-  }
-
-  async function expectDefaultElasticsearchOutput() {
-    await retry.waitForWithTimeout('get default Elasticsearch output', 30_000, async () => {
-      const { body, status } = await supertest.get(
-        `/api/fleet/outputs/${defaultElasticsearchOutputId}`
-      );
-      if (status === 200 && body.item.hosts.includes(defaultElasticsearchOutputHostUrl)) {
-        return true;
-      } else {
-        throw new Error(
-          `Expected default Elasticsearch output id ${defaultElasticsearchOutputId} to exist`
-        );
-      }
-    });
-  }
-
-  // FLAKY: https://github.com/elastic/kibana/issues/176754
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
-      await expectDefaultFleetServer();
+      await expectDefaultFleetServer(ctx);
 
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
@@ -63,13 +32,13 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         statusCode: 403,
         error: 'Forbidden',
-        message: `Fleet server host must have default URL in serverless: ${defaultFleetServerHostUrl}`,
+        message: 'Fleet server host must have default URL in serverless: https://localhost:8220',
       });
       expect(status).toBe(403);
     });
 
     it('accepts request to create a new fleet server hosts if host url is same as default', async () => {
-      await expectDefaultFleetServer();
+      await expectDefaultFleetServer(ctx);
 
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
@@ -82,14 +51,14 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         item: expect.objectContaining({
           name: 'Test Fleet server host',
-          host_urls: [defaultFleetServerHostUrl],
+          host_urls: ['https://localhost:8220'],
         }),
       });
       expect(status).toBe(200);
     });
 
     it('rejects request to create a new elasticsearch output if host is different from default', async () => {
-      await expectDefaultElasticsearchOutput();
+      await expectDefaultElasticsearchOutput(ctx);
 
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
@@ -104,13 +73,14 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         statusCode: 400,
         error: 'Bad Request',
-        message: `Elasticsearch output host must have default URL in serverless: ${defaultElasticsearchOutputHostUrl}`,
+        message:
+          'Elasticsearch output host must have default URL in serverless: https://localhost:9200',
       });
       expect(status).toBe(400);
     });
 
     it('accepts request to create a new elasticsearch output if host url is same as default', async () => {
-      await expectDefaultElasticsearchOutput();
+      await expectDefaultElasticsearchOutput(ctx);
 
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
@@ -124,7 +94,7 @@ export default function ({ getService }: FtrProviderContext) {
       expect(body).toEqual({
         item: expect.objectContaining({
           name: 'Test output',
-          hosts: [defaultElasticsearchOutputHostUrl],
+          hosts: ['https://localhost:9200'],
         }),
       });
       expect(status).toBe(200);


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/176352
Closes https://github.com/elastic/kibana/issues/176399

https://github.com/elastic/kibana/pull/175315 added the possibility to configure new Fleet Server hosts in serverless, with the constraint that the host URL must match the default URL. The API integration tests written to test this have been flaky, due to failure retrieving the default Fleet Server host or default Elasticsearch output from saved objects. This PR adds retry in the tests.

Note: I have tried adding retry logic in the API handlers but kept hitting test flakiness.

This fix has been tested using the Flaky Test Runner Pipeline, with 48/49 test runs for observability and security project types:
🟢 https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5218
🟢 https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5222
🟢 https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5225

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->