### PR TITLE
[Ops] Create a pipeline staging job

### DIFF
--- a/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
+++ b/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml
@@ -1,0 +1,32 @@
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: kibana_migration_pipeline_staging_area
+  description: Kibana / Pipeline migration staging area
+spec:
+  type: buildkite-pipeline
+  owner: 'group:kibana-operations'
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: kibana_migration_pipeline_staging
+      description: Kibana / Pipeline migration staging
+    spec:
+      env:
+        SLACK_NOTIFICATIONS_ENABLED: 'false'
+      repository: elastic/kibana
+      pipeline_file: .buildkite/pipelines/upload_pipeline.yml
+      provider_settings:
+        build_branches: false
+        build_pull_requests: false
+        publish_commit_status: false
+        skip_pull_request_builds_for_existing_commits: false
+        trigger_mode: none
+        build_tags: false
+      teams:
+        kibana-operations:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: BUILD_AND_READ

--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: kibana-buildkite-pipelines
+  description: This file points to individual buildkite pipeline definition files
+spec:
+  type: url
+  targets:
+    - kibana-migration-staging.yml

--- a/.buildkite/pipelines/upload_pipeline.yml
+++ b/.buildkite/pipelines/upload_pipeline.yml
@@ -1,0 +1,5 @@
+# This pipeline can be used to upload any tested pipeline in the Elastic-wide buildkite infrastructure to be tested
+
+steps:
+  - label: Upload tested pipeline
+    command: buildkite-agent pipeline upload .buildkite/pipelines/pipeline_to_test.yml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -30,6 +30,16 @@ spec:
   lifecycle: production
 
 ---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  name: kibana-buildkite-pipelines
+  description: A location re-routing file, pointing to individual buildkite pipeline definition files
+spec:
+  type: url
+  location: .buildkite/pipeline-resource-definitions/locations.yml
+
+---
 
 apiVersion: backstage.io/v1alpha1
 kind: Resource


### PR DESCRIPTION
## Summary
This job is to help with the kibana-buildkite -> elastic-wide buildkite migration (https://github.com/elastic/kibana-operations/issues/15). 

The idea is the following:
 - this PR will create a backstage resource in `catalog-info.yaml` that triggers the creation of a buildkite pipeline. (*)
 - this pipeline will be within the `gobld` universe, using the elastic-wide infrastructure and agent images.
 - if we use this pipeline, edit, and run on a specific branch, we can test further pipelines in the `gobld` universe, thus we can test a pipeline's behavior before creating a resource for it, or altering the currently existing pipelines 

(*) - by creating this pipeline, it also tests the idea of having a router file (`locations.yml`) instead of cramming every pipeline def to `catalog-info.yaml`