### PR TITLE
[Console] fix(embeddable): lower control bar z-index by 2

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
+++ b/src/plugins/console/public/application/containers/embeddable/_embeddable_console.scss
@@ -19,7 +19,7 @@
 
   &--fixed {
     position: fixed;
-    z-index: $euiZLevel1;
+    z-index: $euiZLevel1 - 2;
   }
 
   &--projectChrome {


### PR DESCRIPTION
## Summary

Updated the z-index of the embedded console control bar to be header (1000) - 2. This will ensure it does not conflict with any flyouts that are also rendered at z-index: 1000.

Closes #177607


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->