### PR TITLE
proposal(quality-gates): Add slo check for prod-canary and prod-noncanary stages

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production-canary.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production-canary.yaml
@@ -1,0 +1,37 @@
+# These pipeline steps constitute the quality gate for your service within the production environment.
+# Incorporate any necessary additional logic to validate the service's integrity.
+# A failure in this pipeline build will prevent further progression to the subsequent stage.
+
+steps:
+  - label: ":kibana: Canary SLO check"
+    trigger: "serverless-quality-gates" # https://buildkite.com/elastic/serverless-quality-gates
+    build:
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-production-canary.yaml)"
+      env:
+        TARGET_ENV: production
+        CHECK_SLO: true
+        CHECK_SLO_TAG: kibana-canary # new tag for canary (internal projects)
+        CHECK_SLO_WAITING_PERIOD: 15m
+        CHECK_SLO_BURN_RATE_THRESHOLD: 0.1
+    soft_fail: true
+
+  - label: ":rocket: control-plane e2e tests"
+    if: build.env("ENVIRONMENT") == "production-canary" # To be confirmed
+    trigger: "ess-k8s-production-e2e-tests" # https://buildkite.com/elastic/ess-k8s-production-e2e-tests
+    build:
+      env:
+        REGION_ID: aws-us-east-1
+        NAME_PREFIX: ci_test_kibana-promotion_
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-production-canary.yaml)"
+
+  - label: ":cookie: 24h bake time before continuing promotion"
+    if: build.env("ENVIRONMENT") == "production-canary" # To be confirmed
+    command: "sleep 86400"
+    soft_fail:
+      # A manual cancel of that step produces return code 255.
+      # We're treating this case as a soft fail to allow manual bake time skipping.
+      # To stop the promotion entirely, instead click the "Cancel" button at the top of the page
+      - exit_status: 255
+    agents:
+      # How long can this agent live for in minutes - 25 hours
+      instanceMaxAge: 1500

--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production-noncanary.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production-noncanary.yaml
@@ -1,0 +1,37 @@
+# These pipeline steps constitute the quality gate for your service within the production environment.
+# Incorporate any necessary additional logic to validate the service's integrity.
+# A failure in this pipeline build will prevent further progression to the subsequent stage.
+
+steps:
+  - label: ":kibana: NonCanary SLO check"
+    trigger: "serverless-quality-gates" # https://buildkite.com/elastic/serverless-quality-gates
+    build:
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-production-noncanary.yaml)"
+      env:
+        TARGET_ENV: production
+        CHECK_SLO: true
+        CHECK_SLO_TAG: kibana-noncanary # new tag for noncanary (non-internal projects)
+        CHECK_SLO_WAITING_PERIOD: 15m
+        CHECK_SLO_BURN_RATE_THRESHOLD: 0.1
+    soft_fail: true
+
+  - label: ":rocket: control-plane e2e tests"
+    if: build.env("ENVIRONMENT") == "production-noncanary" # the slice we want to use (To Be Confirmed)
+    trigger: "ess-k8s-production-e2e-tests" # https://buildkite.com/elastic/ess-k8s-production-e2e-tests
+    build:
+      env:
+        REGION_ID: aws-us-east-1
+        NAME_PREFIX: ci_test_kibana-promotion_
+      message: "${BUILDKITE_MESSAGE} (triggered by pipeline.tests-production-noncanary.yaml)"
+
+  - label: ":cookie: 24h bake time before continuing promotion"
+    if: build.env("ENVIRONMENT") == "production-noncanary" # the slice we want to use (To Be Confirmed)
+    command: "sleep 86400"
+    soft_fail:
+      # A manual cancel of that step produces return code 255.
+      # We're treating this case as a soft fail to allow manual bake time skipping.
+      # To stop the promotion entirely, instead click the "Cancel" button at the top of the page
+      - exit_status: 255
+    agents:
+      # How long can this agent live for in minutes - 25 hours
+      instanceMaxAge: 1500


### PR DESCRIPTION
We release to canary projects in prod and allow a bake time to ensure that the release is stable before releasing to noncanary projects.

ATM, our SLO's don't distinguish between these, meaning that any significant change in either will have a large effect on the overall metrics.

This PR proposes region-specific quality gate pipelines to give release managers more confidence to rollout to non-canary projects.

It will also help with deciding the severity of an incident and how best to respond to it regarding external communication. ie. an issue in canary-only projects doesn't need to be publicly announced. 

## Summary

The new pipelines are duplicates of https://github.com/elastic/kibana/blob/main/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml targetting new tags that we would like to use.

## Implications:
If the proposal is accepted, the following dependencies would have to be handled first:
- Add new tags for canary & non-canary regions
- Decide on SLO's to use & the dashboards to use
- Split each SLO into canary & non-canary
- Move all SLO's to terraform
- Have canary/non-canary specific QG pipelines
- Dashboards for complete overall view
- Dashboards (separate) for canary and non-canary
- Create new region-specific actions for alerting & onCall monitoring
