### PR TITLE
[Security Solution] Enable per field diffs feature

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -209,7 +209,7 @@ export const allowedExperimentalValues = Object.freeze({
    * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
    * Added: on Feb 12, 2023 in https://github.com/elastic/kibana/pull/174564
    */
-  perFieldPrebuiltRulesDiffingEnabled: false,
+  perFieldPrebuiltRulesDiffingEnabled: true,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -21,6 +21,7 @@ export const allowedExperimentalValues = Object.freeze({
   kubernetesEnabled: true,
   chartEmbeddablesEnabled: true,
   donutChartEmbeddablesEnabled: false, // Depends on https://github.com/elastic/kibana/issues/136409 item 2 - 6
+
   /**
    * This is used for enabling the end-to-end tests for the security_solution telemetry.
    * We disable the telemetry since we don't have specific roles or permissions around it and
@@ -70,7 +71,7 @@ export const allowedExperimentalValues = Object.freeze({
    */
   responseActionUploadEnabled: true,
 
-  /*
+  /**
    * Enables Automated Endpoint Process actions
    */
   automatedProcessActionsEnabled: false,
@@ -84,22 +85,25 @@ export const allowedExperimentalValues = Object.freeze({
    * Enables top charts on Alerts Page
    */
   alertsPageChartsEnabled: true,
+
   /**
    * Enables the alert type column in KPI visualizations on Alerts Page
    */
   alertTypeEnabled: false,
+
   /**
    * Enables expandable flyout in create rule page, alert preview
    */
   expandableFlyoutInCreateRuleEnabled: true,
+
   /**
    * Enables expandable flyout for event type documents
    */
   expandableEventFlyoutEnabled: false,
-  /*
+
+  /**
    * Enables new Set of filters on the Alerts page.
-   *
-   **/
+   */
   alertsPageFiltersEnabled: true,
 
   /**
@@ -107,23 +111,20 @@ export const allowedExperimentalValues = Object.freeze({
    */
   assistantModelEvaluation: false,
 
-  /*
+  /**
    * Enables the new user details flyout displayed on the Alerts table.
-   *
-   **/
+   */
   newUserDetailsFlyout: true,
 
-  /*
+  /**
    * Enables the Managed User section inside the new user details flyout.
    * To see this section you also need newUserDetailsFlyout flag enabled.
-   *
-   **/
+   */
   newUserDetailsFlyoutManagedUser: false,
 
-  /*
+  /**
    * Enables the new host details flyout displayed on the Alerts table.
-   *
-   **/
+   */
   newHostDetailsFlyout: true,
 
   /**
@@ -163,7 +164,7 @@ export const allowedExperimentalValues = Object.freeze({
    */
   alertSuppressionForIndicatorMatchRuleEnabled: false,
 
-  /*
+  /**
    * Enables experimental Experimental S1 integration data to be available in Analyzer
    */
   sentinelOneDataInAnalyzerEnabled: false,
@@ -173,12 +174,12 @@ export const allowedExperimentalValues = Object.freeze({
    */
   sentinelOneManualHostActionsEnabled: true,
 
-  /*
+  /**
    * Enables experimental Crowdstrike integration data to be available in Analyzer
    */
   crowdstrikeDataInAnalyzerEnabled: false,
 
-  /*
+  /**
    * Enables experimental "Updates" tab in the prebuilt rule upgrade flyout.
    * This tab shows the JSON diff between the installed prebuilt rule
    * version and the latest available version.
@@ -190,26 +191,27 @@ export const allowedExperimentalValues = Object.freeze({
    * Expires: on Feb 20, 2024
    */
   jsonPrebuiltRulesDiffingEnabled: true,
-  /*
-   * Disables discover esql tab within timeline
-   *
-   */
-  timelineEsqlTabDisabled: false,
-
-  /*
-   * Disables date pickers and sourcerer in analyzer if needed.
-   *
-   */
-  analyzerDatePickersAndSourcererDisabled: false,
 
   /**
    * Enables per-field rule diffs tab in the prebuilt rule upgrade flyout
    *
    * Ticket: https://github.com/elastic/kibana/issues/166489
    * Owners: https://github.com/orgs/elastic/teams/security-detection-rule-management
-   * Added: on Feb 12, 2023 in https://github.com/elastic/kibana/pull/174564
+   * Added: on Feb 12, 2024 in https://github.com/elastic/kibana/pull/174564
+   * Turned: on Feb 23, 2024 in https://github.com/elastic/kibana/pull/177495
+   * Expires: on Apr 23, 2024
    */
   perFieldPrebuiltRulesDiffingEnabled: true,
+
+  /**
+   * Disables discover esql tab within timeline
+   */
+  timelineEsqlTabDisabled: false,
+
+  /**
+   * Disables date pickers and sourcerer in analyzer if needed.
+   */
+  analyzerDatePickersAndSourcererDisabled: false,
 });
 
 type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;


### PR DESCRIPTION
**Addresses:** https://github.com/elastic/kibana/issues/166489

## Summary

Turns on the `perFieldPrebuiltRulesDiffingEnabled` feature flag by default.

This will enable the `Updates` tab containing per-field rule diffs in the rule upgrade flyout. The feature will be enabled in `8.13.0` and Serverless. See more info in the related ticket.


### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->