### PR TITLE
[Security Solution] Unskip flacky hover action test

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
@@ -23,9 +23,7 @@ import { networkUrl } from '../../../urls/navigation';
 const testDomainOne = 'myTest';
 const testDomainTwo = 'myTest2';
 
-// FLAKY: https://github.com/elastic/kibana/issues/165692
-// Tracked by https://github.com/elastic/security-team/issues/7696
-describe.skip('Overflow items', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Overflow items', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
   context('Network stats and tables', () => {
     before(() => {
       cy.task('esArchiverLoad', { archiveName: 'network' });

--- a/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/explore/network/overflow_items.cy.ts
@@ -23,7 +23,7 @@ import { networkUrl } from '../../../urls/navigation';
 const testDomainOne = 'myTest';
 const testDomainTwo = 'myTest2';
 
-describe('Overflow items', { tags: ['@ess', '@serverless', '@brokenInServerless'] }, () => {
+describe('Overflow items', { tags: ['@ess', '@serverless'] }, () => {
   context('Network stats and tables', () => {
     before(() => {
       cy.task('esArchiverLoad', { archiveName: 'network' });


### PR DESCRIPTION
## Summary

closes: https://github.com/elastic/kibana/issues/165692
part of: https://github.com/elastic/kibana/issues/161874

Hover action flakiness was fixed here https://github.com/elastic/kibana/pull/177577

This PR unskips the test and enables it for serverless execution.

Flaky test runner execution after changes:
https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5401
