### PR TITLE
[Ops] Pin Puppeteer download path to stable host

### DIFF
--- a/kbn_pm/src/lib/bazel.mjs
+++ b/kbn_pm/src/lib/bazel.mjs
@@ -153,7 +153,7 @@ export async function installYarnDeps(log, opts = undefined) {
       RE2_DOWNLOAD_MIRROR:
         'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2',
       PUPPETEER_DOWNLOAD_BASE_URL:
-         'https://storage.googleapis.com/chrome-for-testing-public-test-xoxo/'
+         'https://storage.googleapis.com/chrome-for-testing-public-test/'
     },
   });
 

--- a/kbn_pm/src/lib/bazel.mjs
+++ b/kbn_pm/src/lib/bazel.mjs
@@ -152,6 +152,8 @@ export async function installYarnDeps(log, opts = undefined) {
     env: {
       RE2_DOWNLOAD_MIRROR:
         'https://us-central1-elastic-kibana-184716.cloudfunctions.net/kibana-ci-proxy-cache/node-re2',
+      PUPPETEER_DOWNLOAD_BASE_URL:
+         'https://storage.googleapis.com/chrome-for-testing-public-test-xoxo/'
     },
   });
 


### PR DESCRIPTION
## Summary
During our bootstrap, Puppeteer is downloaded, and it downloads a chrome(ium) for itself, since it's using the same faulty url (https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing) it sometimes fails.
```
[bazel] [5/5] Building fresh packages...
[bazel] error /root/.qaf/data/git/kibana/node_modules/puppeteer: Command failed.
[bazel] Exit code: 1
[bazel] Command: node install.mjs
[bazel] Arguments:
[bazel] Directory: /root/.qaf/data/git/kibana/node_modules/puppeteer
[bazel] Output:
[bazel] ERROR: Failed to set up Chrome r121.0.6167.85! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
[bazel] Error: Download failed: server returned code 500. URL: https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/121.0.6167.85/linux64/chrome-linux64.zip
[bazel]     at file:///root/.qaf/data/git/kibana/node_modules/@puppeteer/browsers/lib/esm/httpUtil.js:64:31
```

That chromium url is the unstable URL we discussed earlier and replaced it for our own usage in (https://github.com/elastic/kibana-ci-proxy-cache/pull/20). The issue was raised with puppeteer (https://github.com/puppeteer/puppeteer/issues/11967) but they won't change the URLs, or at least not now. 

In this PR, we are making use of the `PUPPETEER_DOWNLOAD_BASE_URL` param to control the URL, and try to avoid the flakiness.

