### PR TITLE
[8.13] [Logs Explorer] Fix undefined issue cased due row check missing (#177293)

### DIFF
--- a/x-pack/plugins/observability_solution/logs_explorer/public/customizations/custom_control_column.tsx
+++ b/x-pack/plugins/observability_solution/logs_explorer/public/customizations/custom_control_column.tsx
@@ -36,9 +36,8 @@ const ConnectedMalformedDocs = ({
 }) => {
   const [state] = useActor(service);
 
-  if (state.matches('initialized') && state.context.rows) {
-    const row = state.context.rows[rowIndex];
-    return <MalformedDocs row={row} rowIndex={rowIndex} />;
+  if (state.matches('initialized') && state.context.rows[rowIndex]) {
+    return <MalformedDocs row={state.context.rows[rowIndex]} rowIndex={rowIndex} />;
   }
 
   return null;
@@ -52,17 +51,15 @@ const ConnectedStacktraceDocs = ({
   service: LogsExplorerControllerStateService;
 }) => {
   const [state] = useActor(service);
-
-  if (state.matches('initialized') && state.context.rows) {
-    const row = state.context.rows[rowIndex];
-    return <Stacktrace row={row} rowIndex={rowIndex} />;
+  if (state.matches('initialized') && state.context.rows[rowIndex]) {
+    return <Stacktrace row={state.context.rows[rowIndex]} rowIndex={rowIndex} />;
   }
 
   return null;
 };
 
 const MalformedDocs = ({ row, rowIndex }: { row: DataTableRecord; rowIndex: number }) => {
-  const isMalformedDocumentExists = !!row.raw[constants.MALFORMED_DOCS_FIELD];
+  const isMalformedDocumentExists = constants.MALFORMED_DOCS_FIELD in row.raw;
 
   return isMalformedDocumentExists ? (
     <DataTableRowControl>


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Logs Explorer] Fix undefined issue cased due row check missing (#177293)](https://github.com/elastic/kibana/pull/177293)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Achyut Jhunjhunwala","email":"achyut.jhunjhunwala@elastic.co"},"sourceCommit":{"committedDate":"2024-02-20T16:18:37Z","message":"[Logs Explorer] Fix undefined issue cased due row check missing (#177293)\n\n## Summary\r\n\r\nThis PR fixes issue where when applying filter on Resource Virtual\r\ncolumn after resizing of the column, causes the row property to be\r\nundefined in between renders","sha":"c2c07a8498f47aeec965afdb5e0b03b9ea393223","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","Team:obs-ux-logs","v8.13.0","v8.14.0"],"number":177293,"url":"https://github.com/elastic/kibana/pull/177293","mergeCommit":{"message":"[Logs Explorer] Fix undefined issue cased due row check missing (#177293)\n\n## Summary\r\n\r\nThis PR fixes issue where when applying filter on Resource Virtual\r\ncolumn after resizing of the column, causes the row property to be\r\nundefined in between renders","sha":"c2c07a8498f47aeec965afdb5e0b03b9ea393223"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177293","number":177293,"mergeCommit":{"message":"[Logs Explorer] Fix undefined issue cased due row check missing (#177293)\n\n## Summary\r\n\r\nThis PR fixes issue where when applying filter on Resource Virtual\r\ncolumn after resizing of the column, causes the row property to be\r\nundefined in between renders","sha":"c2c07a8498f47aeec965afdb5e0b03b9ea393223"}}]}] BACKPORT-->