### PR TITLE
[8.13] [ES|QL] Improve handling of functions for variadic signatures with minParams (#177165)

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/autocomplete/autocomplete.test.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/autocomplete/autocomplete.test.ts
@@ -975,6 +975,39 @@ describe('autocomplete', () => {
       ],
       '('
     );
+    // test that comma is correctly added to the suggestions if minParams is not reached yet
+    testSuggestions('from a | eval a=concat( ', [
+      ...getFieldNamesByType('string').map((v) => `${v},`),
+      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+        'concat',
+      ]).map((v) => `${v},`),
+    ]);
+    testSuggestions('from a | eval a=concat(stringField, ', [
+      ...getFieldNamesByType('string'),
+      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+        'concat',
+      ]),
+    ]);
+    // test that the arg type is correct after minParams
+    testSuggestions('from a | eval a=cidr_match(ipField, stringField,', [
+      ...getFieldNamesByType('string'),
+      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+        'cidr_match',
+      ]),
+    ]);
+    // test that comma is correctly added to the suggestions if minParams is not reached yet
+    testSuggestions('from a | eval a=cidr_match( ', [
+      ...getFieldNamesByType('ip').map((v) => `${v},`),
+      ...getFunctionSignaturesByReturnType('eval', 'ip', { evalMath: true }, undefined, [
+        'cidr_match',
+      ]).map((v) => `${v},`),
+    ]);
+    testSuggestions('from a | eval a=cidr_match(ipField, ', [
+      ...getFieldNamesByType('string'),
+      ...getFunctionSignaturesByReturnType('eval', 'string', { evalMath: true }, undefined, [
+        'cidr_match',
+      ]),
+    ]);
     // test deep function nesting suggestions (and check that the same function is not suggested)
     // round(round(
     // round(round(round(

