### PR TITLE
[Search] Rename outdated toggle tooltip

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_indices/search_indices.tsx
@@ -211,8 +211,8 @@ export const SearchIndices: React.FC = () => {
                       <EuiToolTip
                         content={
                           <FormattedMessage
-                            id="xpack.enterpriseSearch.content.searchIndices.searchIndices.onlySearchOptimized.tooltipContent"
-                            defaultMessage="Search-optimized indices are prefixed with {code}. They are managed by ingestion mechanisms such as crawlers, connectors or ingestion APIs."
+                            id="xpack.enterpriseSearch.content.searchIndices.searchIndices.onlyCrawlerIndices.tooltipContent"
+                            defaultMessage="Crawler indices are prefixed with {code}. Connector and ingestion API indices created prior to 8.13.0 may also have this prefix, but it is not longer required."
                             values={{ code: <EuiCode>search-</EuiCode> }}
                           />
                         }
@@ -220,9 +220,9 @@ export const SearchIndices: React.FC = () => {
                         <EuiSwitch
                           checked={onlyShowSearchOptimizedIndices}
                           label={i18n.translate(
-                            'xpack.enterpriseSearch.content.searchIndices.searchIndices.onlySearchOptimized.label',
+                            'xpack.enterpriseSearch.content.searchIndices.searchIndices.onlyCrawlerIndices.label',
                             {
-                              defaultMessage: 'Only show search-optimized indices',
+                              defaultMessage: 'Only show crawler indices',
                             }
                           )}
                           onChange={(event) =>


### PR DESCRIPTION
## Summary

Since 8.13.0 search-optimized indices are no longer a thing. We do still require `search-` as a prefix for crawler indices.
This PR renames the toggle to more accurately reflect what the filter can be used for.
Our intention is to remove the filter entirely in a later patch, but as we are so late in FF it's safest to just rename.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->