### PR TITLE
[Search] Fix connectors router blocking detail views

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_router.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connectors/connectors_router.tsx
@@ -9,7 +9,13 @@ import React from 'react';
 
 import { Routes, Route } from '@kbn/shared-ux-router';
 
-import { CONNECTORS_PATH, NEW_INDEX_SELECT_CONNECTOR_PATH, NEW_CONNECTOR_PATH } from '../../routes';
+import {
+  CONNECTORS_PATH,
+  NEW_INDEX_SELECT_CONNECTOR_PATH,
+  NEW_CONNECTOR_PATH,
+  CONNECTOR_DETAIL_PATH,
+} from '../../routes';
+import { ConnectorDetailRouter } from '../connector_detail/connector_detail_router';
 import { NewSearchIndexPage } from '../new_index/new_search_index_page';
 
 import { Connectors } from './connectors';
@@ -24,8 +30,11 @@ export const ConnectorsRouter: React.FC = () => {
       <Route path={NEW_CONNECTOR_PATH}>
         <NewSearchIndexPage type="connector" />
       </Route>
-      <Route path={CONNECTORS_PATH}>
+      <Route path={CONNECTORS_PATH} exact>
         <Connectors isCrawler={false} />
+      </Route>
+      <Route path={CONNECTOR_DETAIL_PATH}>
+        <ConnectorDetailRouter />
       </Route>
     </Routes>
   );

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/index.tsx
@@ -20,14 +20,12 @@ import { HttpLogic } from '../shared/http';
 import { KibanaLogic } from '../shared/kibana';
 import { VersionMismatchPage } from '../shared/version_mismatch';
 
-import { ConnectorDetailRouter } from './components/connector_detail/connector_detail_router';
 import { ConnectorsRouter } from './components/connectors/connectors_router';
 import { CrawlersRouter } from './components/connectors/crawlers_router';
 import { NotFound } from './components/not_found';
 import { SearchIndicesRouter } from './components/search_indices';
 import {
   CONNECTORS_PATH,
-  CONNECTOR_DETAIL_PATH,
   CRAWLERS_PATH,
   ERROR_STATE_PATH,
   ROOT_PATH,
@@ -80,9 +78,6 @@ export const EnterpriseSearchContentConfigured: React.FC<Required<InitialAppData
       </Route>
       <Route path={CONNECTORS_PATH}>
         <ConnectorsRouter />
-      </Route>
-      <Route path={CONNECTOR_DETAIL_PATH}>
-        <ConnectorDetailRouter />
       </Route>
       <Route path={CRAWLERS_PATH}>
         <CrawlersRouter />


### PR DESCRIPTION
## Summary

This fixes a routing issue where the connector detail routes were unreachable.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->