### PR TITLE
[DO NOT MERGE] 8.13 version of [ResponseOps] add parallel number arrays to task manager metric histograms

### DIFF
--- a/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/create_aggregator.test.ts
@@ -122,47 +122,102 @@ describe('createAggregator', () => {
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 1, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 1,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[1]).toEqual({
               key: 'task_claim',
-              value: { success: 2, total: 2, duration: { counts: [2], values: [100] } },
+              value: {
+                success: 2,
+                total: 2,
+                duration: { counts: [2], values: [100] },
+                duration_values: [10, 10],
+              },
             });
             expect(metrics[2]).toEqual({
               key: 'task_claim',
-              value: { success: 3, total: 3, duration: { counts: [3], values: [100] } },
+              value: {
+                success: 3,
+                total: 3,
+                duration: { counts: [3], values: [100] },
+                duration_values: [10, 10, 10],
+              },
             });
             expect(metrics[3]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 4, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 4,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[4]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 5, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 5,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[5]).toEqual({
               key: 'task_claim',
-              value: { success: 5, total: 6, duration: { counts: [5], values: [100] } },
+              value: {
+                success: 5,
+                total: 6,
+                duration: { counts: [5], values: [100] },
+                duration_values: [10, 10, 10, 10, 10],
+              },
             });
             expect(metrics[6]).toEqual({
               key: 'task_claim',
-              value: { success: 6, total: 7, duration: { counts: [6], values: [100] } },
+              value: {
+                success: 6,
+                total: 7,
+                duration: { counts: [6], values: [100] },
+                duration_values: [10, 10, 10, 10, 10, 10],
+              },
             });
             expect(metrics[7]).toEqual({
               key: 'task_claim',
-              value: { success: 7, total: 8, duration: { counts: [7], values: [100] } },
+              value: {
+                success: 7,
+                total: 8,
+                duration: { counts: [7], values: [100] },
+                duration_values: [10, 10, 10, 10, 10, 10, 10],
+              },
             });
             expect(metrics[8]).toEqual({
               key: 'task_claim',
-              value: { success: 8, total: 9, duration: { counts: [8], values: [100] } },
+              value: {
+                success: 8,
+                total: 9,
+                duration: { counts: [8], values: [100] },
+                duration_values: [10, 10, 10, 10, 10, 10, 10, 10],
+              },
             });
             expect(metrics[9]).toEqual({
               key: 'task_claim',
-              value: { success: 8, total: 10, duration: { counts: [8], values: [100] } },
+              value: {
+                success: 8,
+                total: 10,
+                duration: { counts: [8], values: [100] },
+                duration_values: [10, 10, 10, 10, 10, 10, 10, 10],
+              },
             });
             expect(metrics[10]).toEqual({
               key: 'task_claim',
-              value: { success: 9, total: 11, duration: { counts: [9], values: [100] } },
+              value: {
+                success: 9,
+                total: 11,
+                duration: { counts: [9], values: [100] },
+                duration_values: [10, 10, 10, 10, 10, 10, 10, 10, 10],
+              },
             });
             resolve();
           });
@@ -214,48 +269,103 @@ describe('createAggregator', () => {
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 1, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 1,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[1]).toEqual({
               key: 'task_claim',
-              value: { success: 2, total: 2, duration: { counts: [2], values: [100] } },
+              value: {
+                success: 2,
+                total: 2,
+                duration: { counts: [2], values: [100] },
+                duration_values: [10, 10],
+              },
             });
             expect(metrics[2]).toEqual({
               key: 'task_claim',
-              value: { success: 3, total: 3, duration: { counts: [3], values: [100] } },
+              value: {
+                success: 3,
+                total: 3,
+                duration: { counts: [3], values: [100] },
+                duration_values: [10, 10, 10],
+              },
             });
             expect(metrics[3]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 4, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 4,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[4]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 5, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 5,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[5]).toEqual({
               key: 'task_claim',
-              value: { success: 5, total: 6, duration: { counts: [5], values: [100] } },
+              value: {
+                success: 5,
+                total: 6,
+                duration: { counts: [5], values: [100] },
+                duration_values: [10, 10, 10, 10, 10],
+              },
             });
             // reset event should have been received here
             expect(metrics[6]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 1, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 1,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[7]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 2, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 2,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[8]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 3, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 3,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[9]).toEqual({
               key: 'task_claim',
-              value: { success: 2, total: 4, duration: { counts: [2], values: [100] } },
+              value: {
+                success: 2,
+                total: 4,
+                duration: { counts: [2], values: [100] },
+                duration_values: [10, 10],
+              },
             });
             expect(metrics[10]).toEqual({
               key: 'task_claim',
-              value: { success: 3, total: 5, duration: { counts: [3], values: [100] } },
+              value: {
+                success: 3,
+                total: 5,
+                duration: { counts: [3], values: [100] },
+                duration_values: [10, 10, 10],
+              },
             });
             resolve();
           });
