### PR TITLE
Fix CDN task assets discovery

### DIFF
--- a/src/dev/build/cli.ts
+++ b/src/dev/build/cli.ts
@@ -43,6 +43,7 @@ if (showHelp) {
         --docker-cross-compile               {dim Produce arm64 and amd64 Docker images}
         --docker-contexts                    {dim Only build the Docker build contexts}
         --skip-canvas-shareable-runtime      {dim Don't build the Canvas shareable runtime}
+        --skip-cdn-assets                    {dim Don't build CDN assets}
         --skip-docker-ubi                    {dim Don't build the docker ubi image}
         --skip-docker-ubuntu                 {dim Don't build the docker ubuntu image}
         --skip-docker-fips                   {dim Don't build the docker fips image}

--- a/src/dev/build/tasks/create_cdn_assets_task.ts
+++ b/src/dev/build/tasks/create_cdn_assets_task.ts
@@ -38,27 +38,15 @@ export const CreateCdnAssets: Task = {
       const manifest = Jsonc.parse(readFileSync(path, 'utf8')) as any;
       if (manifest?.plugin?.id) {
         const pluginRoot = resolve(dirname(path));
-        const assetsSources = [
-          resolve(pluginRoot, 'public', 'assets'),
-          resolve(pluginRoot, 'assets'),
-        ];
         // packages/core/apps/core-apps-server-internal/src/core_app.ts
+        const assetsSource = resolve(pluginRoot, 'public', 'assets');
         const assetsDest = resolve(assets, buildSha, 'plugins', manifest.plugin.id, 'assets');
-
-        for (const assetsSource of assetsSources) {
-          try {
-            await access(assetsSource);
-            await mkdirp(assetsDest);
-            await copyAll(assetsSource, assetsDest);
-          } catch (e) {
-            if (e.code === 'ENOENT' && e.syscall === 'access') {
-              // miss, check the next asset source path
-              continue;
-            }
-            throw e;
-          }
-          // found and copied assets, no need to look further
-          break;
+        try {
+          await access(assetsSource);
+          await mkdirp(assetsDest);
+          await copyAll(assetsSource, assetsDest);
+        } catch (e) {
+          if (!(e.code === 'ENOENT' && e.syscall === 'access')) throw e;
         }
 
         try {


### PR DESCRIPTION
## Summary

Plugin static assets were not being included in the CDN bundle due to the task looking in `<plugin_root>/assets`. This fix updates the task to look in `<plugin_root>/public/assets`.

## Output structure

<details>

<summary>tree</summary>

```
❯ tree -dL 3 .
.
└── <hash>
    ├── bundles
    │   ├── core
    │   ├── kbn-monaco
    │   ├── kbn-ui-shared-deps-npm
    │   ├── kbn-ui-shared-deps-src
    │   └── plugin
    ├── plugins
    │   ├── apm
    │   ├── cloudDefend
    │   ├── cloudSecurityPosture
    │   ├── customIntegrations
    │   ├── dashboard
    │   ├── dataViewFieldEditor
    │   ├── discover
    │   ├── enterpriseSearch
    │   ├── fleet
    │   ├── globalSearchBar
    │   ├── home
    │   ├── indexManagement
    │   ├── kibanaOverview
    │   ├── kibanaReact
    │   ├── lens
    │   ├── maps
    │   ├── observability
    │   ├── observabilityAIAssistant
    │   ├── observabilityOnboarding
    │   ├── osquery
    │   ├── remoteClusters
    │   ├── serverlessSearch
    │   └── timelines
    └── ui
        ├── favicons
        └── fonts

35 directories
```

</details>


## Test

1. Build distributable using `node scripts/build.js` to get CDN assets
2. Untar `./target/kibana-8.14.0-SNAPSHOT-cdn-assets.tar.gz`
3. Add an entry to `/etc/hosts` to resolve to `127.0.0.1`
4. `cd` into the untarred folder and serve the assets, I used `npx http-server -p 1772 --cors --gzip --brotli`
5. Add `server.cdn.url: "http://my.cdn.test:1772"` to your Kibana config
6. Start Kibana and ES, see assets are loading for the home app from our "CDN"

<img width="1813" alt="Screenshot 2024-03-05 at 11 14 45" src="https://github.com/elastic/kibana/assets/8155004/e322c02b-2d42-4adc-9767-3a5b276b7be4">

