### PR TITLE
[ML] Data Frame Analytics Creation: ensure correct permissions before allowing creation

### DIFF
--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/create_analytics_button_wrapper.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/create_analytics_button_wrapper.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+
+const indicesPermissionMessage = i18n.translate(
+  'xpack.ml.dataFrame.analyticsList.disabledCreationTooltipText',
+  {
+    defaultMessage:
+      'Analytics creation requires permission to create, start, and stop analytics as well as creation and management permissions for indices.',
+  }
+);
+
+export const CreateAnalyticsButtonWrapper: FC<{
+  children: any;
+  disabled: boolean;
+  tooltipContent?: string;
+}> = ({ children, disabled, tooltipContent }) => {
+  if (!disabled) {
+    return <>{children}</>;
+  }
+
+  return (
+    <EuiToolTip content={tooltipContent ?? indicesPermissionMessage}>
+      <>{children}</>
+    </EuiToolTip>
+  );
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/index.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { useIndexData } from './use_index_data';
+export { useHasRequiredIndicesPermissions } from './use_has_required_indices_permissions';

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_required_indices_permissions.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_required_indices_permissions.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect } from 'react';
+
+import { useMlKibana } from '../../../../contexts/kibana';
+
+export const useHasRequiredIndicesPermissions = () => {
+  const [hasIndexPermissions, setHasIndexPermissions] = useState<boolean>(false);
+  const {
+    services: {
+      mlServices: {
+        mlApiServices: { hasPrivileges },
+      },
+    },
+  } = useMlKibana();
+
+  useEffect(
+    function checkRequiredIndexPermissions() {
+      async function checkPrivileges() {
+        const privileges = await hasPrivileges({
+          index: [
+            {
+              names: ['*'], // uses wildcard
+              privileges: ['create_index', 'manage', 'index', 'read'],
+            },
+          ],
+        });
+
+        setHasIndexPermissions(
+          privileges.hasPrivileges === undefined ||
+            privileges.hasPrivileges.has_all_requested === true
+        );
+      }
+      if (hasPrivileges !== undefined) {
+        checkPrivileges();
+      }
+    },
+    [hasPrivileges]
+  );
+
+  return hasIndexPermissions;
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/create_analytics_button/create_analytics_button.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/create_analytics_button/create_analytics_button.tsx
@@ -6,9 +6,13 @@
  */
 
 import React, { FC } from 'react';
-import { EuiButton, EuiToolTip } from '@elastic/eui';
+import { EuiButton } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { createPermissionFailureMessage } from '../../../../../capabilities/check_capabilities';
+import { CreateAnalyticsButtonWrapper } from '../../../analytics_creation/components/create_analytics_button_wrapper';
+import { useHasRequiredIndicesPermissions } from '../../../analytics_creation/hooks';
+
+const createPermissionMessage = createPermissionFailureMessage('canCreateDataFrameAnalytics');
 
 interface Props {
   isDisabled: boolean;
@@ -20,31 +24,25 @@ export const CreateAnalyticsButton: FC<Props> = ({ isDisabled, navigateToSourceS
     navigateToSourceSelection();
   };
 
-  const button = (
-    <EuiButton
-      disabled={isDisabled}
-      fill
-      onClick={handleClick}
-      iconType="plusInCircle"
-      size="s"
-      data-test-subj="mlAnalyticsButtonCreate"
+  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions();
+
+  return (
+    <CreateAnalyticsButtonWrapper
+      disabled={isDisabled || !hasRequiredIndicesPermissions}
+      tooltipContent={!hasRequiredIndicesPermissions ? undefined : createPermissionMessage}
     >
-      {i18n.translate('xpack.ml.dataframe.analyticsList.createDataFrameAnalyticsButton', {
-        defaultMessage: 'Create job',
-      })}
-    </EuiButton>
-  );
-
-  if (isDisabled) {
-    return (
-      <EuiToolTip
-        position="top"
-        content={createPermissionFailureMessage('canCreateDataFrameAnalytics')}
+      <EuiButton
+        disabled={isDisabled || !hasRequiredIndicesPermissions}
+        fill
+        onClick={handleClick}
+        iconType="plusInCircle"
+        size="s"
+        data-test-subj="mlAnalyticsButtonCreate"
       >
-        {button}
-      </EuiToolTip>
-    );
-  }
-
-  return button;
+        {i18n.translate('xpack.ml.dataframe.analyticsList.createDataFrameAnalyticsButton', {
+          defaultMessage: 'Create job',
+        })}
+      </EuiButton>
+    </CreateAnalyticsButtonWrapper>
+  );
 };

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/empty_prompt/empty_prompt.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/components/empty_prompt/empty_prompt.tsx
@@ -14,11 +14,15 @@ import { mlNodesAvailable } from '../../../../../ml_nodes_check';
 import { useMlKibana, useNavigateToPath } from '../../../../../contexts/kibana';
 import { ML_PAGES } from '../../../../../../../common/constants/locator';
 import { usePermissionCheck } from '../../../../../capabilities/check_capabilities';
+import { useHasRequiredIndicesPermissions } from '../../../analytics_creation/hooks';
+import { CreateAnalyticsButtonWrapper } from '../../../analytics_creation/components/create_analytics_button_wrapper';
 
 export const AnalyticsEmptyPrompt: FC = () => {
   const {
     services: { docLinks },
   } = useMlKibana();
+
+  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions();
 
   const [canCreateDataFrameAnalytics, canStartStopDataFrameAnalytics] = usePermissionCheck([
     'canCreateDataFrameAnalytics',
@@ -26,7 +30,10 @@ export const AnalyticsEmptyPrompt: FC = () => {
   ]);
 
   const disabled =
-    !mlNodesAvailable() || !canCreateDataFrameAnalytics || !canStartStopDataFrameAnalytics;
+    !mlNodesAvailable() ||
+    !canCreateDataFrameAnalytics ||
+    !canStartStopDataFrameAnalytics ||
+    !hasRequiredIndicesPermissions;
 
   const navigateToPath = useNavigateToPath();
 
@@ -67,16 +74,18 @@ export const AnalyticsEmptyPrompt: FC = () => {
         </>
       }
       actions={[
-        <EuiButton
-          onClick={navigateToSourceSelection}
-          isDisabled={disabled}
-          color="primary"
-          data-test-subj="mlAnalyticsCreateFirstButton"
-        >
-          {i18n.translate('xpack.ml.dataFrame.analyticsList.emptyPromptButtonText', {
-            defaultMessage: 'Create data frame analytics job',
-          })}
-        </EuiButton>,
+        <CreateAnalyticsButtonWrapper disabled={disabled}>
+          <EuiButton
+            onClick={navigateToSourceSelection}
+            isDisabled={disabled}
+            color="primary"
+            data-test-subj="mlAnalyticsCreateFirstButton"
+          >
+            {i18n.translate('xpack.ml.dataFrame.analyticsList.emptyPromptButtonText', {
+              defaultMessage: 'Create data frame analytics job',
+            })}
+          </EuiButton>
+        </CreateAnalyticsButtonWrapper>,
         <EuiLink href={docLinks.links.ml.dataFrameAnalytics} target="_blank" external>
           <FormattedMessage
             id="xpack.ml.common.readDocumentationLink"


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/174125

This PR adds a check for the additional [permissions](https://www.elastic.co/guide/en/elasticsearch/reference/current/start-dfanalytics.html) needed for data frame analytics creation - particularly the indices permissions needed. 

When those permissions are not met, the creation button is disabled.

<img width="1175" alt="image" src="https://github.com/elastic/kibana/assets/6446462/569706e3-77f7-44b1-9f3a-5394995522e6">

<img width="1185" alt="image" src="https://github.com/elastic/kibana/assets/6446462/5f0101c8-79b3-41ba-b08c-22881bf36334">



### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

