### PR TITLE
[Fleet] Allow to upload package for non superuser

### DIFF
--- a/x-pack/plugins/fleet/common/authz.ts
+++ b/x-pack/plugins/fleet/common/authz.ts
@@ -94,7 +94,7 @@ export const calculateAuthz = ({
     installPackages: fleet.all && integrations.all,
     upgradePackages: fleet.all && integrations.all,
     removePackages: fleet.all && integrations.all,
-    uploadPackages: isSuperuser,
+    uploadPackages: fleet.all && integrations.all,
 
     readPackageSettings: fleet.all && integrations.all,
     writePackageSettings: fleet.all && integrations.all,

--- a/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
+++ b/x-pack/test/fleet_api_integration/apis/epm/install_by_upload.ts
@@ -261,7 +261,7 @@ export default function (providerContext: FtrProviderContext) {
         .expect(403);
     });
 
-    it('should not allow non superusers', async () => {
+    it('should allow user with all access', async () => {
       const buf = fs.readFileSync(testPkgArchiveTgz);
       await supertestWithoutAuth
         .post(`/api/fleet/epm/packages`)
@@ -269,7 +269,7 @@ export default function (providerContext: FtrProviderContext) {
         .set('kbn-xsrf', 'xxxx')
         .type('application/gzip')
         .send(buf)
-        .expect(403);
+        .expect(200);
     });
   });
 }


### PR DESCRIPTION
## Summary

Resolve https://github.com/elastic/kibana/issues/166473

Allow to upload package for non superuser, user with permission fleet all and integration all should be able to install a package by upload. cc @kpollich 


## How to test 

### Automated

I updated the related api integration tests

### Manual tests

1. create an api key with a superuser
2. install a package 

```
curl -XPOST -H 'content-type: application/zip' -H 'kbn-xsrf: true' -H 'Authorization: ApiKey ***' http://localhost:5601/api/fleet/epm/packages --data-binary @test_package-0.1.0.zip
```
