### PR TITLE
[Lens] [ES|QL] Fixes inline documentation in cloud

### DIFF
--- a/packages/kbn-language-documentation-popover/package.json
+++ b/packages/kbn-language-documentation-popover/package.json
@@ -3,5 +3,7 @@
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true,
-  "sideEffects": false
+  "sideEffects": [
+    "*.scss"
+  ]
 }


### PR DESCRIPTION
## Summary

In the cloud distribution the documentation popovers are not rendered correctly (ES|QL and Lens) This is because the documentation.scss file is not loaded. This happens due to the sideEffects option.

This is happening only on production mode and not on dev mode.
You can use this a la carte instance for testing or create your own https://stratoula-pr-177774-fix-documentation-in-cloud.kbndev.co/

### How to test
Open the ES|QL inline documentation or the Lens formula inline documentation,
