### PR TITLE
[Search] Remove hidden indices from default data view

### DIFF
--- a/x-pack/plugins/serverless_search/server/plugin.ts
+++ b/x-pack/plugins/serverless_search/server/plugin.ts
@@ -69,7 +69,7 @@ export class ServerlessSearchPlugin
         await dataViewsService.createAndSave({
           allowNoIndex: false,
           name: 'default:all-data',
-          title: '*',
+          title: '*,-.*',
           id: 'default_all_data_id',
         });
       }


### PR DESCRIPTION
## Summary

This updates the default Serverless data view to exclude system indices.