### PR TITLE
Fix decimals in diff. flamegraph tooltips

### DIFF
--- a/x-pack/plugins/observability_solution/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
+++ b/x-pack/plugins/observability_solution/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
@@ -25,6 +25,7 @@ import { useCalculateImpactEstimate } from '../../hooks/use_calculate_impact_est
 import { asCost } from '../../utils/formatters/as_cost';
 import { asPercentage } from '../../utils/formatters/as_percentage';
 import { asWeight } from '../../utils/formatters/as_weight';
+import { asInteger } from '../../utils/formatters/as_integer';
 import { CPULabelWithHint } from '../cpu_label_with_hint';
 import { TooltipRow } from './tooltip_row';
 
@@ -171,6 +172,7 @@ export function FlameGraphTooltip({
                 ? comparisonCountInclusive * comparisonScaleFactor
                 : undefined
             }
+            formatValue={asInteger}
             showDifference
             formatDifferenceAsPercentage={false}
           />

--- a/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.test.ts
+++ b/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { asInteger } from './as_integer';
+
+describe('asInteger', () => {
+  it('rounds numbers appropriately', () => {
+    expect(asInteger(999)).toBe('999');
+
+    expect(asInteger(1.11)).toBe('1');
+
+    expect(asInteger(1.5)).toBe('2');
+
+    expect(asInteger(0.001)).toBe('0');
+
+    expect(asInteger(0)).toBe('0');
+  });
+});

--- a/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.ts
+++ b/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function asInteger(value: number) {
+  return Math.round(value ?? 0).toString();
+}

--- a/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.ts
+++ b/x-pack/plugins/observability_solution/profiling/public/utils/formatters/as_integer.ts
@@ -6,5 +6,5 @@
  */
 
 export function asInteger(value: number) {
-  return Math.round(value ?? 0).toString();
+  return Math.round(value).toString();
 }


### PR DESCRIPTION
## Summary

In the differential flamegraph tooltips, comparison integer values are shown with decimal digits. This PR fixes it.


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->