### PR TITLE
[Actions] [ServiceNow] Add required UI validation for correlation_id when recovered action

### DIFF
--- a/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.test.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.test.tsx
@@ -339,5 +339,27 @@ describe('ServiceNowITSMParamsFields renders', () => {
         incident: { correlation_id: 'updated correlation id' },
       });
     });
+
+    test('throws error if correlation_id is null and sub action is recovered', () => {
+      const newProps = {
+        ...defaultProps,
+        actionParams: {
+          subAction: 'closeIncident',
+          subActionParams: {
+            incident: {
+              ...defaultProps.actionParams.subActionParams.incident,
+              correlation_id: null,
+            },
+            comments: null,
+          },
+        },
+        errors: { 'subActionParams.incident.correlation_id': ['correlation_id_error'] },
+        selectedActionGroupId: ACTION_GROUP_RECOVERED,
+      };
+
+      const wrapper = mountWithIntl(<ServiceNowITSMParamsFields {...newProps} />);
+
+      expect(wrapper.find('.euiFormErrorText').text()).toBe('correlation_id_error');
+    });
   });
 });

--- a/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.tsx
@@ -79,15 +79,11 @@ const CorrelationIdField: React.FunctionComponent<
         </EuiLink>
       }
       labelAppend={
-        selectedActionGroupId !== ACTION_GROUP_RECOVERED ? (
-          <EuiText size="xs" color="subdued">
-            {i18n.OPTIONAL_LABEL}
-          </EuiText>
-        ) : (
-          <EuiText size="xs" color="subdued">
-            {i18n.REQUIRED_LABEL}
-          </EuiText>
-        )
+        <EuiText size="xs" color="subdued">
+          {selectedActionGroupId !== ACTION_GROUP_RECOVERED
+            ? i18n.OPTIONAL_LABEL
+            : i18n.REQUIRED_LABEL}
+        </EuiText>
       }
     >
       <TextFieldWithMessageVariables

--- a/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.tsx
+++ b/x-pack/plugins/stack_connectors/public/connector_types/servicenow_itsm/servicenow_itsm_params.tsx
@@ -45,16 +45,31 @@ const defaultFields: Fields = {
 };
 
 const CorrelationIdField: React.FunctionComponent<
-  Pick<ActionParamsProps<ServiceNowITSMActionParams>, 'index' | 'messageVariables'> & {
+  Pick<ActionParamsProps<ServiceNowITSMActionParams>, 'index' | 'messageVariables' | 'errors'> & {
     correlationId: string | null;
+    selectedActionGroupId?: string;
     editSubActionProperty: (key: string, value: any) => void;
   }
-> = ({ index, messageVariables, correlationId, editSubActionProperty }) => {
+> = ({
+  index,
+  messageVariables,
+  correlationId,
+  editSubActionProperty,
+  selectedActionGroupId,
+  errors,
+}) => {
   const { docLinks } = useKibana().services;
   return (
     <EuiFormRow
       fullWidth
       label={i18n.CORRELATION_ID}
+      error={errors['subActionParams.incident.correlation_id']}
+      isInvalid={
+        errors['subActionParams.incident.correlation_id'] !== undefined &&
+        errors['subActionParams.incident.correlation_id'].length > 0 &&
+        !correlationId &&
+        selectedActionGroupId === ACTION_GROUP_RECOVERED
+      }
       helpText={
         <EuiLink href={docLinks.links.alerting.serviceNowAction} target="_blank">
           <FormattedMessage
@@ -64,9 +79,15 @@ const CorrelationIdField: React.FunctionComponent<
         </EuiLink>
       }
       labelAppend={
-        <EuiText size="xs" color="subdued">
-          {i18n.OPTIONAL_LABEL}
-        </EuiText>
+        selectedActionGroupId !== ACTION_GROUP_RECOVERED ? (
+          <EuiText size="xs" color="subdued">
+            {i18n.OPTIONAL_LABEL}
+          </EuiText>
+        ) : (
+          <EuiText size="xs" color="subdued">
+            {i18n.REQUIRED_LABEL}
+          </EuiText>
+        )
       }
     >
       <TextFieldWithMessageVariables
@@ -75,6 +96,7 @@ const CorrelationIdField: React.FunctionComponent<
         messageVariables={messageVariables}
         paramsProperty={'correlation_id'}
         inputTargetValue={correlationId ?? undefined}
+        errors={errors['subActionParams.incident.correlation_id'] as string[]}
       />
     </EuiFormRow>
   );
@@ -297,6 +319,8 @@ const ServiceNowParamsFields: React.FunctionComponent<
                     messageVariables={messageVariables}
                     correlationId={incident.correlation_id}
                     editSubActionProperty={editSubActionProperty}
+                    selectedActionGroupId={selectedActionGroupId}
+                    errors={errors}
                   />
                 </EuiFlexItem>
                 <EuiFlexItem>
@@ -374,6 +398,8 @@ const ServiceNowParamsFields: React.FunctionComponent<
           messageVariables={messageVariables}
           correlationId={incident.correlation_id}
           editSubActionProperty={editSubActionProperty}
+          selectedActionGroupId={selectedActionGroupId}
+          errors={errors}
         />
       )}
     </>


### PR DESCRIPTION
## Summary

This PR adds UI validation for `correlation_id` field in case of Recovered action.

<img width="503" alt="image" src="https://github.com/elastic/kibana/assets/117571355/60731f81-1dc5-4d34-b9f8-4a3488df244f">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->