### PR TITLE
[Infra] Revert change to only consider system module docs

### DIFF
--- a/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_host_count.ts
+++ b/x-pack/plugins/observability_solution/infra/public/pages/metrics/hosts/hooks/use_host_count.ts
@@ -32,24 +32,6 @@ export const useHostCount = () => {
       const filters: QueryDslQueryContainer = {
         bool: {
           ...query.bool,
-          must: [
-            {
-              bool: {
-                should: [
-                  {
-                    term: {
-                      'event.module': 'system',
-                    },
-                  },
-                  {
-                    term: {
-                      'metricset.module': 'system', // Needed for hosts where metricbeat version < 8
-                    },
-                  },
-                ],
-              },
-            },
-          ],
           filter: [
             ...query.bool.filter,
             {

--- a/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/helpers/query.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/helpers/query.ts
@@ -85,27 +85,6 @@ export const runQuery = <T>(
     );
 };
 
-export const systemMetricsFilter = {
-  must: [
-    {
-      bool: {
-        should: [
-          {
-            term: {
-              'event.module': 'system',
-            },
-          },
-          {
-            term: {
-              'metricset.module': 'system', // Needed for hosts where metricbeat version < 8
-            },
-          },
-        ],
-      },
-    },
-  ],
-};
-
 export const getInventoryModelAggregations = (
   metrics: InfraAssetMetricType[]
 ): Record<string, estypes.AggregationsAggregationContainer> => {

--- a/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_all_hosts.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_all_hosts.ts
@@ -17,12 +17,7 @@ import {
   HostsMetricsSearchAggregationResponse,
   HostsMetricsSearchAggregationResponseRT,
 } from '../types';
-import {
-  createFilters,
-  systemMetricsFilter,
-  getInventoryModelAggregations,
-  runQuery,
-} from '../helpers/query';
+import { createFilters, getInventoryModelAggregations, runQuery } from '../helpers/query';
 
 export const getAllHosts = async (
   { searchClient, sourceConfig, params }: GetHostsArgs,
@@ -49,7 +44,6 @@ const createQuery = (
       size: 0,
       query: {
         bool: {
-          ...systemMetricsFilter,
           filter: createFilters({
             params,
             hostNamesShortList,

--- a/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
+++ b/x-pack/plugins/observability_solution/infra/server/routes/infra/lib/host/get_filtered_hosts.ts
@@ -18,7 +18,7 @@ import {
 } from '../types';
 import { BUCKET_KEY, MAX_SIZE } from '../constants';
 import { assertQueryStructure } from '../utils';
-import { createFilters, runQuery, systemMetricsFilter } from '../helpers/query';
+import { createFilters, runQuery } from '../helpers/query';
 
 export const getFilteredHosts = async ({
   searchClient,
@@ -46,7 +46,6 @@ const createQuery = (
       query: {
         bool: {
           ...params.query.bool,
-          ...systemMetricsFilter,
           filter: createFilters({ params, extraFilter: params.query }),
         },
       },


### PR DESCRIPTION
fixes [#178007](https://github.com/elastic/kibana/issues/178007)

## Summary

Reverts changes made in https://github.com/elastic/kibana/pull/177239

After considering only system module documents, the page was no longer able to properly filter by any APM attributes like `service.name`.

That happened because when considering only documents with `event.module: system` we ignored all APM docs that contained `service.name` attribute, therefore making it impossible for the queries to find documents that matched with the searched Service Name.

The consequence of reverting the fix is that we'll see APM hosts again in the Hosts UI, but there is no easy fix for the original problem, and perhaps the fix should happen at the data level.


### How to test
- Start a local Kibana instance
- Navigate to Infrastructure > Hosts
- Filter by Service Name
