### PR TITLE
[8.13] [Synthetics] Hide unwanted Synthetics nav items (#177040)

### DIFF
--- a/x-pack/plugins/synthetics/kibana.jsonc
+++ b/x-pack/plugins/synthetics/kibana.jsonc
@@ -33,7 +33,16 @@
       "usageCollection",
       "bfetch"
     ],
-    "optionalPlugins": ["cloud", "data", "fleet", "home", "ml", "spaces", "telemetry"],
+    "optionalPlugins": [
+      "cloud",
+      "data",
+      "fleet",
+      "home",
+      "ml",
+      "serverless",
+      "spaces",
+      "telemetry"
+    ],
     "requiredBundles": [
       "data",
       "fleet",

--- a/x-pack/plugins/synthetics/public/plugin.ts
+++ b/x-pack/plugins/synthetics/public/plugin.ts
@@ -11,6 +11,7 @@ import {
   Plugin,
   PluginInitializerContext,
   AppMountParameters,
+  PackageInfo,
   AppNavLinkStatus,
 } from '@kbn/core/public';
 import { from } from 'rxjs';
@@ -54,6 +55,7 @@ import {
   ObservabilityAIAssistantPluginStart,
   ObservabilityAIAssistantPluginSetup,
 } from '@kbn/observability-ai-assistant-plugin/public';
+import { ServerlessPluginSetup } from '@kbn/serverless/public';
 import { PLUGIN } from '../common/constants/plugin';
 import { OVERVIEW_ROUTE } from '../common/constants/ui';
 import { locators } from './apps/locators';
@@ -70,6 +72,7 @@ export interface ClientPluginsSetup {
   share: SharePluginSetup;
   triggersActionsUi: TriggersAndActionsUIPublicPluginSetup;
   cloud?: CloudSetup;
+  serverless?: ServerlessPluginSetup;
 }
 
 export interface ClientPluginsStart {
@@ -112,7 +115,11 @@ export type ClientStart = void;
 export class UptimePlugin
   implements Plugin<ClientSetup, ClientStart, ClientPluginsSetup, ClientPluginsStart>
 {
-  constructor(private readonly initContext: PluginInitializerContext) {}
+  private readonly _packageInfo: Readonly<PackageInfo>;
+
+  constructor(private readonly initContext: PluginInitializerContext) {
+    this._packageInfo = initContext.env.packageInfo;
+  }
 
   public setup(core: CoreSetup<ClientPluginsStart, unknown>, plugins: ClientPluginsSetup): void {
     locators.forEach((locator) => {
@@ -154,7 +161,7 @@ export class UptimePlugin
             defaultMessage: 'Overview',
           }),
           path: '/',
-          navLinkStatus: AppNavLinkStatus.visible,
+          navLinkStatus: this._isServerless ? AppNavLinkStatus.visible : AppNavLinkStatus.hidden,
         },
         {
           id: 'management',
@@ -162,7 +169,7 @@ export class UptimePlugin
             defaultMessage: 'Management',
           }),
           path: '/monitors',
-          navLinkStatus: AppNavLinkStatus.visible,
+          navLinkStatus: this._isServerless ? AppNavLinkStatus.visible : AppNavLinkStatus.hidden,
         },
       ],
       mount: async (params: AppMountParameters) => {
@@ -193,6 +200,10 @@ export class UptimePlugin
   }
 
   public stop(): void {}
+
+  private get _isServerless(): boolean {
+    return this._packageInfo.buildFlavor === 'serverless';
+  }
 }
 
 function registerSyntheticsRoutesWithNavigation(

--- a/x-pack/plugins/synthetics/tsconfig.json
+++ b/x-pack/plugins/synthetics/tsconfig.json
@@ -82,6 +82,7 @@
     "@kbn/shared-ux-link-redirect-app",
     "@kbn/code-editor",
     "@kbn/code-editor-mock",
+    "@kbn/serverless",
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Summary from the author

The reason this failed to backport automagically is because, in 8.14+ we have changed the visibility flag for deep links in public Kibana plugins. That enhancement was not backported to 8.13, so this failed. I've reverted the visibility flag to the classic style of providing a boolean val for the deep links, while keeping the same `isServerless` build flavor check.

I tested this branch against an 8.13 snapshot and it worked fine, the unwanted nav items were hidden again.

# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Synthetics] Hide unwanted Synthetics nav items (#177040)](https://github.com/elastic/kibana/pull/177040)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Justin Kambic","email":"jk@elastic.co"},"sourceCommit":{"committedDate":"2024-02-20T15:35:00Z","message":"[Synthetics] Hide unwanted Synthetics nav items (#177040)\n\n## Summary\r\n\r\nResolves #177034.\r\n\r\nWe accidentally showed some nav items that we do not want to be visible\r\nin the top-level Kibana nav in stateful Kibana. This will hide them\r\noutside of the intended Serverless context.\r\n\r\n## Testing this PR\r\n\r\nSimply run Kibana and verify that you do not see the unintended nav\r\nitems that are shown in the linked issue.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c34cdec0856b2ac1fcd1fe8994d91cf63e4f44a9","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-infra_services","v8.13.0","v8.14.0"],"number":177040,"url":"https://github.com/elastic/kibana/pull/177040","mergeCommit":{"message":"[Synthetics] Hide unwanted Synthetics nav items (#177040)\n\n## Summary\r\n\r\nResolves #177034.\r\n\r\nWe accidentally showed some nav items that we do not want to be visible\r\nin the top-level Kibana nav in stateful Kibana. This will hide them\r\noutside of the intended Serverless context.\r\n\r\n## Testing this PR\r\n\r\nSimply run Kibana and verify that you do not see the unintended nav\r\nitems that are shown in the linked issue.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c34cdec0856b2ac1fcd1fe8994d91cf63e4f44a9"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177040","number":177040,"mergeCommit":{"message":"[Synthetics] Hide unwanted Synthetics nav items (#177040)\n\n## Summary\r\n\r\nResolves #177034.\r\n\r\nWe accidentally showed some nav items that we do not want to be visible\r\nin the top-level Kibana nav in stateful Kibana. This will hide them\r\noutside of the intended Serverless context.\r\n\r\n## Testing this PR\r\n\r\nSimply run Kibana and verify that you do not see the unintended nav\r\nitems that are shown in the linked issue.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"c34cdec0856b2ac1fcd1fe8994d91cf63e4f44a9"}}]}] BACKPORT-->