### PR TITLE
[8.13] [Console] Update console to provide cloud es url if available with cURL (#176944)

### DIFF
--- a/src/plugins/console/kibana.jsonc
+++ b/src/plugins/console/kibana.jsonc
@@ -15,7 +15,8 @@
     ],
     "optionalPlugins": [
       "usageCollection",
-      "home"
+      "home",
+      "cloud"
     ],
     "requiredBundles": [
       "esUiShared",

--- a/src/plugins/console/server/plugin.ts
+++ b/src/plugins/console/server/plugin.ts
@@ -7,6 +7,7 @@
  */
 
 import { CoreSetup, Logger, Plugin, PluginInitializerContext } from '@kbn/core/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import { SemVer } from 'semver';
 
 import { ProxyConfigCollection } from './lib';
@@ -18,6 +19,9 @@ import { registerRoutes } from './routes';
 import { ESConfigForProxy, ConsoleSetup, ConsoleStart } from './types';
 import { handleEsError } from './shared_imports';
 
+interface PluginsSetup {
+  cloud?: CloudSetup;
+}
 export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
   log: Logger;
 
@@ -29,7 +33,7 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
     this.log = this.ctx.logger.get();
   }
 
-  setup({ http, capabilities, elasticsearch }: CoreSetup) {
+  setup({ http, capabilities, elasticsearch }: CoreSetup, { cloud }: PluginsSetup) {
     capabilities.registerProvider(() => ({
       dev_tools: {
         show: true,
@@ -48,7 +52,7 @@ export class ConsoleServerPlugin implements Plugin<ConsoleSetup, ConsoleStart> {
       proxyConfigCollection = new ProxyConfigCollection((config as ConsoleConfig7x).proxyConfig);
     }
 
-    this.esLegacyConfigService.setup(elasticsearch.legacy.config$);
+    this.esLegacyConfigService.setup(elasticsearch.legacy.config$, cloud);
 
     const router = http.createRouter();
 

--- a/src/plugins/console/server/routes/api/console/es_config/index.ts
+++ b/src/plugins/console/server/routes/api/console/es_config/index.ts
@@ -11,6 +11,12 @@ import { RouteDependencies } from '../../..';
 
 export const registerEsConfigRoute = ({ router, services }: RouteDependencies): void => {
   router.get({ path: '/api/console/es_config', validate: false }, async (ctx, req, res) => {
+    const cloudUrl = services.esLegacyConfigService.getCloudUrl();
+    if (cloudUrl) {
+      const body: EsConfigApiResponse = { host: cloudUrl };
+
+      return res.ok({ body });
+    }
     const {
       hosts: [host],
     } = await services.esLegacyConfigService.readConfig();

--- a/src/plugins/console/server/services/es_legacy_config_service.ts
+++ b/src/plugins/console/server/services/es_legacy_config_service.ts
@@ -8,6 +8,7 @@
 
 import { firstValueFrom, Observable, Subscription } from 'rxjs';
 import { ElasticsearchConfig } from '@kbn/core/server';
+import type { CloudSetup } from '@kbn/cloud-plugin/server';
 
 export class EsLegacyConfigService {
   /**
@@ -25,11 +26,17 @@ export class EsLegacyConfigService {
    */
   private configSub?: Subscription;
 
-  setup(config$: Observable<ElasticsearchConfig>) {
+  /**
+   * URL to cloud instance of elasticsearch if available
+   */
+  private cloudUrl?: string;
+
+  setup(config$: Observable<ElasticsearchConfig>, cloud?: CloudSetup) {
     this.config$ = config$;
     this.configSub = this.config$.subscribe((config) => {
       this.config = config;
     });
+    this.cloudUrl = cloud?.elasticsearchUrl;
   }
 
   stop() {
@@ -48,5 +55,9 @@ export class EsLegacyConfigService {
     }
 
     return this.config;
+  }
+
+  getCloudUrl(): string | undefined {
+    return this.cloudUrl;
   }
 }

--- a/src/plugins/console/tsconfig.json
+++ b/src/plugins/console/tsconfig.json
@@ -27,6 +27,7 @@
     "@kbn/core-elasticsearch-server",
     "@kbn/core-http-browser-mocks",
     "@kbn/react-kibana-context-theme",
+    "@kbn/cloud-plugin"
   ],
   "exclude": [
     "target/**/*",


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Console] Update console to provide cloud es url if available with cURL (#176944)](https://github.com/elastic/kibana/pull/176944)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Rodney Norris","email":"rodney.norris@elastic.co"},"sourceCommit":{"committedDate":"2024-02-22T16:20:32Z","message":"[Console] Update console to provide cloud es url if available with cURL (#176944)\n\n## Summary\r\n\r\nUpdated the console route `/api/console/es_config` to default to the\r\n`cloud.elasticsearchUrl` if it's available vs reading the first host\r\nvalue from the legacy config. This will ensure that when a user use the\r\n\"copy as cURL\" in the console the host will default to the cloud URL.\r\n\r\n### Checklist\r\n\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"6d44340e52aa283362d8013287d3d48956a03830","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:Search","v8.13.0","v8.14.0"],"number":176944,"url":"https://github.com/elastic/kibana/pull/176944","mergeCommit":{"message":"[Console] Update console to provide cloud es url if available with cURL (#176944)\n\n## Summary\r\n\r\nUpdated the console route `/api/console/es_config` to default to the\r\n`cloud.elasticsearchUrl` if it's available vs reading the first host\r\nvalue from the legacy config. This will ensure that when a user use the\r\n\"copy as cURL\" in the console the host will default to the cloud URL.\r\n\r\n### Checklist\r\n\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"6d44340e52aa283362d8013287d3d48956a03830"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/176944","number":176944,"mergeCommit":{"message":"[Console] Update console to provide cloud es url if available with cURL (#176944)\n\n## Summary\r\n\r\nUpdated the console route `/api/console/es_config` to default to the\r\n`cloud.elasticsearchUrl` if it's available vs reading the first host\r\nvalue from the legacy config. This will ensure that when a user use the\r\n\"copy as cURL\" in the console the host will default to the cloud URL.\r\n\r\n### Checklist\r\n\r\n- [ ]\r\n[Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html)\r\nwas added for features that require explanation or tutorials\r\n- [ ] [Unit or functional\r\ntests](https://www.elastic.co/guide/en/kibana/master/development-tests.html)\r\nwere updated or added to match the most common scenarios","sha":"6d44340e52aa283362d8013287d3d48956a03830"}}]}] BACKPORT-->