### PR TITLE
[Obs AI Assistant] Show prompt suggestions from LLM (WIP)

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/common/functions/prompt_suggestions.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/functions/prompt_suggestions.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { FromSchema } from 'json-schema-to-ts';
+
+export const promptSuggestionsFunctionDefinition = {
+  name: 'prompt_suggestions',
+  contexts: ['core' as const],
+
+  description:
+    'Use this function to suggest questions that the user can ask to continue the conversation. Call this for every message.',
+  descriptionForUser:
+    'This function allows the Elastic Assistant to guide the user to the next step in the conversation.',
+  parameters: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      suggestions: {
+        type: 'array',
+        minItems: 1,
+        maxItems: 4,
+        items: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            title: {
+              type: 'string',
+              additionalProperties: false,
+              description: 'The title of the suggestion',
+            },
+            prompt: {
+              type: 'string',
+              additionalProperties: false,
+              description: 'The prompt that the user can use to continue the conversation',
+            },
+          },
+        },
+      },
+    },
+    required: ['suggestions' as const],
+  } as const,
+};
+
+export type PromptSuggestionFunctionArguments = FromSchema<
+  typeof promptSuggestionsFunctionDefinition['parameters']
+>;

--- a/x-pack/plugins/observability_ai_assistant/public/functions/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/public/functions/index.ts
@@ -11,6 +11,7 @@ import type {
   RegisterRenderFunctionDefinition,
 } from '../types';
 import { registerLensRenderFunction } from './lens';
+import { registerPromptSuggestionRenderFunction } from './prompt_suggestions';
 import { registerVisualizeQueryRenderFunction } from './visualize_esql';
 
 export async function registerFunctions({
@@ -24,4 +25,5 @@ export async function registerFunctions({
 }) {
   registerLensRenderFunction({ service, pluginsStart, registerRenderFunction });
   registerVisualizeQueryRenderFunction({ service, pluginsStart, registerRenderFunction });
+  registerPromptSuggestionRenderFunction({ service, pluginsStart, registerRenderFunction });
 }

--- a/x-pack/plugins/observability_ai_assistant/public/functions/prompt_suggestions.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/functions/prompt_suggestions.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { EuiCard, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import React from 'react';
+import { PromptSuggestionFunctionArguments } from '../../common/functions/prompt_suggestions';
+import type {
+  ObservabilityAIAssistantPluginStartDependencies,
+  ObservabilityAIAssistantService,
+  RegisterRenderFunctionDefinition,
+  RenderFunction,
+} from '../types';
+
+function PromptSuggestions({
+  suggestions,
+}: {
+  suggestions: PromptSuggestionFunctionArguments['suggestions'];
+}) {
+  return (
+    <EuiFlexGroup gutterSize="l">
+      {suggestions.map((suggestion, i) => (
+        <EuiFlexItem>
+          <EuiCard
+            title={suggestion.title ?? ''}
+            description={suggestion.prompt}
+            onClick={() => {}}
+          />
+        </EuiFlexItem>
+      ))}
+    </EuiFlexGroup>
+  );
+}
+
+export function registerPromptSuggestionRenderFunction({
+  service,
+  registerRenderFunction,
+  pluginsStart,
+}: {
+  service: ObservabilityAIAssistantService;
+  registerRenderFunction: RegisterRenderFunctionDefinition;
+  pluginsStart: ObservabilityAIAssistantPluginStartDependencies;
+}) {
+  registerRenderFunction(
+    'prompt_suggestions',
+    ({
+      arguments: { suggestions },
+    }: Parameters<RenderFunction<PromptSuggestionFunctionArguments, {}>>[0]) => {
+      return <PromptSuggestions suggestions={suggestions} />;
+    }
+  );
+}

--- a/x-pack/plugins/observability_ai_assistant/server/functions/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/index.ts
@@ -68,7 +68,7 @@ export const registerFunctions: ChatRegistrationFunction = async ({
 
         If the "get_dataset_info" function returns no data, and the user asks for a query, generate a query anyway with the "query" function, but be explicit about it potentially being incorrect.
 
-        Use the "prompt_suggestions" prompts that the user can ask to continue the conversation. Call this function after every message.
+        Use the "prompt_suggestions" function to suggest prompts that the user can ask to continue the conversation. Call this function after every message.
 
         ${
           hasFunction('get_data_on_screen')

--- a/x-pack/plugins/observability_ai_assistant/server/functions/index.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/index.ts
@@ -68,7 +68,7 @@ export const registerFunctions: ChatRegistrationFunction = async ({
 
         If the "get_dataset_info" function returns no data, and the user asks for a query, generate a query anyway with the "query" function, but be explicit about it potentially being incorrect.
 
-        Use the "prompt_suggestions" function to suggest prompts that the user can ask to continue the conversation. Call this function after every message.
+        Use the "prompt_suggestions" function to suggest prompts that the user can ask to continue the conversation. YOU MUST CALL THIS FUNCTION if you don't call any other functions.
 
         ${
           hasFunction('get_data_on_screen')

--- a/x-pack/plugins/observability_ai_assistant/server/functions/prompt_suggestions.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/prompt_suggestions.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import dedent from 'dedent';
+import { promptSuggestionsFunctionDefinition } from '../../common/functions/prompt_suggestions';
+import type { FunctionRegistrationParameters } from '.';
+
+export function registerPromptSuggestionsFunction({
+  registerFunction,
+}: FunctionRegistrationParameters) {
+  registerFunction(
+    promptSuggestionsFunctionDefinition,
+    async ({ arguments: { suggestions } }, signal) => {
+      return {
+        content: dedent(`Displaying ${suggestions.length} prompt suggestions to the user:
+        ${suggestions.join('\n')}`),
+      };
+    }
+  );
+}


### PR DESCRIPTION
This adds a function that retrieves prompts prompt suggestions (based on the conversation context) from the LLM. Currently the function must be invoked manually with a prompt like "Can you suggest questions to ask". The plan is to get the LLM to call the function automatically whenever it sees fit.

<img width="983" alt="image" src="https://github.com/elastic/kibana/assets/209966/2b0208cc-c9ce-4547-9abd-a95d917b3be2">
