### PR TITLE
[Fleet] On policy deploy, delete revisions newer or equal current revision

### DIFF
--- a/x-pack/plugins/fleet/server/services/agent_policy.test.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.test.ts
@@ -413,8 +413,14 @@ describe('agent policy', () => {
         expect.objectContaining({
           index: AGENT_POLICY_INDEX,
           query: {
-            term: {
-              policy_id: 'mocked',
+            bool: {
+              filter: [
+                {
+                  term: {
+                    policy_id: 'mocked',
+                  },
+                },
+              ],
             },
           },
         })
@@ -899,6 +905,24 @@ describe('agent policy', () => {
             }),
           ],
           refresh: 'wait_for',
+        })
+      );
+
+      expect(esClient.deleteByQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          index: AGENT_POLICY_INDEX,
+          query: {
+            bool: {
+              filter: [
+                {
+                  term: {
+                    policy_id: 'policy123',
+                  },
+                },
+                { range: { revision_idx: { gte: 1 } } },
+              ],
+            },
+          },
         })
       );
     });


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/178275

Another improvement on making sure `.fleet-policies` stays in sync with agent policy SO.
On deploy policy logic, before creating the `.fleet-policies` doc with the revision matching the SO, running a delete of revisions that are newer or equal to the current SO revision. Usually there shouldn't be any policies like this, so this is a "self healing" update to clean up any revisions that were incorrectly remained.

This improvement should help recover from the error scenario in the linked issue (the issue it's not reproducible yet).

Steps to verify:
- Create an agent policy
- Update any fields
- Check that SO and .fleet-policies contains revision 2.
- Manually delete the agent policy SO (needs superuser role)
- Recreate the agent policy with the same id.
- Verify that the SO and latest revision in .fleet-policies is revision 1.

Alternatively can be tested by manually updating a revision in .fleet-policies to a higher revision (e.g. 3) and then update the agent policy from the UI to trigger `deployPolicies`.


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
