### PR TITLE
[Search] Show attach index box on connectors pages

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -39,7 +39,7 @@ export interface AttachIndexBoxProps {
 }
 
 export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => {
-  const indexName = decodeURIComponent(useParams<{ indexName: string }>().indexName);
+  const { indexName } = useParams<{ indexName: string }>();
   const { createIndex, attachIndex, setConnector, checkIndexExists } = useActions(AttachIndexLogic);
   const {
     isLoading: isSaveLoading,
@@ -116,7 +116,6 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
           }
         )
       : attachApiError?.body?.message || createApiError?.body?.message || undefined;
-
   if (indexName) {
     // We don't want to let people edit indices when on the index route
     return <></>;


### PR DESCRIPTION
## Summary

This fixes an issue where the attach index box would never show up.

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->