### PR TITLE
Fix Cases Context issue

### DIFF
--- a/x-pack/plugins/cases/public/components/cases_context/index.tsx
+++ b/x-pack/plugins/cases/public/components/cases_context/index.tsx
@@ -49,6 +49,11 @@ export interface CasesContextValue {
   dispatch: CasesContextValueDispatch;
 }
 
+export interface CasesContextStateValue extends Omit<CasesContextValue, 'appId' | 'appTitle'> {
+  appId?: string;
+  appTitle?: string;
+}
+
 export interface CasesContextProps
   extends Pick<
     CasesContextValue,
@@ -154,7 +159,7 @@ export const CasesProvider: React.FC<{ value: CasesContextProps; queryClient?: Q
     [getFilesClient, owner]
   );
 
-  return (
+  return isCasesContextValue(value) ? (
     <QueryClientProvider client={queryClient}>
       <CasesContext.Provider value={value}>
         {applyFilesContext(
@@ -165,10 +170,13 @@ export const CasesProvider: React.FC<{ value: CasesContextProps; queryClient?: Q
         )}
       </CasesContext.Provider>
     </QueryClientProvider>
-  );
+  ) : null;
 };
-
 CasesProvider.displayName = 'CasesProvider';
+
+function isCasesContextValue(value: CasesContextStateValue): value is CasesContextValue {
+  return value.appId != null && value.appTitle != null && value.permissions != null;
+}
 
 // eslint-disable-next-line import/no-default-export
 export default CasesProvider;


### PR DESCRIPTION
This PR reverts a minimal change done https://github.com/elastic/kibana/pull/176863 that caused an edge case when rendering Osquery Attachment in Cases. 
This fixes an issue + unblocks pipelines due to Osquery catching the issue in e2e tests. 
It's not a end solution, just a way to unblock folks before EAH. 
@cnasikas what do you think? can we have this as a temporary solution? Let's see if this doesn't break any of your functionality (🤞 for cases & osquery tests)