### PR TITLE
Fix links to create connector/crawler in search guide and integrations

### DIFF
--- a/x-pack/plugins/enterprise_search/common/guided_onboarding/search_guide_config.ts
+++ b/x-pack/plugins/enterprise_search/common/guided_onboarding/search_guide_config.ts
@@ -13,9 +13,9 @@ export const websiteSearchGuideId = 'websiteSearch';
 export const databaseSearchGuideId = 'databaseSearch';
 
 const apiRoutes = {
-  [appSearchGuideId]: 'api',
-  [databaseSearchGuideId]: 'select_connector',
-  [websiteSearchGuideId]: 'crawler',
+  [appSearchGuideId]: '/search_indices/new_index/api',
+  [databaseSearchGuideId]: '/connectors/select_connector',
+  [websiteSearchGuideId]: '/crawlers',
 };
 
 export type EnterpriseSearchGuideIds =
@@ -35,7 +35,7 @@ const getAddDataStep: (method?: EnterpriseSearchGuideIds) => StepConfig = (metho
     }),
     location: {
       appID: 'enterpriseSearchContent',
-      path: `/search_indices/new_index/${method ? apiRoutes[method] : ''}`,
+      path: `${method ? apiRoutes[method] : '/search_indices/new_index'}`,
     },
   };
 };

--- a/x-pack/plugins/enterprise_search/cypress/e2e/content/selectors.ts
+++ b/x-pack/plugins/enterprise_search/cypress/e2e/content/selectors.ts
@@ -6,10 +6,10 @@
  */
 
 export const ROUTES = {
-  CRAWLER_INDEX: '/app/enterprise_search/content/search_indices/new_index/crawler',
+  CRAWLER_INDEX: '/app/enterprise_search/content/crawlers/new_crawler',
   NEW_INDEX: '/app/enterprise_search/content/search_indices/new_index',
   SEARCH_INDICES_OVERVIEW: '/app/enterprise_search/content/search_indices/',
-  SELECT_CONNECTOR: '/app/enterprise_search/content/search_indices/new_index/select_connector',
+  SELECT_CONNECTOR: '/app/enterprise_search/content/connectors/select_connector',
 };
 
 export const SEARCH_INDICES = {

--- a/x-pack/plugins/enterprise_search/server/integrations.ts
+++ b/x-pack/plugins/enterprise_search/server/integrations.ts
@@ -52,7 +52,7 @@ export const registerEnterpriseSearchIntegrations = (
         defaultMessage: 'Add search to your website with the web crawler.',
       }),
       categories: ['enterprise_search', 'app_search', 'web', 'elastic_stack', 'crawler'],
-      uiInternalPath: '/app/enterprise_search/content/search_indices/new_index/crawler',
+      uiInternalPath: '/app/enterprise_search/content/crawlers/new_crawler',
       icons: [
         {
           type: 'eui',
@@ -106,7 +106,7 @@ export const registerEnterpriseSearchIntegrations = (
         isBeta: connector.isBeta,
         shipper: 'enterprise_search',
         title: connector.name,
-        uiInternalPath: `/app/enterprise_search/content/search_indices/new_index/connector?connector_type=${connectorType}&service_type=${connector.serviceType}`,
+        uiInternalPath: `/app/enterprise_search/content/connectors/new_connector?connector_type=${connectorType}&service_type=${connector.serviceType}`,
       });
     });
   }


### PR DESCRIPTION
## Summary

Follow-up PR for https://github.com/elastic/kibana/pull/178078 (hit auto-merge on creation, but was not supposed to merge before checking those).

Previous PR broke routing for:
1. Guided onboarding
2. Integration tiles

This PR fixes urls in UI components to lead to correct routes.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->