### PR TITLE
[Synthetics] Simplify write access default behavior

### DIFF
--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
@@ -6,8 +6,7 @@
  */
 
 import { createSyntheticsRouteWithAuth } from './create_route_with_auth';
-
-type SupportedMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+import { SupportedMethod } from './types';
 
 const methods: SupportedMethod[][] = [['GET'], ['POST'], ['PUT'], ['DELETE']];
 

--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.test.ts
@@ -7,8 +7,37 @@
 
 import { createSyntheticsRouteWithAuth } from './create_route_with_auth';
 
+type SupportedMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+const methods: SupportedMethod[][] = [['GET'], ['POST'], ['PUT'], ['DELETE']];
+
 describe('createSyntheticsRouteWithAuth', () => {
-  it('should create a route with auth', () => {
+  it.each(
+    methods
+      .map<[SupportedMethod, boolean]>((m) => [m[0], true])
+      .concat(methods.map((m) => [m[0], false]))
+  )('%s methods continues to support the writeAccess %s flag', (mStr, writeAccess) => {
+    const method: SupportedMethod = mStr as SupportedMethod;
+    const route = createSyntheticsRouteWithAuth(() => ({
+      method,
+      path: '/foo',
+      validate: {},
+      writeAccess,
+      handler: async () => {
+        return { success: true };
+      },
+    }));
+
+    expect(route).toEqual({
+      method,
+      path: '/foo',
+      validate: {},
+      handler: expect.any(Function),
+      writeAccess,
+    });
+  });
+
+  it('by default allows read access for GET by default', () => {
     const route = createSyntheticsRouteWithAuth(() => ({
       method: 'GET',
       path: '/foo',
@@ -27,11 +56,9 @@ describe('createSyntheticsRouteWithAuth', () => {
     });
   });
 
-  it.each([['POST'], ['PUT'], ['DELETE']])(
-    'requires write permissions for %s requests',
+  it.each(methods.filter((m) => m[0] !== 'GET'))(
+    'by default requires write access for %s route requests',
     (method) => {
-      if (method !== 'POST' && method !== 'PUT' && method !== 'DELETE')
-        throw Error('Invalid method');
       const route = createSyntheticsRouteWithAuth(() => ({
         method,
         path: '/foo',
@@ -47,31 +74,6 @@ describe('createSyntheticsRouteWithAuth', () => {
         validate: {},
         handler: expect.any(Function),
         writeAccess: true,
-      });
-    }
-  );
-
-  it.each([['POST'], ['PUT'], ['DELETE']])(
-    'allows write access override for %s requests',
-    (method) => {
-      if (method !== 'POST' && method !== 'PUT' && method !== 'DELETE')
-        throw Error('Invalid method');
-      const route = createSyntheticsRouteWithAuth(() => ({
-        method,
-        path: '/foo',
-        validate: {},
-        handler: async () => {
-          return { success: true };
-        },
-        writeAccessOverride: true,
-      }));
-
-      expect(route).toEqual({
-        method,
-        path: '/foo',
-        validate: {},
-        handler: expect.any(Function),
-        writeAccess: undefined,
       });
     }
   );

--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
@@ -13,18 +13,16 @@ import {
 } from '../../common/constants';
 import { SyntheticsRestApiRouteFactory, SyntheticsRoute, SyntheticsRouteHandler } from './types';
 
-function getWriteAccessFlag(method: string, writeAccessOverride?: boolean, writeAccess?: boolean) {
-  // if route includes an override, skip write-only access with `undefined`
-  // otherwise, if route is not a GET, require write access
-  // if route is get, use writeAccess value with `false` as default
-  return writeAccessOverride === true ? undefined : method !== 'GET' ? true : writeAccess ?? false;
+function getDefaultWriteAccessFlag(method: string) {
+  // if the method is not GET, it defaults to requiring write access
+  return method !== 'GET';
 }
 
 export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
   routeCreator: SyntheticsRestApiRouteFactory
 ): SyntheticsRoute<ClientContract> => {
   const restRoute = routeCreator();
-  const { handler, method, path, options, writeAccess, writeAccessOverride, ...rest } = restRoute;
+  const { handler, method, path, options, writeAccess, ...rest } = restRoute;
   const licenseCheckHandler: SyntheticsRouteHandler<ClientContract> = async ({
     context,
     response,
@@ -56,7 +54,7 @@ export const createSyntheticsRouteWithAuth = <ClientContract = unknown>(
     options,
     handler: licenseCheckHandler,
     ...rest,
-    writeAccess: getWriteAccessFlag(method, writeAccessOverride, writeAccess),
+    writeAccess: writeAccess ?? getDefaultWriteAccessFlag(method),
   };
 };
 

--- a/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
+++ b/x-pack/plugins/synthetics/server/routes/create_route_with_auth.ts
@@ -11,9 +11,14 @@ import {
   LICENSE_NOT_ACTIVE_ERROR,
   LICENSE_NOT_SUPPORTED_ERROR,
 } from '../../common/constants';
-import { SyntheticsRestApiRouteFactory, SyntheticsRoute, SyntheticsRouteHandler } from './types';
+import {
+  SupportedMethod,
+  SyntheticsRestApiRouteFactory,
+  SyntheticsRoute,
+  SyntheticsRouteHandler,
+} from './types';
 
-function getDefaultWriteAccessFlag(method: string) {
+function getDefaultWriteAccessFlag(method: SupportedMethod) {
   // if the method is not GET, it defaults to requiring write access
   return method !== 'GET';
 }

--- a/x-pack/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
+++ b/x-pack/plugins/synthetics/server/routes/pings/journey_screenshot_blocks.ts
@@ -22,7 +22,7 @@ export const createJourneyScreenshotBlocksRoute: SyntheticsRestApiRouteFactory =
       hashes: schema.arrayOf(schema.string()),
     }),
   },
-  writeAccessOverride: true,
+  writeAccess: false,
   handler: async (routeProps) => {
     return await journeyScreenshotBlocksHandler(routeProps);
   },

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/enablement.ts
@@ -16,7 +16,7 @@ import {
 export const getSyntheticsEnablementRoute: SyntheticsRestApiRouteFactory = () => ({
   method: 'PUT',
   path: SYNTHETICS_API_URLS.SYNTHETICS_ENABLEMENT,
-  writeAccessOverride: true,
+  writeAccess: false,
   validate: {},
   handler: async ({ savedObjectsClient, request, server }): Promise<any> => {
     try {

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -27,6 +27,7 @@ export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse>
     const { monitorId } = routeContext.request.params;
     return triggerTestNow(monitorId, routeContext);
   },
+  writeAccess: true,
 });
 
 export const triggerTestNow = async (

--- a/x-pack/plugins/synthetics/server/routes/types.ts
+++ b/x-pack/plugins/synthetics/server/routes/types.ts
@@ -26,11 +26,13 @@ export type SyntheticsRequest = KibanaRequest<
   Record<string, any>
 >;
 
+export type SupportedMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
 /**
  * Defines the basic properties employed by Uptime routes.
  */
 export interface UMServerRoute<T> {
-  method: 'GET' | 'PUT' | 'POST' | 'DELETE';
+  method: SupportedMethod;
   writeAccess?: boolean;
   handler: T;
   validation?: FullValidationConfig<any, any, any>;

--- a/x-pack/plugins/synthetics/server/routes/types.ts
+++ b/x-pack/plugins/synthetics/server/routes/types.ts
@@ -32,7 +32,6 @@ export type SyntheticsRequest = KibanaRequest<
 export interface UMServerRoute<T> {
   method: 'GET' | 'PUT' | 'POST' | 'DELETE';
   writeAccess?: boolean;
-  writeAccessOverride?: boolean;
   handler: T;
   validation?: FullValidationConfig<any, any, any>;
   streamHandler?: (


### PR DESCRIPTION
## Summary

Simplifies the override functionality. Now, `writeAccess` is the only flag controlling this. All non-GET routes are defaulted to requiring write access. Also applies write access restriction to the trigger route, which is a GET.

## Testing instructions

Test the override routes, and the default behavior.

```shell
# Create a test user with user/pass: testuser/testuser

# Override: trigger route should return 403
curl -X GET http://localhost:5601/internal/synthetics/service/monitors/trigger/{monitorId} -u testuser:testuser 

# Override: enablement route should work for read user
curl -X PUT http://localhost:5601/internal/synthetics/service/enablement -u testuser:testuser -H "kbn-xsrf: true"

# Override: screenshot blocks should work
curl -X POST http://localhost:5601/internal/synthetics/journey/screenshot/block -u testuser:testuser -H "kbn-xsrf: true"

# a normal GET route returns 200
curl -X GET http://localhost:5601/internal/synthetics/service/monitor/{monitorId} -u testuser:testuser 

# a normal non-GET route returns 403
curl -X POST http://localhost:5601/internal/synthetics/enable_default_alerting -u testuser:testuser -H "kbn-xsrf: true"
```

<!--ONMERGE {"backportTargets":["8.12","8.13"]} ONMERGE-->