### PR TITLE
[POC] Portable Dashboards in Hosts page

### DIFF
--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share/show_share_modal.tsx
@@ -24,7 +24,7 @@ import { shareModalStrings } from '../../_dashboard_app_strings';
 import { pluginServices } from '../../../services/plugin_services';
 import { convertPanelMapToSavedPanels } from '../../../../common';
 import { DASHBOARD_APP_LOCATOR } from '../../locator/locator';
-import { DashboardLocatorParams } from '../../../dashboard_container';
+import { DashboardContainer, DashboardLocatorParams } from '../../../dashboard_container';
 
 const showFilterBarId = 'showFilterBar';
 
@@ -33,6 +33,7 @@ export interface ShowShareModalProps {
   savedObjectId?: string;
   dashboardTitle?: string;
   anchorElement: HTMLElement;
+  dashboard: DashboardContainer;
 }
 
 export const showPublicUrlSwitch = (anonymousUserCapabilities: Capabilities) => {
@@ -48,6 +49,7 @@ export function ShowShareModal({
   anchorElement,
   savedObjectId,
   dashboardTitle,
+  dashboard,
 }: ShowShareModalProps) {
   const {
     dashboardCapabilities: { createShortUrl: allowShortUrl },
@@ -185,6 +187,10 @@ export function ShowShareModal({
       locatorParams: {
         id: DASHBOARD_APP_LOCATOR,
         params: locatorParams,
+      },
+      fullInput: {
+        ...dashboard.getInput(),
+        controlGroupInput: dashboard?.controlGroup?.getInput(),
       },
     },
     embedUrlParamExtensions: [

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/share_portable_dashboard.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/share_portable_dashboard.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+
+import { copyToClipboard, EuiButton, EuiPanel } from '@elastic/eui';
+import { ShareContext } from '@kbn/share-plugin/public';
+import { ViewMode } from '@kbn/embeddable-plugin/public';
+import { DashboardContainerInput } from '../../../common';
+
+export const SharePortableDashboard = ({ context }: { context: ShareContext }) => {
+  const copyPortableDashboardJSON = async () => {
+    const input = context?.sharingData?.fullInput as DashboardContainerInput;
+
+    const content = JSON.stringify({ ...input, viewMode: ViewMode.VIEW }, null, 2);
+    copyToClipboard(content);
+  };
+
+  return (
+    <EuiPanel>
+      <EuiButton iconType="copyClipboard" onClick={copyPortableDashboardJSON}>
+        Copy JSON
+      </EuiButton>
+    </EuiPanel>
+  );
+};

--- a/src/plugins/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
+++ b/src/plugins/dashboard/public/dashboard_app/top_nav/use_dashboard_menu_items.tsx
@@ -72,9 +72,10 @@ export const useDashboardMenuItems = ({
         anchorElement,
         savedObjectId: lastSavedId,
         isDirty: Boolean(hasUnsavedChanges),
+        dashboard,
       });
     },
-    [dashboardTitle, hasUnsavedChanges, lastSavedId]
+    [dashboard, dashboardTitle, hasUnsavedChanges, lastSavedId]
   );
 
   const maybeRedirect = useCallback(

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -55,6 +55,7 @@ import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
 
 import { CustomBrandingStart } from '@kbn/core-custom-branding-browser';
 import { SavedObjectsManagementPluginStart } from '@kbn/saved-objects-management-plugin/public';
+import React from 'react';
 import { DashboardContainerFactoryDefinition } from './dashboard_container/embeddable/dashboard_container_factory';
 import {
   type DashboardAppLocator,
@@ -70,6 +71,7 @@ import { DashboardMountContextProps } from './dashboard_app/types';
 import type { FindDashboardsService } from './services/dashboard_content_management/types';
 import { CONTENT_ID, LATEST_VERSION } from '../common/content_management';
 import { addPanelMenuTrigger } from './triggers';
+import { SharePortableDashboard } from './dashboard_app/top_nav/share_portable_dashboard';
 
 export interface DashboardFeatureFlagConfig {
   allowByValueEmbeddables: boolean;
@@ -318,6 +320,24 @@ export class DashboardPlugin
       },
       name: dashboardAppTitle,
     });
+
+    if (share && this.initializerContext.env.mode.dev) {
+      share.register({
+        id: 'copyPortableDashboardJSON',
+        getShareMenuItems: (context) => [
+          {
+            panel: {
+              id: 'copyPortableDashboardJSON',
+              title: 'Copy portable dashboard JSON',
+              content: <SharePortableDashboard context={context} />,
+            },
+            shareMenuItem: {
+              name: 'Copy portable dashboard JSON',
+            },
+          },
+        ],
+      });
+    }
 
     return {
       locator: this.locator,

--- a/src/plugins/data_views/public/data_views/data_views_api_client.ts
+++ b/src/plugins/data_views/public/data_views/data_views_api_client.ts
@@ -112,7 +112,6 @@ export class DataViewsApiClient implements IDataViewsApiClient {
         fields,
         // default to undefined to keep value out of URL params and improve caching
         allow_hidden: allowHidden || undefined,
-        include_empty_fields: includeEmptyFields,
         ...versionQueryParam,
       },
       indexFilter ? JSON.stringify({ index_filter: indexFilter }) : undefined,

--- a/src/plugins/data_views/server/fetcher/lib/es_api.ts
+++ b/src/plugins/data_views/server/fetcher/lib/es_api.ts
@@ -83,8 +83,6 @@ export async function callFieldCapsApi(params: FieldCapsApiParams) {
         ignore_unavailable: true,
         index_filter: indexFilter,
         expand_wildcards: expandWildcards,
-        // @ts-expect-error
-        include_empty_fields: includeEmptyFields ?? true,
         ...fieldCapsOptions,
       },
       { meta: true }

--- a/x-pack/plugins/observability_solution/infra/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/infra/kibana.jsonc
@@ -56,7 +56,8 @@
       "kibanaReact",
       "ml",
       "embeddable",
-      "controls"
+      // "controls",
+      "dashboard"
     ]
   }
 }

--- a/x-pack/plugins/observability_solution/infra/public/pages/link_to/use_node_details_redirect.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/link_to/use_node_details_redirect.ts
@@ -39,6 +39,7 @@ export interface NodeDetailsRedirectParams<T extends InventoryItemType> {
 
 export const useNodeDetailsRedirect = () => {
   const location = useLocation();
+
   const {
     services: {
       application: { currentAppId$ },

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/create_hosts_table_action.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/create_hosts_table_action.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { i18n } from '@kbn/i18n';
+import { apiIsPresentationContainer } from '@kbn/presentation-containers';
+import { EmbeddableApiContext } from '@kbn/presentation-publishing';
+import { IncompatibleActionError, UiActionsStart } from '@kbn/ui-actions-plugin/public';
+
+// -----------------------------------------------------------------------------
+// Create and register an action which allows this embeddable to be created from
+// the dashboard toolbar context menu.
+// -----------------------------------------------------------------------------
+export const registerCreateHostsTableAction = (uiActions: UiActionsStart) => {
+  uiActions.registerAction<EmbeddableApiContext>({
+    id: 'create_hosts_table',
+    getIconType: () => 'editorCodeBlock',
+    isCompatible: async ({ embeddable }) => {
+      return apiIsPresentationContainer(embeddable);
+    },
+    execute: async ({ embeddable }) => {
+      if (!apiIsPresentationContainer(embeddable)) throw new IncompatibleActionError();
+      embeddable.addNewPanel(
+        {
+          panelType: 'hosts_table',
+        },
+        true
+      );
+    },
+    getDisplayName: () =>
+      i18n.translate('xpack.infra.registerCreateHostsTableAction.', {
+        defaultMessage: 'Hosts table',
+      }),
+  });
+  uiActions.attachAction('ADD_PANEL_TRIGGER', 'create_hosts_table');
+};

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_container.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_container.tsx
@@ -5,15 +5,18 @@
  * 2.0.
  */
 import React from 'react';
-import { EuiSpacer } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+
 import { InfraLoadingPanel } from '../../../../components/loading';
 import { useMetricsDataViewContext } from '../hooks/use_metrics_data_view';
 import { UnifiedSearchBar } from './search_bar/unified_search_bar';
 import { HostsContent } from './hosts_content';
 import { ErrorCallout } from './error_callout';
 import { UnifiedSearchProvider } from '../hooks/use_unified_search';
+import { HostsTableProvider } from '../hooks/use_hosts_table';
+import { HostsViewProvider } from '../hooks/use_hosts_view';
+import { HostCountProvider } from '../hooks/use_host_count';
 
 export const HostContainer = () => {
   const { dataView, loading, error, metricAlias, retry } = useMetricsDataViewContext();
@@ -48,8 +51,13 @@ export const HostContainer = () => {
   ) : (
     <UnifiedSearchProvider>
       <UnifiedSearchBar />
-      <EuiSpacer size="m" />
-      <HostsContent />
+      <HostsViewProvider>
+        <HostsTableProvider>
+          <HostCountProvider>
+            <HostsContent />
+          </HostCountProvider>
+        </HostsTableProvider>
+      </HostsViewProvider>
     </UnifiedSearchProvider>
   );
 };

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_content.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_content.tsx
@@ -4,46 +4,96 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { DashboardContainerInput } from '@kbn/dashboard-plugin/common';
+import { DashboardAPI, DashboardRenderer } from '@kbn/dashboard-plugin/public';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
 
-import { HostsTable } from './hosts_table';
-import { KPIGrid } from './kpis/kpi_grid';
-import { Tabs } from './tabs/tabs';
-import { AlertsQueryProvider } from '../hooks/use_alerts_query';
-import { HostsViewProvider } from '../hooks/use_hosts_view';
-import { HostsTableProvider } from '../hooks/use_hosts_table';
+import { buildCombinedHostsFilter } from '../../../../utils/filters/build';
+import { useHostsViewContext } from '../hooks/use_hosts_view';
 import { ErrorCallout } from './error_callout';
 import { useUnifiedSearchContext } from '../hooks/use_unified_search';
-import { HostCountProvider } from '../hooks/use_host_count';
+import { useAfterLoadedState } from '../hooks/use_after_loaded_state';
+import { useMetricsDataViewContext } from '../hooks/use_metrics_data_view';
+import { AlertsQueryProvider } from '../hooks/use_alerts_query';
+import { Tabs } from './tabs/tabs';
+import hostsDashboardInput from './hosts_dashboard.json';
 
 export const HostsContent = () => {
-  const { error } = useUnifiedSearchContext();
+  const { error, parsedDateRange, searchCriteria } = useUnifiedSearchContext();
+  const { loading, searchSessionId, hostNodes } = useHostsViewContext();
+  const [dashboard, setDashboard] = useState<DashboardAPI | null>(null);
+  const { dataView } = useMetricsDataViewContext();
+
+  const shouldUseSearchCriteria = hostNodes.length === 0;
+
+  // prevents searchCriteria state from reloading the chart
+  // we want it to reload only once the table has finished loading.
+  // attributes passed to useAfterLoadedState don't need to be memoized
+  const { afterLoadedState } = useAfterLoadedState(loading, {
+    dateRange: searchCriteria.dateRange,
+    query: shouldUseSearchCriteria ? searchCriteria.query : undefined,
+    searchSessionId,
+  });
+
+  const filters = useMemo(() => {
+    return shouldUseSearchCriteria
+      ? searchCriteria.filters
+      : [
+          buildCombinedHostsFilter({
+            field: 'host.name',
+            values: hostNodes.map((p) => p.name),
+            dataView,
+          }),
+        ];
+  }, [shouldUseSearchCriteria, searchCriteria.filters, hostNodes, dataView]);
+
+  useEffect(() => {
+    if (!dashboard) return;
+
+    dashboard.updateInput({
+      timeRange: afterLoadedState.dateRange,
+      query: afterLoadedState.query,
+      searchSessionId: afterLoadedState.searchSessionId,
+      filters,
+    });
+  }, [
+    afterLoadedState.dateRange,
+    afterLoadedState.query,
+    afterLoadedState.searchSessionId,
+    dashboard,
+    filters,
+  ]);
+
+  const getInitialInput = () =>
+    ({
+      ...hostsDashboardInput,
+      timeRange: parsedDateRange,
+    } as DashboardContainerInput);
+
+  const getCreationOptions = () => {
+    return Promise.resolve({
+      getInitialInput,
+      useControlGroupIntegration: true,
+      useUnifiedSearchIntegration: true,
+    });
+  };
 
   return (
     <>
       {error ? (
         <ErrorCallout error={error} hasDetailsModal />
       ) : (
-        <HostsViewProvider>
-          <HostsTableProvider>
-            <EuiFlexGroup direction="column" gutterSize="m">
-              <EuiFlexItem grow={false}>
-                <HostCountProvider>
-                  <KPIGrid />
-                </HostCountProvider>
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <HostsTable />
-              </EuiFlexItem>
-              <EuiFlexItem grow={false}>
-                <AlertsQueryProvider>
-                  <Tabs />
-                </AlertsQueryProvider>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </HostsTableProvider>
-        </HostsViewProvider>
+        <EuiFlexGroup direction="column" gutterSize="m">
+          <EuiFlexItem grow={false}>
+            <DashboardRenderer getCreationOptions={getCreationOptions} ref={setDashboard} />
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <AlertsQueryProvider>
+              <Tabs />
+            </AlertsQueryProvider>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       )}
     </>
   );

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_dashboard.json
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_dashboard.json
@@ -1,0 +1,1482 @@
+{
+  "viewMode": "view",
+  "timeRestore": false,
+  "query": {
+    "query": "",
+    "language": "kuery"
+  },
+  "description": "",
+  "filters": [],
+  "panels": {
+    "81f400af-196a-4ad4-820e-c5748779f4a4": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "81f400af-196a-4ad4-820e-c5748779f4a4"
+      },
+      "explicitInput": {
+        "id": "81f400af-196a-4ad4-820e-c5748779f4a4",
+        "title": "CPU Usage",
+        "attributes": {
+          "title": "CPU Usage",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "",
+              "showBar": false
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor": {
+                        "label": "Hosts",
+                        "dataType": "number",
+                        "operationType": "unique_count",
+                        "scale": "ratio",
+                        "sourceField": "host.name",
+                        "isBucketed": false,
+                        "params": {
+                          "emptyAsNull": true
+                        },
+                        "customLabel": true
+                      }
+                    },
+                    "incompleteColumns": {}
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "hidePanelTitles": true,
+        "enhancements": {}
+      }
+    },
+    "9db57409-5b4e-49c0-8eed-8dd19e43fb04": {
+      "type": "lens",
+      "gridData": {
+        "x": 8,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "9db57409-5b4e-49c0-8eed-8dd19e43fb04"
+      },
+      "explicitInput": {
+        "id": "9db57409-5b4e-49c0-8eed-8dd19e43fb04",
+        "title": "CPU Usage",
+        "attributes": {
+          "title": "CPU Usage",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "Average",
+              "showBar": false,
+              "trendlineLayerId": "36c51eea-ab02-4711-a68d-c0887762a321",
+              "trendlineLayerType": "metricTrendline",
+              "trendlineTimeAccessor": "27fcfbec-cf85-4a54-ba3d-ec77a3363bcc",
+              "trendlineMetricAccessor": "d31d495c-076d-4c1d-be0a-3c7bc154d4eb"
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessorX0",
+                      "metric_formula_accessorX1",
+                      "metric_formula_accessorX2",
+                      "metric_formula_accessorX3",
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessorX0": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.user.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX1": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.system.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX2": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.cpu.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX3": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              {
+                                "type": "function",
+                                "name": "add",
+                                "args": [
+                                  "metric_formula_accessorX0",
+                                  "metric_formula_accessorX1"
+                                ],
+                                "location": {
+                                  "min": 1,
+                                  "max": 62
+                                },
+                                "text": "average(system.cpu.user.pct) + average(system.cpu.system.pct)"
+                              },
+                              "metric_formula_accessorX2"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 87
+                            },
+                            "text": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessorX0",
+                          "metric_formula_accessorX1",
+                          "metric_formula_accessorX2"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor": {
+                        "label": "CPU Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessorX3"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    }
+                  },
+                  "36c51eea-ab02-4711-a68d-c0887762a321": {
+                    "linkToLayers": [
+                      "layer_0"
+                    ],
+                    "columns": {
+                      "27fcfbec-cf85-4a54-ba3d-ec77a3363bcc": {
+                        "label": "@timestamp",
+                        "dataType": "date",
+                        "operationType": "date_histogram",
+                        "sourceField": "@timestamp",
+                        "isBucketed": true,
+                        "scale": "interval",
+                        "params": {
+                          "interval": "auto",
+                          "includeEmptyRows": true,
+                          "dropPartials": false
+                        }
+                      },
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX0": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.user.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX1": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.system.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX2": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.cpu.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX3": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              {
+                                "type": "function",
+                                "name": "add",
+                                "args": [
+                                  "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX0",
+                                  "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX1"
+                                ],
+                                "location": {
+                                  "min": 1,
+                                  "max": 62
+                                },
+                                "text": "average(system.cpu.user.pct) + average(system.cpu.system.pct)"
+                              },
+                              "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX2"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 87
+                            },
+                            "text": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)"
+                          }
+                        },
+                        "references": [
+                          "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX0",
+                          "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX1",
+                          "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX2"
+                        ],
+                        "customLabel": true
+                      },
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4eb": {
+                        "label": "CPU Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX3"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "columnOrder": [
+                      "27fcfbec-cf85-4a54-ba3d-ec77a3363bcc",
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4eb",
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX0",
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX1",
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX2",
+                      "d31d495c-076d-4c1d-be0a-3c7bc154d4ebX3"
+                    ],
+                    "sampling": 1,
+                    "ignoreGlobalFilters": false,
+                    "incompleteColumns": {}
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-36c51eea-ab02-4711-a68d-c0887762a321"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "hidePanelTitles": true,
+        "enhancements": {}
+      }
+    },
+    "d4934d04-55ae-4ae1-9fea-b371c231487e": {
+      "type": "lens",
+      "gridData": {
+        "x": 16,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "d4934d04-55ae-4ae1-9fea-b371c231487e"
+      },
+      "explicitInput": {
+        "id": "d4934d04-55ae-4ae1-9fea-b371c231487e",
+        "title": "Normalized Load",
+        "attributes": {
+          "title": "Normalized Load",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-layer_0"
+            },
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-4c2406ac-f790-4c5d-9fb6-0f7110b8f243"
+            }
+          ],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "Average",
+              "showBar": false,
+              "trendlineLayerId": "4c2406ac-f790-4c5d-9fb6-0f7110b8f243",
+              "trendlineLayerType": "metricTrendline",
+              "trendlineTimeAccessor": "3e1d6c85-af28-4b1a-8701-a9f8f218e713",
+              "trendlineMetricAccessor": "8ce94bf2-b9f0-441f-84f4-e4292e748bb8"
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessorX0",
+                      "metric_formula_accessorX1",
+                      "metric_formula_accessorX2",
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessorX0": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.load.1",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX1": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.load.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX2": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              "metric_formula_accessorX0",
+                              "metric_formula_accessorX1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 47
+                            },
+                            "text": "average(system.load.1) / max(system.load.cores)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessorX0",
+                          "metric_formula_accessorX1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor": {
+                        "label": "Normalized Load",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessorX2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.load.1) / max(system.load.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+                  },
+                  "4c2406ac-f790-4c5d-9fb6-0f7110b8f243": {
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                    "linkToLayers": [
+                      "layer_0"
+                    ],
+                    "columns": {
+                      "3e1d6c85-af28-4b1a-8701-a9f8f218e713": {
+                        "label": "@timestamp",
+                        "dataType": "date",
+                        "operationType": "date_histogram",
+                        "sourceField": "@timestamp",
+                        "isBucketed": true,
+                        "scale": "interval",
+                        "params": {
+                          "interval": "auto",
+                          "includeEmptyRows": true,
+                          "dropPartials": false
+                        }
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.load.1",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.load.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                              "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 47
+                            },
+                            "text": "average(system.load.1) / max(system.load.cores)"
+                          }
+                        },
+                        "references": [
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8": {
+                        "label": "Normalized Load",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.load.1) / max(system.load.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "columnOrder": [
+                      "3e1d6c85-af28-4b1a-8701-a9f8f218e713",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2"
+                    ],
+                    "sampling": 1,
+                    "ignoreGlobalFilters": false,
+                    "incompleteColumns": {}
+                  }
+                },
+                "currentIndexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0_trendline"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "hidePanelTitles": true,
+        "enhancements": {}
+      }
+    },
+    "488c0b24-92e7-440d-816f-09669a31d3b2": {
+      "type": "lens",
+      "gridData": {
+        "x": 32,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "488c0b24-92e7-440d-816f-09669a31d3b2"
+      },
+      "explicitInput": {
+        "id": "488c0b24-92e7-440d-816f-09669a31d3b2",
+        "title": "Normalized Load",
+        "attributes": {
+          "title": "Normalized Load",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-layer_0"
+            },
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-4c2406ac-f790-4c5d-9fb6-0f7110b8f243"
+            }
+          ],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "Average",
+              "showBar": false,
+              "trendlineLayerId": "4c2406ac-f790-4c5d-9fb6-0f7110b8f243",
+              "trendlineLayerType": "metricTrendline",
+              "trendlineTimeAccessor": "3e1d6c85-af28-4b1a-8701-a9f8f218e713",
+              "trendlineMetricAccessor": "8ce94bf2-b9f0-441f-84f4-e4292e748bb8"
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessorX0",
+                      "metric_formula_accessorX1",
+                      "metric_formula_accessorX2",
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessorX0": {
+                        "label": "Part of Memory free",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.memory.total",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX1": {
+                        "label": "Part of Memory free",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessorX2": {
+                        "label": "Part of Memory free",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "subtract",
+                            "args": [
+                              "metric_formula_accessorX0",
+                              "metric_formula_accessorX1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 67
+                            },
+                            "text": "max(system.memory.total) - average(system.memory.actual.used.bytes)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessorX0",
+                          "metric_formula_accessorX1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor": {
+                        "label": "Memory Free",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessorX2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "max(system.memory.total) - average(system.memory.actual.used.bytes)",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+                  },
+                  "4c2406ac-f790-4c5d-9fb6-0f7110b8f243": {
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                    "linkToLayers": [
+                      "layer_0"
+                    ],
+                    "columns": {
+                      "3e1d6c85-af28-4b1a-8701-a9f8f218e713": {
+                        "label": "@timestamp",
+                        "dataType": "date",
+                        "operationType": "date_histogram",
+                        "sourceField": "@timestamp",
+                        "isBucketed": true,
+                        "scale": "interval",
+                        "params": {
+                          "interval": "auto",
+                          "includeEmptyRows": true,
+                          "dropPartials": false
+                        }
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.memory.total",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "subtract",
+                            "args": [
+                              "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                              "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 67
+                            },
+                            "text": "max(system.memory.total) - average(system.memory.actual.used.bytes)"
+                          }
+                        },
+                        "references": [
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8": {
+                        "label": "Memory Free",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "max(system.memory.total) - average(system.memory.actual.used.bytes)",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "columnOrder": [
+                      "3e1d6c85-af28-4b1a-8701-a9f8f218e713",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X0",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X1",
+                      "8ce94bf2-b9f0-441f-84f4-e4292e748bb8X2"
+                    ],
+                    "sampling": 1,
+                    "ignoreGlobalFilters": false,
+                    "incompleteColumns": {}
+                  }
+                },
+                "currentIndexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0_trendline"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "hidePanelTitles": true,
+        "enhancements": {}
+      }
+    },
+    "736a1bd7-58e3-4a99-abe1-b532380e0e1c": {
+      "type": "lens",
+      "gridData": {
+        "x": 40,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "736a1bd7-58e3-4a99-abe1-b532380e0e1c"
+      },
+      "explicitInput": {
+        "id": "736a1bd7-58e3-4a99-abe1-b532380e0e1c",
+        "title": "Disk Usage",
+        "attributes": {
+          "title": "Disk Usage",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-layer_0"
+            },
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-9af3ce4f-a1c7-4401-97c0-8f019e9e870d"
+            }
+          ],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "Average",
+              "showBar": false,
+              "trendlineLayerId": "9af3ce4f-a1c7-4401-97c0-8f019e9e870d",
+              "trendlineLayerType": "metricTrendline",
+              "trendlineTimeAccessor": "58bb6149-d84b-49ce-a93a-53d26a2043d6",
+              "trendlineMetricAccessor": "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97f"
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessorX0",
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessorX0": {
+                        "label": "Part of Disk Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.filesystem.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor": {
+                        "label": "Disk Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessorX0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.filesystem.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+                  },
+                  "9af3ce4f-a1c7-4401-97c0-8f019e9e870d": {
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                    "linkToLayers": [
+                      "layer_0"
+                    ],
+                    "columns": {
+                      "58bb6149-d84b-49ce-a93a-53d26a2043d6": {
+                        "label": "@timestamp",
+                        "dataType": "date",
+                        "operationType": "date_histogram",
+                        "sourceField": "@timestamp",
+                        "isBucketed": true,
+                        "scale": "interval",
+                        "params": {
+                          "interval": "auto",
+                          "includeEmptyRows": true,
+                          "dropPartials": false
+                        }
+                      },
+                      "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97fX0": {
+                        "label": "Part of Disk Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.filesystem.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97f": {
+                        "label": "Disk Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97fX0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.filesystem.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "columnOrder": [
+                      "58bb6149-d84b-49ce-a93a-53d26a2043d6",
+                      "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97fX0",
+                      "e6ca6181-7e64-4efe-b2fe-aeb64e3bd97f"
+                    ],
+                    "sampling": 1,
+                    "ignoreGlobalFilters": false,
+                    "incompleteColumns": {}
+                  }
+                },
+                "currentIndexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0_trendline"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {},
+        "hidePanelTitles": true
+      }
+    },
+    "07e4891d-ed7d-476b-a1b2-f055ed9623ff": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 0,
+        "w": 8,
+        "h": 6,
+        "i": "07e4891d-ed7d-476b-a1b2-f055ed9623ff"
+      },
+      "explicitInput": {
+        "id": "07e4891d-ed7d-476b-a1b2-f055ed9623ff",
+        "title": "Memory Usage",
+        "attributes": {
+          "title": "Memory Usage",
+          "description": "",
+          "visualizationType": "lnsMetric",
+          "type": "lens",
+          "references": [
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-layer_0"
+            },
+            {
+              "type": "index-pattern",
+              "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+              "name": "indexpattern-datasource-layer-a0f73811-6912-4219-b00e-a875f1a96426"
+            }
+          ],
+          "state": {
+            "visualization": {
+              "layerId": "layer_0",
+              "layerType": "data",
+              "metricAccessor": "metric_formula_accessor",
+              "color": "#F1F4FA",
+              "subtitle": "Average",
+              "showBar": false,
+              "trendlineLayerId": "a0f73811-6912-4219-b00e-a875f1a96426",
+              "trendlineLayerType": "metricTrendline",
+              "trendlineTimeAccessor": "11238e67-baeb-41f4-aebf-ea90e431723a",
+              "trendlineMetricAccessor": "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5"
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "metric_formula_accessorX0",
+                      "metric_formula_accessor"
+                    ],
+                    "columns": {
+                      "metric_formula_accessorX0": {
+                        "label": "Part of Memory Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor": {
+                        "label": "Memory Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessorX0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.memory.actual.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+                  },
+                  "a0f73811-6912-4219-b00e-a875f1a96426": {
+                    "indexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                    "linkToLayers": [
+                      "layer_0"
+                    ],
+                    "columns": {
+                      "11238e67-baeb-41f4-aebf-ea90e431723a": {
+                        "label": "@timestamp",
+                        "dataType": "date",
+                        "operationType": "date_histogram",
+                        "sourceField": "@timestamp",
+                        "isBucketed": true,
+                        "scale": "interval",
+                        "params": {
+                          "interval": "auto",
+                          "includeEmptyRows": true,
+                          "dropPartials": false
+                        }
+                      },
+                      "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5X0": {
+                        "label": "Part of Memory Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5": {
+                        "label": "Memory Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5X0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.memory.actual.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      }
+                    },
+                    "columnOrder": [
+                      "11238e67-baeb-41f4-aebf-ea90e431723a",
+                      "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5X0",
+                      "cc8d6fed-7ad0-4aa4-9bdf-46526647dee5"
+                    ],
+                    "sampling": 1,
+                    "ignoreGlobalFilters": false,
+                    "incompleteColumns": {}
+                  }
+                },
+                "currentIndexPatternId": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6"
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0_trendline"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {},
+        "hidePanelTitles": true
+      }
+    },
+    "a21aa807-55ed-4b39-928c-57cf836373ba": {
+      "type": "hosts_table",
+      "gridData": {
+        "x": 0,
+        "y": 6,
+        "w": 48,
+        "h": 18,
+        "i": "a21aa807-55ed-4b39-928c-57cf836373ba"
+      },
+      "explicitInput": {
+        "id": "a21aa807-55ed-4b39-928c-57cf836373ba",
+        "enhancements": {}
+      }
+    },
+    "691b59a0-453c-4a31-853c-02ef3ab4b081": {
+      "type": "links",
+      "gridData": {
+        "x": 0,
+        "y": 24,
+        "w": 48,
+        "h": 2,
+        "i": "691b59a0-453c-4a31-853c-02ef3ab4b081"
+      },
+      "explicitInput": {
+        "id": "691b59a0-453c-4a31-853c-02ef3ab4b081",
+        "title": "Hosts links",
+        "disabledActions": [
+          "OPEN_FLYOUT_ADD_DRILLDOWN"
+        ],
+        "attributes": {
+          "links": [
+            {
+              "label": "Metrics",
+              "type": "externalLink",
+              "id": "e5addb82-5560-4d9f-824a-c135f52e021d",
+              "destination": "http://localhost:5601/app/metrics/hosts?tabId=metrics",
+              "options": {
+                "encodeUrl": false,
+                "openInNewTab": false
+              },
+              "order": 0
+            },
+            {
+              "label": "Logs",
+              "type": "externalLink",
+              "id": "62407dcd-e037-455d-b1bf-fefea0719faa",
+              "destination": "http://localhost:5601/app/metrics/hosts?tabId=logs",
+              "options": {
+                "encodeUrl": false,
+                "openInNewTab": false
+              },
+              "order": 1
+            },
+            {
+              "label": "Alerts",
+              "type": "externalLink",
+              "id": "b620d6be-dcfe-4390-ad6f-f456648157b3",
+              "destination": "http://localhost:5601/app/metrics/hosts?tabId=alerts",
+              "options": {
+                "encodeUrl": false,
+                "openInNewTab": false
+              },
+              "order": 2
+            }
+          ],
+          "layout": "horizontal"
+        },
+        "enhancements": {},
+        "hidePanelTitles": true
+      }
+    }
+  },
+  "title": "New hosts dashboard",
+  "tags": [],
+  "useMargins": true,
+  "syncColors": false,
+  "syncCursor": true,
+  "syncTooltips": false,
+  "hidePanelTitles": false,
+  "id": "6da5d2da-622d-4d2d-a105-7f41396633dc",
+  "timeRange": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "version": "1.0.0",
+  "executionContext": {
+    "type": "dashboard",
+    "description": "New hosts dashboard"
+  },
+  "controlGroupInput": {
+    "viewMode": "edit",
+    "id": "control_group_6da5d2da-622d-4d2d-a105-7f41396633dc",
+    "panels": {
+      "b38b88ad-ff00-45a1-ab8d-fe5cc77fed91": {
+        "type": "optionsListControl",
+        "order": 0,
+        "grow": false,
+        "width": "medium",
+        "explicitInput": {
+          "id": "b38b88ad-ff00-45a1-ab8d-fe5cc77fed91",
+          "fieldName": "host.os.platform",
+          "title": "Operating System",
+          "grow": false,
+          "width": "medium",
+          "searchTechnique": "wildcard",
+          "enhancements": {},
+          "dataViewId": "06fb290e-1f19-4a7e-b963-a5fabf653b8b"
+        }
+      },
+      "cf796337-1488-440d-ba8b-6159a01d0535": {
+        "type": "optionsListControl",
+        "order": 1,
+        "grow": false,
+        "width": "medium",
+        "explicitInput": {
+          "id": "cf796337-1488-440d-ba8b-6159a01d0535",
+          "fieldName": "cloud.provider",
+          "title": "Cloud Provider",
+          "grow": false,
+          "width": "medium",
+          "searchTechnique": "wildcard",
+          "enhancements": {},
+          "dataViewId": "06fb290e-1f19-4a7e-b963-a5fabf653b8b"
+        }
+      },
+      "6c901c42-79a9-4720-8975-91d70dd788b7": {
+        "type": "optionsListControl",
+        "order": 2,
+        "grow": false,
+        "width": "medium",
+        "explicitInput": {
+          "id": "6c901c42-79a9-4720-8975-91d70dd788b7",
+          "fieldName": "service.name",
+          "title": "Service Name",
+          "grow": false,
+          "width": "medium",
+          "searchTechnique": "wildcard",
+          "enhancements": {},
+          "dataViewId": "06fb290e-1f19-4a7e-b963-a5fabf653b8b"
+        }
+      }
+    },
+    "defaultControlWidth": "medium",
+    "defaultControlGrow": true,
+    "controlStyle": "oneLine",
+    "chainingSystem": "HIERARCHICAL",
+    "ignoreParentSettings": {
+      "ignoreFilters": false,
+      "ignoreQuery": false,
+      "ignoreTimerange": false,
+      "ignoreValidations": false
+    },
+    "timeRange": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "filters": [],
+    "query": {
+      "query": "",
+      "language": "kuery"
+    }
+  }
+}

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_table_react_embeddable.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/hosts_table_react_embeddable.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { AppMountParameters } from '@kbn/core-application-browser';
+import {
+  DefaultEmbeddableApi,
+  initializeReactEmbeddableTitles,
+  initializeReactEmbeddableUuid,
+  ReactEmbeddableFactory,
+  RegisterReactEmbeddable,
+  registerReactEmbeddableFactory,
+  useReactEmbeddableApiHandle,
+  useReactEmbeddableUnsavedChanges,
+} from '@kbn/embeddable-plugin/public';
+import React from 'react';
+import { CoreStart } from '@kbn/core/public';
+import { InfraPublicConfig } from '../../../../../common/plugin_config_types';
+import { PluginConfigProvider } from '../../../../containers/plugin_config_context';
+import { SourceProvider, useSourceContext } from '../../../../containers/metrics_source';
+import { InfraClientStartDeps } from '../../../../types';
+import { KibanaEnvContext } from '../../../../hooks/use_kibana';
+import { InfraClientStartExports } from '../../../..';
+import { CoreProviders } from '../../../../apps/common_providers';
+import { HostsTableProvider } from '../hooks/use_hosts_table';
+import { HostsViewProvider } from '../hooks/use_hosts_view';
+import { HostCountProvider } from '../hooks/use_host_count';
+import { HostsTable } from './hosts_table';
+import { UnifiedSearchProvider } from '../hooks/use_unified_search';
+import { MetricsDataViewProvider } from '../hooks/use_metrics_data_view';
+
+const HOSTS_TABLE_ID = 'hosts_table';
+
+interface HostsTableSerializedState {}
+
+type HostsTableApi = DefaultEmbeddableApi;
+
+interface Props {
+  core: CoreStart;
+  pluginStart: InfraClientStartExports;
+  plugins: InfraClientStartDeps;
+  theme$: AppMountParameters['theme$'];
+  kibanaEnvironment?: KibanaEnvContext;
+  pluginConfig: InfraPublicConfig;
+}
+
+export const registerHostsTableEmbeddable = ({
+  core,
+  pluginStart,
+  plugins,
+  theme$,
+  kibanaEnvironment,
+  pluginConfig,
+}: Props) => {
+  const hostsTableEmbeddableFactory: ReactEmbeddableFactory<
+    HostsTableSerializedState,
+    HostsTableApi
+  > = {
+    deserializeState: (state) => {
+      /**
+       * Here we can run migrations and inject references.
+       */
+      return state.rawState as HostsTableSerializedState;
+    },
+    getComponent: async (state, maybeId) => {
+      /**
+       * initialize state (source of truth)
+       */
+      const uuid = initializeReactEmbeddableUuid(maybeId);
+      const { titlesApi, titleComparators, serializeTitles } =
+        initializeReactEmbeddableTitles(state);
+
+      /**
+       * getComponent is async so you can async import the component or load a saved object here.
+       * the loading will be handed gracefully by the Presentation Container.
+       */
+
+      return RegisterReactEmbeddable((apiRef) => {
+        /**
+         * Unsaved changes logic is handled automatically by this hook. You only need to provide
+         * a subject, setter, and optional state comparator for each key in your state type.
+         */
+        const { unsavedChanges, resetUnsavedChanges } = useReactEmbeddableUnsavedChanges(
+          uuid,
+          hostsTableEmbeddableFactory,
+          titleComparators
+        );
+
+        /**
+         * Publish the API. This is what gets forwarded to the Actions framework, and to whatever the
+         * parent of this embeddable is.
+         */
+        useReactEmbeddableApiHandle(
+          {
+            ...titlesApi,
+            unsavedChanges,
+            resetUnsavedChanges,
+            serializeState: async () => {
+              return {
+                rawState: serializeTitles(),
+              };
+            },
+          },
+          apiRef,
+          uuid
+        );
+
+        return (
+          <CoreProviders
+            core={core}
+            pluginStart={pluginStart}
+            plugins={plugins}
+            theme$={theme$}
+            kibanaEnvironment={kibanaEnvironment}
+          >
+            <SourceProvider sourceId="default">
+              <PluginConfigProvider value={pluginConfig}>
+                <HostsTableComponent />
+              </PluginConfigProvider>
+            </SourceProvider>
+          </CoreProviders>
+        );
+      });
+    },
+  };
+
+  /**
+   * Register the defined Embeddable Factory - notice that this isn't defined
+   * on the plugin. Instead, it's a simple imported function. I.E to register an
+   * embeddable, you only need the embeddable plugin in your requiredBundles
+   */
+  registerReactEmbeddableFactory(HOSTS_TABLE_ID, hostsTableEmbeddableFactory);
+};
+
+const HostsTableComponent: React.FC = () => {
+  const { source } = useSourceContext();
+
+  if (!source) return null;
+
+  return (
+    <MetricsDataViewProvider metricAlias={source.configuration.metricAlias}>
+      <UnifiedSearchProvider>
+        <HostsViewProvider>
+          <HostsTableProvider>
+            <HostCountProvider>
+              <HostsTable />
+            </HostCountProvider>
+          </HostsTableProvider>
+        </HostsViewProvider>
+      </UnifiedSearchProvider>
+    </MetricsDataViewProvider>
+  );
+};

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/search_bar/unified_search_bar.tsx
@@ -13,7 +13,6 @@ import { css } from '@emotion/react';
 import { useKibanaHeader } from '../../../../../hooks/use_kibana_header';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import { useUnifiedSearchContext } from '../../hooks/use_unified_search';
-import { ControlsContent } from './controls_content';
 import { useMetricsDataViewContext } from '../../hooks/use_metrics_data_view';
 import { LimitOptions } from './limit_options';
 import { HostLimitOptions } from '../../types';
@@ -72,7 +71,7 @@ export const UnifiedSearchBar = () => {
         </EuiFlexItem>
         <EuiFlexItem>
           <EuiFlexGroup direction="row" alignItems="center" wrap={false} gutterSize="s">
-            <EuiFlexItem>
+            {/* <EuiFlexItem>
               <ControlsContent
                 timeRange={searchCriteria.dateRange}
                 dataView={dataView}
@@ -80,7 +79,7 @@ export const UnifiedSearchBar = () => {
                 filters={searchCriteria.filters}
                 onFiltersChange={onPanelFiltersChange}
               />
-            </EuiFlexItem>
+            </EuiFlexItem> */}
             <EuiFlexItem grow={false}>
               <LimitOptions
                 limit={searchCriteria.limit as HostLimitOptions}
@@ -113,7 +112,6 @@ const StickyContainer = ({ children }: { children: React.ReactNode }) => {
         background: ${euiTheme.colors.emptyShade};
         padding: ${euiTheme.size.l} ${euiTheme.size.l} 0px;
         margin: -${euiTheme.size.l} -${euiTheme.size.l} 0px;
-        min-height: calc(${euiTheme.size.xxxl} * 2);
       `}
     >
       {children}

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/entry_title.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/table/entry_title.tsx
@@ -6,11 +6,11 @@
  */
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiLink, EuiToolTip } from '@elastic/eui';
-import { useLinkProps } from '@kbn/observability-shared-plugin/public';
+// import { useLinkProps } from '@kbn/observability-shared-plugin/public';
 import { CloudProviderIcon } from '@kbn/custom-icons';
-import { useNodeDetailsRedirect } from '../../../../link_to';
+// import { useNodeDetailsRedirect } from '../../../../link_to';
 import type { HostNodeRow } from '../../hooks/use_hosts_table';
-import { useUnifiedSearchContext } from '../../hooks/use_unified_search';
+// import { useUnifiedSearchContext } from '../../hooks/use_unified_search';
 
 interface EntryTitleProps {
   onClick: () => void;
@@ -19,20 +19,22 @@ interface EntryTitleProps {
 
 export const EntryTitle = ({ onClick, title }: EntryTitleProps) => {
   const { name, cloudProvider } = title;
-  const { getNodeDetailUrl } = useNodeDetailsRedirect();
-  const { parsedDateRange } = useUnifiedSearchContext();
+  // const { getNodeDetailUrl } = useNodeDetailsRedirect();
+  // const { parsedDateRange } = useUnifiedSearchContext();
 
-  const link = useLinkProps({
-    ...getNodeDetailUrl({
-      assetId: name,
-      assetType: 'host',
-      search: {
-        from: parsedDateRange?.from ? new Date(parsedDateRange?.from).getTime() : undefined,
-        to: parsedDateRange?.to ? new Date(parsedDateRange.to).getTime() : undefined,
-        name,
-      },
-    }),
-  });
+  // const link = useLinkProps({
+  //   ...getNodeDetailUrl({
+  //     assetId: name,
+  //     assetType: 'host',
+  //     search: {
+  //       from: parsedDateRange?.from ? new Date(parsedDateRange?.from).getTime() : undefined,
+  //       to: parsedDateRange?.to ? new Date(parsedDateRange.to).getTime() : undefined,
+  //       name,
+  //     },
+  //   }),
+  // });
+
+  const link = {};
 
   const providerName = cloudProvider ?? 'Unknown';
 

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_dashboard.json
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/metrics/metrics_dashboard.json
@@ -1,0 +1,2608 @@
+{
+  "viewMode": "view",
+  "timeRestore": false,
+  "query": {
+    "query": "",
+    "language": "kuery"
+  },
+  "description": "",
+  "filters": [],
+  "panels": {
+    "fbc75a8a-c116-466d-af1c-78a79394418d": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 12,
+        "i": "fbc75a8a-c116-466d-af1c-78a79394418d"
+      },
+      "explicitInput": {
+        "id": "fbc75a8a-c116-466d-af1c-78a79394418d",
+        "attributes": {
+          "title": "CPU Usage",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "custom",
+                "lowerBound": 0,
+                "upperBound": 1
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0X2",
+                      "metric_formula_accessor0_0X3",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.user.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.cpu.system.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X2": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.cpu.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X3": {
+                        "label": "Part of CPU Usage",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              {
+                                "type": "function",
+                                "name": "add",
+                                "args": [
+                                  "metric_formula_accessor0_0X0",
+                                  "metric_formula_accessor0_0X1"
+                                ],
+                                "location": {
+                                  "min": 1,
+                                  "max": 62
+                                },
+                                "text": "average(system.cpu.user.pct) + average(system.cpu.system.pct)"
+                              },
+                              "metric_formula_accessor0_0X2"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 87
+                            },
+                            "text": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessor0_0X0",
+                          "metric_formula_accessor0_0X1",
+                          "metric_formula_accessor0_0X2"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "CPU Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X3"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "(average(system.cpu.user.pct) + average(system.cpu.system.pct)) / max(system.cpu.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "cec0c22a-fd1b-4b7e-a18c-f25130e12717": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 0,
+        "w": 24,
+        "h": 12,
+        "i": "cec0c22a-fd1b-4b7e-a18c-f25130e12717"
+      },
+      "explicitInput": {
+        "id": "cec0c22a-fd1b-4b7e-a18c-f25130e12717",
+        "attributes": {
+          "title": "Normalized Load",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                },
+                {
+                  "layerId": "layer_1",
+                  "layerType": "referenceLine",
+                  "accessors": [
+                    "metric_formula_accessor1_0"
+                  ],
+                  "yConfig": [
+                    {
+                      "forAccessor": "metric_formula_accessor1_0",
+                      "axisMode": "left"
+                    }
+                  ]
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0X2",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.load.1",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.load.cores",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X2": {
+                        "label": "Part of Normalized Load",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              "metric_formula_accessor0_0X0",
+                              "metric_formula_accessor0_0X1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 47
+                            },
+                            "text": "average(system.load.1) / max(system.load.cores)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessor0_0X0",
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Normalized Load",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.load.1) / max(system.load.cores)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  },
+                  "layer_1": {
+                    "columnOrder": [
+                      "metric_formula_accessor1_0X0",
+                      "metric_formula_accessor1_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor1_0X0": {
+                        "label": "Part of 1",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": 1
+                        },
+                        "references": [],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor1_0": {
+                        "label": "1",
+                        "customLabel": false,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor1_0X0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "1",
+                          "isFormulaBroken": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              },
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_1"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "e1d14f9f-e231-4d99-9d5a-fbec94b7dd31": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 12,
+        "w": 24,
+        "h": 12,
+        "i": "e1d14f9f-e231-4d99-9d5a-fbec94b7dd31"
+      },
+      "explicitInput": {
+        "id": "e1d14f9f-e231-4d99-9d5a-fbec94b7dd31",
+        "attributes": {
+          "title": "Memory Usage",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Memory Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Memory Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.memory.actual.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "8161e6ff-ac9d-4bff-a34a-1abd717fa419": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 12,
+        "w": 24,
+        "h": 12,
+        "i": "8161e6ff-ac9d-4bff-a34a-1abd717fa419"
+      },
+      "explicitInput": {
+        "id": "8161e6ff-ac9d-4bff-a34a-1abd717fa419",
+        "attributes": {
+          "title": "Memory Free",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0X2",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.memory.total",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.memory.actual.used.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X2": {
+                        "label": "Part of Memory Free",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "subtract",
+                            "args": [
+                              "metric_formula_accessor0_0X0",
+                              "metric_formula_accessor0_0X1"
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 67
+                            },
+                            "text": "max(system.memory.total) - average(system.memory.actual.used.bytes)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessor0_0X0",
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Memory Free",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X2"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "max(system.memory.total) - average(system.memory.actual.used.bytes)",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "f595c77e-28fa-4438-9687-9b0447c9bcfe": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 12,
+        "i": "f595c77e-28fa-4438-9687-9b0447c9bcfe"
+      },
+      "explicitInput": {
+        "id": "f595c77e-28fa-4438-9687-9b0447c9bcfe",
+        "attributes": {
+          "title": "Disk Usage",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "custom",
+                "lowerBound": 0,
+                "upperBound": 1
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Usage",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.filesystem.used.pct",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Usage",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.filesystem.used.pct)",
+                          "format": {
+                            "id": "percent",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "77f0cf09-d572-4a60-9ae9-16efff11ba38": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 24,
+        "w": 24,
+        "h": 12,
+        "i": "77f0cf09-d572-4a60-9ae9-16efff11ba38"
+      },
+      "explicitInput": {
+        "id": "77f0cf09-d572-4a60-9ae9-16efff11ba38",
+        "attributes": {
+          "title": "Disk Space Available",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Space Available",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "system.filesystem.free",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Space Available",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "isBucketed": false,
+                        "params": {
+                          "formula": "average(system.filesystem.free)",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "99c9313f-2861-49fb-9fa4-98920dbcc6ef": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 36,
+        "w": 24,
+        "h": 12,
+        "i": "99c9313f-2861-49fb-9fa4-98920dbcc6ef"
+      },
+      "explicitInput": {
+        "id": "99c9313f-2861-49fb-9fa4-98920dbcc6ef",
+        "attributes": {
+          "title": "Disk Read IOPS",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Read IOPS",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.diskio.read.count",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Disk Read IOPS",
+                        "dataType": "number",
+                        "operationType": "counter_rate",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "timeScale": "s",
+                        "filter": {
+                          "query": "system.diskio.read.count: *",
+                          "language": "kuery"
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Read IOPS",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "counter_rate(max(system.diskio.read.count), kql='system.diskio.read.count: *')",
+                          "format": {
+                            "id": "number",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "341811e9-1cfe-4f2c-b188-a8fadc8be4c0": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 36,
+        "w": 24,
+        "h": 12,
+        "i": "341811e9-1cfe-4f2c-b188-a8fadc8be4c0"
+      },
+      "explicitInput": {
+        "id": "341811e9-1cfe-4f2c-b188-a8fadc8be4c0",
+        "attributes": {
+          "title": "Disk Write IOPS",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Write IOPS",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.diskio.write.count",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Disk Write IOPS",
+                        "dataType": "number",
+                        "operationType": "counter_rate",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "timeScale": "s",
+                        "filter": {
+                          "query": "system.diskio.write.count: *",
+                          "language": "kuery"
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Write IOPS",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "counter_rate(max(system.diskio.write.count), kql='system.diskio.write.count: *')",
+                          "format": {
+                            "id": "number",
+                            "params": {
+                              "decimals": 0
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "44d8e0e1-fe39-4abb-be4e-cc65d9504ab0": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 48,
+        "w": 24,
+        "h": 12,
+        "i": "44d8e0e1-fe39-4abb-be4e-cc65d9504ab0"
+      },
+      "explicitInput": {
+        "id": "44d8e0e1-fe39-4abb-be4e-cc65d9504ab0",
+        "attributes": {
+          "title": "Disk Read Throughput",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Read Throughput",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.diskio.read.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Disk Read Throughput",
+                        "dataType": "number",
+                        "operationType": "counter_rate",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "timeScale": "s",
+                        "filter": {
+                          "query": "system.diskio.read.bytes: *",
+                          "language": "kuery"
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Read Throughput",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "counter_rate(max(system.diskio.read.bytes), kql='system.diskio.read.bytes: *')",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "8cc3b7af-88ac-414f-9680-43c8a423ff26": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 48,
+        "w": 24,
+        "h": 12,
+        "i": "8cc3b7af-88ac-414f-9680-43c8a423ff26"
+      },
+      "explicitInput": {
+        "id": "8cc3b7af-88ac-414f-9680-43c8a423ff26",
+        "attributes": {
+          "title": "Disk Write Throughput",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Disk Write Throughput",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "system.diskio.write.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Disk Write Throughput",
+                        "dataType": "number",
+                        "operationType": "counter_rate",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "references": [
+                          "metric_formula_accessor0_0X0"
+                        ],
+                        "timeScale": "s",
+                        "filter": {
+                          "query": "system.diskio.write.bytes: *",
+                          "language": "kuery"
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Disk Write Throughput",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "counter_rate(max(system.diskio.write.bytes), kql='system.diskio.write.bytes: *')",
+                          "format": {
+                            "id": "bytes",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "620fd254-25d2-45ca-8fe7-035c4d97c241": {
+      "type": "lens",
+      "gridData": {
+        "x": 0,
+        "y": 60,
+        "w": 24,
+        "h": 13,
+        "i": "620fd254-25d2-45ca-8fe7-035c4d97c241"
+      },
+      "explicitInput": {
+        "id": "620fd254-25d2-45ca-8fe7-035c4d97c241",
+        "attributes": {
+          "title": "Network Inbound (RX)",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0X2",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Network Inbound (RX)",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "host.network.ingress.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Network Inbound (RX)",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "metricset.period",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "filter": {
+                          "query": "host.network.ingress.bytes: *",
+                          "language": "kuery"
+                        },
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X2": {
+                        "label": "Part of Network Inbound (RX)",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              {
+                                "type": "function",
+                                "name": "multiply",
+                                "args": [
+                                  "metric_formula_accessor0_0X0",
+                                  8
+                                ]
+                              },
+                              {
+                                "type": "function",
+                                "name": "divide",
+                                "args": [
+                                  "metric_formula_accessor0_0X1",
+                                  1000
+                                ],
+                                "location": {
+                                  "min": 43,
+                                  "max": 108
+                                },
+                                "text": "max(metricset.period, kql='host.network.ingress.bytes: *') / 1000"
+                              }
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 109
+                            },
+                            "text": "average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessor0_0X0",
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Network Inbound (RX)",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X2"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "average(host.network.ingress.bytes) * 8 / (max(metricset.period, kql='host.network.ingress.bytes: *') / 1000)",
+                          "format": {
+                            "id": "bits",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    },
+    "803c702e-d2da-481f-9501-74419318956e": {
+      "type": "lens",
+      "gridData": {
+        "x": 24,
+        "y": 60,
+        "w": 24,
+        "h": 13,
+        "i": "803c702e-d2da-481f-9501-74419318956e"
+      },
+      "explicitInput": {
+        "id": "803c702e-d2da-481f-9501-74419318956e",
+        "attributes": {
+          "title": "Network Outbound (TX)",
+          "description": "",
+          "visualizationType": "lnsXY",
+          "type": "lens",
+          "references": [],
+          "state": {
+            "visualization": {
+              "axisTitlesVisibilitySettings": {
+                "x": false,
+                "yLeft": false,
+                "yRight": true
+              },
+              "legend": {
+                "isVisible": false,
+                "position": "bottom"
+              },
+              "hideEndzones": true,
+              "preferredSeriesType": "line",
+              "valueLabels": "hide",
+              "emphasizeFitting": false,
+              "fittingFunction": "Linear",
+              "yLeftExtent": {
+                "mode": "full"
+              },
+              "tickLabelsVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "labelsOrientation": {
+                "x": 0,
+                "yLeft": 0,
+                "yRight": 0
+              },
+              "gridlinesVisibilitySettings": {
+                "x": true,
+                "yLeft": true,
+                "yRight": true
+              },
+              "layers": [
+                {
+                  "layerId": "layer_0",
+                  "layerType": "data",
+                  "xAccessor": "x_metric_formula_accessor0",
+                  "splitAccessor": "y_metric_formula_accessor0",
+                  "accessors": [
+                    "metric_formula_accessor0_0"
+                  ],
+                  "seriesType": "line"
+                }
+              ]
+            },
+            "query": {
+              "language": "kuery",
+              "query": ""
+            },
+            "filters": [],
+            "datasourceStates": {
+              "formBased": {
+                "layers": {
+                  "layer_0": {
+                    "columnOrder": [
+                      "y_metric_formula_accessor0",
+                      "x_metric_formula_accessor0",
+                      "metric_formula_accessor0_0X0",
+                      "metric_formula_accessor0_0X1",
+                      "metric_formula_accessor0_0X2",
+                      "metric_formula_accessor0_0"
+                    ],
+                    "columns": {
+                      "metric_formula_accessor0_0X0": {
+                        "label": "Part of Network Outbound (TX)",
+                        "dataType": "number",
+                        "operationType": "average",
+                        "sourceField": "host.network.egress.bytes",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X1": {
+                        "label": "Part of Network Outbound (TX)",
+                        "dataType": "number",
+                        "operationType": "max",
+                        "sourceField": "metricset.period",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "filter": {
+                          "query": "host.network.egress.bytes: *",
+                          "language": "kuery"
+                        },
+                        "params": {
+                          "emptyAsNull": false
+                        },
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0X2": {
+                        "label": "Part of Network Outbound (TX)",
+                        "dataType": "number",
+                        "operationType": "math",
+                        "isBucketed": false,
+                        "scale": "ratio",
+                        "params": {
+                          "tinymathAst": {
+                            "type": "function",
+                            "name": "divide",
+                            "args": [
+                              {
+                                "type": "function",
+                                "name": "multiply",
+                                "args": [
+                                  "metric_formula_accessor0_0X0",
+                                  8
+                                ]
+                              },
+                              {
+                                "type": "function",
+                                "name": "divide",
+                                "args": [
+                                  "metric_formula_accessor0_0X1",
+                                  1000
+                                ],
+                                "location": {
+                                  "min": 42,
+                                  "max": 106
+                                },
+                                "text": "max(metricset.period, kql='host.network.egress.bytes: *') / 1000"
+                              }
+                            ],
+                            "location": {
+                              "min": 0,
+                              "max": 107
+                            },
+                            "text": "average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)"
+                          }
+                        },
+                        "references": [
+                          "metric_formula_accessor0_0X0",
+                          "metric_formula_accessor0_0X1"
+                        ],
+                        "customLabel": true
+                      },
+                      "metric_formula_accessor0_0": {
+                        "label": "Network Outbound (TX)",
+                        "customLabel": true,
+                        "operationType": "formula",
+                        "dataType": "number",
+                        "references": [
+                          "metric_formula_accessor0_0X2"
+                        ],
+                        "isBucketed": false,
+                        "timeScale": "s",
+                        "params": {
+                          "formula": "average(host.network.egress.bytes) * 8 / (max(metricset.period, kql='host.network.egress.bytes: *') / 1000)",
+                          "format": {
+                            "id": "bits",
+                            "params": {
+                              "decimals": 1
+                            }
+                          },
+                          "isFormulaBroken": false
+                        }
+                      },
+                      "x_metric_formula_accessor0": {
+                        "dataType": "date",
+                        "isBucketed": true,
+                        "label": "@timestamp",
+                        "operationType": "date_histogram",
+                        "scale": "interval",
+                        "sourceField": "@timestamp",
+                        "params": {
+                          "interval": "auto"
+                        }
+                      },
+                      "y_metric_formula_accessor0": {
+                        "label": "Top 20 values of host.name",
+                        "dataType": "string",
+                        "operationType": "terms",
+                        "scale": "ordinal",
+                        "sourceField": "host.name",
+                        "isBucketed": true,
+                        "params": {
+                          "size": 20,
+                          "orderBy": {
+                            "type": "alphabetical",
+                            "fallback": false
+                          },
+                          "orderDirection": "asc",
+                          "otherBucket": false,
+                          "missingBucket": false,
+                          "parentFormat": {
+                            "id": "terms"
+                          },
+                          "include": [],
+                          "exclude": [],
+                          "includeIsRegex": false,
+                          "excludeIsRegex": false
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "internalReferences": [
+              {
+                "type": "index-pattern",
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "name": "indexpattern-datasource-layer-layer_0"
+              }
+            ],
+            "adHocDataViews": {
+              "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6": {
+                "id": "infra_metrics_8bf7e99f-ca01-5a18-b70d-573d73a17bb6",
+                "title": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "timeFieldName": "@timestamp",
+                "sourceFilters": [],
+                "fieldFormats": {},
+                "runtimeFieldMap": {},
+                "fieldAttrs": {},
+                "allowNoIndex": false,
+                "name": "remote_cluster:metricbeat-*,metricbeat-*,remote_cluster:metrics-*,metrics-*",
+                "allowHidden": false
+              }
+            }
+          }
+        },
+        "enhancements": {}
+      }
+    }
+  },
+  "title": "Metrics dashboard",
+  "tags": [],
+  "useMargins": true,
+  "syncColors": false,
+  "syncCursor": true,
+  "syncTooltips": false,
+  "hidePanelTitles": false,
+  "id": "76c27ed3-4bc0-4da1-94bf-a39326e48775",
+  "timeRange": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "version": "1.0.0",
+  "executionContext": {
+    "type": "dashboard",
+    "description": "metrics dashboard"
+  },
+  "controlGroupInput": {
+    "viewMode": "edit",
+    "id": "control_group_76c27ed3-4bc0-4da1-94bf-a39326e48775",
+    "panels": {},
+    "defaultControlWidth": "medium",
+    "defaultControlGrow": true,
+    "controlStyle": "oneLine",
+    "chainingSystem": "HIERARCHICAL",
+    "ignoreParentSettings": {
+      "ignoreFilters": false,
+      "ignoreQuery": false,
+      "ignoreTimerange": false,
+      "ignoreValidations": false
+    },
+    "timeRange": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "filters": [],
+    "query": {
+      "query": "",
+      "language": "kuery"
+    }
+  }
+}

--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/tabs.tsx
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/components/tabs/tabs.tsx
@@ -45,27 +45,27 @@ export const Tabs = () => {
   const [selectedTabId, setSelectedTabId] = useTabId(tabs[0].id);
   // This map allow to keep track of which tabs content have been rendered the first time.
   // We need it in order to load a tab content only if it gets clicked, and then keep it in the DOM for performance improvement.
-  const renderedTabsSet = useLazyRef(() => new Set([selectedTabId]));
+  const renderedTabsSet = useLazyRef(() => new Set(['alerts', 'logs', 'metrics']));
 
-  const tabEntries = tabs.map((tab, index) => (
-    <EuiTab
-      {...tab}
-      key={index}
-      onClick={() => {
-        renderedTabsSet.current.add(tab.id); // On a tab click, mark the tab content as allowed to be rendered
-        setSelectedTabId(tab.id);
-      }}
-      isSelected={tab.id === selectedTabId}
-      append={tab.append}
-    >
-      {tab.name}
-    </EuiTab>
-  ));
+  // const tabEntries = tabs.map((tab, index) => (
+  //   <EuiTab
+  //     {...tab}
+  //     key={index}
+  //     onClick={() => {
+  //       renderedTabsSet.current.add(tab.id); // On a tab click, mark the tab content as allowed to be rendered
+  //       setSelectedTabId(tab.id);
+  //     }}
+  //     isSelected={tab.id === selectedTabId}
+  //     append={tab.append}
+  //   >
+  //     {tab.name}
+  //   </EuiTab>
+  // ));
 
   return (
     <>
-      <EuiTabs>{tabEntries}</EuiTabs>
-      <EuiSpacer />
+      {/* <EuiTabs>{tabEntries}</EuiTabs>
+      <EuiSpacer /> */}
       {renderedTabsSet.current.has(TabIds.METRICS) && (
         <div hidden={selectedTabId !== TabIds.METRICS}>
           <MetricsGrid />

--- a/x-pack/plugins/observability_solution/infra/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/infra/public/plugin.ts
@@ -44,6 +44,8 @@ import type {
   InfraClientStartExports,
 } from './types';
 import { getLogsHasDataFetcher, getLogsOverviewDataFetcher } from './utils/logs_overview_fetchers';
+import { registerHostsTableEmbeddable } from './pages/metrics/hosts/components/hosts_table_react_embeddable';
+import { registerCreateHostsTableAction } from './pages/metrics/hosts/components/create_hosts_table_action';
 
 export class Plugin implements InfraClientPluginClass {
   public config: InfraPublicConfig;
@@ -393,6 +395,16 @@ export class Plugin implements InfraClientPluginClass {
       telemetry,
       locators: this.locators!,
     };
+
+    registerHostsTableEmbeddable({
+      core,
+      pluginStart: startContract,
+      plugins,
+      theme$: core.theme.theme$,
+      pluginConfig: this.config,
+    });
+
+    registerCreateHostsTableAction(plugins.uiActions);
 
     return startContract;
   }


### PR DESCRIPTION
## Summary

Related to https://github.com/elastic/kibana/issues/175326

This is a POC for embedding portable dashboards on the O11y Hosts page.

<img width="1279" alt="Screenshot 2024-02-21 at 11 46 57 AM" src="https://github.com/elastic/kibana/assets/1697105/09dd0c4f-302c-4ef0-8825-4c4051a586b3">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
