### PR TITLE
[Search] Show correct heading when deleting a crawler

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors.tsx
@@ -72,7 +72,7 @@ export const Connectors: React.FC<ConnectorsProps> = ({ isCrawler }) => {
     <SelectConnector />
   ) : (
     <>
-      <DeleteConnectorModal />
+      <DeleteConnectorModal isCrawler={isCrawler} />
       <EnterpriseSearchContentPageTemplate
         pageChrome={baseBreadcrumbs}
         pageViewTelemetry={!isCrawler ? 'Connectors' : 'Web Crawlers'}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -49,15 +49,17 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
 
   return isDeleteModalVisible ? (
     <EuiConfirmModal
-    title={!isCrawler
-            ? i18n.translate('xpack.enterpriseSearch.content.connectors.deleteModal.title', {
+      title={
+        !isCrawler
+          ? i18n.translate('xpack.enterpriseSearch.content.connectors.deleteModal.title', {
               defaultMessage: 'Delete {connectorCount} connector?',
               values: { connectorCount: 1 },
             })
-            : i18n.translate('xpack.enterpriseSearch.content.crawlers.deleteModal.title', {
+          : i18n.translate('xpack.enterpriseSearch.content.crawlers.deleteModal.title', {
               defaultMessage: 'Delete {connectorCount} crawler?',
               values: { connectorCount: 1 },
-            })}
+            })
+      }
       onCancel={() => {
         closeDeleteModal();
       }}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -26,7 +26,10 @@ import { FormattedMessage } from '@kbn/i18n-react';
 
 import { ConnectorsLogic } from './connectors_logic';
 
-export const DeleteConnectorModal: React.FC = () => {
+export interface DeleteConnectorModalProps {
+  isCrawler: boolean;
+}
+export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCrawler }) => {
   const { closeDeleteModal, deleteConnector } = useActions(ConnectorsLogic);
   const {
     deleteModalConnectorId: connectorId,
@@ -42,14 +45,19 @@ export const DeleteConnectorModal: React.FC = () => {
   useEffect(() => {
     setShouldDeleteIndex(false);
     setInputConnectorName('');
-  }, [isDeleteModalVisible]);
+  }, [isDeleteModalVisible, isCrawler]);
 
   return isDeleteModalVisible ? (
     <EuiConfirmModal
-      title={i18n.translate('xpack.enterpriseSearch.content.connectors.deleteModal.title', {
-        defaultMessage: 'Delete {connectorCount} connector?',
-        values: { connectorCount: 1 },
-      })}
+    title={!isCrawler
+            ? i18n.translate('xpack.enterpriseSearch.content.connectors.deleteModal.title', {
+              defaultMessage: 'Delete {connectorCount} connector?',
+              values: { connectorCount: 1 },
+            })
+            : i18n.translate('xpack.enterpriseSearch.content.crawlers.deleteModal.title', {
+              defaultMessage: 'Delete {connectorCount} crawler?',
+              values: { connectorCount: 1 },
+            })}
       onCancel={() => {
         closeDeleteModal();
       }}


### PR DESCRIPTION
When deleting a crawler the modal showed "Delete 1 connector" instead of "Delete 1 crawler". I'm passing the `isCrawler` property now down to the delete modal to be able to show the correct title.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->