### PR TITLE
[npmrc] Fix puppeteer_skip_download configuration

### DIFF
--- a/.buildkite/scripts/steps/bazel_cache/bootstrap_linux.sh
+++ b/.buildkite/scripts/steps/bazel_cache/bootstrap_linux.sh
@@ -6,7 +6,6 @@ source .buildkite/scripts/common/util.sh
 
 export BAZEL_CACHE_MODE=populate-local-gcs
 export DISABLE_BOOTSTRAP_VALIDATION=true
-export PUPPETEER_SKIP_DOWNLOAD=true
 
 # Clear out bazel cache between runs to make sure that any artifacts that don't exist in the cache are uploaded
 rm -rf ~/.bazel-cache

--- a/.buildkite/scripts/steps/bazel_cache/bootstrap_mac.sh
+++ b/.buildkite/scripts/steps/bazel_cache/bootstrap_mac.sh
@@ -6,7 +6,6 @@ source .buildkite/scripts/common/util.sh
 
 export BAZEL_CACHE_MODE=populate-local-gcs
 export DISABLE_BOOTSTRAP_VALIDATION=true
-export PUPPETEER_SKIP_CHROME_DOWNLOAD=true
 
 # Because we're manually deleting node_modules and bazel directories in-between runs, we need to --force-install
 export BOOTSTRAP_ALWAYS_FORCE_INSTALL=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-puppeteer_skip_chromium_download=true
+puppeteer_skip_download=true


### PR DESCRIPTION
This was a breaking change introduced in puppeteer 20 See https://github.com/puppeteer/puppeteer/commit/df4d60c187aa11c4ad783827242e9511f4ec2aab



<!--ONMERGE {"backportTargets":["7.17","8.13"]} ONMERGE-->