### PR TITLE
[POC] Space aware uninstall tokens using only saved objects

### DIFF
--- a/x-pack/plugins/fleet/server/plugin.ts
+++ b/x-pack/plugins/fleet/server/plugin.ts
@@ -323,7 +323,7 @@ export class FleetPlugin
           ? [
               {
                 name: 'Agents',
-                requireAllSpaces: true,
+                requireAllSpaces: false,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -357,7 +357,7 @@ export class FleetPlugin
               },
               {
                 name: 'Agent policies',
-                requireAllSpaces: true,
+                requireAllSpaces: false,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -394,7 +394,7 @@ export class FleetPlugin
               },
               {
                 name: 'Settings',
-                requireAllSpaces: true,
+                requireAllSpaces: false,
                 privilegeGroups: [
                   {
                     groupType: 'mutually_exclusive',
@@ -432,7 +432,7 @@ export class FleetPlugin
           all: {
             api: [`${PLUGIN_ID}-read`, `${PLUGIN_ID}-all`],
             app: [PLUGIN_ID],
-            requireAllSpaces: true,
+            requireAllSpaces: false,
             catalogue: ['fleet'],
             savedObject: {
               all: allSavedObjectTypes,
@@ -444,7 +444,7 @@ export class FleetPlugin
             api: [`${PLUGIN_ID}-read`],
             app: [PLUGIN_ID],
             catalogue: ['fleet'],
-            requireAllSpaces: true,
+            requireAllSpaces: false,
             savedObject: {
               all: [],
               read: allSavedObjectTypes,

--- a/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/agent_policy/handlers.ts
@@ -189,6 +189,7 @@ export const createAgentPolicyHandler: FleetRequestHandler<
         user,
         authorizationHeader,
         force,
+        request,
       }),
     };
 

--- a/x-pack/plugins/fleet/server/routes/uninstall_token/handlers.ts
+++ b/x-pack/plugins/fleet/server/routes/uninstall_token/handlers.ts
@@ -68,7 +68,9 @@ export const getUninstallTokensMetadataHandler: FleetRequestHandler<
       policyNameSearchTerm,
       page,
       perPage,
-      managedPolicyIds.length > 0 ? managedPolicyIds : undefined
+      managedPolicyIds.length > 0 ? managedPolicyIds : undefined,
+      fleetContext.spaceId,
+      request
     );
 
     return response.ok({ body });

--- a/x-pack/plugins/fleet/server/saved_objects/index.ts
+++ b/x-pack/plugins/fleet/server/saved_objects/index.ts
@@ -693,7 +693,7 @@ export const getSavedObjectTypes = (): { [key: string]: SavedObjectsType } => ({
     name: UNINSTALL_TOKENS_SAVED_OBJECT_TYPE,
     indexPattern: INGEST_SAVED_OBJECT_INDEX,
     hidden: true,
-    namespaceType: 'agnostic',
+    namespaceType: 'multiple',
     management: {
       importableAndExportable: false,
     },

--- a/x-pack/plugins/fleet/server/services/agent_policy.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy.ts
@@ -12,6 +12,7 @@ import pMap from 'p-map';
 import { lt } from 'semver';
 import type {
   ElasticsearchClient,
+  KibanaRequest,
   SavedObjectsBulkUpdateResponse,
   SavedObjectsClientContract,
   SavedObjectsUpdateResponse,
@@ -293,6 +294,8 @@ class AgentPolicyService {
       user?: AuthenticatedUser;
       authorizationHeader?: HTTPAuthorizationHeader | null;
       skipDeploy?: boolean;
+      spaceId?: string;
+      request?: KibanaRequest;
     } = {}
   ): Promise<AgentPolicy> {
     // Ensure an ID is provided, so we can include it in the audit logs below
@@ -336,7 +339,9 @@ class AgentPolicyService {
       options
     );
 
-    await appContextService.getUninstallTokenService()?.generateTokenForPolicyId(newSo.id);
+    await appContextService
+      .getUninstallTokenService()
+      ?.generateTokenForPolicyId(newSo.id, false, options.spaceId, options.request);
     await this.triggerAgentPolicyUpdatedEvent(soClient, esClient, 'created', newSo.id, {
       skipDeploy: options.skipDeploy,
     });

--- a/x-pack/plugins/fleet/server/services/agent_policy_create.ts
+++ b/x-pack/plugins/fleet/server/services/agent_policy_create.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import type { ElasticsearchClient, SavedObjectsClientContract } from '@kbn/core/server';
+import type {
+  ElasticsearchClient,
+  KibanaRequest,
+  SavedObjectsClientContract,
+} from '@kbn/core/server';
 
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 
@@ -94,6 +98,7 @@ interface CreateAgentPolicyParams {
   user?: AuthenticatedUser;
   authorizationHeader?: HTTPAuthorizationHeader | null;
   force?: boolean;
+  request?: KibanaRequest;
 }
 
 export async function createAgentPolicyWithPackages({
@@ -107,6 +112,7 @@ export async function createAgentPolicyWithPackages({
   user,
   authorizationHeader,
   force,
+  request,
 }: CreateAgentPolicyParams) {
   let agentPolicyId = newPolicy.id;
   const packagesToInstall = [];
@@ -143,6 +149,8 @@ export async function createAgentPolicyWithPackages({
     id: agentPolicyId,
     authorizationHeader,
     skipDeploy: true, // skip deploying the policy until package policies are added
+    spaceId,
+    request,
   });
 
   // Create the fleet server package policy and add it to agent policy.


### PR DESCRIPTION
## Summary

This is a quick POC to see that Saved Objects live in Spaces: there is practically no need for adding any new logic for uninstall token handling, just forwarding the `request` and the `spaceId` to the `soClient` functions.

The POC does only the following:
- creates Uninstall Tokens based on the space defined in the request
- reads Uninstall Tokens based on the space defined in the request

![spaces](https://github.com/elastic/kibana/assets/39014407/aa445ff0-aca1-4a6e-8488-6664873836bd)

GIF transcription:
- we have 3 spaces: default, red, green
- create a policy in default space
- go to red space: you can see the policies there (I did not touch them), but not the uninstall tokens
- create a policy in red space: its uninstall token is visible
- go to green: no other tokens are visible
- create a policy in green space: only its uninstall token is visible
- remove the policy in green space: the uninstall token is still visible because the SO contains space information
- but, it will crawl neither into default nor into red space