### PR TITLE
[Security Solution] Make sure we do not silently delete the output directory on running mappings_generator script

### DIFF
--- a/x-pack/plugins/security_solution/scripts/mappings/README.md
+++ b/x-pack/plugins/security_solution/scripts/mappings/README.md
@@ -24,6 +24,7 @@ Available attributes:
 * `--unmappedRate` (*required*): the percentage of unmapped fields in each index (value ranges from 0.0 to 1.0)
 * `--buckets` (*optional, default value is 1*): it is possible to split the generated indices mappings into the smaller chunks
 * `--outputDirectory` (*required*): the output folder
+* `--purgeOutputDirectory` (*optional, default value is false*): the flag indicating whether we should purge output folder before generating new mappings
 
 ### Load all generated buckets generated via previous command
 

--- a/x-pack/plugins/security_solution/scripts/mappings/mappings_generator_script.ts
+++ b/x-pack/plugins/security_solution/scripts/mappings/mappings_generator_script.ts
@@ -64,14 +64,17 @@ const generateIndices = (
   indexPrefix: string,
   fieldsCount: number,
   numberOfMappedFieldsPerIndex: number,
-  numberOfIndexBuckets: number
+  numberOfIndexBuckets: number,
+  purgeOutputDirectory: boolean
 ) => {
   const absoluteOutputDir = path.resolve(outputDirectory);
 
-  // Delete output directory if exists
-  console.log(`Deleting directory: ${absoluteOutputDir}`);
-  if (fs.existsSync(absoluteOutputDir)) {
-    fs.rmSync(absoluteOutputDir, { recursive: true, force: true });
+  if (purgeOutputDirectory) {
+    // Delete output directory if exists
+    console.log(`Deleting directory: ${absoluteOutputDir}`);
+    if (fs.existsSync(absoluteOutputDir)) {
+      fs.rmSync(absoluteOutputDir, { recursive: true, force: true });
+    }
   }
 
   // Create output directory if needed
@@ -138,6 +141,15 @@ const main = () => {
       type: 'string',
       description: 'The name of the directory to save generated mappings to',
     })
+    .option('purgeOutputDirectory', {
+      alias: 'p',
+      demandOption: false,
+      type: 'boolean',
+      default: false,
+      description:
+        'Indicates whether we should purge existing output directory before running main script (default is false)',
+    })
+
     .check(({ unmappedRate }) => {
       if (unmappedRate < 0.0 || unmappedRate > 1.0) {
         throw new Error('--unmappedRate can only be in range [0.0, 1.0]');
@@ -147,7 +159,15 @@ const main = () => {
     })
     .help();
 
-  const { fieldsCount, indexCount, indexPrefix, unmappedRate, buckets, outputDirectory } = argv;
+  const {
+    fieldsCount,
+    indexCount,
+    indexPrefix,
+    unmappedRate,
+    buckets,
+    outputDirectory,
+    purgeOutputDirectory,
+  } = argv;
   const numberOfMappedFieldsPerIndex = Math.max(Math.floor(fieldsCount * (1.0 - unmappedRate)), 1);
   const numberOfIndexBuckets = Math.max(1, Math.min(buckets, indexCount));
 
@@ -157,7 +177,8 @@ const main = () => {
     indexPrefix,
     fieldsCount,
     numberOfMappedFieldsPerIndex,
-    numberOfIndexBuckets
+    numberOfIndexBuckets,
+    purgeOutputDirectory
   );
 };
 


### PR DESCRIPTION
## Summary

@kqualters-elastic discovered hard way that mappings generator silently deletes output folder. To avoid this script behaviour in future we decided add an explicit option to indicate willing to purge the output directory before generating new mappings.

The new option `--purgeOutputDirectory` is optional and has `false` as a default value. The alias for this option is `-p`.