### PR TITLE
[Ops] skip flaky custom_fields tests

### DIFF
--- a/x-pack/plugins/cases/public/components/custom_fields/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/index.test.tsx
@@ -17,7 +17,8 @@ import { MAX_CUSTOM_FIELDS_PER_CASE } from '../../../common/constants';
 import { CustomFields } from '.';
 import * as i18n from './translations';
 
-describe('CustomFields', () => {
+// Flaky: https://github.com/elastic/kibana/issues/176805
+describe.skip('CustomFields', () => {
   let appMockRender: AppMockRenderer;
 
   const props = {


### PR DESCRIPTION
## Summary
Skips flaky suite: https://github.com/elastic/kibana/issues/176805