### PR TITLE
Better styling for connectors

### DIFF
--- a/src/plugins/ai_assistant_management/observability/public/routes/components/settings_tab.tsx
+++ b/src/plugins/ai_assistant_management/observability/public/routes/components/settings_tab.tsx
@@ -162,6 +162,7 @@ export function SettingsTab() {
             )}
           >
             <EuiFormRow
+              style={{ alignSelf: 'end', width: '80%' }}
               fullWidth
               label={i18n.translate(
                 'aiAssistantManagementObservability.settingsPage.selectConnectorLabel',

--- a/x-pack/plugins/observability_ai_assistant/public/components/connector_selector/connector_selector_base.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/connector_selector/connector_selector_base.tsx
@@ -11,6 +11,7 @@ import {
   EuiLoadingSpinner,
   EuiSuperSelect,
   EuiText,
+  EuiTextTruncate,
 } from '@elastic/eui';
 import React from 'react';
 import { i18n } from '@kbn/i18n';
@@ -30,8 +31,8 @@ const wrapperClassName = css`
   }
 `;
 
-const noWrapClassName = css`
-  white-space: nowrap;
+const smallFontClassName = css`
+  font-size: 12px;
 `;
 
 export function ConnectorSelectorBase(props: ConnectorSelectorBaseProps) {
@@ -84,14 +85,14 @@ export function ConnectorSelectorBase(props: ConnectorSelectorBaseProps) {
       gutterSize="xs"
       responsive={false}
     >
-      <EuiFlexItem grow={false}>
+      <EuiFlexItem grow>
         <EuiSuperSelect
           compressed
           valueOfSelected={props.selectedConnector}
           options={props.connectors.map((connector) => ({
             value: connector.id,
             inputDisplay: (
-              <EuiFlexGroup direction="row" gutterSize="s">
+              <EuiFlexGroup direction="row" gutterSize="s" alignItems="center">
                 <EuiFlexItem grow={false}>
                   <EuiText size="xs" color="subdued">
                     {i18n.translate(
@@ -102,18 +103,16 @@ export function ConnectorSelectorBase(props: ConnectorSelectorBaseProps) {
                     )}
                   </EuiText>
                 </EuiFlexItem>
-                <EuiFlexItem grow={false}>
-                  <EuiText size="xs" className={noWrapClassName}>
-                    {connector.name}
-                  </EuiText>
+                <EuiFlexItem grow>
+                  <EuiTextTruncate
+                    text={connector.name}
+                    className={smallFontClassName}
+                    truncation="end"
+                  />
                 </EuiFlexItem>
               </EuiFlexGroup>
             ),
-            dropdownDisplay: (
-              <EuiText size="xs" className={noWrapClassName}>
-                {connector.name}
-              </EuiText>
-            ),
+            dropdownDisplay: <EuiText size="xs">{connector.name}</EuiText>,
           }))}
           onChange={(id) => {
             props.selectConnector(id);


### PR DESCRIPTION
## Summary

Improves styling for the Connectors pulldown.

<img width="418" alt="Screenshot 2024-02-15 at 17 56 37" src="https://github.com/elastic/kibana/assets/535564/62359bd6-02f8-4c90-8e47-912015aa7787">


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->