### PR TITLE
Fleet/flaky serverless api tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -12,6 +12,24 @@ const defaultFleetServerHostUrl = 'https://localhost:8220';
 const defaultElasticsearchOutputId = 'es-default-output';
 const defaultElasticsearchOutputHostUrl = 'https://localhost:9200';
 
+export const kbnServerArgs = [
+  '--xpack.cloud.serverless.project_id=ftr_fake_project_id',
+  `--xpack.fleet.fleetServerHosts=[${JSON.stringify({
+    id: defaultFleetServerHostId,
+    name: 'Default Fleet Server',
+    is_default: true,
+    host_urls: [defaultFleetServerHostUrl],
+  })}]`,
+  `--xpack.fleet.outputs=[${JSON.stringify({
+    id: defaultElasticsearchOutputId,
+    name: 'Default Output',
+    type: 'elasticsearch',
+    is_default: true,
+    is_default_monitoring: true,
+    hosts: [defaultElasticsearchOutputHostUrl],
+  })}]`,
+];
+
 export async function expectDefaultFleetServer({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const retry = getService('retry');
@@ -45,21 +63,3 @@ export async function expectDefaultElasticsearchOutput({ getService }: FtrProvid
     }
   });
 }
-
-export const kbnServerArgs = [
-  '--xpack.cloud.serverless.project_id=ftr_fake_project_id',
-  `--xpack.fleet.fleetServerHosts=[${JSON.stringify({
-    id: defaultFleetServerHostId,
-    name: 'Default Fleet Server',
-    is_default: true,
-    host_urls: [defaultFleetServerHostUrl],
-  })}]`,
-  `--xpack.fleet.outputs=[${JSON.stringify({
-    id: defaultElasticsearchOutputId,
-    name: 'Default Output',
-    type: 'elasticsearch',
-    is_default: true,
-    is_default_monitoring: true,
-    hosts: [defaultElasticsearchOutputHostUrl],
-  })}]`,
-];

--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -16,7 +16,7 @@ export async function expectDefaultFleetServer({ getService }: FtrProviderContex
   const supertest = getService('supertest');
   const retry = getService('retry');
 
-  await retry.waitForWithTimeout('get default fleet server', 30_000, async () => {
+  await retry.waitForWithTimeout('get default fleet server', 60_000, async () => {
     const { body, status } = await supertest.get(
       `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
     );
@@ -32,7 +32,7 @@ export async function expectDefaultElasticsearchOutput({ getService }: FtrProvid
   const supertest = getService('supertest');
   const retry = getService('retry');
 
-  await retry.waitForWithTimeout('get default Elasticsearch output', 30_000, async () => {
+  await retry.waitForWithTimeout('get default Elasticsearch output', 60_000, async () => {
     const { body, status } = await supertest.get(
       `/api/fleet/outputs/${defaultElasticsearchOutputId}`
     );


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/176754
Closes https://github.com/elastic/kibana/issues/176858

Fleet serverless API integration tests tests have already experienced flakiness due to slowness as they expect a preconfigured Fleet Server host and Elasticsearch output to exist. https://github.com/elastic/kibana/pull/176808 added retry logic in the tests, which improved flakiness a lot.

However, it seems we are still experiencing failure due to Saved Object not found errors. This indicates that the test setup with retrying is not fully working as intended: if the default fleet server host or output was not found during setup, the failure should be one of:
```
Expected default Fleet Server id default-fleet-server to exist
Expected default Elasticsearch output id es-default-output to exist
```

This PR increases the timeout of the setup retry and renames the error message thrown by Fleet backend when the SO is not found.

### Flaky Test Runner builds

* 🟢 [x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts x 100](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5449)
* 🟢 [x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5450)
* 🟢 [x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5451)
* 🟢 [x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5457)