### PR TITLE
[bin/kibana-docker] Add server.cdn.url

### DIFF
--- a/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
+++ b/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker
@@ -142,6 +142,7 @@ kibana_vars=(
     savedObjects.allowHttpApiAccess
     security.showInsecureClusterWarning
     server.basePath
+    server.cdn.url
     server.compression.enabled
     server.compression.referrerWhitelist
     server.cors


### PR DESCRIPTION
Adds support for setting `server.cdn.url` in our docker containers.  Implemented at https://github.com/elastic/kibana/pull/169408.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->