### PR TITLE
[Custom threshold] Improve types by making SerializedSearchSourceFields query type generic

### DIFF
--- a/src/plugins/data/common/search/search_source/search_source.ts
+++ b/src/plugins/data/common/search/search_source/search_source.ts
@@ -73,11 +73,13 @@ import {
 import { defer, EMPTY, from, lastValueFrom, Observable } from 'rxjs';
 import type * as estypes from '@elastic/elasticsearch/lib/api/typesWithBodyKey';
 import {
+  AggregateQuery,
   buildEsQuery,
   Filter,
   isOfQueryType,
   isPhraseFilter,
   isPhrasesFilter,
+  Query,
 } from '@kbn/es-query';
 import { fieldWildcardFilter } from '@kbn/kibana-utils-plugin/common';
 import { getHighlightRequest } from '@kbn/field-formats-plugin/common';
@@ -233,8 +235,8 @@ export class SearchSource {
   /**
    * returns all search source fields
    */
-  getFields(): SearchSourceFields {
-    return { ...this.fields };
+  getFields<Q extends Query | AggregateQuery = Query | AggregateQuery>() {
+    return { ...this.fields } as SearchSourceFields<Q>;
   }
 
   /**
@@ -947,7 +949,9 @@ export class SearchSource {
   /**
    * serializes search source fields (which can later be passed to {@link ISearchStartSearchSource})
    */
-  public getSerializedFields(recurse = false): SerializedSearchSourceFields {
+  public getSerializedFields<Q extends Query | AggregateQuery = Query | AggregateQuery>(
+    recurse = false
+  ): SerializedSearchSourceFields<Q> {
     const {
       filter: originalFilters,
       aggs: searchSourceAggs,
@@ -956,9 +960,9 @@ export class SearchSource {
       sort,
       index,
       ...searchSourceFields
-    } = this.getFields();
+    } = this.getFields<Q>();
 
-    let serializedSearchSourceFields: SerializedSearchSourceFields = {
+    let serializedSearchSourceFields: SerializedSearchSourceFields<Q> = {
       ...searchSourceFields,
     };
     if (index) {

--- a/src/plugins/data/common/search/search_source/types.ts
+++ b/src/plugins/data/common/search/search_source/types.ts
@@ -71,12 +71,12 @@ export type SearchFieldValue = string | SearchField;
 /**
  * search source fields
  */
-export interface SearchSourceFields {
+export interface SearchSourceFields<Q extends Query | AggregateQuery = Query | AggregateQuery> {
   type?: string;
   /**
    * {@link Query}
    */
-  query?: Query | AggregateQuery;
+  query?: Q;
   /**
    * {@link Filter}
    */
@@ -122,12 +122,14 @@ export interface SearchSourceFields {
 }
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
-export type SerializedSearchSourceFields = {
+export type SerializedSearchSourceFields<
+  Q extends Query | AggregateQuery = Query | AggregateQuery
+> = {
   type?: string;
   /**
    * {@link Query}
    */
-  query?: Query | AggregateQuery;
+  query?: Q;
   /**
    * {@link Filter}
    */

--- a/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/types.ts
+++ b/x-pack/plugins/observability_solution/observability/common/custom_threshold_rule/types.ts
@@ -7,7 +7,7 @@
 
 import * as rt from 'io-ts';
 import { DataViewSpec, SerializedSearchSourceFields } from '@kbn/data-plugin/common';
-import { Filter } from '@kbn/es-query';
+import { Filter, Query } from '@kbn/es-query';
 import { TimeUnitChar } from '../utils/formatters/duration';
 
 export const ThresholdFormatterTypeRT = rt.keyof({
@@ -65,7 +65,7 @@ export interface ThresholdParams {
   sourceId?: string;
   alertOnNoData?: boolean;
   alertOnGroupDisappear?: boolean;
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SerializedSearchSourceFields<Query>;
   groupBy?: string[];
 }
 

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/rule_condition_chart/rule_condition_chart.test.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/rule_condition_chart/rule_condition_chart.test.tsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import { SerializedSearchSourceFields } from '@kbn/data-plugin/common';
+import { Query } from '@kbn/es-query';
 import { act } from 'react-dom/test-utils';
 import { DataView } from '@kbn/data-views-plugin/common';
 import { mountWithIntl, nextTick } from '@kbn/test-jest-helpers';
@@ -36,7 +37,7 @@ describe('Rule condition chart', () => {
       <RuleConditionChart
         metricExpression={expression}
         dataView={dataView}
-        searchConfiguration={{} as SerializedSearchSourceFields}
+        searchConfiguration={{} as SerializedSearchSourceFields<Query>}
         groupBy={[]}
         error={{}}
         timeRange={{ from: 'now-15m', to: 'now' }}

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/rule_condition_chart/rule_condition_chart.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/rule_condition_chart/rule_condition_chart.tsx
@@ -46,7 +46,7 @@ interface ChartOptions {
 
 interface RuleConditionChartProps {
   metricExpression: MetricExpression;
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SerializedSearchSourceFields<Query>;
   dataView?: DataView;
   groupBy?: string | string[];
   error?: IErrorObject;
@@ -355,7 +355,7 @@ export function RuleConditionChart({
         timeRange={timeRange}
         attributes={attributes}
         disableTriggers={true}
-        query={(searchConfiguration.query as Query) || defaultQuery}
+        query={searchConfiguration.query || defaultQuery}
         filters={filters}
       />
     </div>

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/validation.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/components/validation.tsx
@@ -24,7 +24,7 @@ export function validateCustomThreshold({
   uiSettings,
 }: {
   criteria: CustomMetricExpressionParams[];
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SerializedSearchSourceFields<Query>;
   uiSettings: IUiSettingsClient;
 }): ValidationResult {
   const validationResult = { errors: {} };
@@ -58,7 +58,7 @@ export function validateCustomThreshold({
     try {
       buildEsQuery(
         undefined,
-        [{ query: (searchConfiguration.query as Query).query, language: 'kuery' }],
+        [{ query: searchConfiguration.query.query, language: 'kuery' }],
         [],
         getEsQueryConfig(uiSettings)
       );

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/custom_threshold_rule_expression.tsx
@@ -412,7 +412,7 @@ export default function Expressions(props: Props) {
         onQueryChange={debouncedOnFilterChange}
         onQuerySubmit={onFilterChange}
         dataTestSubj="thresholdRuleUnifiedSearchBar"
-        query={ruleParams.searchConfiguration?.query as Query}
+        query={ruleParams.searchConfiguration?.query}
         filters={ruleParams.searchConfiguration?.filter}
         onFiltersUpdated={(filter) => {
           // Since rule params will be sent to the API as is, and we only need meta and query parameters to be

--- a/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/types.ts
+++ b/x-pack/plugins/observability_solution/observability/public/components/custom_threshold/types.ts
@@ -12,6 +12,7 @@ import { DataPublicPluginStart, SerializedSearchSourceFields } from '@kbn/data-p
 import { DataView, DataViewsPublicPluginStart } from '@kbn/data-views-plugin/public';
 import { DiscoverStart } from '@kbn/discover-plugin/public';
 import { EmbeddableStart } from '@kbn/embeddable-plugin/public';
+import { Query } from '@kbn/es-query';
 import { IStorageWrapper } from '@kbn/kibana-utils-plugin/public';
 import { LensPublicStart } from '@kbn/lens-plugin/public';
 import { ObservabilitySharedPluginStart } from '@kbn/observability-shared-plugin/public';
@@ -61,7 +62,7 @@ export interface AlertParams {
   filterQuery?: string;
   alertOnNoData?: boolean;
   alertOnGroupDisappear?: boolean;
-  searchConfiguration: SerializedSearchSourceFields;
+  searchConfiguration: SerializedSearchSourceFields<Query>;
   shouldDropPartialBuckets?: boolean;
 }
 

--- a/x-pack/plugins/observability_solution/observability/public/rules/register_observability_rule_types.ts
+++ b/x-pack/plugins/observability_solution/observability/public/rules/register_observability_rule_types.ts
@@ -7,7 +7,7 @@
 
 import { lazy } from 'react';
 import { i18n } from '@kbn/i18n';
-import { SerializedSearchSourceFields } from '@kbn/data-plugin/common';
+import { Query, SerializedSearchSourceFields } from '@kbn/data-plugin/common';
 import {
   ALERT_GROUP_FIELD,
   ALERT_GROUP_VALUE,
@@ -129,7 +129,7 @@ export const registerObservabilityRuleTypes = async (
     searchConfiguration,
   }: {
     criteria: CustomMetricExpressionParams[];
-    searchConfiguration: SerializedSearchSourceFields;
+    searchConfiguration: SerializedSearchSourceFields<Query>;
   }) => validateCustomThreshold({ criteria, searchConfiguration, uiSettings });
   observabilityRuleTypeRegistry.register({
     id: OBSERVABILITY_THRESHOLD_RULE_TYPE_ID,


### PR DESCRIPTION
Closes #176382

## Summary

The main point of this improvement is removing casting `searchConfiguration.query as Query` by specifying `Query` for SerializedSearchSourceFields (e.i. `SerializedSearchSourceFields<Query>`).

At the moment, we don't support `AggregateQuery` in the custom threshold rule.

Please let me know if you have any other suggestions to improve this case.