### PR TITLE
[Ops] Make a few tests agnostic of agents' umask

### DIFF
--- a/src/dev/build/lib/integration_tests/fs.test.ts
+++ b/src/dev/build/lib/integration_tests/fs.test.ts
@@ -166,17 +166,16 @@ describe('copyAll()', () => {
   });
 
   it('copies files and directories from source to dest, creating dest if necessary, respecting mode', async () => {
-    const path777 = resolve(FIXTURES, 'bin/world_executable');
-    const path644 = resolve(FIXTURES, 'foo_dir/bar.txt');
+    const pathToExecutable = resolve(FIXTURES, 'bin/world_executable');
+    const pathToNonExecutable = resolve(FIXTURES, 'foo_dir/bar.txt');
 
-    // we're seeing flaky failures because the resulting files sometimes have
-    // 755 permissions. Unless there's a bug in vinyl-fs I can't figure out
-    // where the issue might be, so trying to validate the mode first to narrow
-    // down where the issue might be
-    expect(getCommonMode(path777)).toBe(isWindows ? '666' : '777');
-    expect(getCommonMode(path644)).toBe(isWindows ? '666' : '644');
+    const modeExecutable = getCommonMode(pathToExecutable);
+    const modeNonExecutable = getCommonMode(pathToNonExecutable);
 
     const destination = resolve(TMP, 'a/b/c');
+    const newPathExecutable = resolve(destination, 'bin/world_executable');
+    const newPathNonExecutable = resolve(destination, 'foo_dir/bar.txt');
+
     await copyAll(FIXTURES, destination);
 
     expect((await getChildPaths(resolve(destination, 'foo_dir'))).sort()).toEqual([
@@ -184,8 +183,8 @@ describe('copyAll()', () => {
       resolve(destination, 'foo_dir/foo'),
     ]);
 
-    expect(getCommonMode(path777)).toBe(isWindows ? '666' : '777');
-    expect(getCommonMode(path644)).toBe(isWindows ? '666' : '644');
+    expect(getCommonMode(newPathExecutable)).toBe(isWindows ? '666' : modeExecutable);
+    expect(getCommonMode(newPathNonExecutable)).toBe(isWindows ? '666' : modeNonExecutable);
   });
 
   it('applies select globs if specified, ignores dot files', async () => {

--- a/src/dev/build/lib/integration_tests/scan_copy.test.ts
+++ b/src/dev/build/lib/integration_tests/scan_copy.test.ts
@@ -70,6 +70,8 @@ it('copies files and directories from source to dest, including dot files, creat
     source: FIXTURES,
     destination,
   });
+  const executableMode = getCommonMode(resolve(FIXTURES, 'bin/world_executable'));
+  const textFileMode = getCommonMode(resolve(FIXTURES, 'foo_dir/bar.txt'));
 
   expect((await getChildPaths(resolve(destination, 'foo_dir'))).sort()).toEqual([
     resolve(destination, 'foo_dir/.bar'),
@@ -78,10 +80,12 @@ it('copies files and directories from source to dest, including dot files, creat
   ]);
 
   expect(getCommonMode(resolve(destination, 'bin/world_executable'))).toBe(
-    IS_WINDOWS ? '666' : '777'
+    IS_WINDOWS ? '666' : executableMode
   );
 
-  expect(getCommonMode(resolve(destination, 'foo_dir/bar.txt'))).toBe(IS_WINDOWS ? '666' : '644');
+  expect(getCommonMode(resolve(destination, 'foo_dir/bar.txt'))).toBe(
+    IS_WINDOWS ? '666' : textFileMode
+  );
 });
 
 it('applies filter function specified', async () => {


### PR DESCRIPTION
## Summary
These tests in their current state would break on the new agents after we migrate to the elastic-wide agents, due to a bit different file permissions. This problem remained even after setting the `umask` to `0x002` in our new agent images. 

In this PR, I'm switching the tests, so that they compare reference file permissions to the to-be permissions, instead of pre-baked values.