### PR TITLE
[Search] Update help text error condition to avoid confusion on attach box

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -50,6 +50,8 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
   useEffect(() => {
     if (!canCreateSameNameIndex) {
       setShowError(true);
+    } else {
+      setShowError(false);
     }
   }, [canCreateSameNameIndex]);
 
@@ -117,14 +119,17 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
                 ? ''
                 : i18n.translate(
                     'xpack.enterpriseSearch.attachIndexBox.euiFormRow.associatedIndexHelpTextLabel',
-                    { defaultMessage: 'You can use an existing index or create a new one' }
+                    { defaultMessage: 'You can use an existing index or create a new one.' }
                   )
             }
             error={
               showError
                 ? i18n.translate(
                     'xpack.enterpriseSearch.attachIndexBox.euiFormRow.associatedIndexErrorTextLabel',
-                    { defaultMessage: 'You can use another existing index or create a new one' }
+                    {
+                      defaultMessage:
+                        "Choose an index or create a new one. We can't create one with same name as it already exists.",
+                    }
                   )
                 : undefined
             }
@@ -152,6 +157,9 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
               }}
               selectedOptions={selectedIndex ? [selectedIndex] : undefined}
               onCreateOption={(value) => {
+                if (showError) {
+                  setShowError(false);
+                }
                 setSelectedIndex({ label: value.trim(), shouldCreate: true });
               }}
               singleSelection={{ asPlainText: true }}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -128,7 +128,7 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
                     'xpack.enterpriseSearch.attachIndexBox.euiFormRow.associatedIndexErrorTextLabel',
                     {
                       defaultMessage:
-                        "Choose an index or create a new one. We can't create one with same name as it already exists.",
+                        "You can't create a new index using an existing index name. Choose an existing index or create a new index with a new name.",
                     }
                   )
                 : undefined


### PR DESCRIPTION
## Summary

This help text caused some confusion, updated logic to make it invalid and help text to explain what is going on better. 

![Screenshot 2024-03-04 at 14 57 57](https://github.com/elastic/kibana/assets/1410658/a54ffa95-0029-447f-9034-2fcb2bb5b70d)



### Checklist

Delete any items that are not applicable to this PR.

- [x] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->