### PR TITLE
[ML] AIOPs: Unskip API integrations tests.

### DIFF
--- a/x-pack/plugins/aiops/common/__mocks__/artificial_logs/significant_log_patterns.ts
+++ b/x-pack/plugins/aiops/common/__mocks__/artificial_logs/significant_log_patterns.ts
@@ -18,8 +18,8 @@ export const significantLogPatterns: SignificantItem[] = [
     normalizedScore: 0,
     pValue: 0.000001,
     score: -13.815510557964274,
-    total_bg_count: 2528,
-    total_doc_count: 6650,
+    total_bg_count: 1975,
+    total_doc_count: 4669,
     type: 'log_pattern',
   },
 ];

--- a/x-pack/test/api_integration/apis/aiops/log_rate_analysis_full_analysis.ts
+++ b/x-pack/test/api_integration/apis/aiops/log_rate_analysis_full_analysis.ts
@@ -31,8 +31,7 @@ export default ({ getService }: FtrProviderContext) => {
   const kibanaServerUrl = formatUrl(config.get('servers.kibana'));
   const esArchiver = getService('esArchiver');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/176053
-  describe.skip('POST /internal/aiops/log_rate_analysis - full analysis', () => {
+  describe('POST /internal/aiops/log_rate_analysis - full analysis', () => {
     API_VERSIONS.forEach((apiVersion) => {
       getLogRateAnalysisTestData<typeof apiVersion>().forEach((testData) => {
         describe(`with v${apiVersion} - ${testData.testName}`, () => {


### PR DESCRIPTION
## Summary

Fixes #176053.

The fix in #176587 should stabilize tests so this PR adjuest test data and reenables AIOps API integration tests for log rate analysis.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->