### PR TITLE
[Controls] Add back support for `key_as_string`

### DIFF
--- a/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.test.ts
+++ b/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.test.ts
@@ -88,7 +88,7 @@ describe('options list fetch all suggestions query', () => {
   });
 
   describe('suggestion parsing', () => {
-    test('key is already a string', () => {
+    test('test parsing for number field', () => {
       const optionsListRequestBodyMock: OptionsListRequestBody = {
         size: 10,
         fieldName: 'bytes',
@@ -141,7 +141,7 @@ describe('options list fetch all suggestions query', () => {
       });
     });
 
-    test('key is not a string - boolean field', () => {
+    test('test parsing for boolean field', () => {
       const optionsListRequestBodyMock: OptionsListRequestBody = {
         size: 10,
         fieldName: 'cancelled',
@@ -189,6 +189,59 @@ describe('options list fetch all suggestions query', () => {
           { value: 'true', docCount: 46 },
         ],
         totalCardinality: 2,
+      });
+    });
+
+    test('test parsing for date field', () => {
+      const optionsListRequestBodyMock: OptionsListRequestBody = {
+        size: 10,
+        fieldName: '@timestamp',
+        allowExpensiveQueries: true,
+        fieldSpec: {
+          type: 'date',
+        } as unknown as FieldSpec,
+        sort: {
+          by: '_key',
+          direction: 'desc',
+        },
+      };
+      const aggregationBuilder = getAllSuggestionsAggregationBuilder();
+      const searchResponseMock = {
+        hits: {
+          total: 10,
+          max_score: 10,
+          hits: [],
+        },
+        took: 10,
+        timed_out: false,
+        _shards: {
+          failed: 0,
+          successful: 1,
+          total: 1,
+          skipped: 0,
+        },
+        aggregations: {
+          suggestions: {
+            buckets: [
+              { doc_count: 5, key: 1707810859000, key_as_string: 'Feb 13, 2024 @ 00:54:19.000' },
+              { doc_count: 4, key: 1707728532000, key_as_string: 'Feb 12, 2024 @ 02:02:12.000' },
+              { doc_count: 2, key: 1707216874000, key_as_string: 'Feb 6, 2024 @ 03:54:34.000' },
+            ],
+          },
+          unique_terms: {
+            value: 3,
+          },
+        },
+      };
+
+      const parsed = aggregationBuilder.parse(searchResponseMock, optionsListRequestBodyMock);
+      expect(parsed).toMatchObject({
+        suggestions: [
+          { value: 1707810859000, docCount: 5 },
+          { value: 1707728532000, docCount: 4 },
+          { value: 1707216874000, docCount: 2 },
+        ],
+        totalCardinality: 3,
       });
     });
   });

--- a/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.ts
+++ b/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.ts
@@ -72,7 +72,10 @@ const allSuggestionsAggregationBuilder: OptionsListSuggestionAggregationBuilder 
       rawEsResult,
       `aggregations.${subTypeNested ? 'nestedSuggestions.suggestions' : 'suggestions'}.buckets`
     )?.reduce((acc: OptionsListSuggestions, suggestion: EsBucket) => {
-      acc.push({ value: suggestion.key, docCount: suggestion.doc_count });
+      acc.push({
+        value: suggestion.key_as_string ? suggestion.key_as_string : suggestion.key,
+        docCount: suggestion.doc_count,
+      });
       return acc;
     }, []);
     return {

--- a/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.ts
+++ b/src/plugins/controls/server/options_list/suggestion_queries/options_list_all_suggestions.ts
@@ -73,7 +73,10 @@ const allSuggestionsAggregationBuilder: OptionsListSuggestionAggregationBuilder 
       `aggregations.${subTypeNested ? 'nestedSuggestions.suggestions' : 'suggestions'}.buckets`
     )?.reduce((acc: OptionsListSuggestions, suggestion: EsBucket) => {
       acc.push({
-        value: suggestion.key_as_string ? suggestion.key_as_string : suggestion.key,
+        value:
+          fieldSpec?.type === 'boolean' && suggestion.key_as_string
+            ? suggestion.key_as_string
+            : suggestion.key,
         docCount: suggestion.doc_count,
       });
       return acc;

--- a/src/plugins/controls/server/options_list/types.ts
+++ b/src/plugins/controls/server/options_list/types.ts
@@ -13,7 +13,8 @@ import {
 } from '../../common/options_list/types';
 
 export interface EsBucket {
-  key: string;
+  key: any;
+  key_as_string?: string;
   doc_count: number;
 }
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/176645

## Summary

This is PR fixes a regression caused by https://github.com/elastic/kibana/pull/172106 - specifically, in the major refactor of the options list queries, I accidentally dropped support for the `key_as_string` key in the ES response. This broke `boolean` fields because, in the ES response, the `key` is the numeric representation of booleans (`0 / 1`) while `key_as_string` is the string representation `"false" / "true"` - this caused an error to be thrown when selections were included in the fetch request because we began storing **selections** as `0 / 1` due to this but the ES client expected only `"false" / "true"`.

This PR fixes this by re-introducing support for `key_as_string`, so boolean selections are once again stored as `"false" / "true"`.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
