### PR TITLE
[SLO] Rename Attach to dashboard to Add dashboard for slo embeddables

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/pages/slo_details/components/error_budget_actions.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/slo_details/components/error_budget_actions.tsx
@@ -16,7 +16,7 @@ interface Props {
 export function ErrorBudgetActions({ setDashboardAttachmentReady }: Props) {
   const [isActionsPopoverOpen, setIsActionsPopoverOpen] = useState(false);
 
-  const handleAttachToDashboard = () => {
+  const handleAddToDashboard = () => {
     setIsActionsPopoverOpen(false);
     if (setDashboardAttachmentReady) {
       setDashboardAttachmentReady(true);
@@ -38,12 +38,12 @@ export function ErrorBudgetActions({ setDashboardAttachmentReady }: Props) {
       <EuiContextMenuPanel>
         <EuiContextMenuItem
           icon="dashboardApp"
-          key="attachToDashboard"
-          onClick={handleAttachToDashboard}
-          data-test-subj="sloActinsAttachToDashboard"
+          key="addToDashboard"
+          onClick={handleAddToDashboard}
+          data-test-subj="sloActionsAddToDashboard"
         >
-          {i18n.translate('xpack.observability.slo.item.actions.attachToDashboard', {
-            defaultMessage: 'Attach to Dashboard',
+          {i18n.translate('xpack.observability.slo.item.actions.addToDashboard', {
+            defaultMessage: 'Add to Dashboard',
           })}
         </EuiContextMenuItem>
       </EuiContextMenuPanel>

--- a/x-pack/plugins/observability_solution/observability/public/pages/slos/components/card_view/slo_card_item.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/slos/components/card_view/slo_card_item.tsx
@@ -149,12 +149,12 @@ export function SloCardItem({ slo, rules, activeAlerts, historicalSummary, cards
       {isDashboardAttachmentReady ? (
         <SavedObjectSaveModalDashboard
           objectType={i18n.translate(
-            'xpack.observability.slo.item.actions.attachToDashboard.objectTypeLabel',
+            'xpack.observability.slo.item.actions.addToDashboard.objectTypeLabel',
             { defaultMessage: 'SLO Overview' }
           )}
           documentInfo={{
             title: i18n.translate(
-              'xpack.observability.slo.item.actions.attachToDashboard.attachmentTitle',
+              'xpack.observability.slo.item.actions.addToDashboard.attachmentTitle',
               { defaultMessage: 'SLO Overview' }
             ),
           }}

--- a/x-pack/plugins/observability_solution/observability/public/pages/slos/components/slo_item_actions.tsx
+++ b/x-pack/plugins/observability_solution/observability/public/pages/slos/components/slo_item_actions.tsx
@@ -112,7 +112,7 @@ export function SloItemActions({
     setIsAddRuleFlyoutOpen(true);
   };
 
-  const handleAttachToDashboard = () => {
+  const handleAddToDashboard = () => {
     setIsActionsPopoverOpen(false);
     if (setDashboardAttachmentReady) {
       setDashboardAttachmentReady(true);
@@ -213,12 +213,12 @@ export function SloItemActions({
           </EuiContextMenuItem>,
           <EuiContextMenuItem
             icon="dashboardApp"
-            key="attachToDashboard"
-            onClick={handleAttachToDashboard}
-            data-test-subj="sloActinsAttachToDashboard"
+            key="addToDashboard"
+            onClick={handleAddToDashboard}
+            data-test-subj="sloActionsAddToDashboard"
           >
-            {i18n.translate('xpack.observability.slo.item.actions.attachToDashboard', {
-              defaultMessage: 'Attach to Dashboard',
+            {i18n.translate('xpack.observability.slo.item.actions.addToDashboard', {
+              defaultMessage: 'Add to Dashboard',
             })}
           </EuiContextMenuItem>,
         ]}


### PR DESCRIPTION
## 🍒 Summary 

This PR renames `Attach to Dashboard` to `Add to Dashboard` in following places
- SLO list page > SLO Card actions
- SLO detail page > Error budget burn down chart

<img width="352" alt="Screenshot 2024-03-11 at 13 38 50" src="https://github.com/elastic/kibana/assets/2852703/6a903086-5015-481f-ad6c-199cf64ac23a">
<img width="1227" alt="Screenshot 2024-03-11 at 13 39 11" src="https://github.com/elastic/kibana/assets/2852703/6ae49144-2ca8-4a65-b19d-41ce4e70c63d">

cc @ThomThomson 

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->