### PR TITLE
[8.13] [Search] Fix connectors pages breaking if index has been deleted (#178147)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_connectors.api.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/fetch_connectors.api.ts
@@ -21,6 +21,7 @@ export interface FetchConnectorsApiLogicArgs {
 export interface FetchConnectorsApiLogicResponse {
   connectors: Connector[];
   counts: Record<string, number>;
+  indexExists: Record<string, boolean>;
   isInitialRequest: boolean;
   meta: Meta;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_configuration_api_logic.test.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_configuration_api_logic.test.ts
@@ -24,14 +24,13 @@ describe('updateConnectorConfigurationLogic', () => {
       const result = postConnectorConfiguration({
         configuration,
         connectorId: 'anIndexId',
-        indexName: 'anIndexName',
       });
       await nextTick();
       expect(http.post).toHaveBeenCalledWith(
         '/internal/enterprise_search/connectors/anIndexId/configuration',
         { body: JSON.stringify(configuration) }
       );
-      await expect(result).resolves.toEqual({ configuration: 'result', indexName: 'anIndexName' });
+      await expect(result).resolves.toEqual({ configuration: 'result' });
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_configuration_api_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/api/connector/update_connector_configuration_api_logic.ts
@@ -15,25 +15,22 @@ import { HttpLogic } from '../../../shared/http';
 export interface PostConnectorConfigurationArgs {
   configuration: Record<string, string | number | boolean | null>;
   connectorId: string;
-  indexName: string;
 }
 
 export interface PostConnectorConfigurationResponse {
   configuration: ConnectorConfiguration;
-  indexName: string;
 }
 
 export const postConnectorConfiguration = async ({
   configuration,
   connectorId,
-  indexName,
 }: PostConnectorConfigurationArgs) => {
   const route = `/internal/enterprise_search/connectors/${connectorId}/configuration`;
 
   const responseConfig = await HttpLogic.values.http.post<ConnectorConfiguration>(route, {
     body: JSON.stringify(configuration),
   });
-  return { configuration: responseConfig, indexName };
+  return { configuration: responseConfig };
 };
 
 export const ConnectorConfigurationApiLogic = createApiLogic(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -6,6 +6,8 @@
  */
 import React, { useEffect, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
+
 import { useActions, useValues } from 'kea';
 
 import {
@@ -81,8 +83,21 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
     }
   }, [connector.id]);
 
+  const { hash } = useLocation();
+  useEffect(() => {
+    if (hash) {
+      const id = hash.replace('#', '');
+      if (id === 'attachIndexBox') {
+        const element = document.getElementById(id);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth' });
+        }
+      }
+    }
+  }, [hash]);
+
   return (
-    <EuiPanel hasShadow={false} hasBorder>
+    <EuiPanel hasShadow={false} hasBorder id="attachIndexBox">
       <EuiTitle size="s">
         <h4>
           {i18n.translate('xpack.enterpriseSearch.attachIndexBox.h4.attachAnIndexLabel', {

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_configuration.tsx
@@ -54,18 +54,17 @@ import { NativeConnectorConfiguration } from './native_connector_configuration';
 
 export const ConnectorConfiguration: React.FC = () => {
   const { data: apiKeyData } = useValues(GenerateConnectorApiKeyApiLogic);
+  const { fetchConnector } = useActions(ConnectorViewLogic);
   const { index, isLoading, connector } = useValues(ConnectorViewLogic);
   const cloudContext = useCloudDetails();
   const { hasPlatinumLicense } = useValues(LicensingLogic);
   const { status } = useValues(ConnectorConfigurationApiLogic);
   const { makeRequest } = useActions(ConnectorConfigurationApiLogic);
   const { http } = useValues(HttpLogic);
-  const { fetchConnector } = useActions(ConnectorViewLogic);
 
   if (!connector) {
     return <></>;
   }
-  const indexName = connector.index_name ?? '';
 
   // TODO make it work without index if possible
   if (connector.is_native && connector.service_type) {
@@ -90,12 +89,19 @@ export const ConnectorConfiguration: React.FC = () => {
             <EuiSteps
               steps={[
                 {
-                  children: (
+                  children: connector.index_name ? (
                     <ApiKeyConfig
-                      indexName={indexName}
+                      indexName={connector.index_name}
                       hasApiKey={!!connector.api_key_id}
                       isNative={false}
                     />
+                  ) : (
+                    i18n.translate(
+                      'xpack.enterpriseSearch.content.connectorDetail.configuration.apiKey.noApiKeyLabel',
+                      {
+                        defaultMessage: 'Please set an index name before generating an API key',
+                      }
+                    )
                   ),
                   status: hasApiKey ? 'complete' : 'incomplete',
                   title: i18n.translate(
@@ -191,14 +197,10 @@ export const ConnectorConfiguration: React.FC = () => {
                       connector={connector}
                       hasPlatinumLicense={hasPlatinumLicense}
                       isLoading={status === Status.LOADING}
-                      saveConfig={(
-                        configuration // TODO update endpoints
-                      ) =>
-                        index &&
+                      saveConfig={(configuration) =>
                         makeRequest({
                           configuration,
                           connectorId: connector.id,
-                          indexName: index.name,
                         })
                       }
                       subscriptionLink={docLinks.licenseManagement}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail.tsx
@@ -123,7 +123,7 @@ export const ConnectorDetail: React.FC = () => {
       ? [
           {
             content: <ConnectorSyncRules />,
-            disabled: !index,
+            disabled: !connector?.index_name,
             id: ConnectorDetailTabId.SYNC_RULES,
             isSelected: tabId === ConnectorDetailTabId.SYNC_RULES,
             label: i18n.translate(
@@ -144,7 +144,7 @@ export const ConnectorDetail: React.FC = () => {
       : []),
     {
       content: <ConnectorSchedulingComponent />,
-      disabled: !index,
+      disabled: !connector?.index_name,
       id: ConnectorDetailTabId.SCHEDULING,
       isSelected: tabId === ConnectorDetailTabId.SCHEDULING,
       label: i18n.translate(
@@ -186,7 +186,7 @@ export const ConnectorDetail: React.FC = () => {
 
   const PIPELINES_TAB = {
     content: <SearchIndexPipelines />,
-    disabled: !index,
+    disabled: !connector?.index_name,
     id: ConnectorDetailTabId.PIPELINES,
     isSelected: tabId === ConnectorDetailTabId.PIPELINES,
     label: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_detail_router.tsx
@@ -7,6 +7,8 @@
 
 import React, { useEffect } from 'react';
 
+import { useActions, useValues } from 'kea';
+
 import { Routes, Route } from '@kbn/shared-ux-router';
 
 import { CONNECTOR_DETAIL_PATH, CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
@@ -25,6 +27,12 @@ export const ConnectorDetailRouter: React.FC = () => {
       unmountView();
     };
   }, []);
+  const { setIndexName } = useActions(IndexNameLogic);
+  const { connector } = useValues(ConnectorViewLogic);
+  const indexName = connector?.index_name || '';
+  useEffect(() => {
+    setIndexName(indexName);
+  }, [indexName]);
   return (
     <Routes>
       <Route path={CONNECTOR_DETAIL_PATH} exact>

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/connector_stats.tsx
@@ -22,6 +22,8 @@ import { i18n } from '@kbn/i18n';
 
 import { Connector, ConnectorStatus } from '@kbn/search-connectors';
 
+import { ElasticsearchIndex } from '../../../../../common/types/indices';
+
 import { generateEncodedPath } from '../../../shared/encode_path_params';
 import { EuiButtonEmptyTo, EuiButtonTo } from '../../../shared/react_router_helpers';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../../routes';
@@ -33,7 +35,6 @@ import {
 import { CONNECTORS } from '../search_index/connector/constants';
 
 import { ConnectorDetailTabId } from './connector_detail';
-import { ElasticsearchIndex } from '@kbn/enterprise-search-plugin/common/types/indices';
 
 export interface ConnectorStatsProps {
   connector: Connector;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/overview.logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/overview.logic.ts
@@ -8,18 +8,8 @@
 import { kea, MakeLogicType } from 'kea';
 
 import { Status } from '../../../../../common/types/api';
-import { KibanaLogic } from '../../../shared/kibana';
 
-import {
-  CachedFetchIndexApiLogic,
-  CachedFetchIndexApiLogicActions,
-} from '../../api/index/cached_fetch_index_api_logic';
-
-import { CONNECTORS_PATH } from '../../routes';
-
-interface OverviewLogicActions {
-  apiError: CachedFetchIndexApiLogicActions['apiError'];
-}
+import { CachedFetchIndexApiLogic } from '../../api/index/cached_fetch_index_api_logic';
 
 interface OverviewLogicValues {
   apiKey: string;
@@ -30,18 +20,10 @@ interface OverviewLogicValues {
   status: typeof CachedFetchIndexApiLogic.values.status;
 }
 
-export const OverviewLogic = kea<MakeLogicType<OverviewLogicValues, OverviewLogicActions>>({
+export const OverviewLogic = kea<MakeLogicType<OverviewLogicValues, {}>>({
   connect: {
-    actions: [CachedFetchIndexApiLogic, ['apiError']],
     values: [CachedFetchIndexApiLogic, ['indexData', 'status']],
   },
-  listeners: () => ({
-    apiError: async (_, breakpoint) => {
-      // show error for a second before navigating away
-      await breakpoint(1000);
-      KibanaLogic.values.navigateToUrl(CONNECTORS_PATH);
-    },
-  }),
   path: ['enterprise_search', 'connector_detail', 'overview'],
   selectors: ({ selectors }) => ({
     isError: [() => [selectors.status], (status) => status === Status.ERROR],

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_logic.ts
@@ -21,7 +21,7 @@ import {
   FetchConnectorsApiLogicActions,
 } from '../../api/connector/fetch_connectors.api';
 
-export type ConnectorViewItem = Connector & { docsCount?: number };
+export type ConnectorViewItem = Connector & { docsCount?: number; indexExists: boolean };
 export interface ConnectorsActions {
   apiError: FetchConnectorsApiLogicActions['apiError'];
   apiSuccess: FetchConnectorsApiLogicActions['apiSuccess'];
@@ -192,6 +192,7 @@ export const ConnectorsLogic = kea<MakeLogicType<ConnectorsValues, ConnectorsAct
               return {
                 ...connector,
                 docsCount: data?.counts[indexName],
+                indexExists: data?.indexExists[indexName],
               };
             }
             return connector;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_table.tsx
@@ -20,8 +20,6 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { Connector, ConnectorStatus } from '@kbn/search-connectors';
-
 import { Meta } from '../../../../../common/types/pagination';
 
 import { generateEncodedPath } from '../../../shared/encode_path_params';
@@ -41,7 +39,7 @@ interface ConnectorsTableProps {
   isLoading?: boolean;
   items: ConnectorViewItem[];
   meta?: Meta;
-  onChange: (criteria: CriteriaWithPagination<Connector>) => void;
+  onChange: (criteria: CriteriaWithPagination<ConnectorViewItem>) => void;
   onDelete: (connectorName: string, connectorId: string, indexName: string | null) => void;
 }
 export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
@@ -69,7 +67,7 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
                 defaultMessage: 'Connector name',
               }
             ),
-            render: (connector: Connector) => (
+            render: (connector: ConnectorViewItem) => (
               <EuiLinkTo
                 to={generateEncodedPath(CONNECTOR_DETAIL_PATH, { connectorId: connector.id })}
               >
@@ -81,18 +79,23 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
         ]
       : []),
     {
-      field: 'index_name',
       name: i18n.translate(
         'xpack.enterpriseSearch.content.connectors.connectorTable.columns.indexName',
         {
           defaultMessage: 'Index name',
         }
       ),
-      render: (indexName: string) =>
-        indexName ? (
-          <EuiLinkTo to={generateEncodedPath(SEARCH_INDEX_PATH, { indexName })}>
-            {indexName}
-          </EuiLinkTo>
+      render: (connector: ConnectorViewItem) =>
+        connector.index_name ? (
+          connector.indexExists ? (
+            <EuiLinkTo
+              to={generateEncodedPath(SEARCH_INDEX_PATH, { indexName: connector.index_name })}
+            >
+              {connector.index_name}
+            </EuiLinkTo>
+          ) : (
+            connector.index_name
+          )
         ) : (
           '--'
         ),
@@ -125,16 +128,19 @@ export const ConnectorsTable: React.FC<ConnectorsTableProps> = ({
         ]
       : []),
     {
-      field: 'status',
       name: i18n.translate(
         'xpack.enterpriseSearch.content.connectors.connectorTable.columns.status',
         {
           defaultMessage: 'Ingestion status',
         }
       ),
-      render: (connectorStatus: ConnectorStatus) => {
-        const label = connectorStatusToText(connectorStatus);
-        return <EuiBadge color={connectorStatusToColor(connectorStatus)}>{label}</EuiBadge>;
+      render: (connector: ConnectorViewItem) => {
+        const label = connectorStatusToText(connector.status, !!connector.index_name);
+        return (
+          <EuiBadge color={connectorStatusToColor(connector.status, !!connector.index_name)}>
+            {label}
+          </EuiBadge>
+        );
       },
       truncateText: true,
       width: '15%',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -31,12 +31,11 @@ import { LicensingLogic } from '../../../../shared/licensing';
 import { EuiButtonTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { UnsavedChangesPrompt } from '../../../../shared/unsaved_changes_prompt';
 import { CONNECTOR_DETAIL_TAB_PATH } from '../../../routes';
-import { IngestionStatus } from '../../../types';
-import { IndexViewLogic } from '../index_view_logic';
-import { ConnectorContentScheduling } from './connector_scheduling/full_content';
-import { ConnectorSchedulingLogic } from './connector_scheduling_logic';
 import { ConnectorDetailTabId } from '../../connector_detail/connector_detail';
 import { ConnectorViewLogic } from '../../connector_detail/connector_view_logic';
+
+import { ConnectorContentScheduling } from './connector_scheduling/full_content';
+import { ConnectorSchedulingLogic } from './connector_scheduling_logic';
 
 interface SchedulePanelProps {
   description: string;
@@ -65,9 +64,8 @@ export const SchedulePanel: React.FC<SchedulePanelProps> = ({ title, description
 
 export const ConnectorSchedulingComponent: React.FC = () => {
   const { productFeatures } = useValues(KibanaLogic);
-  const { ingestionStatus, hasDocumentLevelSecurityFeature, hasIncrementalSyncFeature } =
-    useValues(IndexViewLogic);
-  const { connector } = useValues(ConnectorViewLogic);
+  const { connector, hasDocumentLevelSecurityFeature, hasIncrementalSyncFeature } =
+    useValues(ConnectorViewLogic);
   const { hasChanges } = useValues(ConnectorSchedulingLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
 
@@ -139,7 +137,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
       />
 
       <EuiSpacer size="l" />
-      {ingestionStatus === IngestionStatus.ERROR ? (
+      {connector.status === ConnectorStatus.ERROR ? (
         <>
           <EuiCallOut
             color="warning"

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling.tsx
@@ -30,15 +30,13 @@ import { KibanaLogic } from '../../../../shared/kibana';
 import { LicensingLogic } from '../../../../shared/licensing';
 import { EuiButtonTo, EuiLinkTo } from '../../../../shared/react_router_helpers';
 import { UnsavedChangesPrompt } from '../../../../shared/unsaved_changes_prompt';
-import { SEARCH_INDEX_TAB_PATH } from '../../../routes';
+import { CONNECTOR_DETAIL_TAB_PATH } from '../../../routes';
 import { IngestionStatus } from '../../../types';
-import * as indices from '../../../utils/indices';
 import { IndexViewLogic } from '../index_view_logic';
-
-import { SearchIndexTabId } from '../search_index';
-
 import { ConnectorContentScheduling } from './connector_scheduling/full_content';
 import { ConnectorSchedulingLogic } from './connector_scheduling_logic';
+import { ConnectorDetailTabId } from '../../connector_detail/connector_detail';
+import { ConnectorViewLogic } from '../../connector_detail/connector_view_logic';
 
 interface SchedulePanelProps {
   description: string;
@@ -69,7 +67,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
   const { productFeatures } = useValues(KibanaLogic);
   const { ingestionStatus, hasDocumentLevelSecurityFeature, hasIncrementalSyncFeature } =
     useValues(IndexViewLogic);
-  const { index } = useValues(IndexViewLogic);
+  const { connector } = useValues(ConnectorViewLogic);
   const { hasChanges } = useValues(ConnectorSchedulingLogic);
   const { hasPlatinumLicense } = useValues(LicensingLogic);
 
@@ -77,16 +75,16 @@ export const ConnectorSchedulingComponent: React.FC = () => {
     hasIncrementalSyncFeature && productFeatures.hasIncrementalSyncEnabled;
   const shouldShowAccessControlSync =
     hasDocumentLevelSecurityFeature && productFeatures.hasDocumentLevelSecurityEnabled;
-  if (!indices.isConnectorIndex(index)) {
+  if (!connector) {
     return <></>;
   }
 
   const isDocumentLevelSecurityDisabled =
-    !index.connector.configuration.use_document_level_security?.value;
+    !connector.configuration.use_document_level_security?.value;
 
   if (
-    index.connector.status === ConnectorStatus.CREATED ||
-    index.connector.status === ConnectorStatus.NEEDS_CONFIGURATION
+    connector.status === ConnectorStatus.CREATED ||
+    connector.status === ConnectorStatus.NEEDS_CONFIGURATION
   ) {
     return (
       <>
@@ -112,9 +110,9 @@ export const ConnectorSchedulingComponent: React.FC = () => {
           <EuiSpacer size="s" />
           <EuiButtonTo
             data-telemetry-id="entSearchContent-connector-scheduling-configure"
-            to={generateEncodedPath(SEARCH_INDEX_TAB_PATH, {
-              indexName: index.name,
-              tabId: SearchIndexTabId.CONFIGURATION,
+            to={generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+              connectorId: connector.id,
+              tabId: ConnectorDetailTabId.CONFIGURATION,
             })}
             fill
             size="s"
@@ -191,11 +189,14 @@ export const ConnectorSchedulingComponent: React.FC = () => {
           >
             <EuiFlexGroup direction="column" gutterSize="m">
               <EuiFlexItem>
-                <ConnectorContentScheduling type={SyncJobType.FULL} index={index} />
+                <ConnectorContentScheduling type={SyncJobType.FULL} connector={connector} />
               </EuiFlexItem>
               {shouldShowIncrementalSync && (
                 <EuiFlexItem>
-                  <ConnectorContentScheduling type={SyncJobType.INCREMENTAL} index={index} />
+                  <ConnectorContentScheduling
+                    type={SyncJobType.INCREMENTAL}
+                    connector={connector}
+                  />
                 </EuiFlexItem>
               )}
             </EuiFlexGroup>
@@ -220,7 +221,7 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                 >
                   <ConnectorContentScheduling
                     type={SyncJobType.ACCESS_CONTROL}
-                    index={index}
+                    connector={connector}
                     hasPlatinumLicense={hasPlatinumLicense}
                   />
                 </SchedulePanel>
@@ -242,9 +243,9 @@ export const ConnectorSchedulingComponent: React.FC = () => {
                         values={{
                           link: (
                             <EuiLinkTo
-                              to={generateEncodedPath(SEARCH_INDEX_TAB_PATH, {
-                                indexName: index.name,
-                                tabId: SearchIndexTabId.CONFIGURATION,
+                              to={generateEncodedPath(CONNECTOR_DETAIL_TAB_PATH, {
+                                connectorId: connector.id,
+                                tabId: ConnectorDetailTabId.CONFIGURATION,
                               })}
                             >
                               {i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/connector_scheduling/full_content.tsx
@@ -23,9 +23,7 @@ import {
 
 import { i18n } from '@kbn/i18n';
 
-import { SyncJobType } from '@kbn/search-connectors';
-
-import { ConnectorViewIndex, CrawlerViewIndex } from '../../../../types';
+import { Connector, SyncJobType } from '@kbn/search-connectors';
 
 import { PlatinumLicensePopover } from '../../../shared/platinum_license_popover/platinum_license_popover';
 import { ConnectorSchedulingLogic } from '../connector_scheduling_logic';
@@ -34,7 +32,7 @@ import { ConnectorCronEditor } from './connector_cron_editor';
 
 export interface ConnectorContentSchedulingProps {
   hasPlatinumLicense?: boolean;
-  index: CrawlerViewIndex | ConnectorViewIndex;
+  connector: Connector;
   type: SyncJobType;
 }
 const getAccordionTitle = (type: ConnectorContentSchedulingProps['type']) => {
@@ -103,11 +101,11 @@ const EnableSwitch: React.FC<{
 
 export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProps> = ({
   type,
-  index,
+  connector,
   hasPlatinumLicense = false,
 }) => {
   const { setHasChanges, updateScheduling } = useActions(ConnectorSchedulingLogic);
-  const schedulingInput = index.connector.scheduling;
+  const schedulingInput = connector.scheduling;
   const [scheduling, setScheduling] = useState(schedulingInput);
   const [isAccordionOpen, setIsAccordionOpen] = useState<'open' | 'closed'>(
     scheduling[type].enabled ? 'open' : 'closed'
@@ -116,7 +114,7 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
 
   const isGated = !hasPlatinumLicense && type === SyncJobType.ACCESS_CONTROL;
   const isDocumentLevelSecurityDisabled =
-    !index.connector.configuration.use_document_level_security?.value;
+    !connector.configuration.use_document_level_security?.value;
 
   const isEnableSwitchDisabled =
     type === SyncJobType.ACCESS_CONTROL && (!hasPlatinumLicense || isDocumentLevelSecurityDisabled);
@@ -231,9 +229,9 @@ export const ConnectorContentScheduling: React.FC<ConnectorContentSchedulingProp
                 }}
                 onSave={(interval) => {
                   updateScheduling(type, {
-                    connectorId: index.connector.id,
+                    connectorId: connector.id,
                     scheduling: {
-                      ...index.connector.scheduling,
+                      ...connector.scheduling,
                       [type]: {
                         ...scheduling[type],
                         interval,

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector_logic.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/convert_connector_logic.tsx
@@ -20,7 +20,8 @@ import {
   ConvertConnectorApiLogicArgs,
   ConvertConnectorApiLogicResponse,
 } from '../../../../api/connector/convert_connector_api_logic';
-import { IndexViewActions, IndexViewLogic } from '../../index_view_logic';
+import { ConnectorViewLogic } from '../../../connector_detail/connector_view_logic';
+import { IndexViewLogic } from '../../index_view_logic';
 
 interface ConvertConnectorValues {
   connectorId: typeof IndexViewLogic.values.connectorId;
@@ -34,7 +35,6 @@ type ConvertConnectorActions = Pick<
   'apiError' | 'apiSuccess' | 'makeRequest'
 > & {
   convertConnector(): void;
-  fetchIndex(): IndexViewActions['fetchIndex'];
   hideModal(): void;
   showModal(): void;
 };
@@ -49,15 +49,13 @@ export const ConvertConnectorLogic = kea<
     showModal: () => true,
   },
   connect: {
-    actions: [
-      ConvertConnectorApiLogic,
-      ['apiError', 'apiSuccess', 'makeRequest'],
-      IndexViewLogic,
-      ['fetchIndex'],
-    ],
-    values: [ConvertConnectorApiLogic, ['status'], IndexViewLogic, ['connectorId']],
+    actions: [ConvertConnectorApiLogic, ['apiError', 'apiSuccess', 'makeRequest']],
+    values: [ConvertConnectorApiLogic, ['status'], ConnectorViewLogic, ['connectorId']],
   },
   listeners: ({ actions, values }) => ({
+    apiSuccess: () => {
+      actions.hideModal();
+    },
     convertConnector: () => {
       if (values.connectorId) {
         actions.makeRequest({ connectorId: values.connectorId });

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration_config.tsx
@@ -24,7 +24,6 @@ import { HttpLogic } from '../../../../../shared/http';
 import { LicensingLogic } from '../../../../../shared/licensing';
 
 import { ConnectorConfigurationApiLogic } from '../../../../api/connector/update_connector_configuration_api_logic';
-import { IndexNameLogic } from '../../index_name_logic';
 import { ConnectorDefinition } from '../types';
 
 interface NativeConnectorConfigurationConfigProps {
@@ -37,7 +36,6 @@ export const NativeConnectorConfigurationConfig: React.FC<
   NativeConnectorConfigurationConfigProps
 > = ({ connector, nativeConnector, status }) => {
   const { hasPlatinumLicense } = useValues(LicensingLogic);
-  const { indexName } = useValues(IndexNameLogic);
   const { status: updateStatus } = useValues(ConnectorConfigurationApiLogic);
   const { makeRequest } = useActions(ConnectorConfigurationApiLogic);
   const { http } = useValues(HttpLogic);
@@ -50,7 +48,6 @@ export const NativeConnectorConfigurationConfig: React.FC<
         makeRequest({
           configuration,
           connectorId: connector.id,
-          indexName,
         })
       }
       subscriptionLink={docLinks.licenseManagement}

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/utils/connector_status_helpers.ts
@@ -8,7 +8,15 @@
 import { i18n } from '@kbn/i18n';
 import { ConnectorStatus } from '@kbn/search-connectors';
 
-export function connectorStatusToText(connectorStatus: ConnectorStatus): string {
+const incompleteText = i18n.translate(
+  'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.incomplete.label',
+  { defaultMessage: 'Incomplete' }
+);
+
+export function connectorStatusToText(
+  connectorStatus: ConnectorStatus,
+  hasIndexName: boolean
+): string {
   if (
     connectorStatus === ConnectorStatus.CREATED ||
     connectorStatus === ConnectorStatus.NEEDS_CONFIGURATION
@@ -24,6 +32,9 @@ export function connectorStatusToText(connectorStatus: ConnectorStatus): string 
       { defaultMessage: 'Connector Failure' }
     );
   }
+  if (!hasIndexName) {
+    return incompleteText;
+  }
   if (connectorStatus === ConnectorStatus.CONFIGURED) {
     return i18n.translate(
       'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.configured.label',
@@ -37,15 +48,16 @@ export function connectorStatusToText(connectorStatus: ConnectorStatus): string 
     );
   }
 
-  return i18n.translate(
-    'xpack.enterpriseSearch.content.searchIndices.ingestionStatus.incomplete.label',
-    { defaultMessage: 'Incomplete' }
-  );
+  return incompleteText;
 }
 
 export function connectorStatusToColor(
-  connectorStatus: ConnectorStatus
+  connectorStatus: ConnectorStatus,
+  hasIndexName: boolean
 ): 'warning' | 'danger' | 'success' {
+  if (!hasIndexName) {
+    return 'warning';
+  }
   if (connectorStatus === ConnectorStatus.CONNECTED) {
     return 'success';
   }

--- a/x-pack/plugins/enterprise_search/server/lib/indices/fetch_index_counts.ts
+++ b/x-pack/plugins/enterprise_search/server/lib/indices/fetch_index_counts.ts
@@ -10,8 +10,13 @@ import { IScopedClusterClient } from '@kbn/core/server';
 export const fetchIndexCounts = async (client: IScopedClusterClient, indicesNames: string[]) => {
   // TODO: is there way to batch this? Passing multiple index names or a pattern still returns a singular count
   const countPromises = indicesNames.map(async (indexName) => {
-    const { count } = await client.asCurrentUser.count({ index: indexName });
-    return { [indexName]: count };
+    try {
+      const { count } = await client.asCurrentUser.count({ index: indexName });
+      return { [indexName]: count };
+    } catch {
+      // we don't want to error out the whole API call if one index breaks (eg: doesn't exist or is closed)
+      return { [indexName]: 0 };
+    }
   });
   const indexCountArray = await Promise.all(countPromises);
   return indexCountArray.reduce((acc, current) => Object.assign(acc, current), {});

--- a/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
+++ b/x-pack/plugins/enterprise_search/server/routes/enterprise_search/indices.ts
@@ -24,7 +24,11 @@ import { DEFAULT_PIPELINE_NAME } from '../../../common/constants';
 import { ErrorCode } from '../../../common/types/error_codes';
 import { AlwaysShowPattern } from '../../../common/types/indices';
 
-import type { AttachMlInferencePipelineResponse } from '../../../common/types/pipelines';
+import type {
+  AttachMlInferencePipelineResponse,
+  MlInferenceError,
+  MlInferenceHistoryResponse,
+} from '../../../common/types/pipelines';
 
 import { fetchCrawlerByIndexName, fetchCrawlers } from '../../lib/crawler/fetch_crawlers';
 
@@ -774,8 +778,14 @@ export function registerIndexRoutes({
       const indexName = decodeURIComponent(request.params.indexName);
       const { client } = (await context.core).elasticsearch;
 
-      const errors = await getMlInferenceErrors(indexName, client.asCurrentUser);
-
+      let errors: MlInferenceError[] = [];
+      try {
+        errors = await getMlInferenceErrors(indexName, client.asCurrentUser);
+      } catch (error) {
+        if (!isIndexNotFoundException(error)) {
+          throw error;
+        }
+      }
       return response.ok({
         body: {
           errors,
@@ -914,9 +924,14 @@ export function registerIndexRoutes({
     elasticsearchErrorHandler(log, async (context, request, response) => {
       const indexName = decodeURIComponent(request.params.indexName);
       const { client } = (await context.core).elasticsearch;
-
-      const history = await fetchMlInferencePipelineHistory(client.asCurrentUser, indexName);
-
+      let history: MlInferenceHistoryResponse = { history: [] };
+      try {
+        history = await fetchMlInferencePipelineHistory(client.asCurrentUser, indexName);
+      } catch (error) {
+        if (!isIndexNotFoundException(error)) {
+          throw error;
+        }
+      }
       return response.ok({
         body: history,
         headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Search] Fix connectors pages breaking if index has been deleted (#178147)](https://github.com/elastic/kibana/pull/178147)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-03-07T13:14:45Z","message":"[Search] Fix connectors pages breaking if index has been deleted (#178147)\n\n## Summary\r\n\r\nThis fixes the new connector pages to work even if the attached index\r\nhas been deleted. Mostly does this by heavily relying on\r\nConnectorViewLogic instead of IndexViewLogic.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0dc0d3d6c49374065bc83832d4ec47515f2c727f","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.13.0","v8.14.0"],"number":178147,"url":"https://github.com/elastic/kibana/pull/178147","mergeCommit":{"message":"[Search] Fix connectors pages breaking if index has been deleted (#178147)\n\n## Summary\r\n\r\nThis fixes the new connector pages to work even if the attached index\r\nhas been deleted. Mostly does this by heavily relying on\r\nConnectorViewLogic instead of IndexViewLogic.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0dc0d3d6c49374065bc83832d4ec47515f2c727f"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178147","number":178147,"mergeCommit":{"message":"[Search] Fix connectors pages breaking if index has been deleted (#178147)\n\n## Summary\r\n\r\nThis fixes the new connector pages to work even if the attached index\r\nhas been deleted. Mostly does this by heavily relying on\r\nConnectorViewLogic instead of IndexViewLogic.\r\n\r\n---------\r\n\r\nCo-authored-by: kibanamachine <42973632+kibanamachine@users.noreply.github.com>","sha":"0dc0d3d6c49374065bc83832d4ec47515f2c727f"}}]}] BACKPORT-->