### PR TITLE
[8.13] [Obs AI Assistant] More lenient parsing of suggestion scores (#177898)

### DIFF
--- a/x-pack/plugins/observability_ai_assistant/server/functions/parse_suggestion_scores.test.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/parse_suggestion_scores.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import dedent from 'dedent';
+import { parseSuggestionScores } from './parse_suggestion_scores';
+
+describe('parseSuggestionScores', () => {
+  it('parses newlines as separators', () => {
+    expect(
+      parseSuggestionScores(
+        dedent(
+          `0,1
+      2,7
+      3,10`
+        )
+      )
+    ).toEqual([
+      {
+        index: 0,
+        score: 1,
+      },
+      {
+        index: 2,
+        score: 7,
+      },
+      {
+        index: 3,
+        score: 10,
+      },
+    ]);
+  });
+
+  it('parses semi-colons as separators', () => {
+    expect(parseSuggestionScores(`0,1;2,7;3,10`)).toEqual([
+      {
+        index: 0,
+        score: 1,
+      },
+      {
+        index: 2,
+        score: 7,
+      },
+      {
+        index: 3,
+        score: 10,
+      },
+    ]);
+  });
+
+  it('parses spaces as separators', () => {
+    expect(parseSuggestionScores(`0,1 2,7 3,10`)).toEqual([
+      {
+        index: 0,
+        score: 1,
+      },
+      {
+        index: 2,
+        score: 7,
+      },
+      {
+        index: 3,
+        score: 10,
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/observability_ai_assistant/server/functions/parse_suggestion_scores.ts
+++ b/x-pack/plugins/observability_ai_assistant/server/functions/parse_suggestion_scores.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function parseSuggestionScores(scoresAsString: string) {
+  // make sure that spaces, semi-colons etc work as separators as well
+  const scores = scoresAsString
+    .replace(/[^0-9,]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .map((pair) => {
+      const [index, score] = pair.split(',').map((str) => parseInt(str, 10));
+
+      return {
+        index,
+        score,
+      };
+    });
+
+  return scores;
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Obs AI Assistant] More lenient parsing of suggestion scores (#177898)](https://github.com/elastic/kibana/pull/177898)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dario Gieselaar","email":"dario.gieselaar@elastic.co"},"sourceCommit":{"committedDate":"2024-03-04T08:39:26Z","message":"[Obs AI Assistant] More lenient parsing of suggestion scores (#177898)\n\nCloses #177855. Also adds the scores to `data` for easier debugging.","sha":"0fd880be2ba63da78505465a999f3102f1ded714","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","v8.13.0","v8.14.0","v8.12.3"],"number":177898,"url":"https://github.com/elastic/kibana/pull/177898","mergeCommit":{"message":"[Obs AI Assistant] More lenient parsing of suggestion scores (#177898)\n\nCloses #177855. Also adds the scores to `data` for easier debugging.","sha":"0fd880be2ba63da78505465a999f3102f1ded714"}},"sourceBranch":"main","suggestedTargetBranches":["8.13","8.12"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177898","number":177898,"mergeCommit":{"message":"[Obs AI Assistant] More lenient parsing of suggestion scores (#177898)\n\nCloses #177855. Also adds the scores to `data` for easier debugging.","sha":"0fd880be2ba63da78505465a999f3102f1ded714"}},{"branch":"8.12","label":"v8.12.3","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"}]}] BACKPORT-->