### PR TITLE
[maps] fix Request-URI Too Long (414) with heatmap layer when data view has larger number of date fields

### DIFF
--- a/x-pack/plugins/maps/common/mvt_request_body.ts
+++ b/x-pack/plugins/maps/common/mvt_request_body.ts
@@ -53,7 +53,6 @@ export function getAggsTileRequest({
       grid_agg: renderAs === RENDER_AS.HEX ? 'geohex' : 'geotile',
       grid_type: renderAs === RENDER_AS.GRID || renderAs === RENDER_AS.HEX ? 'grid' : 'centroid',
       aggs: requestBody.aggs,
-      fields: requestBody.fields ? requestBody.fields : [],
       runtime_mappings: requestBody.runtime_mappings,
       with_labels: hasLabels,
     } as SearchMvtRequest['body'],

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.test.ts
@@ -37,7 +37,11 @@ export class MockSearchSource {
   setField = jest.fn();
   setParent() {}
   getSearchRequestBody() {
-    return { scripted_fields: 'shouldNotGetAddedToTileUrl', fields: this.setField.mock.calls };
+    return {
+      aggs: {},
+      scripted_fields: 'shouldNotGetAddedToTileUrl',
+      fields: this.setField.mock.calls
+    };
   }
 }
 
@@ -330,8 +334,7 @@ describe('ESGeoGridSource', () => {
         hasLabels: 'false',
         index: 'foo-*',
         renderAs: 'heatmap',
-        requestBody:
-          "(fields:('0':('0':index,'1':(fields:())),'1':('0':size,'1':0),'2':('0':filter,'1':!()),'3':('0':query),'4':('0':index,'1':(fields:())),'5':('0':query,'1':(language:KQL,query:'')),'6':('0':aggs,'1':()),'7':('0':filter,'1':!((meta:(),query:(exists:(field:bar)))))))",
+        requestBody: '(aggs:())',
         token: '1234',
       });
     });

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.test.ts
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.test.ts
@@ -40,7 +40,7 @@ export class MockSearchSource {
     return {
       aggs: {},
       scripted_fields: 'shouldNotGetAddedToTileUrl',
-      fields: this.setField.mock.calls
+      fields: this.setField.mock.calls,
     };
   }
 }

--- a/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
+++ b/x-pack/plugins/maps/public/classes/sources/es_geo_grid_source/es_geo_grid_source.tsx
@@ -572,7 +572,6 @@ export class ESGeoGridSource extends AbstractESAggSource implements IMvtVectorSo
       buffer,
       requestBody: _.pick(searchSource.getSearchRequestBody(), [
         'aggs',
-        'fields',
         'query',
         'runtime_mappings',
       ]),

