### PR TITLE
[Synthetics] Require `unifiedSearch` plugin and include in top-level Kibana Context Provider

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/synthetics/kibana.jsonc
@@ -31,7 +31,8 @@
       "taskManager",
       "triggersActionsUi",
       "usageCollection",
-      "bfetch"
+      "bfetch",
+      "unifiedSearch"
     ],
     "optionalPlugins": [
       "cloud",

--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/synthetics_app.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/synthetics_app.tsx
@@ -95,6 +95,7 @@ const Application = (props: SyntheticsAppProps) => {
                 cases: startPlugins.cases,
                 spaces: startPlugins.spaces,
                 fleet: startPlugins.fleet,
+                unifiedSearch: startPlugins.unifiedSearch,
               }}
             >
               <SyntheticsDataViewContextProvider dataViews={startPlugins.dataViews}>


### PR DESCRIPTION
## Summary

Resolves #173751.

Despite our reliance on `unifiedSearch`, our usage seems to have been imperfect. This includes `unifiedSearch` in the list of required plugins, and explicitly adds it to the creation of our `KibanaContextProvider` at the root of the app. This seems to have resolved the problem.

## Testing

Load the Synthetics UI and open the alerting flyout at the top of the page. Add a connector. If you're able to toggle on the `If alert matches query` feature, then the fix should be working. You can learn a bit more about the expected failure by clicking through to the linked issue.

![20240311135128](https://github.com/elastic/kibana/assets/18429259/4625946d-e7f2-4bc0-96e6-69c38f609861)



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->