### PR TITLE
[8.13] [Fleet] Do not allow to add fleet server to cloud policy from UI (#177338)

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/advanced_tab.tsx
@@ -66,7 +66,9 @@ export const AdvancedTab: React.FunctionComponent<AdvancedTabProps> = ({
       serviceToken,
       generateServiceToken,
       isLoadingServiceToken,
-      disabled: Boolean(!fleetServerHostForm.fleetServerHost),
+      disabled:
+        Boolean(!fleetServerHostForm.fleetServerHost) ||
+        !Boolean(fleetServerPolicyId || selectedPolicyId),
     }),
     getInstallFleetServerStep({
       isFleetServerReady,

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.test.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useGetAgentPolicies } from '../../../hooks';
+import { createFleetTestRendererMock } from '../../../../../mock';
+
+import { useSelectFleetServerPolicy } from './use_select_fleet_server_policy';
+
+jest.mock('../../../hooks');
+
+describe('useSelectFleetServerPolicy hook', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Return eligible fleet server policies', async () => {
+    jest.mocked(useGetAgentPolicies).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'test1',
+            is_default_fleet_server: true,
+            package_policies: [
+              {
+                package: {
+                  name: 'fleet_server',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as any);
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() => useSelectFleetServerPolicy());
+
+    expect(result.current.fleetServerPolicyId).toEqual('test1');
+    expect(result.current.eligibleFleetServerPolicies.map(({ id }) => id)).toEqual(['test1']);
+  });
+
+  it('Do not return managed fleet server policies', async () => {
+    jest.mocked(useGetAgentPolicies).mockReturnValue({
+      data: {
+        items: [
+          {
+            id: 'test1',
+            is_managed: true,
+            is_default_fleet_server: true,
+            package_policies: [
+              {
+                package: {
+                  name: 'fleet_server',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as any);
+    const renderer = createFleetTestRendererMock();
+    const { result } = renderer.renderHook(() => useSelectFleetServerPolicy());
+
+    expect(result.current.fleetServerPolicyId).toBeUndefined();
+    expect(result.current.eligibleFleetServerPolicies.map(({ id }) => id)).toEqual([]);
+  });
+});

--- a/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
+++ b/x-pack/plugins/fleet/public/applications/fleet/components/fleet_server_instructions/hooks/use_select_fleet_server_policy.ts
@@ -26,7 +26,7 @@ export const useSelectFleetServerPolicy = (defaultAgentPolicyId?: string) => {
   const eligibleFleetServerPolicies = useMemo(
     () =>
       agentPoliciesData
-        ? agentPoliciesData.items?.filter((item) => policyHasFleetServer(item))
+        ? agentPoliciesData.items?.filter((item) => !item.is_managed && policyHasFleetServer(item))
         : [],
     [agentPoliciesData]
   );


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Fleet] Do not allow to add fleet server to cloud policy from UI (#177338)](https://github.com/elastic/kibana/pull/177338)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Nicolas Chaulet","email":"nicolas.chaulet@elastic.co"},"sourceCommit":{"committedDate":"2024-02-21T13:17:21Z","message":"[Fleet] Do not allow to add fleet server to cloud policy from UI (#177338)","sha":"27e8167179ea2eda4827399d776d1a1eb3123979","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","backport:skip","Team:Fleet","v8.14.0"],"number":177338,"url":"https://github.com/elastic/kibana/pull/177338","mergeCommit":{"message":"[Fleet] Do not allow to add fleet server to cloud policy from UI (#177338)","sha":"27e8167179ea2eda4827399d776d1a1eb3123979"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/177338","number":177338,"mergeCommit":{"message":"[Fleet] Do not allow to add fleet server to cloud policy from UI (#177338)","sha":"27e8167179ea2eda4827399d776d1a1eb3123979"}}]}] BACKPORT-->