### PR TITLE
[Search] Update the docs count field to use _count instead of total count

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -115,7 +115,7 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ connector, index
                           {
                             defaultMessage: '{documentAmount} Documents',
                             values: {
-                              documentAmount: indexData?.total.docs.count ?? '-',
+                              documentAmount: indexData?.count ?? '-',
                             },
                           }
                         )}


### PR DESCRIPTION
## Summary

Update docs count field to use result from `_count` instead of checking total docs.

### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->