### PR TITLE
[Search] Fix crawler deletion confirmation

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -33,11 +33,13 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
   const { closeDeleteModal, deleteConnector } = useActions(ConnectorsLogic);
   const {
     deleteModalConnectorId: connectorId,
-    deleteModalConnectorName: connectorName,
+    deleteModalConnectorName,
     deleteModalIndexName,
     isDeleteLoading,
     isDeleteModalVisible,
   } = useValues(ConnectorsLogic);
+
+  const connectorName = isCrawler ? deleteModalIndexName : deleteModalConnectorName;
 
   const [inputConnectorName, setInputConnectorName] = useState('');
   const [shouldDeleteIndex, setShouldDeleteIndex] = useState(false);


### PR DESCRIPTION
A crawler has an empty `name` property. It directly relates to the attached index, therefore simply using the index name as `connectorName` fixes the bug that you could delete the crawler with an empty input field, which is used for confirming that you want to delete the crawler.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->