--- a/packages/kbn-monaco/src/esql/lib/ast/definitions/helpers.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/definitions/helpers.ts
@@ -12,12 +12,44 @@ export function getFunctionSignatures(
   { name, signatures }: FunctionDefinition,
   { withTypes }: { withTypes: boolean } = { withTypes: true }
 ) {
-  return signatures.map(({ params, returnType, infiniteParams, examples }) => ({
-    declaration: `${name}(${params.map((arg) => printArguments(arg, withTypes)).join(', ')}${
-      infiniteParams ? ` ,[... ${params.map((arg) => printArguments(arg, withTypes))}]` : ''
-    })${withTypes ? `: ${returnType}` : ''}`,
-    examples,
-  }));
+  return signatures.map(({ params, returnType, infiniteParams, minParams, examples }) => {
+    // for functions with a minimum number of args, repeat the last arg multiple times
+    // just make sure to compute the right number of args to add
+    const minParamsToAdd = Math.max((minParams || 0) - params.length, 0);
+    const hasMoreOptionalArgs = !!infiniteParams || !!minParams;
+    const extraArg = Array(minParamsToAdd || 1).fill(params[Math.max(params.length - 1, 0)]);
+    return {
+      declaration: `${name}(${params
+        .map((arg) => printArguments(arg, withTypes))
+        .join(', ')}${handleAdditionalArgs(
+        minParamsToAdd > 0,
+        extraArg,
+        withTypes,
+        false
+      )}${handleAdditionalArgs(hasMoreOptionalArgs, extraArg, withTypes)})${
+        withTypes ? `: ${returnType}` : ''
+      }`,
+      examples,
+    };
+  });
+}
+
+function handleAdditionalArgs(
+  criteria: boolean,
+  additionalArgs: Array<{
+    name: string;
+    type: string | string[];
+    optional?: boolean;
+    reference?: string;
+  }>,
+  withTypes: boolean,
+  optionalArg: boolean = true
+) {
+  return criteria
+    ? `${withTypes && optionalArg ? ' ,[... ' : ', '}${additionalArgs
+        .map((arg) => printArguments(arg, withTypes))
+        .join(', ')}${withTypes && optionalArg ? ']' : ''}`
+    : '';
 }
 
 export function getCommandSignature(

--- a/packages/kbn-monaco/src/esql/lib/ast/shared/helpers.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/shared/helpers.ts
@@ -91,7 +91,7 @@ export function isIncompleteItem(arg: ESQLAstItem): boolean {
 }
 
 export function isMathFunction(query: string, offset: number) {
-  const queryTrimmed = query.substring(0, offset).trimEnd();
+  const queryTrimmed = query.trimEnd();
   // try to get the full operation token (e.g. "+", "in", "like", etc...) but it requires the token
   // to be spaced out from a field/function (e.g. "field + ") so it is subject to issues
   const [opString] = queryTrimmed.split(' ').reverse();

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/errors.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/errors.ts
@@ -57,14 +57,39 @@ function getMessageAndTypeFromId<K extends ErrorTypes>({
       };
     case 'wrongArgumentNumber':
       return {
-        message: i18n.translate('monaco.esql.validation.wrongArgumentNumber', {
+        message: i18n.translate('monaco.esql.validation.wrongArgumentExactNumber', {
           defaultMessage:
-            'Error building [{fn}]: expects {canHaveMoreArgs, plural, =0 {exactly } other {}}{numArgs, plural, one {one argument} other {{numArgs} arguments}}, passed {passedArgs} instead.',
+            'Error building [{fn}]: expects exactly {numArgs, plural, one {one argument} other {{numArgs} arguments}}, passed {passedArgs} instead.',
           values: {
             fn: out.fn,
             numArgs: out.numArgs,
             passedArgs: out.passedArgs,
-            canHaveMoreArgs: out.exactly,
+          },
+        }),
+      };
+    case 'wrongArgumentNumberTooMany':
+      return {
+        message: i18n.translate('monaco.esql.validation.wrongArgumentTooManyNumber', {
+          defaultMessage:
+            'Error building [{fn}]: expects {extraArgs, plural, =0 {} other {no more than }}{numArgs, plural, one {one argument} other {{numArgs} arguments}}, passed {passedArgs} instead.',
+          values: {
+            fn: out.fn,
+            numArgs: out.numArgs,
+            passedArgs: out.passedArgs,
+            extraArgs: out.extraArgs,
+          },
+        }),
+      };
+    case 'wrongArgumentNumberTooFew':
+      return {
+        message: i18n.translate('monaco.esql.validation.wrongArgumentTooFewNumber', {
+          defaultMessage:
+            'Error building [{fn}]: expects {missingArgs, plural, =0 {} other {at least }}{numArgs, plural, one {one argument} other {{numArgs} arguments}}, passed {passedArgs} instead.',
+          values: {
+            fn: out.fn,
+            numArgs: out.numArgs,
+            passedArgs: out.passedArgs,
+            missingArgs: out.missingArgs,
           },
         }),
       };

--- a/packages/kbn-monaco/src/esql/lib/ast/validation/types.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/validation/types.ts
@@ -47,7 +47,29 @@ export interface ValidationErrors {
   };
   wrongArgumentNumber: {
     message: string;
-    type: { fn: string; numArgs: number; passedArgs: number; exactly: number };
+    type: {
+      fn: string;
+      numArgs: number;
+      passedArgs: number;
+    };
+  };
+  wrongArgumentNumberTooMany: {
+    message: string;
+    type: {
+      fn: string;
+      numArgs: number;
+      passedArgs: number;
+      extraArgs: number;
+    };
+  };
+  wrongArgumentNumberTooFew: {
+    message: string;
+    type: {
+      fn: string;
+      numArgs: number;
+      passedArgs: number;
+      missingArgs: number;
+    };
   };
   unknownColumn: {
     message: string;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[ES|QL] Improve handling of functions for variadic signatures with minParams (#177165)](https://github.com/elastic/kibana/pull/177165)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Marco Liberati","email":"dej611@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-02-21T08:07:44Z","message":"[ES|QL] Improve handling of functions for variadic signatures with minParams (#177165)\n\n## Summary\r\n\r\nFix an issue with functions with the `minParams` configuration\r\n(`concat`, `case`, `cidr_match`).\r\n\r\nValidation fix:\r\n* now validation engine understands the minimum number of args and\r\nprovide a better message based on the function signature\r\n* if the function has a single exact signature, then make it explicit\r\nthe `exact` nature\r\n<img width=\"442\" alt=\"Screenshot 2024-02-19 at 11 46 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/14aa9cb4-bce2-404b-936e-cb92ec966c2d\">\r\n\r\n<img width=\"227\" alt=\"Screenshot 2024-02-19 at 11 45 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/94b2a051-5cd2-4f60-b65a-c3ac77c17b85\">\r\n\r\n* if the function has some optional args in the signature, then make it\r\nexplicit that there are too few or too many args\r\n  \r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 48 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/55acf5f7-ce6b-452d-ba49-cd38ac05120e\">\r\n\r\n<img width=\"443\" alt=\"Screenshot 2024-02-19 at 11 45 03\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/653f62d3-7ee5-44d2-91e9-aae812f08394\">\r\n\r\n* if the function has a minParams configuration, then it should make it\r\nexplicit that there are too few args:\r\n<img width=\"467\" alt=\"Screenshot 2024-02-19 at 11 41 46\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/8a4030e0-317d-4371-abd0-11b333ad26d9\">\r\n\r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 41 16\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/d8f8048e-edda-44c2-b84e-b908cd7b29a5\">\r\n\r\n<img width=\"446\" alt=\"Screenshot 2024-02-19 at 11 41 04\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/c6ac58ef-a1b7-48a6-b2ad-a8994ae2b885\">\r\n\r\n* autocomplete now understand the `minParams` and suggest the right\r\nvalue in the right place\r\n\r\n![esql_min_params_autocomplete](https://github.com/elastic/kibana/assets/924948/fd21a819-8310-4f94-88e6-3a2967c7a8bd)\r\n\r\n* signature hover tooltip now provides a better signature for functions\r\nwith minParams (arg should not be optional, rather mandatory until the\r\n#minParams, optional after)\r\n\r\n\r\n![esql_min_params_signature](https://github.com/elastic/kibana/assets/924948/421f22f3-8d00-4acb-a65c-495a05b8d400)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"eb708f5f4e4f43fd6bd180eb45cd3596e6145f71","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","backport:prev-minor","Feature:ES|QL","v8.13.0","v8.14.0"],"number":177165,"url":"https://github.com/elastic/kibana/pull/177165","mergeCommit":{"message":"[ES|QL] Improve handling of functions for variadic signatures with minParams (#177165)\n\n## Summary\r\n\r\nFix an issue with functions with the `minParams` configuration\r\n(`concat`, `case`, `cidr_match`).\r\n\r\nValidation fix:\r\n* now validation engine understands the minimum number of args and\r\nprovide a better message based on the function signature\r\n* if the function has a single exact signature, then make it explicit\r\nthe `exact` nature\r\n<img width=\"442\" alt=\"Screenshot 2024-02-19 at 11 46 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/14aa9cb4-bce2-404b-936e-cb92ec966c2d\">\r\n\r\n<img width=\"227\" alt=\"Screenshot 2024-02-19 at 11 45 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/94b2a051-5cd2-4f60-b65a-c3ac77c17b85\">\r\n\r\n* if the function has some optional args in the signature, then make it\r\nexplicit that there are too few or too many args\r\n  \r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 48 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/55acf5f7-ce6b-452d-ba49-cd38ac05120e\">\r\n\r\n<img width=\"443\" alt=\"Screenshot 2024-02-19 at 11 45 03\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/653f62d3-7ee5-44d2-91e9-aae812f08394\">\r\n\r\n* if the function has a minParams configuration, then it should make it\r\nexplicit that there are too few args:\r\n<img width=\"467\" alt=\"Screenshot 2024-02-19 at 11 41 46\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/8a4030e0-317d-4371-abd0-11b333ad26d9\">\r\n\r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 41 16\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/d8f8048e-edda-44c2-b84e-b908cd7b29a5\">\r\n\r\n<img width=\"446\" alt=\"Screenshot 2024-02-19 at 11 41 04\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/c6ac58ef-a1b7-48a6-b2ad-a8994ae2b885\">\r\n\r\n* autocomplete now understand the `minParams` and suggest the right\r\nvalue in the right place\r\n\r\n![esql_min_params_autocomplete](https://github.com/elastic/kibana/assets/924948/fd21a819-8310-4f94-88e6-3a2967c7a8bd)\r\n\r\n* signature hover tooltip now provides a better signature for functions\r\nwith minParams (arg should not be optional, rather mandatory until the\r\n#minParams, optional after)\r\n\r\n\r\n![esql_min_params_signature](https://github.com/elastic/kibana/assets/924948/421f22f3-8d00-4acb-a65c-495a05b8d400)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"eb708f5f4e4f43fd6bd180eb45cd3596e6145f71"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177165","number":177165,"mergeCommit":{"message":"[ES|QL] Improve handling of functions for variadic signatures with minParams (#177165)\n\n## Summary\r\n\r\nFix an issue with functions with the `minParams` configuration\r\n(`concat`, `case`, `cidr_match`).\r\n\r\nValidation fix:\r\n* now validation engine understands the minimum number of args and\r\nprovide a better message based on the function signature\r\n* if the function has a single exact signature, then make it explicit\r\nthe `exact` nature\r\n<img width=\"442\" alt=\"Screenshot 2024-02-19 at 11 46 59\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/14aa9cb4-bce2-404b-936e-cb92ec966c2d\">\r\n\r\n<img width=\"227\" alt=\"Screenshot 2024-02-19 at 11 45 18\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/94b2a051-5cd2-4f60-b65a-c3ac77c17b85\">\r\n\r\n* if the function has some optional args in the signature, then make it\r\nexplicit that there are too few or too many args\r\n  \r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 48 00\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/55acf5f7-ce6b-452d-ba49-cd38ac05120e\">\r\n\r\n<img width=\"443\" alt=\"Screenshot 2024-02-19 at 11 45 03\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/653f62d3-7ee5-44d2-91e9-aae812f08394\">\r\n\r\n* if the function has a minParams configuration, then it should make it\r\nexplicit that there are too few args:\r\n<img width=\"467\" alt=\"Screenshot 2024-02-19 at 11 41 46\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/8a4030e0-317d-4371-abd0-11b333ad26d9\">\r\n\r\n<img width=\"441\" alt=\"Screenshot 2024-02-19 at 11 41 16\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/d8f8048e-edda-44c2-b84e-b908cd7b29a5\">\r\n\r\n<img width=\"446\" alt=\"Screenshot 2024-02-19 at 11 41 04\"\r\nsrc=\"https://github.com/elastic/kibana/assets/924948/c6ac58ef-a1b7-48a6-b2ad-a8994ae2b885\">\r\n\r\n* autocomplete now understand the `minParams` and suggest the right\r\nvalue in the right place\r\n\r\n![esql_min_params_autocomplete](https://github.com/elastic/kibana/assets/924948/fd21a819-8310-4f94-88e6-3a2967c7a8bd)\r\n\r\n* signature hover tooltip now provides a better signature for functions\r\nwith minParams (arg should not be optional, rather mandatory until the\r\n#minParams, optional after)\r\n\r\n\r\n![esql_min_params_signature](https://github.com/elastic/kibana/assets/924948/421f22f3-8d00-4acb-a65c-495a05b8d400)\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\n- [x] Any text added follows [EUI's writing\r\nguidelines](https://elastic.github.io/eui/#/guidelines/writing), uses\r\nsentence case text and includes [i18n\r\nsupport](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"eb708f5f4e4f43fd6bd180eb45cd3596e6145f71"}}]}] BACKPORT-->