### PR TITLE
[Profiling] Allow paginating all Topn functions

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/public/components/differential_topn_functions_grid/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/differential_topn_functions_grid/index.tsx
@@ -231,7 +231,7 @@ export function DifferentialTopNFunctionsGrid({
     );
   }
 
-  const rowCount = Math.min(Math.max(sortedBaseRows.length, sortedComparisonRows.length), 100);
+  const rowCount = Math.max(sortedBaseRows.length, sortedComparisonRows.length);
 
   return (
     <>

--- a/x-pack/plugins/observability_solution/profiling/public/components/differential_topn_functions_grid/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/differential_topn_functions_grid/index.tsx
@@ -303,7 +303,7 @@ export function DifferentialTopNFunctionsGrid({
         }}
         pagination={{
           pageIndex,
-          pageSize: 50,
+          pageSize: 100,
           // Left it empty on purpose as it is a required property on the pagination
           onChangeItemsPerPage: () => {},
           onChangePage,

--- a/x-pack/plugins/observability_solution/profiling/public/components/topn_functions/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/topn_functions/index.tsx
@@ -299,7 +299,7 @@ export const TopNFunctionsGrid = ({
         )}
         columns={columns}
         columnVisibility={{ visibleColumns, setVisibleColumns }}
-        rowCount={sortedRows.length > 100 ? 100 : sortedRows.length}
+        rowCount={sortedRows.length}
         renderCellValue={RenderCellValue}
         sorting={{ columns: [{ id: sortField, direction: sortDirection }], onSort }}
         leadingControlColumns={leadingControlColumns}

--- a/x-pack/plugins/observability_solution/profiling/public/components/topn_functions/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/topn_functions/index.tsx
@@ -305,7 +305,7 @@ export const TopNFunctionsGrid = ({
         leadingControlColumns={leadingControlColumns}
         pagination={{
           pageIndex,
-          pageSize: 50,
+          pageSize: 100,
           // Left it empty on purpose as it is a required property on the pagination
           onChangeItemsPerPage: () => {},
           onChangePage,


### PR DESCRIPTION
This PR fixes a bug where the pagination only shows 2 pages (up to 100 items) in the TopN Functions view.

Additionally, the number of items per page are raised from 50 to 100.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->