### PR TITLE
[DataViews] Fix management functional tests for serverless

### DIFF
--- a/src/plugins/data_view_editor/public/components/form_fields/timestamp_field.tsx
+++ b/src/plugins/data_view_editor/public/components/form_fields/timestamp_field.tsx
@@ -150,6 +150,7 @@ export const TimestampField = ({ options$, isLoadingOptions$, matchedIndices$ }:
                     }
                   )}
                   isLoading={isLoadingOptions}
+                  data-is-loading={isLoadingOptions ? '1' : '0'}
                   fullWidth
                 />
                 <EuiFormHelpText>

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -22,10 +22,6 @@ export class SettingsPageObject extends FtrService {
   private readonly savedObjects = this.ctx.getPageObject('savedObjects');
   private readonly monacoEditor = this.ctx.getService('monacoEditor');
 
-  async clickNavigation() {
-    await this.find.clickDisplayedByCssSelector('.app-link:nth-child(5) a');
-  }
-
   async clickLinkText(text: string) {
     await this.find.clickByDisplayedLinkText(text);
   }
@@ -127,22 +123,6 @@ export class SettingsPageObject extends FtrService {
     await this.header.waitUntilLoadingHasFinished();
   }
 
-  async setAdvancedSettingsTextArea(propertyName: string, propertyValue: string) {
-    const wrapper = await this.testSubjects.find(`management-settings-editField-${propertyName}`);
-    const textarea = await wrapper.findByTagName('textarea');
-    await textarea.focus();
-    // only way to properly replace the value of the ace editor is via the JS api
-    await this.browser.execute(
-      (editor: string, value: string) => {
-        return (window as any).ace.edit(editor).setValue(value);
-      },
-      `management-settings-editField-${propertyName}-editor`,
-      propertyValue
-    );
-    await this.testSubjects.click(`settings-save-button`);
-    await this.header.waitUntilLoadingHasFinished();
-  }
-
   async setAdvancedSettingsImage(propertyName: string, path: string) {
     const input = await this.testSubjects.find(`management-settings-editField-${propertyName}`);
     await input.type(path);
@@ -172,11 +152,6 @@ export class SettingsPageObject extends FtrService {
     return this.testSubjects.find('createIndexPatternTitleInput');
   }
 
-  async getTimeFieldNameField() {
-    const wrapperElement = await this.testSubjects.find('timestampField');
-    return wrapperElement.findByTestSubject('comboBoxSearchInput');
-  }
-
   async selectTimeFieldOption(selection: string) {
     const testSubj = 'timestampField';
     const timefield = await this.testSubjects.find(testSubj);
@@ -190,12 +165,8 @@ export class SettingsPageObject extends FtrService {
     await this.retry.waitFor('time field dropdown have the right value', async () => {
       await this.comboBox.clearInputField(testSubj);
       await this.comboBox.set(testSubj, selection);
-      return (await this.comboBox.isOptionSelected(timefield, selection));
+      return await this.comboBox.isOptionSelected(timefield, selection);
     });
-  }
-
-  async getTimeFieldOption(selection: string) {
-    return await this.find.displayedByCssSelector('option[value="' + selection + '"]');
   }
 
   async getNameField() {
@@ -225,15 +196,6 @@ export class SettingsPageObject extends FtrService {
     return await this.testSubjects.find('saveIndexPatternButton');
   }
 
-  async getCreateButton() {
-    return await this.find.displayedByCssSelector('[type="submit"]');
-  }
-
-  async clickDefaultIndexButton() {
-    await this.testSubjects.click('setDefaultIndexPatternButton');
-    await this.header.waitUntilLoadingHasFinished();
-  }
-
   async clickEditIndexButton() {
     await this.testSubjects.click('editIndexPatternButton');
     await this.retry.waitFor('flyout', async () => {
@@ -247,10 +209,6 @@ export class SettingsPageObject extends FtrService {
 
   async getIndexPageHeading() {
     return await this.testSubjects.getVisibleText('indexPatternTitle');
-  }
-
-  async getConfigureHeader() {
-    return await this.find.byCssSelector('h1');
   }
 
   async getTableHeader() {
@@ -450,10 +408,6 @@ export class SettingsPageObject extends FtrService {
     await this.header.waitUntilLoadingHasFinished();
   }
 
-  async hasIndexPattern(name: string) {
-    return await this.find.existsByLinkText(name);
-  }
-
   async clickIndexPatternByName(name: string) {
     const indexLink = await this.find.byXPath(`//a[text()='${name}']`);
     await indexLink.click();
@@ -507,7 +461,7 @@ export class SettingsPageObject extends FtrService {
       await this.header.waitUntilLoadingHasFinished();
       if (
         options.ignoreMissing &&
-        (await this.testSubjects.exists(`detail-link-${dataViewName}`)) === false
+        !(await this.testSubjects.exists(`detail-link-${dataViewName}`))
       ) {
         return;
       }
@@ -717,10 +671,6 @@ export class SettingsPageObject extends FtrService {
     });
   }
 
-  async getCreateIndexPatternGoToStep2Button() {
-    return await this.testSubjects.find('createIndexPatternGoToStep2Button');
-  }
-
   async removeIndexPattern() {
     let alertText;
     await this.retry.try(async () => {
@@ -742,11 +692,6 @@ export class SettingsPageObject extends FtrService {
       }
     });
     return alertText;
-  }
-
-  async clickFieldsTab() {
-    this.log.debug('click Fields tab');
-    await this.testSubjects.click('tab-indexedFields');
   }
 
   async clickScriptedFieldsTab() {
@@ -1100,9 +1045,5 @@ export class SettingsPageObject extends FtrService {
       `select[data-test-subj="managementChangeIndexSelection-${oldIndexPatternId}"] >
       [data-test-subj="indexPatternOption-${newIndexPatternTitle}"]`
     );
-  }
-
-  async clickChangeIndexConfirmButton() {
-    await this.testSubjects.click('changeIndexConfirmButton');
   }
 }

--- a/test/functional/page_objects/settings_page.ts
+++ b/test/functional/page_objects/settings_page.ts
@@ -178,21 +178,19 @@ export class SettingsPageObject extends FtrService {
   }
 
   async selectTimeFieldOption(selection: string) {
+    const testSubj = 'timestampField';
+    const timefield = await this.testSubjects.find(testSubj);
     // open dropdown
-    const timefield = await this.getTimeFieldNameField();
-    const prevValue = await timefield.getAttribute('value');
-    const enabled = await timefield.isEnabled();
+    const isSelected = await this.comboBox.isOptionSelected(timefield, selection);
+    const isDisabled = await this.comboBox.isDisabled(timefield);
 
-    if (prevValue === selection || !enabled) {
+    if (isSelected || isDisabled) {
       return;
     }
     await this.retry.waitFor('time field dropdown have the right value', async () => {
-      await timefield.click();
-      await timefield.type(this.browser.keys.DELETE, { charByChar: true });
-      await this.browser.pressKeys(selection);
-      await this.browser.pressKeys(this.browser.keys.TAB);
-      const value = await timefield.getAttribute('value');
-      return value === selection;
+      await this.comboBox.clearInputField(testSubj);
+      await this.comboBox.set(testSubj, selection);
+      return (await this.comboBox.isOptionSelected(timefield, selection));
     });
   }
 


### PR DESCRIPTION
## Summary

Fixes #175900 
Fixes #176861

This PR stabilizes the setting of the timestamp field, when a data view is being added / edited. Those tests just occasionally failed in serverless.
Furthermore it cleans up unused functions.

Flaky test runner 75x
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5230 - A run of 25 failed, stopped due an unrelated error

Flaky test runner 50x
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5233 - Running the failed ones again, successfully

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios