### PR TITLE
[SLO] Prevent users from picking date fields for the group-by selector

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/pages/slo_edit/components/common/group_by_field.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/slo_edit/components/common/group_by_field.tsx
@@ -20,7 +20,8 @@ import { getGroupKeysProse } from '../../../../utils/slo/groupings';
 export function GroupByField({ dataView, isLoading }: { dataView?: DataView; isLoading: boolean }) {
   const { watch } = useFormContext<CreateSLOForm>();
 
-  const groupByFields = dataView?.fields?.filter((field) => field.aggregatable) ?? [];
+  const groupByFields =
+    dataView?.fields?.filter((field) => field.aggregatable && field.type !== 'date') ?? [];
   const index = watch('indicator.params.index');
   const timestampField = watch('indicator.params.timestampField');
   const groupByField = watch('groupBy');


### PR DESCRIPTION
## Summary

This PR prevents users from picking a date field for the group by selector. 

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->