### PR TITLE
[Ops] Use urls instead of file locations in backstage location entries

### DIFF
--- a/.buildkite/pipeline-resource-definitions/locations.yml
+++ b/.buildkite/pipeline-resource-definitions/locations.yml
@@ -4,6 +4,6 @@ metadata:
   name: kibana-buildkite-pipelines-list
   description: This file points to individual buildkite pipeline definition files
 spec:
-  type: file
+  type: url
   targets:
-    - ./kibana-migration-staging.yml
+    - https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/kibana-migration-staging.yml

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -36,8 +36,8 @@ metadata:
   name: kibana-buildkite-pipelines
   description: A location re-routing file, pointing to individual buildkite pipeline definition files
 spec:
-  type: file
-  target: ./.buildkite/pipeline-resource-definitions/locations.yml
+  type: url
+  target: https://github.com/elastic/kibana/blob/main/.buildkite/pipeline-resource-definitions/locations.yml
 
 ---
 


### PR DESCRIPTION
## Summary
Another episode of the https://github.com/elastic/kibana/pull/178136 saga. It seems I can't find a way to figure out `file` based locations, backstage always says they don't exist. It's also apparent, that a sourcegraph.com doesn't show any public `catalog-info.yaml`s that would use a `type: file` - so it could be a broken approach to begin with.