### PR TITLE
[8.13] [Security Solution][Endpoint] Revert Badges for SentinelOne functionality back to Tech Preview (from Beta) (#177488)

### DIFF
--- a/x-pack/plugins/security_solution/public/common/translations.ts
+++ b/x-pack/plugins/security_solution/public/common/translations.ts
@@ -24,6 +24,21 @@ export const BETA_TOOLTIP = i18n.translate('xpack.securitySolution.pages.common.
     'This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.',
 });
 
+export const TECHNICAL_PREVIEW = i18n.translate(
+  'xpack.securitySolution.pages.common.technicalPreviewLabel',
+  {
+    defaultMessage: 'Technical Preview',
+  }
+);
+
+export const TECHNICAL_PREVIEW_TOOLTIP = i18n.translate(
+  'xpack.securitySolution.pages.common.technicalPreviewTooltip',
+  {
+    defaultMessage:
+      'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.',
+  }
+);
+
 export const UPDATE_ALERT_STATUS_FAILED = (conflicts: number) =>
   i18n.translate('xpack.securitySolution.pages.common.updateAlertStatusFailed', {
     values: { conflicts },

--- a/x-pack/plugins/security_solution/public/flyout/document_details/isolate_host/header.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/isolate_host/header.test.tsx
@@ -13,6 +13,7 @@ import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_exper
 import { PanelHeader } from './header';
 import { FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
 import { isAlertFromSentinelOneEvent } from '../../../common/utils/sentinelone_alert_check';
+import { TECHNICAL_PREVIEW } from '../../../common/translations';
 
 jest.mock('../../../common/hooks/use_experimental_features');
 jest.mock('../../../common/utils/sentinelone_alert_check');
@@ -63,7 +64,7 @@ describe('<PanelHeader />', () => {
       const { getByTestId } = renderPanelHeader();
 
       expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).toHaveTextContent('Beta');
+      expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).toHaveTextContent(TECHNICAL_PREVIEW);
     }
   );
 
@@ -79,7 +80,7 @@ describe('<PanelHeader />', () => {
       const { getByTestId } = renderPanelHeader();
 
       expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).toBeInTheDocument();
-      expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).not.toHaveTextContent('Beta');
+      expect(getByTestId(FLYOUT_HEADER_TITLE_TEST_ID)).not.toHaveTextContent(TECHNICAL_PREVIEW);
     }
   );
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/isolate_host/header.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/isolate_host/header.tsx
@@ -9,8 +9,8 @@ import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem, EuiTitle } from '@elastic/eui'
 import type { FC } from 'react';
 import React from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { TECHNICAL_PREVIEW, TECHNICAL_PREVIEW_TOOLTIP } from '../../../common/translations';
 import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
-import { BETA, BETA_TOOLTIP } from '../../../common/translations';
 import { isAlertFromSentinelOneEvent } from '../../../common/utils/sentinelone_alert_check';
 import { useIsolateHostPanelContext } from './context';
 import { FLYOUT_HEADER_TITLE_TEST_ID } from './test_ids';
