### PR TITLE
[ML] Data Frame Analytics creation: add messaging when permission requirements are not met

### DIFF
--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -537,6 +537,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       dataFrameAnalytics: `${MACHINE_LEARNING_DOCS}ml-dfanalytics.html`,
       dFAPrepareData: `${MACHINE_LEARNING_DOCS}ml-dfa-overview.html#prepare-transform-data`,
       dFAStartJob: `${ELASTICSEARCH_DOCS}start-dfanalytics.html`,
+      dFACreateJob: `${ELASTICSEARCH_DOCS}put-dfanalytics.html`,
       featureImportance: `${MACHINE_LEARNING_DOCS}ml-feature-importance.html`,
       outlierDetectionRoc: `${MACHINE_LEARNING_DOCS}ml-dfa-finding-outliers.html#ml-dfanalytics-roc`,
       regressionEvaluation: `${MACHINE_LEARNING_DOCS}ml-dfa-regression.html#ml-dfanalytics-regression-evaluation`,

--- a/packages/kbn-doc-links/src/get_doc_links.ts
+++ b/packages/kbn-doc-links/src/get_doc_links.ts
@@ -536,6 +536,7 @@ export const getDocLinks = ({ kibanaBranch, buildFlavor }: GetDocLinkOptions): D
       customUrls: `${MACHINE_LEARNING_DOCS}ml-configuring-url.html`,
       dataFrameAnalytics: `${MACHINE_LEARNING_DOCS}ml-dfanalytics.html`,
       dFAPrepareData: `${MACHINE_LEARNING_DOCS}ml-dfa-overview.html#prepare-transform-data`,
