### PR TITLE
[Ops] Propagate DRY_RUN to gpctl-promote

### DIFF
--- a/.buildkite/pipelines/emergency_release.yml
+++ b/.buildkite/pipelines/emergency_release.yml
@@ -17,3 +17,4 @@ steps:
       env:
         REMOTE_SERVICE_CONFIG: "${EMERGENCY_RELEASE_REMOTE_SERVICE_CONFIG}"
         SERVICE_COMMIT_HASH: "${VERSION}"
+        DRY_RUN: "${DRY_RUN:-false}"

--- a/.buildkite/scripts/serverless/create_deploy_tag/generate_gpctl_trigger.ts
+++ b/.buildkite/scripts/serverless/create_deploy_tag/generate_gpctl_trigger.ts
@@ -28,6 +28,7 @@ function uploadTriggerStep(commitSha: string) {
       env: {
         SERVICE_COMMIT_HASH: commitSha.slice(0, 12),
         REMOTE_SERVICE_CONFIG,
+        ...(IS_DRY_RUN ? { DRY_RUN: 'true' } : {}),
       },
     },
   };

--- a/.buildkite/scripts/steps/artifacts/docker_image.sh
+++ b/.buildkite/scripts/steps/artifacts/docker_image.sh
@@ -136,6 +136,7 @@ steps:
         SERVICE_COMMIT_HASH: "$GIT_ABBREV_COMMIT"
         SERVICE: kibana
         REMOTE_SERVICE_CONFIG: https://raw.githubusercontent.com/elastic/serverless-gitops/main/gen/gpctl/kibana/dev.yaml
+        DRY_RUN: "${DRY_RUN:-false}"
 EOF
 
 else


### PR DESCRIPTION
## Summary
We've had some issues with the weekly scheduled serverless release after we've switched to a direct trigger to `gpctl-promote`.

Although we've tried a few options, and we've probably found the solution, but we can still go for sure, and try a dry-run cross trigger. This wasn't possible before, but https://github.com/elastic/gpctl/pull/261 should now respect DRY_RUN env vars coming in.  

This PR propagates those variables, so we can test the setup.