@@ -315,48 +425,103 @@ describe('createAggregator', () => {
           .subscribe((metrics: Array<AggregatedStat<TaskClaimMetric>>) => {
             expect(metrics[0]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 1, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 1,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[1]).toEqual({
               key: 'task_claim',
-              value: { success: 2, total: 2, duration: { counts: [2], values: [100] } },
+              value: {
+                success: 2,
+                total: 2,
+                duration: { counts: [2], values: [100] },
+                duration_values: [10, 10],
+              },
             });
             expect(metrics[2]).toEqual({
               key: 'task_claim',
-              value: { success: 3, total: 3, duration: { counts: [3], values: [100] } },
+              value: {
+                success: 3,
+                total: 3,
+                duration: { counts: [3], values: [100] },
+                duration_values: [10, 10, 10],
+              },
             });
             expect(metrics[3]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 4, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 4,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[4]).toEqual({
               key: 'task_claim',
-              value: { success: 4, total: 5, duration: { counts: [4], values: [100] } },
+              value: {
+                success: 4,
+                total: 5,
+                duration: { counts: [4], values: [100] },
+                duration_values: [10, 10, 10, 10],
+              },
             });
             expect(metrics[5]).toEqual({
               key: 'task_claim',
-              value: { success: 5, total: 6, duration: { counts: [5], values: [100] } },
+              value: {
+                success: 5,
+                total: 6,
+                duration: { counts: [5], values: [100] },
+                duration_values: [10, 10, 10, 10, 10],
+              },
             });
             // reset interval should have fired here
             expect(metrics[6]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 1, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 1,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[7]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 2, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 2,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[8]).toEqual({
               key: 'task_claim',
-              value: { success: 1, total: 3, duration: { counts: [1], values: [100] } },
+              value: {
+                success: 1,
+                total: 3,
+                duration: { counts: [1], values: [100] },
+                duration_values: [10],
+              },
             });
             expect(metrics[9]).toEqual({
               key: 'task_claim',
-              value: { success: 2, total: 4, duration: { counts: [2], values: [100] } },
+              value: {
+                success: 2,
+                total: 4,
+                duration: { counts: [2], values: [100] },
+                duration_values: [10, 10],
+              },
             });
             expect(metrics[10]).toEqual({
               key: 'task_claim',
-              value: { success: 3, total: 5, duration: { counts: [3], values: [100] } },
+              value: {
+                success: 3,
+                total: 5,
+                duration: { counts: [3], values: [100] },
+                duration_values: [10, 10, 10],
+              },
             });
             resolve();
           });
@@ -428,6 +593,7 @@ describe('createAggregator', () => {
                   not_timed_out: 0,
                   total: 0,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -441,6 +607,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -470,6 +637,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [3, 10],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -499,6 +667,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [3, 10],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -535,6 +704,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [3, 10, 3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -571,6 +741,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [3, 10, 3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -607,6 +778,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -643,6 +815,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -686,6 +859,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -729,6 +903,7 @@ describe('createAggregator', () => {
                   not_timed_out: 5,
                   total: 5,
                   delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -772,6 +947,7 @@ describe('createAggregator', () => {
                   not_timed_out: 5,
                   total: 5,
                   delay: { counts: [4, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -815,6 +991,7 @@ describe('createAggregator', () => {
                   not_timed_out: 6,
                   total: 6,
                   delay: { counts: [4, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -865,6 +1042,7 @@ describe('createAggregator', () => {
                   not_timed_out: 6,
                   total: 6,
                   delay: { counts: [4, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -915,6 +1093,7 @@ describe('createAggregator', () => {
                   not_timed_out: 7,
                   total: 7,
                   delay: { counts: [4, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -965,6 +1144,7 @@ describe('createAggregator', () => {
                   not_timed_out: 7,
                   total: 7,
                   delay: { counts: [5, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -1015,6 +1195,7 @@ describe('createAggregator', () => {
                   not_timed_out: 8,
                   total: 8,
                   delay: { counts: [5, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4],
                   framework_errors: 2,
                   user_errors: 0,
                 },
@@ -1065,6 +1246,7 @@ describe('createAggregator', () => {
                   not_timed_out: 8,
                   total: 8,
                   delay: { counts: [6, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4, 4],
                   framework_errors: 2,
                   user_errors: 0,
                 },
@@ -1115,6 +1297,7 @@ describe('createAggregator', () => {
                   not_timed_out: 9,
                   total: 9,
                   delay: { counts: [6, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4, 4],
                   framework_errors: 2,
                   user_errors: 0,
                 },
@@ -1165,6 +1348,7 @@ describe('createAggregator', () => {
                   not_timed_out: 9,
                   total: 9,
                   delay: { counts: [7, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4, 4, 3],
                   framework_errors: 2,
                   user_errors: 0,
                 },
@@ -1215,6 +1399,7 @@ describe('createAggregator', () => {
                   not_timed_out: 10,
                   total: 10,
                   delay: { counts: [7, 2, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9, 5, 12, 4, 4, 3],
                   framework_errors: 3,
                   user_errors: 0,
                 },
@@ -1337,6 +1522,7 @@ describe('createAggregator', () => {
                   not_timed_out: 0,
                   total: 0,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1350,6 +1536,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1379,6 +1566,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [3, 10],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1408,6 +1596,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [3, 10],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1444,6 +1633,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [3, 10, 3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1480,6 +1670,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [3, 10, 3],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1516,6 +1707,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1552,6 +1744,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1595,6 +1788,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1638,6 +1832,7 @@ describe('createAggregator', () => {
                   not_timed_out: 5,
                   total: 5,
                   delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
+                  delay_values: [3, 10, 3, 35, 9],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -1682,6 +1877,7 @@ describe('createAggregator', () => {
                   not_timed_out: 0,
                   total: 0,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [5],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1725,6 +1921,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1], values: [10] },
+                  delay_values: [5],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1768,6 +1965,7 @@ describe('createAggregator', () => {
                   not_timed_out: 1,
                   total: 1,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [5, 12],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1811,6 +2009,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [1, 1], values: [10, 20] },
+                  delay_values: [5, 12],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1854,6 +2053,7 @@ describe('createAggregator', () => {
                   not_timed_out: 2,
                   total: 2,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4],
                   framework_errors: 0,
                   user_errors: 0,
                 },
@@ -1897,6 +2097,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [2, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -1940,6 +2141,7 @@ describe('createAggregator', () => {
                   not_timed_out: 3,
                   total: 3,
                   delay: { counts: [3, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4, 4],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -1983,6 +2185,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [3, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4, 4],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -2026,6 +2229,7 @@ describe('createAggregator', () => {
                   not_timed_out: 4,
                   total: 4,
                   delay: { counts: [4, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4, 4, 3],
                   framework_errors: 1,
                   user_errors: 0,
                 },
@@ -2069,6 +2273,7 @@ describe('createAggregator', () => {
                   not_timed_out: 5,
                   total: 5,
                   delay: { counts: [4, 1], values: [10, 20] },
+                  delay_values: [5, 12, 4, 4, 3],
                   framework_errors: 2,
                   user_errors: 0,
                 },
@@ -2184,795 +2389,1086 @@ describe('createAggregator', () => {
             bufferCount(taskRunEvents1.length + taskRunEvents2.length)
           )
           .subscribe((metrics: Array<AggregatedStat<TaskRunMetric>>) => {
-            expect(metrics[0]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 0,
-                  not_timed_out: 0,
-                  total: 0,
-                  delay: { counts: [1], values: [10] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-              },
-            });
-            expect(metrics[1]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 1,
-                  not_timed_out: 1,
-                  total: 1,
-                  delay: { counts: [1], values: [10] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
+            expect(metrics).toMatchInlineSnapshot(`
+              Array [
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 0,
+                      "success": 0,
+                      "total": 0,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[2]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 1,
-                  not_timed_out: 1,
-                  total: 1,
-                  delay: { counts: [1, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[3]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 2,
-                  total: 2,
-                  delay: { counts: [1, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 1,
+                      "success": 1,
+                      "total": 1,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[4]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 2,
-                  total: 2,
-                  delay: { counts: [2, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[5]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 3,
-                  not_timed_out: 3,
-                  total: 3,
-                  delay: { counts: [2, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 1,
+                      "success": 1,
+                      "total": 1,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[6]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 3,
-                  not_timed_out: 3,
-                  total: 3,
-                  delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[7]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 4,
-                  not_timed_out: 4,
-                  total: 4,
-                  delay: { counts: [2, 1, 0, 1], values: [10, 20, 30, 40] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 2,
+                      "success": 2,
+                      "total": 2,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[8]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 4,
-                  not_timed_out: 4,
-                  total: 4,
-                  delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[9]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 4,
-                  not_timed_out: 5,
-                  total: 5,
-                  delay: { counts: [3, 1, 0, 1], values: [10, 20, 30, 40] },
-                  framework_errors: 1,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 2,
+                      "success": 2,
+                      "total": 2,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            // reset event should have been received here
-            expect(metrics[10]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 0,
-                  not_timed_out: 0,
-                  total: 0,
-                  delay: { counts: [1], values: [10] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[11]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 1,
-                  not_timed_out: 1,
-                  total: 1,
-                  delay: { counts: [1], values: [10] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 3,
+                      "success": 3,
+                      "total": 3,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[12]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 1,
-                  not_timed_out: 1,
-                  total: 1,
-                  delay: { counts: [1, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 1,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[13]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 2,
-                  total: 2,
-                  delay: { counts: [1, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                          0,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                          30,
+                          40,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                        35,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 3,
+                      "success": 3,
+                      "total": 3,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[14]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 2,
-                  total: 2,
-                  delay: { counts: [2, 1], values: [10, 20] },
-                  framework_errors: 0,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 2,
-                    total: 2,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[15]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 3,
-                  total: 3,
-                  delay: { counts: [2, 1], values: [10, 20] },
-                  framework_errors: 1,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                          0,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                          30,
+                          40,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                        35,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 4,
+                      "success": 4,
+                      "total": 4,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[16]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 2,
-                  not_timed_out: 3,
-                  total: 3,
-                  delay: { counts: [3, 1], values: [10, 20] },
-                  framework_errors: 1,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 2,
-                    not_timed_out: 3,
-                    total: 3,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[17]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 3,
-                  not_timed_out: 4,
-                  total: 4,
-                  delay: { counts: [3, 1], values: [10, 20] },
-                  framework_errors: 1,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          3,
+                          1,
+                          0,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                          30,
+                          40,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                        35,
+                        9,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 4,
+                      "success": 4,
+                      "total": 4,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
-            expect(metrics[18]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 3,
-                  not_timed_out: 4,
-                  total: 4,
-                  delay: { counts: [4, 1], values: [10, 20] },
-                  framework_errors: 1,
-                  user_errors: 0,
-                },
-                by_type: {
-                  alerting: {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                },
-              },
-            });
-            expect(metrics[19]).toEqual({
-              key: 'task_run',
-              value: {
-                overall: {
-                  success: 3,
-                  not_timed_out: 5,
-                  total: 5,
-                  delay: { counts: [4, 1], values: [10, 20] },
-                  framework_errors: 2,
-                  user_errors: 0,
-                },
-                by_type: {
-                  actions: {
-                    success: 0,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  alerting: {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'actions:webhook': {
-                    success: 0,
-                    not_timed_out: 1,
-                    total: 1,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  'alerting:example': {
-                    success: 3,
-                    not_timed_out: 4,
-                    total: 4,
-                    framework_errors: 1,
-                    user_errors: 0,
-                  },
-                  report: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
-                  },
-                  telemetry: {
-                    success: 0,
-                    not_timed_out: 0,
-                    total: 0,
-                    framework_errors: 0,
-                    user_errors: 0,
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          3,
+                          1,
+                          0,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                          30,
+                          40,
+                        ],
+                      },
+                      "delay_values": Array [
+                        3,
+                        10,
+                        3,
+                        35,
+                        9,
+                      ],
+                      "framework_errors": 1,
+                      "not_timed_out": 5,
+                      "success": 4,
+                      "total": 5,
+                      "user_errors": 0,
+                    },
                   },
                 },
-              },
-            });
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 0,
+                      "success": 0,
+                      "total": 0,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 1,
+                      "success": 1,
+                      "total": 1,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 1,
+                        "success": 1,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 1,
+                      "success": 1,
+                      "total": 1,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          1,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 2,
+                      "success": 2,
+                      "total": 2,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 2,
+                        "success": 2,
+                        "total": 2,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                      ],
+                      "framework_errors": 0,
+                      "not_timed_out": 2,
+                      "success": 2,
+                      "total": 2,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          2,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                      ],
+                      "framework_errors": 1,
+                      "not_timed_out": 3,
+                      "success": 2,
+                      "total": 3,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 3,
+                        "success": 2,
+                        "total": 3,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          3,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                        4,
+                      ],
+                      "framework_errors": 1,
+                      "not_timed_out": 3,
+                      "success": 2,
+                      "total": 3,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          3,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                        4,
+                      ],
+                      "framework_errors": 1,
+                      "not_timed_out": 4,
+                      "success": 3,
+                      "total": 4,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          4,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                        4,
+                        3,
+                      ],
+                      "framework_errors": 1,
+                      "not_timed_out": 4,
+                      "success": 3,
+                      "total": 4,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+                Object {
+                  "key": "task_run",
+                  "value": Object {
+                    "by_type": Object {
+                      "actions": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 1,
+                        "success": 0,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "actions:webhook": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 1,
+                        "success": 0,
+                        "total": 1,
+                        "user_errors": 0,
+                      },
+                      "alerting": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "alerting:example": Object {
+                        "framework_errors": 1,
+                        "not_timed_out": 4,
+                        "success": 3,
+                        "total": 4,
+                        "user_errors": 0,
+                      },
+                      "report": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                      "telemetry": Object {
+                        "framework_errors": 0,
+                        "not_timed_out": 0,
+                        "success": 0,
+                        "total": 0,
+                        "user_errors": 0,
+                      },
+                    },
+                    "overall": Object {
+                      "delay": Object {
+                        "counts": Array [
+                          4,
+                          1,
+                        ],
+                        "values": Array [
+                          10,
+                          20,
+                        ],
+                      },
+                      "delay_values": Array [
+                        5,
+                        12,
+                        4,
+                        4,
+                        3,
+                      ],
+                      "framework_errors": 2,
+                      "not_timed_out": 5,
+                      "success": 3,
+                      "total": 5,
+                      "user_errors": 0,
+                    },
+                  },
+                },
+              ]
+            `);
             resolve();
           });
 
@@ -3065,6 +3561,7 @@ describe('createAggregator', () => {
                     counts: [3, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
                     values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
                   },
+                  overdue_by_values: [0, 0, 0, 20, 20, 40, 120],
                 },
                 by_type: {
                   'alerting:example': {
@@ -3072,36 +3569,42 @@ describe('createAggregator', () => {
                       counts: [0, 0, 0, 0, 1],
                       values: [10, 20, 30, 40, 50],
                     },
+                    overdue_by_values: [40],
                   },
                   'alerting:__index-threshold': {
                     overdue_by: {
                       counts: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
                       values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
                     },
+                    overdue_by_values: [20, 20, 120],
                   },
                   alerting: {
                     overdue_by: {
                       counts: [0, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
                       values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
                     },
+                    overdue_by_values: [40, 20, 20, 120],
                   },
                   'actions:webhook': {
                     overdue_by: {
                       counts: [2],
                       values: [10],
                     },
+                    overdue_by_values: [0, 0],
                   },
                   'actions:__email': {
                     overdue_by: {
                       counts: [1],
                       values: [10],
                     },
+                    overdue_by_values: [0],
                   },
                   actions: {
                     overdue_by: {
                       counts: [3],
                       values: [10],
                     },
+                    overdue_by_values: [0, 0, 0],
                   },
                 },
               },
@@ -3109,7 +3612,10 @@ describe('createAggregator', () => {
             expect(metrics[1]).toEqual({
               key: 'task_overdue',
               value: {
-                overall: { overdue_by: { counts: [], values: [] } },
+                overall: {
+                  overdue_by: { counts: [], values: [] },
+                  overdue_by_values: [],
+                },
                 by_type: {},
               },
             });
@@ -3121,6 +3627,9 @@ describe('createAggregator', () => {
                     counts: [16, 0, 1, 2, 0, 1],
                     values: [10, 20, 30, 40, 50, 60],
                   },
+                  overdue_by_values: [
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 20, 30, 30, 50,
+                  ],
                 },
                 by_type: {
                   telemetry: {
@@ -3128,30 +3637,35 @@ describe('createAggregator', () => {
                       counts: [1, 0, 1],
                       values: [10, 20, 30],
                     },
+                    overdue_by_values: [0, 20],
                   },
                   reporting: {
                     overdue_by: {
                       counts: [1],
                       values: [10],
                     },
+                    overdue_by_values: [0],
                   },
                   'actions:webhook': {
                     overdue_by: {
                       counts: [3, 0, 0, 2, 0, 1],
                       values: [10, 20, 30, 40, 50, 60],
                     },
+                    overdue_by_values: [0, 0, 0, 30, 30, 50],
                   },
                   'actions:__email': {
                     overdue_by: {
                       counts: [11],
                       values: [10],
                     },
+                    overdue_by_values: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                   },
                   actions: {
                     overdue_by: {
                       counts: [14, 0, 0, 2, 0, 1],
                       values: [10, 20, 30, 40, 50, 60],
                     },
+                    overdue_by_values: [0, 0, 0, 30, 30, 50, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                   },
                 },
               },

--- a/x-pack/plugins/task_manager/server/metrics/lib/simple_histogram.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/lib/simple_histogram.test.ts
@@ -28,6 +28,7 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 0 },
     ]);
+    expect(histogram.getAllValues()).toEqual([]);
   });
 
   test('should correctly initialize when bucketSize does not evenly divides range', () => {
@@ -49,6 +50,7 @@ describe('SimpleHistogram', () => {
       { value: 98, count: 0 },
       { value: 105, count: 0 },
     ]);
+    expect(histogram.getAllValues()).toEqual([]);
   });
 
   test('should correctly record values', () => {
@@ -77,6 +79,7 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 1 },
     ]);
+    expect(histogram.getAllValues()).toEqual([0, 10, 23, 34, 21, 56, 78, 33, 99, 1, 2]);
   });
 
   test('should correctly record values with specific increment', () => {
@@ -104,6 +107,9 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 5 },
     ]);
+    expect(histogram.getAllValues()).toEqual([
+      0, 23, 23, 34, 21, 56, 78, 33, 33, 33, 33, 99, 99, 99, 99, 99, 1, 2,
+    ]);
   });
 
   test('should ignore values less than 0 and greater than max', () => {
@@ -119,11 +125,13 @@ describe('SimpleHistogram', () => {
     histogram.record(2);
 
     const hist1 = histogram.get();
+    const hist1AllValues = histogram.getAllValues();
 
     histogram.record(-1);
     histogram.record(200);
 
     expect(histogram.get()).toEqual(hist1);
+    expect(histogram.getAllValues()).toEqual(hist1AllValues);
   });
 
   test('should correctly reset values', () => {
@@ -150,6 +158,7 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 1 },
     ]);
+    expect(histogram.getAllValues()).toEqual([23, 34, 21, 56, 78, 33, 99, 1, 2]);
 
     histogram.reset();
 
@@ -165,6 +174,7 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 0 },
     ]);
+    expect(histogram.getAllValues()).toEqual([]);
   });
 
   test('should correctly truncate zero values', () => {
@@ -189,6 +199,7 @@ describe('SimpleHistogram', () => {
       { value: 90, count: 0 },
       { value: 100, count: 0 },
     ]);
+    expect(histogram.getAllValues()).toEqual([23, 34, 21, 56, 33, 1, 2]);
 
     expect(histogram.get(true)).toEqual([
       { value: 10, count: 2 },
@@ -204,6 +215,7 @@ describe('SimpleHistogram', () => {
     const histogram = new SimpleHistogram(100, 10);
 
     expect(histogram.get(true)).toEqual([]);
+    expect(histogram.getAllValues()).toEqual([]);
   });
 
   test('should correctly serialize histogram data', () => {

--- a/x-pack/plugins/task_manager/server/metrics/lib/simple_histogram.ts
+++ b/x-pack/plugins/task_manager/server/metrics/lib/simple_histogram.ts
@@ -23,6 +23,7 @@ export class SimpleHistogram {
   private maxValue: number;
   private bucketSize: number;
   private histogramBuckets: Bucket[] = [];
+  private allValues: number[] = [];
 
   constructor(max: number, bucketSize: number) {
     if (bucketSize > max) {
@@ -38,6 +39,7 @@ export class SimpleHistogram {
     for (let i = 0; i < this.histogramBuckets.length; i++) {
       this.histogramBuckets[i].count = 0;
     }
+    this.allValues = [];
   }
 
   public record(value: number, increment: number = 1) {
@@ -51,6 +53,10 @@ export class SimpleHistogram {
 
         break;
       }
+    }
+
+    for (let i = 0; i < increment; i++) {
+      this.allValues.push(value);
     }
   }
 
@@ -72,6 +78,10 @@ export class SimpleHistogram {
       count: bucket.count,
       value: bucket.max,
     }));
+  }
+
+  public getAllValues(truncate: boolean = false) {
+    return this.allValues.slice();
   }
 
   public serialize(): SerializedHistogram {

--- a/x-pack/plugins/task_manager/server/metrics/task_claim_metrics_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_claim_metrics_aggregator.test.ts
@@ -47,6 +47,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 0,
       total: 0,
       duration: { counts: [], values: [] },
+      duration_values: [],
     });
   });
 
@@ -55,6 +56,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 0,
       total: 0,
       duration: { counts: [], values: [] },
+      duration_values: [],
     });
   });
 
@@ -65,6 +67,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 2,
       total: 2,
       duration: { counts: [2], values: [100] },
+      duration_values: [10, 10],
     });
   });
 
@@ -75,6 +78,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 0,
       total: 2,
       duration: { counts: [], values: [] },
+      duration_values: [],
     });
   });
 
@@ -90,6 +94,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 4,
       total: 7,
       duration: { counts: [4], values: [100] },
+      duration_values: [10, 10, 10, 10],
     });
 
     taskClaimMetricsAggregator.reset();
@@ -97,6 +102,7 @@ describe('TaskClaimMetricsAggregator', () => {
       success: 0,
       total: 0,
       duration: { counts: [], values: [] },
+      duration_values: [],
     });
   });
 });

--- a/x-pack/plugins/task_manager/server/metrics/task_claim_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_claim_metrics_aggregator.ts
@@ -26,6 +26,7 @@ interface TaskClaimCounts extends JsonObject {
 
 export type TaskClaimMetric = TaskClaimCounts & {
   duration: SerializedHistogram;
+  duration_values: number[];
 };
 
 export class TaskClaimMetricsAggregator implements ITaskMetricsAggregator<TaskClaimMetric> {
@@ -38,12 +39,14 @@ export class TaskClaimMetricsAggregator implements ITaskMetricsAggregator<TaskCl
     return {
       ...this.counter.initialMetrics(),
       duration: { counts: [], values: [] },
+      duration_values: [],
     };
   }
   public collect(): TaskClaimMetric {
     return {
       ...this.counter.collect(),
       duration: this.durationHistogram.serialize(),
+      duration_values: this.durationHistogram.getAllValues(),
     };
   }
 

--- a/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_overdue_metrics_aggregator.test.ts
@@ -22,14 +22,20 @@ describe('TaskOverdueMetricsAggregator', () => {
 
   test('should correctly initialize', () => {
     expect(taskOverdueMetricsAggregator.collect()).toEqual({
-      overall: { overdue_by: { counts: [], values: [] } },
+      overall: {
+        overdue_by: { counts: [], values: [] },
+        overdue_by_values: [],
+      },
       by_type: {},
     });
   });
 
   test('should correctly return initialMetrics', () => {
     expect(taskOverdueMetricsAggregator.initialMetric()).toEqual({
-      overall: { overdue_by: { counts: [], values: [] } },
+      overall: {
+        overdue_by: { counts: [], values: [] },
+        overdue_by_values: [],
+      },
       by_type: {},
     });
   });
@@ -50,9 +56,15 @@ describe('TaskOverdueMetricsAggregator', () => {
       })
     );
     expect(taskOverdueMetricsAggregator.collect()).toEqual({
-      overall: { overdue_by: { counts: [1, 0, 1], values: [10, 20, 30] } },
+      overall: {
+        overdue_by: { counts: [1, 0, 1], values: [10, 20, 30] },
+        overdue_by_values: [0, 20],
+      },
       by_type: {
-        telemetry: { overdue_by: { counts: [1, 0, 1], values: [10, 20, 30] } },
+        telemetry: {
+          overdue_by: { counts: [1, 0, 1], values: [10, 20, 30] },
+          overdue_by_values: [0, 20],
+        },
       },
     });
   });
@@ -66,7 +78,10 @@ describe('TaskOverdueMetricsAggregator', () => {
       })
     );
     expect(taskOverdueMetricsAggregator.collect()).toEqual({
-      overall: { overdue_by: { counts: [], values: [] } },
+      overall: {
+        overdue_by: { counts: [], values: [] },
+        overdue_by_values: [],
+      },
       by_type: {},
     });
   });
@@ -95,9 +110,15 @@ describe('TaskOverdueMetricsAggregator', () => {
       })
     );
     expect(taskOverdueMetricsAggregator.collect()).toEqual({
-      overall: { overdue_by: { counts: [0, 0, 0, 0, 1], values: [10, 20, 30, 40, 50] } },
+      overall: {
+        overdue_by: { counts: [0, 0, 0, 0, 1], values: [10, 20, 30, 40, 50] },
+        overdue_by_values: [40],
+      },
       by_type: {
-        telemetry: { overdue_by: { counts: [0, 0, 0, 0, 1], values: [10, 20, 30, 40, 50] } },
+        telemetry: {
+          overdue_by: { counts: [0, 0, 0, 0, 1], values: [10, 20, 30, 40, 50] },
+          overdue_by_values: [40],
+        },
       },
     });
   });
@@ -129,6 +150,7 @@ describe('TaskOverdueMetricsAggregator', () => {
           counts: [3, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
           values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
         },
+        overdue_by_values: [0, 0, 0, 20, 20, 40, 120],
       },
       by_type: {
         'alerting:example': {
@@ -136,36 +158,42 @@ describe('TaskOverdueMetricsAggregator', () => {
             counts: [0, 0, 0, 0, 1],
             values: [10, 20, 30, 40, 50],
           },
+          overdue_by_values: [40],
         },
         'alerting:__index-threshold': {
           overdue_by: {
             counts: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
             values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
           },
+          overdue_by_values: [20, 20, 120],
         },
         alerting: {
           overdue_by: {
             counts: [0, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
             values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
           },
+          overdue_by_values: [40, 20, 20, 120],
         },
         'actions:webhook': {
           overdue_by: {
             counts: [2],
             values: [10],
           },
+          overdue_by_values: [0, 0],
         },
         'actions:__email': {
           overdue_by: {
             counts: [1],
             values: [10],
           },
+          overdue_by_values: [0],
         },
         actions: {
           overdue_by: {
             counts: [3],
             values: [10],
           },
+          overdue_by_values: [0, 0, 0],
         },
       },
     });
@@ -198,44 +226,50 @@ describe('TaskOverdueMetricsAggregator', () => {
           counts: [3, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
           values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
         },
+        overdue_by_values: [0, 0, 0, 20, 20, 40, 120],
       },
       by_type: {
         'alerting:example': {
           overdue_by: {
             counts: [0, 0, 0, 0, 1],
-
             values: [10, 20, 30, 40, 50],
           },
+          overdue_by_values: [40],
         },
         'alerting:__index-threshold': {
           overdue_by: {
             counts: [0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
             values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
           },
+          overdue_by_values: [20, 20, 120],
         },
         alerting: {
           overdue_by: {
             counts: [0, 0, 2, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1],
             values: [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120, 130],
           },
+          overdue_by_values: [40, 20, 20, 120],
         },
         'actions:webhook': {
           overdue_by: {
             counts: [2],
             values: [10],
           },
+          overdue_by_values: [0, 0],
         },
         'actions:__email': {
           overdue_by: {
             counts: [1],
             values: [10],
           },
+          overdue_by_values: [0],
         },
         actions: {
           overdue_by: {
             counts: [3],
             values: [10],
           },
+          overdue_by_values: [0, 0, 0],
         },
       },
     });

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.test.ts
@@ -93,6 +93,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
     });
   });
@@ -106,6 +107,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {},
     });
@@ -122,6 +124,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         telemetry: { success: 2, not_timed_out: 2, total: 2, framework_errors: 0, user_errors: 0 },
@@ -139,6 +142,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [1], values: [10] },
+        delay_values: [3],
       },
     });
   });
@@ -155,6 +159,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
     });
   });
@@ -170,6 +175,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         telemetry: { success: 2, not_timed_out: 0, total: 2, framework_errors: 0, user_errors: 0 },
@@ -188,6 +194,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 2,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         telemetry: { success: 0, not_timed_out: 2, total: 2, framework_errors: 2, user_errors: 0 },
@@ -206,6 +213,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 2,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         telemetry: { success: 0, not_timed_out: 0, total: 2, framework_errors: 2, user_errors: 0 },
@@ -226,6 +234,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 1,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         report: { success: 2, not_timed_out: 1, total: 2, framework_errors: 0, user_errors: 0 },
@@ -263,6 +272,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 3,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         actions: { success: 3, not_timed_out: 3, total: 3, framework_errors: 0, user_errors: 0 },
@@ -333,6 +343,7 @@ describe('TaskRunMetricsAggregator', () => {
         not_timed_out: 12,
         total: 14,
         delay: { counts: [3, 0, 1], values: [10, 20, 30] },
+        delay_values: [3, 25, 6, 9],
         framework_errors: 3,
         user_errors: 0,
       },
@@ -381,6 +392,7 @@ describe('TaskRunMetricsAggregator', () => {
         framework_errors: 0,
         user_errors: 0,
         delay: { counts: [], values: [] },
+        delay_values: [],
       },
       by_type: {
         actions: { success: 0, not_timed_out: 0, total: 0, framework_errors: 0, user_errors: 0 },

--- a/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
+++ b/x-pack/plugins/task_manager/server/metrics/task_run_metrics_aggregator.ts
@@ -56,6 +56,7 @@ export interface TaskRunMetrics extends JsonObject {
 export interface TaskRunMetric extends JsonObject {
   overall: TaskRunMetrics['overall'] & {
     delay: SerializedHistogram;
+    delay_values: number[];
   };
   by_type: TaskRunMetrics['by_type'];
 }
@@ -70,12 +71,20 @@ export class TaskRunMetricsAggregator implements ITaskMetricsAggregator<TaskRunM
   public initialMetric(): TaskRunMetric {
     return merge(this.counter.initialMetrics(), {
       by_type: {},
-      overall: { delay: { counts: [], values: [] } },
+      overall: {
+        delay: { counts: [], values: [] },
+        delay_values: [],
+      },
     });
   }
 
   public collect(): TaskRunMetric {
-    return merge(this.counter.collect(), { overall: { delay: this.delayHistogram.serialize() } });
+    return merge(this.counter.collect(), {
+      overall: {
+        delay: this.delayHistogram.serialize(),
+        delay_values: this.delayHistogram.getAllValues(),
+      },
+    });
   }
 
   public reset() {


### PR DESCRIPTION
Can't build #176881 cloud images via CI since there's no 8.14.0 snapshot yet. Till then, there's this, the commit cherry-picked on 8.13. 