### PR TITLE
Fix CO2/cost values in diff flamegraph tooltip

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/public/components/flamegraph/index.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/flamegraph/index.tsx
@@ -194,12 +194,8 @@ export function FlameGraph({
                             primaryFlamegraph.TotalAnnualCostsUSDItems[valueIndex]
                           }
                           baselineScaleFactor={baseline}
-                          comparisonAnnualCO2KgsInclusive={
-                            comparisonFlamegraph?.TotalAnnualCO2KgsItems[valueIndex]
-                          }
-                          comparisonAnnualCostsUSDInclusive={
-                            comparisonFlamegraph?.TotalAnnualCostsUSDItems[valueIndex]
-                          }
+                          comparisonAnnualCO2KgsInclusive={comparisonNode.TotalAnnualCO2Kgs}
+                          comparisonAnnualCostsUSDInclusive={comparisonNode?.TotalAnnualCostUSD}
                           comparisonCountExclusive={comparisonNode?.CountExclusive}
                           comparisonCountInclusive={comparisonNode?.CountInclusive}
                           comparisonScaleFactor={comparison}


### PR DESCRIPTION
Fixes the wrong CO2 and cost values shown in the differential flamegraph tooltip.

**example of wrong tooltip values**
![Screenshot_20240312_084224](https://github.com/elastic/kibana/assets/2087964/a13f4cf1-5d4b-4ff1-8569-be7e29338a7b)



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->