### PR TITLE
[Search] Fix singular/plural for connector and crawler counts

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -58,26 +58,32 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
-              <EuiText>
-                {!isCrawler
-                  ? hasMultipleConnectors
-                    ? i18n.translate('xpack.enterpriseSearch.connectorStats.multipleConnectorsText', {
-                        defaultMessage: '{count} connectors',
+                <EuiText>
+                  {!isCrawler
+                    ? hasMultipleConnectors
+                      ? i18n.translate(
+                          'xpack.enterpriseSearch.connectorStats.multipleConnectorsText',
+                          {
+                            defaultMessage: '{count} connectors',
+                            values: { count: connectorCount },
+                          }
+                        )
+                      : i18n.translate(
+                          'xpack.enterpriseSearch.connectorStats.singleConnectorText',
+                          {
+                            defaultMessage: '{count} connector',
+                            values: { count: connectorCount },
+                          }
+                        )
+                    : hasMultipleConnectors
+                    ? i18n.translate('xpack.enterpriseSearch.connectorStats.multipleCrawlersText', {
+                        defaultMessage: '{count} web crawlers',
                         values: { count: connectorCount },
                       })
-                    : i18n.translate('xpack.enterpriseSearch.connectorStats.singleConnectorText', {
-                        defaultMessage: '{count} connector',
+                    : i18n.translate('xpack.enterpriseSearch.connectorStats.singleCrawlerText', {
+                        defaultMessage: '{count} web crawler',
                         values: { count: connectorCount },
-                      })
-                  : hasMultipleConnectors
-                  ? i18n.translate('xpack.enterpriseSearch.connectorStats.multipleCrawlersText', {
-                      defaultMessage: '{count} web crawlers',
-                      values: { count: connectorCount },
-                    })
-                  : i18n.translate('xpack.enterpriseSearch.connectorStats.singleCrawlerText', {
-                      defaultMessage: '{count} web crawler',
-                      values: { count: connectorCount },
-                    })}
+                      })}
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -58,24 +58,26 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
                 </EuiTitle>
               </EuiFlexItem>
               <EuiFlexItem>
-                <EuiText>
-                  {!isCrawler
-                    ? i18n.translate('xpack.enterpriseSearch.connectorStats.connectorsTextLabel', {
-                        defaultMessage: hasMultipleConnectors
-                          ? '{count} connectors'
-                          : '{count} connector',
-                        values: {
-                          count: connectorCount,
-                        },
+              <EuiText>
+                {!isCrawler
+                  ? hasMultipleConnectors
+                    ? i18n.translate('xpack.enterpriseSearch.connectorStats.multipleConnectorsText', {
+                        defaultMessage: '{count} connectors',
+                        values: { count: connectorCount },
                       })
-                    : i18n.translate('xpack.enterpriseSearch.connectorStats.crawlersTextLabel', {
-                        defaultMessage: hasMultipleConnectors
-                          ? '{count} web crawlers'
-                          : '{count} web crawler',
-                        values: {
-                          count: connectorCount,
-                        },
-                      })}
+                    : i18n.translate('xpack.enterpriseSearch.connectorStats.singleConnectorText', {
+                        defaultMessage: '{count} connector',
+                        values: { count: connectorCount },
+                      })
+                  : hasMultipleConnectors
+                  ? i18n.translate('xpack.enterpriseSearch.connectorStats.multipleCrawlersText', {
+                      defaultMessage: '{count} web crawlers',
+                      values: { count: connectorCount },
+                    })
+                  : i18n.translate('xpack.enterpriseSearch.connectorStats.singleCrawlerText', {
+                      defaultMessage: '{count} web crawler',
+                      values: { count: connectorCount },
+                    })}
                 </EuiText>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -29,6 +29,8 @@ export interface ConnectorStatsProps {
 export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => {
   const { makeRequest } = useActions(FetchSyncJobsStatsApiLogic);
   const { data } = useValues(FetchSyncJobsStatsApiLogic);
+  const connectorCount = (data?.connected || 0) + (data?.incomplete || 0);
+  const hasMultipleConnectors = connectorCount > 1;
 
   useEffect(() => {
     makeRequest({ isCrawler });
@@ -59,15 +61,15 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
                 <EuiText>
                   {!isCrawler
                     ? i18n.translate('xpack.enterpriseSearch.connectorStats.connectorsTextLabel', {
-                        defaultMessage: '{count} connectors',
+                        defaultMessage: hasMultipleConnectors ? '{count} connectors' : '{count} connector',
                         values: {
-                          count: (data?.connected || 0) + (data?.incomplete || 0),
+                          count: connectorCount,
                         },
                       })
                     : i18n.translate('xpack.enterpriseSearch.connectorStats.crawlersTextLabel', {
-                        defaultMessage: '{count} web crawlers',
+                        defaultMessage: hasMultipleConnectors ? '{count} web crawlers' : '{count} web crawler',
                         values: {
-                          count: (data?.connected || 0) + (data?.incomplete || 0),
+                          count: connectorCount,
                         },
                       })}
                 </EuiText>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connector_stats.tsx
@@ -61,13 +61,17 @@ export const ConnectorStats: React.FC<ConnectorStatsProps> = ({ isCrawler }) => 
                 <EuiText>
                   {!isCrawler
                     ? i18n.translate('xpack.enterpriseSearch.connectorStats.connectorsTextLabel', {
-                        defaultMessage: hasMultipleConnectors ? '{count} connectors' : '{count} connector',
+                        defaultMessage: hasMultipleConnectors
+                          ? '{count} connectors'
+                          : '{count} connector',
                         values: {
                           count: connectorCount,
                         },
                       })
                     : i18n.translate('xpack.enterpriseSearch.connectorStats.crawlersTextLabel', {
-                        defaultMessage: hasMultipleConnectors ? '{count} web crawlers' : '{count} web crawler',
+                        defaultMessage: hasMultipleConnectors
+                          ? '{count} web crawlers'
+                          : '{count} web crawler',
                         values: {
                           count: connectorCount,
                         },


### PR DESCRIPTION
The crawler and connectors overview page always used plural even if only 1 connector/crawler was configured. This PR fixes this bug by adapting the default message accordingly.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->