### PR TITLE
Fix SAML provider incorrectly added to Docker SSL

### DIFF
--- a/packages/kbn-es/src/cli_commands/serverless.ts
+++ b/packages/kbn-es/src/cli_commands/serverless.ts
@@ -92,7 +92,7 @@ export const serverless: Command = {
       string: ['projectType', 'tag', 'image', 'basePath', 'resources', 'host', 'kibanaUrl'],
       boolean: ['clean', 'ssl', 'kill', 'background', 'skipTeardown', 'waitForReady'],
 
-      default: defaults,
+      default: { ...defaults, kibanaUrl: 'https://localhost:5601/' },
     }) as unknown as ServerlessOptions;
 
     if (!options.projectType) {

--- a/scripts/es.js
+++ b/scripts/es.js
@@ -20,7 +20,6 @@ kbnEs
     'source-path': resolve(__dirname, '../../elasticsearch'),
     'base-path': resolve(__dirname, '../.es'),
     ssl: false,
-    kibanaUrl: 'https://localhost:5601/',
   })
   .catch(function (e) {
     console.error(e);


### PR DESCRIPTION
## Summary

The existence of `kibanaUrl` in the default parameters leads to the SAML role provider being enabled for `yarn es docker --ssl` and then ES crashing on startup. This option should only be a default for `yarn es serverless --ssl`
