### PR TITLE
[Security Solution] Entity Analytics: Risk score alert contribution score

### DIFF
--- a/x-pack/plugins/security_solution/common/entity_analytics/risk_engine/types.ts
+++ b/x-pack/plugins/security_solution/common/entity_analytics/risk_engine/types.ts
@@ -68,6 +68,7 @@ export interface RiskScore {
   category_2_count?: number;
   notes: string[];
   inputs: RiskInputs;
+  poc_contributions: Array<{ alert: unknown; score: number; norm_score: number }>;
 }
 
 export enum RiskLevels {

--- a/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_preview_table.tsx
+++ b/x-pack/plugins/security_solution/public/entity_analytics/components/risk_score_preview_table.tsx
@@ -25,9 +25,11 @@ type RiskScoreColumn = EuiBasicTableColumn<IRiskScore> & {
 export const RiskScorePreviewTable = ({
   items,
   type,
+  onSelect,
 }: {
   items: IRiskScore[];
   type: RiskScoreEntity;
+  onSelect: (name: string) => void;
 }) => {
   const columns: RiskScoreColumn[] = [
     {
@@ -89,6 +91,7 @@ export const RiskScorePreviewTable = ({
       items={items}
       columns={columns}
       loading={false}
+      rowProps={(item) => ({ onClick: () => onSelect(item.id_value) })}
     />
   );
 };

--- a/x-pack/plugins/security_solution/server/lib/entity_analytics/types.ts
+++ b/x-pack/plugins/security_solution/server/lib/entity_analytics/types.ts
@@ -119,6 +119,9 @@ export interface RiskScoreBucket {
       notes: string[];
       category_1_score: number;
       category_1_count: number;
+      contributions: number[];
+      contributions_norm: number[];
+      inputs: unknown[];
     };
   };
   inputs: SearchResponse;


### PR DESCRIPTION
This PR is a Proof of Concept on how we can calculate and display individual risk contributions for each alert.

This main driver for this is Explainability in the the Risk contributions tab from an Entity details flyout.

Right now, this PoC piggybacks the Preview endpoint from the Risk Engine management page.
If we chose this approach, we can create a separate endpoint specifically for our use case.

How to test:

1. Run the datagen for the entity store: https://github.com/elastic/security-documents-generator
2. In kibana, go to Security -> Manage -> Entity Risk Score. 
3. Some entities should show up on the preview panel. Clicking on a row will open a modal with JSON describing the contribution inputs

![Screenshot 2024-03-13 at 17 01 30](https://github.com/elastic/kibana/assets/2423976/6742ea79-0d29-4c2a-b7a0-749768e66893)

![Screenshot 2024-03-13 at 17 01 39](https://github.com/elastic/kibana/assets/2423976/1859e83a-f54f-43fa-b4ff-a6f378361c59)


The JSOn format is as follows: 

```js
{
  "score":70, // pre normalised contribution score for this risk input (only alerts in this case)
  "norm_score": 26.799387442572744, // normalized contribution score
  "alert": {
     "score":70, // alert score. Comes from the rule which triggered this alert
     "weighted_score":70, // weighted alert score
     "time":"2024-03-13T14:18:05.090Z",
     "category":"signal"
  }
},
```