### PR TITLE
[Search] Execute model enrichment calls in parallel

### DIFF
--- a/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.test.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.test.ts
@@ -5,6 +5,8 @@
  * 2.0.
  */
 
+import { mockLogger } from '../../__mocks__';
+
 import { MlTrainedModels } from '@kbn/ml-plugin/server';
 
 import { MlModelDeploymentState } from '../../../common/types/ml';
@@ -34,7 +36,9 @@ describe('fetchMlModels', () => {
   });
 
   it('errors when there is no trained model provider', () => {
-    expect(() => fetchMlModels(undefined)).rejects.toThrowError('Machine Learning is not enabled');
+    expect(() => fetchMlModels(undefined, mockLogger)).rejects.toThrowError(
+      'Machine Learning is not enabled'
+    );
   });
 
   it('returns placeholders if no model is found', async () => {
@@ -47,7 +51,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelConfigs)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(2);
     expect(models[0]).toMatchObject({
@@ -105,7 +112,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(3);
     expect(models[0].modelId).toEqual(ELSER_MODEL_ID); // Placeholder
@@ -150,7 +160,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(2);
     expect(models[0].modelId).toEqual(ELSER_MODEL_ID); // Placeholder
@@ -212,7 +225,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(2);
     expect(models[0].modelId).toEqual(ELSER_MODEL_ID);
@@ -279,7 +295,10 @@ describe('fetchMlModels', () => {
       modelName,
     }));
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(2);
     expect(models[0].modelId).toEqual(ELSER_LINUX_OPTIMIZED_MODEL_ID);
@@ -350,7 +369,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(3);
     expect(models[0]).toMatchObject({
@@ -408,7 +430,45 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
+
+    expect(models.length).toBe(2);
+    expect(models[0]).toMatchObject({
+      modelId: ELSER_MODEL_ID,
+      deploymentState: MlModelDeploymentState.NotDeployed,
+    });
+    expect(mockTrainedModelsProvider.getTrainedModels).toHaveBeenCalledTimes(2);
+  });
+
+  it('gracefully handles errors when fetching downloading/downloaded deployment state for promoted models', async () => {
+    const mockModelConfigs = {
+      count: 1,
+      trained_model_configs: [
+        {
+          model_id: ELSER_MODEL_ID,
+          inference_config: {
+            text_expansion: {},
+          },
+          input: {
+            fields: ['text_field'],
+          },
+        },
+      ],
+    };
+
+    // 1st call: get models
+    // 2nd call: error while getting definition_status for ELSER
+    mockTrainedModelsProvider.getTrainedModels
+      .mockImplementationOnce(() => Promise.resolve(mockModelConfigs))
+      .mockImplementationOnce(() => Promise.reject('some error'));
+
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(2);
     expect(models[0]).toMatchObject({
@@ -464,7 +524,10 @@ describe('fetchMlModels', () => {
       Promise.resolve(mockModelStats)
     );
 
-    const models = await fetchMlModels(mockTrainedModelsProvider as unknown as MlTrainedModels);
+    const models = await fetchMlModels(
+      mockTrainedModelsProvider as unknown as MlTrainedModels,
+      mockLogger
+    );
 
     expect(models.length).toBe(5);
     expect(models[0].modelId).toEqual(ELSER_MODEL_ID); // Pinned to top

--- a/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.ts
@@ -80,12 +80,9 @@ export const fetchMlModels = async (
 
   // Undeployed placeholder models might be in the Downloading phase; let's evaluate this with a call
   // We must do this one by one because the API doesn't support fetching multiple models with include=definition_status
-  const enrichmentCalls = [];
-  for (const model of models) {
-    if (model.isPromoted && !model.isPlaceholder && !model.hasStats) {
-      enrichmentCalls.push(enrichModelWithDownloadStatus(model, trainedModelsProvider));
-    }
-  }
+  const enrichmentCalls = models
+    .filter((model) => model.isPromoted && !model.isPlaceholder && !model.hasStats)
+    .map((model) => enrichModelWithDownloadStatus(model, trainedModelsProvider));
   await Promise.all(enrichmentCalls);
 
   // Pin ELSER to the top, then E5 below, then the rest of the models sorted alphabetically

--- a/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/ml/fetch_ml_models.ts
@@ -191,9 +191,9 @@ const mergeModels = (modelPlaceholders: MlModel[], fetchedModels: MlModel[]) => 
   ...fetchedModels.map((f) => {
     const modelPlaceholder = modelPlaceholders.find((m) => m.modelId === f.modelId);
     if (modelPlaceholder) {
-      // Keep title and other properties from placeholder that are undefined in fetched model
-      const { title, ...modelWithoutTitle } = f;
-      return Object.assign({}, modelPlaceholder, modelWithoutTitle);
+      // Keep title, description and those properties from placeholder that are undefined in fetched model
+      const { title, description, ...modelWithoutTitleAndDescription } = f;
+      return Object.assign({}, modelPlaceholder, modelWithoutTitleAndDescription);
     }
 
     return f;

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -1142,7 +1142,7 @@ export function registerIndexRoutes({
         ? await ml.trainedModelsProvider(request, savedObjectsClient)
         : undefined;
 
-      const modelsResult = await fetchMlModels(trainedModelsProvider);
+      const modelsResult = await fetchMlModels(trainedModelsProvider, log);
 
       return response.ok({
         body: modelsResult,


### PR DESCRIPTION
## Summary

This PR optimizes the model enrichment calls (`GET _ml/trained_models/<model_id>?include=definition_status`) for ELSER and E5 by making them execute in parallel. There are no functional changes.

Local manual testing of performance before change: 1960 ms to make the calls in sequence.
After change: 1880 ms to run them in parallel.
With the addition of further curated models the speed increase will be more significant.