### PR TITLE
Fix flaky test #116463

### DIFF
--- a/test/examples/index_pattern_field_editor_example/index_pattern_field_editor_example.ts
+++ b/test/examples/index_pattern_field_editor_example/index_pattern_field_editor_example.ts
@@ -13,7 +13,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
   const testSubjects = getService('testSubjects');
   const retry = getService('retry');
 
-  describe('', () => {
+  describe('index pattern field editor example', () => {
     it('finds an index pattern', async () => {
       await retry.try(async () => {
         await testSubjects.existOrFail('indexPatternTitle');

--- a/test/examples/index_pattern_field_editor_example/index_pattern_field_editor_example.ts
+++ b/test/examples/index_pattern_field_editor_example/index_pattern_field_editor_example.ts
@@ -11,15 +11,19 @@ import { PluginFunctionalProviderContext } from 'test/plugin_functional/services
 // eslint-disable-next-line import/no-default-export
 export default function ({ getService }: PluginFunctionalProviderContext) {
   const testSubjects = getService('testSubjects');
+  const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/116463
-  describe.skip('', () => {
+  describe('', () => {
     it('finds an index pattern', async () => {
-      await testSubjects.existOrFail('indexPatternTitle');
+      await retry.try(async () => {
+        await testSubjects.existOrFail('indexPatternTitle');
+      });
     });
     it('opens the field editor', async () => {
       await testSubjects.click('addField');
-      await testSubjects.existOrFail('flyoutTitle');
+      await retry.try(async () => {
+        await testSubjects.existOrFail('flyoutTitle');
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

This PR fixes and unskips the flaky test from #116463.

Flaky test runner x95: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5188.

Resolves #116463.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)