### PR TITLE
[ES|QL] Provide some guidance to new users during typing

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/signature/index.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/signature/index.ts
@@ -6,15 +6,45 @@
  * Side Public License, v 1.
  */
 
+import { i18n } from '@kbn/i18n';
 import type { monaco } from '../../../../monaco_imports';
+import { getAstContext } from '../shared/context';
+import { monacoPositionToOffset } from '../shared/helpers';
 import type { AstProviderFn } from '../types';
 
-export function getSignatureHelp(
+export async function getSignatureHelp(
   model: monaco.editor.ITextModel,
   position: monaco.Position,
   context: monaco.languages.SignatureHelpContext,
   astProvider: AstProviderFn
-): monaco.languages.SignatureHelpResult {
+): Promise<monaco.languages.SignatureHelpResult> {
+  const innerText = model.getValue();
+  const offset = monacoPositionToOffset(innerText, position);
+
+  const { ast } = await astProvider(innerText);
+  const astContext = getAstContext(innerText, ast, offset);
+  if (
+    astContext.type === 'newCommand' &&
+    ast.length > 0 &&
+    !ast.some((command) => ['eval', 'stats'].includes(command.name))
+  ) {
+    return {
+      value: {
+        signatures: [
+          {
+            label: i18n.translate('monaco.esql.signature.evalStatsHint', {
+              defaultMessage:
+                'type EVAL to create new field, STATS [...] BY to group by or aggregate.',
+            }),
+            parameters: [],
+          },
+        ],
+        activeParameter: 0,
+        activeSignature: 0,
+      },
+      dispose: () => {},
+    };
+  }
   return {
     value: { signatures: [], activeParameter: 0, activeSignature: 0 },
     dispose: () => {},

--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.tsx
@@ -448,6 +448,11 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
     [serverErrors, serverWarning, code]
   );
 
+  const signatureProvider = useMemo(
+    () => (language === 'esql' ? ESQLLang.getSignatureProvider?.(esqlCallbacks) : undefined),
+    [language, esqlCallbacks]
+  );
+
   const suggestionProvider = useMemo(
     () => (language === 'esql' ? ESQLLang.getSuggestionProvider?.(esqlCallbacks) : undefined),
     [language, esqlCallbacks]
@@ -800,6 +805,7 @@ export const TextBasedLanguagesEditor = memo(function TextBasedLanguagesEditor({
                       options={codeEditorOptions}
                       width="100%"
                       suggestionProvider={suggestionProvider}
+                      signatureProvider={signatureProvider}
                       hoverProvider={{
                         provideHover: (model, position, token) => {
                           if (isCompactFocused || !hoverProvider?.provideHover) {


### PR DESCRIPTION
## Summary

PoC for #177450

The tooltip will be shown in these conditions:
* a `from` has to be declared (perhaps it should be extended to all source commands - `row`/`show`)
* after a `|` and before a command is declared
* if an `eval` or `stats` has not been declared yet


![esql_tooltip](https://github.com/elastic/kibana/assets/924948/aee415bb-1ec7-40ff-9da1-978beb8c248d)