### PR TITLE
[Logs Onboarding] skip flaky tests

### DIFF
--- a/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
+++ b/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts
@@ -682,7 +682,9 @@ describe('[Logs onboarding] System logs', () => {
       });
     });
 
-    describe('when integration installation succeed', () => {
+    // Skpping this test because it's failing in the CI
+    // https://github.com/elastic/kibana/issues/176995
+    xdescribe('when integration installation succeed', () => {
       beforeEach(() => {
         cy.deleteIntegration('system');
         cy.intercept('GET', '/api/fleet/epm/packages/system').as(


### PR DESCRIPTION
## Summary

Skip flaky tests blocking 8.13 backports (already skipped on [main](https://github.com/elastic/kibana/blob/main/x-pack/plugins/observability_onboarding/e2e/cypress/e2e/logs/system_logs.cy.ts#L685-L687)).
Related to https://github.com/elastic/kibana/issues/176995

