### PR TITLE
[Infra] RX and TX should be line charts

### DIFF
--- a/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/network.ts
+++ b/x-pack/plugins/metrics_data_access/common/inventory_models/host/metrics/charts/network.ts
@@ -53,7 +53,7 @@ const rx: LensConfigWithId = {
   title: formulas.rx.label ?? '',
   layers: [
     {
-      seriesType: 'area',
+      seriesType: 'line',
       type: 'series',
       xAxis: '@timestamp',
       yAxis: [formulas.rx],
@@ -70,7 +70,7 @@ const tx: LensConfigWithId = {
   title: formulas.tx.label ?? '',
   layers: [
     {
-      seriesType: 'area',
+      seriesType: 'line',
       type: 'series',
       xAxis: '@timestamp',
       yAxis: [formulas.tx],


### PR DESCRIPTION
part of https://github.com/elastic/kibana/issues/175446

## Summary

RX and TX charts should be line charts

<img width="1469" alt="image" src="https://github.com/elastic/kibana/assets/2767137/ce40dc8d-4de7-4195-802e-2eea70495fab">


There were wrongly changed to `area` in this PR https://github.com/elastic/kibana/pull/177612/files#diff-9f20f44044ef5f49c03fc4dda7b18925775a10965abfd76d86ea7b4469a6ecd1R73


### How to test

- Start local Kibana instance
- Navigate to Infrastructure > hosts
- Verify the RX and TX charts
