### PR TITLE
[ESQL] Add chart switch

### DIFF
--- a/packages/kbn-text-based-editor/src/text_based_languages_editor.styles.ts
+++ b/packages/kbn-text-based-editor/src/text_based_languages_editor.styles.ts
@@ -68,7 +68,6 @@ export const textBasedLanguagedEditorStyles = (
       transform: 'translate(0, -50%)',
     },
     bottomContainer: {
-      border: euiTheme.border.thin,
       borderLeft: editorIsInline ? 'none' : euiTheme.border.thin,
       borderRight: editorIsInline ? 'none' : euiTheme.border.thin,
       borderTop:

--- a/packages/kbn-visualization-ui-components/components/chart_switch_trigger.tsx
+++ b/packages/kbn-visualization-ui-components/components/chart_switch_trigger.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { EuiIcon, EuiText, EuiFlexGroup, EuiFlexItem, IconType } from '@elastic/eui';
 import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
+import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
 
 export const ChartSwitchTrigger = function ({
@@ -67,7 +68,7 @@ const LayerChartSwitchLabel = function ({ label, icon }: { label: string; icon?:
           css={css`
             font-weight: 600;
             display: inline;
-            padding-left: 8px;
+            padding-left: ${euiThemeVars.euiSizeS};
           `}
         >
           {label}

--- a/packages/kbn-visualization-ui-components/components/chart_switch_trigger.tsx
+++ b/packages/kbn-visualization-ui-components/components/chart_switch_trigger.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import React from 'react';
+import { EuiIcon, EuiText, EuiFlexGroup, EuiFlexItem, IconType } from '@elastic/eui';
+import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
+import { css } from '@emotion/react';
+
+export const ChartSwitchTrigger = function ({
+  label,
+  icon,
+  onClick,
+  dataTestSubj,
+  size = 's',
+}: {
+  label: string;
+  icon?: IconType;
+  onClick: () => void;
+  dataTestSubj?: string;
+  size?: 's' | 'm';
+}) {
+  return (
+    <ToolbarButton
+      data-test-subj={dataTestSubj}
+      aria-label={label}
+      onClick={onClick}
+      fullWidth
+      size={size}
+      fontWeight="bold"
+      label={
+        size === 'm' ? (
+          <ChartSwitchLabel label={label} icon={icon} />
+        ) : (
+          <LayerChartSwitchLabel label={label} icon={icon} />
+        )
+      }
+    />
+  );
+};
+
+const ChartSwitchLabel = function ({ label, icon }: { label: string; icon?: IconType }) {
+  return (
+    <>
+      {icon && <EuiIcon size="l" className="lnsChartSwitch__summaryIcon" type={icon} />}
+      <span className="lnsChartSwitch__summaryText">{label}</span>
+    </>
+  );
+};
+
+const LayerChartSwitchLabel = function ({ label, icon }: { label: string; icon?: IconType }) {
+  return (
+    <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
+      {icon && (
+        <EuiFlexItem grow={false}>
+          <EuiIcon type={icon} />
+        </EuiFlexItem>
+      )}
+
+      <EuiFlexItem grow={false}>
+        <EuiText
+          size="s"
+          css={css`
+            font-weight: 600;
+            display: inline;
+            padding-left: 8px;
+          `}
+        >
+          {label}
+        </EuiText>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+};

--- a/packages/kbn-visualization-ui-components/components/index.ts
+++ b/packages/kbn-visualization-ui-components/components/index.ts
@@ -30,6 +30,8 @@ export * from './line_style_settings';
 
 export * from './text_decoration_setting';
 
+export * from './chart_switch_trigger';
+
 export type { AccessorConfig } from './dimension_buttons';
 
 export type { FieldOptionValue, FieldOption, DataType } from './field_picker';

--- a/packages/kbn-visualization-ui-components/index.ts
+++ b/packages/kbn-visualization-ui-components/index.ts
@@ -29,6 +29,7 @@ export {
   LineStyleSettings,
   TextDecorationSetting,
   emptyTitleText,
+  ChartSwitchTrigger,
 } from './components';
 
 export { isFieldLensCompatible } from './util';

--- a/packages/kbn-visualization-ui-components/tsconfig.json
+++ b/packages/kbn-visualization-ui-components/tsconfig.json
@@ -32,6 +32,7 @@
     "@kbn/field-formats-plugin",
     "@kbn/field-utils",
     "@kbn/calculate-width-from-char-count",
-    "@kbn/visualization-utils"
+    "@kbn/visualization-utils",
+    "@kbn/shared-ux-button-toolbar"
   ],
 }

--- a/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/__snapshots__/metric_vis_function.test.ts.snap
+++ b/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/__snapshots__/metric_vis_function.test.ts.snap
@@ -104,7 +104,3 @@ Object {
 `;
 
 exports[`interpreter/functions#metric returns error if bucket and colorFullBackground specified 1`] = `"Full background coloring cannot be applied to visualizations that have a bucket specified."`;
-
-exports[`interpreter/functions#metric returns error if data includes several rows and colorFullBackground specified 1`] = `"Full background coloring cannot be applied to a visualization with multiple metrics."`;
-
-exports[`interpreter/functions#metric returns error if several metrics and colorFullBackground specified 1`] = `"Full background coloring cannot be applied to a visualization with multiple metrics."`;

--- a/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.test.ts
+++ b/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.test.ts
@@ -94,7 +94,7 @@ describe('interpreter/functions#metric', () => {
     expect(() => fn(context, args)).toThrowErrorMatchingSnapshot();
   });
 
-  it('returns error if several metrics and colorFullBackground specified', () => {
+  it('ignores colorFullBackground setting if several metrics are specified', () => {
     args.colorFullBackground = true;
     args.metric.push({
       type: 'vis_dimension',
@@ -105,13 +105,13 @@ describe('interpreter/functions#metric', () => {
       },
     });
 
-    expect(() => fn(context, args)).toThrowErrorMatchingSnapshot();
+    expect(fn(context, args).value.visConfig.metric.colorFullBackground).toBeFalsy();
   });
 
-  it('returns error if data includes several rows and colorFullBackground specified', () => {
+  it('ignores colorFullBackground if data includes several rows', () => {
     args.colorFullBackground = true;
     context.rows.push({ 'col-0-1': 0 });
 
-    expect(() => fn(context, args)).toThrowErrorMatchingSnapshot();
+    expect(fn(context, args).value.visConfig.metric.colorFullBackground).toBeFalsy();
   });
 });

--- a/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.ts
+++ b/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.ts
@@ -145,7 +145,7 @@ export const metricVisFunction = (): MetricVisExpressionFunctionDefinition => ({
       }
 
       if (args.metric.length > 1 || input.rows.length > 1) {
-        throw new Error(errors.severalMetricsAndColorFullBackgroundSpecifiedError());
+        // throw new Error(errors.severalMetricsAndColorFullBackgroundSpecifiedError());
       }
     }
 

--- a/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.ts
+++ b/src/plugins/chart_expressions/expression_legacy_metric/common/expression_functions/metric_vis_function.ts
@@ -143,10 +143,6 @@ export const metricVisFunction = (): MetricVisExpressionFunctionDefinition => ({
       if (args.bucket) {
         throw new Error(errors.splitByBucketAndColorFullBackgroundSpecifiedError());
       }
-
-      if (args.metric.length > 1 || input.rows.length > 1) {
-        // throw new Error(errors.severalMetricsAndColorFullBackgroundSpecifiedError());
-      }
     }
 
     args.metric.forEach((metric) => validateAccessor(metric, input.columns));
@@ -197,7 +193,8 @@ export const metricVisFunction = (): MetricVisExpressionFunctionDefinition => ({
                 ...args.labelFont,
               },
             },
-            colorFullBackground: args.colorFullBackground,
+            colorFullBackground:
+              args.metric.length > 1 || input.rows.length > 1 ? false : args.colorFullBackground,
             style: {
               bgColor: args.colorMode === ColorMode.Background,
               labelColor: args.colorMode === ColorMode.Labels,

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
@@ -67,16 +67,23 @@ export function LayerConfiguration({
   return (
     <div
       css={css`
-        padding: ${hasPadding ? euiTheme.size.s : 0};
+        padding-left: ${euiTheme.size.base};
+        padding-right: ${euiTheme.size.base};
       `}
     >
-      <EuiSpacer size="xs" />
-      <VisualizationToolbar
-        activeVisualization={activeVisualization}
-        framePublicAPI={framePublicAPI}
-      />
-      <EuiSpacer size="m" />
-      <ConfigPanelWrapper {...layerPanelsProps} />
+      <div
+        css={css`
+          padding: ${hasPadding ? euiTheme.size.s : 0};
+        `}
+      >
+        <EuiSpacer size="xs" />
+        <VisualizationToolbar
+          activeVisualization={activeVisualization}
+          framePublicAPI={framePublicAPI}
+        />
+        <EuiSpacer size="m" />
+        <ConfigPanelWrapper {...layerPanelsProps} />
+      </div>
     </div>
   );
 }

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/layer_configuration_section.tsx
@@ -27,6 +27,7 @@ export function LayerConfiguration({
   hasPadding,
   setIsInlineFlyoutVisible,
   getUserMessages,
+  shouldDisplayChartSwitch,
 }: LayerConfigurationProps) {
   const dispatch = useLensDispatch();
   const { euiTheme } = useEuiTheme();
@@ -57,6 +58,8 @@ export function LayerConfiguration({
     dataViews: startDependencies.dataViews,
     uiActions: startDependencies.uiActions,
     hideLayerHeader: datasourceId === 'textBased',
+    // TODO: remove this prop once we display the chart switch in Discover
+    shouldDisplayChartSwitch,
     indexPatternService,
     setIsInlineFlyoutVisible,
     getUserMessages,
@@ -67,6 +70,7 @@ export function LayerConfiguration({
         padding: ${hasPadding ? euiTheme.size.s : 0};
       `}
     >
+      <EuiSpacer size="xs" />
       <VisualizationToolbar
         activeVisualization={activeVisualization}
         framePublicAPI={framePublicAPI}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -500,7 +500,8 @@ export function LensEditConfigurationFlyout({
             >
               <>
                 <LayerConfiguration
-                  shouldDisplayChartSwitch
+                  // TODO: remove this prop once we add support for multiple layers (form-based mode)
+                  shouldDisplayChartSwitch={!!textBasedMode}
                   attributes={attributes}
                   getUserMessages={getUserMessages}
                   coreStart={coreStart}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -461,8 +461,6 @@ export function LensEditConfigurationFlyout({
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`
                 position: relative;
-                padding-left: ${euiThemeVars.euiSize};
-                padding-right: ${euiThemeVars.euiSize};
                 .euiAccordion__childWrapper {
                   flex: ${isLayerAccordionOpen ? 1 : 'none'}
                 }
@@ -470,6 +468,11 @@ export function LensEditConfigurationFlyout({
             `}
           >
             <EuiAccordion
+              css={css`
+                .euiAccordion__triggerWrapper {
+                  padding: 0 ${euiThemeVars.euiSize};
+                }
+              `}
               id="layer-configuration"
               buttonContent={
                 <EuiTitle

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -462,7 +462,6 @@ export function LensEditConfigurationFlyout({
             css={css`
                 .euiAccordion__childWrapper {
                   flex: ${isLayerAccordionOpen ? 1 : 'none'}
-                  position: relative;
                 }
               }
             `}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -461,6 +461,7 @@ export function LensEditConfigurationFlyout({
           <EuiFlexItem
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`
+                position: relative;
                 padding-left: ${euiThemeVars.euiSizeS};
                 padding-right: ${euiThemeVars.euiSizeS};
                 .euiAccordion__childWrapper {
@@ -480,8 +481,8 @@ export function LensEditConfigurationFlyout({
             `}
                 >
                   <h5>
-                    {i18n.translate('xpack.lens.config.chartConfigurationLabel', {
-                      defaultMessage: 'Chart configuration',
+                    {i18n.translate('xpack.lens.config.visualizationConfigurationLabel', {
+                      defaultMessage: 'Visualization configuration',
                     })}
                   </h5>
                 </EuiTitle>

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -13,6 +13,7 @@ import {
   EuiTitle,
   EuiAccordion,
   useEuiTheme,
+  EuiSpacer,
   EuiFlexGroup,
   EuiFlexItem,
   euiScrollBarStyles,
@@ -360,7 +361,7 @@ export function LensEditConfigurationFlyout({
         onCancel={onCancel}
         navigateToLensEditor={navigateToLensEditor}
         onApply={onApply}
-        isScrollable={true}
+        isScrollable
         isNewPanel={isNewPanel}
         isSaveable={isSaveable}
       >
@@ -372,7 +373,7 @@ export function LensEditConfigurationFlyout({
           visualizationMap={visualizationMap}
           datasourceMap={datasourceMap}
           datasourceId={datasourceId}
-          hasPadding={true}
+          hasPadding
           framePublicAPI={framePublicAPI}
           setIsInlineFlyoutVisible={setIsInlineFlyoutVisible}
         />
@@ -412,6 +413,8 @@ export function LensEditConfigurationFlyout({
               ${euiScrollBarStyles(euiTheme)}
               padding-left: ${euiThemeVars.euiFormMaxWidth};
               margin-left: -${euiThemeVars.euiFormMaxWidth};
+              padding-right: ${euiThemeVars.euiSizeXS};
+
               .euiAccordion-isOpen & {
                 block-size: auto !important;
                 flex: 1;
@@ -451,15 +454,15 @@ export function LensEditConfigurationFlyout({
                   }
                 }}
                 isDisabled={false}
-                allowQueryCancellation={true}
+                allowQueryCancellation
               />
             </EuiFlexItem>
           )}
           <EuiFlexItem
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`
-                padding-left: ${euiThemeVars.euiSize};
-                padding-right: ${euiThemeVars.euiSize};
+                padding-left: ${euiThemeVars.euiSizeS};
+                padding-right: ${euiThemeVars.euiSizeS};
                 .euiAccordion__childWrapper {
                   flex: ${isLayerAccordionOpen ? 1 : 'none'}
                 }
@@ -477,8 +480,8 @@ export function LensEditConfigurationFlyout({
             `}
                 >
                   <h5>
-                    {i18n.translate('xpack.lens.config.layerConfigurationLabel', {
-                      defaultMessage: 'Layer configuration',
+                    {i18n.translate('xpack.lens.config.chartConfigurationLabel', {
+                      defaultMessage: 'Chart configuration',
                     })}
                   </h5>
                 </EuiTitle>
@@ -495,17 +498,21 @@ export function LensEditConfigurationFlyout({
                 setIsLayerAccordionOpen(!isLayerAccordionOpen);
               }}
             >
-              <LayerConfiguration
-                attributes={attributes}
-                getUserMessages={getUserMessages}
-                coreStart={coreStart}
-                startDependencies={startDependencies}
-                visualizationMap={visualizationMap}
-                datasourceMap={datasourceMap}
-                datasourceId={datasourceId}
-                framePublicAPI={framePublicAPI}
-                setIsInlineFlyoutVisible={setIsInlineFlyoutVisible}
-              />
+              <>
+                <LayerConfiguration
+                  shouldDisplayChartSwitch
+                  attributes={attributes}
+                  getUserMessages={getUserMessages}
+                  coreStart={coreStart}
+                  startDependencies={startDependencies}
+                  visualizationMap={visualizationMap}
+                  datasourceMap={datasourceMap}
+                  datasourceId={datasourceId}
+                  framePublicAPI={framePublicAPI}
+                  setIsInlineFlyoutVisible={setIsInlineFlyoutVisible}
+                />
+                <EuiSpacer />
+              </>
             </EuiAccordion>
           </EuiFlexItem>
 
@@ -515,8 +522,8 @@ export function LensEditConfigurationFlyout({
             css={css`
                 border-top: ${euiThemeVars.euiBorderThin};
                 border-bottom: ${euiThemeVars.euiBorderThin};
-                padding-left: ${euiThemeVars.euiSize};
-                padding-right: ${euiThemeVars.euiSize};
+                padding-left: ${euiThemeVars.euiSizeS};
+                padding-right: ${euiThemeVars.euiSizeS};
                 .euiAccordion__childWrapper {
                   flex: ${isSuggestionsAccordionOpen ? 1 : 'none'}
                 }

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -460,9 +460,9 @@ export function LensEditConfigurationFlyout({
           <EuiFlexItem
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`
-                position: relative;
                 .euiAccordion__childWrapper {
                   flex: ${isLayerAccordionOpen ? 1 : 'none'}
+                  position: relative;
                 }
               }
             `}

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/lens_configuration_flyout.tsx
@@ -413,7 +413,6 @@ export function LensEditConfigurationFlyout({
               ${euiScrollBarStyles(euiTheme)}
               padding-left: ${euiThemeVars.euiFormMaxWidth};
               margin-left: -${euiThemeVars.euiFormMaxWidth};
-              padding-right: ${euiThemeVars.euiSizeXS};
 
               .euiAccordion-isOpen & {
                 block-size: auto !important;
@@ -462,8 +461,8 @@ export function LensEditConfigurationFlyout({
             grow={isLayerAccordionOpen ? 1 : false}
             css={css`
                 position: relative;
-                padding-left: ${euiThemeVars.euiSizeS};
-                padding-right: ${euiThemeVars.euiSizeS};
+                padding-left: ${euiThemeVars.euiSize};
+                padding-right: ${euiThemeVars.euiSize};
                 .euiAccordion__childWrapper {
                   flex: ${isLayerAccordionOpen ? 1 : 'none'}
                 }
@@ -524,8 +523,8 @@ export function LensEditConfigurationFlyout({
             css={css`
                 border-top: ${euiThemeVars.euiBorderThin};
                 border-bottom: ${euiThemeVars.euiBorderThin};
-                padding-left: ${euiThemeVars.euiSizeS};
-                padding-right: ${euiThemeVars.euiSizeS};
+                padding-left: ${euiThemeVars.euiSize};
+                padding-right: ${euiThemeVars.euiSize};
                 .euiAccordion__childWrapper {
                   flex: ${isSuggestionsAccordionOpen ? 1 : 'none'}
                 }

--- a/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
+++ b/x-pack/plugins/lens/public/app_plugin/shared/edit_on_the_fly/types.ts
@@ -102,4 +102,5 @@ export interface LayerConfigurationProps {
   hasPadding?: boolean;
   setIsInlineFlyoutVisible: (flag: boolean) => void;
   getUserMessages: UserMessagesGetter;
+  shouldDisplayChartSwitch?: boolean;
 }

--- a/x-pack/plugins/lens/public/datasources/form_based/datapanel.scss
+++ b/x-pack/plugins/lens/public/datasources/form_based/datapanel.scss
@@ -17,9 +17,3 @@
 .lnsChangeIndexPatternPopover__trigger {
   padding: 0 $euiSize;
 }
-
-.lnsLayerPanelChartSwitch_title {
-  font-weight: 600;
-  display: inline;
-  padding-left: 8px;
-}

--- a/x-pack/plugins/lens/public/datasources/form_based/form_based_suggestions.ts
+++ b/x-pack/plugins/lens/public/datasources/form_based/form_based_suggestions.ts
@@ -603,9 +603,12 @@ function createNewLayerWithMetricAggregation(
 
 export function getDatasourceSuggestionsFromCurrentState(
   state: FormBasedPrivateState,
-  indexPatterns: IndexPatternMap,
+  indexPatterns?: IndexPatternMap,
   filterLayers: (layerId: string) => boolean = () => true
 ): Array<DatasourceSuggestion<FormBasedPrivateState>> {
+  if (!indexPatterns) {
+    return [];
+  }
   const layers = Object.entries(state.layers || {}).filter(([layerId]) => filterLayers(layerId));
 
   if (layers.length > 1) {

--- a/x-pack/plugins/lens/public/datasources/text_based/components/dimension_editor.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/components/dimension_editor.tsx
@@ -14,6 +14,7 @@ import type { DatasourceDimensionEditorProps, DataType } from '../../../types';
 import { FieldSelect } from './field_select';
 import type { TextBasedPrivateState } from '../types';
 import { retrieveLayerColumnsFromCache, getColumnsFromCache } from '../fieldlist_cache';
+import { isNotNumeric, isNumeric } from '../utils';
 
 export type TextBasedDimensionEditorProps =
   DatasourceDimensionEditorProps<TextBasedPrivateState> & {
@@ -28,7 +29,7 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
     query
   );
   const allFields = query ? getColumnsFromCache(query) : [];
-  const hasNumberTypeColumns = allColumns?.some((c) => c?.meta?.type === 'number');
+  const hasNumberTypeColumns = allColumns?.some(isNumeric);
   const fields = allFields.map((col) => {
     return {
       id: col.id,
@@ -38,7 +39,7 @@ export function TextBasedDimensionEditor(props: TextBasedDimensionEditorProps) {
         props.isMetricDimension && hasNumberTypeColumns
           ? props.filterOperations({
               dataType: col?.meta?.type as DataType,
-              isBucketed: Boolean(col?.meta?.type !== 'number'),
+              isBucketed: Boolean(isNotNumeric(col)),
               scale: 'ordinal',
             })
           : true,

--- a/x-pack/plugins/lens/public/datasources/text_based/dnd/get_drop_props.tsx
+++ b/x-pack/plugins/lens/public/datasources/text_based/dnd/get_drop_props.tsx
@@ -10,7 +10,7 @@ import { isOperation } from '../../../types';
 import type { TextBasedPrivateState } from '../types';
 import type { GetDropPropsArgs } from '../../../types';
 import { isDraggedField, isOperationFromTheSameGroup } from '../../../utils';
-import { canColumnBeDroppedInMetricDimension } from '../utils';
+import { canColumnBeDroppedInMetricDimension, isNotNumeric } from '../utils';
 import { retrieveLayerColumnsFromCache } from '../fieldlist_cache';
 
 export const getDropProps = (
@@ -28,7 +28,7 @@ export const getDropProps = (
 
   if (isDraggedField(source)) {
     const nextLabel = source.humanData.label;
-    if (target?.isMetricDimension && sourceField?.meta?.type !== 'number') {
+    if (target?.isMetricDimension && sourceField && isNotNumeric(sourceField)) {
       return;
     }
     return {

--- a/x-pack/plugins/lens/public/datasources/text_based/utils.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/utils.ts
@@ -142,12 +142,17 @@ export function getIndexPatternFromTextBasedQuery(query: AggregateQuery): string
   return indexPattern;
 }
 
+export const isNumeric = (column: TextBasedLayerColumn | DatatableColumn) =>
+  column?.meta?.type === 'number';
+export const isNotNumeric = (column: TextBasedLayerColumn | DatatableColumn) =>
+  column?.meta?.type !== 'number';
+
 export function canColumnBeDroppedInMetricDimension(
   columns: TextBasedLayerColumn[] | DatatableColumn[],
   selectedColumnType?: string
 ): boolean {
   // check if at least one numeric field exists
-  const hasNumberTypeColumns = columns?.some((c) => c?.meta?.type === 'number');
+  const hasNumberTypeColumns = columns?.some(isNumeric);
   return !hasNumberTypeColumns || (hasNumberTypeColumns && selectedColumnType === 'number');
 }
 
@@ -156,7 +161,7 @@ export function canColumnBeUsedBeInMetricDimension(
   selectedColumnType?: string
 ): boolean {
   // check if at least one numeric field exists
-  const hasNumberTypeColumns = columns?.some((c) => c?.meta?.type === 'number');
+  const hasNumberTypeColumns = columns?.some(isNumeric);
   return (
     !hasNumberTypeColumns ||
     columns.length >= MAX_NUM_OF_COLUMNS ||

--- a/x-pack/plugins/lens/public/datasources/text_based/utils.ts
+++ b/x-pack/plugins/lens/public/datasources/text_based/utils.ts
@@ -144,8 +144,7 @@ export function getIndexPatternFromTextBasedQuery(query: AggregateQuery): string
 
 export const isNumeric = (column: TextBasedLayerColumn | DatatableColumn) =>
   column?.meta?.type === 'number';
-export const isNotNumeric = (column: TextBasedLayerColumn | DatatableColumn) =>
-  column?.meta?.type !== 'number';
+export const isNotNumeric = (column: TextBasedLayerColumn | DatatableColumn) => !isNumeric(column);
 
 export function canColumnBeDroppedInMetricDimension(
   columns: TextBasedLayerColumn[] | DatatableColumn[],

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/config_panel.tsx
@@ -275,10 +275,12 @@ export function LayerPanels(
               layerId={layerId}
               layerIndex={layerIndex}
               visualizationState={visualization.state}
+              visualizationMap={props.visualizationMap}
               updateVisualization={setVisualizationState}
               updateDatasource={updateDatasource}
               updateDatasourceAsync={updateDatasourceAsync}
               displayLayerSettings={!props.hideLayerHeader}
+              shouldDisplayChartSwitch={props.shouldDisplayChartSwitch}
               onChangeIndexPattern={(args) => {
                 onChangeIndexPattern(args);
                 const layersToRemove =

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.test.tsx
@@ -80,6 +80,9 @@ describe('LayerPanel', () => {
   function getDefaultProps() {
     return {
       layerId: 'first',
+      visualizationMap: {
+        testVis: mockVisualization,
+      },
       activeVisualization: mockVisualization,
       dimensionGroups: mockVisualization.getConfiguration({} as VisualizationConfigProps).groups,
       datasourceMap: {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_panel.tsx
@@ -61,6 +61,8 @@ export function LayerPanel(props: LayerPanelProps) {
     registerNewLayerRef,
     layerIndex,
     activeVisualization,
+    visualizationMap,
+    datasourceMap,
     updateVisualization,
     updateDatasource,
     toggleFullscreen,
@@ -71,6 +73,7 @@ export function LayerPanel(props: LayerPanelProps) {
     core,
     onDropToDimension,
     setIsInlineFlyoutVisible,
+    shouldDisplayChartSwitch,
   } = props;
 
   const isSaveable = useLensSelector((state) => state.lens.isSaveable);
@@ -375,6 +378,9 @@ export function LayerPanel(props: LayerPanelProps) {
                       }),
                   }}
                   activeVisualization={activeVisualization}
+                  visualizationMap={visualizationMap}
+                  datasourceMap={datasourceMap}
+                  shouldDisplayChartSwitch={shouldDisplayChartSwitch}
                 />
               </EuiFlexItem>
               {props.displayLayerSettings && (

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.test.tsx
@@ -8,7 +8,11 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import faker from 'faker';
-import { createMockFramePublicAPI, createMockVisualization } from '../../../mocks';
+import {
+  createMockDatasource,
+  createMockFramePublicAPI,
+  createMockVisualization,
+} from '../../../mocks';
 import { LayerSettings } from './layer_settings';
 import { renderWithReduxStore } from '../../../mocks';
 
@@ -16,6 +20,12 @@ describe('LayerSettings', () => {
   const renderLayerSettings = (propsOverrides = {}) => {
     return renderWithReduxStore(
       <LayerSettings
+        datasourceMap={{
+          testDatasource: createMockDatasource(),
+        }}
+        visualizationMap={{
+          testVis: createMockVisualization(),
+        }}
         activeVisualization={createMockVisualization()}
         layerConfigProps={{
           layerId: 'myLayer',

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/layer_settings.tsx
@@ -6,16 +6,38 @@
  */
 
 import React from 'react';
-import { Visualization, VisualizationLayerWidgetProps } from '../../../types';
+import {
+  DatasourceMap,
+  Visualization,
+  VisualizationLayerWidgetProps,
+  VisualizationMap,
+} from '../../../types';
 import { StaticHeader } from '../../../shared_components';
+import { ChartSwitch } from '../workspace_panel/chart_switch';
 
 export function LayerSettings({
   activeVisualization,
   layerConfigProps,
+  visualizationMap,
+  datasourceMap,
+  shouldDisplayChartSwitch,
 }: {
+  visualizationMap: VisualizationMap;
+  datasourceMap: DatasourceMap;
   activeVisualization: Visualization;
   layerConfigProps: VisualizationLayerWidgetProps;
+  shouldDisplayChartSwitch?: boolean;
 }) {
+  if (shouldDisplayChartSwitch) {
+    return (
+      <ChartSwitch
+        datasourceMap={datasourceMap}
+        visualizationMap={visualizationMap}
+        framePublicAPI={layerConfigProps.frame}
+        size="s"
+      />
+    );
+  }
   if (!activeVisualization.LayerHeaderComponent) {
     const description = activeVisualization.getDescription(layerConfigProps.state);
     return <StaticHeader label={description.label} icon={description.icon} />;

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/config_panel/types.ts
@@ -35,11 +35,13 @@ export interface ConfigPanelWrapperProps {
   getUserMessages?: UserMessagesGetter;
   hideLayerHeader?: boolean;
   setIsInlineFlyoutVisible?: (status: boolean) => void;
+  shouldDisplayChartSwitch?: boolean;
 }
 
 export interface LayerPanelProps {
   visualizationState: unknown;
   datasourceMap: DatasourceMap;
+  visualizationMap: VisualizationMap;
   framePublicAPI: FramePublicAPI;
   core: DatasourceDimensionEditorProps['core'];
   activeVisualization: Visualization;
@@ -82,6 +84,7 @@ export interface LayerPanelProps {
   getUserMessages?: UserMessagesGetter;
   displayLayerSettings: boolean;
   setIsInlineFlyoutVisible?: (status: boolean) => void;
+  shouldDisplayChartSwitch?: boolean;
 }
 
 export interface LayerDatasourceDropProps {

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.test.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.test.tsx
@@ -64,6 +64,7 @@ describe('chart_switch', () => {
    *  - Never switches to subvisC2
    *  - Allows a switch to subvisC3
    *  - Allows a switch to subvisC1
+   * visD: is not visible because hideFromChartSwitch returns true
    */
   function mockVisualizationMap() {
     return {
@@ -113,6 +114,10 @@ describe('chart_switch', () => {
             },
           ];
         }),
+      },
+      visD: {
+        ...generateVisualization('visD'),
+        hideFromChartSwitch: () => true,
       },
     };
   }
@@ -545,7 +550,7 @@ describe('chart_switch', () => {
     });
   });
 
-  it('should show all visualization types', async () => {
+  it('should show all visualization types and subtypes except from one that are hidden (D)', async () => {
     const { openChartSwitch, getMenuItem } = renderChartSwitch();
     openChartSwitch();
     const allDisplayed = ['visA', 'visB', 'subvisC1', 'subvisC2', 'subvisC3'].every((subType) =>

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -384,9 +384,13 @@ export const ChartSwitch = memo(function ChartSwitch({
     ]
   );
 
-  const { icon, label } = visualizationMap[visualization.activeId || ''].getDescription(
-    visualization.state
-  );
+  const { icon, label } = (visualization.activeId &&
+    visualizationMap[visualization.activeId]?.getDescription(visualization.state)) || {
+    label: i18n.translate('xpack.lens.configPanel.selectVisualization', {
+      defaultMessage: 'Select a visualization',
+    }),
+    icon: undefined,
+  };
 
   return (
     <div className="lnsChartSwitch__header">

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -95,7 +95,7 @@ function getCurrentVisualizationId(
 
 export const ChartSwitch = memo(function ChartSwitch({
   framePublicAPI,
-  visualizationMap,
+  visualizationMap: completeVisualizationMap,
   datasourceMap,
   size = 'm',
 }: ChartSwitchProps) {
@@ -104,6 +104,13 @@ export const ChartSwitch = memo(function ChartSwitch({
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
   const visualization = useLensSelector(selectVisualization);
   const datasourceStates = useLensSelector(selectDatasourceStates);
+
+  const visualizationMap = { ...completeVisualizationMap };
+  Object.keys(visualizationMap).forEach((key) => {
+    if (completeVisualizationMap[key]?.hideFromChartSwitch?.(framePublicAPI)) {
+      delete visualizationMap[key];
+    }
+  });
 
   const commitSelection = (selection: VisualizationSelection) => {
     setFlyoutOpen(false);

--- a/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
+++ b/x-pack/plugins/lens/public/editor_frame_service/editor_frame/workspace_panel/chart_switch.tsx
@@ -20,7 +20,7 @@ import {
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
+import { ChartSwitchTrigger } from '@kbn/visualization-ui-components';
 import {
   Visualization,
   FramePublicAPI,
@@ -59,43 +59,10 @@ export interface ChartSwitchProps {
   framePublicAPI: FramePublicAPI;
   visualizationMap: VisualizationMap;
   datasourceMap: DatasourceMap;
+  size?: 's' | 'm';
 }
 
 type SelectableEntry = EuiSelectableOption<{ value: string }>;
-
-function VisualizationSummary({
-  visualizationMap,
-  visualization,
-}: {
-  visualizationMap: VisualizationMap;
-  visualization: {
-    activeId: string | null;
-    state: unknown;
-  };
-}) {
-  const activeVisualization = visualizationMap[visualization.activeId || ''];
-
-  if (!activeVisualization) {
-    return (
-      <>
-        {i18n.translate('xpack.lens.configPanel.selectVisualization', {
-          defaultMessage: 'Select a visualization',
-        })}
-      </>
-    );
-  }
-
-  const description = activeVisualization.getDescription(visualization.state);
-
-  return (
-    <>
-      {description.icon && (
-        <EuiIcon size="l" className="lnsChartSwitch__summaryIcon" type={description.icon} />
-      )}
-      <span className="lnsChartSwitch__summaryText">{description.label}</span>
-    </>
-  );
-}
 
 const MAX_LIST_HEIGHT = 380;
 const ENTRY_HEIGHT = 32;
@@ -126,7 +93,12 @@ function getCurrentVisualizationId(
   );
 }
 
-export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
+export const ChartSwitch = memo(function ChartSwitch({
+  framePublicAPI,
+  visualizationMap,
+  datasourceMap,
+  size = 'm',
+}: ChartSwitchProps) {
   const [flyoutOpen, setFlyoutOpen] = useState<boolean>(false);
   const dispatchLens = useLensDispatch();
   const activeDatasourceId = useLensSelector(selectActiveDatasourceId);
@@ -152,7 +124,7 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
       dispatchLens(
         removeLayers({
           visualizationId: visualization.activeId,
-          layerIds: Object.keys(props.framePublicAPI.datasourceLayers),
+          layerIds: Object.keys(framePublicAPI.datasourceLayers),
         })
       );
     }
@@ -162,17 +134,17 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
     visualizationId: string,
     subVisualizationId: string
   ): VisualizationSelection {
-    const newVisualization = props.visualizationMap[visualizationId];
+    const newVisualization = visualizationMap[visualizationId];
     const switchVisType = (type: string, state: unknown) => {
-      if (props.visualizationMap[visualizationId].switchVisualizationType) {
+      if (visualizationMap[visualizationId].switchVisualizationType) {
         return safeFnCall(
-          () => props.visualizationMap[visualizationId].switchVisualizationType!(type, state),
+          () => visualizationMap[visualizationId].switchVisualizationType!(type, state),
           state
         );
       }
       return state;
     };
-    const layers = Object.entries(props.framePublicAPI.datasourceLayers);
+    const layers = Object.entries(framePublicAPI.datasourceLayers);
     const containsData = layers.some(
       ([_layerId, datasource]) => datasource && datasource.getTableSpec().length > 0
     );
@@ -189,14 +161,16 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
         visualizationId,
         subVisualizationId,
         dataLoss: 'nothing',
-        keptLayerIds: Object.keys(props.framePublicAPI.datasourceLayers),
+        keptLayerIds: Object.keys(framePublicAPI.datasourceLayers),
         getVisualizationState: () => switchVisType(subVisualizationId, visualization.state),
         sameDatasources: true,
       };
     }
 
     const topSuggestion = getTopSuggestion(
-      props,
+      visualizationMap,
+      datasourceMap,
+      framePublicAPI,
       visualizationId,
       datasourceStates,
       visualization,
@@ -245,11 +219,8 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
               newVisualization.initialize(
                 addNewLayer,
                 visualization.activeId === newVisualization.id ? visualization.state : undefined,
-                visualization.activeId &&
-                  props.visualizationMap[visualization.activeId].getMainPalette
-                  ? props.visualizationMap[visualization.activeId].getMainPalette!(
-                      visualization.state
-                    )
+                visualization.activeId && visualizationMap[visualization.activeId].getMainPalette
+                  ? visualizationMap[visualization.activeId].getMainPalette!(visualization.state)
                   : undefined
               )
             ),
@@ -268,11 +239,8 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
         return { visualizationTypes: [], visualizationsLookup: {} };
       }
       const subVisualizationId =
-        visualization.activeId && props.visualizationMap[visualization.activeId]
-          ? getCurrentVisualizationId(
-              props.visualizationMap[visualization.activeId],
-              visualization.state
-            )
+        visualization.activeId && visualizationMap[visualization.activeId]
+          ? getCurrentVisualizationId(visualizationMap[visualization.activeId], visualization.state)
           : undefined;
       const lowercasedSearchTerm = searchTerm.toLowerCase();
       // reorganize visualizations in groups
@@ -296,7 +264,7 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
           selection: VisualizationSelection;
         }
       > = {};
-      Object.entries(props.visualizationMap).forEach(([visualizationId, v]) => {
+      Object.entries(visualizationMap).forEach(([visualizationId, v]) => {
         for (const visualizationType of v.visualizationTypes) {
           const isSearchMatch =
             visualizationType.label.toLowerCase().includes(lowercasedSearchTerm) ||
@@ -408,12 +376,16 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       flyoutOpen,
-      props.visualizationMap,
-      props.framePublicAPI,
+      visualizationMap,
+      framePublicAPI,
       visualization.activeId,
       visualization.state,
       searchTerm,
     ]
+  );
+
+  const { icon, label } = visualizationMap[visualization.activeId || ''].getDescription(
+    visualization.state
   );
 
   return (
@@ -425,16 +397,12 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
         panelClassName="lnsChartSwitch__popoverPanel"
         panelPaddingSize="s"
         button={
-          <ToolbarButton
+          <ChartSwitchTrigger
+            size={size}
+            icon={icon}
+            label={label}
+            dataTestSubj="lnsChartSwitchPopover"
             onClick={() => setFlyoutOpen(!flyoutOpen)}
-            data-test-subj="lnsChartSwitchPopover"
-            fontWeight="bold"
-            label={
-              <VisualizationSummary
-                visualization={visualization}
-                visualizationMap={props.visualizationMap}
-              />
-            }
           />
         }
         isOpen={flyoutOpen}
@@ -494,7 +462,9 @@ export const ChartSwitch = memo(function ChartSwitch(props: ChartSwitchProps) {
 });
 
 function getTopSuggestion(
-  props: ChartSwitchProps,
+  visualizationMap: VisualizationMap,
+  datasourceMap: DatasourceMap,
+  framePublicAPI: FramePublicAPI,
   visualizationId: string,
   datasourceStates: DatasourceStates,
   visualization: VisualizationState,
@@ -503,23 +473,23 @@ function getTopSuggestion(
 ): Suggestion | undefined {
   const mainPalette =
     visualization.activeId &&
-    props.visualizationMap[visualization.activeId] &&
-    props.visualizationMap[visualization.activeId].getMainPalette
-      ? props.visualizationMap[visualization.activeId].getMainPalette!(visualization.state)
+    visualizationMap[visualization.activeId] &&
+    visualizationMap[visualization.activeId].getMainPalette
+      ? visualizationMap[visualization.activeId].getMainPalette!(visualization.state)
       : undefined;
 
   const unfilteredSuggestions = getSuggestions({
-    datasourceMap: props.datasourceMap,
+    datasourceMap,
     datasourceStates,
     visualizationMap: { [visualizationId]: newVisualization },
     activeVisualization: visualization.activeId
-      ? props.visualizationMap[visualization.activeId]
+      ? visualizationMap[visualization.activeId]
       : undefined,
     visualizationState: visualization.state,
     subVisualizationId,
-    activeData: props.framePublicAPI.activeData,
+    activeData: framePublicAPI.activeData,
     mainPalette,
-    dataViews: props.framePublicAPI.dataViews,
+    dataViews: framePublicAPI.dataViews,
   });
   const suggestions = unfilteredSuggestions.filter((suggestion) => {
     // don't use extended versions of current data table on switching between visualizations

--- a/x-pack/plugins/lens/public/embeddable/embeddable.tsx
+++ b/x-pack/plugins/lens/public/embeddable/embeddable.tsx
@@ -885,7 +885,7 @@ export class Embeddable
           navigateToLensEditor={
             !this.isTextBasedLanguage() ? this.navigateToLensEditor.bind(this) : undefined
           }
-          displayFlyoutHeader={true}
+          displayFlyoutHeader
           canEditTextBasedQuery={this.isTextBasedLanguage()}
           isNewPanel={isNewPanel}
           deletePanel={deletePanel}

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -1071,6 +1071,8 @@ export interface Visualization<T = unknown, P = T, ExtraAppendLayerArg = unknown
    * the active subtype of the visualization.
    */
   getVisualizationTypeId: (state: T) => string;
+
+  hideFromChartSwitch?: (frame: FramePublicAPI) => boolean;
   /**
    * If the visualization has subtypes, update the subtype in state.
    */

--- a/x-pack/plugins/lens/public/types.ts
+++ b/x-pack/plugins/lens/public/types.ts
@@ -442,7 +442,7 @@ export interface Datasource<T = unknown, P = unknown> {
   ) => Array<DatasourceSuggestion<T>>;
   getDatasourceSuggestionsFromCurrentState: (
     state: T,
-    indexPatterns: IndexPatternMap,
+    indexPatterns?: IndexPatternMap,
     filterFn?: (layerId: string) => boolean,
     activeData?: Record<string, Datatable>
   ) => Array<DatasourceSuggestion<T>>;

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.test.ts
@@ -135,7 +135,7 @@ describe('metric_suggestions', () => {
     expect(suggestion).toHaveLength(0);
   });
 
-  test('does not suggest for text based languages', () => {
+  test('suggests for text based languages', () => {
     const col = {
       columnId: 'id',
       operation: {
@@ -155,7 +155,7 @@ describe('metric_suggestions', () => {
       datasourceId: 'textBased',
     });
 
-    expect(suggestion).toHaveLength(0);
+    expect(suggestion).toHaveLength(1);
   });
   test('suggests a basic metric chart', () => {
     const [suggestion, ...rest] = getSuggestions({

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.test.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.test.ts
@@ -171,6 +171,7 @@ describe('metric_suggestions', () => {
     expect(rest).toHaveLength(0);
     expect(suggestion).toMatchInlineSnapshot(`
       Object {
+        "hide": false,
         "previewIcon": [Function],
         "score": 0.1,
         "state": Object {
@@ -206,6 +207,7 @@ describe('metric_suggestions', () => {
     expect(rest).toHaveLength(0);
     expect(suggestion).toMatchInlineSnapshot(`
       Object {
+        "hide": false,
         "previewIcon": [Function],
         "score": 0.1,
         "state": Object {

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
@@ -40,11 +40,6 @@ export function getSuggestions({
     return [];
   }
 
-  // do not return the legacy metric vis for the textbased mode (i.e. ES|QL)
-  if (datasourceId === 'textBased') {
-    return [];
-  }
-
   return [getSuggestion(table)];
 }
 

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
@@ -40,16 +40,19 @@ export function getSuggestions({
     return [];
   }
 
-  return [getSuggestion(table)];
+  return [getSuggestion(table, datasourceId)];
 }
 
-function getSuggestion(table: TableSuggestion): VisualizationSuggestion<LegacyMetricState> {
+function getSuggestion(
+  table: TableSuggestion,
+  datasourceId?: string
+): VisualizationSuggestion<LegacyMetricState> {
   const col = table.columns[0];
   const title = table.label || col.operation.label;
 
   return {
     title,
-    score: 0.1,
+    score: datasourceId === 'textBased' ? 0 : 0.1,
     previewIcon: IconChartMetric,
     state: {
       layerId: table.layerId,

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/metric_suggestions.ts
@@ -52,7 +52,8 @@ function getSuggestion(
 
   return {
     title,
-    score: datasourceId === 'textBased' ? 0 : 0.1,
+    hide: datasourceId === 'textBased',
+    score: 0.1,
     previewIcon: IconChartMetric,
     state: {
       layerId: table.layerId,

--- a/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
+++ b/x-pack/plugins/lens/public/visualizations/legacy_metric/visualization.tsx
@@ -23,7 +23,7 @@ import {
 import { ExpressionFunctionVisDimension } from '@kbn/visualizations-plugin/common';
 import type { MetricVisExpressionFunctionDefinition } from '@kbn/expression-legacy-metric-vis-plugin/common';
 import { getSuggestions } from './metric_suggestions';
-import { Visualization, OperationMetadata, DatasourceLayers } from '../../types';
+import { Visualization, OperationMetadata, DatasourceLayers, FramePublicAPI } from '../../types';
 import type { LegacyMetricState } from '../../../common/types';
 import { MetricDimensionEditor } from './dimension_editor';
 import { MetricToolbar } from './metric_config_panel';
@@ -169,6 +169,11 @@ export const getLegacyMetricVisualization = ({
       }),
     },
   ],
+  hideFromChartSwitch(frame: FramePublicAPI) {
+    return Object.values(frame.datasourceLayers).some(
+      (datasource) => datasource && datasource.datasourceId === 'textBased'
+    );
+  },
 
   getVisualizationTypeId() {
     return 'lnsLegacyMetric';

--- a/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/layer_header.tsx
+++ b/x-pack/plugins/lens/public/visualizations/xy/xy_config_panel/layer_header.tsx
@@ -11,14 +11,11 @@ import {
   EuiIcon,
   EuiPopover,
   EuiSelectable,
-  EuiText,
   EuiPopoverTitle,
   useEuiTheme,
   EuiIconTip,
-  EuiFlexGroup,
-  EuiFlexItem,
 } from '@elastic/eui';
-import { ToolbarButton } from '@kbn/shared-ux-button-toolbar';
+import { ChartSwitchTrigger } from '@kbn/visualization-ui-components';
 import { IconChartBarReferenceLine, IconChartBarAnnotations } from '@kbn/chart-icons';
 import { euiThemeVars } from '@kbn/ui-theme';
 import { css } from '@emotion/react';
@@ -26,7 +23,6 @@ import { getIgnoreGlobalFilterIcon } from '../../../shared_components/ignore_glo
 import type {
   VisualizationLayerHeaderContentProps,
   VisualizationLayerWidgetProps,
-  VisualizationType,
 } from '../../../types';
 import { State, visualizationTypes, SeriesType, XYAnnotationLayerConfig } from '../types';
 import {
@@ -171,9 +167,11 @@ function DataLayerHeader(props: VisualizationLayerWidgetProps<State>) {
   return (
     <EuiPopover
       button={
-        <DataLayerHeaderTrigger
+        <ChartSwitchTrigger
+          label={currentVisType.fullLabel || currentVisType.label}
+          icon={currentVisType.icon}
+          dataTestSubj="lns_layer_settings"
           onClick={() => setPopoverIsOpen(!isPopoverOpen)}
-          currentVisType={currentVisType}
         />
       }
       isOpen={isPopoverOpen}
@@ -225,33 +223,3 @@ function DataLayerHeader(props: VisualizationLayerWidgetProps<State>) {
     </EuiPopover>
   );
 }
-
-const DataLayerHeaderTrigger = function ({
-  currentVisType,
-  onClick,
-}: {
-  currentVisType: VisualizationType;
-  onClick: () => void;
-}) {
-  return (
-    <ToolbarButton
-      data-test-subj="lns_layer_settings"
-      aria-label={currentVisType.fullLabel || currentVisType.label}
-      onClick={onClick}
-      fullWidth
-      size="s"
-      label={
-        <EuiFlexGroup gutterSize="none" alignItems="center" responsive={false}>
-          <EuiFlexItem grow={false}>
-            <EuiIcon type={currentVisType.icon} />
-          </EuiFlexItem>
-          <EuiFlexItem grow={false}>
-            <EuiText size="s" className="lnsLayerPanelChartSwitch_title">
-              {currentVisType.fullLabel || currentVisType.label}
-            </EuiText>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      }
-    />
-  );
-};


### PR DESCRIPTION
## Summary

Solves the first part of https://github.com/elastic/kibana/issues/173222


Adds chart switcher to ESQL inline Lens editor only (only on Dashbaord):
<img width="303" alt="Screenshot 2024-02-26 at 13 19 41" src="https://github.com/elastic/kibana/assets/4283304/14f958ed-7c5e-4641-82e0-2638654219a7">
<img width="350" alt="Screenshot 2024-02-26 at 13 19 46" src="https://github.com/elastic/kibana/assets/4283304/2f2c1ae8-ead1-4535-9a72-7264a780a9c9">

### Very slight design (paddings) changes
<img width="698" alt="Screenshot 2024-02-26 at 13 46 39" src="https://github.com/elastic/kibana/assets/4283304/2f75403f-5d8e-4d5b-8ea5-df44e09be16a">

Added padding to not cut the icon buttons when hovered:
<img width="810" alt="Screenshot 2024-02-26 at 13 56 02" src="https://github.com/elastic/kibana/assets/4283304/fbfccbf7-0305-40c2-86ff-7fa148408320">


