### PR TITLE
[Search] Remove unnecessary columns from Web Crawler table

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -214,6 +214,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
                 />
               </EuiFlexItem>
               <ConnectorsTable
+                isCrawler={isCrawler}
                 items={connectors || []}
                 meta={data?.meta}
                 onChange={handlePageChange(onPaginate)}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
@@ -60,6 +60,26 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
 }) => {
   const { navigateToUrl } = useValues(KibanaLogic);
   const columns: Array<EuiBasicTableColumn<ConnectorViewItem>> = [
+    ...(!isCrawler
+      ? [
+          {
+            name: i18n.translate(
+              'xpack.enterpriseSearch.content.connectors.connectorTable.columns.connectorName',
+              {
+                defaultMessage: 'Connector name',
+              }
+            ),
+            render: (connector: Connector) => (
+              <EuiLinkTo
+                to={generateEncodedPath(CONNECTOR_DETAIL_PATH, { connectorId: connector.id })}
+              >
+                {connector.name}
+              </EuiLinkTo>
+            ),
+            width: '25%',
+          },
+        ]
+      : []),
     {
       field: 'index_name',
       name: i18n.translate(
@@ -88,6 +108,22 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
       ),
       truncateText: true,
     },
+    ...(!isCrawler
+      ? [
+          {
+            field: 'service_type',
+            name: i18n.translate(
+              'xpack.enterpriseSearch.content.connectors.connectorTable.columns.type',
+              {
+                defaultMessage: 'Connector type',
+              }
+            ),
+            render: (serviceType: string) => <ConnectorType serviceType={serviceType} />,
+            truncateText: true,
+            width: '15%',
+          },
+        ]
+      : []),
     {
       field: 'status',
       name: i18n.translate(
@@ -158,35 +194,6 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
       ),
     },
   ];
-
-  if (!isCrawler) {
-    columns.splice(0, 0, {
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.connectorName',
-        {
-          defaultMessage: 'Connector name',
-        }
-      ),
-      render: (connector: Connector) => (
-        <EuiLinkTo to={generateEncodedPath(CONNECTOR_DETAIL_PATH, { connectorId: connector.id })}>
-          {connector.name}
-        </EuiLinkTo>
-      ),
-      width: '25%',
-    });
-    columns.splice(3, 0, {
-      field: 'service_type',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.type',
-        {
-          defaultMessage: 'Connector type',
-        }
-      ),
-      render: (serviceType: string) => <ConnectorType serviceType={serviceType} />,
-      truncateText: true,
-      width: '15%',
-    });
-  }
 
   return (
     <EuiFlexGroup direction="column">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
@@ -37,6 +37,7 @@ import { ConnectorType } from './connector_type';
 import { ConnectorViewItem } from './connectors_logic';
 
 interface ConnectorsTableProps {
+  isCrawler: boolean;
   isLoading?: boolean;
   items: ConnectorViewItem[];
   meta?: Meta;
@@ -53,25 +54,12 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
     },
   },
   onChange,
+  isCrawler,
   isLoading,
   onDelete,
 }) => {
   const { navigateToUrl } = useValues(KibanaLogic);
   const columns: Array<EuiBasicTableColumn<ConnectorViewItem>> = [
-    {
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.connectorName',
-        {
-          defaultMessage: 'Connector name',
-        }
-      ),
-      render: (connector: Connector) => (
-        <EuiLinkTo to={generateEncodedPath(CONNECTOR_DETAIL_PATH, { connectorId: connector.id })}>
-          {connector.name}
-        </EuiLinkTo>
-      ),
-      width: '25%',
-    },
     {
       field: 'index_name',
       name: i18n.translate(
@@ -88,7 +76,7 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
         ) : (
           '--'
         ),
-      width: '25%',
+      width: isCrawler ? '70%' : '25%',
     },
     {
       field: 'docsCount',
@@ -99,18 +87,6 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
         }
       ),
       truncateText: true,
-    },
-    {
-      field: 'service_type',
-      name: i18n.translate(
-        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.type',
-        {
-          defaultMessage: 'Connector type',
-        }
-      ),
-      render: (serviceType: string) => <ConnectorType serviceType={serviceType} />,
-      truncateText: true,
-      width: '25%',
     },
     {
       field: 'status',
@@ -125,6 +101,7 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
         return <EuiBadge color={connectorStatusToColor(connectorStatus)}>{label}</EuiBadge>;
       },
       truncateText: true,
+      width: '15%',
     },
     {
       actions: [
@@ -181,6 +158,36 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
       ),
     },
   ];
+
+  if (!isCrawler) {
+    columns.splice(0, 0, {
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.connectorName',
+        {
+          defaultMessage: 'Connector name',
+        }
+      ),
+      render: (connector: Connector) => (
+        <EuiLinkTo to={generateEncodedPath(CONNECTOR_DETAIL_PATH, { connectorId: connector.id })}>
+          {connector.name}
+        </EuiLinkTo>
+      ),
+      width: '25%',
+    });
+    columns.splice(3, 0, {
+      field: 'service_type',
+      name: i18n.translate(
+        'xpack.enterpriseSearch.content.connectors.connectorTable.columns.type',
+        {
+          defaultMessage: 'Connector type',
+        }
+      ),
+      render: (serviceType: string) => <ConnectorType serviceType={serviceType} />,
+      truncateText: true,
+      width: '15%',
+    });
+  }
+
   return (
     <EuiFlexGroup direction="column">
       <EuiFlexItem>


### PR DESCRIPTION
## Summary

Remove the following columns from Web Crawler tables:

- Connecter Name
- Connector Type

Also resize some columns so headers aren't cut off.

Connectors:
![Screenshot 2024-02-21 at 17 24 52](https://github.com/elastic/kibana/assets/13634519/1a49c8de-828c-48d8-a96e-0482179b591e)

Crawler:
![Screenshot 2024-02-21 at 17 36 36](https://github.com/elastic/kibana/assets/13634519/16491955-3bce-4f57-9429-9cae939d1686)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->