### PR TITLE
[8.13] [Lens] [ES|QL] Fixes inline documentation in cloud (#177774)

### DIFF
--- a/packages/kbn-language-documentation-popover/package.json
+++ b/packages/kbn-language-documentation-popover/package.json
@@ -3,5 +3,7 @@
   "version": "1.0.0",
   "license": "SSPL-1.0 OR Elastic License 2.0",
   "private": true,
-  "sideEffects": false
+  "sideEffects": [
+    "*.scss"
+  ]
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Lens] [ES|QL] Fixes inline documentation in cloud (#177774)](https://github.com/elastic/kibana/pull/177774)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Stratoula Kalafateli","email":"efstratia.kalafateli@elastic.co"},"sourceCommit":{"committedDate":"2024-02-25T12:32:45Z","message":"[Lens] [ES|QL] Fixes inline documentation in cloud (#177774)\n\n## Summary\r\n\r\nIn the cloud distribution the documentation popovers are not rendered\r\ncorrectly (ES|QL and Lens) This is because the documentation.scss file\r\nis not loaded. This happens due to the sideEffects option.\r\n\r\nThis is happening only on production mode and not on dev mode.\r\nYou can use this a la carte instance for testing or create your own\r\nhttps://stratoula-pr-177774-fix-documentation-in-cloud.kbndev.co/\r\n\r\n### How to test\r\nOpen the ES|QL inline documentation or the Lens formula inline\r\ndocumentation,","sha":"b4019a2e5c40131adf811530dddc8f6c6ac8d915","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["Team:Visualizations","release_note:skip","Feature:Lens","backport:prev-minor","Feature:ES|QL","v8.13.0","v8.14.0"],"number":177774,"url":"https://github.com/elastic/kibana/pull/177774","mergeCommit":{"message":"[Lens] [ES|QL] Fixes inline documentation in cloud (#177774)\n\n## Summary\r\n\r\nIn the cloud distribution the documentation popovers are not rendered\r\ncorrectly (ES|QL and Lens) This is because the documentation.scss file\r\nis not loaded. This happens due to the sideEffects option.\r\n\r\nThis is happening only on production mode and not on dev mode.\r\nYou can use this a la carte instance for testing or create your own\r\nhttps://stratoula-pr-177774-fix-documentation-in-cloud.kbndev.co/\r\n\r\n### How to test\r\nOpen the ES|QL inline documentation or the Lens formula inline\r\ndocumentation,","sha":"b4019a2e5c40131adf811530dddc8f6c6ac8d915"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177774","number":177774,"mergeCommit":{"message":"[Lens] [ES|QL] Fixes inline documentation in cloud (#177774)\n\n## Summary\r\n\r\nIn the cloud distribution the documentation popovers are not rendered\r\ncorrectly (ES|QL and Lens) This is because the documentation.scss file\r\nis not loaded. This happens due to the sideEffects option.\r\n\r\nThis is happening only on production mode and not on dev mode.\r\nYou can use this a la carte instance for testing or create your own\r\nhttps://stratoula-pr-177774-fix-documentation-in-cloud.kbndev.co/\r\n\r\n### How to test\r\nOpen the ES|QL inline documentation or the Lens formula inline\r\ndocumentation,","sha":"b4019a2e5c40131adf811530dddc8f6c6ac8d915"}}]}] BACKPORT-->