### PR TITLE
[8.13] [SecuritySolution] Fix 'Category 2' category score displays '-0.00' (#177015)

### DIFF
--- a/x-pack/plugins/security_solution/public/entity_analytics/common/utils.test.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/common/utils.test.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { formatRiskScore } from './utils';
+
+describe('formatRiskScore', () => {
+  it('returns two digits after the decimal separator', () => {
+    expect(formatRiskScore(10)).toEqual('10.00');
+    expect(formatRiskScore(10.5)).toEqual('10.50');
+    expect(formatRiskScore(10.55)).toEqual('10.55');
+    expect(formatRiskScore(10.555)).toEqual('10.56');
+    expect(formatRiskScore(-1.4210854715202004e-14)).toEqual('0.00');
+    expect(formatRiskScore(-15.4210854715202)).toEqual('-15.42'); // risk score contributions can be negative
+    expect(formatRiskScore(8.421)).toEqual('8.42');
+  });
+});

--- a/x-pack/plugins/security_solution/public/entity_analytics/common/utils.ts
+++ b/x-pack/plugins/security_solution/public/entity_analytics/common/utils.ts
@@ -54,3 +54,12 @@ export enum HostRiskScoreQueryId {
   OVERVIEW_RISKY_HOSTS = 'OverviewRiskyHosts',
   HOSTS_BY_RISK = 'HostsByRisk',
 }
+
+/**
+ *
+ * @returns risk score rounded with 2 digits after the decimal separator
+ * @example
+ * formatRiskScore(10.555) // '10.56'
+ */
+export const formatRiskScore = (riskScore: number) =>
+  (Math.round(riskScore * 100) / 100).toFixed(2);

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_summary_flyout/common.tsx
@@ -11,6 +11,7 @@ import { i18n } from '@kbn/i18n';
 import { sumBy } from 'lodash/fp';
 
 import type { HostRiskScore, RiskStats, UserRiskScore } from '../../../../common/search_strategy';
+import { formatRiskScore } from '../../common';
 
 interface TableItem {
   category: string;
@@ -57,11 +58,11 @@ export const buildColumns: (showFooter: boolean) => Array<EuiBasicTableColumn<Ta
     sortable: true,
     dataType: 'number',
     align: 'right',
-    render: (score: number) => displayNumber(score),
+    render: formatRiskScore,
     footer: (props) =>
       showFooter ? (
         <span data-test-subj="risk-summary-result-score">
-          {displayNumber(sumBy((i) => i.score, props.items))}
+          {formatRiskScore(sumBy((i) => i.score, props.items))}
         </span>
       ) : undefined,
   },
@@ -135,8 +136,6 @@ export const getEntityData = (
 
   return riskData.host;
 };
-
-const displayNumber = (num: number) => num.toFixed(2);
 
 export const LENS_VISUALIZATION_HEIGHT = 126; //  Static height in pixels specified by design
 export const LENS_VISUALIZATION_MIN_WIDTH = 160; // Lens visualization min-width in pixels


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[SecuritySolution] Fix 'Category 2' category score displays '-0.00' (#177015)](https://github.com/elastic/kibana/pull/177015)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Pablo Machado","email":"pablo.nevesmachado@elastic.co"},"sourceCommit":{"committedDate":"2024-02-19T13:52:47Z","message":"[SecuritySolution] Fix 'Category 2' category score displays '-0.00' (#177015)\n\n## Summary\r\n\r\n Fix 'Category 2' category score displays '-0.00'\r\n\r\nTest for this scenario: \r\n\r\nhttps://github.com/elastic/kibana/pull/177015/files#diff-2e1d1cae4924e3ed8b390a09104c9a6111631cca0927e33eaa55e0f1152e719bR16\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\nfeatures that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"64a4bc50de3a9ae6add126434b7e8fc298fc505a","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport:skip","Team: SecuritySolution","Team:Entity Analytics","v8.13.0","v8.14.0"],"number":177015,"url":"https://github.com/elastic/kibana/pull/177015","mergeCommit":{"message":"[SecuritySolution] Fix 'Category 2' category score displays '-0.00' (#177015)\n\n## Summary\r\n\r\n Fix 'Category 2' category score displays '-0.00'\r\n\r\nTest for this scenario: \r\n\r\nhttps://github.com/elastic/kibana/pull/177015/files#diff-2e1d1cae4924e3ed8b390a09104c9a6111631cca0927e33eaa55e0f1152e719bR16\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\nfeatures that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"64a4bc50de3a9ae6add126434b7e8fc298fc505a"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177015","number":177015,"mergeCommit":{"message":"[SecuritySolution] Fix 'Category 2' category score displays '-0.00' (#177015)\n\n## Summary\r\n\r\n Fix 'Category 2' category score displays '-0.00'\r\n\r\nTest for this scenario: \r\n\r\nhttps://github.com/elastic/kibana/pull/177015/files#diff-2e1d1cae4924e3ed8b390a09104c9a6111631cca0927e33eaa55e0f1152e719bR16\r\n\r\n### Checklist\r\n\r\nDelete any items that are not applicable to this PR.\r\n\r\nfeatures that require explanation or tutorials\r\n- [x] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"64a4bc50de3a9ae6add126434b7e8fc298fc505a"}}]}] BACKPORT-->