### PR TITLE
[Infra] Fix Hosts View KPI order

### DIFF
--- a/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/dashboards/kpi.ts
+++ b/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/dashboards/kpi.ts
@@ -23,7 +23,7 @@ export const kpi = {
   }) => {
     const { cpuUsage, diskUsage, memoryUsage, normalizedLoad1m } = createBasicCharts({
       chartType: 'metric',
-      fromFormulas: ['cpuUsage', 'diskUsage', 'memoryUsage', 'normalizedLoad1m'],
+      fromFormulas: ['cpuUsage', 'normalizedLoad1m', 'memoryUsage', 'diskUsage'],
       chartConfig: {
         trendLine: true,
         subtitle: options?.subtitle ?? AVERAGE,
@@ -33,7 +33,7 @@ export const kpi = {
     });
 
     return createDashboardModel({
-      charts: [cpuUsage, diskUsage, memoryUsage, normalizedLoad1m].map((p) => ({
+      charts: [cpuUsage, normalizedLoad1m, memoryUsage, diskUsage].map((p) => ({
         ...p,
         decimals: 1,
       })),


### PR DESCRIPTION
closes [176898](https://github.com/elastic/kibana/issues/176898)

## Summary

Fixes KPI order

<img width="1467" alt="image" src="https://github.com/elastic/kibana/assets/2767137/c9382a75-a5bb-46e1-a8d0-12c80f74e7b1">

<img width="864" alt="image" src="https://github.com/elastic/kibana/assets/2767137/9f318b80-cf36-4768-ba23-416b4a014315">


### How to test

- Start local Kibana instance
- Navigate to `Infrastructure` > `Hosts`


<!--ONMERGE {"backportTargets":["8.12","8.14"]} ONMERGE-->