### PR TITLE
[APM] Fix indexing of labels in alert document

### DIFF
--- a/packages/kbn-apm-synthtrace/src/lib/apm/aggregators/create_transaction_metrics_aggregator.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/aggregators/create_transaction_metrics_aggregator.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import { ApmFields, appendHash, hashKeysOf } from '@kbn/apm-synthtrace-client';
-import { pick } from 'lodash';
+import { pick, random } from 'lodash';
 import { createLosslessHistogram } from '../../utils/create_lossless_histogram';
 import { createApmMetricAggregator } from './create_apm_metric_aggregator';
 
@@ -80,6 +80,10 @@ export function createTransactionMetricsAggregator(flushInterval: string) {
             sum: 0,
             value_count: 0,
           },
+          labels:
+            random(0, 100, false) % 2 === 0
+              ? { custom_label: 'value' }
+              : { custom_label: ['value1', 'value2'] },
         };
       },
     },

--- a/packages/kbn-apm-synthtrace/src/lib/apm/aggregators/create_transaction_metrics_aggregator.ts
+++ b/packages/kbn-apm-synthtrace/src/lib/apm/aggregators/create_transaction_metrics_aggregator.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 import { ApmFields, appendHash, hashKeysOf } from '@kbn/apm-synthtrace-client';
-import { pick, random } from 'lodash';
+import { pick } from 'lodash';
 import { createLosslessHistogram } from '../../utils/create_lossless_histogram';
 import { createApmMetricAggregator } from './create_apm_metric_aggregator';
 
@@ -81,7 +81,7 @@ export function createTransactionMetricsAggregator(flushInterval: string) {
             value_count: 0,
           },
           labels:
-            random(0, 100, false) % 2 === 0
+            event['service.name'] === 'synth-node-0'
               ? { custom_label: 'value' }
               : { custom_label: ['value1', 'value2'] },
         };

--- a/x-pack/plugins/apm/common/service_groups.ts
+++ b/x-pack/plugins/apm/common/service_groups.ts
@@ -15,7 +15,7 @@ import {
   SERVICE_LANGUAGE_NAME,
 } from './es_fields/apm';
 
-const LABELS = 'labels'; // implies labels.* wildcard
+export const LABELS = 'labels'; // implies labels.* wildcard
 
 export const APM_SERVICE_GROUP_SAVED_OBJECT_TYPE = 'apm-service-group';
 export const SERVICE_GROUP_COLOR_DEFAULT = '#D1DAE7';

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
@@ -21,16 +21,10 @@ const mockSourceObj = {
   },
   labels: {
     team: 'test',
+    event: ['event-0', 'event-1'],
   },
   agent: {
     name: 'nodejs',
-  },
-};
-
-const mockSourceObj2 = {
-  ...mockSourceObj,
-  labels: {
-    team: ['test1', 'test2'],
   },
 };
 
@@ -42,14 +36,6 @@ const mockBucket = {
   },
 };
 
