### PR TITLE
[8.13] [Cases] Display correct custom fields based on the selected owner in the cases flyout. (#178201)

### DIFF
--- a/x-pack/plugins/cases/common/ui/types.ts
+++ b/x-pack/plugins/cases/common/ui/types.ts
@@ -119,7 +119,7 @@ export interface ResolvedCase {
 
 export type CasesConfigurationUI = Pick<
   SnakeToCamelCase<Configuration>,
-  'closureType' | 'connector' | 'mappings' | 'customFields' | 'id' | 'version'
+  'closureType' | 'connector' | 'mappings' | 'customFields' | 'id' | 'version' | 'owner'
 >;
 
 export type CasesConfigurationUICustomField = CasesConfigurationUI['customFields'][number];

--- a/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
+++ b/x-pack/plugins/cases/public/components/configure_cases/__mock__/index.tsx
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { mockedTestProvidersOwner } from '../../../common/mock';
 import type { ActionTypeConnector } from '../../../../common/types/domain';
 import { ConnectorTypes } from '../../../../common/types/domain';
 import type { ActionConnector } from '../../../containers/configure/types';
@@ -17,20 +18,30 @@ export const actionTypes: ActionTypeConnector[] = actionTypesMock;
 export const searchURL =
   '?timerange=(global:(linkTo:!(),timerange:(from:1585487656371,fromStr:now-24h,kind:relative,to:1585574056371,toStr:now)),timeline:(linkTo:!(),timerange:(from:1585227005527,kind:absolute,to:1585313405527)))';
 
-export const useCaseConfigureResponse = {
-  data: {
-    closureType: 'close-by-user',
-    connector: {
-      fields: null,
-      id: 'none',
-      name: 'none',
-      type: ConnectorTypes.none,
-    },
-    customFields: [],
-    mappings: [],
-    version: '',
-    id: '',
+const mockConfigurationData = {
+  closureType: 'close-by-user',
+  connector: {
+    fields: null,
+    id: 'none',
+    name: 'none',
+    type: ConnectorTypes.none,
   },
+  customFields: [],
+  mappings: [],
+  version: '',
+  id: '',
+  owner: mockedTestProvidersOwner[0],
+};
+
+export const useCaseConfigureResponse = {
+  data: mockConfigurationData,
+  isLoading: false,
+  isFetching: false,
+  refetch: jest.fn(),
+};
+
+export const useGetAllCaseConfigurationsResponse = {
+  data: [mockConfigurationData],
   isLoading: false,
   isFetching: false,
   refetch: jest.fn(),

--- a/x-pack/plugins/cases/public/components/create/custom_fields.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/custom_fields.test.tsx
@@ -15,6 +15,12 @@ import { FormTestComponent } from '../../common/test_utils';
 import { customFieldsConfigurationMock } from '../../containers/mock';
 import { CustomFields } from './custom_fields';
 import * as i18n from './translations';
+import { useGetAllCaseConfigurations } from '../../containers/configure/use_get_all_case_configurations';
+import { useGetAllCaseConfigurationsResponse } from '../configure_cases/__mock__';
+
+jest.mock('../../containers/configure/use_get_all_case_configurations');
+
+const useGetAllCaseConfigurationsMock = useGetAllCaseConfigurations as jest.Mock;
 
 // FLAKY: https://github.com/elastic/kibana/issues/176805
 describe.skip('CustomFields', () => {
@@ -24,12 +30,21 @@ describe.skip('CustomFields', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     appMockRender = createAppMockRenderer();
+    useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+      ...useGetAllCaseConfigurationsResponse,
+      data: [
+        {
+          ...useGetAllCaseConfigurationsResponse.data[0],
+          customFields: customFieldsConfigurationMock,
+        },
+      ],
+    }));
   });
 
   it('renders correctly', async () => {
     appMockRender.render(
       <FormTestComponent onSubmit={onSubmit}>
-        <CustomFields isLoading={false} customFieldsConfiguration={customFieldsConfigurationMock} />
+        <CustomFields isLoading={false} />
       </FormTestComponent>
     );
 
@@ -44,9 +59,19 @@ describe.skip('CustomFields', () => {
   });
 
   it('should not show the custom fields if the configuration is empty', async () => {
+    useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+      ...useGetAllCaseConfigurationsResponse,
+      data: [
+        {
+          ...useGetAllCaseConfigurationsResponse.data[0],
+          customFields: [],
+        },
+      ],
+    }));
+
     appMockRender.render(
       <FormTestComponent onSubmit={onSubmit}>
-        <CustomFields isLoading={false} customFieldsConfiguration={[]} />
+        <CustomFields isLoading={false} />
       </FormTestComponent>
     );
 
@@ -55,11 +80,21 @@ describe.skip('CustomFields', () => {
   });
 
   it('should sort the custom fields correctly', async () => {
-    const reversedConfiguration = [...customFieldsConfigurationMock].reverse();
+    const reversedCustomFieldsConfiguration = [...customFieldsConfigurationMock].reverse();
+
+    useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+      ...useGetAllCaseConfigurationsResponse,
+      data: [
+        {
+          ...useGetAllCaseConfigurationsResponse.data[0],
+          customFields: reversedCustomFieldsConfiguration,
+        },
+      ],
+    }));
 
     appMockRender.render(
       <FormTestComponent onSubmit={onSubmit}>
-        <CustomFields isLoading={false} customFieldsConfiguration={reversedConfiguration} />
+        <CustomFields isLoading={false} />
       </FormTestComponent>
     );
 
@@ -80,7 +115,7 @@ describe.skip('CustomFields', () => {
 
     appMockRender.render(
       <FormTestComponent onSubmit={onSubmit}>
-        <CustomFields isLoading={false} customFieldsConfiguration={customFieldsConfigurationMock} />
+        <CustomFields isLoading={false} />
       </FormTestComponent>
     );
 

--- a/x-pack/plugins/cases/public/components/create/form.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.test.tsx
@@ -18,8 +18,8 @@ import type { FormProps } from './schema';
 import { schema } from './schema';
 import type { CreateCaseFormProps } from './form';
 import { CreateCaseForm } from './form';
-import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
-import { useCaseConfigureResponse } from '../configure_cases/__mock__';
+import { useGetAllCaseConfigurations } from '../../containers/configure/use_get_all_case_configurations';
+import { useGetAllCaseConfigurationsResponse } from '../configure_cases/__mock__';
 import { TestProviders } from '../../common/mock';
 import { useGetSupportedActionConnectors } from '../../containers/configure/use_get_supported_action_connectors';
 import { useGetTags } from '../../containers/use_get_tags';
@@ -27,13 +27,13 @@ import { useAvailableCasesOwners } from '../app/use_available_owners';
 
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_get_supported_action_connectors');
-jest.mock('../../containers/configure/use_get_case_configuration');
+jest.mock('../../containers/configure/use_get_all_case_configurations');
 jest.mock('../markdown_editor/plugins/lens/use_lens_draft_comment');
 jest.mock('../app/use_available_owners');
 
 const useGetTagsMock = useGetTags as jest.Mock;
 const useGetConnectorsMock = useGetSupportedActionConnectors as jest.Mock;
-const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
+const useGetAllCaseConfigurationsMock = useGetAllCaseConfigurations as jest.Mock;
 const useAvailableOwnersMock = useAvailableCasesOwners as jest.Mock;
 
 const initialCaseValue: FormProps = {
@@ -81,7 +81,7 @@ describe('CreateCaseForm', () => {
     useAvailableOwnersMock.mockReturnValue(['securitySolution', 'observability']);
     useGetTagsMock.mockReturnValue({ data: ['test'] });
     useGetConnectorsMock.mockReturnValue({ isLoading: false, data: connectorsMock });
-    useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+    useGetAllCaseConfigurationsMock.mockImplementation(() => useGetAllCaseConfigurationsResponse);
   });
 
   afterEach(() => {
@@ -219,12 +219,14 @@ describe('CreateCaseForm', () => {
   });
 
   it('should render custom fields when available', () => {
-    useGetCaseConfigurationMock.mockImplementation(() => ({
-      ...useCaseConfigureResponse,
-      data: {
-        ...useCaseConfigureResponse.data,
-        customFields: customFieldsConfigurationMock,
-      },
+    useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+      ...useGetAllCaseConfigurationsResponse,
+      data: [
+        {
+          ...useGetAllCaseConfigurationsResponse.data[0],
+          customFields: customFieldsConfigurationMock,
+        },
+      ],
     }));
 
     const result = render(

--- a/x-pack/plugins/cases/public/components/create/form.tsx
+++ b/x-pack/plugins/cases/public/components/create/form.tsx
@@ -19,7 +19,6 @@ import { useFormContext } from '@kbn/es-ui-shared-plugin/static/forms/hook_form_
 
 import type { ActionConnector } from '../../../common/types/domain';
 import type { CasePostRequest } from '../../../common/types/api';
-import type { CasesConfigurationUI } from '../../../common/ui';
 import { Title } from './title';
 import { Description, fieldName as descriptionFieldName } from './description';
 import { Tags } from './tags';
@@ -66,11 +65,8 @@ const MySpinner = styled(EuiLoadingSpinner)`
 
 export interface CreateCaseFormFieldsProps {
   connectors: ActionConnector[];
-  customFieldsConfiguration: CasesConfigurationUI['customFields'];
-  isLoadingCaseConfiguration: boolean;
   isLoadingConnectors: boolean;
   withSteps: boolean;
-  owner: string[];
   draftStorageKey: string;
 }
 export interface CreateCaseFormProps extends Pick<Partial<CreateCaseFormFieldsProps>, 'withSteps'> {
@@ -87,15 +83,8 @@ export interface CreateCaseFormProps extends Pick<Partial<CreateCaseFormFieldsPr
 
 const empty: ActionConnector[] = [];
 export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.memo(
-  ({
-    connectors,
-    isLoadingConnectors,
-    withSteps,
-    owner,
-    draftStorageKey,
-    customFieldsConfiguration,
-    isLoadingCaseConfiguration,
-  }) => {
+  ({ connectors, isLoadingConnectors, withSteps, draftStorageKey }) => {
+    const { owner } = useCasesContext();
     const { isSubmitting } = useFormContext();
     const { isSyncAlertsEnabled, caseAssignmentAuthorized } = useCasesFeatures();
     const availableOwners = useAvailableCasesOwners();
@@ -133,10 +122,7 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
               <Description isLoading={isSubmitting} draftStorageKey={draftStorageKey} />
             </Container>
             <Container>
-              <CustomFields
-                isLoading={isSubmitting || isLoadingCaseConfiguration}
-                customFieldsConfiguration={customFieldsConfiguration}
-              />
+              <CustomFields isLoading={isSubmitting} />
             </Container>
             <Container />
           </>
@@ -148,8 +134,6 @@ export const CreateCaseFormFields: React.FC<CreateCaseFormFieldsProps> = React.m
         canShowCaseSolutionSelection,
         availableOwners,
         draftStorageKey,
-        customFieldsConfiguration,
-        isLoadingCaseConfiguration,
       ]
     );
 
@@ -219,7 +203,7 @@ export const CreateCaseForm: React.FC<CreateCaseFormProps> = React.memo(
     attachments,
     initialValue,
   }) => {
-    const { owner, appId } = useCasesContext();
+    const { appId } = useCasesContext();
     const draftStorageKey = getMarkdownEditorStorageKey(appId, 'createCase', 'description');
 
     const handleOnConfirmationCallback = (): void => {
@@ -247,11 +231,8 @@ export const CreateCaseForm: React.FC<CreateCaseFormProps> = React.memo(
         >
           <CreateCaseFormFields
             connectors={empty}
-            customFieldsConfiguration={[]}
             isLoadingConnectors={false}
-            isLoadingCaseConfiguration={false}
             withSteps={withSteps}
-            owner={owner}
             draftStorageKey={draftStorageKey}
           />
           <Container>

--- a/x-pack/plugins/cases/public/components/create/form_context.test.tsx
+++ b/x-pack/plugins/cases/public/components/create/form_context.test.tsx
@@ -15,13 +15,19 @@ import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
 import { usePostCase } from '../../containers/use_post_case';
 import { useCreateAttachments } from '../../containers/use_create_attachments';
+
 import { useGetCaseConfiguration } from '../../containers/configure/use_get_case_configuration';
+import { useGetAllCaseConfigurations } from '../../containers/configure/use_get_all_case_configurations';
+
 import { useGetIncidentTypes } from '../connectors/resilient/use_get_incident_types';
 import { useGetSeverity } from '../connectors/resilient/use_get_severity';
 import { useGetIssueTypes } from '../connectors/jira/use_get_issue_types';
 import { useGetChoices } from '../connectors/servicenow/use_get_choices';
 import { useGetFieldsByIssueType } from '../connectors/jira/use_get_fields_by_issue_type';
-import { useCaseConfigureResponse } from '../configure_cases/__mock__';
+import {
+  useCaseConfigureResponse,
+  useGetAllCaseConfigurationsResponse,
+} from '../configure_cases/__mock__';
 import {
   sampleConnectorData,
   sampleData,
@@ -53,6 +59,7 @@ import {
   ConnectorTypes,
   CustomFieldTypes,
 } from '../../../common/types/domain';
+import { useAvailableCasesOwners } from '../app/use_available_owners';
 
 jest.mock('../../containers/use_post_case');
 jest.mock('../../containers/use_create_attachments');
@@ -60,6 +67,7 @@ jest.mock('../../containers/use_post_push_to_service');
 jest.mock('../../containers/use_get_tags');
 jest.mock('../../containers/configure/use_get_supported_action_connectors');
 jest.mock('../../containers/configure/use_get_case_configuration');
+jest.mock('../../containers/configure/use_get_all_case_configurations');
 jest.mock('../connectors/resilient/use_get_incident_types');
 jest.mock('../connectors/resilient/use_get_severity');
 jest.mock('../connectors/jira/use_get_issue_types');
@@ -70,9 +78,11 @@ jest.mock('../../common/lib/kibana');
 jest.mock('../../containers/user_profiles/api');
 jest.mock('../../common/use_license');
 jest.mock('../../containers/use_get_categories');
+jest.mock('../app/use_available_owners');
 
 const useGetConnectorsMock = useGetSupportedActionConnectors as jest.Mock;
 const useGetCaseConfigurationMock = useGetCaseConfiguration as jest.Mock;
+const useGetAllCaseConfigurationsMock = useGetAllCaseConfigurations as jest.Mock;
 const usePostCaseMock = usePostCase as jest.Mock;
 const useCreateAttachmentsMock = useCreateAttachments as jest.Mock;
 const usePostPushToServiceMock = usePostPushToService as jest.Mock;
@@ -86,6 +96,7 @@ const pushCaseToExternalService = jest.fn();
 const useKibanaMock = useKibana as jest.Mocked<typeof useKibana>;
 const useLicenseMock = useLicense as jest.Mock;
 const useGetCategoriesMock = useGetCategories as jest.Mock;
+const useAvailableOwnersMock = useAvailableCasesOwners as jest.Mock;
 
 const sampleId = 'case-id';
 
@@ -97,11 +108,8 @@ const defaultPostCase = {
 
 const defaultCreateCaseForm: CreateCaseFormFieldsProps = {
   isLoadingConnectors: false,
-  isLoadingCaseConfiguration: false,
   connectors: [],
-  customFieldsConfiguration: [],
   withSteps: true,
-  owner: ['securitySolution'],
   draftStorageKey: 'cases.kibana.createCase.description.markdownEditor',
 };
 
@@ -199,12 +207,14 @@ describe.skip('Create case', () => {
     usePostPushToServiceMock.mockImplementation(() => defaultPostPushToService);
     useGetConnectorsMock.mockReturnValue(sampleConnectorData);
     useGetCaseConfigurationMock.mockImplementation(() => useCaseConfigureResponse);
+    useGetAllCaseConfigurationsMock.mockImplementation(() => useGetAllCaseConfigurationsResponse);
     useGetIncidentTypesMock.mockReturnValue(useGetIncidentTypesResponse);
     useGetSeverityMock.mockReturnValue(useGetSeverityResponse);
     useGetIssueTypesMock.mockReturnValue(useGetIssueTypesResponse);
     useGetFieldsByIssueTypeMock.mockReturnValue(useGetFieldsByIssueTypeResponse);
     useGetChoicesMock.mockReturnValue(useGetChoicesResponse);
     useGetCategoriesMock.mockReturnValue({ isLoading: false, data: categories });
+    useAvailableOwnersMock.mockReturnValue(['securitySolution', 'observability', 'cases']);
 
     (useGetTags as jest.Mock).mockImplementation(() => ({
       data: sampleTags,
@@ -437,20 +447,22 @@ describe.skip('Create case', () => {
     });
 
     it('should submit form with custom fields', async () => {
-      useGetCaseConfigurationMock.mockImplementation(() => ({
-        ...useCaseConfigureResponse,
-        data: {
-          ...useCaseConfigureResponse.data,
-          customFields: [
-            ...customFieldsConfigurationMock,
-            {
-              key: 'my_custom_field_key',
-              type: CustomFieldTypes.TEXT,
-              label: 'my custom field label',
-              required: false,
-            },
-          ],
-        },
+      useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+        ...useGetAllCaseConfigurationsResponse,
+        data: [
+          {
+            ...useGetAllCaseConfigurationsResponse.data[0],
+            customFields: [
+              ...customFieldsConfigurationMock,
+              {
+                key: 'my_custom_field_key',
+                type: CustomFieldTypes.TEXT,
+                label: 'my custom field label',
+                required: false,
+              },
+            ],
+          },
+        ],
       }));
 
       appMockRender.render(
@@ -468,10 +480,12 @@ describe.skip('Create case', () => {
 
       expect(screen.getByTestId('create-case-custom-fields')).toBeInTheDocument();
 
-      userEvent.paste(
-        screen.getByTestId(`${textField.key}-${textField.type}-create-custom-field`),
-        'My text test value 1'
+      const textCustomField = await screen.findByTestId(
+        `${textField.key}-${textField.type}-create-custom-field`
       );
+
+      userEvent.clear(textCustomField);
+      userEvent.paste(textCustomField, 'My text test value 1');
 
       userEvent.click(
         screen.getByTestId(`${toggleField.key}-${toggleField.type}-create-custom-field`)
@@ -485,7 +499,10 @@ describe.skip('Create case', () => {
         request: {
           ...sampleDataWithoutTags,
           customFields: [
-            ...customFieldsMock,
+            customFieldsMock[0],
+            { ...customFieldsMock[1], value: false }, // toggled the default
+            customFieldsMock[2],
+            { ...customFieldsMock[3], value: false },
             {
               key: 'my_custom_field_key',
               type: CustomFieldTypes.TEXT,
@@ -494,6 +511,120 @@ describe.skip('Create case', () => {
           ],
         },
       });
+    });
+
+    it('should change custom fields based on the selected owner', async () => {
+      appMockRender = createAppMockRenderer({ owner: [] });
+
+      const securityCustomField = {
+        key: 'security_custom_field',
+        type: CustomFieldTypes.TEXT,
+        label: 'security custom field',
+        required: false,
+      };
+      const o11yCustomField = {
+        key: 'o11y_field_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'observability custom field',
+        required: false,
+      };
+      const stackCustomField = {
+        key: 'stack_field_key',
+        type: CustomFieldTypes.TEXT,
+        label: 'stack custom field',
+        required: false,
+      };
+
+      useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+        ...useGetAllCaseConfigurationsResponse,
+        data: [
+          {
+            ...useGetAllCaseConfigurationsResponse.data[0],
+            owner: 'securitySolution',
+            customFields: [securityCustomField],
+          },
+          {
+            ...useGetAllCaseConfigurationsResponse.data[0],
+            owner: 'observability',
+            customFields: [o11yCustomField],
+          },
+          {
+            ...useGetAllCaseConfigurationsResponse.data[0],
+            owner: 'cases',
+            customFields: [stackCustomField],
+          },
+        ],
+      }));
+
+      appMockRender.render(
+        <FormContext onSuccess={onFormSubmitSuccess}>
+          <CreateCaseFormFields {...defaultCreateCaseForm} />
+          <SubmitCaseButton />
+        </FormContext>
+      );
+
+      await waitForFormToRender(screen);
+      await fillFormReactTestingLib({ renderer: screen });
+
+      const createCaseCustomFields = await screen.findByTestId('create-case-custom-fields');
+
+      // the default selectedOwner is securitySolution
+      // only the security custom field should be displayed
+      expect(
+        await within(createCaseCustomFields).findByTestId(
+          `${securityCustomField.key}-${securityCustomField.type}-create-custom-field`
+        )
+      ).toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${o11yCustomField.key}-${o11yCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${stackCustomField.key}-${stackCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
+
+      const caseOwnerSelector = await screen.findByTestId('caseOwnerSelector');
+
+      userEvent.click(await within(caseOwnerSelector).findByLabelText('Observability'));
+
+      // only the o11y custom field should be displayed
+      expect(
+        await within(createCaseCustomFields).findByTestId(
+          `${o11yCustomField.key}-${o11yCustomField.type}-create-custom-field`
+        )
+      ).toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${securityCustomField.key}-${securityCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${stackCustomField.key}-${stackCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
+
+      userEvent.click(await within(caseOwnerSelector).findByLabelText('Stack'));
+
+      // only the stack custom field should be displayed
+      expect(
+        await within(createCaseCustomFields).findByTestId(
+          `${stackCustomField.key}-${stackCustomField.type}-create-custom-field`
+        )
+      ).toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${securityCustomField.key}-${securityCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
+      expect(
+        await within(createCaseCustomFields).queryByTestId(
+          `${o11yCustomField.key}-${o11yCustomField.type}-create-custom-field`
+        )
+      ).not.toBeInTheDocument();
     });
 
     it('should select the default connector set in the configuration', async () => {
@@ -508,6 +639,21 @@ describe.skip('Create case', () => {
             fields: null,
           },
         },
+      }));
+
+      useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+        ...useGetAllCaseConfigurationsResponse,
+        data: [
+          {
+            ...useGetAllCaseConfigurationsResponse.data,
+            connector: {
+              id: 'servicenow-1',
+              name: 'SN',
+              type: ConnectorTypes.serviceNowITSM,
+              fields: null,
+            },
+          },
+        ],
       }));
 
       useGetConnectorsMock.mockReturnValue({
@@ -560,6 +706,21 @@ describe.skip('Create case', () => {
             fields: null,
           },
         },
+      }));
+
+      useGetAllCaseConfigurationsMock.mockImplementation(() => ({
+        ...useGetAllCaseConfigurationsResponse,
+        data: [
+          {
+            ...useGetAllCaseConfigurationsResponse.data,
+            connector: {
+              id: 'not-exist',
+              name: 'SN',
+              type: ConnectorTypes.serviceNowITSM,
+              fields: null,
+            },
+          },
+        ],
       }));
 
       useGetConnectorsMock.mockReturnValue({

--- a/x-pack/plugins/cases/public/components/custom_fields/index.tsx
+++ b/x-pack/plugins/cases/public/components/custom_fields/index.tsx
@@ -101,7 +101,7 @@ const CustomFieldsComponent: React.FC<Props> = ({
         <EuiSpacer size="m" />
         {!customFields.length ? (
           <EuiFlexGroup justifyContent="center">
-            <EuiFlexItem grow={false}>
+            <EuiFlexItem grow={false} data-test-subj="empty-custom-fields">
               {i18n.NO_CUSTOM_FIELDS}
               <EuiSpacer size="m" />
             </EuiFlexItem>

--- a/x-pack/plugins/cases/public/containers/configure/api.test.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.test.ts
@@ -18,7 +18,6 @@ import {
   casesConfigurationsMock,
 } from './mock';
 import { ConnectorTypes } from '../../../common/types/domain';
-import { SECURITY_SOLUTION_OWNER } from '../../../common/constants';
 import { KibanaServices } from '../../common/lib/kibana';
 import { actionTypesMock, connectorsMock } from '../../common/mock/connectors';
 
@@ -57,29 +56,24 @@ describe('Case Configuration API', () => {
     });
 
     test('check url, method, signal', async () => {
-      await getCaseConfigure({ signal: abortCtrl.signal, owner: [SECURITY_SOLUTION_OWNER] });
+      await getCaseConfigure({ signal: abortCtrl.signal });
       expect(fetchMock).toHaveBeenCalledWith('/api/cases/configure', {
         method: 'GET',
         signal: abortCtrl.signal,
-        query: {
-          owner: [SECURITY_SOLUTION_OWNER],
-        },
       });
     });
 
     test('happy path', async () => {
       const resp = await getCaseConfigure({
         signal: abortCtrl.signal,
-        owner: [SECURITY_SOLUTION_OWNER],
       });
-      expect(resp).toEqual(casesConfigurationsMock);
+      expect(resp).toEqual([casesConfigurationsMock]);
     });
 
     test('return null on empty response', async () => {
       fetchMock.mockResolvedValue({});
       const resp = await getCaseConfigure({
         signal: abortCtrl.signal,
-        owner: [SECURITY_SOLUTION_OWNER],
       });
       expect(resp).toBe(null);
     });

--- a/x-pack/plugins/cases/public/containers/configure/api.ts
+++ b/x-pack/plugins/cases/public/containers/configure/api.ts
@@ -41,23 +41,23 @@ export const getSupportedActionConnectors = async ({
 
 export const getCaseConfigure = async ({
   signal,
-  owner,
-}: ApiProps & { owner: string[] }): Promise<CasesConfigurationUI | null> => {
+}: ApiProps): Promise<CasesConfigurationUI[] | null> => {
   const response = await KibanaServices.get().http.fetch<GetConfigureResponse>(CASE_CONFIGURE_URL, {
     method: 'GET',
     signal,
-    query: { ...(owner.length > 0 ? { owner } : {}) },
   });
 
   if (!isEmpty(response)) {
     const decodedConfigs = decodeCaseConfigurationsResponse(response);
     if (Array.isArray(decodedConfigs) && decodedConfigs.length > 0) {
-      const configuration = convertToCamelCase<
-        GetConfigureResponse[number],
-        SnakeToCamelCase<GetConfigureResponse[number]>
-      >(decodedConfigs[0]);
+      return decodedConfigs.map((decodedConfig) => {
+        const configuration = convertToCamelCase<
+          GetConfigureResponse[number],
+          SnakeToCamelCase<GetConfigureResponse[number]>
+        >(decodedConfig);
 
-      return convertConfigureResponseToCasesConfigure(configuration);
+        return convertConfigureResponseToCasesConfigure(configuration);
+      });
     }
   }
 
@@ -115,7 +115,7 @@ export const fetchActionTypes = async ({ signal }: ApiProps): Promise<ActionType
 const convertConfigureResponseToCasesConfigure = (
   configuration: SnakeToCamelCase<Configuration>
 ): CasesConfigurationUI => {
-  const { id, version, mappings, customFields, closureType, connector } = configuration;
+  const { id, version, mappings, customFields, closureType, connector, owner } = configuration;
 
-  return { id, version, mappings, customFields, closureType, connector };
+  return { id, version, mappings, customFields, closureType, connector, owner };
 };

--- a/x-pack/plugins/cases/public/containers/configure/mock.ts
+++ b/x-pack/plugins/cases/public/containers/configure/mock.ts
@@ -74,4 +74,5 @@ export const casesConfigurationsMock: CasesConfigurationUI = {
   mappings: [],
   version: 'WzHJ12',
   customFields: customFieldsConfigurationMock,
+  owner: 'securitySolution',
 };

--- a/x-pack/plugins/cases/public/containers/configure/use_get_all_case_configurations.test.ts
+++ b/x-pack/plugins/cases/public/containers/configure/use_get_all_case_configurations.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useGetAllCaseConfigurations } from './use_get_all_case_configurations';
+import * as api from './api';
+import type { AppMockRenderer } from '../../common/mock';
+import { createAppMockRenderer } from '../../common/mock';
+
+jest.mock('./api');
+
+describe('Use get all case configurations hook', () => {
+  let appMockRender: AppMockRenderer;
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+    jest.clearAllMocks();
+  });
+
+  it('returns all available configurations', async () => {
+    const spy = jest.spyOn(api, 'getCaseConfigure');
+    spy.mockResolvedValue([
+      // @ts-expect-error: no need to define all properties
+      { id: 'my-configuration-1', owner: '1' },
+      // @ts-expect-error: no need to define all properties
+      { id: 'my-configuration-2', owner: '2' },
+      // @ts-expect-error: no need to define all properties
+      { id: 'my-configuration-3', owner: '3' },
+    ]);
+
+    const { result, waitForNextUpdate } = renderHook(() => useGetAllCaseConfigurations(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    await waitForNextUpdate();
+
+    /**
+     * Ensures that the initial data is returned≠
+     * before fetching
+     */
+    // @ts-expect-error: data is defined
+    expect(result.all[0].data).toEqual([
+      {
+        closureType: 'close-by-user',
+        connector: { fields: null, id: 'none', name: 'none', type: '.none' },
+        customFields: [],
+        id: '',
+        mappings: [],
+        version: '',
+        owner: '',
+      },
+    ]);
+
+    /**
+     * The response after fetching
+     */
+    // @ts-expect-error: data is defined
+    expect(result.all[1].data).toEqual([
+      { id: 'my-configuration-1', owner: '1' },
+      { id: 'my-configuration-2', owner: '2' },
+      { id: 'my-configuration-3', owner: '3' },
+    ]);
+  });
+
+  it('returns the initial configuration if none is available', async () => {
+    const spy = jest.spyOn(api, 'getCaseConfigure');
+    spy.mockResolvedValue([]);
+
+    const { result, waitForNextUpdate } = renderHook(() => useGetAllCaseConfigurations(), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    await waitForNextUpdate();
+
+    /**
+     * Ensures that the initial data is returned≠
+     * before fetching
+     */
+    // @ts-expect-error: data is defined
+    expect(result.all[0].data).toEqual([
+      {
+        closureType: 'close-by-user',
+        connector: { fields: null, id: 'none', name: 'none', type: '.none' },
+        customFields: [],
+        id: '',
+        mappings: [],
+        version: '',
+        owner: '',
+      },
+    ]);
+  });
+});

--- a/x-pack/plugins/cases/public/containers/configure/use_get_all_case_configurations.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_get_all_case_configurations.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CasesConfigurationUI } from '../types';
+import { initialConfiguration } from './utils';
+import { useGetCaseConfigurationsQuery } from './use_get_case_configurations_query';
+
+const transformConfiguration = (data: CasesConfigurationUI[] | null): CasesConfigurationUI[] => {
+  if (data) {
+    return data;
+  }
+
+  return [initialConfiguration];
+};
+
+export const useGetAllCaseConfigurations = () =>
+  useGetCaseConfigurationsQuery<CasesConfigurationUI[]>({ select: transformConfiguration });
+
+export type UseGetAllCaseConfigurations = ReturnType<typeof useGetAllCaseConfigurations>;

--- a/x-pack/plugins/cases/public/containers/configure/use_get_case_configuration.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_get_case_configuration.tsx
@@ -4,54 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-
-import { useQuery } from '@tanstack/react-query';
-import { ConnectorTypes } from '../../../common';
-import * as i18n from './translations';
-import { getCaseConfigure } from './api';
-import type { ServerError } from '../../types';
-import { casesQueriesKeys } from '../constants';
-import type { CasesConfigurationUI } from '../types';
-import { useCasesToast } from '../../common/use_cases_toast';
 import { useCasesContext } from '../../components/cases_context/use_cases_context';
-
-const initialConfiguration: CasesConfigurationUI = {
-  closureType: 'close-by-user',
-  connector: {
-    fields: null,
-    id: 'none',
-    name: 'none',
-    type: ConnectorTypes.none,
-  },
-  customFields: [],
-  mappings: [],
-  version: '',
-  id: '',
-};
-
-const transformConfiguration = (data: CasesConfigurationUI | null): CasesConfigurationUI => {
-  if (data) {
-    return data;
-  }
-
-  return initialConfiguration;
-};
+import type { CasesConfigurationUI } from '../types';
+import { useGetCaseConfigurationsQuery } from './use_get_case_configurations_query';
+import { getConfigurationByOwner } from './utils';
 
 export const useGetCaseConfiguration = () => {
   const { owner } = useCasesContext();
-  const { showErrorToast } = useCasesToast();
 
-  return useQuery<CasesConfigurationUI | null, ServerError, CasesConfigurationUI>(
-    casesQueriesKeys.configuration({ owner }),
-    ({ signal }) => getCaseConfigure({ owner, signal }),
-    {
-      select: transformConfiguration,
-      onError: (error: ServerError) => {
-        showErrorToast(error, { title: i18n.ERROR_TITLE });
-      },
-      initialData: initialConfiguration,
-    }
-  );
+  return useGetCaseConfigurationsQuery<CasesConfigurationUI>({
+    select: (data: CasesConfigurationUI[] | null) =>
+      getConfigurationByOwner({ configurations: data, owner: owner[0] }),
+  });
 };
 
 export type UseGetCaseConfiguration = ReturnType<typeof useGetCaseConfiguration>;

--- a/x-pack/plugins/cases/public/containers/configure/use_get_case_configurations_query.test.ts
+++ b/x-pack/plugins/cases/public/containers/configure/use_get_case_configurations_query.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useGetCaseConfigurationsQuery } from './use_get_case_configurations_query';
+import * as api from './api';
+import { waitFor } from '@testing-library/react';
+import { useToasts } from '../../common/lib/kibana';
+import type { AppMockRenderer } from '../../common/mock';
+import { createAppMockRenderer } from '../../common/mock';
+import { initialConfiguration } from './utils';
+
+jest.mock('./api');
+jest.mock('../../common/lib/kibana');
+
+describe('Use get case configurations query hook', () => {
+  let appMockRender: AppMockRenderer;
+
+  beforeEach(() => {
+    appMockRender = createAppMockRenderer();
+    jest.clearAllMocks();
+  });
+
+  it('calls the api when invoked with the correct parameters', async () => {
+    const spy = jest.spyOn(api, 'getCaseConfigure');
+
+    renderHook(
+      () => useGetCaseConfigurationsQuery({ select: (data) => data || initialConfiguration }),
+      {
+        wrapper: appMockRender.AppWrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        signal: expect.any(AbortSignal),
+      });
+    });
+  });
+
+  it('shows a toast error when the api return an error', async () => {
+    const addError = jest.fn();
+    (useToasts as jest.Mock).mockReturnValue({ addError });
+
+    const spy = jest.spyOn(api, 'getCaseConfigure').mockRejectedValue(new Error('error'));
+
+    renderHook(
+      () => useGetCaseConfigurationsQuery({ select: (data) => data || initialConfiguration }),
+      {
+        wrapper: appMockRender.AppWrapper,
+      }
+    );
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        signal: expect.any(AbortSignal),
+      });
+
+      expect(addError).toHaveBeenCalled();
+    });
+  });
+
+  it('calls select correctly', async () => {
+    const select = jest.fn();
+    const spy = jest.spyOn(api, 'getCaseConfigure');
+    const data = [{ ...initialConfiguration, id: 'my-new-configuration' }];
+
+    spy.mockResolvedValue(data);
+
+    renderHook(() => useGetCaseConfigurationsQuery({ select }), {
+      wrapper: appMockRender.AppWrapper,
+    });
+
+    await waitFor(() => {
+      expect(select).toHaveBeenCalledWith(data);
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/containers/configure/use_get_case_configurations_query.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_get_case_configurations_query.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as i18n from './translations';
+import { getCaseConfigure } from './api';
+import type { ServerError } from '../../types';
+import { casesQueriesKeys } from '../constants';
+import type { CasesConfigurationUI } from '../types';
+import { useCasesToast } from '../../common/use_cases_toast';
+import { initialConfiguration } from './utils';
+
+export const useGetCaseConfigurationsQuery = <T,>({
+  select,
+}: {
+  select: (data: CasesConfigurationUI[] | null) => T;
+}) => {
+  const { showErrorToast } = useCasesToast();
+
+  return useQuery<CasesConfigurationUI[] | null, ServerError, T>(
+    casesQueriesKeys.configuration({}),
+    ({ signal }) => getCaseConfigure({ signal }),
+    {
+      select,
+      onError: (error: ServerError) => {
+        showErrorToast(error, { title: i18n.ERROR_TITLE });
+      },
+      initialData: [initialConfiguration],
+    }
+  );
+};
+
+export type UseGetAllCaseConfigurations = ReturnType<typeof useGetCaseConfigurationsQuery>;

--- a/x-pack/plugins/cases/public/containers/configure/use_persist_configuration.test.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_persist_configuration.test.tsx
@@ -12,7 +12,7 @@ import * as api from './api';
 import { useToasts } from '../../common/lib/kibana';
 import type { AppMockRenderer } from '../../common/mock';
 import { createAppMockRenderer } from '../../common/mock';
-import { ConnectorTypes, SECURITY_SOLUTION_OWNER } from '../../../common';
+import { ConnectorTypes } from '../../../common';
 import { casesQueriesKeys } from '../constants';
 
 jest.mock('./api');
@@ -130,9 +130,7 @@ describe('useCreateAttachments', () => {
 
     await waitForNextUpdate();
 
-    expect(queryClientSpy).toHaveBeenCalledWith(
-      casesQueriesKeys.configuration({ owner: [SECURITY_SOLUTION_OWNER] })
-    );
+    expect(queryClientSpy).toHaveBeenCalledWith(casesQueriesKeys.configuration({}));
   });
 
   it('shows the success toaster', async () => {

--- a/x-pack/plugins/cases/public/containers/configure/use_persist_configuration.tsx
+++ b/x-pack/plugins/cases/public/containers/configure/use_persist_configuration.tsx
@@ -47,7 +47,7 @@ export const usePersistConfiguration = () => {
     {
       mutationKey: casesMutationsKeys.persistCaseConfiguration,
       onSuccess: () => {
-        queryClient.invalidateQueries(casesQueriesKeys.configuration({ owner }));
+        queryClient.invalidateQueries(casesQueriesKeys.configuration({}));
         showSuccessToast(i18n.SUCCESS_CONFIGURE);
       },
       onError: (error: ServerError) => {

--- a/x-pack/plugins/cases/public/containers/configure/utils.test.ts
+++ b/x-pack/plugins/cases/public/containers/configure/utils.test.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { CasesConfigurationUI } from '../types';
+import { getConfigurationByOwner, initialConfiguration } from './utils';
+
+describe('Utils', () => {
+  describe('getConfigurationByOwner', () => {
+    it('returns the initial configuration if there are no configurations', () => {
+      expect(getConfigurationByOwner({ configurations: [], owner: 'foobar' })).toBe(
+        initialConfiguration
+      );
+    });
+
+    it('returns the initial configuration if the owner is not found', () => {
+      expect(
+        getConfigurationByOwner({
+          configurations: [{ owner: 'foo' }, { owner: 'bar' }] as CasesConfigurationUI[],
+          owner: 'foobar',
+        })
+      ).toBe(initialConfiguration);
+    });
+
+    it('returns the expected configuration when searching by owner', () => {
+      expect(
+        getConfigurationByOwner({
+          configurations: [{ owner: 'foobar' }, { owner: 'bar' }] as CasesConfigurationUI[],
+          owner: 'foobar',
+        })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "owner": "foobar",
+        }
+      `);
+    });
+
+    it('returns the initial configuration if the owner is undefined', () => {
+      expect(
+        getConfigurationByOwner({
+          configurations: [{ owner: 'foobar' }, { owner: 'bar' }] as CasesConfigurationUI[],
+          owner: undefined,
+        })
+      ).toBe(initialConfiguration);
+    });
+  });
+});

--- a/x-pack/plugins/cases/public/containers/configure/utils.ts
+++ b/x-pack/plugins/cases/public/containers/configure/utils.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import type { CasesConfigurationUI } from '../types';
+import { ConnectorTypes } from '../../../common';
+
+export const initialConfiguration: CasesConfigurationUI = {
+  closureType: 'close-by-user',
+  connector: {
+    fields: null,
+    id: 'none',
+    name: 'none',
+    type: ConnectorTypes.none,
+  },
+  customFields: [],
+  mappings: [],
+  version: '',
+  id: '',
+  owner: '',
+};
+
+export const getConfigurationByOwner = ({
+  configurations,
+  owner,
+}: {
+  configurations: CasesConfigurationUI[] | null;
+  owner: string | undefined;
+}): CasesConfigurationUI => {
+  if (!configurations || !configurations.length || !owner) {
+    return initialConfiguration;
+  }
+
+  // fallback to configuration 0 which was what happened before
+  return configurations.find((element) => element.owner === owner) ?? initialConfiguration;
+};

--- a/x-pack/test/functional_with_es_ssl/apps/cases/group2/configure.ts
+++ b/x-pack/test/functional_with_es_ssl/apps/cases/group2/configure.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { CustomFieldTypes } from '@kbn/cases-plugin/common/types/domain';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
@@ -57,6 +58,27 @@ export default ({ getPageObject, getService }: FtrProviderContext) => {
     });
 
     describe('Custom fields', function () {
+      before(async () => {
+        await cases.api.createConfigWithCustomFields({
+          customFields: [
+            {
+              key: 'o11y_custom_field',
+              label: 'My o11y field',
+              type: CustomFieldTypes.TOGGLE,
+              required: false,
+            },
+          ],
+          owner: 'observability',
+        });
+      });
+
+      it('existing configurations do not interfere', async () => {
+        // A configuration created in o11y should not be visible in stack
+        expect(await testSubjects.getVisibleText('empty-custom-fields')).to.be(
+          'You do not have any fields yet'
+        );
+      });
+
       it('adds a custom field', async () => {
         await testSubjects.existOrFail('custom-fields-form-group');
         await common.clickAndValidate('add-custom-field', 'custom-field-flyout');


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Cases] Display correct custom fields based on the selected owner in the cases flyout. (#178201)](https://github.com/elastic/kibana/pull/178201)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Antonio","email":"antonio.coelho@elastic.co"},"sourceCommit":{"committedDate":"2024-03-13T09:31:37Z","message":"[Cases] Display correct custom fields based on the selected owner in the cases flyout. (#178201)\n\nFixes #176862\r\n\r\n## Summary\r\n\r\n- The create case flyout now displays the correct custom fields when\r\nchanging the owner.\r\n- Rebased some logic in the `CreateCaseForm`.\r\n- Created the `useGetAllCaseConfigurations` hook.","sha":"02efdf1a397ac1b9263abe75b372b63b83d39d0a","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["bug","release_note:skip","Team:ResponseOps","Feature:Cases","v8.13.0","v8.14.0"],"number":178201,"url":"https://github.com/elastic/kibana/pull/178201","mergeCommit":{"message":"[Cases] Display correct custom fields based on the selected owner in the cases flyout. (#178201)\n\nFixes #176862\r\n\r\n## Summary\r\n\r\n- The create case flyout now displays the correct custom fields when\r\nchanging the owner.\r\n- Rebased some logic in the `CreateCaseForm`.\r\n- Created the `useGetAllCaseConfigurations` hook.","sha":"02efdf1a397ac1b9263abe75b372b63b83d39d0a"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"url":"https://github.com/elastic/kibana/pull/178608","number":178608,"state":"OPEN"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178201","number":178201,"mergeCommit":{"message":"[Cases] Display correct custom fields based on the selected owner in the cases flyout. (#178201)\n\nFixes #176862\r\n\r\n## Summary\r\n\r\n- The create case flyout now displays the correct custom fields when\r\nchanging the owner.\r\n- Rebased some logic in the `CreateCaseForm`.\r\n- Created the `useGetAllCaseConfigurations` hook.","sha":"02efdf1a397ac1b9263abe75b372b63b83d39d0a"}}]}] BACKPORT-->