### PR TITLE
[Ops] fix used catalog entry type to files rather than urls

### DIFF
--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -4,6 +4,6 @@ metadata:
   name: kibana-buildkite-pipelines
   description: This file points to individual buildkite pipeline definition files
 spec:
-  type: url
+  type: file
   targets:
     - kibana-migration-staging.yml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -36,7 +36,7 @@ metadata:
   name: kibana-buildkite-pipelines
   description: A location re-routing file, pointing to individual buildkite pipeline definition files
 spec:
-  type: url
+  type: file
   location: .buildkite/pipeline-resource-definitions/locations.yml
 
 ---


### PR DESCRIPTION
## Summary
For some reason in the previous (https://github.com/elastic/kibana/pull/178136) PR I've used URL but didn't actually give urls, this PR fixes the entry types to files.

