### PR TITLE
[Controls] Fix flaky apply button test

### DIFF
--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -50,12 +50,12 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         fieldName: 'weightLbs',
         title: 'Animal Name',
       });
+      await dashboardControls.createTimeSliderControl();
+
+      // wait for all controls to finish loading before saving
       controlIds = await dashboardControls.getAllControlIds();
       await dashboardControls.optionsListWaitForLoading(controlIds[0]);
       await dashboardControls.rangeSliderWaitForLoading(controlIds[1]);
-
-      await dashboardControls.createTimeSliderControl();
-      controlIds = await dashboardControls.getAllControlIds();
 
       // save the dashboard
       await dashboard.saveDashboard('Test Control Group Apply Button', { exitFromEditMode: false });

--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -43,14 +43,18 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         fieldName: 'animal.keyword',
         title: 'Animal',
       });
+      controlIds = await dashboardControls.getAllControlIds();
       await dashboardControls.createControl({
         controlType: RANGE_SLIDER_CONTROL,
         dataViewTitle: 'animals-*',
         fieldName: 'weightLbs',
         title: 'Animal Name',
       });
-      await dashboardControls.createTimeSliderControl();
+      controlIds = await dashboardControls.getAllControlIds();
+      await dashboardControls.optionsListWaitForLoading(controlIds[0]);
+      await dashboardControls.rangeSliderWaitForLoading(controlIds[1]);
 
+      await dashboardControls.createTimeSliderControl();
       controlIds = await dashboardControls.getAllControlIds();
 
       // save the dashboard

--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -49,7 +49,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         fieldName: 'weightLbs',
         title: 'Animal Name',
       });
-      await dashboardControls.createTimeSliderControl();
+      // await dashboardControls.createTimeSliderControl();
+      // await dashboardControls.waitFor
       controlIds = await dashboardControls.getAllControlIds();
 
       // save the dashboard
@@ -178,7 +179,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe('time slider selections', () => {
+    describe.skip('time slider selections', () => {
       let valueBefore: string;
 
       before(async () => {

--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -24,8 +24,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'header',
   ]);
 
-  // FLAKY: https://github.com/elastic/kibana/issues/178581
-  describe.skip('Dashboard control group apply button', () => {
+  describe.only('Dashboard control group apply button', () => {
     let controlIds: string[];
 
     before(async () => {

--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -49,8 +49,8 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         fieldName: 'weightLbs',
         title: 'Animal Name',
       });
-      // await dashboardControls.createTimeSliderControl();
-      // await dashboardControls.waitFor
+      await dashboardControls.createTimeSliderControl();
+
       controlIds = await dashboardControls.getAllControlIds();
 
       // save the dashboard

--- a/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
+++ b/test/functional/apps/dashboard_elements/controls/common/control_group_apply_button.ts
@@ -24,7 +24,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
     'header',
   ]);
 
-  describe.only('Dashboard control group apply button', () => {
+  describe('Dashboard control group apply button', () => {
     let controlIds: string[];
 
     before(async () => {
@@ -43,7 +43,6 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
         fieldName: 'animal.keyword',
         title: 'Animal',
       });
-      controlIds = await dashboardControls.getAllControlIds();
       await dashboardControls.createControl({
         controlType: RANGE_SLIDER_CONTROL,
         dataViewTitle: 'animals-*',
@@ -183,7 +182,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
       });
     });
 
-    describe.skip('time slider selections', () => {
+    describe('time slider selections', () => {
       let valueBefore: string;
 
       before(async () => {

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -303,9 +303,6 @@ export class DashboardPageControls extends FtrService {
     this.log.debug(`Creating time slider control`);
     await this.openControlsMenu();
     await this.testSubjects.click('controls-create-timeslider-button');
-    await this.retry.waitFor('time slider control to load', async () => {
-      return this.testSubjects.exists('timeSlider-popoverToggleButton');
-    });
   }
 
   public async hoverOverExistingControl(controlId: string) {

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -303,6 +303,9 @@ export class DashboardPageControls extends FtrService {
     this.log.debug(`Creating time slider control`);
     await this.openControlsMenu();
     await this.testSubjects.click('controls-create-timeslider-button');
+    await this.retry.waitFor('time slider control to load', async () => {
+      return this.testSubjects.exists('timeSlider__popoverOverride');
+    });
   }
 
   public async hoverOverExistingControl(controlId: string) {

--- a/test/functional/page_objects/dashboard_page_controls.ts
+++ b/test/functional/page_objects/dashboard_page_controls.ts
@@ -304,7 +304,7 @@ export class DashboardPageControls extends FtrService {
     await this.openControlsMenu();
     await this.testSubjects.click('controls-create-timeslider-button');
     await this.retry.waitFor('time slider control to load', async () => {
-      return this.testSubjects.exists('timeSlider__popoverOverride');
+      return this.testSubjects.exists('timeSlider-popoverToggleButton');
     });
   }
 


### PR DESCRIPTION
Closes https://github.com/elastic/kibana/issues/178581

## Summary

Because the control group publishes its own filters to trigger unsaved changes, and because the controls must **load** for the filters to be published, we need to await for each control to load **before** saving the dashboard - otherwise, if the controls fully load **after** the dashboard is saved, this can re-trigger the unsaved changes badge.

### [Flaky Test Runner](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5472)

![image](https://github.com/elastic/kibana/assets/8698078/271ecbca-9aee-43c1-83cf-54b4b7bf5a0d)


### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
