### PR TITLE
[Lens] Move region map to GA

### DIFF
--- a/x-pack/plugins/maps/public/lens/choropleth_chart/visualization.tsx
+++ b/x-pack/plugins/maps/public/lens/choropleth_chart/visualization.tsx
@@ -44,7 +44,7 @@ export const getVisualization = ({
         defaultMessage: 'Map',
       }),
       sortPriority: 1,
-      showExperimentalBadge: true,
+      showExperimentalBadge: false,
     },
   ],
 


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/175418

This is as simple as removing the Tech Preview badge from the chart switcher. Region maps were already part of our suggestions.

<img width="463" alt="image" src="https://github.com/elastic/kibana/assets/17003240/4fd4d868-bbcb-4803-a020-c1592e3d1c37">

Although region map usage in Lens is quite low, we decided to move it to GA. I have discussed it with @nreese asynchronously.