--- a/x-pack/plugins/maps/public/inspector/vector_tile_adapter/components/get_tile_request.test.ts
+++ b/x-pack/plugins/maps/public/inspector/vector_tile_adapter/components/get_tile_request.test.ts
@@ -11,7 +11,7 @@ test('Should return elasticsearch vector tile request for aggs tiles', () => {
   expect(
     getTileRequest({
       layerId: '1',
-      tileUrl: `/pof/internal/maps/mvt/getGridTile/{z}/{x}/{y}.pbf?geometryFieldName=geo.coordinates&hasLabels=false&buffer=7&index=kibana_sample_data_logs&gridPrecision=8&requestBody=(_source%3A(excludes%3A!())%2Caggs%3A()%2Cfields%3A!((field%3A'%40timestamp'%2Cformat%3Adate_time)%2C(field%3Atimestamp%2Cformat%3Adate_time)%2C(field%3Autc_time%2Cformat%3Adate_time))%2Cquery%3A(bool%3A(filter%3A!((match_phrase%3A(machine.os.keyword%3Aios))%2C(range%3A(timestamp%3A(format%3Astrict_date_optional_time%2Cgte%3A'2022-04-22T16%3A46%3A00.744Z'%2Clte%3A'2022-04-29T16%3A46%3A05.345Z'))))%2Cmust%3A!()%2Cmust_not%3A!()%2Cshould%3A!()))%2Cruntime_mappings%3A(hour_of_day%3A(script%3A(source%3A'emit(doc%5B!'timestamp!'%5D.value.getHour())%3B')%2Ctype%3Along))%2Cscript_fields%3A()%2Csize%3A0%2Cstored_fields%3A!('*'))&renderAs=heatmap&token=e8bff005-ccea-464a-ae56-2061b4f8ce68`,
+      tileUrl: `/pof/internal/maps/mvt/getGridTile/{z}/{x}/{y}.pbf?geometryFieldName=geo.coordinates&hasLabels=false&buffer=7&index=kibana_sample_data_logs&gridPrecision=8&requestBody=(_source%3A(excludes%3A!())%2Caggs%3A()%2Cquery%3A(bool%3A(filter%3A!((match_phrase%3A(machine.os.keyword%3Aios))%2C(range%3A(timestamp%3A(format%3Astrict_date_optional_time%2Cgte%3A'2022-04-22T16%3A46%3A00.744Z'%2Clte%3A'2022-04-29T16%3A46%3A05.345Z'))))%2Cmust%3A!()%2Cmust_not%3A!()%2Cshould%3A!()))%2Cruntime_mappings%3A(hour_of_day%3A(script%3A(source%3A'emit(doc%5B!'timestamp!'%5D.value.getHour())%3B')%2Ctype%3Along))%2Cscript_fields%3A()%2Csize%3A0%2Cstored_fields%3A!('*'))&renderAs=heatmap&token=e8bff005-ccea-464a-ae56-2061b4f8ce68`,
       x: 3,
       y: 0,
       z: 2,
@@ -50,20 +50,6 @@ test('Should return elasticsearch vector tile request for aggs tiles', () => {
       grid_agg: 'geotile',
       grid_type: 'centroid',
       aggs: {},
-      fields: [
-        {
-          field: '@timestamp',
-          format: 'date_time',
-        },
-        {
-          field: 'timestamp',
-          format: 'date_time',
-        },
-        {
-          field: 'utc_time',
-          format: 'date_time',
-        },
-      ],
       runtime_mappings: {
         hour_of_day: {
           script: {

--- a/x-pack/test/functional/apps/maps/group4/mvt_geotile_grid.js
+++ b/x-pack/test/functional/apps/maps/group4/mvt_geotile_grid.js
@@ -53,7 +53,7 @@ export default function ({ getPageObjects, getService }) {
         index: 'logstash-*',
         gridPrecision: '8',
         renderAs: 'grid',
-        requestBody: `(aggs:(max_of_bytes:(max:(field:bytes))),fields:!((field:'@timestamp',format:date_time),(field:'relatedContent.article:modified_time',format:date_time),(field:'relatedContent.article:published_time',format:date_time),(field:utc_time,format:date_time)),query:(bool:(filter:!((range:('@timestamp':(format:strict_date_optional_time,gte:'2015-09-20T00:00:00.000Z',lte:'2015-09-20T01:00:00.000Z'))),(exists:(field:geo.coordinates))),must:!(),must_not:!(),should:!())),runtime_mappings:())`,
+        requestBody: `(aggs:(max_of_bytes:(max:(field:bytes))),query:(bool:(filter:!((range:('@timestamp':(format:strict_date_optional_time,gte:'2015-09-20T00:00:00.000Z',lte:'2015-09-20T01:00:00.000Z'))),(exists:(field:geo.coordinates))),must:!(),must_not:!(),should:!())),runtime_mappings:())`,
       });
 
       //Should correctly load meta for style-rule (sigma is set to 1, opacity to 1)


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/177899

EsGeoGridSource includes fields in tile URL. This can result in a 414 error where the URL is too long when the data view contains lots of date fields. 

The problem is resolved by removing `fields` from the tile url. Fields are not needed from [vector tile API](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-vector-tile-api.html) since EsGeoGridSource only requests `aggs` and `fields` only applies to `hits`.
<img width="300" alt="Screenshot 2024-03-02 at 6 45 19 AM" src="https://github.com/elastic/kibana/assets/373691/4804882d-59d1-4bff-a636-aa8934707916">




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->