### PR TITLE
fix(slo): embedded SLO selector

### DIFF
--- a/x-pack/plugins/observability/public/embeddable/slo/alerts/slo_selector.tsx
+++ b/x-pack/plugins/observability/public/embeddable/slo/alerts/slo_selector.tsx
@@ -36,9 +36,9 @@ export function SloSelector({ initialSlos, onSelected, hasError, singleSelection
     mapSlosToOptions(initialSlos)
   );
   const [searchValue, setSearchValue] = useState<string>('');
-  const query = `${searchValue.replaceAll(' ', '*')}*`;
+  const query = `${searchValue}*`;
   const { isLoading, data: sloList } = useFetchSloList({
-    kqlQuery: `slo.name: ${query} or slo.instanceId: ${query}`,
+    kqlQuery: `slo.name: (${query}) or slo.instanceId: (${query})`,
     perPage: 100,
   });
 

--- a/x-pack/plugins/observability/public/embeddable/slo/alerts/slo_selector.tsx
+++ b/x-pack/plugins/observability/public/embeddable/slo/alerts/slo_selector.tsx
@@ -38,7 +38,7 @@ export function SloSelector({ initialSlos, onSelected, hasError, singleSelection
   const [searchValue, setSearchValue] = useState<string>('');
   const query = `${searchValue}*`;
   const { isLoading, data: sloList } = useFetchSloList({
-    kqlQuery: `slo.name: (${query}) or slo.instanceId: (${query})`,
+    kqlQuery: `slo.name: (${query}) or slo.instanceId.text: (${query})`,
     perPage: 100,
   });
 


### PR DESCRIPTION
Fix https://github.com/elastic/kibana/issues/177264

## Summary

This PR fixes searching issue with space in name. It removes the need for the '*' as we can rely on the full text search on the name and other fields of the SLO summary documents.

## Testing

Generate some data: `node x-pack/scripts/data_forge.js --events-per-cycle 100 --lookback now-7d  --dataset fake_stack --install-kibana-assets --kibana-url http://localhost:5601/kibana`

Then, setup some SLOs with long and different names, e.g. "my very long name" and `an admin console availability service in production"

You should be able to add embeddable SLO overview and search with:
- "very lo"
- "admin console"
- "lability ser"
- "name"

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->