### PR TITLE
[Search] Add missing name and description prompt

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_name_and_description_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_name_and_description_api_logic.ts
@@ -16,17 +16,13 @@ export type PutConnectorNameAndDescriptionArgs = Partial<
   Pick<Connector, 'name' | 'description'>
 > & {
   connectorId: string;
-  indexName: string;
 };
 
-export type PutConnectorNameAndDescriptionResponse = Pick<Connector, 'name' | 'description'> & {
-  indexName: string;
-};
+export type PutConnectorNameAndDescriptionResponse = Pick<Connector, 'name' | 'description'>;
 
 export const putConnectorNameAndDescription = async ({
   connectorId,
   description = null,
-  indexName,
   name = '',
 }: PutConnectorNameAndDescriptionArgs) => {
   const route = `/internal/enterprise_search/connectors/${connectorId}/name_and_description`;
@@ -34,7 +30,7 @@ export const putConnectorNameAndDescription = async ({
   await HttpLogic.values.http.put(route, {
     body: JSON.stringify({ description, name }),
   });
-  return { description, indexName, name };
+  return { description, name };
 };
 
 export const ConnectorNameAndDescriptionApiLogic = createApiLogic(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail.tsx
@@ -26,6 +26,7 @@ import { SearchIndexIndexMappings } from '../search_index/index_mappings';
 import { SearchIndexPipelines } from '../search_index/pipelines/pipelines';
 
 import { ConnectorConfiguration } from './connector_configuration';
+import { ConnectorNameAndDescription } from './connector_name_and_description';
 import { ConnectorViewLogic } from './connector_view_logic';
 import { ConnectorDetailOverview } from './overview';
 
@@ -225,7 +226,7 @@ export const ConnectorDetail: React.FC = () => {
       pageViewTelemetry={tabId}
       isLoading={isLoading}
       pageHeader={{
-        pageTitle: connector?.name ?? '...',
+        pageTitle: connector ? <ConnectorNameAndDescription connector={connector} /> : '...',
         rightSideItems: getHeaderActions(index, hasAppSearchAccess),
         tabs,
       }}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { ChangeEvent, useEffect, useState } from 'react';
+
+import { useActions, useValues } from 'kea';
+
+import { EuiFlexGroup, EuiFlexItem, EuiInlineEditText, EuiInlineEditTitle } from '@elastic/eui';
+
+import { i18n } from '@kbn/i18n';
+import { Connector } from '@kbn/search-connectors';
+
+import { ConnectorNameAndDescriptionLogic } from './connector_name_and_description_logic';
+
+export interface ConnectorNameAndDescriptionProps {
+  connector: Connector;
+}
+
+export interface ResolverObject {
+  rej: (value: boolean | void | PromiseLike<boolean | void>) => void;
+  res: (value: boolean | void | PromiseLike<boolean | void>) => void;
+}
+
+let promise: Promise<boolean | void> | undefined;
+
+const getValidationPromiseResolvers = (): ResolverObject => {
+  const resolvers = {
+    rej: () => {},
+    res: () => {},
+  };
+  promise = new Promise((resolve, reject) => {
+    resolvers.res = resolve;
+    resolvers.rej = reject;
+  });
+  return resolvers;
+};
+
+export const ConnectorNameAndDescription: React.FC<ConnectorNameAndDescriptionProps> = ({
+  connector,
+}) => {
+  const [resolverObject, setResolverObject] = useState<ResolverObject>({
+    rej: () => {},
+    res: () => {},
+  });
+  const [connectorName, setConnectorName] = useState<string>(connector.name);
+  const [connectorDescription, setConnectorDescription] = useState<string | null>(
+    connector.description
+  );
+  const [nameErrors, setNameErrors] = useState<string[]>([]);
+  const { saveNameAndDescription, setConnector } = useActions(ConnectorNameAndDescriptionLogic);
+  const { status, isLoading, isFailed, isSuccess } = useValues(ConnectorNameAndDescriptionLogic);
+  useEffect(() => {
+    setConnector(connector);
+  }, [connector]);
+
+  useEffect(() => {
+    if (isSuccess) {
+      resolverObject.res(true);
+    }
+    if (isFailed) {
+      resolverObject.rej();
+    }
+  }, [status]);
+
+  return (
+    <EuiFlexGroup direction="column" gutterSize="xs">
+      <EuiFlexItem grow={false}>
+        <EuiInlineEditTitle
+          heading="h1"
+          inputAriaLabel={i18n.translate(
+            'xpack.enterpriseSearch.content.connectors.nameAndDescription.name.ariaLabel',
+            { defaultMessage: 'Edit connector name' }
+          )}
+          placeholder={i18n.translate(
+            'xpack.enterpriseSearch.content.connectors.nameAndDescription.name.placeholder',
+            { defaultMessage: 'Add a name to your connector' }
+          )}
+          value={connectorName}
+          isLoading={isLoading}
+          isInvalid={nameErrors.length > 0}
+          size="m"
+          editModeProps={{
+            formRowProps: { error: nameErrors },
+            cancelButtonProps: { onClick: () => setNameErrors([]) },
+            inputProps: { readOnly: isLoading },
+          }}
+          onSave={(inputValue) => {
+            if (inputValue.trim().length <= 0) {
+              setNameErrors([
+                i18n.translate(
+                  'xpack.enterpriseSearch.content.nameAndDescription.name.error.empty',
+                  { defaultMessage: 'Connector name cannot be empty' }
+                ),
+              ]);
+              return false;
+            }
+            setConnectorName(inputValue);
+            saveNameAndDescription({ description: connectorDescription, name: inputValue });
+            setResolverObject(getValidationPromiseResolvers());
+            return promise;
+          }}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setConnectorName(event.target.value);
+          }}
+          onCancel={(previousValue) => {
+            setConnectorName(previousValue);
+          }}
+        />
+      </EuiFlexItem>
+      <EuiFlexItem grow={false}>
+        <EuiInlineEditText
+          isLoading={isLoading}
+          inputAriaLabel={i18n.translate(
+            'xpack.enterpriseSearch.content.connectors.nameAndDescription.description.ariaLabel',
+            { defaultMessage: 'Edit connector description' }
+          )}
+          placeholder={i18n.translate(
+            'xpack.enterpriseSearch.content.connectors.nameAndDescription.description.placeholder',
+            { defaultMessage: 'Add a description' }
+          )}
+          value={connectorDescription || ''}
+          onSave={(inputValue) => {
+            setConnectorDescription(inputValue);
+            saveNameAndDescription({ description: inputValue, name: connectorName });
+            setResolverObject(getValidationPromiseResolvers());
+            return promise;
+          }}
+          onChange={(event: ChangeEvent<HTMLInputElement>) => {
+            setConnectorDescription(event.target.value);
+          }}
+          onCancel={(previousValue) => {
+            setConnectorDescription(previousValue);
+          }}
+        />
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description_logic.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { kea, MakeLogicType } from 'kea';
+
+import { Connector } from '@kbn/search-connectors';
+
+import { Status } from '../../../../../common/types/api';
+
+import { Actions } from '../../../shared/api_logic/create_api_logic';
+import {
+  ConnectorNameAndDescriptionApiLogic,
+  PutConnectorNameAndDescriptionArgs,
+  PutConnectorNameAndDescriptionResponse,
+} from '../../api/connector/update_connector_name_and_description_api_logic';
+
+type NameAndDescription = Partial<Pick<Connector, 'name' | 'description'>>;
+
+type ConnectorNameAndDescriptionActions = Pick<
+  Actions<PutConnectorNameAndDescriptionArgs, PutConnectorNameAndDescriptionResponse>,
+  'makeRequest'
+> & {
+  saveNameAndDescription(nameAndDescription: NameAndDescription): NameAndDescription;
+  setConnector(connector: Connector): Connector;
+};
+
+interface ConnectorNameAndDescriptionValues {
+  connector: Connector | null;
+  isFailed: boolean;
+  isLoading: boolean;
+  isSuccess: boolean;
+  status: Status;
+}
+
+export const ConnectorNameAndDescriptionLogic = kea<
+  MakeLogicType<ConnectorNameAndDescriptionValues, ConnectorNameAndDescriptionActions>
+>({
+  actions: {
+    saveNameAndDescription: (nameAndDescription) => nameAndDescription,
+    setConnector: (connector) => connector,
+  },
+  connect: {
+    actions: [ConnectorNameAndDescriptionApiLogic, ['makeRequest']],
+    values: [ConnectorNameAndDescriptionApiLogic, ['status']],
+  },
+  listeners: ({ actions, values }) => ({
+    saveNameAndDescription: ({ name, description }) => {
+      if (values.connector) {
+        actions.makeRequest({
+          connectorId: values.connector.id,
+          description,
+          indexName: values.connector.index_name || '',
+          name,
+        });
+      }
+    },
+  }),
+  path: ['enterprise_search', 'content', 'connector', 'name_and_description'],
+  reducers: () => ({
+    connector: [
+      null,
+      {
+        setConnector: (_, connector) => connector,
+      },
+    ],
+  }),
+  selectors: ({ selectors }) => ({
+    isFailed: [() => [selectors.status], (status: Status) => status === Status.ERROR],
+    isLoading: [() => [selectors.status], (status: Status) => status === Status.LOADING],
+    isSuccess: [() => [selectors.status], (status: Status) => status === Status.SUCCESS],
+  }),
+});

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_name_and_description_logic.ts
@@ -53,7 +53,6 @@ export const ConnectorNameAndDescriptionLogic = kea<
         actions.makeRequest({
           connectorId: values.connector.id,
           description,
-          indexName: values.connector.index_name || '',
           name,
         });
       }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_view_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_view_logic.ts
@@ -95,15 +95,6 @@ export const ConnectorViewLogic = kea<MakeLogicType<ConnectorViewValues, Connect
     },
   }),
   path: ['enterprise_search', 'content', 'connector_view_logic'],
-  reducers: {
-    syncTriggeredLocally: [
-      false,
-      {
-        fetchIndexApiSuccess: () => false,
-        startSyncApiSuccess: () => true,
-      },
-    ],
-  },
   selectors: ({ selectors }) => ({
     connector: [
       () => [selectors.connectorData],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_name_and_description/connector_name_and_description_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_name_and_description/connector_name_and_description_logic.ts
@@ -80,7 +80,6 @@ export const ConnectorNameAndDescriptionLogic = kea<
       if (isConnectorIndex(values.index) || isCrawlerIndex(values.index)) {
         actions.makeRequest({
           connectorId: values.index.connector.id,
-          indexName: values.index.connector.index_name ?? '',
           ...values.localNameAndDescription,
         });
       }


### PR DESCRIPTION
## Summary


https://github.com/elastic/kibana/assets/1410658/0e93c5c8-4c01-44ba-b230-bff4ad87aa63

Add name and description prompt to the connector view. This is an important feature that was missing, we cannot ship without this.

### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->