### PR TITLE
chore(console): rename metric id for opening embedded

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/console_wrapper.tsx
@@ -76,7 +76,7 @@ const loadDependencies = async (
     theme: { theme$ },
   } = core;
   const trackUiMetric = createUsageTracker(usageCollection);
-  trackUiMetric.load('opened_remote_app');
+  trackUiMetric.load('opened_embedded_app');
 
   await loadActiveApi(core.http);
   const autocompleteInfo = getAutocompleteInfo();


### PR DESCRIPTION
## Summary

Renaming the metric for opening the embedded console, this was still using "remote" which we renamed before the initial PR merged.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->