### PR TITLE
[Search] Hide API key UI when FF disabled

### DIFF
--- a/packages/kbn-search-connectors/types/connectors.ts
+++ b/packages/kbn-search-connectors/types/connectors.ts
@@ -190,6 +190,7 @@ export enum FeatureName {
   FILTERING_RULES = 'filtering_rules',
   DOCUMENT_LEVEL_SECURITY = 'document_level_security',
   INCREMENTAL_SYNC = 'incremental_sync',
+  NATIVE_CONNECTOR_API_KEYS = 'native_connector_api_keys',
   SYNC_RULES = 'sync_rules',
 }
 
@@ -198,6 +199,7 @@ export type ConnectorFeatures = Partial<{
   [FeatureName.FILTERING_ADVANCED_CONFIG]: boolean;
   [FeatureName.FILTERING_RULES]: boolean;
   [FeatureName.INCREMENTAL_SYNC]: { enabled: boolean };
+  [FeatureName.NATIVE_CONNECTOR_API_KEYS]: { enabled: boolean };
   [FeatureName.SYNC_RULES]: {
     advanced?: {
       enabled: boolean;

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -175,7 +175,11 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ? [
                       {
                         children: (
-                          <ApiKeyConfig indexName={connector.name} hasApiKey={hasApiKey} isNative />
+                          <ApiKeyConfig
+                            indexName={connector.index_name || ''}
+                            hasApiKey={hasApiKey}
+                            isNative
+                          />
                         ),
                         status: hasApiKey ? 'complete' : 'incomplete',
                         title: i18n.translate(

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/native_connector_configuration.tsx
@@ -22,6 +22,7 @@ import {
   EuiTitle,
 } from '@elastic/eui';
 
+import { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 import { i18n } from '@kbn/i18n';
 
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -86,6 +87,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
   const hasDocumentLevelSecurity =
     connector.features?.[FeatureName.DOCUMENT_LEVEL_SECURITY]?.enabled || false;
 
+  const apiKeysEnabled = connector.features?.native_connector_api_keys?.enabled || false;
   const hasApiKey = !!(connector.api_key_id ?? apiKeyData);
 
   // TODO service_type === "" is considered unknown/custom connector multipleplaces replace all of them with a better solution
@@ -169,23 +171,23 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ),
                   titleSize: 'xs',
                 },
-                {
-                  children: (
-                    <ApiKeyConfig
-                      indexName={connector.index_name || ''}
-                      hasApiKey={hasApiKey}
-                      isNative
-                    />
-                  ),
-                  status: hasApiKey ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
-                    {
-                      defaultMessage: 'Manage API key',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
+                ...(apiKeysEnabled
+                  ? [
+                      {
+                        children: (
+                          <ApiKeyConfig indexName={connector.name} hasApiKey={hasApiKey} isNative />
+                        ),
+                        status: hasApiKey ? 'complete' : 'incomplete',
+                        title: i18n.translate(
+                          'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
+                          {
+                            defaultMessage: 'Manage API key',
+                          }
+                        ),
+                        titleSize: 'xs',
+                      } as EuiContainedStepProps,
+                    ]
+                  : []),
                 {
                   children: (
                     <EuiFlexGroup direction="column">

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -21,6 +21,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
+import { EuiContainedStepProps } from '@elastic/eui/src/components/steps/steps';
 
 import { i18n } from '@kbn/i18n';
 
@@ -77,6 +78,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
   const hasResearched = hasDescription || hasConfigured || hasConfiguredAdvanced;
   const icon = nativeConnector.icon;
 
+  const apiKeysEnabled = index.connector.features?.native_connector_api_keys?.enabled || false;
   const hasApiKey = !!(index.connector.api_key_id ?? apiKeyData);
 
   // TODO service_type === "" is considered unknown/custom connector multipleplaces replace all of them with a better solution
@@ -146,19 +148,6 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   titleSize: 'xs',
                 },
                 {
-                  children: (
-                    <ApiKeyConfig indexName={index.connector.name} hasApiKey={hasApiKey} isNative />
-                  ),
-                  status: hasApiKey ? 'complete' : 'incomplete',
-                  title: i18n.translate(
-                    'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
-                    {
-                      defaultMessage: 'Manage API key',
-                    }
-                  ),
-                  titleSize: 'xs',
-                },
-                {
                   children: <ConnectorNameAndDescription />,
                   status: hasDescription ? 'complete' : 'incomplete',
                   title: i18n.translate(
@@ -186,6 +175,27 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ),
                   titleSize: 'xs',
                 },
+                ...(apiKeysEnabled
+                  ? [
+                      {
+                        children: (
+                          <ApiKeyConfig
+                            indexName={index.connector.name}
+                            hasApiKey={hasApiKey}
+                            isNative
+                          />
+                        ),
+                        status: hasApiKey ? 'complete' : 'incomplete',
+                        title: i18n.translate(
+                          'xpack.enterpriseSearch.content.indices.configurationConnector.nativeConnector.steps.manageApiKeyTitle',
+                          {
+                            defaultMessage: 'Manage API key',
+                          }
+                        ),
+                        titleSize: 'xs',
+                      } as EuiContainedStepProps,
+                    ]
+                  : []),
                 {
                   children: <NativeConnectorAdvancedConfiguration />,
                   status: hasConfiguredAdvanced ? 'complete' : 'incomplete',

--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/connector/native_connector_configuration/native_connector_configuration.tsx
@@ -179,11 +179,7 @@ export const NativeConnectorConfiguration: React.FC = () => {
                   ? [
                       {
                         children: (
-                          <ApiKeyConfig
-                            indexName={index.connector.name}
-                            hasApiKey={hasApiKey}
-                            isNative
-                          />
+                          <ApiKeyConfig indexName={index.name} hasApiKey={hasApiKey} isNative />
                         ),
                         status: hasApiKey ? 'complete' : 'incomplete',
                         title: i18n.translate(


### PR DESCRIPTION
## Summary

Hide the `Manage API key` step from native connector configurations if the connector's FF `native_connector_api_keys` is disabled.
This is to prevent confusion for users upgrading to 8.13, as their native connectors will not initially have API keys.
