### PR TITLE
[Synthetics] Enable in Serverless by default

### DIFF
--- a/config/serverless.oblt.yml
+++ b/config/serverless.oblt.yml
@@ -4,6 +4,7 @@
 enterpriseSearch.enabled: false
 xpack.cloudSecurityPosture.enabled: false
 xpack.infra.enabled: true
+xpack.uptime.enabled: true
 xpack.securitySolution.enabled: false
 
 ## Cloud settings
@@ -39,11 +40,7 @@ xpack.uptime.service.tls.certificate: /mnt/elastic-internal/http-certs/tls.crt
 xpack.uptime.service.tls.key: /mnt/elastic-internal/http-certs/tls.key
 
 # Fleet specific configuration
-xpack.fleet.internal.registry.capabilities: [
-  'apm',
-  'observability',
-  'uptime',
-]
+xpack.fleet.internal.registry.capabilities: ['apm', 'observability', 'uptime']
 xpack.fleet.internal.registry.kibanaVersionCheckEnabled: false
 xpack.fleet.internal.registry.spec.max: '3.0'
 # Temporary until all packages implement new spec https://github.com/elastic/kibana/issues/166742

--- a/config/serverless.yml
+++ b/config/serverless.yml
@@ -149,7 +149,6 @@ xpack.reporting.statefulSettings.enabled: false
 # Disabled Observability plugins
 xpack.ux.enabled: false
 xpack.monitoring.enabled: false
-xpack.uptime.enabled: false
 xpack.legacy_uptime.enabled: false
 monitoring.ui.enabled: false
 


### PR DESCRIPTION
## Summary

At present, we have the MKI Kibana Controller disable Synthetics in production Serverless by default.

This patch will make Synthetics enabled by default, so at the point when we want to remove the injected disable config on the controller side, Synthetics will be available to all production Observability projects immediately.
