### PR TITLE
Change key for Select Connector component from serviceType to name

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/select_connector/select_connector.tsx
@@ -319,7 +319,7 @@ export const SelectConnector: React.FC = () => {
           <EuiSpacer size="s" />
           <EuiFlexGrid columns={3}>
             {filteredConnectors.map((connector) => (
-              <EuiFlexItem key={connector.serviceType} grow>
+              <EuiFlexItem key={connector.name} grow>
                 <ConnectorCheckable
                   showNativePopover={(!hasNativeAccess && useNativeFilter) ?? false}
                   showLicensePopover={connector.platinumOnly && !hasPlatinumLicense && !isCloud}


### PR DESCRIPTION
## Summary

Fixing a problem with Select Connector component being broken due to elements with duplicate ids.

Confluence Data Center and Jira Data Center tiles were added with duplicate service_type (by design). Because of that, the component broke, as it uses service_type as an unique key when rendering the table.

See for example this log message with an error:

```
2react-dom.development.js:67 Warning: Encountered two children with the same key, `confluence`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
```

This PR changes the unique key field from `service_type` to `name` - this way the table is rendered correctly and works as expected.

Before: 

https://github.com/elastic/kibana/assets/12238374/81da28b6-06b6-46de-80ac-ba4c529ffd97


After:

https://github.com/elastic/kibana/assets/12238374/447ad868-b296-4eef-8813-46cc65bddf7c




### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->