### PR TITLE
[Obs AI Assistant] Show conversation token count in UI

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/common/conversation_complete.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/conversation_complete.ts
@@ -6,7 +6,7 @@
  */
 
 import { i18n } from '@kbn/i18n';
-import { Message } from './types';
+import { Conversation, Message } from './types';
 
 export enum StreamingChatResponseEventType {
   ChatCompletionChunk = 'chatCompletionChunk',
@@ -41,22 +41,14 @@ export type ChatCompletionChunkEvent = StreamingChatResponseEventBase<
 export type ConversationCreateEvent = StreamingChatResponseEventBase<
   StreamingChatResponseEventType.ConversationCreate,
   {
-    conversation: {
-      id: string;
-      title: string;
-      last_updated: string;
-    };
+    conversation: Conversation['conversation'];
   }
 >;
 
 export type ConversationUpdateEvent = StreamingChatResponseEventBase<
   StreamingChatResponseEventType.ConversationUpdate,
   {
-    conversation: {
-      id: string;
-      title: string;
-      last_updated: string;
-    };
+    conversation: Conversation['conversation'];
   }
 >;
 

--- a/x-pack/plugins/observability_ai_assistant/common/types.ts
+++ b/x-pack/plugins/observability_ai_assistant/common/types.ts
@@ -63,6 +63,7 @@ export interface Conversation {
     id: string;
     title: string;
     last_updated: string;
+    token_count?: number;
   };
   messages: Message[];
   labels: Record<string, string>;
@@ -72,7 +73,7 @@ export interface Conversation {
 }
 
 export type ConversationRequestBase = Omit<Conversation, 'user' | 'conversation' | 'namespace'> & {
-  conversation: { title: string };
+  conversation: { title: string; token_count?: number };
 };
 
 export type ConversationCreateRequest = ConversationRequestBase;

--- a/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
+++ b/x-pack/plugins/observability_ai_assistant/public/components/chat/chat_body.tsx
@@ -16,6 +16,7 @@ import {
   EuiSpacer,
   useEuiTheme,
   euiScrollBarStyles,
+  EuiText,
 } from '@elastic/eui';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { euiThemeVars } from '@kbn/ui-theme';
@@ -390,6 +391,18 @@ export function ChatBody({
                 return next(messages.concat(message));
               }}
             />
+            {conversation.value?.conversation.token_count && (
+              <EuiFlexGroup justifyContent="flexEnd">
+                <EuiFlexItem grow={false}>
+                  <EuiText size="xs">
+                    {i18n.translate('xpack.observabilityAiAssistant.chatBody.tokenCountTextLabel', {
+                      defaultMessage: '{tokenCount} tokens',
+                      values: { tokenCount: conversation.value?.conversation.token_count },
+                    })}
+                  </EuiText>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            )}
             <EuiSpacer size="s" />
           </EuiPanel>
         </EuiFlexItem>

--- a/x-pack/plugins/observability_ai_assistant/server/routes/runtime_types.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/routes/runtime_types.ts
@@ -54,9 +54,12 @@ export const messageRt: t.Type<Message> = t.type({
 
 export const baseConversationRt: t.Type<ConversationRequestBase> = t.type({
   '@timestamp': t.string,
-  conversation: t.type({
-    title: t.string,
-  }),
+  conversation: t.intersection([
+    t.type({
+      title: t.string,
+    }),
+    t.partial({ token_count: t.number }),
+  ]),
   messages: t.array(messageRt),
   labels: t.record(t.string, t.string),
   numeric_labels: t.record(t.string, t.number),
@@ -75,10 +78,13 @@ export const conversationCreateRt: t.Type<ConversationCreateRequest> = t.interse
 export const conversationUpdateRt: t.Type<ConversationUpdateRequest> = t.intersection([
   baseConversationRt,
   t.type({
-    conversation: t.type({
-      id: t.string,
-      title: t.string,
-    }),
+    conversation: t.intersection([
+      t.type({
+        id: t.string,
+        title: t.string,
+      }),
+      t.partial({ token_count: t.number }),
+    ]),
   }),
 ]);
 

--- a/x-pack/plugins/observability_ai_assistant/server/service/conversation_component_template.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/service/conversation_component_template.ts
@@ -20,6 +20,10 @@ const date = {
   type: 'date' as const,
 };
 
+const integer = {
+  type: 'integer' as const,
+};
+
 const dynamic = {
   type: 'object' as const,
   dynamic: true,
@@ -55,6 +59,7 @@ export const conversationComponentTemplate: ClusterComponentTemplate['component_
             id: keyword,
             title: text,
             last_updated: date,
+            token_count: integer,
           },
         },
         namespace: keyword,


### PR DESCRIPTION
Closes https://github.com/elastic/obs-ai-assistant-team/issues/121

This displays the token count for the entire conversation in the UI. Then token count only includes sent messages. It does not include functions or unsent messages.

While not entirely accurate this gives the user an impression of the size of the conversation (and thus cost)


<img width="948" alt="image" src="https://github.com/elastic/kibana/assets/209966/a6e4bd12-16ac-45e5-a11d-306f61ade1b7">

_Token count is displayed in the bottom right corner_
