### PR TITLE
[Security Solution] Fix cell actions in Explore pages

### DIFF
--- a/x-pack/packages/security-solution/data_table/components/data_table/helpers.tsx
+++ b/x-pack/packages/security-solution/data_table/components/data_table/helpers.tsx
@@ -85,25 +85,13 @@ export const mapSortingColumns = ({
 export const addBuildingBlockStyle = (
   ecs: Ecs,
   theme: EuiTheme,
-  setCellProps: EuiDataGridCellValueElementProps['setCellProps'],
-  defaultStyles?: React.CSSProperties
+  setCellProps: EuiDataGridCellValueElementProps['setCellProps']
 ) => {
-  const currentStyles = defaultStyles ?? {};
   if (isEventBuildingBlockType(ecs)) {
-    setCellProps({
-      style: {
-        ...currentStyles,
-        backgroundColor: `${theme.eui.euiColorHighlight}`,
-      },
-    });
+    setCellProps({ style: { backgroundColor: `${theme.eui.euiColorHighlight}` } });
   } else {
     // reset cell style
-    setCellProps({
-      style: {
-        ...currentStyles,
-        backgroundColor: 'inherit',
-      },
-    });
+    setCellProps({ style: { backgroundColor: 'inherit' } });
   }
 };
 

--- a/x-pack/packages/security-solution/data_table/components/data_table/index.tsx
+++ b/x-pack/packages/security-solution/data_table/components/data_table/index.tsx
@@ -410,10 +410,8 @@ export const DataTableComponent = React.memo<DataTableProps>(
         const ecs = pageRowIndex < data.length ? data[pageRowIndex].ecs : null;
 
         useEffect(() => {
-          const defaultStyles = { overflow: 'hidden' };
-          setCellProps({ style: { ...defaultStyles } });
           if (ecs && rowData) {
-            addBuildingBlockStyle(ecs, theme, setCellProps, defaultStyles);
+            addBuildingBlockStyle(ecs, theme, setCellProps);
           } else {
             // disable the cell when it has no data
             setCellProps({ style: { display: 'none' } });


### PR DESCRIPTION
## Summary

issue: https://github.com/elastic/kibana/issues/177410

Adding `overflow: hidden` style was causing the cell actions to disappear after the upgrade to [EUI upgrade to v91.3.1](https://github.com/elastic/kibana/pull/173569)

The `overflow: hidden` style is no longer needed, it has been removed. So cell actions are displayed


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->