### PR TITLE
[8.13] [Inventory rule] Fix bug in inventory rule for Inbound and Outbound traffic threshold (both preview and executor) (#177997)

### DIFF
--- a/x-pack/plugins/infra/public/alerting/inventory/components/expression_chart.tsx
+++ b/x-pack/plugins/infra/public/alerting/inventory/components/expression_chart.tsx
@@ -229,4 +229,6 @@ const convertMetricValue = (metric: SnapshotMetricType, value: number) => {
 const converters: Record<string, (n: number) => number> = {
   cpu: (n) => Number(n) / 100,
   memory: (n) => Number(n) / 100,
+  tx: (n) => Number(n) / 8,
+  rx: (n) => Number(n) / 8,
 };

--- a/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/convert_metric_value.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/convert_metric_value.ts
@@ -18,4 +18,6 @@ export const convertMetricValue = (metric: SnapshotMetricType, value: number) =>
 const converters: Record<string, (n: number) => number> = {
   cpu: (n) => Number(n) / 100,
   memory: (n) => Number(n) / 100,
+  tx: (n) => Number(n) / 8,
+  rx: (n) => Number(n) / 8,
 };

--- a/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/create_bucket_selector.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/create_bucket_selector.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Comparator, InventoryMetricConditions } from '../../../../../common/alerting/metrics';
+import { createBucketSelector } from './create_bucket_selector';
+
+describe('createBucketSelector', () => {
+  it('should convert tx threshold from bits to byte', () => {
+    const inventoryMetricConditions: InventoryMetricConditions = {
+      metric: 'tx',
+      timeSize: 5,
+      timeUnit: 'm',
+      threshold: [8],
+      comparator: Comparator.GT_OR_EQ,
+      warningThreshold: [16],
+      warningComparator: Comparator.LT_OR_EQ,
+    };
+    expect(createBucketSelector('tx', inventoryMetricConditions)).toEqual({
+      selectedBucket: {
+        bucket_selector: {
+          buckets_path: {
+            shouldTrigger: 'shouldTrigger',
+            shouldWarn: 'shouldWarn',
+          },
+          script:
+            '(params.shouldWarn != null && params.shouldWarn > 0) || (params.shouldTrigger != null && params.shouldTrigger > 0)',
+        },
+      },
+      shouldTrigger: {
+        bucket_script: {
+          buckets_path: {
+            value: 'tx',
+          },
+          script: {
+            params: {
+              // Threshold has been converted from 8 bits to 1 byte
+              threshold: 1,
+            },
+            source: 'params.value >= params.threshold ? 1 : 0',
+          },
+        },
+      },
+      shouldWarn: {
+        bucket_script: {
+          buckets_path: {
+            value: 'tx',
+          },
+          script: {
+            params: {
+              // Threshold has been converted from 16 bits to 2 byte
+              threshold: 2,
+            },
+            source: 'params.value <= params.threshold ? 1 : 0',
+          },
+        },
+      },
+    });
+  });
+});

--- a/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/create_condition_script.test.ts
+++ b/x-pack/plugins/infra/server/lib/alerting/inventory_metric_threshold/lib/create_condition_script.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Comparator } from '../../../../../common/alerting/metrics';
+import { createConditionScript } from './create_condition_script';
+
+describe('createConditionScript', () => {
+  it('should convert tx threshold from bits to byte', () => {
+    expect(createConditionScript([8], Comparator.GT_OR_EQ, 'tx')).toEqual({
+      params: {
+        // Threshold has been converted from 8 bits to 1 byte
+        threshold: 1,
+      },
+      source: 'params.value >= params.threshold ? 1 : 0',
+    });
+  });
+});


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Inventory rule] Fix bug in inventory rule for Inbound and Outbound traffic threshold (both preview and executor) (#177997)](https://github.com/elastic/kibana/pull/177997)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Maryam Saeidi","email":"maryam.saeidi@elastic.co"},"sourceCommit":{"committedDate":"2024-03-05T18:07:50Z","message":"[Inventory rule] Fix bug in inventory rule for Inbound and Outbound traffic threshold (both preview and executor) (#177997)\n\nFixes #177912\r\n\r\n## Summary\r\n\r\nThis PR fixes the wrong threshold value in the preview and execution of\r\nthe inventory rule type for both Inbound and Outbound traffic.\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/12370520/015761c0-31f7-4ce0-8c6c-9d889b50df97)|![image](https://github.com/elastic/kibana/assets/12370520/48434ee0-4a0d-4fee-9fd1-e60bcb31f216)|\r\n\r\n## 🧪  How to test\r\n- Adjust data forge package and hard code a specific value for ingress\r\nand/or egress\r\n- For example, I changed this\r\n[line](https://github.com/elastic/kibana/blob/main/x-pack/packages/kbn-data-forge/src/data_sources/fake_hosts/index.ts#L100)\r\nto `bytes: 64,`, then when I created a rule, I always had 8.5 bit/s (64\r\n* 8 = 512, and 512 / 60 = 8.5) Before the fix, if I added 8 bit/s as\r\nthreshold, I didn't get any alert because the value that was compared to\r\n1.7 bit/s (8.5 / 8) was 8 instead of 1 (8 / 8) which was incorrect.\r\n<img\r\nsrc=\"https://github.com/elastic/kibana/assets/12370520/a8c372c5-f5f7-4168-b329-168dbfd20101\"\r\nwidth=500 />\r\n\r\n- Run the data forge command to generate some data\r\n```\r\nnode x-pack/scripts/data_forge.js \\\r\n  --events-per-cycle 7 \\\r\n  --lookback now-20m \\\r\n  --install-kibana-assets \\\r\n  --dataset fake_hosts\r\n```\r\n- Create an inventory rule for egress/ingress depending on which one you\r\nadjusted, and make sure the rule generates an alert correctly and the\r\ndata shown in the alert table and flyout are also correct.","sha":"8f9c130a0605393cec853b2fca9b739881510dec","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:fix","backport:prev-minor","v8.14.0"],"number":177997,"url":"https://github.com/elastic/kibana/pull/177997","mergeCommit":{"message":"[Inventory rule] Fix bug in inventory rule for Inbound and Outbound traffic threshold (both preview and executor) (#177997)\n\nFixes #177912\r\n\r\n## Summary\r\n\r\nThis PR fixes the wrong threshold value in the preview and execution of\r\nthe inventory rule type for both Inbound and Outbound traffic.\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/12370520/015761c0-31f7-4ce0-8c6c-9d889b50df97)|![image](https://github.com/elastic/kibana/assets/12370520/48434ee0-4a0d-4fee-9fd1-e60bcb31f216)|\r\n\r\n## 🧪  How to test\r\n- Adjust data forge package and hard code a specific value for ingress\r\nand/or egress\r\n- For example, I changed this\r\n[line](https://github.com/elastic/kibana/blob/main/x-pack/packages/kbn-data-forge/src/data_sources/fake_hosts/index.ts#L100)\r\nto `bytes: 64,`, then when I created a rule, I always had 8.5 bit/s (64\r\n* 8 = 512, and 512 / 60 = 8.5) Before the fix, if I added 8 bit/s as\r\nthreshold, I didn't get any alert because the value that was compared to\r\n1.7 bit/s (8.5 / 8) was 8 instead of 1 (8 / 8) which was incorrect.\r\n<img\r\nsrc=\"https://github.com/elastic/kibana/assets/12370520/a8c372c5-f5f7-4168-b329-168dbfd20101\"\r\nwidth=500 />\r\n\r\n- Run the data forge command to generate some data\r\n```\r\nnode x-pack/scripts/data_forge.js \\\r\n  --events-per-cycle 7 \\\r\n  --lookback now-20m \\\r\n  --install-kibana-assets \\\r\n  --dataset fake_hosts\r\n```\r\n- Create an inventory rule for egress/ingress depending on which one you\r\nadjusted, and make sure the rule generates an alert correctly and the\r\ndata shown in the alert table and flyout are also correct.","sha":"8f9c130a0605393cec853b2fca9b739881510dec"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177997","number":177997,"mergeCommit":{"message":"[Inventory rule] Fix bug in inventory rule for Inbound and Outbound traffic threshold (both preview and executor) (#177997)\n\nFixes #177912\r\n\r\n## Summary\r\n\r\nThis PR fixes the wrong threshold value in the preview and execution of\r\nthe inventory rule type for both Inbound and Outbound traffic.\r\n\r\n|Before|After|\r\n|---|---|\r\n\r\n|![image](https://github.com/elastic/kibana/assets/12370520/015761c0-31f7-4ce0-8c6c-9d889b50df97)|![image](https://github.com/elastic/kibana/assets/12370520/48434ee0-4a0d-4fee-9fd1-e60bcb31f216)|\r\n\r\n## 🧪  How to test\r\n- Adjust data forge package and hard code a specific value for ingress\r\nand/or egress\r\n- For example, I changed this\r\n[line](https://github.com/elastic/kibana/blob/main/x-pack/packages/kbn-data-forge/src/data_sources/fake_hosts/index.ts#L100)\r\nto `bytes: 64,`, then when I created a rule, I always had 8.5 bit/s (64\r\n* 8 = 512, and 512 / 60 = 8.5) Before the fix, if I added 8 bit/s as\r\nthreshold, I didn't get any alert because the value that was compared to\r\n1.7 bit/s (8.5 / 8) was 8 instead of 1 (8 / 8) which was incorrect.\r\n<img\r\nsrc=\"https://github.com/elastic/kibana/assets/12370520/a8c372c5-f5f7-4168-b329-168dbfd20101\"\r\nwidth=500 />\r\n\r\n- Run the data forge command to generate some data\r\n```\r\nnode x-pack/scripts/data_forge.js \\\r\n  --events-per-cycle 7 \\\r\n  --lookback now-20m \\\r\n  --install-kibana-assets \\\r\n  --dataset fake_hosts\r\n```\r\n- Create an inventory rule for egress/ingress depending on which one you\r\nadjusted, and make sure the rule generates an alert correctly and the\r\ndata shown in the alert table and flyout are also correct.","sha":"8f9c130a0605393cec853b2fca9b739881510dec"}}]}] BACKPORT-->