### PR TITLE
[Discover] Improve types for saved search embeddable props (legacy table vs data grid props)

### DIFF
--- a/src/plugins/discover/public/components/doc_table/create_doc_table_embeddable.tsx
+++ b/src/plugins/discover/public/components/doc_table/create_doc_table_embeddable.tsx
@@ -34,7 +34,6 @@ export function DiscoverDocTableEmbeddable(renderProps: DocTableEmbeddableProps)
         isLoading={renderProps.isLoading}
         isPlainRecord={renderProps.isPlainRecord}
         interceptedWarnings={renderProps.interceptedWarnings}
-        dataTestSubj="embeddedSavedSearchDocTable"
       />
     </I18nProvider>
   );

--- a/src/plugins/discover/public/components/doc_table/doc_table_embeddable.tsx
+++ b/src/plugins/discover/public/components/doc_table/doc_table_embeddable.tsx
@@ -19,13 +19,18 @@ import {
 import { DocTableProps, DocTableRenderProps, DocTableWrapper } from './doc_table_wrapper';
 import { SavedSearchEmbeddableBase } from '../../embeddable/saved_search_embeddable_base';
 
-export interface DocTableEmbeddableProps extends DocTableProps {
+export interface DocTableEmbeddableProps extends Omit<DocTableProps, 'dataTestSubj'> {
   totalHitCount?: number;
   rowsPerPageState?: number;
   sampleSizeState: number;
   interceptedWarnings?: SearchResponseWarning[];
   onUpdateRowsPerPage?: (rowsPerPage?: number) => void;
 }
+
+export type DocTableEmbeddableSearchProps = Omit<
+  DocTableEmbeddableProps,
+  'sampleSizeState' | 'isPlainRecord'
+>;
 
 const DocTableWrapperMemoized = memo(DocTableWrapper);
 
@@ -124,7 +129,12 @@ export const DocTableEmbeddable = (props: DocTableEmbeddableProps) => {
         ) : undefined
       }
     >
-      <DocTableWrapperMemoized ref={tableWrapperRef} {...props} render={renderDocTable} />
+      <DocTableWrapperMemoized
+        ref={tableWrapperRef}
+        {...props}
+        dataTestSubj="embeddedSavedSearchDocTable"
+        render={renderDocTable}
+      />
     </SavedSearchEmbeddableBase>
   );
 };

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.test.ts
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.test.ts
@@ -202,10 +202,14 @@ describe('saved search embeddable', () => {
     await waitOneTick();
     expect(searchProps.rowsPerPageState).toEqual(100);
 
-    expect(searchProps.sampleSizeState).toEqual(250);
+    expect(
+      discoverComponent.find(SavedSearchEmbeddableComponent).prop('fetchedSampleSize')
+    ).toEqual(250);
     searchProps.onUpdateSampleSize!(300);
     await waitOneTick();
-    expect(searchProps.sampleSizeState).toEqual(300);
+    expect(
+      discoverComponent.find(SavedSearchEmbeddableComponent).prop('fetchedSampleSize')
+    ).toEqual(300);
 
     searchProps.onFilter!({ name: 'customer_id', type: 'string', scripted: false }, [17], '+');
     await waitOneTick();

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable.tsx
@@ -38,7 +38,7 @@ import {
   mapAndFlattenFilters,
 } from '@kbn/data-plugin/public';
 import type { ISearchSource } from '@kbn/data-plugin/public';
-import type { DataView, DataViewField } from '@kbn/data-views-plugin/public';
+import type { DataView } from '@kbn/data-views-plugin/public';
 import type { UiActionsStart } from '@kbn/ui-actions-plugin/public';
 import { KibanaRenderContextProvider } from '@kbn/react-kibana-context-render';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
@@ -46,7 +46,7 @@ import type { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { METRIC_TYPE } from '@kbn/analytics';
 import { CellActionsProvider } from '@kbn/cell-actions';
 import type { SearchResponseWarning } from '@kbn/search-response-warnings';
-import type { DataTableRecord, EsHitRecord } from '@kbn/discover-utils/types';
+import type { EsHitRecord } from '@kbn/discover-utils/types';
 import {
   DOC_HIDE_TIME_COLUMN_SETTING,
   DOC_TABLE_LEGACY,
@@ -55,17 +55,15 @@ import {
   SORT_DEFAULT_ORDER_SETTING,
   buildDataTableRecord,
 } from '@kbn/discover-utils';
-import type { UnifiedDataTableProps, UnifiedDataTableSettings } from '@kbn/unified-data-table';
 import { columnActions, getTextBasedColumnTypes } from '@kbn/unified-data-table';
 import { VIEW_MODE, getDefaultRowsPerPage } from '../../common/constants';
-import type { ISearchEmbeddable, SearchInput, SearchOutput } from './types';
+import type { ISearchEmbeddable, SearchInput, SearchOutput, SearchProps } from './types';
 import type { DiscoverServices } from '../build_services';
 import { getSortForEmbeddable, SortPair } from '../utils/sorting';
 import { getMaxAllowedSampleSize, getAllowedSampleSize } from '../utils/get_allowed_sample_size';
 import { SEARCH_EMBEDDABLE_TYPE, SEARCH_EMBEDDABLE_CELL_ACTIONS_TRIGGER_ID } from './constants';
 import { SavedSearchEmbeddableComponent } from './saved_search_embeddable_component';
 import { handleSourceColumnState } from '../utils/state_helpers';
-import type { DocTableProps } from '../components/doc_table/doc_table_wrapper';
 import { updateSearchSource } from './utils/update_search_source';
 import { FieldStatisticsTable } from '../application/main/components/field_stats_table';
 import { fetchTextBased } from '../application/main/utils/fetch_text_based';
@@ -73,26 +71,6 @@ import { isTextBasedQuery } from '../application/main/utils/is_text_based_query'
 import { getValidViewMode } from '../application/main/utils/get_valid_view_mode';
 import { ADHOC_DATA_VIEW_RENDER_EVENT } from '../constants';
 import { getDiscoverLocatorParams } from './get_discover_locator_params';
-
-export type SearchProps = Partial<UnifiedDataTableProps> &
-  Partial<DocTableProps> & {
-    savedSearchId?: string;
-    filters?: Filter[];
-    settings?: UnifiedDataTableSettings;
-    description?: string;
-    sharedItemTitle?: string;
-    inspectorAdapters?: Adapters;
-    services: DiscoverServices;
-    filter?: (field: DataViewField, value: string[], operator: string) => void;
-    hits?: DataTableRecord[];
-    totalHitCount?: number;
-    interceptedWarnings?: SearchResponseWarning[];
-    onMoveColumn?: (column: string, index: number) => void;
-    onUpdateRowHeight?: (rowHeight?: number) => void;
-    onUpdateHeaderRowHeight?: (headerRowHeight?: number) => void;
-    onUpdateRowsPerPage?: (rowsPerPage?: number) => void;
-    onUpdateSampleSize?: (sampleSize?: number) => void;
-  };
 
 export interface SearchEmbeddableConfig {
   editable: boolean;
@@ -435,7 +413,7 @@ export class SavedSearchEmbeddable
     }
 
     const props: SearchProps = {
-      columns: savedSearch.columns,
+      columns: savedSearch.columns || [],
       savedSearchId: savedSearch.id,
       filters: savedSearch.searchSource.getField('filter') as Filter[],
       dataView,
@@ -595,7 +573,7 @@ export class SavedSearchEmbeddable
       this.services.core.uiSettings
     );
 
-    searchProps.columns = columnState.columns;
+    searchProps.columns = columnState.columns || [];
     searchProps.sort = this.getSort(this.input.sort || savedSearch.sort, searchProps?.dataView);
     searchProps.sharedItemTitle = this.panelTitleInternal;
     searchProps.searchTitle = this.panelTitleInternal;

--- a/src/plugins/discover/public/embeddable/saved_search_embeddable_component.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_embeddable_component.tsx
@@ -9,15 +9,14 @@
 import React from 'react';
 import { AggregateQuery, Query } from '@kbn/es-query';
 import { DataLoadingState } from '@kbn/unified-data-table';
-import { DiscoverGridEmbeddable, DiscoverGridEmbeddableProps } from './saved_search_grid';
+import { DiscoverGridEmbeddable } from './saved_search_grid';
 import { DiscoverDocTableEmbeddable } from '../components/doc_table/create_doc_table_embeddable';
-import { DocTableEmbeddableProps } from '../components/doc_table/doc_table_embeddable';
 import { isTextBasedQuery } from '../application/main/utils/is_text_based_query';
-import { SearchProps } from './saved_search_embeddable';
+import type { EmbeddableComponentSearchProps } from './types';
 
 interface SavedSearchEmbeddableComponentProps {
   fetchedSampleSize: number;
-  searchProps: SearchProps;
+  searchProps: EmbeddableComponentSearchProps;
   useLegacyTable: boolean;
   query?: AggregateQuery | Query;
 }
@@ -35,7 +34,7 @@ export function SavedSearchEmbeddableComponent({
     const isPlainRecord = isTextBasedQuery(query);
     return (
       <DiscoverDocTableEmbeddableMemoized
-        {...(searchProps as DocTableEmbeddableProps)} // TODO later: remove the type casting to prevent unexpected errors due to missing props!
+        {...searchProps}
         sampleSizeState={fetchedSampleSize}
         isPlainRecord={isPlainRecord}
       />
@@ -43,12 +42,10 @@ export function SavedSearchEmbeddableComponent({
   }
   return (
     <DiscoverGridEmbeddableMemoized
-      {...(searchProps as DiscoverGridEmbeddableProps)} // TODO later: remove the type casting to prevent unexpected errors due to missing props!
+      {...searchProps}
       sampleSizeState={fetchedSampleSize}
       loadingState={searchProps.isLoading ? DataLoadingState.loading : DataLoadingState.loaded}
-      showFullScreenButton={false}
       query={query}
-      className="unifiedDataTable"
     />
   );
 }

--- a/src/plugins/discover/public/embeddable/saved_search_grid.tsx
+++ b/src/plugins/discover/public/embeddable/saved_search_grid.tsx
@@ -33,6 +33,11 @@ export interface DiscoverGridEmbeddableProps
   savedSearchId?: string;
 }
 
+export type DiscoverGridEmbeddableSearchProps = Omit<
+  DiscoverGridEmbeddableProps,
+  'sampleSizeState' | 'loadingState' | 'query'
+>;
+
 export const DiscoverGridMemoized = React.memo(DiscoverGrid);
 
 export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
@@ -102,6 +107,8 @@ export function DiscoverGridEmbeddable(props: DiscoverGridEmbeddableProps) {
         renderCustomToolbar={renderCustomToolbar}
         showColumnTokens
         configHeaderRowHeight={3}
+        showFullScreenButton={false}
+        className="unifiedDataTable"
       />
     </SavedSearchEmbeddableBase>
   );

--- a/src/plugins/discover/public/embeddable/types.ts
+++ b/src/plugins/discover/public/embeddable/types.ts
@@ -13,6 +13,10 @@ import type {
   SearchByReferenceInput,
   SearchByValueInput,
 } from '@kbn/saved-search-plugin/public';
+import type { Adapters } from '@kbn/embeddable-plugin/public';
+import type { DiscoverGridEmbeddableSearchProps } from './saved_search_grid';
+import type { DocTableEmbeddableSearchProps } from '../components/doc_table/doc_table_embeddable';
+import type { DiscoverServices } from '../build_services';
 
 export type SearchInput = SearchByValueInput | SearchByReferenceInput;
 
@@ -29,3 +33,13 @@ export interface ISearchEmbeddable extends IEmbeddable<SearchInput, SearchOutput
 export interface SearchEmbeddable extends Embeddable<SearchInput, SearchOutput> {
   type: string;
 }
+
+export type EmbeddableComponentSearchProps = DiscoverGridEmbeddableSearchProps &
+  DocTableEmbeddableSearchProps;
+export type SearchProps = EmbeddableComponentSearchProps & {
+  sampleSizeState: number | undefined;
+  description?: string;
+  sharedItemTitle?: string;
+  inspectorAdapters?: Adapters;
+  services: DiscoverServices;
+};


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/163804

## Summary

This PR improves types. Now all necessary legacy table and data grid props will be required for `searchProps`.
