### PR TITLE
Rebroadcast mouse event for mouse down event in monaco editor

### DIFF
--- a/packages/shared-ux/code_editor/impl/__snapshots__/code_editor.test.tsx.snap
+++ b/packages/shared-ux/code_editor/impl/__snapshots__/code_editor.test.tsx.snap
@@ -290,51 +290,21 @@ exports[`<CodeEditor /> is rendered 1`] = `
       </EuiToolTipAnchor>
     </EuiToolTip>
     <Component>
-      <MockedMonacoEditor
-        editorDidMount={[Function]}
-        editorWillMount={[Function]}
-        editorWillUnmount={[Function]}
-        height={250}
-        language="loglang"
-        onChange={[Function]}
-        options={
-          Object {
-            "bracketPairColorization.enabled": false,
-            "fontFamily": "Roboto Mono",
-            "fontSize": 12,
-            "lineHeight": 21,
-            "matchBrackets": "never",
-            "minimap": Object {
-              "enabled": false,
-            },
-            "padding": Object {},
-            "renderLineHighlight": "none",
-            "scrollBeyondLastLine": false,
-            "scrollbar": Object {
-              "alwaysConsumeMouseWheel": false,
-              "useShadows": false,
-            },
-            "wordBasedSuggestions": false,
-            "wordWrap": "on",
-            "wrappingIndent": "indent",
+      <UseBug177756ReBroadcastMouseDown>
+        <div
+          style={
+            Object {
+              "display": "contents",
+            }
           }
-        }
-        theme="euiColors"
-        value="
-[Sun Mar 7 20:54:27 2004] [notice] [client xx.xx.xx.xx] This is a notice!
-[Sun Mar 7 20:58:27 2004] [info] [client xx.xx.xx.xx] (104)Connection reset by peer: client stopped connection before send body completed
-[Sun Mar 7 21:16:17 2004] [error] [client xx.xx.xx.xx] File does not exist: /home/httpd/twiki/view/Main/WebHome
-"
-      >
-        <div>
-          <div />
-          <textarea
-            data-test-subj="monacoEditorTextarea"
+        >
+          <MockedMonacoEditor
+            editorDidMount={[Function]}
+            editorWillMount={[Function]}
             editorWillUnmount={[Function]}
             height={250}
             language="loglang"
             onChange={[Function]}
-            onKeyDown={[Function]}
             options={
               Object {
                 "bracketPairColorization.enabled": false,
@@ -363,9 +333,49 @@ exports[`<CodeEditor /> is rendered 1`] = `
 [Sun Mar 7 20:58:27 2004] [info] [client xx.xx.xx.xx] (104)Connection reset by peer: client stopped connection before send body completed
 [Sun Mar 7 21:16:17 2004] [error] [client xx.xx.xx.xx] File does not exist: /home/httpd/twiki/view/Main/WebHome
 "
-          />
+          >
+            <div>
+              <div />
+              <textarea
+                data-test-subj="monacoEditorTextarea"
+                editorWillUnmount={[Function]}
+                height={250}
+                language="loglang"
+                onChange={[Function]}
+                onKeyDown={[Function]}
+                options={
+                  Object {
+                    "bracketPairColorization.enabled": false,
+                    "fontFamily": "Roboto Mono",
+                    "fontSize": 12,
+                    "lineHeight": 21,
+                    "matchBrackets": "never",
+                    "minimap": Object {
+                      "enabled": false,
+                    },
+                    "padding": Object {},
+                    "renderLineHighlight": "none",
+                    "scrollBeyondLastLine": false,
+                    "scrollbar": Object {
+                      "alwaysConsumeMouseWheel": false,
+                      "useShadows": false,
+                    },
+                    "wordBasedSuggestions": false,
+                    "wordWrap": "on",
+                    "wrappingIndent": "indent",
+                  }
+                }
+                theme="euiColors"
+                value="
+[Sun Mar 7 20:54:27 2004] [notice] [client xx.xx.xx.xx] This is a notice!
+[Sun Mar 7 20:58:27 2004] [info] [client xx.xx.xx.xx] (104)Connection reset by peer: client stopped connection before send body completed
+[Sun Mar 7 21:16:17 2004] [error] [client xx.xx.xx.xx] File does not exist: /home/httpd/twiki/view/Main/WebHome
+"
+              />
+            </div>
+          </MockedMonacoEditor>
         </div>
-      </MockedMonacoEditor>
+      </UseBug177756ReBroadcastMouseDown>
     </Component>
   </div>
 </CodeEditor>


### PR DESCRIPTION
## Summary


Closes https://github.com/elastic/kibana/issues/177756

Introduces a wrapper that will ~trap~ listen on `mousedown` events from the monaco editor and rebroadcast this event type so that when it's integrated, any component that needs interaction events still gets events related to the monaco but with the wrapper as the event target.

The advantage of this approach is we keep the default behaviour for events propagated for monaco editor as is, also applying style of [`display:contents`](https://www.w3.org/TR/css-display-3/#box-generation) ensures this extra wrapper element does not modify the existing layout.

<!-- 
### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
-->