### PR TITLE
[SecuritySolution] Fix Entity risk score visualization displays 'N/A' instead of score

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/lens_embeddable.tsx
@@ -63,6 +63,7 @@ const LensComponentWrapper = styled.div<{
 
 const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
   applyGlobalQueriesAndFilters = true,
+  applyPageAndTabsFilters = true,
   extraActions,
   extraOptions,
   getLensAttributes,
@@ -99,6 +100,7 @@ const LensEmbeddableComponent: React.FC<LensEmbeddableComponentProps> = ({
   const { searchSessionId } = useVisualizationResponse({ visualizationId: id });
   const attributes = useLensAttributes({
     applyGlobalQueriesAndFilters,
+    applyPageAndTabsFilters,
     extraOptions,
     getLensAttributes,
     lensAttributes,

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/types.ts
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/types.ts
@@ -28,6 +28,7 @@ export type GetLensAttributes = (
 
 export interface UseLensAttributesProps {
   applyGlobalQueriesAndFilters?: boolean;
+  applyPageAndTabsFilters?: boolean;
   extraOptions?: ExtraOptions;
   getLensAttributes?: GetLensAttributes;
   lensAttributes?: LensAttributes | null;
@@ -83,6 +84,7 @@ export enum VisualizationContextMenuDefaultActionName {
 
 export interface LensEmbeddableComponentProps {
   applyGlobalQueriesAndFilters?: boolean;
+  applyPageAndTabsFilters?: boolean;
   extraActions?: Action[];
   extraOptions?: ExtraOptions;
   getLensAttributes?: GetLensAttributes;

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.test.tsx
@@ -153,6 +153,31 @@ describe('useLensAttributes', () => {
     ]);
   });
 
+  it('should not apply tabs and pages when applyPageAndTabsFilters = false', () => {
+    (useRouteSpy as jest.Mock).mockReturnValue([
+      {
+        detailName: 'elastic',
+        pageName: 'user',
+        tabName: 'events',
+      },
+    ]);
+    const { result } = renderHook(
+      () =>
+        useLensAttributes({
+          applyPageAndTabsFilters: false,
+          getLensAttributes: getExternalAlertLensAttributes,
+          stackByField: 'event.dataset',
+        }),
+      { wrapper }
+    );
+
+    expect(result?.current?.state.filters).toEqual([
+      ...getExternalAlertLensAttributes().state.filters,
+      ...getIndexFilters(['auditbeat-*']),
+      ...filterFromSearchBar,
+    ]);
+  });
+
   it('should add data view id to references', () => {
     const { result } = renderHook(
       () =>

--- a/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/visualization_actions/use_lens_attributes.tsx
@@ -24,6 +24,7 @@ import {
 
 export const useLensAttributes = ({
   applyGlobalQueriesAndFilters = true,
+  applyPageAndTabsFilters = true,
   extraOptions,
   getLensAttributes,
   lensAttributes,
@@ -95,8 +96,8 @@ export const useLensAttributes = ({
         ...(applyGlobalQueriesAndFilters ? { query } : {}),
         filters: [
           ...attrs.state.filters,
-          ...pageFilters,
-          ...tabsFilters,
+          ...(applyPageAndTabsFilters ? pageFilters : []),
+          ...(applyPageAndTabsFilters ? tabsFilters : []),
           ...indexFilters,
           ...(applyGlobalQueriesAndFilters ? filters : []),
         ],
@@ -108,6 +109,7 @@ export const useLensAttributes = ({
     } as LensAttributes;
   }, [
     applyGlobalQueriesAndFilters,
+    applyPageAndTabsFilters,
     attrs,
     dataViewId,
     filters,

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/risk_summary.tsx
@@ -210,6 +210,7 @@ const RiskSummaryComponent = <T extends RiskScoreEntity>({
               {riskData && (
                 <VisualizationEmbeddable
                   applyGlobalQueriesAndFilters={false}
+                  applyPageAndTabsFilters={false}
                   lensAttributes={lensAttributes}
                   id={`RiskSummary-risk_score_metric`}
                   timerange={timerange}


### PR DESCRIPTION
## Summary

Add a new property to the `LensVisualization`  that prevents the table and tab filters from being applied.

### BEFORE
<img src="https://github.com/elastic/kibana/assets/1490444/e13deb8f-d023-404d-9cea-e749b8ee2694" width="500" />

### AFTER
<img src="https://github.com/elastic/kibana/assets/1490444/ad12325d-fe4f-40cd-83a8-45d755707061" width="500" />


### How to test it?
* Open the User flyout on the host's page / Events
* The risk score visualization should not be filtered by *exists host.name"

### Checklist

Delete any items that are not applicable to this PR.


- [X] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->