### PR TITLE
[Synthetics] Change test now trigger route from GET to POST

### DIFF
--- a/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/api.ts
+++ b/x-pack/plugins/synthetics/public/apps/synthetics/state/manual_test_runs/api.ts
@@ -16,7 +16,7 @@ export const triggerTestNowMonitor = async ({
   configId: string;
   name: string;
 }): Promise<TestNowResponse | undefined> => {
-  return await apiService.get(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${configId}`);
+  return await apiService.post(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${configId}`);
 };
 
 export const runOnceMonitor = async ({

--- a/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
+++ b/x-pack/plugins/synthetics/server/routes/synthetics_service/test_now_monitor.ts
@@ -16,7 +16,7 @@ import { SYNTHETICS_API_URLS } from '../../../common/constants';
 import { normalizeSecrets } from '../../synthetics_service/utils/secrets';
 
 export const testNowMonitorRoute: SyntheticsRestApiRouteFactory<TestNowResponse> = () => ({
-  method: 'GET',
+  method: 'POST',
   path: SYNTHETICS_API_URLS.TRIGGER_MONITOR + '/{monitorId}',
   validate: {
     params: schema.object({

--- a/x-pack/test/api_integration/apis/synthetics/test_now_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/test_now_monitor.ts
@@ -38,7 +38,7 @@ export default function ({ getService }: FtrProviderContext) {
       const resp = await monitorTestService.addMonitor(newMonitor);
 
       const res = await supertest
-        .get(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${resp.id}`)
+        .post(SYNTHETICS_API_URLS.TRIGGER_MONITOR + `/${resp.id}`)
         .set('kbn-xsrf', 'true')
         .expect(200);
 
@@ -79,7 +79,7 @@ export default function ({ getService }: FtrProviderContext) {
         .expect(200);
 
       const res = await supertest
-        .get(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.TRIGGER_MONITOR}/${resp.body.id}`)
+        .post(`/s/${SPACE_ID}${SYNTHETICS_API_URLS.TRIGGER_MONITOR}/${resp.body.id}`)
         .set('kbn-xsrf', 'true')
         .expect(200);
 


### PR DESCRIPTION
## Summary

This route should not be a `GET`. The processing initiated from this route causes persisted data and resource usage, not mere data retrieval.

## Testing

```bash
# on `main`, this is the route
curl -X GET http://localhost:5601/internal/synthetics/service/monitors/trigger/{monitorId} -u {user}:{pass} 

# on this branch, the route above returns a 404 and you must request like:
curl -X POST http://localhost:5601/internal/synthetics/service/monitors/trigger/{monitorId} -u {user}:{pass} -H "kbn-xsrf: true"
```

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->