+      dFAStartJob: `${ELASTICSEARCH_DOCS}start-dfanalytics.html`,
       featureImportance: `${MACHINE_LEARNING_DOCS}ml-feature-importance.html`,
       outlierDetectionRoc: `${MACHINE_LEARNING_DOCS}ml-dfa-finding-outliers.html#ml-dfanalytics-roc`,
       regressionEvaluation: `${MACHINE_LEARNING_DOCS}ml-dfa-regression.html#ml-dfanalytics-regression-evaluation`,

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step.tsx
@@ -15,6 +15,7 @@ import { ANALYTICS_STEPS } from '../../page';
 
 export interface ConfigurationStepProps extends CreateAnalyticsStepProps {
   isClone: boolean;
+  sourceDataViewTitle: string;
 }
 
 export const ConfigurationStep: FC<ConfigurationStepProps> = ({

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step.tsx
@@ -25,6 +25,7 @@ export const ConfigurationStep: FC<ConfigurationStepProps> = ({
   step,
   stepActivated,
   isClone,
+  sourceDataViewTitle,
 }) => {
   const showForm = step === ANALYTICS_STEPS.CONFIGURATION;
   const showDetails = step !== ANALYTICS_STEPS.CONFIGURATION && stepActivated === true;
@@ -41,6 +42,7 @@ export const ConfigurationStep: FC<ConfigurationStepProps> = ({
           isClone={isClone}
           state={state}
           setCurrentStep={setCurrentStep}
+          sourceDataViewTitle={sourceDataViewTitle}
         />
       )}
       {showDetails && <ConfigurationStepDetails setCurrentStep={setCurrentStep} state={state} />}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
@@ -60,7 +60,7 @@ import { JobType } from './job_type';
 import { SupportedFieldsMessage } from './supported_fields_message';
 import { AnalysisFieldsTable } from './analysis_fields_table';
 import { fetchExplainData } from '../shared';
-import { useIndexData } from '../../hooks';
+import { useIndexData, useHasRequiredIndicesPermissions } from '../../hooks';
 import { ExplorationQueryBar } from '../../../analytics_exploration/components/exploration_query_bar';
 import { useSavedSearch, SavedSearchQuery } from './use_saved_search';
 import { ExplorationQueryBarProps } from '../../../analytics_exploration/components/exploration_query_bar/exploration_query_bar';
@@ -68,6 +68,7 @@ import { ExplorationQueryBarProps } from '../../../analytics_exploration/compone
 import { ScatterplotMatrix } from '../../../../../components/scatterplot_matrix';
 import { RuntimeMappings } from '../runtime_mappings';
 import { ConfigurationStepProps } from './configuration_step';
+import { IndexPermissionsCallout } from '../index_permissions_callout';
 
 const runtimeMappingKey = 'runtime_mapping';
 const notIncludedReason = 'field not in includes list';
@@ -119,6 +120,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
   isClone,
   state,
   setCurrentStep,
+  sourceDataViewTitle,
 }) => {
   const { selectedDataView, selectedSavedSearch } = useDataSource();
   const { savedSearchQuery, savedSearchQueryStr } = useSavedSearch();
@@ -141,6 +143,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
   const { setEstimatedModelMemoryLimit, setFormState } = actions;
   const { cloneJob, estimatedModelMemoryLimit, form, isJobCreated, requestMessages } = state;
   const firstUpdate = useRef<boolean>(true);
+  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions(sourceDataViewTitle);
   const {
     dependentVariable,
     includes,
@@ -583,6 +586,12 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
       <Fragment>
         <Messages messages={requestMessages} />
         <SupportedFieldsMessage jobType={jobType} />
+        {hasRequiredIndicesPermissions === false ? (
+          <>
+            <IndexPermissionsCallout indexName={sourceDataViewTitle} docsType="create" />
+            <EuiSpacer />
+          </>
+        ) : null}
         <JobType type={jobType} setFormState={setFormState} />
         {savedSearchQuery === null && (
           <EuiFormRow

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/configuration_step/configuration_step_form.tsx
@@ -60,7 +60,7 @@ import { JobType } from './job_type';
 import { SupportedFieldsMessage } from './supported_fields_message';
 import { AnalysisFieldsTable } from './analysis_fields_table';
 import { fetchExplainData } from '../shared';
-import { useIndexData, useHasRequiredIndicesPermissions } from '../../hooks';
+import { useIndexData } from '../../hooks';
 import { ExplorationQueryBar } from '../../../analytics_exploration/components/exploration_query_bar';
 import { useSavedSearch, SavedSearchQuery } from './use_saved_search';
 import { ExplorationQueryBarProps } from '../../../analytics_exploration/components/exploration_query_bar/exploration_query_bar';
@@ -143,7 +143,6 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
   const { setEstimatedModelMemoryLimit, setFormState } = actions;
   const { cloneJob, estimatedModelMemoryLimit, form, isJobCreated, requestMessages } = state;
   const firstUpdate = useRef<boolean>(true);
-  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions(sourceDataViewTitle);
   const {
     dependentVariable,
     includes,
@@ -586,12 +585,7 @@ export const ConfigurationStepForm: FC<ConfigurationStepProps> = ({
       <Fragment>
         <Messages messages={requestMessages} />
         <SupportedFieldsMessage jobType={jobType} />
-        {hasRequiredIndicesPermissions === false ? (
-          <>
-            <IndexPermissionsCallout indexName={sourceDataViewTitle} docsType="create" />
-            <EuiSpacer />
-          </>
-        ) : null}
+        <IndexPermissionsCallout indexName={sourceDataViewTitle} docsType="create" />
         <JobType type={jobType} setFormState={setFormState} />
         {savedSearchQuery === null && (
           <EuiFormRow

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
@@ -7,15 +7,7 @@
 
 import React, { FC, Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { debounce } from 'lodash';
-import {
-  EuiCallOut,
-  EuiFieldText,
-  EuiFormRow,
-  EuiLink,
-  EuiSpacer,
-  EuiSwitch,
-  EuiTextArea,
-} from '@elastic/eui';
+import { EuiFieldText, EuiFormRow, EuiSpacer, EuiSwitch, EuiTextArea } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { extractErrorMessage } from '@kbn/ml-error-utils';
 import { CreateDataViewForm } from '@kbn/ml-data-view-utils/components/create_data_view_form_row';
@@ -31,6 +23,7 @@ import { useCanCreateDataView } from '../../hooks/use_can_create_data_view';
 import { useDataViewTimeFields } from '../../hooks/use_data_view_time_fields';
 import { useHasRequiredIndicesPermissions } from '../../hooks';
 import { AdditionalSection } from './additional_section';
+import { IndexPermissionsCallout } from '../index_permissions_callout';
 
 const DEFAULT_RESULTS_FIELD = 'ml';
 
@@ -58,7 +51,6 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
   });
 
   const createIndexLink = docLinks.links.apis.createIndex;
-  const startDFAJobLink = docLinks.links.ml.dFAStartJob;
   const { setFormState } = actions;
   const { form, cloneJob, hasSwitchedToEditor, isJobCreated } = state;
   const {
@@ -172,15 +164,7 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
     <Fragment>
       {hasRequiredIndicesPermissions === false ? (
         <>
-          <EuiCallOut title="You will not be able to start the job." iconType="warning">
-            <p>
-              You can create the job but you may not be able to start it. Check out the{' '}
-              <EuiLink href={startDFAJobLink} target="_blank">
-                documentation
-              </EuiLink>{' '}
-              for more information on requirements.
-            </p>
-          </EuiCallOut>
+          <IndexPermissionsCallout indexName={destinationIndex} docsType="start" />
           <EuiSpacer />
         </>
       ) : null}

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
@@ -7,7 +7,15 @@
 
 import React, { FC, Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import { debounce } from 'lodash';
-import { EuiFieldText, EuiFormRow, EuiSpacer, EuiSwitch, EuiTextArea } from '@elastic/eui';
+import {
+  EuiCallOut,
+  EuiFieldText,
+  EuiFormRow,
+  EuiLink,
+  EuiSpacer,
+  EuiSwitch,
+  EuiTextArea,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { extractErrorMessage } from '@kbn/ml-error-utils';
 import { CreateDataViewForm } from '@kbn/ml-data-view-utils/components/create_data_view_form_row';
@@ -21,6 +29,7 @@ import { ANALYTICS_STEPS } from '../../page';
 import { ml } from '../../../../../services/ml_api_service';
 import { useCanCreateDataView } from '../../hooks/use_can_create_data_view';
 import { useDataViewTimeFields } from '../../hooks/use_data_view_time_fields';
+import { useHasRequiredIndicesPermissions } from '../../hooks';
 import { AdditionalSection } from './additional_section';
 
 const DEFAULT_RESULTS_FIELD = 'ml';
@@ -49,6 +58,7 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
   });
 
   const createIndexLink = docLinks.links.apis.createIndex;
+  const startDFAJobLink = docLinks.links.ml.dFAStartJob;
   const { setFormState } = actions;
   const { form, cloneJob, hasSwitchedToEditor, isJobCreated } = state;
   const {
@@ -156,8 +166,24 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [destIndexSameAsId, jobId]);
 
+  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions(destinationIndex);
+
   return (
     <Fragment>
+      {hasRequiredIndicesPermissions === false ? (
+        <>
+          <EuiCallOut title="You will not be able to start the job." iconType="warning">
+            <p>
+              You can create the job but you may not be able to start it. Check out the{' '}
+              <EuiLink href={startDFAJobLink} target="_blank">
+                documentation
+              </EuiLink>{' '}
+              for more information on requirements.
+            </p>
+          </EuiCallOut>
+          <EuiSpacer />
+        </>
+      ) : null}
       <EuiFormRow
         fullWidth
         label={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/details_step/details_step_form.tsx
@@ -21,7 +21,6 @@ import { ANALYTICS_STEPS } from '../../page';
 import { ml } from '../../../../../services/ml_api_service';
 import { useCanCreateDataView } from '../../hooks/use_can_create_data_view';
 import { useDataViewTimeFields } from '../../hooks/use_data_view_time_fields';
-import { useHasRequiredIndicesPermissions } from '../../hooks';
 import { AdditionalSection } from './additional_section';
 import { IndexPermissionsCallout } from '../index_permissions_callout';
 
@@ -158,16 +157,9 @@ export const DetailsStepForm: FC<CreateAnalyticsStepProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [destIndexSameAsId, jobId]);
 
-  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions(destinationIndex);
-
   return (
     <Fragment>
-      {hasRequiredIndicesPermissions === false ? (
-        <>
-          <IndexPermissionsCallout indexName={destinationIndex} docsType="start" />
-          <EuiSpacer />
-        </>
-      ) : null}
+      <IndexPermissionsCallout indexName={destinationIndex} docsType="start" />
       <EuiFormRow
         fullWidth
         label={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
@@ -6,10 +6,11 @@
  */
 
 import React, { FC } from 'react';
-import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { EuiCallOut, EuiLink, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 import { useMlKibana } from '../../../../contexts/kibana';
+import { useHasRequiredIndicesPermissions } from '../hooks';
 
 export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' | 'create' }> = ({
   indexName,
@@ -26,32 +27,43 @@ export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' 
   } = useMlKibana();
 
   const docsLink = docsType === 'start' ? dFAStartJob : dFACreateJob;
+  const hasRequiredIndicesPermissions = useHasRequiredIndicesPermissions(
+    indexName,
+    docsType === 'start'
+  );
+  // If 'hasRequiredIndicesPermissions' is undefined - the index passed to the check is an empty string
+  if (hasRequiredIndicesPermissions === undefined || hasRequiredIndicesPermissions === true) {
+    return null;
+  }
 
   return (
-    <EuiCallOut
-      title={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {
-        defaultMessage: 'Job cannot be created',
-      })}
-      iconType="warning"
-      color="warning"
-    >
-      <p>
-        <FormattedMessage
-          id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage"
-          defaultMessage="You don't have the required permissions on the {indexName} index. Refer to the {docLink} documentation for more information on requirements."
-          values={{
-            indexName,
-            docLink: (
-              <EuiLink href={docsLink} target="_blank">
-                <FormattedMessage
-                  id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage.docsLink"
-                  defaultMessage="documentation"
-                />
-              </EuiLink>
-            ),
-          }}
-        />
-      </p>
-    </EuiCallOut>
+    <>
+      <EuiCallOut
+        title={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {
+          defaultMessage: 'Job cannot be created',
+        })}
+        iconType="warning"
+        color="warning"
+      >
+        <p>
+          <FormattedMessage
+            id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage"
+            defaultMessage="You don't have the required permissions on the {indexName} index. Refer to the {docLink} documentation for more information on requirements."
+            values={{
+              indexName,
+              docLink: (
+                <EuiLink href={docsLink} target="_blank">
+                  <FormattedMessage
+                    id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage.docsLink"
+                    defaultMessage="documentation"
+                  />
+                </EuiLink>
+              ),
+            }}
+          />
+        </p>
+      </EuiCallOut>
+      <EuiSpacer />
+    </>
   );
 };

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
@@ -30,7 +30,7 @@ export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' 
   return (
     <EuiCallOut
       title={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {
-        defaultMessage: 'You will not be able to create the job',
+        defaultMessage: 'Job cannot be created',
       })}
       iconType="warning"
       color="warning"
@@ -38,7 +38,7 @@ export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' 
       <p>
         <FormattedMessage
           id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage"
-          defaultMessage="You are lacking required permissions on the {indexName} index. Check out the {docLink} documentation for more information on requirements."
+          defaultMessage="You don't have the required permissions on the {indexName} index. Refer to the {docLink} documentation for more information on requirements."
           values={{
             indexName,
             docLink: (

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
@@ -39,8 +39,8 @@ export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' 
   return (
     <>
       <EuiCallOut
-        title={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {
-          defaultMessage: 'Job cannot be created',
+        title={i18n.translate('xpack.ml.dataframe.analytics.create.permissionsCalloutTitle', {
+          defaultMessage: 'Indices permissions required',
         })}
         iconType="warning"
         color="warning"

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { FC } from 'react';
+import { EuiCallOut, EuiLink } from '@elastic/eui';
+import { FormattedMessage } from '@kbn/i18n-react';
+import { i18n } from '@kbn/i18n';
+import { useMlKibana } from '../../../../contexts/kibana';
+
+export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' | 'create' }> = ({
+  indexName,
+  docsType,
+}) => {
+  const {
+    services: {
+      docLinks: {
+        links: {
+          ml: { dFAStartJob, dFACreateJob },
+        },
+      },
+    },
+  } = useMlKibana();
+
+  const docsLink = docsType === 'start' ? dFAStartJob : dFACreateJob;
+
+  return (
+    <EuiCallOut
+      title={i18n.translate('xpack.ml.dataframe.analytics.create.jobIdLabel', {
+        defaultMessage: 'You will not be able to create the job',
+      })}
+      iconType="warning"
+      color="warning"
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage"
+          defaultMessage="You are lacking required permissions on the {indexName} index. Check out the {docLink} documentation for more information on requirements."
+          values={{
+            indexName,
+            docLink: (
+              <EuiLink href={docsLink} target="_blank">
+                <FormattedMessage
+                  id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage.docsLink"
+                  defaultMessage="documentation"
+                />
+              </EuiLink>
+            ),
+          }}
+        />
+      </p>
+    </EuiCallOut>
+  );
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/components/index_permissions_callout.tsx
@@ -48,7 +48,7 @@ export const IndexPermissionsCallout: FC<{ indexName: string; docsType: 'start' 
         <p>
           <FormattedMessage
             id="xpack.ml.dataframe.analytics.create.indicesPermissionsMessage"
-            defaultMessage="You don't have the required permissions on the {indexName} index. Refer to the {docLink} documentation for more information on requirements."
+            defaultMessage="You don't have the required permissions on the {indexName} index. Refer to the {docLink} for more information on requirements."
             values={{
               indexName,
               docLink: (

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/index.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/index.ts
@@ -6,3 +6,4 @@
  */
 
 export { useIndexData } from './use_index_data';
+export { useHasRequiredIndicesPermissions } from './use_has_index_permission';

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
@@ -39,9 +39,8 @@ export const useHasRequiredIndicesPermissions = (
 
         setHasIndexPermissions(privileges.hasPrivileges?.has_all_requested === true);
       }
-      if (hasPrivileges !== undefined) {
-        checkPrivileges();
-      }
+
+      checkPrivileges();
     },
     [hasPrivileges, indexName, isDestIndex]
   );

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useState, useEffect } from 'react';
+
+import { useMlKibana } from '../../../../contexts/kibana';
+
+export const useHasRequiredIndicesPermissions = (indexName: string) => {
+  const [hasIndexPermissions, setHasIndexPermissions] = useState<boolean>(false);
+  const {
+    services: {
+      mlServices: {
+        mlApiServices: { hasPrivileges },
+      },
+    },
+  } = useMlKibana();
+
+  useEffect(
+    function checkRequiredIndexPermissions() {
+      async function checkPrivileges() {
+        const privileges = await hasPrivileges({
+          index: [
+            {
+              names: [indexName],
+              privileges: ['create_index', 'manage', 'index', 'read'],
+            },
+          ],
+        });
+
+        setHasIndexPermissions(
+          privileges.hasPrivileges === undefined ||
+            privileges.hasPrivileges.has_all_requested === true
+        );
+      }
+      if (hasPrivileges !== undefined) {
+        checkPrivileges();
+      }
+    },
+    [hasPrivileges, indexName]
+  );
+
+  if (typeof indexName === 'string' && indexName === '') {
+    return;
+  }
+
+  return hasIndexPermissions;
+};

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/hooks/use_has_index_permission.ts
@@ -45,7 +45,7 @@ export const useHasRequiredIndicesPermissions = (
     [hasPrivileges, indexName, isDestIndex]
   );
 
-  if (typeof indexName === 'string' && indexName === '') {
+  if (indexName === '') {
     return;
   }
 

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/page.tsx
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_creation/page.tsx
@@ -103,6 +103,7 @@ export const Page: FC<Props> = ({ jobId }) => {
           setCurrentStep={setCurrentStep}
           step={currentStep}
           stepActivated={activatedSteps[ANALYTICS_STEPS.CONFIGURATION]}
+          sourceDataViewTitle={selectedDataView.getIndexPattern()}
         />
       ),
       status:
@@ -188,7 +189,7 @@ export const Page: FC<Props> = ({ jobId }) => {
                   <FormattedMessage
                     id="xpack.ml.dataframe.analytics.creationPageSourceIndexTitle"
                     defaultMessage="Source data view: {dataViewTitle}"
-                    values={{ dataViewTitle: selectedDataView.title }}
+                    values={{ dataViewTitle: selectedDataView.getIndexPattern() }}
                   />
                 </h2>
               </EuiFlexItem>

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
@@ -10,6 +10,7 @@ import { useReducer } from 'react';
 import { i18n } from '@kbn/i18n';
 
 import { extractErrorMessage } from '@kbn/ml-error-utils';
+import { extractErrorProperties } from '@kbn/ml-error-utils';
 import type { DataFrameAnalyticsConfig } from '@kbn/ml-data-frame-analytics-utils';
 
 import { useMlKibana } from '../../../../../contexts/kibana';
@@ -91,14 +92,21 @@ export const useCreateAnalyticsForm = (): CreateAnalyticsFormProps => {
     const analyticsJobConfig = (
       isAdvancedEditorEnabled ? jobConfig : getJobConfigFromFormState(form)
     ) as DataFrameAnalyticsConfig;
+    const errorMessage = i18n.translate(
+      'xpack.ml.dataframe.analytics.create.errorCreatingDataFrameAnalyticsJob',
+      {
+        defaultMessage: 'An error occurred creating the data frame analytics job:',
+      }
+    );
 
     try {
-      await ml.dataFrameAnalytics.createDataFrameAnalytics(
+      const creationResp = await ml.dataFrameAnalytics.createDataFrameAnalytics(
         jobId,
         analyticsJobConfig,
         createDataView,
         form.timeFieldName
       );
+
       addRequestMessage({
         message: i18n.translate(
           'xpack.ml.dataframe.stepCreateForm.createDataFrameAnalyticsSuccessMessage',
@@ -108,21 +116,30 @@ export const useCreateAnalyticsForm = (): CreateAnalyticsFormProps => {
           }
         ),
       });
-      setIsJobCreated(true);
-      refresh();
-      return true;
+
+      if (
+        creationResp?.dataFrameAnalyticsJobsCreated.length &&
+        creationResp?.dataFrameAnalyticsJobsErrors.length === 0
+      ) {
+        setIsJobCreated(true);
+        refresh();
+        return true;
+      } else if (creationResp?.dataFrameAnalyticsJobsErrors.length) {
+        addRequestMessage({
+          error: extractErrorProperties(creationResp?.dataFrameAnalyticsJobsErrors[0].error)
+            .message,
+          message: errorMessage,
+        });
+        return false;
+      }
     } catch (e) {
       addRequestMessage({
         error: extractErrorMessage(e),
-        message: i18n.translate(
-          'xpack.ml.dataframe.analytics.create.errorCreatingDataFrameAnalyticsJob',
-          {
-            defaultMessage: 'An error occurred creating the data frame analytics job:',
-          }
-        ),
+        message: errorMessage,
       });
       return false;
     }
+    return false;
   };
 
   const prepareFormValidation = async () => {

--- a/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
+++ b/x-pack/plugins/ml/public/application/data_frame_analytics/pages/analytics_management/hooks/use_create_analytics_form/use_create_analytics_form.ts
@@ -118,16 +118,15 @@ export const useCreateAnalyticsForm = (): CreateAnalyticsFormProps => {
       });
 
       if (
-        creationResp?.dataFrameAnalyticsJobsCreated.length &&
-        creationResp?.dataFrameAnalyticsJobsErrors.length === 0
+        creationResp.dataFrameAnalyticsJobsCreated.length &&
+        creationResp.dataFrameAnalyticsJobsErrors.length === 0
       ) {
         setIsJobCreated(true);
         refresh();
         return true;
-      } else if (creationResp?.dataFrameAnalyticsJobsErrors.length) {
+      } else if (creationResp.dataFrameAnalyticsJobsErrors.length) {
         addRequestMessage({
-          error: extractErrorProperties(creationResp?.dataFrameAnalyticsJobsErrors[0].error)
-            .message,
+          error: extractErrorProperties(creationResp.dataFrameAnalyticsJobsErrors[0].error).message,
           message: errorMessage,
         });
         return false;

--- a/x-pack/plugins/ml/public/application/services/ml_api_service/data_frame_analytics.ts
+++ b/x-pack/plugins/ml/public/application/services/ml_api_service/data_frame_analytics.ts
@@ -23,6 +23,7 @@ import { useMlKibana } from '../../contexts/kibana';
 import type { ValidateAnalyticsJobResponse } from '../../../../common/constants/validation';
 import type { DeepPartial } from '../../../../common/types/common';
 import type { JobMessage } from '../../../../common/types/audit_message';
+import type { PutDataFrameAnalyticsResponseSchema } from '../../../../server/routes/schemas/data_frame_analytics_schema';
 
 export interface GetDataFrameAnalyticsStatsResponseOk {
   node_failures?: object;
@@ -88,7 +89,7 @@ export const dataFrameAnalyticsApiProvider = (httpService: HttpService) => ({
     timeFieldName?: string
   ) {
     const body = JSON.stringify(analyticsConfig);
-    return httpService.http<any>({
+    return httpService.http<PutDataFrameAnalyticsResponseSchema>({
       path: `${ML_INTERNAL_BASE_PATH}/data_frame/analytics/${analyticsId}`,
       method: 'PUT',
       query: { createDataView, timeFieldName },


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/174125

This PR fixes the way the job creation success is checked - previously a non-error was considered a success and any returned errors were swallowed.

The job creation request returns an object containing information on whether the job was created and whether there were any errors. This returned object is now checked.

Now the job creation error is shown and job start is only attempted if creation is truly successful.

Callouts have also been added at the config and details step if there are permission issues with the selected data views. The user can continue to use the wizard and create a usable job config but they are warned that job creation will fail due to the permission issues and are directed to docs.

Configuration step when insufficient source index permission:

<img width="1698" alt="image" src="https://github.com/elastic/kibana/assets/6446462/139c6f7b-e365-4b3a-bc03-7b39a359e0a6">

Details step when insufficient destination index permission:

<img width="1716" alt="image" src="https://github.com/elastic/kibana/assets/6446462/a693b2cc-5797-4fba-9a22-2ca638c5c911">

Creation error now properly shown to user:

<img width="1388" alt="image" src="https://github.com/elastic/kibana/assets/6446462/16268af2-6054-4e5e-a5a6-d2b43d1d61ab">


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->