### PR TITLE
Refactor `getGenAiTokenTracking` to take response chunks instead of a stream (WIP)

### DIFF
--- a/x-pack/plugins/actions/server/lib/gen_ai_token_tracking.ts
+++ b/x-pack/plugins/actions/server/lib/gen_ai_token_tracking.ts
@@ -8,6 +8,7 @@
 import { PassThrough, Readable } from 'stream';
 import { finished } from 'stream/promises';
 import { Logger } from '@kbn/logging';
+import { isArray } from 'lodash';
 import { getTokenCountFromBedrockInvoke } from './get_token_count_from_bedrock_invoke';
 import { getTokenCountFromOpenAI } from './get_token_count_from_openai_stream';
 import { getTokenCountFromInvokeStream, InvokeBody } from './get_token_count_from_invoke_stream';
@@ -57,7 +58,7 @@ export const getGenAiTokenTracking = async ({
   }
 
   // this is a streamed OpenAI response, which did not use the subAction invokeStream
-  if (actionTypeId === '.gen-ai') {
+  if (actionTypeId === '.gen-ai' && isArray(data)) {
     try {
       const { total, prompt, completion } = await getTokenCountFromOpenAI({
         responseBodyChunks: data as unknown[],

--- a/x-pack/plugins/actions/server/lib/get_token_count_from_openai_stream.test.ts
+++ b/x-pack/plugins/actions/server/lib/get_token_count_from_openai_stream.test.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 import { Transform } from 'stream';
-import { getTokenCountFromOpenAIStream } from './get_token_count_from_openai_stream';
+import { getTokenCountFromOpenAI } from './get_token_count_from_openai_stream';
 import { loggerMock } from '@kbn/logging-mocks';
 
 interface StreamMock {
@@ -35,7 +35,7 @@ function createStreamMock(): StreamMock {
 
 const logger = loggerMock.create();
 describe('getTokenCountFromOpenAIStream', () => {
-  let tokens: Awaited<ReturnType<typeof getTokenCountFromOpenAIStream>>;
+  let tokens: Awaited<ReturnType<typeof getTokenCountFromOpenAI>>;
   let stream: StreamMock;
   const body = {
     messages: [
@@ -77,10 +77,10 @@ describe('getTokenCountFromOpenAIStream', () => {
 
     describe('without function tokens', () => {
       beforeEach(async () => {
-        tokens = await getTokenCountFromOpenAIStream({
+        tokens = await getTokenCountFromOpenAI({
           responseStream: stream.transform,
           logger,
-          body: JSON.stringify(body),
+          requestBody: JSON.stringify(body),
         });
       });
 
@@ -93,10 +93,10 @@ describe('getTokenCountFromOpenAIStream', () => {
 
     describe('with function tokens', () => {
       beforeEach(async () => {
-        tokens = await getTokenCountFromOpenAIStream({
+        tokens = await getTokenCountFromOpenAI({
           responseStream: stream.transform,
           logger,
-          body: JSON.stringify({
+          requestBody: JSON.stringify({
             ...body,
             functions: [
               {
@@ -125,10 +125,10 @@ describe('getTokenCountFromOpenAIStream', () => {
 
   describe('when a stream fails', () => {
     it('resolves the promise with the correct prompt tokens', async () => {
-      const tokenPromise = getTokenCountFromOpenAIStream({
+      const tokenPromise = getTokenCountFromOpenAI({
         responseStream: stream.transform,
         logger,
-        body: JSON.stringify(body),
+        requestBody: JSON.stringify(body),
       });
 
       stream.fail();

--- a/x-pack/plugins/actions/server/lib/get_token_count_from_openai_stream.ts
+++ b/x-pack/plugins/actions/server/lib/get_token_count_from_openai_stream.ts
@@ -7,26 +7,21 @@
 
 import { encode } from 'gpt-tokenizer';
 import { isEmpty, omitBy } from 'lodash';
-import { Readable } from 'stream';
-import { finished } from 'stream/promises';
 import type OpenAI from 'openai';
-import { Logger } from '@kbn/logging';
 
-export async function getTokenCountFromOpenAIStream({
-  responseStream,
-  body,
-  logger,
+export async function getTokenCountFromOpenAI({
+  responseBodyChunks,
+  requestBody,
 }: {
-  responseStream: Readable;
-  body: string;
-  logger: Logger;
+  responseBodyChunks: unknown[];
+  requestBody: string;
 }): Promise<{
   total: number;
   prompt: number;
   completion: number;
 }> {
   const chatCompletionRequest = JSON.parse(
-    body
+    requestBody
   ) as OpenAI.ChatCompletionCreateParams.ChatCompletionCreateParamsStreaming;
 
   // per https://github.com/openai/openai-cookbook/blob/main/examples/How_to_count_tokens_with_tiktoken.ipynb
@@ -62,19 +57,10 @@ export async function getTokenCountFromOpenAIStream({
 
   const promptTokens = tokensFromMessages + tokensFromFunctions;
 
-  let responseBody: string = '';
-
-  responseStream.on('data', (chunk: string) => {
-    responseBody += chunk.toString();
-  });
-
-  try {
-    await finished(responseStream);
-  } catch (e) {
-    logger.error('An error occurred while calculating streaming response tokens');
-  }
-
-  const response = responseBody
+  const response = responseBodyChunks
+    // @ts-expect-error
+    .map((chunk) => chunk.toString())
+    .join('')
     .split('\n')
     .filter((line) => {
       return line.startsWith('data: ') && !line.endsWith('[DONE]');


### PR DESCRIPTION
`getGenAiTokenTracking` should take response chunks instead of a stream in order to be able to invoke it from multiple consumers.