### PR TITLE
(DOC+) Link Kibana Health Troubleshooting blog to related doc

### DIFF
--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -64,4 +64,4 @@ For example:
 * When {kib} is unable to connect to a healthy {es} cluster, errors like `master_not_discovered_exception` or `unable to revive connection` or `license is not available` errors appear.
 * When one or more {kib}-backing indices are unhealthy, the `index_not_green_timeout` error appears.
 
-Kindly also reference our https://www.elastic.co/blog/troubleshooting-kibana-health[walkthrough on troubleshooting Kibana Health].
+For more information, refer to our https://www.elastic.co/blog/troubleshooting-kibana-health[walkthrough on troubleshooting Kibana Health].

--- a/docs/setup/access.asciidoc
+++ b/docs/setup/access.asciidoc
@@ -63,3 +63,5 @@ For example:
 
 * When {kib} is unable to connect to a healthy {es} cluster, errors like `master_not_discovered_exception` or `unable to revive connection` or `license is not available` errors appear.
 * When one or more {kib}-backing indices are unhealthy, the `index_not_green_timeout` error appears.
+
+Kindly also reference our https://www.elastic.co/blog/troubleshooting-kibana-health[walkthrough on troubleshooting Kibana Health].


### PR DESCRIPTION

## Summary

👋 howdy, team! I would like to link our Kibana+Security+ResponseOps Dev approved blog on [Troubleshooting Kibana Health](https://www.elastic.co/blog/troubleshooting-kibana-health) to the Kibana doc section about [Troubleshooting Kibana UI error](https://www.elastic.co/guide/en/kibana/master/access.html#not-ready) (as it was intended as the more verbose / commentary version of the doc).


### Checklist

Delete any items that are not applicable to this PR.

### Risk Matrix


### For maintainers

- [X] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
