### PR TITLE
[APM] Infinite Loop Caused by Matching Child and Parent IDs

### DIFF
--- a/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
+++ b/x-pack/plugins/observability_solution/apm/public/components/app/transaction_details/waterfall_with_summary/waterfall_container/waterfall/index.tsx
@@ -67,7 +67,11 @@ function getWaterfallMaxLevel(waterfall: IWaterfall) {
     const children = waterfall.childrenByParentId[id] || [];
     if (children.length) {
       children.forEach((child) => {
-        countLevels(child.id, currentLevel + 1);
+        // Skip processing when a child node has the same ID as its parent
+        // to prevent infinite loop
+        if (child.id !== id) {
+          countLevels(child.id, currentLevel + 1);
+        }
       });
     } else {
       if (maxLevel < currentLevel) {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/177913

Skip counting children that have the same id as their parents.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->