### PR TITLE
[DataView] Preselect rollup type when editing a rollup data view

### DIFF
--- a/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
+++ b/src/plugins/data_view_editor/public/components/data_view_editor_flyout_content.tsx
@@ -98,7 +98,10 @@ const IndexPatternEditorFlyoutContentComponent = ({
   const { form } = useForm<IndexPatternConfig, FormInternal>({
     // Prefill with data if editData exists
     defaultValue: {
-      type: defaultTypeIsRollup ? INDEX_PATTERN_TYPE.ROLLUP : INDEX_PATTERN_TYPE.DEFAULT,
+      type:
+        defaultTypeIsRollup || editData?.type === INDEX_PATTERN_TYPE.ROLLUP
+          ? INDEX_PATTERN_TYPE.ROLLUP
+          : INDEX_PATTERN_TYPE.DEFAULT,
       isAdHoc: false,
       ...(editData
         ? {

--- a/src/plugins/data_views/common/data_views/abstract_data_views.ts
+++ b/src/plugins/data_views/common/data_views/abstract_data_views.ts
@@ -72,7 +72,7 @@ export abstract class AbstractDataView {
    */
   public timeFieldName: string | undefined;
   /**
-   * Type is used to identify rollup index patterns.
+   * Type is used to identify rollup index patterns or ES|QL data views.
    */
   public type: string | undefined;
   /**


### PR DESCRIPTION
- Closes https://github.com/elastic/kibana/issues/151241

## Summary

This PR restores data view type when editing it.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->