### PR TITLE
[Search] Fetch connector after attaching to update immediately

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_logic.ts
@@ -24,6 +24,8 @@ import {
   IndexExistsApiLogicActions,
 } from '../../api/index/index_exists_api_logic';
 
+import { ConnectorViewActions, ConnectorViewLogic } from './connector_view_logic';
+
 export interface AttachIndexActions {
   attachIndex: AttachIndexApiLogicActions['makeRequest'];
   attachIndexApiError: AttachIndexApiLogicActions['apiError'];
@@ -35,6 +37,7 @@ export interface AttachIndexActions {
   createIndex: CreateApiIndexApiLogicActions['makeRequest'];
   createIndexApiError: CreateApiIndexApiLogicActions['apiError'];
   createIndexApiSuccess: CreateApiIndexApiLogicActions['apiSuccess'];
+  fetchConnector: ConnectorViewActions['fetchConnector'];
   setConnector(connector: Connector): Connector;
 }
 
@@ -77,6 +80,8 @@ export const AttachIndexLogic = kea<MakeLogicType<AttachIndexValues, AttachIndex
         'apiSuccess as checkIndexExistsApiSuccess',
         'apiError as checkIndexExistsApiError',
       ],
+      ConnectorViewLogic,
+      ['fetchConnector'],
     ],
     values: [
       AttachIndexApiLogic,
@@ -88,6 +93,11 @@ export const AttachIndexLogic = kea<MakeLogicType<AttachIndexValues, AttachIndex
     ],
   },
   listeners: ({ actions, values }) => ({
+    attachIndexApiSuccess: () => {
+      if (values.connector) {
+        actions.fetchConnector({ connectorId: values.connector.id });
+      }
+    },
     checkIndexExists: async ({ indexName }, breakpoint) => {
       await breakpoint(200);
       actions.callCheckIndexExists({ indexName });


### PR DESCRIPTION
## Summary

Pulls connector after attaching index to update. 

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->