### PR TITLE
[Infra] Use panel filters in the condition to detemine when to use host.names…

### DIFF
--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/kpis/kpi.tsx
@@ -25,7 +25,7 @@ export const Kpi = ({ id, height, ...chartProps }: LensConfig & { height: number
   const loading = hostsLoading || hostCountLoading;
 
   const filters = shouldUseSearchCriteria
-    ? searchCriteria.filters
+    ? [...searchCriteria.filters, ...(searchCriteria.panelFilters ?? [])]
     : [
         buildCombinedHostsFilter({
           field: 'host.name',

--- a/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
+++ b/x-pack/plugins/infra/public/pages/metrics/hosts/components/tabs/metrics/chart.tsx
@@ -38,7 +38,7 @@ export const Chart = ({ id, ...chartProps }: ChartProps) => {
 
   const filters = useMemo(() => {
     return shouldUseSearchCriteria
-      ? searchCriteria.filters
+      ? [...searchCriteria.filters, ...(searchCriteria.panelFilters ?? [])]
       : [
           buildCombinedHostsFilter({
             field: 'host.name',
@@ -46,7 +46,13 @@ export const Chart = ({ id, ...chartProps }: ChartProps) => {
             dataView,
           }),
         ];
-  }, [shouldUseSearchCriteria, searchCriteria.filters, currentPage, dataView]);
+  }, [
+    shouldUseSearchCriteria,
+    searchCriteria.filters,
+    searchCriteria.panelFilters,
+    currentPage,
+    dataView,
+  ]);
 
   return (
     <LensChart


### PR DESCRIPTION
closes [177162](https://github.com/elastic/kibana/issues/177162)

## Summary

Fixes the condition that determines when to use the host names in the charts' filter

<img width="690" alt="image" src="https://github.com/elastic/kibana/assets/2767137/50f3eae7-2d65-4985-b2f3-f241895356a0">


### How to test

- Start local Kibana instance
- Navigate to `Infrastructure` > `Hosts`
- Select a value in any custom control that won't return any data.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->