### PR TITLE
[Fleet] Do not allow to add fleet server to cloud policy from UI

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -66,7 +66,9 @@ export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({
       serviceToken,
       generateServiceToken,
       isLoadingServiceToken,
-      disabled: Boolean(!fleetServerHostForm.fleetServerHost),
+      disabled:
+        Boolean(!fleetServerHostForm.fleetServerHost) ||
+        !Boolean(fleetServerPolicyId || selectedPolicyId),
     }),
     getInstallFleetServerStep({
       isFleetServerReady,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useGetAgentPolicies } from '../../../hooks';
+import { createFleetTestRendererMock } from '../../../../../mock';
+
+import { useSelectFleetServerPolicy } from './use_select_fleet_server_policy';
+
+jest.mock('../../../hooks');
+
+describe('useSelectFleetServerPolicy hook', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Return eligible fleet server policies', async () => {
+    jest.mocked(useGetAgentPolicies).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'test1',
+            is_default_fleet_server: true,
+            package_policies: [
+              {
+                package: {
+                  name: 'fleet_server',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as any);
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() => useSelectFleetServerPolicy());
+
+    expect(result.current.fleetServerPolicyId).toEqual('test1');
+    expect(result.current.eligibleFleetServerPolicies.map(({ id }) => id)).toEqual(['test1']);
+  });
+
+  it('Do not return managed fleet server policies', async () => {
+    jest.mocked(useGetAgentPolicies).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'test1',
+            is_managed: true,
+            is_default_fleet_server: true,
+            package_policies: [
+              {
+                package: {
+                  name: 'fleet_server',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as any);
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() => useSelectFleetServerPolicy());
+
+    expect(result.current.fleetServerPolicyId).toBeUndefined();
+    expect(result.current.eligibleFleetServerPolicies.map(({ id }) => id)).toEqual([]);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
@@ -26,7 +26,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   const eligibleFleetServerPolicies = useMemo(
     () =>
       agentPoliciesData
-        ? agentPoliciesData.items?.filter((item) => policyHasFleetServer(item))
+        ? agentPoliciesData.items?.filter((item) => !item.is_managed && policyHasFleetServer(item))
         : [],
     [agentPoliciesData]
   );


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/160092
Resolve https://github.com/elastic/kibana/issues/176369

Do not allow to add fleet server to cloud policy, this was possible as the generate service token step was enabled before the policy selection happens.


## Tests

I added some unit tests.

####  manual tests

 add fleet server policy and verify when adding fleet server => advanced tab => you cannot add fleet server to that policy
```
xpack.fleet.agentPolicies:
  # Test policy
  - name: Elastic Cloud agent policy
    description: Default agent policy for agents hosted on Elastic Cloud
    id: test-policy
    is_default: false
    is_managed: true
    is_default_fleet_server: false
    namespace: default
    monitoring_enabled: []
    unenroll_timeout: 86400 # 1 day TTL
    package_policies:
      - name: Fleet Server
        id: elastic-cloud-fleet-server
        package:
          name: fleet_server
        inputs:
          - type: fleet-server
            keep_enabled: true

            vars:
              - name: host
                value: 0.0.0.0
                frozen: true
              - name: port
                value: 8220
                frozen: true
              - name: custom
                value: |
                  server.runtime:
                    gc_percent: 20          # Force the GC to execute more frequently: see https://golang.org/pkg/runtime/debug/#SetGCPercent
```