-const mockBucket2 = {
-  source_fields: {
-    hits: {
-      hits: [{ _source: mockSourceObj2 }],
-    },
-  },
-};
-
 describe('getSourceFields', () => {
   it('should return a flattened record of fields and values for a given bucket except for labels', () => {
     const result = getServiceGroupFields(mockBucket);
@@ -57,25 +43,11 @@ describe('getSourceFields', () => {
       Object {
         "agent.name": "nodejs",
         "labels": Object {
-          "team": "test",
-        },
-        "service.environment": "testing",
-        "service.language.name": "typescript",
-        "service.name": "testbeans",
-      }
-    `);
-  });
-
-  it('should not flatten labels', () => {
-    const result = getServiceGroupFields(mockBucket2);
-    expect(result).toMatchInlineSnapshot(`
-      Object {
-        "agent.name": "nodejs",
-        "labels": Object {
-          "team": Array [
-            "test1",
-            "test2",
+          "event": Array [
+            "event-0",
+            "event-1",
           ],
+          "team": "test",
         },
         "service.environment": "testing",
         "service.language.name": "typescript",
@@ -147,25 +119,11 @@ describe('flattenSourceDoc', () => {
       Object {
         "agent.name": "nodejs",
         "labels": Object {
-          "team": "test",
-        },
-        "service.environment": "testing",
-        "service.language.name": "typescript",
-        "service.name": "testbeans",
-      }
-    `);
-  });
-
-  it('should not flatten labels', () => {
-    const result = flattenSourceDoc(mockSourceObj2);
-    expect(result).toMatchInlineSnapshot(`
-      Object {
-        "agent.name": "nodejs",
-        "labels": Object {
-          "team": Array [
-            "test1",
-            "test2",
+          "event": Array [
+            "event-0",
+            "event-1",
           ],
+          "team": "test",
         },
         "service.environment": "testing",
         "service.language.name": "typescript",

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
@@ -36,12 +36,14 @@ const mockBucket = {
 };
 
 describe('getSourceFields', () => {
-  it('should return a flattened record of fields and values for a given bucket', () => {
+  it('should return a flattened record of fields and values for a given bucket except for labels', () => {
     const result = getServiceGroupFields(mockBucket);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "agent.name": "nodejs",
-        "labels.team": "test",
+        "labels": Object {
+          "team": "test",
+        },
         "service.environment": "testing",
         "service.language.name": "typescript",
         "service.name": "testbeans",
@@ -106,12 +108,14 @@ describe('getSourceFieldsAgg', () => {
 });
 
 describe('flattenSourceDoc', () => {
-  it('should flatten a given nested object with dot delim paths as keys', () => {
+  it('should flatten a given nested object with dot delim paths as keys except for labels', () => {
     const result = flattenSourceDoc(mockSourceObj);
     expect(result).toMatchInlineSnapshot(`
       Object {
         "agent.name": "nodejs",
-        "labels.team": "test",
+        "labels": Object {
+          "team": "test",
+        },
         "service.environment": "testing",
         "service.language.name": "typescript",
         "service.name": "testbeans",

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.test.ts
@@ -27,10 +27,25 @@ const mockSourceObj = {
   },
 };
 
+const mockSourceObj2 = {
+  ...mockSourceObj,
+  labels: {
+    team: ['test1', 'test2'],
+  },
+};
+
 const mockBucket = {
   source_fields: {
     hits: {
       hits: [{ _source: mockSourceObj }],
+    },
+  },
+};
+
+const mockBucket2 = {
+  source_fields: {
+    hits: {
+      hits: [{ _source: mockSourceObj2 }],
     },
   },
 };
@@ -43,6 +58,24 @@ describe('getSourceFields', () => {
         "agent.name": "nodejs",
         "labels": Object {
           "team": "test",
+        },
+        "service.environment": "testing",
+        "service.language.name": "typescript",
+        "service.name": "testbeans",
+      }
+    `);
+  });
+
+  it('should not flatten labels', () => {
+    const result = getServiceGroupFields(mockBucket2);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "agent.name": "nodejs",
+        "labels": Object {
+          "team": Array [
+            "test1",
+            "test2",
+          ],
         },
         "service.environment": "testing",
         "service.language.name": "typescript",
@@ -115,6 +148,24 @@ describe('flattenSourceDoc', () => {
         "agent.name": "nodejs",
         "labels": Object {
           "team": "test",
+        },
+        "service.environment": "testing",
+        "service.language.name": "typescript",
+        "service.name": "testbeans",
+      }
+    `);
+  });
+
+  it('should not flatten labels', () => {
+    const result = flattenSourceDoc(mockSourceObj2);
+    expect(result).toMatchInlineSnapshot(`
+      Object {
+        "agent.name": "nodejs",
+        "labels": Object {
+          "team": Array [
+            "test1",
+            "test2",
+          ],
         },
         "service.environment": "testing",
         "service.language.name": "typescript",

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.ts
@@ -6,7 +6,10 @@
  */
 
 import { AggregationsTopHitsAggregation } from '@elastic/elasticsearch/lib/api/types';
-import { SERVICE_GROUP_SUPPORTED_FIELDS } from '../../../../common/service_groups';
+import {
+  LABELS,
+  SERVICE_GROUP_SUPPORTED_FIELDS,
+} from '../../../../common/service_groups';
 
 export interface SourceDoc {
   [key: string]: string | SourceDoc;
@@ -48,8 +51,8 @@ export function getServiceGroupFields(bucket?: AggResultBucket) {
 export function flattenSourceDoc(
   val: SourceDoc | string,
   path: string[] = []
-): Record<string, string> {
-  if (typeof val !== 'object') {
+): Record<string, string | object> {
+  if (typeof val !== 'object' || (path.length > 0 && path[0] === LABELS)) {
     return { [path.join('.')]: val };
   }
   return Object.keys(val).reduce((acc, key) => {

--- a/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.ts
+++ b/x-pack/plugins/apm/server/routes/alerts/rule_types/get_service_group_fields.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../common/service_groups';
 
 export interface SourceDoc {
-  [key: string]: string | SourceDoc;
+  [key: string]: string | string[] | SourceDoc;
 }
 
 export function getServiceGroupFieldsAgg(
@@ -56,7 +56,10 @@ export function flattenSourceDoc(
     return { [path.join('.')]: val };
   }
   return Object.keys(val).reduce((acc, key) => {
-    const fieldMap = flattenSourceDoc(val[key], [...path, key]);
+    const fieldMap = flattenSourceDoc(val[key] as SourceDoc | string, [
+      ...path,
+      key,
+    ]);
     return Object.assign(acc, fieldMap);
   }, {});
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/172443, https://github.com/elastic/kibana/issues/177430

This PR indexes `labels` without flattening in alert documents. Also, updated `synthtrace` to generate data with `labels` where some documents have label with string value and others have same label with an array of string values.

### Alert with single value for the label
<img width="625" alt="Screenshot 2024-02-21 at 14 09 37" src="https://github.com/elastic/kibana/assets/69037875/a05a1df8-78f4-48f2-9935-21c18d223cb2">

### Alert with an array of values for the label
<img width="635" alt="Screenshot 2024-02-21 at 14 10 14" src="https://github.com/elastic/kibana/assets/69037875/30115181-fa94-4c8c-8201-3cbc0d51f894">

### All active alerts are displayed in UI
<img width="1325" alt="Screenshot 2024-02-21 at 14 12 06" src="https://github.com/elastic/kibana/assets/69037875/2aee71fd-639a-4954-a5d9-7136571c6b1f">

### All recovered alerts have a proper reason message and `View in app` link
<img width="1267" alt="Screenshot 2024-02-21 at 14 14 15" src="https://github.com/elastic/kibana/assets/69037875/50b5801b-5a4a-4d99-a9e1-037d6a69a661">

### How to test
1. Generate data with `node scripts/synthtrace.js simple_trace --live`
2. Create APM Latency threshold/Failed transaction rate/Error count rule
3. Verify that both types of labels (with string, and with array of strings) are able to correctly index in alert documents
4. Verify that all active alerts are displayed in UI
5. Verify that recovered alerts have proper reason message and `View in app` link

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->