### PR TITLE
[Security Solution][Entity Analytics] Change labels in entity flyout risk summary

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.test.tsx
@@ -41,7 +41,7 @@ describe('RiskInputsUtilityBar', () => {
       </TestProviders>
     );
 
-    expect(getByTestId('risk-input-utility-bar')).toHaveTextContent('Showing 1 Risk input');
+    expect(getByTestId('risk-input-utility-bar')).toHaveTextContent('Showing 1 Risk contribution');
   });
 
   it('renders current page message when totalItemCount is 20', () => {
@@ -58,7 +58,7 @@ describe('RiskInputsUtilityBar', () => {
     );
 
     expect(getByTestId('risk-input-utility-bar')).toHaveTextContent(
-      'Showing 1-10 of 20 Risk input'
+      'Showing 1-10 of 20 Risk contribution'
     );
   });
 
@@ -76,7 +76,7 @@ describe('RiskInputsUtilityBar', () => {
     );
 
     expect(getByTestId('risk-input-utility-bar')).toHaveTextContent(
-      'Showing 11-20 of 20 Risk inputs'
+      'Showing 11-20 of 20 Risk contribution'
     );
   });
 
@@ -93,7 +93,7 @@ describe('RiskInputsUtilityBar', () => {
       </TestProviders>
     );
 
-    expect(getByTestId('risk-input-utility-bar')).toHaveTextContent('3 selected risk input');
+    expect(getByTestId('risk-input-utility-bar')).toHaveTextContent('3 selected risk contribution');
   });
 
   it('toggles the popover when button is clicked', () => {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/components/utility_bar.tsx
@@ -57,14 +57,14 @@ export const RiskInputsUtilityBar: FunctionComponent<Props> = React.memo(
               {pagination.totalItemCount <= 1 ? (
                 <FormattedMessage
                   id="xpack.securitySolution.flyout.entityDetails.riskInputs.utilityBar.selectionTextSingle"
-                  defaultMessage="Showing {totalInputs} {riskInputs}"
+                  defaultMessage="Showing {totalContributions} {riskInputs}"
                   values={{
-                    totalInputs: pagination.totalItemCount,
+                    totalContributions: pagination.totalItemCount,
                     riskInputs: (
                       <b>
                         <FormattedMessage
                           id="xpack.securitySolution.flyout.entityDetails.riskInputs.utilityBar.riskInput"
-                          defaultMessage="Risk input"
+                          defaultMessage="Risk contribution"
                         />
                       </b>
                     ),
@@ -73,15 +73,15 @@ export const RiskInputsUtilityBar: FunctionComponent<Props> = React.memo(
               ) : (
                 <FormattedMessage
                   id="xpack.securitySolution.flyout.entityDetails.riskInputs.utilityBar.selectionTextRange"
-                  defaultMessage="Showing {displayedRange} of {totalInputs} {riskInputs}"
+                  defaultMessage="Showing {displayedRange} of {totalContributions} {riskContributions}"
                   values={{
                     displayedRange: <b>{`${fromItem}-${toItem}`}</b>,
-                    totalInputs: pagination.totalItemCount,
-                    riskInputs: (
+                    totalContributions: pagination.totalItemCount,
+                    riskContributions: (
                       <b>
                         <FormattedMessage
                           id="xpack.securitySolution.flyout.entityDetails.riskInputs.utilityBar.riskInputs"
-                          defaultMessage="Risk inputs"
+                          defaultMessage="Risk contributions"
                         />
                       </b>
                     ),
@@ -106,9 +106,9 @@ export const RiskInputsUtilityBar: FunctionComponent<Props> = React.memo(
                   >
                     <FormattedMessage
                       id="xpack.securitySolution.flyout.entityDetails.riskInputs.utilityBar.text"
-                      defaultMessage="{totalSelectedInputs} selected risk input"
+                      defaultMessage="{totalSelectedContributions} selected risk contribution"
                       values={{
-                        totalSelectedInputs: selectedAlerts.length,
+                        totalSelectedContributions: selectedAlerts.length,
                       }}
                     />
                   </EuiButtonEmpty>

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
@@ -20,7 +20,7 @@ export const getRiskInputTab = ({ entityType, entityName }: RiskInputsTabProps) 
   name: (
     <FormattedMessage
       id="xpack.securitySolution.flyout.entityDetails.userDetails.riskInputs.tabLabel"
-      defaultMessage="Risk Contributions"
+      defaultMessage="Risk contributions"
     />
   ),
   content: <RiskInputsTab entityType={entityType} entityName={entityName} />,

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/index.tsx
@@ -20,7 +20,7 @@ export const getRiskInputTab = ({ entityType, entityName }: RiskInputsTabProps) 
   name: (
     <FormattedMessage
       id="xpack.securitySolution.flyout.entityDetails.userDetails.riskInputs.tabLabel"
-      defaultMessage="Risk Inputs"
+      defaultMessage="Risk Contributions"
     />
   ),
   content: <RiskInputsTab entityType={entityType} entityName={entityName} />,

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs.test.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs.test.tsx
@@ -66,7 +66,7 @@ describe('RiskInputsTab', () => {
 
     expect(queryByTestId('risk-input-contexts-title')).not.toBeInTheDocument();
     expect(getByTestId('risk-input-table-description-cell')).toHaveTextContent(
-      'Risk inputRule Name'
+      'Risk contributionRule Name'
     );
   });
 

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/entity_details_flyout/tabs/risk_inputs/risk_inputs_tab.tsx
@@ -114,7 +114,7 @@ export const RiskInputsTab = ({ entityType, entityName }: RiskInputsTabProps) =>
         name: (
           <FormattedMessage
             id="xpack.securitySolution.flyout.entityDetails.riskInputs.riskInputColumn"
-            defaultMessage="Risk input"
+            defaultMessage="Risk contribution"
           />
         ),
         truncateText: true,

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
@@ -142,7 +142,8 @@ const RiskSummaryComponent = <T extends RiskScoreEntity>({
           <h3>
             <FormattedMessage
               id="xpack.securitySolution.flyout.entityDetails.title"
-              defaultMessage="Risk summary"
+              defaultMessage="{entity} risk summary"
+              values={{ entity: isUserRiskData(riskData) ? 'User' : 'Host' }}
             />
           </h3>
         </EuiTitle>
@@ -180,7 +181,7 @@ const RiskSummaryComponent = <T extends RiskScoreEntity>({
           title: (
             <FormattedMessage
               id="xpack.securitySolution.flyout.entityDetails.riskInputs"
-              defaultMessage="Risk inputs"
+              defaultMessage="View risk contributions"
             />
           ),
           link: {

--- a/x-pack/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/lens_attributes/risk_score_summary.ts
@@ -7,6 +7,7 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { LensAttributes } from '@kbn/lens-embeddable-utils';
+import capitalize from 'lodash/capitalize';
 import { SEVERITY_UI_SORT_ORDER, RISK_SEVERITY_COLOUR, RISK_SCORE_RANGES } from '../common/utils';
 import type { RiskSeverity } from '../../../common/search_strategy';
 import { RiskScoreEntity, RiskScoreFields } from '../../../common/search_strategy';
@@ -78,7 +79,7 @@ export const getRiskScoreSummaryAttributes: (
             [layerIds[0]]: {
               columns: {
                 [columnIds[0]]: {
-                  label: 'Risk',
+                  label: `${capitalize(riskEntity)} Risk`,
                   dataType: 'number',
                   operationType: 'last_value',
                   isBucketed: false,

--- a/x-pack/plugins/security_solution/public/flyout/entity_details/user_details_left/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/entity_details/user_details_left/index.test.tsx
@@ -26,7 +26,7 @@ describe('LeftPanel', () => {
       }
     );
 
-    const tabElement = queryByText('Risk Inputs');
+    const tabElement = queryByText('Risk contributions');
 
     expect(tabElement).toBeInTheDocument();
   });


### PR DESCRIPTION
This PR changes the display text for the Risk Summary in the Entity flyout.
Before:
![Image](https://github.com/elastic/security-team/assets/82123779/be643984-a10c-4ca5-b951-fdddbda49fd0)

After:
![Screenshot 2024-02-13 at 14 26 51](https://github.com/elastic/kibana/assets/2423976/34232541-e3c7-4f48-a5a0-9b40e51edc7d)

Expanded tab:
<img width="813" alt="Screenshot 2024-02-13 at 17 22 20" src="https://github.com/elastic/kibana/assets/2423976/09a0b573-0d23-45a7-aadf-397fa41c666f">

