### PR TITLE
[Fleet] fix tags filter

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.test.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.test.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+
+import { createFleetTestRendererMock } from '../../../../../../../mock';
+
+import { TagsFilter } from './tags_filter';
+
+describe('TagsFilter', () => {
+  function render(props: any) {
+    const renderer = createFleetTestRendererMock();
+
+    return renderer.render(<TagsFilter {...props} />);
+  }
+
+  it('should remove one tag on clicking selected tag', async () => {
+    const tags = ['tag1', 'tag2', 'tag3'];
+    const selectedTags = ['tag1', 'tag2', 'tag3'];
+    const onSelectedTagsChange = jest.fn();
+    const props = {
+      tags,
+      selectedTags,
+      onSelectedTagsChange,
+    };
+    const { getByText, getByTestId } = render(props);
+    const filterButton = getByTestId('agentList.tagsFilter');
+    filterButton.click();
+    const tag = getByText('tag1');
+    tag.click();
+    expect(onSelectedTagsChange).toHaveBeenCalledWith(['tag2', 'tag3']);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agents/agent_list_page/components/filter_bar/tags_filter.tsx
@@ -73,18 +73,19 @@ export const TagsFilter: React.FunctionComponent<Props> = ({
       <EuiSelectable
         options={options as any}
         onChange={(newOptions: EuiSelectableOption[]) => {
-          setOptions(newOptions);
           newOptions.forEach((option, index) => {
             if (option.checked !== options[index].checked) {
               const tag = option.key!;
               if (option.checked !== 'on') {
                 removeTagsFilter(tag);
+                return;
               } else {
                 addTagsFilter(tag);
+                return;
               }
-              return;
             }
           });
+          setOptions(newOptions);
         }}
         data-test-subj="agentList.agentPolicyFilterOptions"
         listProps={{


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/176560

Fixed a bug with Tags filter on Agent List UI, where removing a tag filter incorrectly triggered removing all tag filters.
This was only reproducible on cloud.
The screen recording was captured in a cloud pr deployment ([here](https://github.com/elastic/kibana/pull/177195))


https://github.com/elastic/kibana/assets/90178898/6ae713bb-b725-41a7-8a1a-b958ae50811b



Added `release_note:skip` because the bug was introduced in 8.13.0 with the refactoring of the filter to use `EuiSelectable`.

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->