### PR TITLE
[Ops] Run SLO check per slice in production quality gate

### DIFF
--- a/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
+++ b/.buildkite/pipelines/quality-gates/pipeline.tests-production.yaml
@@ -13,6 +13,7 @@ steps:
         CHECK_SLO_TAG: kibana
         CHECK_SLO_WAITING_PERIOD: 15m
         CHECK_SLO_BURN_RATE_THRESHOLD: 0.1
+        CHECK_SLO_OF_SLICE: true
     soft_fail: true
 
   - label: ":rocket: control-plane e2e tests"


### PR DESCRIPTION
I'm not sure if this will work as is, since [the documentation](https://github.com/elastic/serverless-quality-gates?tab=readme-ov-file#slos-error-budget-check_slo) states that:

> Per default, the gate will check all *correctly tagged* SLOs in the production overview cluster. 

What _correctly tagged_ means needs to be discussed with ProdEng

cc @elastic/kibana-core 