### PR TITLE
Rename urlkey event flyout

### DIFF
--- a/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
+++ b/x-pack/plugins/security_solution/public/app/home/template_wrapper/index.tsx
@@ -85,7 +85,7 @@ export const SecuritySolutionTemplateWrapper: React.FC<Omit<KibanaPageTemplatePr
           component="div"
           grow={true}
         >
-          <ExpandableFlyoutProvider urlKey={isPreview ? undefined : URL_PARAM_KEY.eventFlyout}>
+          <ExpandableFlyoutProvider urlKey={isPreview ? undefined : URL_PARAM_KEY.flyout}>
             {children}
             <SecuritySolutionFlyout />
           </ExpandableFlyoutProvider>

--- a/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/flyout/use_init_flyout_url_param.ts
@@ -6,9 +6,8 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-
 import { useDispatch } from 'react-redux';
-
+import { useLocation } from 'react-router-dom';
 import {
   dataTableSelectors,
   TableId,
@@ -21,8 +20,17 @@ import { URL_PARAM_KEY } from '../use_url_state';
 import type { FlyoutUrlState } from './types';
 import { useShallowEqualSelector } from '../use_selector';
 import { useUiSetting$ } from '../../lib/kibana';
+import { getQueryStringKeyValue } from '../timeline/use_query_timeline_by_id_on_url_change';
+
+/**
+ * The state of the old flyout of the table in the Alerts page is stored in local storage.
+ * This hook was created to initialize things and populate the url with the correct param and its value.
+ * This is only be needed with the old flyout.
+ * // TODO remove this hook entirely when we delete the old flyout code
+ */
 
 export const useInitFlyoutFromUrlParam = () => {
+  const { search } = useLocation();
   const [isSecurityFlyoutEnabled] = useUiSetting$<boolean>(ENABLE_EXPANDABLE_FLYOUT_SETTING);
   const [urlDetails, setUrlDetails] = useState<FlyoutUrlState | null>(null);
   const [hasLoadedUrlDetails, updateHasLoadedUrlDetails] = useState(false);
@@ -45,9 +53,11 @@ export const useInitFlyoutFromUrlParam = () => {
   );
 
   const loadExpandedDetailFromUrl = useCallback(() => {
+    if (isSecurityFlyoutEnabled) return;
+
     const { initialized, isLoading, totalCount, additionalFilters } = dataTableCurrent;
     const isTableLoaded = initialized && !isLoading && totalCount > 0;
-    if (!isSecurityFlyoutEnabled && urlDetails) {
+    if (urlDetails) {
       if (!additionalFilters || !additionalFilters.showBuildingBlockAlerts) {
         // We want to show building block alerts when loading the flyout in case the alert is a building block alert
         dispatch(
@@ -73,16 +83,22 @@ export const useInitFlyoutFromUrlParam = () => {
   // The alert page creates a default dataTable slice in redux initially that is later overriden when data is retrieved
   // We use the below to store the urlDetails on app load, and then set it when the table is done loading and has data
   useEffect(() => {
-    if (!hasLoadedUrlDetails) {
+    if (!isSecurityFlyoutEnabled && !hasLoadedUrlDetails) {
       loadExpandedDetailFromUrl();
     }
-  }, [hasLoadedUrlDetails, loadExpandedDetailFromUrl]);
+  }, [hasLoadedUrlDetails, isSecurityFlyoutEnabled, loadExpandedDetailFromUrl]);
 
-  /**
-   * The URL_PARAM_KEY.eventFlyout is used for the old flyout as well as the new expandable flyout here:
-   * x-pack/plugins/security_solution/public/common/hooks/flyout/use_sync_flyout_url_param.ts
-   * We only want this to run for the old flyout.
-   */
-  const initializeKey = isSecurityFlyoutEnabled ? '' : URL_PARAM_KEY.eventFlyout;
-  useInitializeUrlParam(initializeKey, onInitialize);
+  // We check the url for the presence of the old `evenFlyout` parameter. If it exists replace it with the new `flyout` key.
+  const eventFlyoutKey = getQueryStringKeyValue({ urlKey: URL_PARAM_KEY.eventFlyout, search });
+  let currentKey = '';
+  let newKey = '';
+  if (!isSecurityFlyoutEnabled) {
+    if (eventFlyoutKey) {
+      currentKey = URL_PARAM_KEY.eventFlyout;
+      newKey = URL_PARAM_KEY.flyout;
+    } else {
+      currentKey = URL_PARAM_KEY.flyout;
+    }
+  }
+  useInitializeUrlParam(currentKey, onInitialize, newKey);
 };

--- a/x-pack/plugins/security_solution/public/common/hooks/flyout/use_sync_flyout_url_param.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/flyout/use_sync_flyout_url_param.ts
@@ -14,14 +14,22 @@ import {
   tableDefaults,
   TableId,
 } from '@kbn/securitysolution-data-table';
-import { ALERTS_PATH } from '../../../../common/constants';
+import { useUiSetting$ } from '@kbn/kibana-react-plugin/public';
+import { ALERTS_PATH, ENABLE_EXPANDABLE_FLYOUT_SETTING } from '../../../../common/constants';
 import { useUpdateUrlParam } from '../../utils/global_query_string';
 import { useShallowEqualSelector } from '../use_selector';
 import { URL_PARAM_KEY } from '../use_url_state';
 import type { FlyoutUrlState } from './types';
 
+/**
+ * The state of the old flyout of the table in the Alerts page is stored in local storage.
+ * This hook was created to sync the data stored in local storage to the url.
+ * This is only be needed with the old flyout.
+ * // TODO remove this hook entirely when we delete the old flyout code
+ */
 export const useSyncFlyoutUrlParam = () => {
-  const updateUrlParam = useUpdateUrlParam<FlyoutUrlState>(URL_PARAM_KEY.eventFlyout);
+  const [isSecurityFlyoutEnabled] = useUiSetting$<boolean>(ENABLE_EXPANDABLE_FLYOUT_SETTING);
+  const updateUrlParam = useUpdateUrlParam<FlyoutUrlState>(URL_PARAM_KEY.flyout);
   const { pathname } = useLocation();
   const dispatch = useDispatch();
   const getDataTable = dataTableSelectors.getTableByIdSelector();
@@ -32,6 +40,8 @@ export const useSyncFlyoutUrlParam = () => {
   );
 
   useEffect(() => {
+    if (isSecurityFlyoutEnabled) return;
+
     const isOnAlertsPage = pathname === ALERTS_PATH;
     if (isOnAlertsPage && expandedDetail != null && expandedDetail?.query) {
       updateUrlParam(expandedDetail.query.panelView ? expandedDetail.query : null);
@@ -45,5 +55,5 @@ export const useSyncFlyoutUrlParam = () => {
       // Clear the reference from the url
       updateUrlParam(null);
     }
-  }, [dispatch, expandedDetail, pathname, updateUrlParam]);
+  }, [dispatch, expandedDetail, isSecurityFlyoutEnabled, pathname, updateUrlParam]);
 };

--- a/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/timeline/use_query_timeline_by_id_on_url_change.ts
@@ -80,5 +80,5 @@ export const useQueryTimelineByIdOnUrlChange = () => {
   }, [timelineIdFromReduxStore, dispatch, oldId, newId, activeTab, graphEventId]);
 };
 
-const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
+export const getQueryStringKeyValue = ({ search, urlKey }: { search: string; urlKey: string }) =>
   getParamFromQueryString(getQueryStringFromLocation(search), urlKey);

--- a/x-pack/plugins/security_solution/public/common/hooks/use_url_state.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_url_state.ts
@@ -29,7 +29,8 @@ export const useUrlState = () => {
 
 export const URL_PARAM_KEY = {
   appQuery: 'query',
-  eventFlyout: 'eventFlyout',
+  eventFlyout: 'eventFlyout', // TODO remove when we assume it's been long enough that all users should use the newer `flyout` key
+  flyout: 'flyout',
   timelineFlyout: 'timelineFlyout',
   filters: 'filters',
   savedQuery: 'savedQuery',

--- a/x-pack/plugins/security_solution/public/common/hooks/use_url_state.ts
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_url_state.ts
@@ -29,6 +29,7 @@ export const useUrlState = () => {
 
 export const URL_PARAM_KEY = {
   appQuery: 'query',
+  /** @deprecated */
   eventFlyout: 'eventFlyout', // TODO remove when we assume it's been long enough that all users should use the newer `flyout` key
   flyout: 'flyout',
   timelineFlyout: 'timelineFlyout',

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.test.tsx
@@ -120,6 +120,24 @@ describe('global query string', () => {
         })
       );
     });
+
+    it('should use newUrlParamKey if provided', () => {
+      const urlParamKey = 'testKey';
+      const newUrlParamKey = 'newTestKey';
+      const initialValue = 123;
+      window.location.search = `?testKey=${initialValue}`;
+
+      renderHook(() => useInitializeUrlParam(urlParamKey, () => {}, newUrlParamKey), {
+        wrapper: makeWrapper(),
+      });
+
+      expect(mockDispatch).toBeCalledWith(
+        globalUrlParamActions.registerUrlParam({
+          key: newUrlParamKey,
+          initialValue,
+        })
+      );
+    });
   });
 
   describe('updateUrlParam', () => {

--- a/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
+++ b/x-pack/plugins/security_solution/public/common/utils/global_query_string/index.ts
@@ -24,24 +24,27 @@ import { getLinkInfo } from '../../links';
  *
  * @param urlParamKey Must not change.
  * @param onInitialize Called once when initializing. It must not change.
+ * @param newUrlParamKey If we want to register the value under a new key.
  */
 export const useInitializeUrlParam = <State extends {}>(
   urlParamKey: string,
   /**
    * @param state Decoded URL param value.
    */
-  onInitialize: (state: State | null) => void
+  onInitialize: (state: State | null) => void,
+  newUrlParamKey?: string
 ) => {
   const dispatch = useDispatch();
 
   const getInitialUrlParamValue = useGetInitialUrlParamValue(urlParamKey);
 
   useEffect(() => {
+    const key = newUrlParamKey && newUrlParamKey !== '' ? newUrlParamKey : urlParamKey;
     const value = getInitialUrlParamValue();
 
     dispatch(
       globalUrlParamActions.registerUrlParam({
-        key: urlParamKey,
+        key,
         initialValue: value,
       })
     );
@@ -50,7 +53,7 @@ export const useInitializeUrlParam = <State extends {}>(
     onInitialize(value as State);
 
     return () => {
-      dispatch(globalUrlParamActions.deregisterUrlParam({ key: urlParamKey }));
+      dispatch(globalUrlParamActions.deregisterUrlParam({ key }));
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- It must run only once when the application is initializing.
   }, []);

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.test.tsx
@@ -57,7 +57,7 @@ describe('AlertDetailsRedirect', () => {
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272023-04-20T12%3A00%3A00.000Z%27%2Ckind%3Aabsolute%2Cto%3A%272023-04-20T12%3A05%3A00.000Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&eventFlyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
+        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272023-04-20T12%3A00%3A00.000Z%27%2Ckind%3Aabsolute%2Cto%3A%272023-04-20T12%3A05%3A00.000Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
         state: undefined,
       });
     });
@@ -86,7 +86,7 @@ describe('AlertDetailsRedirect', () => {
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&eventFlyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
+        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.someTestIndex%29%29`,
         state: undefined,
       });
     });
@@ -114,7 +114,7 @@ describe('AlertDetailsRedirect', () => {
       expect(historyMock.replace).toHaveBeenCalledWith({
         hash: '',
         pathname: ALERTS_PATH,
-        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&eventFlyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.internal.alerts-security.alerts-default%29%29`,
+        search: `?query=%28language%3Akuery%2Cquery%3A%27_id%3A+test-alert-id%27%29&timerange=%28global%3A%28linkTo%3A%21%28timeline%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2Ckind%3Aabsolute%2Cto%3A%272020-07-08T08%3A25%3A18.966Z%27%29%29%2Ctimeline%3A%28linkTo%3A%21%28global%2CsocTrends%29%2Ctimerange%3A%28from%3A%272020-07-07T08%3A20%3A18.966Z%27%2CfromStr%3Anow%2Fd%2Ckind%3Arelative%2Cto%3A%272020-07-08T08%3A20%3A18.966Z%27%2CtoStr%3Anow%2Fd%29%29%29&pageFilters=%21%28%28exclude%3A%21f%2CexistsSelected%3A%21f%2CfieldName%3Akibana.alert.workflow_status%2CselectedOptions%3A%21%28%29%2Ctitle%3AStatus%29%29&flyout=%28panelView%3AeventDetail%2Cparams%3A%28eventId%3Atest-alert-id%2CindexName%3A.internal.alerts-security.alerts-default%29%29`,
         state: undefined,
       });
     });
@@ -125,7 +125,7 @@ describe('AlertDetailsRedirect', () => {
       jest.mocked(useIsExperimentalFeatureEnabled).mockReturnValue(true);
     });
 
-    describe('when eventFlyout is not in the query', () => {
+    describe('when eventFlyout or flyout are not in the query', () => {
       it('redirects to the expected path with the correct query parameters', () => {
         const testSearch = `?index=${testIndex}&timestamp=${testTimestamp}`;
         const historyMock = {
@@ -147,7 +147,7 @@ describe('AlertDetailsRedirect', () => {
 
         const [{ search, pathname }] = historyMock.replace.mock.lastCall;
 
-        expect(search as string).toMatch(/eventFlyout.*/);
+        expect(search as string).toMatch(/flyout.*/);
         expect(pathname).toEqual(ALERTS_PATH);
       });
     });

--- a/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+++ b/x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
@@ -71,7 +71,7 @@ export const AlertDetailsRedirect = () => {
 
   const pageFiltersQuery = encode(formatPageFilterSearchParam([statusPageFilter]));
 
-  const currentFlyoutParams = searchParams.get(URL_PARAM_KEY.eventFlyout);
+  const currentFlyoutParams = searchParams.get(URL_PARAM_KEY.flyout);
 
   const [isSecurityFlyoutEnabled] = useUiSetting$<boolean>(ENABLE_EXPANDABLE_FLYOUT_SETTING);
 
@@ -79,7 +79,7 @@ export const AlertDetailsRedirect = () => {
     [URL_PARAM_KEY.appQuery]: kqlAppQuery,
     [URL_PARAM_KEY.timerange]: timerange,
     [URL_PARAM_KEY.pageFilter]: pageFiltersQuery,
-    [URL_PARAM_KEY.eventFlyout]: resolveFlyoutParams(
+    [URL_PARAM_KEY.flyout]: resolveFlyoutParams(
       { index, alertId, isSecurityFlyoutEnabled },
       currentFlyoutParams
     ),

--- a/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
+++ b/x-pack/plugins/security_solution/public/timelines/components/side_panel/event_details/expandable_event.tsx
@@ -109,7 +109,9 @@ export const ExpandableEventTitle = React.memo<ExpandableEventTitleProps>(
       timestamp,
     });
     const urlModifier = (value: string) => {
-      return `${value}&${URL_PARAM_KEY.eventFlyout}=(preview:!(),rightPanel:(id:document-details-right,params:(id:${eventId},indexName:${eventIndex},scopeId:${scopeId})))`;
+      // this is actually only needed for when users click on the Share Alert button and then enable the expandable flyout
+      // (for the old (non-expandable) flyout, we do not need to save anything in the url as we automatically open the flyout here: x-pack/plugins/security_solution/public/detections/pages/alerts/alert_details_redirect.tsx
+      return `${value}&${URL_PARAM_KEY.flyout}=(preview:!(),right:(id:document-details-right,params:(id:'${eventId}',indexName:${eventIndex},scopeId:${scopeId})))`;
     };
 
     const { refetch } = useRefetchByScope({ scopeId });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_details.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/alerts/alerts_details.cy.ts
@@ -150,15 +150,13 @@ describe('Alert details flyout', { tags: ['@ess', '@serverless'] }, () => {
       expandFirstAlert();
     });
 
-    it('should store the flyout state in the url when it is opened', () => {
+    it('should store the flyout state in the url when it is opened and remove it when closed', () => {
       cy.get(OVERVIEW_RULE).should('be.visible');
-      cy.url().should('include', 'eventFlyout=');
-    });
+      cy.url().should('include', 'flyout=');
 
-    it('should remove the flyout state from the url when it is closed', () => {
-      cy.get(OVERVIEW_RULE).should('be.visible');
       closeAlertFlyout();
-      cy.url().should('not.include', 'eventFlyout=');
+
+      cy.url().should('not.include', 'flyout=');
     });
 
     it.skip('should open the alert flyout when the page is refreshed', () => {


### PR DESCRIPTION
## Summary

This PR is a follow up of [this PR](https://github.com/elastic/kibana/pull/177087) which introduced the expandable flyout to timeline.
Previously we had only a single flyout which state was saved in the url, under the parameter `eventFlyout`. Now that we have 2 flyouts, we need to parameter. While we could have `eventFlyout` and `timelineFlyout`, renaming the former to simply `flyout` makes more sense, as this flyout is used throughout Security Solution, and not only for events. It is also used for host and users for example...

This PR therefore aims at renaming the url parameter key from `eventFlyout` to `flyout`. The code supports urls with the old `eventFlyout` parameter, but instantly replaces it with the new `flyout` parameter.
After a while (maybe a few releases), we should be able to remove the support for the old `eventFlyout` parameter.

### How to test

- navigate to the alerts page and open a flyout from the alerts table
- test copying the url and opening in a new tab
- test using the share button at the top-right corner of the flyout and open in a new tab
- try to load a url that contains `eventFlyout` (mimicking a older url) and see that `eventFlyout` is replaced with `flyout` when the page loads

In all these scenarios, verify that the url contains `flyout` instead of `eventFlyout`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

https://github.com/elastic/security-team/issues/7464