### PR TITLE
[Obs AI Assistant] Add time range to conversation

### DIFF
--- a/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/service_overview/index.tsx
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import {
   EuiFlexGroup,
@@ -16,6 +16,7 @@ import {
   EuiPanel,
   EuiSpacer,
 } from '@elastic/eui';
+import { useApmPluginContext } from '../../../context/apm_plugin/use_apm_plugin_context';
 import { AgentName } from '../../../../typings/es_schemas/ui/fields/agent';
 import {
   isOpenTelemetryAgentName,
@@ -51,6 +52,22 @@ export function ServiceOverview() {
   const router = useApmRouter();
   const { serviceName, fallbackToTransactions, agentName, serverlessType } =
     useApmServiceContext();
+
+  const { setScreenContext } =
+    useApmPluginContext().observabilityAIAssistant.service;
+
+  useEffect(() => {
+    return setScreenContext({
+      screenDescription: `The user is looking at the service overview page for ${serviceName}.`,
+      data: [
+        {
+          name: 'service_name',
+          description: 'The name of the service',
+          value: serviceName,
+        },
+      ],
+    });
+  }, [setScreenContext, serviceName]);
 
   const {
     query,

--- a/x-pack/plugins/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/plugins/observability_ai_assistant/kibana.jsonc
@@ -10,6 +10,7 @@
     "requiredPlugins": [
       "alerting",
       "actions",
+      "data",
       "dataViews",
       "features",
       "lens",
@@ -24,10 +25,8 @@
       "dataViews",
       "ml"
     ],
-    "requiredBundles": [ "kibanaReact", "kibanaUtils"],
-    "optionalPlugins": [
-      "cloud"
-    ],
+    "requiredBundles": ["kibanaReact", "kibanaUtils"],
+    "optionalPlugins": ["cloud"],
     "extraPublicDirs": []
   }
 }

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import datemath from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import moment from 'moment';
 import { ObservabilityAIAssistantChatServiceProvider } from '../../context/observability_ai_assistant_chat_service_provider';
 import { useAbortableAsync } from '../../hooks/use_abortable_async';
 import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
@@ -49,8 +50,8 @@ export function ObservabilityAIAssistantActionMenuItem() {
 
   const { from, to } = plugins.start.data.query.timefilter.timefilter.getTime();
   useEffect(() => {
-    const start = datemath.parse(from)?.format();
-    const end = datemath.parse(to)?.format();
+    const start = datemath.parse(from)?.format() ?? moment().subtract(1, 'day').toISOString();
+    const end = datemath.parse(to)?.format() ?? moment().toISOString();
 
     return service.setScreenContext({
       screenDescription: `The user is looking at ${window.location.href}. The current time range is ${start} - ${end}.`,

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -8,6 +8,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import datemath from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import moment from 'moment';
 import { ObservabilityAIAssistantChatServiceProvider } from '../../context/observability_ai_assistant_chat_service_provider';
 import { useAbortableAsync } from '../../hooks/use_abortable_async';
 import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
@@ -49,12 +50,8 @@ export function ObservabilityAIAssistantActionMenuItem() {
 
   const { from, to } = plugins.start.data.query.timefilter.timefilter.getTime();
   useEffect(() => {
-    const start = datemath.parse(from)?.format();
-    const end = datemath.parse(to)?.format();
-
-    if (!start || !end) {
-      return;
-    }
+    const start = datemath.parse(from)?.format() ?? moment().subtract(1, 'day').toISOString();
+    const end = datemath.parse(to)?.format() ?? moment().toISOString();
 
     return service.setScreenContext({
       screenDescription: `The user is looking at ${window.location.href}. The current time range is ${start} - ${end}.`,

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -51,7 +51,6 @@ export function ObservabilityAIAssistantActionMenuItem() {
   useEffect(() => {
     const start = datemath.parse(time.from)?.format();
     const end = datemath.parse(time.to)?.format();
-    console.log(start, end);
 
     return service.setScreenContext({
       screenDescription: `The user is looking at ${window.location.href}. The current time range is ${start} - ${end}.`,

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -47,15 +47,15 @@ export function ObservabilityAIAssistantActionMenuItem() {
     };
   }, []);
 
-  const time = plugins.start.data.query.timefilter.timefilter.getTime();
+  const { from, to } = plugins.start.data.query.timefilter.timefilter.getTime();
   useEffect(() => {
-    const start = datemath.parse(time.from)?.format();
-    const end = datemath.parse(time.to)?.format();
+    const start = datemath.parse(from)?.format();
+    const end = datemath.parse(to)?.format();
 
     return service.setScreenContext({
       screenDescription: `The user is looking at ${window.location.href}. The current time range is ${start} - ${end}.`,
     });
-  }, [service, time]);
+  }, [service, from, to]);
 
   if (!service.isEnabled()) {
     return null;

--- a/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/action_menu_item/action_menu_item.tsx
@@ -8,7 +8,6 @@ import React, { useEffect, useMemo, useState } from 'react';
 import datemath from '@elastic/datemath';
 import { EuiFlexGroup, EuiFlexItem, EuiHeaderLink, EuiLoadingSpinner } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
-import moment from 'moment';
 import { ObservabilityAIAssistantChatServiceProvider } from '../../context/observability_ai_assistant_chat_service_provider';
 import { useAbortableAsync } from '../../hooks/use_abortable_async';
 import { useObservabilityAIAssistant } from '../../hooks/use_observability_ai_assistant';
@@ -50,8 +49,12 @@ export function ObservabilityAIAssistantActionMenuItem() {
 
   const { from, to } = plugins.start.data.query.timefilter.timefilter.getTime();
   useEffect(() => {
-    const start = datemath.parse(from)?.format() ?? moment().subtract(1, 'day').toISOString();
-    const end = datemath.parse(to)?.format() ?? moment().toISOString();
+    const start = datemath.parse(from)?.format();
+    const end = datemath.parse(to)?.format();
+
+    if (!start || !end) {
+      return;
+    }
 
     return service.setScreenContext({
       screenDescription: `The user is looking at ${window.location.href}. The current time range is ${start} - ${end}.`,

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
@@ -87,7 +87,7 @@ export function WelcomeMessage({
         className={fullHeightClassName}
       >
         <EuiFlexItem grow className={centerMaxWidthClassName}>
-          <EuiSpacer size={breakpoint === 'xl' ? 'l' : breakpoint === 'l' ? 'l' : 's'} />
+          <EuiSpacer size={breakpoint === 'xl' || breakpoint === 'l' ? 'l' : 's'} />
 
           <EuiImage
             src={ctaImage}

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
@@ -97,7 +97,7 @@ export function WelcomeMessage({
 
           <EuiSpacer size="m" />
 
-          <EuiTitle size={breakpoint === 'xl' ? 'm' : breakpoint === 'l' ? 'm' : 's'}>
+          <EuiTitle size={breakpoint === 'xl' || breakpoint === 'l' ? 'm' : 's'}>
             <h2>
               {i18n.translate('xpack.observabilityAiAssistant.disclaimer.title', {
                 defaultMessage: 'Welcome to the AI Assistant for Observability',

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
@@ -87,7 +87,7 @@ export function WelcomeMessage({
         className={fullHeightClassName}
       >
         <EuiFlexItem grow className={centerMaxWidthClassName}>
-          <EuiSpacer size={breakpoint === 'xl' ? 'l' : 'l' ? 'l' : 's'} />
+          <EuiSpacer size={breakpoint === 'xl' ? 'l' : breakpoint === 'l' ? 'l' : 's'} />
 
           <EuiImage
             src={ctaImage}
@@ -97,7 +97,7 @@ export function WelcomeMessage({
 
           <EuiSpacer size="m" />
 
-          <EuiTitle size={breakpoint === 'xl' ? 'm' : 'l' ? 'm' : 's'}>
+          <EuiTitle size={breakpoint === 'xl' ? 'm' : breakpoint === 'l' ? 'm' : 's'}>
             <h2>
               {i18n.translate('xpack.observabilityAiAssistant.disclaimer.title', {
                 defaultMessage: 'Welcome to the AI Assistant for Observability',

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
@@ -87,7 +87,7 @@ export function WelcomeMessage({
         className={fullHeightClassName}
       >
         <EuiFlexItem grow className={centerMaxWidthClassName}>
-          <EuiSpacer size={['xl', 'l'].includes(breakpoint) ? 'l' : 's'} />
+          <EuiSpacer size={['xl', 'l'].includes(breakpoint!) ? 'l' : 's'} />
 
           <EuiImage
             src={ctaImage}
@@ -97,7 +97,7 @@ export function WelcomeMessage({
 
           <EuiSpacer size="m" />
 
-          <EuiTitle size={['xl', 'l'].includes(breakpoint) ? 'm' : 's'}>
+          <EuiTitle size={['xl', 'l'].includes(breakpoint!) ? 'm' : 's'}>
             <h2>
               {i18n.translate('xpack.observabilityAiAssistant.disclaimer.title', {
                 defaultMessage: 'Welcome to the AI Assistant for Observability',

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/welcome_message.tsx
@@ -87,7 +87,7 @@ export function WelcomeMessage({
         className={fullHeightClassName}
       >
         <EuiFlexItem grow className={centerMaxWidthClassName}>
-          <EuiSpacer size={breakpoint === 'xl' || breakpoint === 'l' ? 'l' : 's'} />
+          <EuiSpacer size={['xl', 'l'].includes(breakpoint) ? 'l' : 's'} />
 
           <EuiImage
             src={ctaImage}
@@ -97,7 +97,7 @@ export function WelcomeMessage({
 
           <EuiSpacer size="m" />
 
-          <EuiTitle size={breakpoint === 'xl' || breakpoint === 'l' ? 'm' : 's'}>
+          <EuiTitle size={['xl', 'l'].includes(breakpoint) ? 'm' : 's'}>
             <h2>
               {i18n.translate('xpack.observabilityAiAssistant.disclaimer.title', {
                 defaultMessage: 'Welcome to the AI Assistant for Observability',

--- a/x-pack/plugins/observability_ai_assistant/public/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/types.ts
@@ -32,6 +32,7 @@ import type {
   TriggersAndActionsUIPublicPluginSetup,
   TriggersAndActionsUIPublicPluginStart,
 } from '@kbn/triggers-actions-ui-plugin/public';
+import { DataPublicPluginSetup, DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { StreamingChatResponseEventWithoutError } from '../common/conversation_complete';
 import type {
   ContextDefinition,
@@ -112,6 +113,7 @@ export type ChatRegistrationRenderFunction = ({}: {
 export interface ConfigSchema {}
 
 export interface ObservabilityAIAssistantPluginSetupDependencies {
+  data: DataPublicPluginSetup;
   dataViews: DataViewsPublicPluginSetup;
   features: FeaturesPluginSetup;
   lens: LensPublicSetup;
@@ -122,6 +124,7 @@ export interface ObservabilityAIAssistantPluginSetupDependencies {
 }
 
 export interface ObservabilityAIAssistantPluginStartDependencies {
+  data: DataPublicPluginStart;
   dataViews: DataViewsPublicPluginStart;
   features: FeaturesPluginStart;
   lens: LensPublicStart;

--- a/x-pack/plugins/observability_ai_assistant/tsconfig.json
+++ b/x-pack/plugins/observability_ai_assistant/tsconfig.json
@@ -68,7 +68,8 @@
     "@kbn/visualization-utils",
     "@kbn/field-types",
     "@kbn/es-types",
-    "@kbn/esql-utils"
+    "@kbn/esql-utils",
+    "@kbn/data-plugin"
   ],
   "exclude": ["target/**/*"]
 }


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/69

This adds the time range to the screen context. This way the assistant will respond with visualisations for the selected range, instead of defaulting to the past 24 hours.


<img width="1769" alt="image" src="https://github.com/elastic/kibana/assets/209966/1ab150d2-9973-4efa-8764-721397c08f01">

_When selecting the past 3 hours the visualisation produced by the assistant adheres to this_



<!--ONMERGE {"backportTargets":["8.12","8.13"]} ONMERGE-->