### PR TITLE
[SLO] Fixing a missed variable in the discover filter

### DIFF
--- a/x-pack/plugins/observability_solution/observability/public/utils/slo/get_discover_link.ts
+++ b/x-pack/plugins/observability_solution/observability/public/utils/slo/get_discover_link.ts
@@ -81,7 +81,7 @@ function createDiscoverLocator(
         alias: i18n.translate('xpack.observability.slo.sloDetails.totalFilterLabel', {
           defaultMessage: 'Total events',
         }),
-        value: JSON.stringify(customBadFilter),
+        value: JSON.stringify(customTotalFilter),
         index: indexId,
       },
       query: customTotalFilter as Record<string, any>,


### PR DESCRIPTION
## Summary
This PR is a follow up to #178260, when we added the "Total events" filter we forgot to update the value's text representation of the `customTotalFilter`.
