### PR TITLE
[8.13] [Search] Show attach index box on connectors pages (#178487)

### DIFF
--- a/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/enterprise_search_content/components/connector_detail/attach_index_box.tsx
@@ -39,7 +39,7 @@ export interface AttachIndexBoxProps {
 }
 
 export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => {
-  const indexName = decodeURIComponent(useParams<{ indexName: string }>().indexName);
+  const { indexName } = useParams<{ indexName: string }>();
   const { createIndex, attachIndex, setConnector, checkIndexExists } = useActions(AttachIndexLogic);
   const {
     isLoading: isSaveLoading,
@@ -116,7 +116,6 @@ export const AttachIndexBox: React.FC<AttachIndexBoxProps> = ({ connector }) => 
           }
         )
       : attachApiError?.body?.message || createApiError?.body?.message || undefined;
-
   if (indexName) {
     // We don't want to let people edit indices when on the index route
     return <></>;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Search] Show attach index box on connectors pages (#178487)](https://github.com/elastic/kibana/pull/178487)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Sander Philipse","email":"94373878+sphilipse@users.noreply.github.com"},"sourceCommit":{"committedDate":"2024-03-12T12:34:55Z","message":"[Search] Show attach index box on connectors pages (#178487)\n\n## Summary\r\n\r\nThis fixes an issue where the attach index box would never show up.","sha":"71665d9d8fd61ac152e778af124efaa02f8dcfff","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","Team:EnterpriseSearch","v8.13.0","v8.14.0"],"number":178487,"url":"https://github.com/elastic/kibana/pull/178487","mergeCommit":{"message":"[Search] Show attach index box on connectors pages (#178487)\n\n## Summary\r\n\r\nThis fixes an issue where the attach index box would never show up.","sha":"71665d9d8fd61ac152e778af124efaa02f8dcfff"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178487","number":178487,"mergeCommit":{"message":"[Search] Show attach index box on connectors pages (#178487)\n\n## Summary\r\n\r\nThis fixes an issue where the attach index box would never show up.","sha":"71665d9d8fd61ac152e778af124efaa02f8dcfff"}}]}] BACKPORT-->