### PR TITLE
[Search] Promote Google Drive, OneDrive, Salesforce to GA

### DIFF
--- a/packages/kbn-search-connectors/connectors.ts
+++ b/packages/kbn-search-connectors/connectors.ts
@@ -86,7 +86,7 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
   },
   {
     iconPath: 'google_drive.svg',
-    isBeta: true,
+    isBeta: false,
     isNative: true,
     keywords: ['google', 'drive', 'connector'],
     name: i18n.translate('searchConnectors.content.nativeConnectors.googleDrive.name', {
@@ -146,9 +146,8 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
   },
   {
     iconPath: 'salesforce.svg',
-    isBeta: true,
+    isBeta: false,
     isNative: true,
-    isTechPreview: false,
     keywords: ['salesforce', 'cloud', 'connector'],
     name: i18n.translate('searchConnectors.content.nativeConnectors.salesforce.name', {
       defaultMessage: 'Salesforce',
@@ -200,7 +199,7 @@ export const CONNECTOR_DEFINITIONS: ConnectorServerSideDefinition[] = [
   },
   {
     iconPath: 'onedrive.svg',
-    isBeta: true,
+    isBeta: false,
     isNative: true,
     keywords: ['network', 'drive', 'file', 'connector'],
     name: i18n.translate('searchConnectors.content.nativeConnectors.oneDrive.name', {


### PR DESCRIPTION
## Summary

- Set `beta` to false
- They already require platinum level

Preview:
<img width="1877" alt="Screenshot 2024-02-14 at 12 39 06" src="https://github.com/elastic/kibana/assets/14121688/e646fe2f-f993-4fe0-87b2-dd461b3e3c61">


<!--ONMERGE {"backportTargets":["8.14"]} ONMERGE-->