### PR TITLE
[Synthetics] Omit the request `Content-Type` header if body check is empty

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -795,7 +795,9 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
       return {
         'data-test-subj': 'syntheticsHeaderFieldRequestHeaders',
         readOnly,
-        contentMode: (requestBody as RequestBodyCheck).type,
+        contentMode: !!(requestBody as Record<string, string>)?.value
+          ? (requestBody as RequestBodyCheck).type
+          : undefined,
       };
     },
   },

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/monitor_add_edit/form/field_config.tsx
@@ -795,7 +795,7 @@ export const FIELD = (readOnly?: boolean): FieldMap => ({
       return {
         'data-test-subj': 'syntheticsHeaderFieldRequestHeaders',
         readOnly,
-        contentMode: !!(requestBody as Record<string, string>)?.value
+        contentMode: !!(requestBody as RequestBodyCheck)?.value
           ? (requestBody as RequestBodyCheck).type
           : undefined,
       };


### PR DESCRIPTION
## Summary

Resolves #175703.

If the user does not specify a body verification check, we should not check the request's `Content-Type` header. This is too opinionated and causes problems for some users. More details in the linked issue.

## Testing

Testing this is quite easy. Go to the Synthetics UI, start creating a new HTTP monitor. Be sure to give a name, URL, and choose a location.

On `main`, if you click the _Inspect Configuration_ button at the top of the create monitor form, you should see the  `check.request.headers` field no matter what you have specified.

<img width="225" alt="image" src="https://github.com/elastic/kibana/assets/18429259/f3247fe6-de15-4fee-8b60-5bdbee681d5c">

<img width="407" alt="image" src="https://github.com/elastic/kibana/assets/18429259/38346a9c-3287-404c-802a-271f7c88e16e">


Now checkout this PR branch and do the same. You should only see the field if you expand _Advanced options_ and specify a **Request body** to check.

### Without request body

<img width="387" alt="image" src="https://github.com/elastic/kibana/assets/18429259/d6b31b54-5f72-42c6-9979-34d3ef0ddbcc">


### With request body

<img width="297" alt="image" src="https://github.com/elastic/kibana/assets/18429259/572458c7-02b7-46d9-a360-5c85ef6c1175">

<img width="383" alt="image" src="https://github.com/elastic/kibana/assets/18429259/0f32949b-1eb6-420b-a532-7c261f4e0bd6">




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->