### PR TITLE
[8.13] Fix decimals in diff. flamegraph tooltips (#178524)

### DIFF
--- a/x-pack/plugins/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
+++ b/x-pack/plugins/profiling/public/components/flamegraph/flamegraph_tooltip.tsx
@@ -25,6 +25,7 @@ import { useCalculateImpactEstimate } from '../../hooks/use_calculate_impact_est
 import { asCost } from '../../utils/formatters/as_cost';
 import { asPercentage } from '../../utils/formatters/as_percentage';
 import { asWeight } from '../../utils/formatters/as_weight';
+import { asInteger } from '../../utils/formatters/as_integer';
 import { CPULabelWithHint } from '../cpu_label_with_hint';
 import { TooltipRow } from './tooltip_row';
 
@@ -171,6 +172,7 @@ export function FlameGraphTooltip({
                 ? comparisonCountInclusive * comparisonScaleFactor
                 : undefined
             }
+            formatValue={asInteger}
             showDifference
             formatDifferenceAsPercentage={false}
           />

--- a/x-pack/plugins/profiling/public/utils/formatters/as_integer.test.ts
+++ b/x-pack/plugins/profiling/public/utils/formatters/as_integer.test.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import { asInteger } from './as_integer';
+
+describe('asInteger', () => {
+  it('rounds numbers appropriately', () => {
+    expect(asInteger(999)).toBe('999');
+
+    expect(asInteger(1.11)).toBe('1');
+
+    expect(asInteger(1.5)).toBe('2');
+
+    expect(asInteger(0.001)).toBe('0');
+
+    expect(asInteger(0)).toBe('0');
+  });
+});

--- a/x-pack/plugins/profiling/public/utils/formatters/as_integer.ts
+++ b/x-pack/plugins/profiling/public/utils/formatters/as_integer.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export function asInteger(value: number) {
+  return Math.round(value).toString();
+}


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [Fix decimals in diff. flamegraph tooltips (#178524)](https://github.com/elastic/kibana/pull/178524)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Tim Rühsen","email":"tim.ruhsen@elastic.co"},"sourceCommit":{"committedDate":"2024-03-13T07:13:16Z","message":"Fix decimals in diff. flamegraph tooltips (#178524)\n\nIn the differential flamegraph tooltips, comparison integer values are\r\nshown with decimal digits. This PR fixes it.","sha":"b3064ba67c25e02639a81ed8581c4fdda43e02e3","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:obs-ux-infra_services","v8.13.0","v8.14.0"],"number":178524,"url":"https://github.com/elastic/kibana/pull/178524","mergeCommit":{"message":"Fix decimals in diff. flamegraph tooltips (#178524)\n\nIn the differential flamegraph tooltips, comparison integer values are\r\nshown with decimal digits. This PR fixes it.","sha":"b3064ba67c25e02639a81ed8581c4fdda43e02e3"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178524","number":178524,"mergeCommit":{"message":"Fix decimals in diff. flamegraph tooltips (#178524)\n\nIn the differential flamegraph tooltips, comparison integer values are\r\nshown with decimal digits. This PR fixes it.","sha":"b3064ba67c25e02639a81ed8581c4fdda43e02e3"}}]}] BACKPORT-->