### PR TITLE
[maps] update ES|QL copy to align with controls copy

### DIFF
--- a/x-pack/plugins/maps/public/classes/sources/esql_source/create_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/create_source_editor.tsx
@@ -213,7 +213,7 @@ export function CreateSourceEditor(props: Props) {
             <EuiFormRow>
               <EuiSwitch
                 label={i18n.translate('xpack.maps.esqlSource.narrowByGlobalSearchLabel', {
-                  defaultMessage: `Narrow ES|QL statement by global search`,
+                  defaultMessage: `Apply global search to ES|QL statement`,
                 })}
                 checked={narrowByGlobalSearch}
                 onChange={(event: EuiSwitchEvent) => {

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/narrow_by_field.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/narrow_by_field.tsx
@@ -15,7 +15,7 @@ export function NarrowByMapBounds(props: Omit<NarrowByFieldProps, 'switchLabel' 
   return (
     <NarrowByField
       switchLabel={i18n.translate('xpack.maps.esqlSource.narrowByMapExtentLabel', {
-        defaultMessage: 'Narrow ES|QL statement by visible map area',
+        defaultMessage: 'Dynamically filter for data in the visible map area',
       })}
       fieldTypes={[ES_GEO_FIELD_TYPE.GEO_POINT, ES_GEO_FIELD_TYPE.GEO_SHAPE]}
       {...props}
@@ -27,7 +27,7 @@ export function NarrowByTime(props: Omit<NarrowByFieldProps, 'switchLabel' | 'fi
   return (
     <NarrowByField
       switchLabel={i18n.translate('xpack.maps.esqlSource.narrowByGlobalTimeLabel', {
-        defaultMessage: `Narrow ES|QL statement by global time`,
+        defaultMessage: `Apply global time range to ES|QL statement`,
       })}
       fieldTypes={['date']}
       {...props}
@@ -96,7 +96,7 @@ function NarrowByField(props: NarrowByFieldProps) {
       {props.narrowByField && (
         <EuiFormRow
           label={i18n.translate('xpack.maps.source.esql.narrowByFieldLabel', {
-            defaultMessage: 'Narrow by',
+            defaultMessage: 'Filter by',
           })}
           display="columnCompressed"
         >

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/update_source_editor.test.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/update_source_editor.test.tsx
@@ -45,7 +45,7 @@ jest.mock('../../../kibana_services', () => {
 describe('UpdateSourceEditor', () => {
   describe('narrow by map bounds switch', () => {
     function getNarrowByMapBoundsSwitch() {
-      return screen.getByText('Narrow ES|QL statement by visible map area');
+      return screen.getByText('Dynamically filter for data in the visible map area');
     }
 
     test('should set geoField when checked and geo field is not set', async () => {
@@ -97,7 +97,7 @@ describe('UpdateSourceEditor', () => {
 
   describe('narrow by time switch', () => {
     function getNarrowByTimeSwitch() {
-      return screen.getByText('Narrow ES|QL statement by global time');
+      return screen.getByText('Apply global time range to ES|QL statement');
     }
 
     test('should set dateField when checked and date field is not set', async () => {

--- a/x-pack/plugins/maps/public/classes/sources/esql_source/update_source_editor.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/esql_source/update_source_editor.tsx
@@ -132,7 +132,7 @@ export function UpdateSourceEditor(props: Props) {
           <EuiFormRow>
             <EuiSwitch
               label={i18n.translate('xpack.maps.esqlSource.narrowByGlobalSearchLabel', {
-                defaultMessage: `Narrow ES|QL statement by global search`,
+                defaultMessage: `Apply global search to ES|QL statement`,
               })}
               checked={props.sourceDescriptor.narrowByGlobalSearch}
               onChange={(event: EuiSwitchEvent) => {


### PR DESCRIPTION
@teresaalvarezsoler suggested updating ES|QL copy to align with existing controls copy

Controls copy
![image](https://github.com/elastic/kibana/assets/373691/976d24a6-6274-44a5-9974-69a533e88983)

Updated ES|QL copy
<img width="300" alt="Screenshot 2024-02-22 at 4 06 56 PM" src="https://github.com/elastic/kibana/assets/373691/86604d42-771b-439c-ba61-2d5e9bcc7a4a">



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->