### PR TITLE
[Ops] Fix backstage location duplicated name

### DIFF
--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: kibana-buildkite-pipelines
+  name: kibana-buildkite-pipelines-list
   description: This file points to individual buildkite pipeline definition files
 spec:
   type: file


### PR DESCRIPTION
## Summary
Follow up on https://github.com/elastic/kibana/pull/178136, fixing a duplicated entity name