### PR TITLE
Fix CI issue for users being unable to retrieve persisted Serverless …

### DIFF
--- a/.buildkite/scripts/steps/serverless/build_and_deploy.sh
+++ b/.buildkite/scripts/steps/serverless/build_and_deploy.sh
@@ -22,6 +22,7 @@ deploy() {
   esac
 
   PROJECT_NAME="kibana-pr-$BUILDKITE_PULL_REQUEST-$PROJECT_TYPE"
+  VAULT_KEY_NAME="$PROJECT_NAME"
   is_pr_with_label "ci:project-persist-deployment" && PROJECT_NAME="keep_$PROJECT_NAME"
   PROJECT_CREATE_CONFIGURATION='{
     "name": "'"$PROJECT_NAME"'",
@@ -81,9 +82,9 @@ deploy() {
 
     # TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
     if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-      vault_set "cloud-deploy/$PROJECT_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
+      vault_set "cloud-deploy/$VAULT_KEY_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
     else
-      vault_kv_set "cloud-deploy/$PROJECT_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
+      vault_kv_set "cloud-deploy/$VAULT_KEY_NAME" username="$PROJECT_USERNAME" password="$PROJECT_PASSWORD" id="$PROJECT_ID"
     fi
 
   else
@@ -101,9 +102,9 @@ deploy() {
 
   # TODO: remove after https://github.com/elastic/kibana-operations/issues/15 is done
   if [[ "$IS_LEGACY_VAULT_ADDR" == "true" ]]; then
-    VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$PROJECT_NAME"
+    VAULT_READ_COMMAND="vault read $VAULT_PATH_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
   else
-    VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$PROJECT_NAME"
+    VAULT_READ_COMMAND="vault kv get $VAULT_KV_PREFIX/cloud-deploy/$VAULT_KEY_NAME"
   fi
 
   cat << EOF | buildkite-agent annotate --style "info" --context "project-$PROJECT_TYPE"


### PR DESCRIPTION
### Background

Currently, whenever the two labels `ci:project-deploy-(security|observability|search)` and `ci:project-persist-deployment` both exist on a pull request, the PR creator does not have the ability to read the generated credentials, because Vault users only have the privileges to view a certain subset of Vault secrets. Specifically, Vault users can only view secrets mathing the prefix `kibana-pr-*`, while the `ci:project-persist-deployment` label causes the project name (and thereby the Vault secret name) to be prefixed with `keep_kibana-pr-*`

An example of the error can be found below:

```
Error reading secret/kibana-issues/dev/cloud-deploy/keep_kibana-pr-173013-security: Error making API request.

URL: GET https://secrets.elastic.co:8200/v1/secret/kibana-issues/dev/cloud-deploy/keep_kibana-pr-173013-security
Code: 403. Errors:

* 1 error occurred:
        * permission denied

```

### Solution

This PR alleviates this problem by removing the "keep-" prefix from the vault secret name, with it still remaining in the Serverless project's name