### PR TITLE
[Cloud Security] Update Toast Message

### DIFF
--- a/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
@@ -112,17 +112,6 @@ export const showChangeBenchmarkRuleStatesSuccessToast = (
                   ruleCount: data.numberOfRules,
                 }}
               />
-              {data.numberOfDetectionRules > 0 ? (
-                <strong>
-                  <FormattedMessage
-                    id="xpack.csp.flyout.ruleEnabledToastDetectionRulesCount"
-                    defaultMessage="and {detectionRuleCount, plural, one {# detection rule} other {# detection rules}}"
-                    values={{
-                      detectionRuleCount: data.numberOfDetectionRules,
-                    }}
-                  />
-                </strong>
-              ) : undefined}
             </>
           ) : (
             <>

--- a/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
@@ -95,57 +95,50 @@ export const showChangeBenchmarkRuleStatesSuccessToast = (
     text: toMountPoint(
       <div>
         <EuiText size="m">
-          {isBenchmarkRuleMuted ? (
-            <>
-              <EuiText size="m">
-                <strong data-test-subj="csp:toast-success-enable-rule-title">
-                  <FormattedMessage
-                    id="xpack.csp.flyout.ruleEnabledToastTitle"
-                    defaultMessage="Rule Enabled"
-                  />
-                </strong>
-              </EuiText>
+          <strong data-test-subj={`csp:toast-success-rule-title`}>
+            {isBenchmarkRuleMuted ? (
               <FormattedMessage
-                id="xpack.csp.flyout.ruleEnabledToastRulesCount"
-                defaultMessage="Successfully enabled {ruleCount, plural, one {# rule} other {# rules}} "
-                values={{
-                  ruleCount: data.numberOfRules,
-                }}
+                id="xpack.csp.flyout.ruleEnabledToastTitle"
+                defaultMessage="Rule Enabled"
               />
-            </>
-          ) : (
-            <>
-              <EuiText size="m">
-                <strong data-test-subj="csp:toast-success-disable-rule-title">
-                  <FormattedMessage
-                    id="xpack.csp.flyout.ruleDisabledToastTitle"
-                    defaultMessage="Rule Disabled"
-                  />
-                </strong>
-              </EuiText>
-
+            ) : (
               <FormattedMessage
-                id="xpack.csp.flyout.ruleDisabledToastRulesCount"
-                defaultMessage="Successfully disabled {ruleCount, plural, one {# rule} other {# rules}} "
-                values={{
-                  ruleCount: data.numberOfRules,
-                }}
+                id="xpack.csp.flyout.ruleDisabledToastTitle"
+                defaultMessage="Rule Disabled"
               />
-
-              {data.numberOfDetectionRules > 0 ? (
-                <strong>
-                  <FormattedMessage
-                    id="xpack.csp.flyout.ruleDisabledToastDetectionRulesCount"
-                    defaultMessage="and {detectionRuleCount, plural, one {# detection rule} other {# detection rules}}"
-                    values={{
-                      detectionRuleCount: data.numberOfDetectionRules,
-                    }}
-                  />
-                </strong>
-              ) : undefined}
-            </>
-          )}
+            )}
+          </strong>
         </EuiText>
+        {isBenchmarkRuleMuted ? (
+          <FormattedMessage
+            id="xpack.csp.flyout.ruleEnabledToastRulesCount"
+            defaultMessage={`Successfully enabled {ruleCount, plural, one {# rule} other {# rules}} `}
+            values={{
+              ruleCount: data.numberOfRules,
+            }}
+          />
+        ) : (
+          <>
+            <FormattedMessage
+              id="xpack.csp.flyout.ruleDisabledToastRulesCount"
+              defaultMessage={`Successfully disabled {ruleCount, plural, one {# rule} other {# rules}} `}
+              values={{
+                ruleCount: data.numberOfRules,
+              }}
+            />
+            {!isBenchmarkRuleMuted && data.numberOfDetectionRules > 0 && (
+              <strong>
+                <FormattedMessage
+                  id="xpack.csp.flyout.ruleDisabledToastDetectionRulesCount"
+                  defaultMessage=" and {detectionRuleCount, plural, one {# detection rule} other {# detection rules}}"
+                  values={{
+                    detectionRuleCount: data.numberOfDetectionRules,
+                  }}
+                />
+              </strong>
+            )}
+          </>
+        )}
       </div>
     ),
   });

--- a/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
+++ b/x-pack/plugins/cloud_security_posture/public/components/take_action.tsx
@@ -112,7 +112,7 @@ export const showChangeBenchmarkRuleStatesSuccessToast = (
         {isBenchmarkRuleMuted ? (
           <FormattedMessage
             id="xpack.csp.flyout.ruleEnabledToastRulesCount"
-            defaultMessage={`Successfully enabled {ruleCount, plural, one {# rule} other {# rules}} `}
+            defaultMessage="Successfully enabled {ruleCount, plural, one {# rule} other {# rules}} "
             values={{
               ruleCount: data.numberOfRules,
             }}
@@ -121,7 +121,7 @@ export const showChangeBenchmarkRuleStatesSuccessToast = (
           <>
             <FormattedMessage
               id="xpack.csp.flyout.ruleDisabledToastRulesCount"
-              defaultMessage={`Successfully disabled {ruleCount, plural, one {# rule} other {# rules}} `}
+              defaultMessage="Successfully disabled {ruleCount, plural, one {# rule} other {# rules}} "
               values={{
                 ruleCount: data.numberOfRules,
               }}


### PR DESCRIPTION


## Summary

This PR updates the toast message to only include Detection Rule number when user disable benchmark rules. When user Enables Benchmark rules, Detection rules won't be mentioned in the Toast message
<img width="261" alt="Screenshot 2024-02-20 at 6 32 19 AM" src="https://github.com/elastic/kibana/assets/8703149/6b6e3a3f-c35f-460e-9f27-1306e2432ae8">




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->