### PR TITLE
Fix how sample data test install state is determined in test

### DIFF
--- a/packages/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
+++ b/packages/home/sample_data_card/src/__snapshots__/sample_data_card.test.tsx.snap
@@ -57,55 +57,60 @@ exports[`SampleDataCard installed renders with app links 1`] = `
       class="emotion-euiCard__footer"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-none-spaceBetween-stretch-row"
+        data-status="installed"
+        style="display:contents"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        >
-          <button
-            aria-label="Remove Sample Data Set"
-            class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-m-empty-danger-flush-left"
-            data-test-subj="removeSampleDataSetsample-data-set"
-            type="button"
-          >
-            <span
-              class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
-            >
-              <span
-                class="eui-textTruncate euiButtonEmpty__text"
-              >
-                Remove
-              </span>
-            </span>
-          </button>
-        </div>
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
+          class="euiFlexGroup emotion-euiFlexGroup-none-spaceBetween-stretch-row"
         >
           <div
-            class="euiPopover emotion-euiPopover-inline-block"
-            data-test-subj="launchSampleDataSetsample-data-set"
-            id="sampleDataLinkssample-data-set"
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
             <button
-              aria-label="View Sample Data Set"
-              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+              aria-label="Remove Sample Data Set"
+              class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-m-empty-danger-flush-left"
+              data-test-subj="removeSampleDataSetsample-data-set"
               type="button"
             >
               <span
-                class="emotion-euiButtonDisplayContent"
+                class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
                 <span
-                  class="eui-textTruncate"
+                  class="eui-textTruncate euiButtonEmpty__text"
                 >
-                  View data
+                  Remove
                 </span>
-                <span
-                  color="inherit"
-                  data-euiicon-type="arrowDown"
-                />
               </span>
             </button>
+          </div>
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
+          >
+            <div
+              class="euiPopover emotion-euiPopover-inline-block"
+              data-test-subj="launchSampleDataSetsample-data-set"
+              id="sampleDataLinkssample-data-set"
+            >
+              <button
+                aria-label="View Sample Data Set"
+                class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+                type="button"
+              >
+                <span
+                  class="emotion-euiButtonDisplayContent"
+                >
+                  <span
+                    class="eui-textTruncate"
+                  >
+                    View data
+                  </span>
+                  <span
+                    color="inherit"
+                    data-euiicon-type="arrowDown"
+                  />
+                </span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -171,47 +176,52 @@ exports[`SampleDataCard installed renders without app links 1`] = `
       class="emotion-euiCard__footer"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-none-spaceBetween-stretch-row"
+        data-status="installed"
+        style="display:contents"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
+          class="euiFlexGroup emotion-euiFlexGroup-none-spaceBetween-stretch-row"
         >
-          <button
-            aria-label="Remove Sample Data Set"
-            class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-m-empty-danger-flush-left"
-            data-test-subj="removeSampleDataSetsample-data-set"
-            type="button"
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <span
-              class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
+            <button
+              aria-label="Remove Sample Data Set"
+              class="euiButtonEmpty emotion-euiButtonDisplay-euiButtonEmpty-m-empty-danger-flush-left"
+              data-test-subj="removeSampleDataSetsample-data-set"
+              type="button"
             >
               <span
-                class="eui-textTruncate euiButtonEmpty__text"
+                class="euiButtonEmpty__content emotion-euiButtonDisplayContent"
               >
-                Remove
+                <span
+                  class="eui-textTruncate euiButtonEmpty__text"
+                >
+                  Remove
+                </span>
               </span>
-            </span>
-          </button>
-        </div>
-        <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
-        >
-          <button
-            aria-label="View Sample Data Set"
-            class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
-            data-test-subj="launchSampleDataSetsample-data-set"
-            type="button"
+            </button>
+          </div>
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <span
-              class="emotion-euiButtonDisplayContent"
+            <button
+              aria-label="View Sample Data Set"
+              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+              data-test-subj="launchSampleDataSetsample-data-set"
+              type="button"
             >
               <span
-                class="eui-textTruncate"
+                class="emotion-euiButtonDisplayContent"
               >
