### PR TITLE
[Synthetics] Hide unwanted Synthetics nav items

### DIFF
--- a/x-pack/plugins/synthetics/kibana.jsonc
+++ b/x-pack/plugins/synthetics/kibana.jsonc
@@ -31,10 +31,18 @@
       "taskManager",
       "triggersActionsUi",
       "usageCollection",
-      "bfetch",
-      "serverless"
+      "bfetch"
     ],
-    "optionalPlugins": ["cloud", "data", "fleet", "home", "ml", "spaces", "telemetry"],
+    "optionalPlugins": [
+      "cloud",
+      "data",
+      "fleet",
+      "home",
+      "ml",
+      "serverless",
+      "spaces",
+      "telemetry"
+    ],
     "requiredBundles": [
       "data",
       "fleet",

--- a/x-pack/plugins/synthetics/kibana.jsonc
+++ b/x-pack/plugins/synthetics/kibana.jsonc
@@ -31,7 +31,8 @@
       "taskManager",
       "triggersActionsUi",
       "usageCollection",
-      "bfetch"
+      "bfetch",
+      "serverless"
     ],
     "optionalPlugins": ["cloud", "data", "fleet", "home", "ml", "spaces", "telemetry"],
     "requiredBundles": [

--- a/x-pack/plugins/synthetics/public/plugin.ts
+++ b/x-pack/plugins/synthetics/public/plugin.ts
@@ -11,6 +11,7 @@ import {
   Plugin,
   PluginInitializerContext,
   AppMountParameters,
+  PackageInfo,
 } from '@kbn/core/public';
 import { from } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -113,7 +114,11 @@ export type ClientStart = void;
 export class UptimePlugin
   implements Plugin<ClientSetup, ClientStart, ClientPluginsSetup, ClientPluginsStart>
 {
-  constructor(private readonly initContext: PluginInitializerContext) {}
+  private readonly _packageInfo: Readonly<PackageInfo>;
+
+  constructor(private readonly initContext: PluginInitializerContext) {
+    this._packageInfo = initContext.env.packageInfo;
+  }
 
   public setup(core: CoreSetup<ClientPluginsStart, unknown>, plugins: ClientPluginsSetup): void {
     locators.forEach((locator) => {
@@ -155,7 +160,7 @@ export class UptimePlugin
             defaultMessage: 'Overview',
           }),
           path: '/',
-          visibleIn: plugins?.serverless ? ['globalSearch', 'sideNav'] : [],
+          visibleIn: this._isServerless ? ['globalSearch', 'sideNav'] : [],
         },
         {
           id: 'management',
@@ -163,7 +168,7 @@ export class UptimePlugin
             defaultMessage: 'Management',
           }),
           path: '/monitors',
-          visibleIn: plugins?.serverless ? ['globalSearch', 'sideNav'] : [],
+          visibleIn: this._isServerless ? ['globalSearch', 'sideNav'] : [],
         },
       ],
       mount: async (params: AppMountParameters) => {
@@ -194,6 +199,10 @@ export class UptimePlugin
   }
 
   public stop(): void {}
+
+  private get _isServerless(): boolean {
+    return this._packageInfo.buildFlavor === 'serverless';
+  }
 }
 
 function registerSyntheticsRoutesWithNavigation(

--- a/x-pack/plugins/synthetics/public/plugin.ts
+++ b/x-pack/plugins/synthetics/public/plugin.ts
@@ -53,6 +53,7 @@ import {
   ObservabilityAIAssistantPluginStart,
   ObservabilityAIAssistantPluginSetup,
 } from '@kbn/observability-ai-assistant-plugin/public';
+import { ServerlessPluginSetup } from '@kbn/serverless/public';
 import { PLUGIN } from '../common/constants/plugin';
 import { OVERVIEW_ROUTE } from '../common/constants/ui';
 import { locators } from './apps/locators';
@@ -69,6 +70,7 @@ export interface ClientPluginsSetup {
   share: SharePluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
   cloud?: CloudSetup;
+  serverless?: ServerlessPluginSetup;
 }
 
 export interface ClientPluginsStart {
@@ -153,7 +155,7 @@ export class UptimePlugin
             defaultMessage: 'Overview',
           }),
           path: '/',
-          visibleIn: ['globalSearch', 'sideNav'],
+          visibleIn: plugins?.serverless ? ['globalSearch', 'sideNav'] : [],
         },
         {
           id: 'management',
@@ -161,7 +163,7 @@ export class UptimePlugin
             defaultMessage: 'Management',
           }),
           path: '/monitors',
-          visibleIn: ['globalSearch', 'sideNav'],
+          visibleIn: plugins?.serverless ? ['globalSearch', 'sideNav'] : [],
         },
       ],
       mount: async (params: AppMountParameters) => {

--- a/x-pack/plugins/synthetics/tsconfig.json
+++ b/x-pack/plugins/synthetics/tsconfig.json
@@ -82,6 +82,7 @@
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/code-editor",
     "@kbn/code-editor-mock",
+    "@kbn/serverless",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
## Summary

Resolves #177034.

We accidentally showed some nav items that we do not want to be visible in the top-level Kibana nav in stateful Kibana. This will hide them outside of the intended Serverless context.

## Testing this PR

Simply run Kibana and verify that you do not see the unintended nav items that are shown in the linked issue.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->