### PR TITLE
[Cases] Use the default value of observables on the `useApplication` hook

### DIFF
--- a/x-pack/plugins/cases/public/components/cases_context/use_application.tsx
+++ b/x-pack/plugins/cases/public/components/cases_context/use_application.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 import useObservable from 'react-use/lib/useObservable';
+import type { BehaviorSubject, Observable } from 'rxjs';
 import { useKibana } from '../../common/lib/kibana';
 
 interface UseApplicationReturn {
@@ -12,11 +13,28 @@ interface UseApplicationReturn {
   appTitle: string | undefined;
 }
 
+const isBehaviorSubjectObservable = <T,>(
+  observable: Observable<T>
+): observable is BehaviorSubject<T> => 'value' in observable;
+
+/**
+ * Checks if the observable is stateful and, in case, sets up `useObservable` with an initial value
+ */
+const useStatefulObservable = <T,>(observable: Observable<T>) => {
+  let initialValue: T | undefined;
+
+  if (isBehaviorSubjectObservable(observable)) {
+    initialValue = observable.value;
+  }
+
+  return useObservable(observable, initialValue);
+};
+
 export const useApplication = (): UseApplicationReturn => {
   const { currentAppId$, applications$ } = useKibana().services.application;
   // retrieve the most recent value from the BehaviorSubject
-  const appId = useObservable(currentAppId$);
-  const applications = useObservable(applications$);
+  const appId = useStatefulObservable(currentAppId$);
+  const applications = useStatefulObservable(applications$);
 
   const appTitle = appId
     ? applications?.get(appId)?.category?.label ?? applications?.get(appId)?.title


### PR DESCRIPTION
## Summary

This PR uses the default values of the `currentAppId$` and `applications$` if they exist in the `useApplication` hook.

### For maintainers

- [x] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->