### PR TITLE
[chore] update selenium-webdriver to 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1653,7 +1653,7 @@
     "rxjs-marbles": "^7.0.1",
     "sass-embedded": "^1.70.0",
     "sass-loader": "^10.5.1",
-    "selenium-webdriver": "^4.17.0",
+    "selenium-webdriver": "^4.18.1",
     "sharp": "0.32.6",
     "simple-git": "^3.16.0",
     "sinon": "^7.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27614,10 +27614,10 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=
 
-selenium-webdriver@^4.17.0:
-  version "4.17.0"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.17.0.tgz#f6c93a9df3e0543df7dc2329d81968af42845a7f"
-  integrity sha512-e2E+2XBlGepzwgFbyQfSwo9Cbj6G5fFfs9MzAS00nC99EewmcS2rwn2MwtgfP7I5p1e7DYv4HQJXtWedsu6DvA==
+selenium-webdriver@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.18.1.tgz#bcd19048b4aba5411edb7b5266d9390578fc7fed"
+  integrity sha512-uP4OJ5wR4+VjdTi5oi/k8oieV2fIhVdVuaOPrklKghgS59w7Zz3nGa5gcG73VcU9EBRv5IZEBRhPr7qFJAj5mQ==
   dependencies:
     jszip "^3.10.1"
     tmp "^0.2.1"


### PR DESCRIPTION
## Summary

Bumping WebDriver package up to 4.18.1 with the hope it might resolve https://github.com/elastic/kibana/issues/177180 https://github.com/elastic/kibana/issues/177181

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->