### PR TITLE
[Fleet UI] Fix name of ES output workers configuration key

### DIFF
--- a/x-pack/plugins/fleet/common/constants/output.ts
+++ b/x-pack/plugins/fleet/common/constants/output.ts
@@ -129,7 +129,7 @@ export const RESERVED_CONFIG_YML_KEYS = [
   'queue.mem.events',
   'queue.mem.flush.min_events',
   'queue.mem.flush.timeout',
-  'workers',
+  'worker',
 ];
 
 export const OUTPUT_TYPES_WITH_PRESET_SUPPORT: Array<ValueOf<OutputType>> = [


### PR DESCRIPTION
## Summary

This PR fixes the name of one of the reserved keys allowed in Elasticsearch output configuration when using the `custom` performance preset.

See also https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#worker-option.



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->