### PR TITLE
[Search] Fix line break bug in Crawler name page

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -7,6 +7,7 @@
 
 import React, { ChangeEvent } from 'react';
 
+import { css } from '@emotion/react';
 import { useValues, useActions } from 'kea';
 
 import {
@@ -180,12 +181,22 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                   )}
                   isInvalid={formInvalid}
                   error={
-                    <EuiText size="xs" style={{ lineBreak: 'anywhere' }}>
+                    <EuiText
+                      size="xs"
+                      css={css`
+                        line-break: anywhere;
+                      `}
+                    >
                       {formError()}
                     </EuiText>
                   }
                   helpText={
-                    <EuiText size="xs" style={{ lineBreak: 'anywhere' }}>
+                    <EuiText
+                      size="xs"
+                      css={css`
+                        line-break: anywhere;
+                      `}
+                    >
                       {searchHelpTest}
                     </EuiText>
                   }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/new_index/new_search_index_template.tsx
@@ -107,6 +107,15 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
     }
     return error;
   };
+  const searchHelpTest = i18n.translate(
+    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineOne',
+    {
+      defaultMessage: 'Your index will be named: {indexName}',
+      values: {
+        indexName: fullIndexName,
+      },
+    }
+  );
 
   return (
     <>
@@ -170,16 +179,16 @@ export const NewSearchIndexTemplate: React.FC<Props> = ({
                     }
                   )}
                   isInvalid={formInvalid}
-                  error={formError()}
-                  helpText={i18n.translate(
-                    'xpack.enterpriseSearch.content.newIndex.newSearchIndexTemplate.nameInputHelpText.lineOne',
-                    {
-                      defaultMessage: 'Your index will be named: {indexName}',
-                      values: {
-                        indexName: fullIndexName,
-                      },
-                    }
-                  )}
+                  error={
+                    <EuiText size="xs" style={{ lineBreak: 'anywhere' }}>
+                      {formError()}
+                    </EuiText>
+                  }
+                  helpText={
+                    <EuiText size="xs" style={{ lineBreak: 'anywhere' }}>
+                      {searchHelpTest}
+                    </EuiText>
+                  }
                   fullWidth
                 >
                   <EuiFieldText


### PR DESCRIPTION
## Summary

The help and error text for the crawler index name input takes a dynamic value (`index_name`) that doesn't line break and pushes elements off the page. This PR fixes the line breaking.

### Before

![out2](https://github.com/elastic/kibana/assets/13634519/5c47d623-519f-4f8b-b427-7a9f84a7fd38)

### After

![out](https://github.com/elastic/kibana/assets/13634519/9c2257fb-151c-44c8-b616-54a1418fc3e5)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->