### PR TITLE
[Discover] Remove Serverless plugin dependency

### DIFF
--- a/src/plugins/discover/kibana.jsonc
+++ b/src/plugins/discover/kibana.jsonc
@@ -37,8 +37,7 @@
       "savedObjectsTaggingOss",
       "lens",
       "noDataPage",
-      "globalSearch",
-      "serverless"
+      "globalSearch"
     ],
     "requiredBundles": ["kibanaUtils", "kibanaReact", "unifiedSearch", "savedObjects"],
     "extraPublicDirs": ["common"]

--- a/src/plugins/discover/public/__mocks__/discover_state.mock.ts
+++ b/src/plugins/discover/public/__mocks__/discover_state.mock.ts
@@ -10,6 +10,7 @@ import { getDiscoverStateContainer } from '../application/main/services/discover
 import { savedSearchMockWithTimeField, savedSearchMock } from './saved_search';
 import { discoverServiceMock } from './services';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
+import { mockCustomizationContext } from '../customizations/__mocks__/customization_context';
 
 export function getDiscoverStateMock({
   isTimeBased = true,
@@ -23,13 +24,7 @@ export function getDiscoverStateMock({
   const container = getDiscoverStateContainer({
     services: discoverServiceMock,
     history,
-    customizationContext: {
-      displayMode: 'standalone',
-      inlineTopNav: {
-        enabled: false,
-        showLogsExplorerTabs: false,
-      },
-    },
+    customizationContext: mockCustomizationContext,
   });
   container.savedSearchState.set(
     savedSearch ? savedSearch : isTimeBased ? savedSearchMockWithTimeField : savedSearchMock

--- a/src/plugins/discover/public/__mocks__/discover_state.mock.ts
+++ b/src/plugins/discover/public/__mocks__/discover_state.mock.ts
@@ -25,7 +25,10 @@ export function getDiscoverStateMock({
     history,
     customizationContext: {
       displayMode: 'standalone',
-      showLogsExplorerTabs: false,
+      inlineTopNav: {
+        enabled: false,
+        showLogsExplorerTabs: false,
+      },
     },
   });
   container.savedSearchState.set(

--- a/src/plugins/discover/public/application/discover_router.test.tsx
+++ b/src/plugins/discover/public/application/discover_router.test.tsx
@@ -51,7 +51,10 @@ const gatherRoutes = (wrapper: ShallowWrapper) => {
 
 const customizationContext: DiscoverCustomizationContext = {
   displayMode: 'standalone',
-  showLogsExplorerTabs: false,
+  inlineTopNav: {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  },
 };
 
 const props: DiscoverRoutesProps = {

--- a/src/plugins/discover/public/application/discover_router.test.tsx
+++ b/src/plugins/discover/public/application/discover_router.test.tsx
@@ -23,7 +23,7 @@ import { ContextAppRoute } from './context';
 import { createProfileRegistry } from '../customizations/profile_registry';
 import { addProfile } from '../../common/customizations';
 import { NotFoundRoute } from './not_found';
-import type { DiscoverCustomizationContext } from './types';
+import { mockCustomizationContext } from '../customizations/__mocks__/customization_context';
 
 let mockProfile: string | undefined;
 
@@ -49,18 +49,10 @@ const gatherRoutes = (wrapper: ShallowWrapper) => {
   });
 };
 
-const customizationContext: DiscoverCustomizationContext = {
-  displayMode: 'standalone',
-  inlineTopNav: {
-    enabled: false,
-    showLogsExplorerTabs: false,
-  },
-};
-
 const props: DiscoverRoutesProps = {
   isDev: false,
   customizationCallbacks: [],
-  customizationContext,
+  customizationContext: mockCustomizationContext,
 };
 
 describe('DiscoverRoutes', () => {
@@ -164,7 +156,7 @@ describe('CustomDiscoverRoutes', () => {
     const component = shallow(
       <CustomDiscoverRoutes
         profileRegistry={profileRegistry}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );
@@ -172,7 +164,7 @@ describe('CustomDiscoverRoutes', () => {
       <DiscoverRoutes
         prefix={addProfile('', mockProfile)}
         customizationCallbacks={callbacks}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );
@@ -183,7 +175,7 @@ describe('CustomDiscoverRoutes', () => {
     const component = shallow(
       <CustomDiscoverRoutes
         profileRegistry={profileRegistry}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );
@@ -202,7 +194,7 @@ describe('DiscoverRouter', () => {
         services={mockDiscoverServices}
         history={history}
         profileRegistry={profileRegistry}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );
@@ -213,7 +205,7 @@ describe('DiscoverRouter', () => {
     expect(pathMap['/']).toMatchObject(
       <DiscoverRoutes
         customizationCallbacks={callbacks}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );
@@ -223,7 +215,7 @@ describe('DiscoverRouter', () => {
     expect(pathMap[profilePath]).toMatchObject(
       <CustomDiscoverRoutes
         profileRegistry={profileRegistry}
-        customizationContext={customizationContext}
+        customizationContext={mockCustomizationContext}
         isDev={props.isDev}
       />
     );

--- a/src/plugins/discover/public/application/discover_router.tsx
+++ b/src/plugins/discover/public/application/discover_router.tsx
@@ -18,10 +18,9 @@ import { DiscoverMainRoute } from './main';
 import { NotFoundRoute } from './not_found';
 import { DiscoverServices } from '../build_services';
 import { ViewAlertRoute } from './view_alert';
-import type { CustomizationCallback } from '../customizations';
+import type { CustomizationCallback, DiscoverCustomizationContext } from '../customizations';
 import type { DiscoverProfileRegistry } from '../customizations/profile_registry';
 import { addProfile } from '../../common/customizations';
-import type { DiscoverCustomizationContext } from './types';
 
 export interface DiscoverRoutesProps {
   prefix?: string;

--- a/src/plugins/discover/public/application/index.tsx
+++ b/src/plugins/discover/public/application/index.tsx
@@ -12,7 +12,7 @@ import { toMountPoint } from '@kbn/react-kibana-mount';
 import { DiscoverRouter } from './discover_router';
 import { DiscoverServices } from '../build_services';
 import type { DiscoverProfileRegistry } from '../customizations/profile_registry';
-import type { DiscoverCustomizationContext } from './types';
+import type { DiscoverCustomizationContext } from '../customizations';
 
 export interface RenderAppProps {
   element: HTMLElement;

--- a/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
+++ b/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
@@ -15,7 +15,7 @@ import { createHashHistory } from 'history';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { buildDataTableRecordList } from '@kbn/discover-utils';
 import { esHitsMock } from '@kbn/discover-utils/src/__mocks__';
-import { DiscoverCustomizationContext, FetchStatus } from '../../../../types';
+import { FetchStatus } from '../../../../types';
 import {
   AvailableFields$,
   DataDocuments$,
@@ -29,6 +29,7 @@ import {
   getDiscoverStateContainer,
 } from '../../../services/discover_state';
 import { services } from '../../../../../__mocks__/__storybook_mocks__/with_discover_services';
+import { mockCustomizationContext } from '../../../../../customizations/__mocks__/customization_context';
 
 const documentObservables = {
   main$: new BehaviorSubject({
@@ -124,20 +125,12 @@ function getSavedSearch(dataView: DataView) {
   } as unknown as SavedSearch;
 }
 
-const customizationContext: DiscoverCustomizationContext = {
-  displayMode: 'standalone',
-  inlineTopNav: {
-    enabled: false,
-    showLogsExplorerTabs: false,
-  },
-};
-
 export function getDocumentsLayoutProps(dataView: DataView) {
   const stateContainer = getDiscoverStateContainer({
     history: createHashHistory(),
     savedSearch: getSavedSearch(dataView),
     services,
-    customizationContext,
+    customizationContext: mockCustomizationContext,
   });
   stateContainer.appState.set({
     columns: ['name', 'message', 'bytes'],
@@ -162,7 +155,7 @@ export const getPlainRecordLayoutProps = (dataView: DataView) => {
     history: createHashHistory(),
     savedSearch: getSavedSearch(dataView),
     services,
-    customizationContext,
+    customizationContext: mockCustomizationContext,
   });
   stateContainer.appState.set({
     columns: ['name', 'message', 'bytes'],

--- a/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
+++ b/src/plugins/discover/public/application/main/components/layout/__stories__/get_layout_props.ts
@@ -126,7 +126,10 @@ function getSavedSearch(dataView: DataView) {
 
 const customizationContext: DiscoverCustomizationContext = {
   displayMode: 'standalone',
-  showLogsExplorerTabs: false,
+  inlineTopNav: {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  },
 };
 
 export function getDocumentsLayoutProps(dataView: DataView) {

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.scss
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.scss
@@ -12,7 +12,7 @@ discover-app {
   @include euiBreakpoint('m', 'l', 'xl') {
     @include kibanaFullBodyHeight();
 
-    &.dscPage--serverless {
+    &.dscPage--topNavInline {
       @include kibanaFullBodyHeight($euiSize * 3);
     }
   }

--- a/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
+++ b/src/plugins/discover/public/application/main/components/layout/discover_layout.tsx
@@ -73,7 +73,6 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
     history,
     spaces,
     docLinks,
-    serverless,
   } = useDiscoverServices();
   const pageBackgroundColor = useEuiBackgroundColor('plain');
   const globalQueryState = data.query.getState();
@@ -263,7 +262,9 @@ export function DiscoverLayout({ stateContainer }: DiscoverLayoutProps) {
 
   return (
     <EuiPage
-      className={classNames('dscPage', { 'dscPage--serverless': serverless })}
+      className={classNames('dscPage', {
+        'dscPage--topNavInline': stateContainer.customizationContext.inlineTopNav.enabled,
+      })}
       data-fetch-counter={fetchCounter.current}
       css={css`
         background-color: ${pageBackgroundColor};

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.test.tsx
@@ -282,8 +282,8 @@ describe('Discover topnav component', () => {
     });
   });
 
-  describe('serverless', () => {
-    it('should render top nav when serverless plugin is not defined', () => {
+  describe('inline top nav', () => {
+    it('should render top nav when inline top nav is not enabled', () => {
       const props = getProps();
       const component = mountWithIntl(
         <DiscoverMainProvider value={props.stateContainer}>
@@ -296,14 +296,9 @@ describe('Discover topnav component', () => {
       expect(searchBar.prop('setMenuMountPoint')).toBeDefined();
     });
 
-    it('should not render top nav when serverless plugin is defined', () => {
-      mockUseKibana.mockReturnValue({
-        services: {
-          ...mockDiscoverService,
-          serverless: true,
-        },
-      });
+    it('should not render top nav when inline top nav is enabled', () => {
       const props = getProps();
+      props.stateContainer.customizationContext.inlineTopNav.enabled = true;
       const component = mountWithIntl(
         <DiscoverMainProvider value={props.stateContainer}>
           <DiscoverTopNav {...props} />

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav.tsx
@@ -166,7 +166,7 @@ export const DiscoverTopNav = ({
   const { topNavBadges, topNavMenu } = useDiscoverTopNav({ stateContainer });
   const setMenuMountPoint = getHeaderActionMenuMounter();
   const topNavProps = useMemo(() => {
-    if (services.serverless) {
+    if (stateContainer.customizationContext.inlineTopNav.enabled) {
       return undefined;
     }
 
@@ -175,7 +175,12 @@ export const DiscoverTopNav = ({
       config: topNavMenu,
       setMenuMountPoint,
     };
-  }, [services.serverless, setMenuMountPoint, topNavBadges, topNavMenu]);
+  }, [
+    setMenuMountPoint,
+    stateContainer.customizationContext.inlineTopNav.enabled,
+    topNavBadges,
+    topNavMenu,
+  ]);
 
   const savedSearchId = useSavedSearch().id;
   const savedSearchHasChanged = useSavedSearchHasChanged();

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.test.tsx
@@ -8,7 +8,7 @@
 
 import React from 'react';
 import { DiscoverMainProvider } from '../../services/discover_state_provider';
-import { DiscoverTopNavServerless } from './discover_topnav_serverless';
+import { DiscoverTopNavInline } from './discover_topnav_inline';
 import { getDiscoverStateMock } from '../../../../__mocks__/discover_state.mock';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import { discoverServiceMock as mockDiscoverService } from '../../../../__mocks__/services';
@@ -23,6 +23,7 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
 function getProps({ hideNavMenuItems }: { hideNavMenuItems?: boolean } = {}) {
   const stateContainer = getDiscoverStateMock({ isTimeBased: true });
   stateContainer.internalState.transitions.setDataView(dataViewMock);
+  stateContainer.customizationContext.inlineTopNav.enabled = true;
 
   return {
     stateContainer,
@@ -32,7 +33,7 @@ function getProps({ hideNavMenuItems }: { hideNavMenuItems?: boolean } = {}) {
 
 const mockUseKibana = useKibana as jest.Mock;
 
-describe('DiscoverTopNavServerless', () => {
+describe('DiscoverTopNavInline', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseKibana.mockReturnValue({
@@ -40,67 +41,50 @@ describe('DiscoverTopNavServerless', () => {
     });
   });
 
-  it('should not render when serverless plugin is not defined', async () => {
+  it('should not render when top nav inline is not enabled', async () => {
     const props = getProps();
+    props.stateContainer.customizationContext.inlineTopNav.enabled = false;
     render(
       <DiscoverMainProvider value={props.stateContainer}>
-        <DiscoverTopNavServerless {...props} />
+        <DiscoverTopNavInline {...props} />
       </DiscoverMainProvider>
     );
-    const topNav = screen.queryByTestId('discoverTopNavServerless');
+    const topNav = screen.queryByTestId('discoverTopNavInline');
     expect(topNav).toBeNull();
   });
 
-  it('should render when serverless plugin is defined and displayMode is "standalone"', async () => {
-    mockUseKibana.mockReturnValue({
-      services: {
-        ...mockDiscoverService,
-        serverless: true,
-      },
-    });
+  it('should render when top nav inline is enabled and displayMode is "standalone"', async () => {
     const props = getProps();
     render(
       <DiscoverMainProvider value={props.stateContainer}>
-        <DiscoverTopNavServerless {...props} />
+        <DiscoverTopNavInline {...props} />
       </DiscoverMainProvider>
     );
-    const topNav = screen.queryByTestId('discoverTopNavServerless');
+    const topNav = screen.queryByTestId('discoverTopNavInline');
     expect(topNav).not.toBeNull();
   });
 
-  it('should not render when serverless plugin is defined and displayMode is not "standalone"', async () => {
-    mockUseKibana.mockReturnValue({
-      services: {
-        ...mockDiscoverService,
-        serverless: true,
-      },
-    });
+  it('should not render when top nav inline is enabled and displayMode is not "standalone"', async () => {
     const props = getProps();
     props.stateContainer.customizationContext.displayMode = 'embedded';
     render(
       <DiscoverMainProvider value={props.stateContainer}>
-        <DiscoverTopNavServerless {...props} />
+        <DiscoverTopNavInline {...props} />
       </DiscoverMainProvider>
     );
-    const topNav = screen.queryByTestId('discoverTopNavServerless');
+    const topNav = screen.queryByTestId('discoverTopNavInline');
     expect(topNav).toBeNull();
   });
 
   describe('nav menu items', () => {
     it('should show nav menu items when hideNavMenuItems is false', async () => {
-      mockUseKibana.mockReturnValue({
-        services: {
-          ...mockDiscoverService,
-          serverless: true,
-        },
-      });
       const props = getProps();
       render(
         <DiscoverMainProvider value={props.stateContainer}>
-          <DiscoverTopNavServerless {...props} />
+          <DiscoverTopNavInline {...props} />
         </DiscoverMainProvider>
       );
-      const topNav = screen.queryByTestId('discoverTopNavServerless');
+      const topNav = screen.queryByTestId('discoverTopNavInline');
       expect(topNav).not.toBeNull();
       await waitFor(() => {
         const topNavMenuItems = screen.queryByTestId('topNavMenuItems');
@@ -109,19 +93,13 @@ describe('DiscoverTopNavServerless', () => {
     });
 
     it('should hide nav menu items when hideNavMenuItems is true', async () => {
-      mockUseKibana.mockReturnValue({
-        services: {
-          ...mockDiscoverService,
-          serverless: true,
-        },
-      });
       const props = getProps({ hideNavMenuItems: true });
       render(
         <DiscoverMainProvider value={props.stateContainer}>
-          <DiscoverTopNavServerless {...props} />
+          <DiscoverTopNavInline {...props} />
         </DiscoverMainProvider>
       );
-      const topNav = screen.queryByTestId('discoverTopNavServerless');
+      const topNav = screen.queryByTestId('discoverTopNavInline');
       expect(topNav).not.toBeNull();
       await waitFor(() => {
         const topNavMenuItems = screen.queryByTestId('topNavMenuItems');
@@ -132,20 +110,14 @@ describe('DiscoverTopNavServerless', () => {
 
   describe('LogsExplorerTabs', () => {
     it('should render when showLogsExplorerTabs is true', async () => {
-      mockUseKibana.mockReturnValue({
-        services: {
-          ...mockDiscoverService,
-          serverless: true,
-        },
-      });
       const props = getProps();
-      props.stateContainer.customizationContext.showLogsExplorerTabs = true;
+      props.stateContainer.customizationContext.inlineTopNav.showLogsExplorerTabs = true;
       render(
         <DiscoverMainProvider value={props.stateContainer}>
-          <DiscoverTopNavServerless {...props} />
+          <DiscoverTopNavInline {...props} />
         </DiscoverMainProvider>
       );
-      const topNav = screen.queryByTestId('discoverTopNavServerless');
+      const topNav = screen.queryByTestId('discoverTopNavInline');
       expect(topNav).not.toBeNull();
       await waitFor(() => {
         const logsExplorerTabs = screen.queryByTestId('logsExplorerTabs');
@@ -154,19 +126,13 @@ describe('DiscoverTopNavServerless', () => {
     });
 
     it('should not render when showLogsExplorerTabs is false', async () => {
-      mockUseKibana.mockReturnValue({
-        services: {
-          ...mockDiscoverService,
-          serverless: true,
-        },
-      });
       const props = getProps();
       render(
         <DiscoverMainProvider value={props.stateContainer}>
-          <DiscoverTopNavServerless {...props} />
+          <DiscoverTopNavInline {...props} />
         </DiscoverMainProvider>
       );
-      const topNav = screen.queryByTestId('discoverTopNavServerless');
+      const topNav = screen.queryByTestId('discoverTopNavInline');
       expect(topNav).not.toBeNull();
       await waitFor(() => {
         const logsExplorerTabs = screen.queryByTestId('logsExplorerTabs');

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.test.tsx
@@ -23,7 +23,9 @@ jest.mock('@kbn/kibana-react-plugin/public', () => ({
 function getProps({ hideNavMenuItems }: { hideNavMenuItems?: boolean } = {}) {
   const stateContainer = getDiscoverStateMock({ isTimeBased: true });
   stateContainer.internalState.transitions.setDataView(dataViewMock);
+  stateContainer.customizationContext.displayMode = 'standalone';
   stateContainer.customizationContext.inlineTopNav.enabled = true;
+  stateContainer.customizationContext.inlineTopNav.showLogsExplorerTabs = false;
 
   return {
     stateContainer,

--- a/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/discover_topnav_inline.tsx
@@ -14,7 +14,7 @@ import { useDiscoverServices } from '../../../../hooks/use_discover_services';
 import { useDiscoverTopNav } from './use_discover_topnav';
 import type { DiscoverStateContainer } from '../../services/discover_state';
 
-export const DiscoverTopNavServerless = ({
+export const DiscoverTopNavInline = ({
   stateContainer,
   hideNavMenuItems,
 }: {
@@ -25,13 +25,16 @@ export const DiscoverTopNavServerless = ({
   const services = useDiscoverServices();
   const { topNavBadges, topNavMenu } = useDiscoverTopNav({ stateContainer });
 
-  if (!services.serverless || customizationContext.displayMode !== 'standalone') {
+  if (
+    !customizationContext.inlineTopNav.enabled ||
+    customizationContext.displayMode !== 'standalone'
+  ) {
     return null;
   }
 
   return (
-    <EuiHeader css={{ boxShadow: 'none' }} data-test-subj="discoverTopNavServerless">
-      {customizationContext.showLogsExplorerTabs && (
+    <EuiHeader css={{ boxShadow: 'none' }} data-test-subj="discoverTopNavInline">
+      {customizationContext.inlineTopNav.showLogsExplorerTabs && (
         <EuiHeaderSection>
           <EuiHeaderSectionItem>
             <LogsExplorerTabs services={services} selectedTab="discover" />

--- a/src/plugins/discover/public/application/main/components/top_nav/on_save_search.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/on_save_search.test.tsx
@@ -27,7 +27,10 @@ function getStateContainer({ dataView }: { dataView?: DataView } = {}) {
     history,
     customizationContext: {
       displayMode: 'standalone',
-      showLogsExplorerTabs: false,
+      inlineTopNav: {
+        enabled: false,
+        showLogsExplorerTabs: false,
+      },
     },
   });
   stateContainer.savedSearchState.set(savedSearch);

--- a/src/plugins/discover/public/application/main/components/top_nav/on_save_search.test.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/on_save_search.test.tsx
@@ -18,6 +18,7 @@ import { ReactElement } from 'react';
 import { discoverServiceMock } from '../../../../__mocks__/services';
 import { SavedSearch } from '@kbn/saved-search-plugin/public';
 import { createBrowserHistory } from 'history';
+import { mockCustomizationContext } from '../../../../customizations/__mocks__/customization_context';
 
 function getStateContainer({ dataView }: { dataView?: DataView } = {}) {
   const savedSearch = savedSearchMock;
@@ -25,13 +26,7 @@ function getStateContainer({ dataView }: { dataView?: DataView } = {}) {
   const stateContainer = getDiscoverStateContainer({
     services: discoverServiceMock,
     history,
-    customizationContext: {
-      displayMode: 'standalone',
-      inlineTopNav: {
-        enabled: false,
-        showLogsExplorerTabs: false,
-      },
-    },
+    customizationContext: mockCustomizationContext,
   });
   stateContainer.savedSearchState.set(savedSearch);
   stateContainer.appState.getState = jest.fn(() => ({

--- a/src/plugins/discover/public/application/main/discover_main_route.test.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.test.tsx
@@ -21,6 +21,7 @@ import {
   DiscoverCustomizationService,
 } from '../../customizations/customization_service';
 import { DiscoverTopNavInline } from './components/top_nav/discover_topnav_inline';
+import { mockCustomizationContext } from '../../customizations/__mocks__/customization_context';
 
 let mockCustomizationService: DiscoverCustomizationService | undefined;
 
@@ -113,13 +114,7 @@ const mountComponent = (hasESData = true, hasUserDataView = true) => {
   const props: MainRouteProps = {
     isDev: false,
     customizationCallbacks: [],
-    customizationContext: {
-      displayMode: 'standalone',
-      inlineTopNav: {
-        enabled: false,
-        showLogsExplorerTabs: false,
-      },
-    },
+    customizationContext: mockCustomizationContext,
   };
 
   return mountWithIntl(

--- a/src/plugins/discover/public/application/main/discover_main_route.test.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.test.tsx
@@ -20,7 +20,7 @@ import {
   createCustomizationService,
   DiscoverCustomizationService,
 } from '../../customizations/customization_service';
-import { DiscoverTopNavServerless } from './components/top_nav/discover_topnav_serverless';
+import { DiscoverTopNavInline } from './components/top_nav/discover_topnav_inline';
 
 let mockCustomizationService: DiscoverCustomizationService | undefined;
 
@@ -100,13 +100,11 @@ describe('DiscoverMainRoute', () => {
     });
   });
 
-  test('should pass hideNavMenuItems=true to DiscoverTopNavServerless while loading', async () => {
+  test('should pass hideNavMenuItems=true to DiscoverTopNavInline while loading', async () => {
     const component = mountComponent(true, true);
-    expect(component.find(DiscoverTopNavServerless).prop('hideNavMenuItems')).toBe(true);
+    expect(component.find(DiscoverTopNavInline).prop('hideNavMenuItems')).toBe(true);
     await waitFor(() => {
-      expect(component.update().find(DiscoverTopNavServerless).prop('hideNavMenuItems')).toBe(
-        false
-      );
+      expect(component.update().find(DiscoverTopNavInline).prop('hideNavMenuItems')).toBe(false);
     });
   });
 });
@@ -117,7 +115,10 @@ const mountComponent = (hasESData = true, hasUserDataView = true) => {
     customizationCallbacks: [],
     customizationContext: {
       displayMode: 'standalone',
-      showLogsExplorerTabs: false,
+      inlineTopNav: {
+        enabled: false,
+        showLogsExplorerTabs: false,
+      },
     },
   };
 

--- a/src/plugins/discover/public/application/main/discover_main_route.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.tsx
@@ -39,7 +39,7 @@ import {
   useDiscoverCustomizationService,
 } from '../../customizations';
 import type { DiscoverCustomizationContext } from '../types';
-import { DiscoverTopNavServerless } from './components/top_nav/discover_topnav_serverless';
+import { DiscoverTopNavInline } from './components/top_nav/discover_topnav_inline';
 import { isTextBasedQuery } from './utils/is_text_based_query';
 import { DiscoverStateContainer, LoadParams } from './services/discover_state';
 
@@ -353,7 +353,7 @@ export function DiscoverMainRoute({
     <DiscoverCustomizationProvider value={customizationService}>
       <DiscoverMainProvider value={stateContainer}>
         <>
-          <DiscoverTopNavServerless stateContainer={stateContainer} hideNavMenuItems={loading} />
+          <DiscoverTopNavInline stateContainer={stateContainer} hideNavMenuItems={loading} />
           {mainContent}
         </>
       </DiscoverMainProvider>

--- a/src/plugins/discover/public/application/main/discover_main_route.tsx
+++ b/src/plugins/discover/public/application/main/discover_main_route.tsx
@@ -35,10 +35,10 @@ import { useAlertResultsToast } from './hooks/use_alert_results_toast';
 import { DiscoverMainProvider } from './services/discover_state_provider';
 import {
   CustomizationCallback,
+  DiscoverCustomizationContext,
   DiscoverCustomizationProvider,
   useDiscoverCustomizationService,
 } from '../../customizations';
-import type { DiscoverCustomizationContext } from '../types';
 import { DiscoverTopNavInline } from './components/top_nav/discover_topnav_inline';
 import { isTextBasedQuery } from './utils/is_text_based_query';
 import { DiscoverStateContainer, LoadParams } from './services/discover_state';

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -25,23 +25,16 @@ import { discoverServiceMock } from '../../../__mocks__/services';
 import { dataViewMock } from '@kbn/discover-utils/src/__mocks__';
 import type { DiscoverAppStateContainer } from './discover_app_state_container';
 import { waitFor } from '@testing-library/react';
-import { DiscoverCustomizationContext, FetchStatus } from '../../types';
+import { FetchStatus } from '../../types';
 import { dataViewAdHoc, dataViewComplexMock } from '../../../__mocks__/data_view_complex';
 import { copySavedSearch } from './discover_saved_search_container';
 import { createKbnUrlStateStorage, IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
+import { mockCustomizationContext } from '../../../customizations/__mocks__/customization_context';
 
 const startSync = (appState: DiscoverAppStateContainer) => {
   const { start, stop } = appState.syncState();
   start();
   return stop;
-};
-
-const customizationContext: DiscoverCustomizationContext = {
-  displayMode: 'standalone',
-  inlineTopNav: {
-    enabled: false,
-    showLogsExplorerTabs: false,
-  },
 };
 
 async function getState(
@@ -61,7 +54,7 @@ async function getState(
   const nextState = getDiscoverStateContainer({
     services: discoverServiceMock,
     history: nextHistory,
-    customizationContext,
+    customizationContext: mockCustomizationContext,
   });
   nextState.appState.isEmptyURL = jest.fn(() => isEmptyUrl ?? true);
   jest.spyOn(nextState.dataState, 'fetch');
@@ -98,7 +91,7 @@ describe('Test discover state', () => {
     state = getDiscoverStateContainer({
       services: discoverServiceMock,
       history,
-      customizationContext,
+      customizationContext: mockCustomizationContext,
     });
     state.savedSearchState.set(savedSearchMock);
     state.appState.update({}, true);
@@ -181,7 +174,7 @@ describe('Test discover state with overridden state storage', () => {
     state = getDiscoverStateContainer({
       services: discoverServiceMock,
       history,
-      customizationContext,
+      customizationContext: mockCustomizationContext,
       stateStorageContainer: stateStorage,
     });
     state.savedSearchState.set(savedSearchMock);
@@ -267,7 +260,7 @@ describe('Test createSearchSessionRestorationDataProvider', () => {
   const discoverStateContainer = getDiscoverStateContainer({
     services: discoverServiceMock,
     history,
-    customizationContext,
+    customizationContext: mockCustomizationContext,
   });
   discoverStateContainer.appState.update({
     index: savedSearchMock.searchSource.getField('index')!.id,
@@ -850,7 +843,7 @@ describe('Test discover state with embedded mode', () => {
       services: discoverServiceMock,
       history,
       customizationContext: {
-        ...customizationContext,
+        ...mockCustomizationContext,
         displayMode: 'embedded',
       },
     });

--- a/src/plugins/discover/public/application/main/services/discover_state.test.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.test.ts
@@ -38,7 +38,10 @@ const startSync = (appState: DiscoverAppStateContainer) => {
 
 const customizationContext: DiscoverCustomizationContext = {
   displayMode: 'standalone',
-  showLogsExplorerTabs: false,
+  inlineTopNav: {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  },
 };
 
 async function getState(

--- a/src/plugins/discover/public/application/main/services/discover_state.ts
+++ b/src/plugins/discover/public/application/main/services/discover_state.ts
@@ -26,7 +26,7 @@ import { merge } from 'rxjs';
 import { AggregateQuery, Query, TimeRange } from '@kbn/es-query';
 import { loadSavedSearch as loadSavedSearchFn } from './load_saved_search';
 import { restoreStateFromSavedSearch } from '../../../services/saved_searches/restore_from_saved_search';
-import { DiscoverCustomizationContext, FetchStatus } from '../../types';
+import { FetchStatus } from '../../types';
 import { changeDataView } from '../hooks/utils/change_data_view';
 import { buildStateSubscribe } from '../hooks/utils/build_state_subscribe';
 import { addLog } from '../../../utils/add_log';
@@ -54,6 +54,7 @@ import {
   getDiscoverGlobalStateContainer,
   DiscoverGlobalStateContainer,
 } from './discover_global_state_container';
+import type { DiscoverCustomizationContext } from '../../../customizations';
 
 export interface DiscoverStateContainerParams {
   /**

--- a/src/plugins/discover/public/application/types.ts
+++ b/src/plugins/discover/public/application/types.ts
@@ -19,28 +19,6 @@ export enum FetchStatus {
   ERROR = 'error',
 }
 
-export type DiscoverDisplayMode = 'embedded' | 'standalone';
-
-export interface DiscoverCustomizationContext {
-  /*
-   * Display mode in which discover is running
-   */
-  displayMode: DiscoverDisplayMode;
-  /**
-   * New inline top nav configuration
-   */
-  inlineTopNav: {
-    /**
-     * Whether or not to show the new inline top nav
-     */
-    enabled: boolean;
-    /**
-     * Whether or not to show the Log Explorer tabs
-     */
-    showLogsExplorerTabs: boolean;
-  };
-}
-
 export interface RecordsFetchResponse {
   records: DataTableRecord[];
   textBasedQueryColumns?: DatatableColumn[];

--- a/src/plugins/discover/public/application/types.ts
+++ b/src/plugins/discover/public/application/types.ts
@@ -27,9 +27,18 @@ export interface DiscoverCustomizationContext {
    */
   displayMode: DiscoverDisplayMode;
   /**
-   * Whether or not to show the Log Explorer tabs
+   * New inline top nav configuration
    */
-  showLogsExplorerTabs: boolean;
+  inlineTopNav: {
+    /**
+     * Whether or not to show the new inline top nav
+     */
+    enabled: boolean;
+    /**
+     * Whether or not to show the Log Explorer tabs
+     */
+    showLogsExplorerTabs: boolean;
+  };
 }
 
 export interface RecordsFetchResponse {

--- a/src/plugins/discover/public/build_services.ts
+++ b/src/plugins/discover/public/build_services.ts
@@ -53,7 +53,6 @@ import type { SettingsStart } from '@kbn/core-ui-settings-browser';
 import type { ContentClient } from '@kbn/content-management-plugin/public';
 import { memoize } from 'lodash';
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
-import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import { getHistory } from './kibana_services';
 import { DiscoverStartPlugins } from './plugin';
 import { DiscoverContextAppLocator } from './application/context/services/locator';
@@ -112,7 +111,6 @@ export interface DiscoverServices {
   uiActions: UiActionsStart;
   contentClient: ContentClient;
   noDataPage?: NoDataPagePluginStart;
-  serverless?: ServerlessPluginStart;
 }
 
 export const buildServices = memoize(function (
@@ -173,6 +171,5 @@ export const buildServices = memoize(function (
     uiActions: plugins.uiActions,
     contentClient: plugins.contentManagement.client,
     noDataPage: plugins.noDataPage,
-    serverless: plugins.serverless,
   };
 });

--- a/src/plugins/discover/public/components/discover_container/discover_container.tsx
+++ b/src/plugins/discover/public/components/discover_container/discover_container.tsx
@@ -48,7 +48,10 @@ const discoverContainerWrapperCss = css`
 
 const customizationContext: DiscoverCustomizationContext = {
   displayMode: 'embedded',
-  showLogsExplorerTabs: false,
+  inlineTopNav: {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  },
 };
 
 export const DiscoverContainerInternal = ({

--- a/src/plugins/discover/public/components/discover_container/discover_container.tsx
+++ b/src/plugins/discover/public/components/discover_container/discover_container.tsx
@@ -14,10 +14,9 @@ import { css } from '@emotion/react';
 import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import { DiscoverMainRoute } from '../../application/main';
 import type { DiscoverServices } from '../../build_services';
-import type { CustomizationCallback } from '../../customizations';
+import type { CustomizationCallback, DiscoverCustomizationContext } from '../../customizations';
 import { setHeaderActionMenuMounter, setScopedHistory } from '../../kibana_services';
 import { LoadingIndicator } from '../common/loading_indicator';
-import type { DiscoverCustomizationContext } from '../../application/types';
 
 export interface DiscoverContainerInternalProps {
   /*

--- a/src/plugins/discover/public/customizations/__mocks__/customization_context.ts
+++ b/src/plugins/discover/public/customizations/__mocks__/customization_context.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+import type { DiscoverCustomizationContext } from '../types';
+
+export const mockCustomizationContext: DiscoverCustomizationContext = {
+  displayMode: 'standalone',
+  inlineTopNav: {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  },
+};

--- a/src/plugins/discover/public/customizations/types.ts
+++ b/src/plugins/discover/public/customizations/types.ts
@@ -36,3 +36,25 @@ export type RegisterCustomizationProfile = (
 export type CustomizationCallback = (
   options: CustomizationCallbackContext
 ) => void | (() => void) | Promise<void | (() => void)>;
+
+export type DiscoverDisplayMode = 'embedded' | 'standalone';
+
+export interface DiscoverCustomizationContext {
+  /*
+   * Display mode in which discover is running
+   */
+  displayMode: DiscoverDisplayMode;
+  /**
+   * Inline top nav configuration
+   */
+  inlineTopNav: {
+    /**
+     * Whether or not to show the inline top nav
+     */
+    enabled: boolean;
+    /**
+     * Whether or not to show the Logs Explorer tabs
+     */
+    showLogsExplorerTabs: boolean;
+  };
+}

--- a/src/plugins/discover/public/mocks.tsx
+++ b/src/plugins/discover/public/mocks.tsx
@@ -17,7 +17,7 @@ export type Start = jest.Mocked<DiscoverStart>;
 const createSetupContract = (): Setup => {
   const setupContract: Setup = {
     locator: sharePluginMock.createLocator(),
-    showLogsExplorerTabs: jest.fn(),
+    showInlineTopNav: jest.fn(),
   };
   return setupContract;
 };

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -45,7 +45,6 @@ import { setStateToKbnUrl } from '@kbn/kibana-utils-plugin/public';
 import type { LensPublicStart } from '@kbn/lens-plugin/public';
 import { TRUNCATE_MAX_HEIGHT, ENABLE_ESQL } from '@kbn/discover-utils';
 import type { NoDataPagePluginStart } from '@kbn/no-data-page-plugin/public';
-import type { ServerlessPluginStart } from '@kbn/serverless/public';
 import { PLUGIN_ID } from '../common';
 import {
   setHeaderActionMenuMounter,
@@ -84,6 +83,7 @@ import {
   type DiscoverContainerProps,
 } from './components/discover_container';
 import { getESQLSearchProvider } from './global_search/search_provider';
+import { DiscoverCustomizationContext } from './application/types';
 
 /**
  * @public
@@ -120,7 +120,9 @@ export interface DiscoverSetup {
    * ```
    */
   readonly locator: undefined | DiscoverAppLocator;
-  readonly showLogsExplorerTabs: () => void;
+  readonly showInlineTopNav: (
+    options?: Partial<Omit<DiscoverCustomizationContext['inlineTopNav'], 'enabled'>>
+  ) => void;
 }
 
 export interface DiscoverStart {
@@ -202,7 +204,6 @@ export interface DiscoverStartPlugins {
   lens: LensPublicStart;
   contentManagement: ContentManagementPublicStart;
   noDataPage?: NoDataPagePluginStart;
-  serverless?: ServerlessPluginStart;
 }
 
 /**
@@ -220,9 +221,15 @@ export class DiscoverPlugin
   private locator?: DiscoverAppLocator;
   private contextLocator?: DiscoverContextAppLocator;
   private singleDocLocator?: DiscoverSingleDocLocator;
-  private showLogsExplorerTabs = false;
+  private inlineTopNav: DiscoverCustomizationContext['inlineTopNav'] = {
+    enabled: false,
+    showLogsExplorerTabs: false,
+  };
 
-  setup(core: CoreSetup<DiscoverStartPlugins, DiscoverStart>, plugins: DiscoverSetupPlugins) {
+  setup(
+    core: CoreSetup<DiscoverStartPlugins, DiscoverStart>,
+    plugins: DiscoverSetupPlugins
+  ): DiscoverSetup {
     const baseUrl = core.http.basePath.prepend('/app/discover');
     const isDev = this.initializerContext.env.mode.dev;
 
@@ -339,7 +346,7 @@ export class DiscoverPlugin
           profileRegistry: this.profileRegistry,
           customizationContext: {
             displayMode: 'standalone',
-            showLogsExplorerTabs: this.showLogsExplorerTabs,
+            inlineTopNav: this.inlineTopNav,
           },
           isDev,
         });
@@ -382,13 +389,14 @@ export class DiscoverPlugin
 
     return {
       locator: this.locator,
-      showLogsExplorerTabs: () => {
-        this.showLogsExplorerTabs = true;
+      showInlineTopNav: ({ showLogsExplorerTabs } = {}) => {
+        this.inlineTopNav.enabled = true;
+        this.inlineTopNav.showLogsExplorerTabs = showLogsExplorerTabs ?? false;
       },
     };
   }
 
-  start(core: CoreStart, plugins: DiscoverStartPlugins) {
+  start(core: CoreStart, plugins: DiscoverStartPlugins): DiscoverStart {
     // we need to register the application service at setup, but to render it
     // there are some start dependencies necessary, for this reason
     // initializeServices are assigned at start and used

--- a/src/plugins/discover/public/plugin.tsx
+++ b/src/plugins/discover/public/plugin.tsx
@@ -72,7 +72,7 @@ import {
   DiscoverAppLocatorDefinition,
   DiscoverESQLLocatorDefinition,
 } from '../common';
-import type { RegisterCustomizationProfile } from './customizations';
+import type { DiscoverCustomizationContext, RegisterCustomizationProfile } from './customizations';
 import {
   createRegisterCustomizationProfile,
   createProfileRegistry,
@@ -83,7 +83,6 @@ import {
   type DiscoverContainerProps,
 } from './components/discover_container';
 import { getESQLSearchProvider } from './global_search/search_provider';
-import { DiscoverCustomizationContext } from './application/types';
 
 /**
  * @public

--- a/src/plugins/discover/tsconfig.json
+++ b/src/plugins/discover/tsconfig.json
@@ -79,7 +79,6 @@
     "@kbn/core-chrome-browser",
     "@kbn/core-plugins-server",
     "@kbn/shared-ux-button-toolbar",
-    "@kbn/serverless",
     "@kbn/deeplinks-observability",
     "@kbn/esql-utils",
     "@kbn/managed-content-badge",

--- a/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
+++ b/x-pack/plugins/observability_solution/observability_logs_explorer/public/plugin.ts
@@ -44,7 +44,7 @@ export class ObservabilityLogsExplorerPlugin
     core: CoreSetup<ObservabilityLogsExplorerStartDeps, ObservabilityLogsExplorerPluginStart>,
     _pluginsSetup: ObservabilityLogsExplorerSetupDeps
   ) {
-    const { share, serverless, discover } = _pluginsSetup;
+    const { share } = _pluginsSetup;
     const useHash = core.uiSettings.get('state:storeInSessionStorage');
 
     core.application.register({
@@ -85,10 +85,6 @@ export class ObservabilityLogsExplorerPlugin
         return renderObservabilityLogsExplorerRedirect(coreStart, appMountParams);
       },
     });
-
-    if (serverless) {
-      discover.showLogsExplorerTabs();
-    }
 
     // Register Locators
     const allDatasetsLocator = share.url.locators.create(

--- a/x-pack/plugins/security_solution_serverless/kibana.jsonc
+++ b/x-pack/plugins/security_solution_serverless/kibana.jsonc
@@ -20,7 +20,8 @@
       "taskManager",
       "cloud",
       "fleet",
-      "actions"
+      "actions",
+      "discover"
     ],
     "optionalPlugins": [
       "securitySolutionEss"

--- a/x-pack/plugins/security_solution_serverless/public/plugin.ts
+++ b/x-pack/plugins/security_solution_serverless/public/plugin.ts
@@ -55,6 +55,9 @@ export class SecuritySolutionServerlessPlugin
     ).features;
 
     setupNavigation(core, setupDeps);
+
+    setupDeps.discover.showInlineTopNav();
+
     return {};
   }
 

--- a/x-pack/plugins/security_solution_serverless/public/types.ts
+++ b/x-pack/plugins/security_solution_serverless/public/types.ts
@@ -13,6 +13,7 @@ import type {
 import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import type { CloudStart } from '@kbn/cloud-plugin/public';
+import type { DiscoverSetup } from '@kbn/discover-plugin/public';
 import type { ServerlessSecurityConfigSchema } from '../common/config';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
@@ -26,6 +27,7 @@ export interface SecuritySolutionServerlessPluginSetupDeps {
   securitySolution: SecuritySolutionPluginSetup;
   serverless: ServerlessPluginSetup;
   management: ManagementSetup;
+  discover: DiscoverSetup;
 }
 
 export interface SecuritySolutionServerlessPluginStartDeps {

--- a/x-pack/plugins/security_solution_serverless/tsconfig.json
+++ b/x-pack/plugins/security_solution_serverless/tsconfig.json
@@ -45,6 +45,7 @@
     "@kbn/stack-connectors-plugin",
     "@kbn/actions-plugin",
     "@kbn/management-cards-navigation",
-    "@kbn/core-application-browser"
+    "@kbn/core-application-browser",
+    "@kbn/discover-plugin"
   ]
 }

--- a/x-pack/plugins/serverless_observability/kibana.jsonc
+++ b/x-pack/plugins/serverless_observability/kibana.jsonc
@@ -21,6 +21,7 @@
       "observability",
       "observabilityShared",
       "management",
+      "discover",
     ],
     "optionalPlugins": [],
     "requiredBundles": []

--- a/x-pack/plugins/serverless_observability/public/plugin.ts
+++ b/x-pack/plugins/serverless_observability/public/plugin.ts
@@ -43,6 +43,8 @@ export class ServerlessObservabilityPlugin
       })
     );
 
+    setupDeps.discover.showInlineTopNav({ showLogsExplorerTabs: true });
+
     return {};
   }
 

--- a/x-pack/plugins/serverless_observability/public/types.ts
+++ b/x-pack/plugins/serverless_observability/public/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
+import type { DiscoverSetup } from '@kbn/discover-plugin/public';
 import type { ManagementSetup, ManagementStart } from '@kbn/management-plugin/public';
 import { ObservabilityPublicSetup } from '@kbn/observability-plugin/public';
 import {
@@ -25,6 +26,7 @@ export interface ServerlessObservabilityPublicSetupDependencies {
   observabilityShared: ObservabilitySharedPluginSetup;
   serverless: ServerlessPluginSetup;
   management: ManagementSetup;
+  discover: DiscoverSetup;
 }
 
 export interface ServerlessObservabilityPublicStartDependencies {

--- a/x-pack/plugins/serverless_observability/tsconfig.json
+++ b/x-pack/plugins/serverless_observability/tsconfig.json
@@ -27,5 +27,6 @@
     "@kbn/io-ts-utils",
     "@kbn/serverless-observability-settings",
     "@kbn/core-chrome-browser",
+    "@kbn/discover-plugin",
   ]
 }

--- a/x-pack/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/plugins/serverless_search/public/plugin.ts
@@ -41,7 +41,7 @@ export class ServerlessSearchPlugin
 {
   public setup(
     core: CoreSetup<ServerlessSearchPluginStartDependencies, ServerlessSearchPluginStart>,
-    _setupDeps: ServerlessSearchPluginSetupDependencies
+    setupDeps: ServerlessSearchPluginSetupDependencies
   ): ServerlessSearchPluginSetup {
     const queryClient = new QueryClient({
       mutationCache: new MutationCache({
@@ -111,6 +111,9 @@ export class ServerlessSearchPlugin
         return await renderApp(element, coreStart, { history, ...services }, queryClient);
       },
     });
+
+    setupDeps.discover.showInlineTopNav();
+
     return {};
   }
 

--- a/x-pack/plugins/serverless_search/public/types.ts
+++ b/x-pack/plugins/serverless_search/public/types.ts
@@ -12,6 +12,7 @@ import { SecurityPluginStart } from '@kbn/security-plugin/public';
 import { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverless/public';
 import { SharePluginStart } from '@kbn/share-plugin/public';
 import { IndexManagementPluginStart } from '@kbn/index-management-plugin/public';
+import type { DiscoverSetup } from '@kbn/discover-plugin/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServerlessSearchPluginSetup {}
@@ -23,6 +24,7 @@ export interface ServerlessSearchPluginSetupDependencies {
   cloud: CloudSetup;
   management: ManagementSetup;
   serverless: ServerlessPluginSetup;
+  discover: DiscoverSetup;
 }
 
 export interface ServerlessSearchPluginStartDependencies {

--- a/x-pack/plugins/serverless_search/tsconfig.json
+++ b/x-pack/plugins/serverless_search/tsconfig.json
@@ -44,5 +44,6 @@
     "@kbn/console-plugin",
     "@kbn/core-chrome-browser",
     "@kbn/core-logging-server-mocks",
+    "@kbn/discover-plugin",
   ]
 }


### PR DESCRIPTION
## Summary

This PR removes the serverless plugin dependency from Discover and replaces it with a `showInlineTopNav` method on the Discover plugin contract, which gets called from within serverless project plugins to enable the serverless top nav. It also modifies the `DiscoverCustomizationContext` and moves it to the `customizations` folder, as well as consolidating customization context mocks, to help lay some groundwork for upcoming Discover extensions work.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)