### PR TITLE
[EDR Workflows][Ops] Increase parallelism in on_merge_unsupported_ftr

### DIFF
--- a/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
+++ b/.buildkite/pipelines/on_merge_unsupported_ftrs.yml
@@ -68,7 +68,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 10
+    parallelism: 16
     retry:
       automatic:
         - exit_status: '*'
@@ -80,7 +80,7 @@ steps:
       queue: n2-4-virt
     depends_on: build
     timeout_in_minutes: 60
-    parallelism: 6
+    parallelism: 10
     retry:
       automatic:
         - exit_status: '*'


### PR DESCRIPTION
The values have been updated to match the current settings in https://github.com/elastic/kibana/blob/0994a2193f0244931107be8a8b75919ca2663e0e/.buildkite/pipelines/pull_request/security_solution/defend_workflows.yml.

We noticed that DW Serverless Cypress tests were timing out on the main branch, and this pull request fixes that issue.