### PR TITLE
[Search] Fix crawler deletion modal body text

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -96,12 +96,19 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
       isLoading={isDeleteLoading}
     >
       <p>
-        {i18n.translate(
-          'xpack.enterpriseSearch.content.connectors.deleteModal.delete.description',
-          {
-            defaultMessage: 'You are about to delete this connector:',
-          }
-        )}
+        {!isCrawler
+          ? i18n.translate(
+              'xpack.enterpriseSearch.content.connectors.deleteModal.delete.connector.description',
+              {
+                defaultMessage: 'You are about to delete this connector:',
+              }
+            )
+          : i18n.translate(
+              'xpack.enterpriseSearch.content.connectors.deleteModal.delete.crawler.description',
+              {
+                defaultMessage: 'You are about to delete this crawler:',
+              }
+            )}
       </p>
       <p>
         <ul>
@@ -148,12 +155,21 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
       )}
       <EuiForm>
         <EuiFormRow
-          label={i18n.translate(
-            'xpack.enterpriseSearch.content.connectors.deleteModal.indexNameInput.label',
-            {
-              defaultMessage: 'Connector name',
-            }
-          )}
+          label={
+            !isCrawler
+              ? i18n.translate(
+                  'xpack.enterpriseSearch.content.connectors.deleteModal.connector.indexNameInput.label',
+                  {
+                    defaultMessage: 'Connector name',
+                  }
+                )
+              : i18n.translate(
+                  'xpack.enterpriseSearch.content.connectors.deleteModal.crawler.indexNameInput.label',
+                  {
+                    defaultMessage: 'Crawler name',
+                  }
+                )
+          }
         >
           <EuiFieldText
             onChange={(e) => setInputConnectorName(e.target.value)}


### PR DESCRIPTION
## Summary

The text in the crawler deletion modal referred to a connector. This PR adapts the text to refer to a crawler.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->