### PR TITLE
[Synthetics] Allow Synthetics global params to include dashes

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
@@ -30,6 +30,16 @@ describe('replaceStringWithParams', () => {
     expect(result).toEqual('https://elastic.co');
   });
 
+  it('works with . in the key', () => {
+    const result = replaceStringWithParams(
+      '${home.pageUrl}',
+      { 'home.pageUrl': 'https://elastic.co' },
+      logger
+    );
+
+    expect(result).toEqual('https://elastic.co');
+  });
+
   it('returns empty value in case no param', () => {
     const result = replaceStringWithParams('${homePageUrl}', {}, logger);
 

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.test.ts
@@ -20,6 +20,16 @@ describe('replaceStringWithParams', () => {
     expect(result).toEqual('https://elastic.co');
   });
 
+  it('works with dashes in the key', () => {
+    const result = replaceStringWithParams(
+      '${home-page-url}',
+      { 'home-page-url': 'https://elastic.co' },
+      logger
+    );
+
+    expect(result).toEqual('https://elastic.co');
+  });
+
   it('returns empty value in case no param', () => {
     const result = replaceStringWithParams('${homePageUrl}', {}, logger);
 

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -51,7 +51,7 @@ export const replaceStringWithParams = (
 };
 
 export const hasNoParams = (strVal: string) => {
-  const shellParamsRegex = /\$\{[a-zA-Z_][a-zA-Z0-9_-]*\}/g;
+  const shellParamsRegex = /\$\{[a-zA-Z_][a-zA-Z0-9\._\-?:]*\}/g;
   return strVal.match(shellParamsRegex) === null;
 };
 

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -50,9 +50,10 @@ export const replaceStringWithParams = (
   return value as string | null;
 };
 
+const SHELL_PARAMS_REGEX = /\$\{[a-zA-Z_][a-zA-Z0-9\._\-?:]*\}/g;
+
 export const hasNoParams = (strVal: string) => {
-  const shellParamsRegex = /\$\{[a-zA-Z_][a-zA-Z0-9\._\-?:]*\}/g;
-  return strVal.match(shellParamsRegex) === null;
+  return strVal.match(SHELL_PARAMS_REGEX) === null;
 };
 
 export const secondsToCronFormatter: FormatterFn = (fields, key) => {

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/formatters/formatting_utils.ts
@@ -51,7 +51,7 @@ export const replaceStringWithParams = (
 };
 
 export const hasNoParams = (strVal: string) => {
-  const shellParamsRegex = /\$\{[a-zA-Z_][a-zA-Z0-9_]*\}/g;
+  const shellParamsRegex = /\$\{[a-zA-Z_][a-zA-Z0-9_-]*\}/g;
   return strVal.match(shellParamsRegex) === null;
 };
 


### PR DESCRIPTION
## Summary

Resolves #178053.

Includes `-` in the regex to filter param names.

## Testing

### Repro instructions

Testing this is straightforward. You can verify the issue in `main` or on a cloud instance. If you spin up an ESS that is the most straightforward way.

1. In Synthetics UI, go to Settings > Global Parameters.
<img width="831" alt="image" src="https://github.com/elastic/kibana/assets/18429259/f6dc78f6-6e0c-4b84-a114-9e88266327e9">

2. Create a param with some dashes in the key, i.e. `TEST-PARAMS`.

3. After saving, create an HTTP monitor. In the create form, you can scroll down and expand `Advanced options`. Include a check for `Request headers`, specify a header name and for the value, reference your global param using [Beats env syntax](https://www.elastic.co/guide/en/beats/libbeat/current/config-file-format-env-vars.html#_examples).
<img width="831" alt="image" src="https://github.com/elastic/kibana/assets/18429259/bcf3c495-1db8-499c-a394-781564744679">

You can either use Test Now or wait for it to fail, and you'll see issues get logged similar to what is documented in the attached issue.

### Testing the fix

I will create an ESS deployment from this PR that will allow you to follow the same steps above. You should be able to see your monitor either succeed (if the response headers you check for are actually there), or fail for legitimate reasons. But you should not see the error documented in the attached issue, with a message like `io:job could not be initialized...`.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->