### PR TITLE
[Search] Fix native connector API key management

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/attach_index_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/attach_index_api_logic.ts
@@ -11,15 +11,21 @@ import { HttpLogic } from '../../../shared/http';
 export interface AttachIndexApiLogicArgs {
   connectorId: string;
   indexName: string;
+  isNative: boolean;
 }
 
 export const attachIndex = async ({
   connectorId,
   indexName,
+  isNative,
 }: AttachIndexApiLogicArgs): Promise<void> => {
   const route = `/internal/enterprise_search/connectors/${connectorId}/index_name/${indexName}`;
 
-  await HttpLogic.values.http.put(route);
+  await HttpLogic.values.http.put(route, {
+    body: JSON.stringify({
+      is_native: isNative,
+    }),
+  });
 };
 
 export const AttachIndexApiLogic = createApiLogic(['add_connector_api_logic'], attachIndex);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/attach_index_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/attach_index_api_logic.ts
@@ -11,21 +11,15 @@ import { HttpLogic } from '../../../shared/http';
 export interface AttachIndexApiLogicArgs {
   connectorId: string;
   indexName: string;
-  isNative: boolean;
 }
 
 export const attachIndex = async ({
   connectorId,
   indexName,
-  isNative,
 }: AttachIndexApiLogicArgs): Promise<void> => {
   const route = `/internal/enterprise_search/connectors/${connectorId}/index_name/${indexName}`;
 
-  await HttpLogic.values.http.put(route, {
-    body: JSON.stringify({
-      is_native: isNative,
-    }),
-  });
+  await HttpLogic.values.http.put(route);
 };
 
 export const AttachIndexApiLogic = createApiLogic(['add_connector_api_logic'], attachIndex);

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_api_key_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_api_key_api_logic.test.ts
@@ -25,12 +25,12 @@ describe('generateConnectorApiKeyApiLogic', () => {
     it('calls correct api', async () => {
       const promise = Promise.resolve('result');
       http.post.mockReturnValue(promise);
-      const result = generateApiKey({ indexName: 'indexName', isNative: false, secretId: null });
+      const result = generateApiKey({ indexName: 'indexName', isNative: false });
       await nextTick();
       expect(http.post).toHaveBeenCalledWith(
         '/internal/enterprise_search/indices/indexName/api_key',
         {
-          body: '{"is_native":false,"secret_id":null}',
+          body: '{"is_native":false}',
         }
       );
       await expect(result).resolves.toEqual('result');
@@ -41,12 +41,12 @@ describe('generateConnectorApiKeyApiLogic', () => {
     it('calls correct api', async () => {
       const promise = Promise.resolve('result');
       http.post.mockReturnValue(promise);
-      const result = generateApiKey({ indexName: 'indexName', isNative: true, secretId: '1234' });
+      const result = generateApiKey({ indexName: 'indexName', isNative: true });
       await nextTick();
       expect(http.post).toHaveBeenCalledWith(
         '/internal/enterprise_search/indices/indexName/api_key',
         {
-          body: '{"is_native":true,"secret_id":"1234"}',
+          body: '{"is_native":true}',
         }
       );
       await expect(result).resolves.toEqual('result');

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_api_key_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/generate_connector_api_key_api_logic.ts
@@ -18,16 +18,13 @@ export interface ApiKey {
 export const generateApiKey = async ({
   indexName,
   isNative,
-  secretId,
 }: {
   indexName: string;
   isNative: boolean;
-  secretId: string | null;
 }) => {
   const route = `/internal/enterprise_search/indices/${indexName}/api_key`;
   const params = {
     is_native: isNative,
-    secret_id: secretId,
   };
   return await HttpLogic.values.http.post<ApiKey>(route, {
     body: JSON.stringify(params),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -51,7 +51,11 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
     if (selectedIndex?.shouldCreate) {
       createIndex({ indexName: selectedIndex.label, language: selectedLanguage ?? null });
     } else if (selectedIndex) {
-      attachIndex({ connectorId: connector.id, indexName: selectedIndex.label });
+      attachIndex({
+        connectorId: connector.id,
+        indexName: selectedIndex.label,
+        isNative: connector.is_native,
+      });
     }
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -54,7 +54,6 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
       attachIndex({
         connectorId: connector.id,
         indexName: selectedIndex.label,
-        isNative: connector.is_native,
       });
     }
   };

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -51,10 +51,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
     if (selectedIndex?.shouldCreate) {
       createIndex({ indexName: selectedIndex.label, language: selectedLanguage ?? null });
     } else if (selectedIndex) {
-      attachIndex({
-        connectorId: connector.id,
-        indexName: selectedIndex.label,
-      });
+      attachIndex({ connectorId: connector.id, indexName: selectedIndex.label });
     }
   };
 

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
@@ -71,7 +71,11 @@ export const AttachIndexLogic = kea<MakeLogicType<AttachIndexValues, AttachIndex
     createIndexApiSuccess: async ({ indexName }, breakpoint) => {
       if (values.connector) {
         await breakpoint(500);
-        actions.attachIndex({ connectorId: values.connector?.id, indexName });
+        actions.attachIndex({
+          connectorId: values.connector?.id,
+          indexName,
+          isNative: values.connector?.is_native,
+        });
       }
     },
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
@@ -74,7 +74,6 @@ export const AttachIndexLogic = kea<MakeLogicType<AttachIndexValues, AttachIndex
         actions.attachIndex({
           connectorId: values.connector?.id,
           indexName,
-          isNative: values.connector?.is_native,
         });
       }
     },

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
@@ -71,10 +71,7 @@ export const AttachIndexLogic = kea<MakeLogicType<AttachIndexValues, AttachIndex
     createIndexApiSuccess: async ({ indexName }, breakpoint) => {
       if (values.connector) {
         await breakpoint(500);
-        actions.attachIndex({
-          connectorId: values.connector?.id,
-          indexName,
-        });
+        actions.attachIndex({ connectorId: values.connector?.id, indexName });
       }
     },
   }),

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -103,7 +103,6 @@ export const ConnectorConfiguration: React.FC = () => {
                       indexName={indexName}
                       hasApiKey={!!connector.api_key_id}
                       isNative={false}
-                      secretId={null}
                     />
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -182,9 +182,9 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',
                   title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.refreshApiKeyTitle',
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
                     {
-                      defaultMessage: 'Refresh API key',
+                      defaultMessage: 'Manage API key',
                     }
                   ),
                   titleSize: 'xs',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -34,10 +34,12 @@ import { CONNECTOR_ICONS } from '../../../shared/icons/connector_icons';
 import { KibanaLogic } from '../../../shared/kibana';
 
 import { EuiButtonTo } from '../../../shared/react_router_helpers';
+import { GenerateConnectorApiKeyApiLogic } from '../../api/connector/generate_connector_api_key_api_logic';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
 import { hasConfiguredConfiguration } from '../../utils/has_configured_configuration';
 
 import { SyncsContextMenu } from '../search_index/components/header_actions/syncs_context_menu';
+import { ApiKeyConfig } from '../search_index/connector/api_key_configuration';
 import { BETA_CONNECTORS, NATIVE_CONNECTORS } from '../search_index/connector/constants';
 import { ConvertConnector } from '../search_index/connector/native_connector_configuration/convert_connector';
 import { NativeConnectorConfigurationConfig } from '../search_index/connector/native_connector_configuration/native_connector_configuration_config';
@@ -51,6 +53,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
   const { connector } = useValues(ConnectorViewLogic);
   const { config } = useValues(KibanaLogic);
   const { errorConnectingMessage } = useValues(HttpLogic);
+  const { data: apiKeyData } = useValues(GenerateConnectorApiKeyApiLogic);
 
   if (!connector) {
     return <></>;
@@ -79,6 +82,8 @@ export const NativeConnectorConfiguration: React.FC = () => {
     connector.scheduling.incremental.enabled;
   const hasResearched = hasDescription || hasConfigured || hasConfiguredAdvanced;
   const icon = nativeConnector.icon;
+
+  const hasApiKey = !!(connector.api_key_id ?? apiKeyData);
 
   // TODO service_type === "" is considered unknown/custom connector multipleplaces replace all of them with a better solution
   const isBeta =
@@ -163,6 +168,23 @@ export const NativeConnectorConfiguration: React.FC = () => {
                     'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.configurationTitle',
                     {
                       defaultMessage: 'Configuration',
+                    }
+                  ),
+                  titleSize: 'xs',
+                },
+                {
+                  children: (
+                    <ApiKeyConfig
+                      indexName={connector.index_name || ''}
+                      hasApiKey={hasApiKey}
+                      isNative
+                    />
+                  ),
+                  status: hasApiKey ? 'complete' : 'incomplete',
+                  title: i18n.translate(
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.refreshApiKeyTitle',
+                    {
+                      defaultMessage: 'Refresh API key',
                     }
                   ),
                   titleSize: 'xs',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
@@ -16,6 +16,7 @@ import {
   EuiButton,
   EuiSpacer,
   EuiConfirmModal,
+  EuiCallOut,
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
@@ -65,8 +66,7 @@ export const ApiKeyConfig: React.FC<{
   hasApiKey: boolean;
   indexName: string;
   isNative: boolean;
-  secretId: string | null;
-}> = ({ hasApiKey, indexName, isNative, secretId }) => {
+}> = ({ hasApiKey, indexName, isNative }) => {
   const { makeRequest, apiReset } = useActions(GenerateConnectorApiKeyApiLogic);
   const { data, status } = useValues(GenerateConnectorApiKeyApiLogic);
   useEffect(() => {
@@ -78,7 +78,7 @@ export const ApiKeyConfig: React.FC<{
     if (hasApiKey || data) {
       setIsModalVisible(true);
     } else {
-      makeRequest({ indexName, isNative, secretId });
+      makeRequest({ indexName, isNative });
     }
   };
 
@@ -89,7 +89,7 @@ export const ApiKeyConfig: React.FC<{
   };
 
   const onConfirm = () => {
-    makeRequest({ indexName, isNative, secretId });
+    makeRequest({ indexName, isNative });
     setIsModalVisible(false);
   };
 
@@ -102,7 +102,7 @@ export const ApiKeyConfig: React.FC<{
             ? i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.apiKey.description',
                 {
-                  defaultMessage: `This native connector's API key {apiKeyName} is managed internally by Elasticsearch. The connector uses this API key to index documents into the {indexName} index. To rollover your API key, click "Generate API key".`,
+                  defaultMessage: `This native connector's API key {apiKeyName} is managed internally by Elasticsearch. The connector uses this API key to index documents into the {indexName} index. To refresh your API key, click "Refresh API key".`,
                   values: {
                     apiKeyName: `${indexName}-connector`,
                     indexName,
@@ -122,6 +122,43 @@ export const ApiKeyConfig: React.FC<{
               )}
         </EuiText>
       </EuiFlexItem>
+      {!isNative || status === Status.LOADING ? (
+        <></>
+      ) : indexName === '' ? (
+        <EuiCallOut
+          iconType="iInCircle"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.waitingForAttachedIndex',
+            {
+              defaultMessage:
+                'An API key will be automatically generated when an index is attached to this connector.',
+            }
+          )}
+        />
+      ) : hasApiKey ? (
+        <EuiCallOut
+          iconType="check"
+          color="success"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.exists',
+            {
+              defaultMessage: `An API has been generated for this connector.`,
+            }
+          )}
+        />
+      ) : (
+        <EuiCallOut
+          iconType="warning"
+          color="danger"
+          title={i18n.translate(
+            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.missing',
+            {
+              defaultMessage:
+                'This connector is missing an API key. Try clicking "Refresh API key" to regenerate it.',
+            }
+          )}
+        />
+      )}
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
           <EuiFlexItem grow={false}>
@@ -133,7 +170,7 @@ export const ApiKeyConfig: React.FC<{
               {i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.apiKey.button.label',
                 {
-                  defaultMessage: 'Generate API key',
+                  defaultMessage: isNative ? 'Rollover API key' : 'Generate API key',
                 }
               )}
             </EuiButton>
@@ -141,7 +178,7 @@ export const ApiKeyConfig: React.FC<{
         </EuiFlexGroup>
       </EuiFlexItem>
 
-      {data && (
+      {data && !isNative && (
         <>
           <EuiSpacer />
           <EuiFlexItem>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
@@ -102,7 +102,7 @@ export const ApiKeyConfig: React.FC<{
             ? i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.apiKey.description',
                 {
-                  defaultMessage: `This native connector's API key {apiKeyName} is managed internally by Elasticsearch. The connector uses this API key to index documents into the {indexName} index. To refresh your API key, click "Refresh API key".`,
+                  defaultMessage: `This native connector's API key {apiKeyName} is managed internally by Elasticsearch. The connector uses this API key to index documents into the {indexName} index. To refresh your API key, click "Generate API key".`,
                   values: {
                     apiKeyName: `${indexName}-connector`,
                     indexName,
@@ -154,7 +154,7 @@ export const ApiKeyConfig: React.FC<{
             'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.missing',
             {
               defaultMessage:
-                'This connector is missing an API key. Try clicking "Refresh API key" to regenerate it.',
+                'This connector is missing an API key. Click "Generate API key" to regenerate it.',
             }
           )}
         />
@@ -170,7 +170,7 @@ export const ApiKeyConfig: React.FC<{
               {i18n.translate(
                 'xpack.enterpriseSearch.content.indices.configurationConnector.apiKey.button.label',
                 {
-                  defaultMessage: isNative ? 'Rollover API key' : 'Generate API key',
+                  defaultMessage: 'Generate API key',
                 }
               )}
             </EuiButton>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
@@ -20,6 +20,7 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
 
 import { Status } from '../../../../../../common/types/api';
 import { GenerateConnectorApiKeyApiLogic } from '../../../api/connector/generate_connector_api_key_api_logic';
@@ -135,29 +136,19 @@ export const ApiKeyConfig: React.FC<{
             }
           )}
         />
-      ) : hasApiKey ? (
-        <EuiCallOut
-          iconType="check"
-          color="success"
-          title={i18n.translate(
-            'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.exists',
-            {
-              defaultMessage: `An API has been generated for this connector.`,
-            }
-          )}
-        />
-      ) : (
+      ) : !hasApiKey ? (
         <EuiCallOut
           iconType="warning"
           color="danger"
           title={i18n.translate(
             'xpack.enterpriseSearch.content.connector_detail.configurationConnector.nativeConnector.apiKey.missing',
             {
-              defaultMessage:
-                'This connector is missing an API key. Click "Generate API key" to regenerate it.',
+              defaultMessage: 'This connector is missing an API key.',
             }
           )}
         />
+      ) : (
+        <></>
       )}
       <EuiFlexItem>
         <EuiFlexGroup justifyContent="spaceBetween" alignItems="center">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/api_key_configuration.tsx
@@ -20,7 +20,6 @@ import {
 } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
-import { FormattedMessage } from '@kbn/i18n-react';
 
 import { Status } from '../../../../../../common/types/api';
 import { GenerateConnectorApiKeyApiLogic } from '../../../api/connector/generate_connector_api_key_api_logic';

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_configuration.tsx
@@ -99,7 +99,6 @@ export const ConnectorConfiguration: React.FC = () => {
                       indexName={indexName}
                       hasApiKey={!!index.connector.api_key_id}
                       isNative={false}
-                      secretId={null}
                     />
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -147,18 +147,13 @@ export const NativeConnectorConfiguration: React.FC = () => {
                 },
                 {
                   children: (
-                    <ApiKeyConfig
-                      indexName={index.connector.name}
-                      hasApiKey={hasApiKey}
-                      isNative
-                      secretId={index.connector.api_key_secret_id}
-                    />
+                    <ApiKeyConfig indexName={index.connector.name} hasApiKey={hasApiKey} isNative />
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',
                   title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.regenerateApiKeyTitle',
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.refreshApiKeyTitle',
                     {
-                      defaultMessage: 'Regenerate API key',
+                      defaultMessage: 'Refresh API key',
                     }
                   ),
                   titleSize: 'xs',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -151,9 +151,9 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',
                   title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.refreshApiKeyTitle',
+                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
                     {
-                      defaultMessage: 'Refresh API key',
+                      defaultMessage: 'Manage API key',
                     }
                   ),
                   titleSize: 'xs',

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.test.ts
@@ -146,7 +146,7 @@ describe('addConnector lib function', () => {
     });
 
     // native connector should generate API key and update secrets storage
-    expect(generateApiKey).toHaveBeenCalledWith(mockClient, 'index_name', true, null);
+    expect(generateApiKey).toHaveBeenCalledWith(mockClient, 'index_name', true);
   });
 
   it('should reject if index already exists', async () => {

--- a/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/connectors/add_connector.ts
@@ -96,7 +96,7 @@ export const addConnector = async (
     input.isNative &&
     input.serviceType !== ENTERPRISE_SEARCH_CONNECTOR_CRAWLER_SERVICE_TYPE
   ) {
-    await generateApiKey(client, index, true, null);
+    await generateApiKey(client, index, true);
   }
 
   return connector;

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.test.ts
@@ -62,7 +62,7 @@ describe('generateApiKey lib function for connector clients', () => {
     (updateConnectorSecret as jest.Mock).mockImplementation(() => undefined);
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', false, null)
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', false)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.index).not.toHaveBeenCalled();
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
@@ -102,7 +102,7 @@ describe('generateApiKey lib function for connector clients', () => {
     (updateConnectorSecret as jest.Mock).mockImplementation(() => undefined);
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'search-test', false, null)
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'search-test', false)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
       name: 'search-test-connector',
@@ -153,7 +153,7 @@ describe('generateApiKey lib function for connector clients', () => {
     (updateConnectorSecret as jest.Mock).mockImplementation(() => undefined);
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', false, null)
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', false)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
       name: 'index_name-connector',
@@ -222,7 +222,7 @@ describe('generateApiKey lib function for native connectors', () => {
     (updateConnectorSecret as jest.Mock).mockImplementation(() => undefined);
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', true, null)
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', true)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.index).not.toHaveBeenCalled();
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
@@ -264,7 +264,7 @@ describe('generateApiKey lib function for native connectors', () => {
     (updateConnectorSecret as jest.Mock).mockImplementation(() => undefined);
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'search-test', true, null)
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'search-test', true)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
       name: 'search-test-connector',
@@ -296,7 +296,7 @@ describe('generateApiKey lib function for native connectors', () => {
           hits: [
             {
               _id: 'connectorId',
-              _source: { api_key_id: '1', doc: 'doc' },
+              _source: { api_key_id: '1', api_key_secret_id: '2', doc: 'doc' },
               fields: { api_key_id: '1' },
             },
           ],
@@ -317,7 +317,7 @@ describe('generateApiKey lib function for native connectors', () => {
     }));
 
     await expect(
-      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', true, '1234')
+      generateApiKey(mockClient as unknown as IScopedClusterClient, 'index_name', true)
     ).resolves.toEqual({ encoded: 'encoded', id: 'apiKeyId' });
     expect(mockClient.asCurrentUser.security.createApiKey).toHaveBeenCalledWith({
       name: 'index_name-connector',
@@ -334,7 +334,7 @@ describe('generateApiKey lib function for native connectors', () => {
       },
     });
     expect(mockClient.asCurrentUser.index).toHaveBeenCalledWith({
-      document: { api_key_id: 'apiKeyId', api_key_secret_id: '1234', doc: 'doc' },
+      document: { api_key_id: 'apiKeyId', api_key_secret_id: '2', doc: 'doc' },
       id: 'connectorId',
       index: CONNECTORS_INDEX,
     });
@@ -342,6 +342,6 @@ describe('generateApiKey lib function for native connectors', () => {
       ids: ['1'],
     });
     expect(createConnectorSecret).toBeCalledTimes(0);
-    expect(updateConnectorSecret).toHaveBeenCalledWith(mockClient.asCurrentUser, 'encoded', '1234');
+    expect(updateConnectorSecret).toHaveBeenCalledWith(mockClient.asCurrentUser, 'encoded', '2');
   });
 });

--- a/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/generate_api_key.ts
@@ -20,8 +20,7 @@ import { toAlphanumeric } from '../../../common/utils/to_alphanumeric';
 export const generateApiKey = async (
   client: IScopedClusterClient,
   indexName: string,
-  isNative: boolean,
-  secretId: string | null
+  isNative: boolean
 ) => {
   const aclIndexName = `${CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX}${indexName}`;
 
@@ -49,7 +48,11 @@ export const generateApiKey = async (
     const apiKeyFields = isNative
       ? {
           api_key_id: apiKeyResult.id,
-          api_key_secret_id: await storeConnectorSecret(client, apiKeyResult.encoded, secretId),
+          api_key_secret_id: await storeConnectorSecret(
+            client,
+            apiKeyResult.encoded,
+            connector._source?.api_key_secret_id || null
+          ),
         }
       : {
           api_key_id: apiKeyResult.id,

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/connectors.ts
@@ -669,8 +669,8 @@ export function registerConnectorRoutes({ router, log }: RouteDependencies) {
 
         const connector = await fetchConnectorById(client.asCurrentUser, connectorId);
         if (connector?.is_native) {
-          // generateApiKey will search for the connector based on index_name, so we need to refresh the index before that.
-          await client.asCurrentUser.indices.refresh({ index: indexName });
+          // generateApiKey will search for the connector doc based on index_name, so we need to refresh the index before that.
+          await client.asCurrentUser.indices.refresh({ index: CONNECTORS_INDEX });
           await generateApiKey(client, indexName, true);
         }
 

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -280,7 +280,6 @@ export function registerIndexRoutes({
       validate: {
         body: schema.object({
           is_native: schema.boolean(),
-          secret_id: schema.maybe(schema.nullable(schema.string())),
         }),
         params: schema.object({
           indexName: schema.string(),
@@ -289,11 +288,11 @@ export function registerIndexRoutes({
     },
     elasticsearchErrorHandler(log, async (context, request, response) => {
       const indexName = decodeURIComponent(request.params.indexName);
-      const { is_native: isNative, secret_id: secretId } = request.body;
+      const { is_native: isNative } = request.body;
 
       const { client } = (await context.core).elasticsearch;
 
-      const apiKey = await generateApiKey(client, indexName, isNative, secretId || null);
+      const apiKey = await generateApiKey(client, indexName, isNative);
 
       return response.ok({
         body: apiKey,


### PR DESCRIPTION
## Summary

Generate API keys for native connectors when attaching indices. Currently no API keys are generated during this flow, and attempting to sync will result in an `AuthorizationException`. Also allow API key management from the new native connector configuration page (with some UI improvements noticed after testing).

### Changes

- Generate API keys when attaching an index to a connector
- Remove unnecessary `secret_id` args from API key generation code (it can be found directly from the connector doc)
- Update native connector configuration page to show a section for managing API keys (see attached screenshots).

**Full page**
![Screenshot 2024-02-20 at 12 55 54](https://github.com/elastic/kibana/assets/13634519/f2e1ef38-f60a-4d3d-bd7e-ed7c85f10876)

**Index not attached yet**
![Screenshot 2024-02-20 at 12 55 41](https://github.com/elastic/kibana/assets/13634519/89fb234c-83af-4ddc-b96b-d76b611ac445)

**Index attached / API key id exists**
![Screenshot 2024-02-20 at 12 55 22](https://github.com/elastic/kibana/assets/13634519/efee035f-2cef-4515-b05f-576e2f3fc0ad)

**Index attached / API key doesn't exist (error state)**
![Screenshot 2024-02-20 at 12 55 17](https://github.com/elastic/kibana/assets/13634519/cbcf78c9-f9ec-41e6-9012-0f5ebeb5d86d)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->