### PR TITLE
[Security Solution][Endpoint] Show offline callout for sentinel one agent

### DIFF
--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.test.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.test.tsx
@@ -5,50 +5,90 @@
  * 2.0.
  */
 
+import type { ResponseActionAgentType } from '../../../../../common/endpoint/service/response_actions/constants';
 import React from 'react';
 import type { HostInfo } from '../../../../../common/endpoint/types';
 import { HostStatus } from '../../../../../common/endpoint/types';
 import type { AppContextTestRender } from '../../../../common/mock/endpoint';
 import { createAppRootMockRenderer } from '../../../../common/mock/endpoint';
+import { useGetSentinelOneAgentStatus } from '../../../../detections/components/host_isolation/use_sentinelone_host_isolation';
 import { useGetEndpointDetails } from '../../../hooks/endpoint/use_get_endpoint_details';
 import { mockEndpointDetailsApiResult } from '../../../pages/endpoint_hosts/store/mock_endpoint_result_list';
 import { OfflineCallout } from './offline_callout';
 
 jest.mock('../../../hooks/endpoint/use_get_endpoint_details');
+jest.mock('../../../../detections/components/host_isolation/use_sentinelone_host_isolation');
 
 const getEndpointDetails = useGetEndpointDetails as jest.Mock;
+const getSentinelOneAgentStatus = useGetSentinelOneAgentStatus as jest.Mock;
 
 describe('Responder offline callout', () => {
-  let render: () => ReturnType<AppContextTestRender['render']>;
+  let render: (agentType?: ResponseActionAgentType) => ReturnType<AppContextTestRender['render']>;
   let renderResult: ReturnType<typeof render>;
   let mockedContext: AppContextTestRender;
   let endpointDetails: HostInfo;
 
   beforeEach(() => {
     mockedContext = createAppRootMockRenderer();
-    render = () => (renderResult = mockedContext.render(<OfflineCallout endpointId={'1234'} />));
+    render = (agentType?: ResponseActionAgentType) =>
+      (renderResult = mockedContext.render(
+        <OfflineCallout
+          endpointId={'1234'}
+          agentType={agentType || 'endpoint'}
+          hostName="Host name"
+        />
+      ));
     endpointDetails = mockEndpointDetailsApiResult();
     getEndpointDetails.mockReturnValue({ data: endpointDetails });
+    getSentinelOneAgentStatus.mockReturnValue({ data: {} });
     render();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
-  it('should be visible when endpoint is offline', () => {
-    getEndpointDetails.mockReturnValue({
-      data: { ...endpointDetails, host_status: HostStatus.OFFLINE },
-    });
-    render();
-    const callout = renderResult.queryByTestId('offlineCallout');
-    expect(callout).toBeTruthy();
-  });
-  it('should not be visible when endpoint is online', () => {
-    getEndpointDetails.mockReturnValue({
-      data: { ...endpointDetails, host_status: HostStatus.HEALTHY },
-    });
-    render();
-    const callout = renderResult.queryByTestId('offlineCallout');
-    expect(callout).toBeFalsy();
-  });
+
+  it.each(['endpoint', 'sentinel_one'] as ResponseActionAgentType[])(
+    'should be visible when agent type is %s and host is offline',
+    (agentType) => {
+      if (agentType === 'endpoint') {
+        getEndpointDetails.mockReturnValue({
+          data: { ...endpointDetails, host_status: HostStatus.OFFLINE },
+        });
+      } else if (agentType === 'sentinel_one') {
+        getSentinelOneAgentStatus.mockReturnValue({
+          data: {
+            '1234': {
+              status: HostStatus.OFFLINE,
+            },
+          },
+        });
+      }
+      render(agentType);
+      const callout = renderResult.queryByTestId('offlineCallout');
+      expect(callout).toBeTruthy();
+    }
+  );
+
+  it.each(['endpoint', 'sentinel_one'] as ResponseActionAgentType[])(
+    'should not be visible when agent type is %s and host is online',
+    (agentType) => {
+      if (agentType === 'endpoint') {
+        getEndpointDetails.mockReturnValue({
+          data: { ...endpointDetails, host_status: HostStatus.HEALTHY },
+        });
+      } else if (agentType === 'sentinel_one') {
+        getSentinelOneAgentStatus.mockReturnValue({
+          data: {
+            '1234': {
+              status: HostStatus.HEALTHY,
+            },
+          },
+        });
+      }
+      render(agentType);
+      const callout = renderResult.queryByTestId('offlineCallout');
+      expect(callout).toBeFalsy();
+    }
+  );
 });

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.tsx
@@ -35,6 +35,7 @@ export const OfflineCallout = memo<OfflineCalloutProps>(({ agentType, endpointId
 
   const { data } = useGetSentinelOneAgentStatus([endpointId]);
 
+  // TODO: simplify this to use the yet to be implemented agentStatus API hook
   const showOfflineCallout = useMemo(
     () =>
       (isEndpointAgent && endpointDetails?.host_status === HostStatus.OFFLINE) ||

--- a/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.tsx
+++ b/x-pack/plugins/security_solution/public/management/components/endpoint_responder/components/offline_callout.tsx
@@ -5,27 +5,51 @@
  * 2.0.
  */
 
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { EuiCallOut, EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
+import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
+import { useGetSentinelOneAgentStatus } from '../../../../detections/components/host_isolation/use_sentinelone_host_isolation';
+import type { ResponseActionAgentType } from '../../../../../common/endpoint/service/response_actions/constants';
 import { useGetEndpointDetails } from '../../../hooks';
 import { HostStatus } from '../../../../../common/endpoint/types';
 
 interface OfflineCalloutProps {
+  agentType: ResponseActionAgentType;
   endpointId: string;
+  hostName: string;
 }
 
-export const OfflineCallout = memo<OfflineCalloutProps>(({ endpointId }) => {
+export const OfflineCallout = memo<OfflineCalloutProps>(({ agentType, endpointId, hostName }) => {
+  const isEndpointAgent = agentType === 'endpoint';
+  const isSentinelOneAgent = agentType === 'sentinel_one';
+  const isSentinelOneV1Enabled = useIsExperimentalFeatureEnabled(
+    'responseActionsSentinelOneV1Enabled'
+  );
+
   const { data: endpointDetails } = useGetEndpointDetails(endpointId, {
     refetchInterval: 10000,
+    enabled: isEndpointAgent,
   });
 
-  if (!endpointDetails) {
+  const { data } = useGetSentinelOneAgentStatus([endpointId]);
+
+  const showOfflineCallout = useMemo(
+    () =>
+      (isEndpointAgent && endpointDetails?.host_status === HostStatus.OFFLINE) ||
+      (isSentinelOneAgent && data?.[endpointId].status === HostStatus.OFFLINE),
+    [data, endpointDetails?.host_status, endpointId, isEndpointAgent, isSentinelOneAgent]
+  );
+
+  if (
+    (isEndpointAgent && !endpointDetails) ||
+    (isSentinelOneV1Enabled && isSentinelOneAgent && !data)
+  ) {
     return null;
   }
 
-  if (endpointDetails.host_status === HostStatus.OFFLINE) {
+  if (showOfflineCallout) {
     return (
       <>
         <EuiCallOut
@@ -40,7 +64,7 @@ export const OfflineCallout = memo<OfflineCalloutProps>(({ endpointId }) => {
             <FormattedMessage
               id="xpack.securitySolution.responder.hostOffline.callout.body"
               defaultMessage="The host {name} is offline, so its responses may be delayed. Pending commands will execute when the host reconnects."
-              values={{ name: <strong>{endpointDetails.metadata.host.name}</strong> }}
+              values={{ name: <strong>{hostName}</strong> }}
             />
           </p>
         </EuiCallOut>

--- a/x-pack/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
+++ b/x-pack/plugins/security_solution/public/management/hooks/use_with_show_responder.tsx
@@ -151,7 +151,11 @@ export const useWithShowResponder = (): ShowResponseActionsConsole => {
               : undefined,
             PageBodyComponent: () => (
               <>
-                <OfflineCallout endpointId={props.agentId} />
+                <OfflineCallout
+                  endpointId={props.agentId}
+                  agentType={agentType}
+                  hostName={hostName}
+                />
                 <MissingEncryptionKeyCallout />
               </>
             ),


### PR DESCRIPTION
## Summary

Shows offline callout for sentinel one agent when it is offline.

![Screenshot 2024-03-04 at 2 41 03 PM](https://github.com/elastic/kibana/assets/1849116/f1d49ad5-53f5-412f-a47e-370d32b79ac9)


refs elastic/kibana/issues/177880

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [x] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [x] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [x] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->