### PR TITLE
[Cases] Unskip filter popover, property actions flaky tests

### DIFF
--- a/x-pack/plugins/cases/public/components/filter_popover/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/filter_popover/index.test.tsx
@@ -6,7 +6,8 @@
  */
 
 import React from 'react';
-import { waitForEuiPopoverOpen } from '@elastic/eui/lib/test/rtl';
+import { waitForEuiPopoverOpen, screen } from '@elastic/eui/lib/test/rtl';
+import { waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import type { AppMockRenderer } from '../../common/mock';
@@ -22,7 +23,7 @@ import { FilterPopover } from '.';
 // FLAKY: https://github.com/elastic/kibana/issues/176684
 // FLAKY: https://github.com/elastic/kibana/issues/176685
 // FLAKY: https://github.com/elastic/kibana/issues/176686
-describe.skip('FilterPopover ', () => {
+describe('FilterPopover ', () => {
   let appMockRender: AppMockRenderer;
   const onSelectedOptionsChanged = jest.fn();
   const tags: string[] = ['coke', 'pepsi'];
@@ -32,8 +33,8 @@ describe.skip('FilterPopover ', () => {
     jest.clearAllMocks();
   });
 
-  it('renders button label correctly', () => {
-    const { getByTestId } = appMockRender.render(
+  it('renders button label correctly', async () => {
+    appMockRender.render(
       <FilterPopover
         buttonLabel={'Tags'}
         onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -42,11 +43,11 @@ describe.skip('FilterPopover ', () => {
       />
     );
 
-    expect(getByTestId('options-filter-popover-button-Tags')).toBeInTheDocument();
+    expect(await screen.findByTestId('options-filter-popover-button-Tags')).toBeInTheDocument();
   });
 
   it('renders empty label correctly', async () => {
-    const { getByTestId, getByText } = appMockRender.render(
+    appMockRender.render(
       <FilterPopover
         buttonLabel={'Tags'}
         onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -56,15 +57,15 @@ describe.skip('FilterPopover ', () => {
       />
     );
 
-    userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+    userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
     await waitForEuiPopoverOpen();
 
-    expect(getByText('No options available')).toBeInTheDocument();
+    expect(await screen.findByText('No options available')).toBeInTheDocument();
   });
 
   it('renders string type options correctly', async () => {
-    const { getByTestId } = appMockRender.render(
+    appMockRender.render(
       <FilterPopover
         buttonLabel={'Tags'}
         onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -73,16 +74,16 @@ describe.skip('FilterPopover ', () => {
       />
     );
 
-    userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+    userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
     await waitForEuiPopoverOpen();
 
-    expect(getByTestId(`options-filter-popover-item-${tags[0]}`)).toBeInTheDocument();
-    expect(getByTestId(`options-filter-popover-item-${tags[1]}`)).toBeInTheDocument();
+    expect(await screen.findByTestId(`options-filter-popover-item-${tags[0]}`)).toBeInTheDocument();
+    expect(await screen.findByTestId(`options-filter-popover-item-${tags[1]}`)).toBeInTheDocument();
   });
 
   it('should call onSelectionChange with selected option', async () => {
-    const { getByTestId } = appMockRender.render(
+    appMockRender.render(
       <FilterPopover
         buttonLabel={'Tags'}
         onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -91,17 +92,19 @@ describe.skip('FilterPopover ', () => {
       />
     );
 
-    userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+    userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
     await waitForEuiPopoverOpen();
 
-    userEvent.click(getByTestId(`options-filter-popover-item-${tags[0]}`));
+    userEvent.click(await screen.findByTestId(`options-filter-popover-item-${tags[0]}`));
 
-    expect(onSelectedOptionsChanged).toHaveBeenCalledWith([tags[0]]);
+    await waitFor(() => {
+      expect(onSelectedOptionsChanged).toHaveBeenCalledWith([tags[0]]);
+    });
   });
 
   it('should call onSelectionChange with empty array when option is deselected', async () => {
-    const { getByTestId } = appMockRender.render(
+    appMockRender.render(
       <FilterPopover
         buttonLabel={'Tags'}
         onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -110,13 +113,15 @@ describe.skip('FilterPopover ', () => {
       />
     );
 
-    userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+    userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
     await waitForEuiPopoverOpen();
 
-    userEvent.click(getByTestId(`options-filter-popover-item-${tags[0]}`));
+    userEvent.click(await screen.findByTestId(`options-filter-popover-item-${tags[0]}`));
 
-    expect(onSelectedOptionsChanged).toHaveBeenCalledWith([]);
+    await waitFor(() => {
+      expect(onSelectedOptionsChanged).toHaveBeenCalledWith([]);
+    });
   });
 
   describe('maximum limit', () => {
@@ -125,7 +130,7 @@ describe.skip('FilterPopover ', () => {
     const maxLengthLabel = `You have selected maximum number of ${maxLength} tags to filter`;
 
     it('should show message when maximum options are selected', async () => {
-      const { getByTestId } = appMockRender.render(
+      appMockRender.render(
         <FilterPopover
           buttonLabel={'Tags'}
           onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -136,18 +141,22 @@ describe.skip('FilterPopover ', () => {
         />
       );
 
-      userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+      userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
       await waitForEuiPopoverOpen();
 
-      expect(getByTestId('maximum-length-warning')).toHaveTextContent(maxLengthLabel);
+      expect(await screen.findByTestId('maximum-length-warning')).toHaveTextContent(maxLengthLabel);
 
-      expect(getByTestId(`options-filter-popover-item-${newTags[3]}`)).toHaveProperty('disabled');
-      expect(getByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty('disabled');
+      expect(await screen.findByTestId(`options-filter-popover-item-${newTags[3]}`)).toHaveProperty(
+        'disabled'
+      );
+      expect(await screen.findByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty(
+        'disabled'
+      );
     });
 
     it('should not show message when maximum length label is missing', async () => {
-      const { getByTestId, queryByTestId } = appMockRender.render(
+      appMockRender.render(
         <FilterPopover
           buttonLabel={'Tags'}
           onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -157,17 +166,21 @@ describe.skip('FilterPopover ', () => {
         />
       );
 
-      userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+      userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
       await waitForEuiPopoverOpen();
 
-      expect(queryByTestId('maximum-length-warning')).not.toBeInTheDocument();
-      expect(getByTestId(`options-filter-popover-item-${newTags[3]}`)).toHaveProperty('disabled');
-      expect(getByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty('disabled');
+      expect(screen.queryByTestId('maximum-length-warning')).not.toBeInTheDocument();
+      expect(await screen.findByTestId(`options-filter-popover-item-${newTags[3]}`)).toHaveProperty(
+        'disabled'
+      );
+      expect(await screen.findByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty(
+        'disabled'
+      );
     });
 
     it('should not show message and disable options when maximum length property is missing', async () => {
-      const { getByTestId, queryByTestId } = appMockRender.render(
+      appMockRender.render(
         <FilterPopover
           buttonLabel={'Tags'}
           onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -177,19 +190,19 @@ describe.skip('FilterPopover ', () => {
         />
       );
 
-      userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+      userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
       await waitForEuiPopoverOpen();
 
-      expect(queryByTestId('maximum-length-warning')).not.toBeInTheDocument();
-      expect(getByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty(
+      expect(screen.queryByTestId('maximum-length-warning')).not.toBeInTheDocument();
+      expect(await screen.findByTestId(`options-filter-popover-item-${newTags[4]}`)).toHaveProperty(
         'disabled',
         false
       );
     });
 
     it('should allow to select more options when maximum length property is missing', async () => {
-      const { getByTestId } = appMockRender.render(
+      appMockRender.render(
         <FilterPopover
           buttonLabel={'Tags'}
           onSelectedOptionsChanged={onSelectedOptionsChanged}
@@ -198,13 +211,15 @@ describe.skip('FilterPopover ', () => {
         />
       );
 
-      userEvent.click(getByTestId('options-filter-popover-button-Tags'));
+      userEvent.click(await screen.findByTestId('options-filter-popover-button-Tags'));
 
       await waitForEuiPopoverOpen();
 
-      userEvent.click(getByTestId(`options-filter-popover-item-${newTags[1]}`));
+      userEvent.click(await screen.findByTestId(`options-filter-popover-item-${newTags[1]}`));
 
-      expect(onSelectedOptionsChanged).toHaveBeenCalledWith([newTags[0], newTags[2], newTags[1]]);
+      await waitFor(() => {
+        expect(onSelectedOptionsChanged).toHaveBeenCalledWith([newTags[0], newTags[2], newTags[1]]);
+      });
     });
   });
 });

--- a/x-pack/plugins/cases/public/components/filter_popover/index.test.tsx
+++ b/x-pack/plugins/cases/public/components/filter_popover/index.test.tsx
@@ -15,14 +15,6 @@ import { createAppMockRenderer } from '../../common/mock';
 
 import { FilterPopover } from '.';
 
-// FLAKY: https://github.com/elastic/kibana/issues/176679
-// FLAKY: https://github.com/elastic/kibana/issues/176680
-// FLAKY: https://github.com/elastic/kibana/issues/176681
-// FLAKY: https://github.com/elastic/kibana/issues/176682
-// FLAKY: https://github.com/elastic/kibana/issues/176683
-// FLAKY: https://github.com/elastic/kibana/issues/176684
-// FLAKY: https://github.com/elastic/kibana/issues/176685
-// FLAKY: https://github.com/elastic/kibana/issues/176686
 describe('FilterPopover ', () => {
   let appMockRender: AppMockRenderer;
   const onSelectedOptionsChanged = jest.fn();

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/alert_property_actions.test.tsx
@@ -17,8 +17,7 @@ import {
 } from '../../../common/mock';
 import { AlertPropertyActions } from './alert_property_actions';
 
-// FLAKY: https://github.com/elastic/kibana/issues/174667
-describe.skip('AlertPropertyActions', () => {
+describe('AlertPropertyActions', () => {
   let appMock: AppMockRenderer;
 
   const props = {

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/registered_attachments_property_actions.test.tsx
@@ -18,8 +18,7 @@ import {
 import { RegisteredAttachmentsPropertyActions } from './registered_attachments_property_actions';
 import { AttachmentActionType } from '../../../client/attachment_framework/types';
 
-// FLAKY: https://github.com/elastic/kibana/issues/174384
-describe.skip('RegisteredAttachmentsPropertyActions', () => {
+describe('RegisteredAttachmentsPropertyActions', () => {
   let appMock: AppMockRenderer;
 
   const props = {

--- a/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.test.tsx
+++ b/x-pack/plugins/cases/public/components/user_actions/property_actions/user_comment_property_actions.test.tsx
@@ -17,8 +17,7 @@ import {
 import { UserCommentPropertyActions } from './user_comment_property_actions';
 import { waitFor } from '@testing-library/react';
 
-// FLAKY: https://github.com/elastic/kibana/issues/175310
-describe.skip('UserCommentPropertyActions', () => {
+describe('UserCommentPropertyActions', () => {
   let appMock: AppMockRenderer;
 
   const props = {


### PR DESCRIPTION
## Summary

As a follow-up to https://github.com/elastic/kibana/pull/176863 unskipping filterPopOver and propertyActions tests  

Fixes https://github.com/elastic/kibana/issues/176679
Fixes https://github.com/elastic/kibana/issues/176680
Fixes https://github.com/elastic/kibana/issues/176681
Fixes https://github.com/elastic/kibana/issues/176682
Fixes https://github.com/elastic/kibana/issues/176683
Fixes https://github.com/elastic/kibana/issues/176684
Fixes https://github.com/elastic/kibana/issues/176685
Fixes https://github.com/elastic/kibana/issues/176686
Fixes https://github.com/elastic/kibana/issues/174384
Fixes #174667
Fixes #175310