@@ -43,7 +43,7 @@ export const PanelHeader: FC = () => {
       </EuiFlexItem>
       {isSentinelOneV1Enabled && isSentinelOneAlert && (
         <EuiFlexItem grow={false}>
-          <EuiBetaBadge label={BETA} tooltipContent={BETA_TOOLTIP} />
+          <EuiBetaBadge label={TECHNICAL_PREVIEW} tooltipContent={TECHNICAL_PREVIEW_TOOLTIP} />
         </EuiFlexItem>
       )}
     </EuiFlexGroup>

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter_popover.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/components/actions_log_filter_popover.tsx
@@ -56,8 +56,8 @@ export const ActionsLogFilterPopover = memo(
         >
           {filterName === 'types'
             ? isSentinelOneV1Enabled
-              ? FILTER_NAMES.types('s')
-              : FILTER_NAMES.types('')
+              ? FILTER_NAMES.types(2)
+              : FILTER_NAMES.types(1)
             : FILTER_NAMES[filterName]}
         </EuiFilterButton>
       ),

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_response_actions_list/translations.tsx
@@ -211,10 +211,10 @@ export const FILTER_NAMES = Object.freeze({
   }),
   // TODO: change it to just a value instead of a function
   //  when responseActionsSentinelOneV1Enabled is enabled/removed
-  types: (suffix: string) =>
+  types: (countOfTypes: number) =>
     i18n.translate('xpack.securitySolution.responseActionsList.list.filter.types', {
-      defaultMessage: `Type{suffix}`,
-      values: { suffix },
+      defaultMessage: `{countOfTypes, plural, one {Type} other {Types}}`,
+      values: { countOfTypes },
     }),
   // replace above with:
   // types: i18n.translate('xpack.securitySolution.responseActionsList.list.filter.types', {

--- a/x-pack/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback } from 'react';
 import { EuiBetaBadge, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
-import { BETA, BETA_TOOLTIP } from '../../common/translations';
+import { TECHNICAL_PREVIEW, TECHNICAL_PREVIEW_TOOLTIP } from '../../common/translations';
 import { useLicense } from '../../common/hooks/use_license';
 import type { ImmutableArray } from '../../../common/endpoint/types';
 import {
@@ -136,7 +136,10 @@ export const useWithShowResponder = (): ShowResponseActionsConsole => {
                   <EuiFlexGroup>
                     <EuiFlexItem>{RESPONDER_PAGE_TITLE}</EuiFlexItem>
                     <EuiFlexItem grow={false}>
-                      <EuiBetaBadge label={BETA} tooltipContent={BETA_TOOLTIP} />
+                      <EuiBetaBadge
+                        label={TECHNICAL_PREVIEW}
+                        tooltipContent={TECHNICAL_PREVIEW_TOOLTIP}
+                      />
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 );

--- a/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/common.ts
@@ -209,7 +209,10 @@ export const installSentinelOneAgent = async ({
 
     try {
       // Generate an alert in SentinelOne
-      await hostVm.exec('nslookup amazon.com');
+      const command = 'nslookup elastic.co';
+
+      log?.info(`Triggering alert using command: ${command}`);
+      await hostVm.exec(command);
     } catch (e) {
       log?.warning(`Attempted to generate an alert on SentinelOne host failed: ${e.message}`);
     }

--- a/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/index.ts
+++ b/x-pack/plugins/security_solution/scripts/endpoint/sentinelone_host/index.ts
@@ -116,6 +116,9 @@ const runCli: RunFn = async ({ log, flags }) => {
     s1Client,
   });
 
+  log.info(`SentinelOne Agent Status:
+${s1Info.status}`);
+
   const {
     id: agentPolicyId,
     agents = 0,
@@ -177,7 +180,5 @@ const runCli: RunFn = async ({ log, flags }) => {
 ${hostVm.info()}
 ${agentPolicyVm ? `${agentPolicyVm.info()}\n` : ''}
 ${await getMultipassVmCountNotice(2)}
-SentinelOne Agent Status:
-${s1Info.status}
 `);
 };

--- a/x-pack/plugins/stack_connectors/common/experimental_features.ts
+++ b/x-pack/plugins/stack_connectors/common/experimental_features.ts
@@ -13,10 +13,7 @@ export type ExperimentalFeatures = typeof allowedExperimentalValues;
  */
 export const allowedExperimentalValues = Object.freeze({
   isMustacheAutocompleteOn: false,
-  // set to true to show tech preview badge on sentinel one connector
   sentinelOneConnectorOn: true,
-  // set to true to show beta badge on sentinel one connector
-  sentinelOneConnectorOnBeta: true,
 });
 
 export type ExperimentalConfigKeys = Array<keyof ExperimentalFeatures>;

--- a/x-pack/plugins/stack_connectors/public/connector_types/index.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/index.ts
@@ -69,14 +69,7 @@ export function registerConnectorTypes({
   connectorTypeRegistry.register(getTinesConnectorType());
   connectorTypeRegistry.register(getD3SecurityConnectorType());
 
-  // get sentinelOne connector type
-  // when either feature flag is enabled
-  if (
-    // 8.12
-    ExperimentalFeaturesService.get().sentinelOneConnectorOn ||
-    // 8.13
-    ExperimentalFeaturesService.get().sentinelOneConnectorOnBeta
-  ) {
+  if (ExperimentalFeaturesService.get().sentinelOneConnectorOn) {
     connectorTypeRegistry.register(getSentinelOneConnectorType());
   }
 }

--- a/x-pack/plugins/stack_connectors/public/connector_types/sentinelone/sentinelone.ts
+++ b/x-pack/plugins/stack_connectors/public/connector_types/sentinelone/sentinelone.ts
@@ -11,16 +11,15 @@ import type {
   ActionTypeModel as ConnectorTypeModel,
   GenericValidationResult,
 } from '@kbn/triggers-actions-ui-plugin/public';
-import { getIsExperimentalFeatureEnabled } from '../../common/get_experimental_features';
 import {
   SENTINELONE_CONNECTOR_ID,
   SENTINELONE_TITLE,
   SUB_ACTION,
 } from '../../../common/sentinelone/constants';
 import type {
-  SentinelOneActionParams,
   SentinelOneConfig,
   SentinelOneSecrets,
+  SentinelOneActionParams,
 } from '../../../common/sentinelone/types';
 
 interface ValidationErrors {
@@ -32,16 +31,11 @@ export function getConnectorType(): ConnectorTypeModel<
   SentinelOneSecrets,
   SentinelOneActionParams
 > {
-  const isSentinelOneBetaBadgeEnabled = getIsExperimentalFeatureEnabled(
-    'sentinelOneConnectorOnBeta'
-  );
-
   return {
     id: SENTINELONE_CONNECTOR_ID,
     actionTypeTitle: SENTINELONE_TITLE,
     iconClass: lazy(() => import('./logo')),
-    isBeta: isSentinelOneBetaBadgeEnabled ? true : undefined,
-    isExperimental: isSentinelOneBetaBadgeEnabled ? undefined : true,
+    isExperimental: true,
     selectMessage: i18n.translate(
       'xpack.stackConnectors.security.sentinelone.config.selectMessageText',
       {

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/action_type_menu.tsx
@@ -6,8 +6,9 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiCard, EuiFlexGrid, EuiFlexItem, EuiIcon, EuiSpacer, EuiToolTip } from '@elastic/eui';
+import { EuiFlexItem, EuiCard, EuiIcon, EuiFlexGrid, EuiSpacer } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
+import { EuiToolTip } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { ActionType, ActionTypeIndex, ActionTypeRegistryContract } from '../../../types';
 import { loadActionTypes } from '../../lib/action_connector_api';
@@ -15,7 +16,7 @@ import { actionTypeCompare } from '../../lib/action_type_compare';
 import { checkActionTypeEnabled } from '../../lib/check_action_type_enabled';
 import { useKibana } from '../../../common/lib/kibana';
 import { SectionLoading } from '../../components/section_loading';
-import { betaBadgeProps, technicalPreviewBadgeProps } from './beta_badge_props';
+import { betaBadgeProps } from './beta_badge_props';
 
 interface Props {
   onActionTypeChange: (actionType: ActionType) => void;
@@ -76,13 +77,12 @@ export const ActionTypeMenu = ({
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
   const registeredActionTypes = Object.entries(actionTypesIndex ?? [])
     .filter(
       ([id, details]) =>
         actionTypeRegistry.has(id) &&
-        !actionTypeRegistry.get(id).hideInUi &&
-        details.enabledInConfig
+        details.enabledInConfig === true &&
+        !actionTypeRegistry.get(id).hideInUi
     )
     .map(([id, actionType]) => {
       const actionTypeModel = actionTypeRegistry.get(id);
@@ -91,7 +91,6 @@ export const ActionTypeMenu = ({
         selectMessage: actionTypeModel ? actionTypeModel.selectMessage : '',
         actionType,
         name: actionType.name,
-        isBeta: actionTypeModel.isBeta,
         isExperimental: actionTypeModel.isExperimental,
       };
     });
@@ -102,13 +101,7 @@ export const ActionTypeMenu = ({
       const checkEnabledResult = checkActionTypeEnabled(item.actionType);
       const card = (
         <EuiCard
-          betaBadgeProps={
-            item.isBeta
-              ? betaBadgeProps
-              : item.isExperimental
-              ? technicalPreviewBadgeProps
-              : undefined
-          }
+          betaBadgeProps={item.isExperimental ? betaBadgeProps : undefined}
           titleSize="xs"
           data-test-subj={`${item.actionType.id}-card`}
           icon={<EuiIcon size="xl" type={item.iconClass} />}
@@ -124,7 +117,7 @@ export const ActionTypeMenu = ({
       return (
         <EuiFlexItem key={index}>
           {checkEnabledResult.isEnabled && card}
-          {!checkEnabledResult.isEnabled && (
+          {checkEnabledResult.isEnabled === false && (
             <EuiToolTip position="top" content={checkEnabledResult.message}>
               {card}
             </EuiToolTip>

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/beta_badge_props.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/beta_badge_props.tsx
@@ -8,16 +8,6 @@
 import { i18n } from '@kbn/i18n';
 
 export const betaBadgeProps = {
-  label: i18n.translate('xpack.triggersActionsUI.betaBadgeLabel', {
-    defaultMessage: 'Beta',
-  }),
-  tooltipContent: i18n.translate('xpack.triggersActionsUI.betaBadgeDescription', {
-    defaultMessage:
-      'This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.',
-  }),
-};
-
-export const technicalPreviewBadgeProps = {
   label: i18n.translate('xpack.triggersActionsUI.technicalPreviewBadgeLabel', {
     defaultMessage: 'Technical preview',
   }),

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/header.tsx
@@ -8,18 +8,18 @@
 import React, { memo } from 'react';
 import {
   EuiBadge,
-  EuiBetaBadge,
+  EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFlyoutHeader,
   EuiIcon,
-  EuiSpacer,
   EuiText,
-  EuiTitle,
+  EuiFlyoutHeader,
   IconType,
+  EuiSpacer,
+  EuiBetaBadge,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { betaBadgeProps, technicalPreviewBadgeProps } from '../beta_badge_props';
+import { betaBadgeProps } from '../beta_badge_props';
 
 interface Props {
   icon?: IconType | null;
@@ -27,7 +27,6 @@ interface Props {
   actionTypeMessage?: string | null;
   compatibility?: string[] | null;
   isExperimental?: boolean;
-  isBeta?: boolean;
 }
 
 const FlyoutHeaderComponent: React.FC<Props> = ({
@@ -36,7 +35,6 @@ const FlyoutHeaderComponent: React.FC<Props> = ({
   actionTypeMessage,
   compatibility,
   isExperimental,
-  isBeta,
 }) => {
   return (
     <EuiFlyoutHeader hasBorder data-test-subj="create-connector-flyout-header">
@@ -63,23 +61,14 @@ const FlyoutHeaderComponent: React.FC<Props> = ({
                     </h3>
                   </EuiTitle>
                 </EuiFlexItem>
-                {actionTypeName
-                  ? isBeta && (
-                      <EuiFlexItem grow={false}>
-                        <EuiBetaBadge
-                          label={betaBadgeProps.label}
-                          tooltipContent={betaBadgeProps.tooltipContent}
-                        />
-                      </EuiFlexItem>
-                    )
-                  : isExperimental && (
-                      <EuiFlexItem grow={false}>
-                        <EuiBetaBadge
-                          label={technicalPreviewBadgeProps.label}
-                          tooltipContent={technicalPreviewBadgeProps.tooltipContent}
-                        />
-                      </EuiFlexItem>
-                    )}
+                {actionTypeName && isExperimental && (
+                  <EuiFlexItem grow={false}>
+                    <EuiBetaBadge
+                      label={betaBadgeProps.label}
+                      tooltipContent={betaBadgeProps.tooltipContent}
+                    />
+                  </EuiFlexItem>
+                )}
               </EuiFlexGroup>
               <EuiText size="s" color="subdued">
                 {actionTypeMessage}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.test.tsx
@@ -9,9 +9,9 @@ import React, { lazy } from 'react';
 
 import { actionTypeRegistryMock } from '../../../action_type_registry.mock';
 import userEvent from '@testing-library/user-event';
-import { act, waitFor } from '@testing-library/react';
+import { waitFor, act } from '@testing-library/react';
 import CreateConnectorFlyout from '.';
-import { technicalPreviewBadgeProps } from '../beta_badge_props';
+import { betaBadgeProps } from '../beta_badge_props';
 import { AppMockRenderer, createAppMockRenderer } from '../../test_utils';
 
 jest.mock('../../../lib/action_connector_api', () => ({
@@ -392,7 +392,7 @@ describe('CreateConnectorFlyout', () => {
       expect(getByText(`selectMessage-${actionTypeModel.id}`)).toBeInTheDocument();
     });
 
-    it('does not show tech preview badge when isExperimental is undefined', async () => {
+    it('does not show beta badge when isExperimental is undefined', async () => {
       const { queryByText } = appMockRenderer.render(
         <CreateConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
@@ -402,10 +402,10 @@ describe('CreateConnectorFlyout', () => {
         />
       );
       await act(() => Promise.resolve());
-      expect(queryByText(technicalPreviewBadgeProps.label)).not.toBeInTheDocument();
+      expect(queryByText(betaBadgeProps.label)).not.toBeInTheDocument();
     });
 
-    it('does not show tech preview badge when isExperimental is false', async () => {
+    it('does not show beta badge when isExperimental is false', async () => {
       actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: false });
       const { queryByText } = appMockRenderer.render(
         <CreateConnectorFlyout
@@ -416,10 +416,10 @@ describe('CreateConnectorFlyout', () => {
         />
       );
       await act(() => Promise.resolve());
-      expect(queryByText(technicalPreviewBadgeProps.label)).not.toBeInTheDocument();
+      expect(queryByText(betaBadgeProps.label)).not.toBeInTheDocument();
     });
 
-    it('shows tech preview badge when isExperimental is true', async () => {
+    it('shows beta badge when isExperimental is true', async () => {
       actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: true });
       const { getByText } = appMockRenderer.render(
         <CreateConnectorFlyout
@@ -430,7 +430,7 @@ describe('CreateConnectorFlyout', () => {
         />
       );
       await act(() => Promise.resolve());
-      expect(getByText(technicalPreviewBadgeProps.label)).toBeInTheDocument();
+      expect(getByText(betaBadgeProps.label)).toBeInTheDocument();
     });
   });
 

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/create_connector_flyout/index.tsx
@@ -21,8 +21,8 @@ import { FormattedMessage } from '@kbn/i18n-react';
 import {
   ActionConnector,
   ActionType,
-  ActionTypeIndex,
   ActionTypeModel,
+  ActionTypeIndex,
   ActionTypeRegistryContract,
 } from '../../../../types';
 import { hasSaveActionsCapability } from '../../../lib/capabilities';
@@ -211,7 +211,6 @@ const CreateConnectorFlyoutComponent: React.FC<CreateConnectorFlyoutProps> = ({
         actionTypeMessage={actionTypeModel?.selectMessage}
         compatibility={getConnectorCompatibility(actionType?.supportedFeatureIds)}
         isExperimental={actionTypeModel?.isExperimental}
-        isBeta={actionTypeModel?.isBeta}
       />
       <EuiFlyoutBody
         banner={!actionType && hasActionsUpgradeableByTrial ? <UpgradeLicenseCallOut /> : null}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/header.tsx
@@ -8,27 +8,26 @@
 import React, { memo, useCallback } from 'react';
 import { css } from '@emotion/react';
 import {
-  EuiBetaBadge,
+  EuiTitle,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFlyoutHeader,
   EuiIcon,
+  EuiText,
+  EuiFlyoutHeader,
+  IconType,
+  EuiBetaBadge,
   EuiTab,
   EuiTabs,
-  EuiText,
-  EuiTitle,
-  IconType,
   useEuiTheme,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
-import { betaBadgeProps, technicalPreviewBadgeProps } from '../beta_badge_props';
+import { betaBadgeProps } from '../beta_badge_props';
 import { EditConnectorTabs } from '../../../../types';
 import { useKibana } from '../../../../common/lib/kibana';
 import { hasExecuteActionsCapability } from '../../../lib/capabilities';
 
 const FlyoutHeaderComponent: React.FC<{
-  isBeta?: boolean;
   isExperimental?: boolean;
   isPreconfigured: boolean;
   connectorName: string;
@@ -39,7 +38,6 @@ const FlyoutHeaderComponent: React.FC<{
   icon?: IconType | null;
 }> = ({
   icon,
-  isBeta = false,
   isExperimental = false,
   isPreconfigured,
   connectorName,
@@ -103,18 +101,11 @@ const FlyoutHeaderComponent: React.FC<{
                   />
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  {isBeta ? (
+                  {isExperimental && (
                     <EuiBetaBadge
                       label={betaBadgeProps.label}
                       tooltipContent={betaBadgeProps.tooltipContent}
                     />
-                  ) : (
-                    isExperimental && (
-                      <EuiBetaBadge
-                        label={technicalPreviewBadgeProps.label}
-                        tooltipContent={technicalPreviewBadgeProps.tooltipContent}
-                      />
-                    )
                   )}
                 </EuiFlexItem>
               </EuiFlexGroup>
@@ -138,20 +129,13 @@ const FlyoutHeaderComponent: React.FC<{
                   </h3>
                 </EuiTitle>
               </EuiFlexItem>
-              {isBeta ? (
-                <EuiBetaBadge
-                  label={betaBadgeProps.label}
-                  tooltipContent={betaBadgeProps.tooltipContent}
-                />
-              ) : (
-                isExperimental && (
-                  <EuiFlexItem grow={false}>
-                    <EuiBetaBadge
-                      label={technicalPreviewBadgeProps.label}
-                      tooltipContent={technicalPreviewBadgeProps.tooltipContent}
-                    />
-                  </EuiFlexItem>
-                )
+              {isExperimental && (
+                <EuiFlexItem grow={false}>
+                  <EuiBetaBadge
+                    label={betaBadgeProps.label}
+                    tooltipContent={betaBadgeProps.tooltipContent}
+                  />
+                </EuiFlexItem>
               )}
             </EuiFlexGroup>
           )}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/index.test.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/index.test.tsx
@@ -9,10 +9,10 @@ import React, { lazy } from 'react';
 
 import { actionTypeRegistryMock } from '../../../action_type_registry.mock';
 import userEvent from '@testing-library/user-event';
-import { act, waitFor } from '@testing-library/react';
+import { waitFor, act } from '@testing-library/react';
 import EditConnectorFlyout from '.';
 import { ActionConnector, EditConnectorTabs, GenericValidationResult } from '../../../../types';
-import { betaBadgeProps, technicalPreviewBadgeProps } from '../beta_badge_props';
+import { betaBadgeProps } from '../beta_badge_props';
 import { AppMockRenderer, createAppMockRenderer } from '../../test_utils';
 
 const updateConnectorResponse = {
@@ -321,7 +321,7 @@ describe('EditConnectorFlyout', () => {
         />
       );
       await act(() => Promise.resolve());
-      expect(queryByText(technicalPreviewBadgeProps.label)).not.toBeInTheDocument();
+      expect(queryByText(betaBadgeProps.label)).not.toBeInTheDocument();
     });
 
     it('shows `tech preview` badge when isExperimental is true', async () => {
@@ -335,11 +335,11 @@ describe('EditConnectorFlyout', () => {
         />
       );
       await act(() => Promise.resolve());
-      expect(getByText(technicalPreviewBadgeProps.label)).toBeInTheDocument();
+      expect(getByText(betaBadgeProps.label)).toBeInTheDocument();
     });
 
-    it('does not show `beta` badge when `isBeta` is `false`', async () => {
-      actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isBeta: false });
+    it('does not show `Technical Preview` badge when `isExperimental` is `false`', async () => {
+      actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: false });
       const { queryByText } = appMockRenderer.render(
         <EditConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}
@@ -352,8 +352,8 @@ describe('EditConnectorFlyout', () => {
       expect(queryByText(betaBadgeProps.label)).not.toBeInTheDocument();
     });
 
-    it('shows `beta` badge when `isBeta` is `true`', async () => {
-      actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isBeta: true });
+    it('shows `Technical Preview` badge when `isExperimental` is `true`', async () => {
+      actionTypeRegistry.get.mockReturnValue({ ...actionTypeModel, isExperimental: true });
       const { getByText } = appMockRenderer.render(
         <EditConnectorFlyout
           actionTypeRegistry={actionTypeRegistry}

--- a/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/index.tsx
+++ b/x-pack/plugins/triggers_actions_ui/public/application/sections/action_connector_form/edit_connector_flyout/index.tsx
@@ -6,11 +6,11 @@
  */
 
 import React, { memo, ReactNode, useCallback, useEffect, useRef, useState } from 'react';
-import { EuiButton, EuiConfirmModal, EuiFlyout, EuiFlyoutBody } from '@elastic/eui';
+import { EuiFlyout, EuiFlyoutBody, EuiButton, EuiConfirmModal } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { ActionTypeExecutorResult, isActionTypeExecutorResult } from '@kbn/actions-plugin/common';
-import { none, Option, some } from 'fp-ts/lib/Option';
+import { Option, none, some } from 'fp-ts/lib/Option';
 import { ReadOnlyConnectorMessage } from './read_only';
 import {
   ActionConnector,
@@ -321,7 +321,6 @@ const EditConnectorFlyoutComponent: React.FC<EditConnectorFlyoutProps> = ({
           setTab={handleSetTab}
           selectedTab={selectedTab}
           icon={actionTypeModel?.iconClass}
-          isBeta={actionTypeModel?.isBeta}
           isExperimental={actionTypeModel?.isExperimental}
         />
         <EuiFlyoutBody>

--- a/x-pack/plugins/triggers_actions_ui/public/types.ts
+++ b/x-pack/plugins/triggers_actions_ui/public/types.ts
@@ -7,55 +7,54 @@
 
 import type { Moment } from 'moment';
 import type { ComponentType, ReactNode, RefObject } from 'react';
-import React from 'react';
 import type { PublicMethodsOf } from '@kbn/utility-types';
 import type { DocLinksStart } from '@kbn/core/public';
-import { HttpSetup } from '@kbn/core/public';
 import type { ChartsPluginSetup } from '@kbn/charts-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import type { UnifiedSearchPublicPluginStart } from '@kbn/unified-search-plugin/public';
 import type {
-  EuiDataGridCellValueElementProps,
-  EuiDataGridColumnCellAction,
-  EuiDataGridOnColumnResizeHandler,
-  EuiDataGridProps,
-  EuiDataGridRefProps,
-  EuiDataGridToolBarAdditionalControlsOptions,
-  EuiDataGridToolBarVisibilityOptions,
-  EuiSuperSelectOption,
   IconType,
   RecursivePartial,
+  EuiDataGridCellValueElementProps,
+  EuiDataGridToolBarAdditionalControlsOptions,
+  EuiDataGridProps,
+  EuiDataGridRefProps,
+  EuiDataGridColumnCellAction,
+  EuiDataGridToolBarVisibilityOptions,
+  EuiSuperSelectOption,
+  EuiDataGridOnColumnResizeHandler,
 } from '@elastic/eui';
-import { EuiDataGridColumn, EuiDataGridControlColumn, EuiDataGridSorting } from '@elastic/eui';
 import type { RuleCreationValidConsumer, ValidFeatureId } from '@kbn/rule-data-utils';
+import { EuiDataGridColumn, EuiDataGridControlColumn, EuiDataGridSorting } from '@elastic/eui';
+import { HttpSetup } from '@kbn/core/public';
 import { KueryNode } from '@kbn/es-query';
 import {
   ActionType,
+  AlertHistoryEsIndexConnectorId,
+  AlertHistoryDocumentTemplate,
   ALERT_HISTORY_PREFIX,
   AlertHistoryDefaultIndexName,
-  AlertHistoryDocumentTemplate,
-  AlertHistoryEsIndexConnectorId,
   AsApiContract,
 } from '@kbn/actions-plugin/common';
 import {
   ActionGroup,
-  ActionVariable,
-  AlertingFrameworkHealth,
-  AlertStatus,
-  AlertSummary as RuleSummary,
-  ExecutionDuration,
-  MaintenanceWindow,
-  RawAlertInstance,
+  RuleActionParam,
+  SanitizedRule as AlertingSanitizedRule,
   ResolvedSanitizedRule,
   RuleAction,
-  RuleActionParam,
-  RuleLastRun,
-  RuleNotifyWhenType,
   RuleTaskState,
-  RuleTypeMetaData,
+  AlertSummary as RuleSummary,
+  ExecutionDuration,
+  AlertStatus,
+  RawAlertInstance,
+  AlertingFrameworkHealth,
+  RuleNotifyWhenType,
   RuleTypeParams,
-  SanitizedRule as AlertingSanitizedRule,
+  RuleTypeMetaData,
+  ActionVariable,
+  RuleLastRun,
+  MaintenanceWindow,
 } from '@kbn/alerting-plugin/common';
 import type { BulkOperationError } from '@kbn/alerting-plugin/server';
 import { RuleRegistrySearchRequestPagination } from '@kbn/rule-registry-plugin/common';
@@ -64,6 +63,7 @@ import {
   QueryDslQueryContainer,
   SortCombinations,
 } from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
+import React from 'react';
 import { ActionsPublicPluginSetup } from '@kbn/actions-plugin/public';
 import type { RuleType, RuleTypeIndex } from '@kbn/triggers-actions-ui-types';
 import { TypeRegistry } from './application/type_registry';
@@ -72,23 +72,23 @@ import type { RuleTagFilterProps } from './application/sections/rules_list/compo
 import type { RuleStatusFilterProps } from './application/sections/rules_list/components/rule_status_filter';
 import type { RulesListProps } from './application/sections/rules_list/components/rules_list';
 import type {
-  RuleTagBadgeOptions,
   RuleTagBadgeProps,
+  RuleTagBadgeOptions,
 } from './application/sections/rules_list/components/rule_tag_badge';
 import type {
-  RuleEventLogListOptions,
   RuleEventLogListProps,
+  RuleEventLogListOptions,
 } from './application/sections/rule_details/components/rule_event_log_list';
 import type { GlobalRuleEventLogListProps } from './application/sections/rule_details/components/global_rule_event_log_list';
 import type { AlertSummaryTimeRange } from './application/sections/alert_summary_widget/types';
 import type { CreateConnectorFlyoutProps } from './application/sections/action_connector_form/create_connector_flyout';
 import type { EditConnectorFlyoutProps } from './application/sections/action_connector_form/edit_connector_flyout';
 import type {
-  BrowserFieldItem,
-  CreateFieldComponent,
   FieldBrowserOptions,
-  FieldBrowserProps,
+  CreateFieldComponent,
   GetFieldTableColumns,
+  FieldBrowserProps,
+  BrowserFieldItem,
 } from './application/sections/field_browser/types';
 import { RulesListVisibleColumns } from './application/sections/rules_list/components/rules_list_column_selector';
 import { TimelineItem } from './application/sections/alerts_table/bulk_actions/components/toolbar';
@@ -173,13 +173,11 @@ export interface ConnectorValidationError {
 }
 
 export type ConnectorValidationFunc = () => Promise<ConnectorValidationError | void | undefined>;
-
 export interface ActionConnectorFieldsProps {
   readOnly: boolean;
   isEdit: boolean;
   registerPreSubmitValidator: (validator: ConnectorValidationFunc) => void;
 }
-
 export interface ActionReadOnlyElementProps {
   connectorId: string;
   connectorName: string;
@@ -211,12 +209,10 @@ interface BulkOperationAttributesByIds {
   ids: string[];
   filter?: never;
 }
-
 interface BulkOperationAttributesByFilter {
   ids?: never;
   filter: KueryNode | null;
 }
-
 export type BulkOperationAttributesWithoutHttp =
   | BulkOperationAttributesByIds
   | BulkOperationAttributesByFilter;
@@ -286,7 +282,6 @@ export interface ActionTypeModel<ActionConfig = any, ActionSecrets = any, Action
   defaultActionParams?: RecursivePartial<ActionParams>;
   defaultRecoveredActionParams?: RecursivePartial<ActionParams>;
   customConnectorSelectItem?: CustomConnectorSelectionItem;
-  isBeta?: boolean;
   isExperimental?: boolean;
   subtype?: Array<{ id: string; name: string }>;
   convertParamsBetweenGroups?: (params: ActionParams) => ActionParams | {};
@@ -477,7 +472,6 @@ export interface RuleAddProps<
   useRuleProducer?: boolean;
   initialSelectedConsumer?: RuleCreationValidConsumer | null;
 }
-
 export interface RuleDefinitionProps<Params extends RuleTypeParams = RuleTypeParams> {
   rule: Rule<Params>;
   ruleTypeRegistry: RuleTypeRegistryContract;
@@ -512,7 +506,6 @@ export interface InspectQuery {
   request: string[];
   response: string[];
 }
-
 export type GetInspectQuery = () => InspectQuery;
 
 export type Alert = EcsFieldsResponse;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Security Solution][Endpoint] Revert Badges for SentinelOne functionality back to Tech Preview (from Beta) (#177488)](https://github.com/elastic/kibana/pull/177488)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Paul Tavares","email":"56442535+paul-tavares@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-02-22T17:52:59Z","message":"[Security Solution][Endpoint] Revert Badges for SentinelOne functionality back to Tech Preview (from Beta) (#177488)\n\n## Summary\r\n\r\nThis PR reverts most of the changes done in #176228 : \r\n\r\n- Reverts changes to Connectors so that the Badge displayed for\r\nSentinelOne is again showing \"Technical Preview\"\r\n- Changes the badge displayed on the Host Isolation flyout and Responder\r\nfor SentinelOne host to \"Technical Preview\"\r\n- Fixes #177337 \r\n\r\nIN addition, the following issue was also addressed:\r\n\r\n- Corrected `i18n` definition for response action log history ( Fixes\r\n#177185 )\r\n\r\n\r\n_____________\r\n\r\n### Host isolation flyout\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/dc1f104a-9792-4aee-ae12-140489562d96\">\r\n\r\n\r\n\r\n### Responder\r\n\r\n<img width=\"1272\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/6361008a-182f-4163-b754-92619b6c9ee1\">\r\n\r\n\r\n### Connector\r\n\r\n<img width=\"638\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/338d03d9-b74d-479d-bfe2-d1796d1f2103\">\r\n\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/4eeeeccb-e966-4897-b97f-17696e0bd5ef\">","sha":"bd311f364420a3948012c183e40c2063308a6f89","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Defend Workflows","v8.13.0","v8.14.0"],"number":177488,"url":"https://github.com/elastic/kibana/pull/177488","mergeCommit":{"message":"[Security Solution][Endpoint] Revert Badges for SentinelOne functionality back to Tech Preview (from Beta) (#177488)\n\n## Summary\r\n\r\nThis PR reverts most of the changes done in #176228 : \r\n\r\n- Reverts changes to Connectors so that the Badge displayed for\r\nSentinelOne is again showing \"Technical Preview\"\r\n- Changes the badge displayed on the Host Isolation flyout and Responder\r\nfor SentinelOne host to \"Technical Preview\"\r\n- Fixes #177337 \r\n\r\nIN addition, the following issue was also addressed:\r\n\r\n- Corrected `i18n` definition for response action log history ( Fixes\r\n#177185 )\r\n\r\n\r\n_____________\r\n\r\n### Host isolation flyout\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/dc1f104a-9792-4aee-ae12-140489562d96\">\r\n\r\n\r\n\r\n### Responder\r\n\r\n<img width=\"1272\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/6361008a-182f-4163-b754-92619b6c9ee1\">\r\n\r\n\r\n### Connector\r\n\r\n<img width=\"638\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/338d03d9-b74d-479d-bfe2-d1796d1f2103\">\r\n\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/4eeeeccb-e966-4897-b97f-17696e0bd5ef\">","sha":"bd311f364420a3948012c183e40c2063308a6f89"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177488","number":177488,"mergeCommit":{"message":"[Security Solution][Endpoint] Revert Badges for SentinelOne functionality back to Tech Preview (from Beta) (#177488)\n\n## Summary\r\n\r\nThis PR reverts most of the changes done in #176228 : \r\n\r\n- Reverts changes to Connectors so that the Badge displayed for\r\nSentinelOne is again showing \"Technical Preview\"\r\n- Changes the badge displayed on the Host Isolation flyout and Responder\r\nfor SentinelOne host to \"Technical Preview\"\r\n- Fixes #177337 \r\n\r\nIN addition, the following issue was also addressed:\r\n\r\n- Corrected `i18n` definition for response action log history ( Fixes\r\n#177185 )\r\n\r\n\r\n_____________\r\n\r\n### Host isolation flyout\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/dc1f104a-9792-4aee-ae12-140489562d96\">\r\n\r\n\r\n\r\n### Responder\r\n\r\n<img width=\"1272\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/6361008a-182f-4163-b754-92619b6c9ee1\">\r\n\r\n\r\n### Connector\r\n\r\n<img width=\"638\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/338d03d9-b74d-479d-bfe2-d1796d1f2103\">\r\n\r\n\r\n<img width=\"1283\" alt=\"image\"\r\nsrc=\"https://github.com/elastic/kibana/assets/56442535/4eeeeccb-e966-4897-b97f-17696e0bd5ef\">","sha":"bd311f364420a3948012c183e40c2063308a6f89"}}]}] BACKPORT-->