### PR TITLE
[EDR Workflows] Increase DW Cypress Serverless parallelism

### DIFF
--- a/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
+++ b/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml
@@ -21,7 +21,7 @@ steps:
       - build
       - quick_checks
     timeout_in_minutes: 60
-    parallelism: 10
+    parallelism: 12
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
Noticed that DW Serverless tests are failing constantly due to `timeout` (60 mins). 
This should release some space and hopefully tests should stop failing this often. 


<img width="501" alt="Zrzut ekranu 2024-02-23 o 12 55 21" src="https://github.com/elastic/kibana/assets/16632552/c3a72d91-4f47-4537-8bca-717f662e8b43">
