### PR TITLE
[Search] Only show DLS docs, if connector supports the feature

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -25,6 +25,7 @@ import {
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
+import { FeatureName } from '@kbn/search-connectors';
 
 import { BetaConnectorCallout } from '../../../shared/beta/beta_connector_callout';
 import { docLinks } from '../../../shared/doc_links';
@@ -82,6 +83,8 @@ export const NativeConnectorConfiguration: React.FC = () => {
     connector.scheduling.incremental.enabled;
   const hasResearched = hasDescription || hasConfigured || hasConfiguredAdvanced;
   const icon = nativeConnector.icon;
+  const hasDocumentLevelSecurity =
+    connector.features?.[FeatureName.DOCUMENT_LEVEL_SECURITY]?.enabled || false;
 
   const hasApiKey = !!(connector.api_key_id ?? apiKeyData);
 
@@ -290,24 +293,26 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer size="s" />
-                <EuiText size="s">
-                  {i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.securityReminder.description',
-                    {
-                      defaultMessage:
-                        'Restrict and personalize the read access users have to the index documents at query time.',
-                    }
-                  )}
-                  <EuiSpacer size="s" />
-                  <EuiLink href={docLinks.documentLevelSecurity} target="_blank">
+                {hasDocumentLevelSecurity && (
+                  <EuiText size="s">
                     {i18n.translate(
-                      'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.securityReminder.securityLinkLabel',
+                      'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.securityReminder.description',
                       {
-                        defaultMessage: 'Document level security',
+                        defaultMessage:
+                          'Restrict and personalize the read access users have to the index documents at query time.',
                       }
                     )}
-                  </EuiLink>
-                </EuiText>
+                    <EuiSpacer size="s" />
+                    <EuiLink href={docLinks.documentLevelSecurity} target="_blank">
+                      {i18n.translate(
+                        'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.securityReminder.securityLinkLabel',
+                        {
+                          defaultMessage: 'Document level security',
+                        }
+                      )}
+                    </EuiLink>
+                  </EuiText>
+                )}
               </EuiPanel>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>


### PR DESCRIPTION
On cloud we should not show the DLS docs, if the connector does not support the feature as this could lead to confusion, what's supported and what not.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->