### PR TITLE
[Security Solution][Data Quality Dashboard] Add missing same-family field in summary chart

### DIFF
--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.test.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.test.ts
@@ -11,6 +11,7 @@ import { euiThemeVars } from '@kbn/ui-theme';
 import { EMPTY_STAT } from '../../../helpers';
 
 import { mockPartitionedFieldMetadata } from '../../../mock/partitioned_field_metadata/mock_partitioned_field_metadata';
+import { mockPartitionedFieldMetadataWithSameFamily } from '../../../mock/partitioned_field_metadata/mock_partitioned_field_metadata_with_same_family';
 import { PartitionedFieldMetadata } from '../../../types';
 import {
   ALL_TAB_ID,
@@ -38,65 +39,11 @@ import {
 describe('helpers', () => {
   describe('getSummaryData', () => {
     test('it returns the expected `SummaryData`', () => {
-      expect(
-        getSummaryData({
-          ...mockPartitionedFieldMetadata,
-          sameFamily: [
-            {
-              dashed_name: 'source-ip',
-              description: 'IP address of the source (IPv4 or IPv6).',
-              flat_name: 'source.ip',
-              level: 'core',
-              name: 'ip',
-              normalize: [],
-              short: 'IP address of the source.',
-              type: 'ip',
-              indexFieldName: 'source.ip',
-              indexFieldType: 'ip',
-              indexInvalidValues: [],
-              hasEcsMetadata: true,
-              isEcsCompliant: true,
-              isInSameFamily: true,
-            },
-            {
-              indexFieldName: 'source.ip.keyword2',
-              indexFieldType: 'keyword2',
-              indexInvalidValues: [],
-              hasEcsMetadata: false,
-              isEcsCompliant: false,
-              isInSameFamily: true,
-            },
-            {
-              indexFieldName: 'source.ip.text',
-              indexFieldType: 'text',
-              indexInvalidValues: [],
-              hasEcsMetadata: false,
-              isEcsCompliant: false,
-              isInSameFamily: true,
-            },
-            {
-              indexFieldName: 'source.ip.text2',
-              indexFieldType: 'text2',
-              indexInvalidValues: [],
-              hasEcsMetadata: false,
-              isEcsCompliant: false,
-              isInSameFamily: true,
-            },
-            {
-              indexFieldName: 'source.port.keyword',
-              indexFieldType: 'keyword',
-              indexInvalidValues: [],
-              hasEcsMetadata: false,
-              isEcsCompliant: false,
-              isInSameFamily: true,
-            },
-          ],
-        })
-      ).toEqual([
+      expect(getSummaryData(mockPartitionedFieldMetadataWithSameFamily)).toEqual([
         { categoryId: 'incompatible', mappings: 3 },
         { categoryId: 'custom', mappings: 4 },
         { categoryId: 'ecs-compliant', mappings: 2 },
-        { categoryId: 'same-family', mappings: 5 },
+        { categoryId: 'same-family', mappings: 1 },
       ]);
     });
   });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.test.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.test.ts
@@ -38,10 +38,65 @@ import {
 describe('helpers', () => {
   describe('getSummaryData', () => {
     test('it returns the expected `SummaryData`', () => {
-      expect(getSummaryData(mockPartitionedFieldMetadata)).toEqual([
+      expect(
+        getSummaryData({
+          ...mockPartitionedFieldMetadata,
+          sameFamily: [
+            {
+              dashed_name: 'source-ip',
+              description: 'IP address of the source (IPv4 or IPv6).',
+              flat_name: 'source.ip',
+              level: 'core',
+              name: 'ip',
+              normalize: [],
+              short: 'IP address of the source.',
+              type: 'ip',
+              indexFieldName: 'source.ip',
+              indexFieldType: 'ip',
+              indexInvalidValues: [],
+              hasEcsMetadata: true,
+              isEcsCompliant: true,
+              isInSameFamily: true,
+            },
+            {
+              indexFieldName: 'source.ip.keyword2',
+              indexFieldType: 'keyword2',
+              indexInvalidValues: [],
+              hasEcsMetadata: false,
+              isEcsCompliant: false,
+              isInSameFamily: true,
+            },
+            {
+              indexFieldName: 'source.ip.text',
+              indexFieldType: 'text',
+              indexInvalidValues: [],
+              hasEcsMetadata: false,
+              isEcsCompliant: false,
+              isInSameFamily: true,
+            },
+            {
+              indexFieldName: 'source.ip.text2',
+              indexFieldType: 'text2',
+              indexInvalidValues: [],
+              hasEcsMetadata: false,
+              isEcsCompliant: false,
+              isInSameFamily: true,
+            },
+            {
+              indexFieldName: 'source.port.keyword',
+              indexFieldType: 'keyword',
+              indexInvalidValues: [],
+              hasEcsMetadata: false,
+              isEcsCompliant: false,
+              isInSameFamily: true,
+            },
+          ],
+        })
+      ).toEqual([
         { categoryId: 'incompatible', mappings: 3 },
         { categoryId: 'custom', mappings: 4 },
         { categoryId: 'ecs-compliant', mappings: 2 },
+        { categoryId: 'same-family', mappings: 5 },
       ]);
     });
   });

--- a/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.ts
+++ b/x-pack/packages/security-solution/ecs_data_quality_dashboard/impl/data_quality/data_quality_panel/tabs/summary_tab/helpers.ts
@@ -35,6 +35,7 @@ export const getSummaryData = (
   { categoryId: 'incompatible', mappings: partitionedFieldMetadata.incompatible.length },
   { categoryId: 'custom', mappings: partitionedFieldMetadata.custom.length },
   { categoryId: 'ecs-compliant', mappings: partitionedFieldMetadata.ecsCompliant.length },
+  { categoryId: 'same-family', mappings: partitionedFieldMetadata.sameFamily.length },
 ];
 
 export const getFillColor = (categoryId: CategoryId | string): string => {


### PR DESCRIPTION
Fixes #177780

## Summary

same-field category is missing in summary tab hollow chart. This PR enables same-field category display in summary tab hollow chart.

#### Before:

https://github.com/elastic/kibana/assets/1625373/b747657a-78c6-4b06-91e0-414317d13d7c

#### After:

https://github.com/elastic/kibana/assets/1625373/0878c593-3a33-418a-94db-54d7922776f9

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->