### PR TITLE
[Security Solution][Detection Engine] removes feature flag for IM rule suppression

### DIFF
--- a/x-pack/plugins/security_solution/common/experimental_features.ts
+++ b/x-pack/plugins/security_solution/common/experimental_features.ts
@@ -155,11 +155,6 @@ export const allowedExperimentalValues = Object.freeze({
   riskEnginePrivilegesRouteEnabled: true,
 
   /**
-   * Enables alerts suppression for indicator match rules
-   */
-  alertSuppressionForIndicatorMatchRuleEnabled: false,
-
-  /**
    * Enables experimental Experimental S1 integration data to be available in Analyzer
    */
   sentinelOneDataInAnalyzerEnabled: true,

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/use_experimental_feature_fields_transform.ts
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_creation_ui/components/step_define_rule/use_experimental_feature_fields_transform.ts
@@ -7,8 +7,6 @@
 
 import { useCallback } from 'react';
 import type { DefineStepRule } from '../../../../detections/pages/detection_engine/rules/types';
-import { useIsExperimentalFeatureEnabled } from '../../../../common/hooks/use_experimental_features';
-import { isThreatMatchRule } from '../../../../../common/detection_engine/utils';
 
 /**
  * transforms  DefineStepRule fields according to experimental feature flags
@@ -16,30 +14,9 @@ import { isThreatMatchRule } from '../../../../../common/detection_engine/utils'
 export const useExperimentalFeatureFieldsTransform = <T extends Partial<DefineStepRule>>(): ((
   fields: T
 ) => T) => {
-  const isAlertSuppressionForIndicatorMatchRuleEnabled = useIsExperimentalFeatureEnabled(
-    'alertSuppressionForIndicatorMatchRuleEnabled'
-  );
-
-  const transformer = useCallback(
-    (fields: T) => {
-      const isIndicatorMatchSuppressionDisabled = isThreatMatchRule(fields.ruleType)
-        ? !isAlertSuppressionForIndicatorMatchRuleEnabled
-        : false;
-      // reset any alert suppression values hidden behind feature flag
-      if (isIndicatorMatchSuppressionDisabled) {
-        return {
-          ...fields,
-          groupByFields: [],
-          groupByRadioSelection: undefined,
-          groupByDuration: undefined,
-          suppressionMissingFields: undefined,
-        };
-      }
-
-      return fields;
-    },
-    [isAlertSuppressionForIndicatorMatchRuleEnabled]
-  );
+  const transformer = useCallback((fields: T) => {
+    return fields;
+  }, []);
 
   return transformer;
 };

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/use_alert_suppression.test.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/use_alert_suppression.test.tsx
@@ -6,29 +6,13 @@
  */
 import { renderHook } from '@testing-library/react-hooks';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
-import * as useIsExperimentalFeatureEnabledMock from '../../../common/hooks/use_experimental_features';
 import { useAlertSuppression } from './use_alert_suppression';
 
 describe('useAlertSuppression', () => {
-  it('should return the correct isSuppressionEnabled value if rule Type exists in SUPPRESSIBLE_ALERT_RULES and Feature Flag is enabled', () => {
-    jest
-      .spyOn(useIsExperimentalFeatureEnabledMock, 'useIsExperimentalFeatureEnabled')
-      .mockImplementation((featureFlagName: string) => {
-        return featureFlagName === 'alertSuppressionForIndicatorMatchRuleEnabled';
-      });
+  it('should return the correct isSuppressionEnabled value fot threat_match rule type', () => {
     const { result } = renderHook(() => useAlertSuppression('threat_match'));
 
     expect(result.current.isSuppressionEnabled).toBe(true);
-  });
-  it('should return the correct isSuppressionEnabled value if rule Type exists in SUPPRESSIBLE_ALERT_RULES and Feature Flag is disabled', () => {
-    jest
-      .spyOn(useIsExperimentalFeatureEnabledMock, 'useIsExperimentalFeatureEnabled')
-      .mockImplementation((featureFlagName: string) => {
-        return featureFlagName !== 'alertSuppressionForIndicatorMatchRuleEnabled';
-      });
-    const { result } = renderHook(() => useAlertSuppression('threat_match'));
-
-    expect(result.current.isSuppressionEnabled).toBe(false);
   });
 
   it('should return the correct isSuppressionEnabled value if rule Type exists in SUPPRESSIBLE_ALERT_RULES', () => {

--- a/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/use_alert_suppression.tsx
+++ b/x-pack/plugins/security_solution/public/detection_engine/rule_management/logic/use_alert_suppression.tsx
@@ -7,25 +7,17 @@
 import { useCallback } from 'react';
 import type { Type } from '@kbn/securitysolution-io-ts-alerting-types';
 import { isSuppressibleAlertRule } from '../../../../common/detection_engine/utils';
-import { useIsExperimentalFeatureEnabled } from '../../../common/hooks/use_experimental_features';
+
 export interface UseAlertSuppressionReturn {
   isSuppressionEnabled: boolean;
 }
 
 export const useAlertSuppression = (ruleType: Type | undefined): UseAlertSuppressionReturn => {
-  const isThreatMatchRuleFFEnabled = useIsExperimentalFeatureEnabled(
-    'alertSuppressionForIndicatorMatchRuleEnabled'
-  );
-
   const isSuppressionEnabledForRuleType = useCallback(() => {
     if (!ruleType) return false;
 
-    // Remove this condition when the Feature Flag for enabling Suppression in the Indicator Match rule is removed.
-    if (ruleType === 'threat_match')
-      return isSuppressibleAlertRule(ruleType) && isThreatMatchRuleFFEnabled;
-
     return isSuppressibleAlertRule(ruleType);
-  }, [ruleType, isThreatMatchRuleFFEnabled]);
+  }, [ruleType]);
 
   return {
     isSuppressionEnabled: isSuppressionEnabledForRuleType(),

--- a/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
+++ b/x-pack/plugins/security_solution/server/lib/detection_engine/rule_types/indicator_match/threat_mapping/create_threat_signals.ts
@@ -224,10 +224,7 @@ export const createThreatSignals = async ({
     completeRule.ruleParams.alertSuppression?.groupBy?.length
   );
 
-  const isAlertSuppressionActive =
-    isAlertSuppressionConfigured &&
-    Boolean(runOpts.experimentalFeatures?.alertSuppressionForIndicatorMatchRuleEnabled) &&
-    hasPlatinumLicense;
+  const isAlertSuppressionActive = isAlertSuppressionConfigured && hasPlatinumLicense;
 
   // alert suppression needs to be performed on results searched in ascending order, so alert's suppression boundaries would be set correctly
   // at the same time, there are concerns on performance of IM rule when sorting is set to asc, as it may lead to longer rule runs, since it will

--- a/x-pack/test/security_solution_api_integration/config/ess/config.base.ts
+++ b/x-pack/test/security_solution_api_integration/config/ess/config.base.ts
@@ -82,7 +82,6 @@ export function createTestConfig(options: CreateTestConfigOptions, testFiles?: s
             'previewTelemetryUrlEnabled',
             'riskScoringPersistence',
             'riskScoringRoutesEnabled',
-            'alertSuppressionForIndicatorMatchRuleEnabled',
           ])}`,
           '--xpack.task_manager.poll_interval=1000',
           `--xpack.actions.preconfigured=${JSON.stringify(PRECONFIGURED_ACTION_CONNECTORS)}`,

--- a/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/trial_license_complete_tier/configs/serverless.config.ts
+++ b/x-pack/test/security_solution_api_integration/test_suites/detections_response/detection_engine/rule_execution_logic/trial_license_complete_tier/configs/serverless.config.ts
@@ -17,8 +17,5 @@ export default createTestConfig({
       'testing_ignored.constant',
       '/testing_regex*/',
     ])}`, // See tests within the file "ignore_fields.ts" which use these values in "alertIgnoreFields"
-    `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-      'alertSuppressionForIndicatorMatchRuleEnabled',
-    ])}`,
   ],
 });

--- a/x-pack/test/security_solution_cypress/config.ts
+++ b/x-pack/test/security_solution_cypress/config.ts
@@ -46,7 +46,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
         '--xpack.ruleRegistry.unsafe.legacyMultiTenancy.enabled=true',
         `--xpack.securitySolution.enableExperimental=${JSON.stringify([
           'chartEmbeddablesEnabled',
-          'alertSuppressionForIndicatorMatchRuleEnabled',
         ])}`,
         // mock cloud to enable the guided onboarding tour in e2e tests
         '--xpack.cloud.id=test',

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule_suppression.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule_suppression.cy.ts
@@ -40,16 +40,6 @@ describe(
   'Detection rules, Indicator Match, Alert Suppression',
   {
     tags: ['@ess', '@serverless'],
-    // alertSuppressionForIndicatorMatchRuleEnabled feature flag is also enabled in a global config
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForIndicatorMatchRuleEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     const rule = getNewThreatIndicatorRule();

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule_suppression_serverless_essentials.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_creation/indicator_match_rule_suppression_serverless_essentials.cy.ts
@@ -37,12 +37,6 @@ describe(
           { product_line: 'security', product_tier: 'essentials' },
           { product_line: 'endpoint', product_tier: 'essentials' },
         ],
-        // alertSuppressionForIndicatorMatchRuleEnabled feature flag is also enabled in a global config
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForIndicatorMatchRuleEnabled',
-          ])}`,
-        ],
       },
     },
   },

--- a/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/indicator_match_rule.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/detection_response/detection_engine/rule_edit/indicator_match_rule.cy.ts
@@ -48,16 +48,6 @@ describe(
   'Detection rules, Indicator Match, Edit',
   {
     tags: ['@ess', '@serverless'],
-    // alertSuppressionForIndicatorMatchRuleEnabled feature flag is also enabled in a global config
-    env: {
-      ftrConfig: {
-        kbnServerArgs: [
-          `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-            'alertSuppressionForIndicatorMatchRuleEnabled',
-          ])}`,
-        ],
-      },
-    },
   },
   () => {
     beforeEach(() => {

--- a/x-pack/test/security_solution_cypress/serverless_config.ts
+++ b/x-pack/test/security_solution_cypress/serverless_config.ts
@@ -34,9 +34,6 @@ export default async function ({ readConfigFile }: FtrConfigProviderContext) {
           { product_line: 'endpoint', product_tier: 'complete' },
           { product_line: 'cloud', product_tier: 'complete' },
         ])}`,
-        `--xpack.securitySolution.enableExperimental=${JSON.stringify([
-          'alertSuppressionForIndicatorMatchRuleEnabled',
-        ])}`,
       ],
     },
     testRunner: SecuritySolutionConfigurableCypressTestRunner,


### PR DESCRIPTION
## Summary

 - removes feature flag `alertSuppressionForIndicatorMatchRuleEnabled ` for ESS 8.13 release


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

