### PR TITLE
[Ops] fix emergency release pipeline to work in Buildkite env

### DIFF
--- a/.buildkite/scripts/serverless/create_deploy_tag/create_fix_tag.sh
+++ b/.buildkite/scripts/serverless/create_deploy_tag/create_fix_tag.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 
 echo "--- Verify $BUILDKITE_COMMIT exists in $BUILDKITE_BRANCH"
 # Step 1: Check if the commit is in the specific named branch
-if git merge-base --is-ancestor $BUILDKITE_COMMIT $BUILDKITE_BRANCH; then
+if git merge-base --is-ancestor $BUILDKITE_COMMIT origin/$BUILDKITE_BRANCH; then
     echo "Commit $BUILDKITE_COMMIT is part of the $BUILDKITE_BRANCH branch"
 
     # Step 2: Check if the commit is also part of any other branches
     # This command lists all branches containing the commit and counts them
-    branches_containing_commit=$(git branch --contains $BUILDKITE_COMMIT | wc -l)
+    branches_containing_commit=$(git branch -r --contains $BUILDKITE_COMMIT | wc -l)
 
     # If the commit is in more than one branch, exit with non-zero
     if [[ $branches_containing_commit -gt 1 ]]; then

--- a/.buildkite/scripts/serverless/create_deploy_tag/create_fix_tag.sh
+++ b/.buildkite/scripts/serverless/create_deploy_tag/create_fix_tag.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-echo "--- Verify $BUILDKITE_COMMIT exists in $BUILDKITE_BRANCH"
+echo "--- Verify $BUILDKITE_COMMIT exists in origin/$BUILDKITE_BRANCH"
 # Step 1: Check if the commit is in the specific named branch
 if git merge-base --is-ancestor $BUILDKITE_COMMIT origin/$BUILDKITE_BRANCH; then
     echo "Commit $BUILDKITE_COMMIT is part of the $BUILDKITE_BRANCH branch"


### PR DESCRIPTION
The old code expected the branch to be available locally. If it wasn't it would fail. With this change, it now runs the commands "against" the remote repository instead, so it shouldn't matter what's available locally.