-                View data
+                <span
+                  class="eui-textTruncate"
+                >
+                  View data
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -265,27 +275,32 @@ exports[`SampleDataCard not installed renders 1`] = `
       class="emotion-euiCard__footer"
     >
       <div
-        class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexEnd-stretch-row"
+        data-status="not_installed"
+        style="display:contents"
       >
         <div
-          class="euiFlexItem emotion-euiFlexItem-growZero"
+          class="euiFlexGroup emotion-euiFlexGroup-responsive-l-flexEnd-stretch-row"
         >
-          <button
-            aria-label="Add Sample Data Set"
-            class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
-            data-test-subj="addSampleDataSetsample-data-set"
-            type="button"
+          <div
+            class="euiFlexItem emotion-euiFlexItem-growZero"
           >
-            <span
-              class="emotion-euiButtonDisplayContent"
+            <button
+              aria-label="Add Sample Data Set"
+              class="euiButton emotion-euiButtonDisplay-m-defaultMinWidth-base-primary"
+              data-test-subj="addSampleDataSetsample-data-set"
+              type="button"
             >
               <span
-                class="eui-textTruncate"
+                class="emotion-euiButtonDisplayContent"
               >
-                Add data
+                <span
+                  class="eui-textTruncate"
+                >
+                  Add data
+                </span>
               </span>
-            </span>
-          </button>
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/home/sample_data_card/src/footer/index.tsx
+++ b/packages/home/sample_data_card/src/footer/index.tsx
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import React from 'react';
+import React, { useCallback } from 'react';
 import { SampleDataSet, InstalledStatus } from '@kbn/home-sample-data-types';
 import { INSTALLED_STATUS, UNINSTALLED_STATUS } from '../constants';
 
@@ -28,13 +28,27 @@ export interface Props {
  * Displays the appropriate Footer component based on the status of the Sample Data Set.
  */
 export const Footer = ({ sampleDataSet, onAction }: Props) => {
-  if (sampleDataSet.status === INSTALLED_STATUS) {
-    return <RemoveFooter onRemove={(id) => onAction(id, UNINSTALLED_STATUS)} {...sampleDataSet} />;
-  }
+  const renderContent = useCallback(() => {
+    if (sampleDataSet.status === INSTALLED_STATUS) {
+      return (
+        <RemoveFooter onRemove={(id) => onAction(id, UNINSTALLED_STATUS)} {...sampleDataSet} />
+      );
+    }
 
-  if (sampleDataSet.status === UNINSTALLED_STATUS) {
-    return <InstallFooter onInstall={(id) => onAction(id, INSTALLED_STATUS)} {...sampleDataSet} />;
-  }
+    if (sampleDataSet.status === UNINSTALLED_STATUS) {
+      return (
+        <InstallFooter onInstall={(id) => onAction(id, INSTALLED_STATUS)} {...sampleDataSet} />
+      );
+    }
 
-  return <DisabledFooter {...sampleDataSet} />;
+    return <DisabledFooter {...sampleDataSet} />;
+  }, [onAction, sampleDataSet]);
+
+  return (
+    // the data-status attribute is added to solve issues with failing test,
+    // see https://github.com/elastic/kibana/issues/112103
+    <div data-status={sampleDataSet.status} style={{ display: 'contents' }}>
+      {renderContent()}
+    </div>
+  );
 };

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -48,9 +48,11 @@ export class HomePageObject extends FtrService {
 
   async isSampleDataSetInstalled(id: string) {
     const sampleDataCard = await this.testSubjects.find(`sampleDataSetCard${id}`);
-    const deleteButton = await sampleDataCard.findAllByTestSubject(`removeSampleDataSet${id}`);
-    this.log.debug(`Sample data installed: ${deleteButton.length > 0}`);
-    return deleteButton.length > 0;
+    const installStatus = await (
+      await sampleDataCard.findByCssSelector('[data-status]')
+    ).getAttribute('data-status');
+
+    return installStatus === 'installed';
   }
 
   async isWelcomeInterstitialDisplayed() {

--- a/test/functional/page_objects/home_page.ts
+++ b/test/functional/page_objects/home_page.ts
@@ -51,8 +51,9 @@ export class HomePageObject extends FtrService {
     const installStatus = await (
       await sampleDataCard.findByCssSelector('[data-status]')
     ).getAttribute('data-status');
-
-    return installStatus === 'installed';
+    const deleteButton = await sampleDataCard.findAllByTestSubject(`removeSampleDataSet${id}`);
+    this.log.debug(`Sample data installed: ${deleteButton.length > 0}`);
+    return installStatus === 'installed' && deleteButton.length > 0;
   }
 
   async isWelcomeInterstitialDisplayed() {

--- a/x-pack/test/functional_execution_context/tests/browser.ts
+++ b/x-pack/test/functional_execution_context/tests/browser.ts
@@ -12,8 +12,7 @@ import { assertLogContains, isExecutionContextLog, readLogFile } from '../test_u
 export default function ({ getService, getPageObjects }: FtrProviderContext) {
   const PageObjects = getPageObjects(['common', 'dashboard', 'header', 'home', 'timePicker']);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/112103
-  describe.skip('Browser apps', () => {
+  describe('Browser apps', () => {
     let logs: Ecs[];
     const retry = getService('retry');
 


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/112103

Make sample data install status available to be read by test util, as documented by @gsoldevila in the issue referenced above. The issue happens because there's a slight delay that really can't be walked around where the install status in this particular instance is still 'installed' but the call to mark the sample data completes so there's that flicker where the `remove` element is displayed momentarily because the component doesn't quite received the update  to the sample data's install status immediately.

The proposed fix opts to complement the current way of determining if any sample data is installed using the newly introduced `data-status` attribute, here we wait till the result of clicking the remove button actually triggers a change in the value of the install state of said sample data, which in turn is reflected in the value of `data-status` alongside checking that the remove button exists.

### Checklist
<!--
Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials -->
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed 
<!--
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->