### PR TITLE
[ci] Update APM transaction sample rate back to 0.1

### DIFF
--- a/.buildkite/scripts/common/env.sh
+++ b/.buildkite/scripts/common/env.sh
@@ -69,7 +69,7 @@ export FORCE_COLOR=1
 export TEST_BROWSER_HEADLESS=1
 
 export ELASTIC_APM_ENVIRONMENT=ci
-export ELASTIC_APM_TRANSACTION_SAMPLE_RATE=0.01
+export ELASTIC_APM_TRANSACTION_SAMPLE_RATE=0.1
 
 if is_pr; then
   if is_pr_with_label "ci:collect-apm"; then


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/177727 updated the endpoint used to collect APM metrics from CI to a project based deployment.  As part of the change we scaled back the sampling rate to monitor stability.  This reverts the sampling rate change.