### PR TITLE
[EDR Workflows] [Osquery] Run Osquery tests on Cases and Timelines changes

### DIFF
--- a/.buildkite/scripts/pipelines/pull_request/pipeline.ts
+++ b/.buildkite/scripts/pipelines/pull_request/pipeline.ts
@@ -305,7 +305,12 @@ const uploadPipeline = (pipelineContent: string | object) => {
     }
 
     if (
-      ((await doAnyChangesMatch([/^x-pack\/plugins\/osquery/, /^x-pack\/test\/osquery_cypress/])) ||
+      ((await doAnyChangesMatch([
+        /^x-pack\/plugins\/osquery/,
+        /^x-pack\/test\/osquery_cypress/,
+        /^x-pack\/plugins\/timelines/,
+        /^x-pack\/plugins\/cases/,
+      ])) ||
         GITHUB_PR_LABELS.includes('ci:all-cypress-suites')) &&
       !GITHUB_PR_LABELS.includes('ci:skip-cypress-osquery')
     ) {


### PR DESCRIPTION
After seeing situations where some external to Osquery changes that break kibana were caught after merge by Osquery tests, it could improve the workflow if we actually run Osquery tests prior to merging. 