### PR TITLE
[Search] Use "Delete" instead of "Delete index" when deleting a crawler/connector

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/delete_connector_modal.tsx
@@ -68,7 +68,7 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
       onConfirm={() => {
         deleteConnector({
           connectorId,
-          shouldDeleteIndex,
+          shouldDeleteIndex: isCrawler ? true : shouldDeleteIndex,
         });
       }}
       cancelButtonText={
@@ -89,7 +89,7 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
       confirmButtonText={i18n.translate(
         'xpack.enterpriseSearch.content.connectors.deleteModal.confirmButton.title',
         {
-          defaultMessage: 'Delete index',
+          defaultMessage: 'Delete',
         }
       )}
       defaultFocusedButton="confirm"
@@ -127,21 +127,40 @@ export const DeleteConnectorModal: React.FC<DeleteConnectorModalProps> = ({ isCr
         </ul>
       </p>
       <p>
-        <EuiText>
-          <FormattedMessage
-            id="xpack.enterpriseSearch.content.connectors.deleteModal.syncsWarning.indexNameDescription"
-            defaultMessage="This action cannot be undone. Please type {connectorName} to confirm."
-            values={{
-              connectorName: (
-                <strong>
-                  <EuiTextColor color="danger">{connectorName}</EuiTextColor>
-                </strong>
-              ),
-            }}
-          />
-        </EuiText>
+        {isCrawler && (
+          <>
+            <EuiText>
+              <FormattedMessage
+                id="xpack.enterpriseSearch.deleteConnectorModal.crawler.warning"
+                defaultMessage="Deleting this crawler will also delete its related index with all of its data and its Crawler configuration. Any associated search applications will no longer be able to access any data stored in this index. This action cannot be undone. Please type {connectorName} to confirm."
+                values={{
+                  connectorName: (
+                    <strong>
+                      <EuiTextColor color="danger">{connectorName}</EuiTextColor>
+                    </strong>
+                  ),
+                }}
+              />
+            </EuiText>
+          </>
+        )}
+        {!isCrawler && (
+          <EuiText>
+            <FormattedMessage
+              id="xpack.enterpriseSearch.content.connectors.deleteModal.syncsWarning.indexNameDescription"
+              defaultMessage="This action cannot be undone. Please type {connectorName} to confirm."
+              values={{
+                connectorName: (
+                  <strong>
+                    <EuiTextColor color="danger">{connectorName}</EuiTextColor>
+                  </strong>
+                ),
+              }}
+            />
+          </EuiText>
+        )}
       </p>
-      {deleteModalIndexName && (
+      {deleteModalIndexName && !isCrawler && (
         <>
           <EuiCheckbox
             id="delete-related-index"


### PR DESCRIPTION
As the modal is responsible for deleting a crawler or a connector and not necessarily an index the text is misleading. I think only "Delete" makes more sense.