### PR TITLE
Copy assets from appropriate directory for kbn-monaco

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -2,6 +2,31 @@ Kibana source code with Kibana X-Pack source code
 Copyright 2012-2024 Elasticsearch B.V.
 
 ---
+Adapted from remote-web-worker, which was available under a "MIT" license.
+
+MIT License (MIT)
+
+Copyright (c) 2022 Jan Nicklas
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---
 Pretty handling of logarithmic axes.
 Copyright (c) 2007-2014 IOLA and Ole Laursen.
 Licensed under the MIT license.

--- a/package.json
+++ b/package.json
@@ -1105,7 +1105,6 @@
     "remark-gfm": "1.0.0",
     "remark-parse-no-trim": "^8.0.4",
     "remark-stringify": "^8.0.3",
-    "remote-web-worker": "^0.0.9",
     "require-in-the-middle": "^7.2.1",
     "reselect": "^4.1.8",
     "resize-observer-polyfill": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -1105,6 +1105,7 @@
     "remark-gfm": "1.0.0",
     "remark-parse-no-trim": "^8.0.4",
     "remark-stringify": "^8.0.3",
+    "remote-web-worker": "^0.0.9",
     "require-in-the-middle": "^7.2.1",
     "reselect": "^4.1.8",
     "resize-observer-polyfill": "1.5.1",

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -30,6 +30,7 @@ SHARED_DEPS = [
   "@npm//monaco-editor",
   "@npm//monaco-yaml",
   "@npm//js-levenshtein",
+  "@npm//remote-web-worker",
 ]
 
 webpack_cli(

--- a/packages/kbn-monaco/BUILD.bazel
+++ b/packages/kbn-monaco/BUILD.bazel
@@ -30,7 +30,6 @@ SHARED_DEPS = [
   "@npm//monaco-editor",
   "@npm//monaco-yaml",
   "@npm//js-levenshtein",
-  "@npm//remote-web-worker",
 ]
 
 webpack_cli(

--- a/packages/kbn-monaco/src/register_globals.ts
+++ b/packages/kbn-monaco/src/register_globals.ts
@@ -6,6 +6,7 @@
  * Side Public License, v 1.
  */
 
+import 'remote-web-worker';
 import { XJsonLang } from './xjson';
 import { PainlessLang } from './painless';
 import { SQLLang } from './sql';

--- a/packages/kbn-monaco/src/register_globals.ts
+++ b/packages/kbn-monaco/src/register_globals.ts
@@ -6,7 +6,6 @@
  * Side Public License, v 1.
  */
 
-import 'remote-web-worker';
 import { XJsonLang } from './xjson';
 import { PainlessLang } from './painless';
 import { SQLLang } from './sql';

--- a/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
+++ b/packages/kbn-test/src/jest/setup/polyfills.jsdom.js
@@ -32,3 +32,18 @@ global.Blob = require('blob-polyfill').Blob;
 if (!global.hasOwnProperty('ResizeObserver')) {
   global.ResizeObserver = require('resize-observer-polyfill');
 }
+
+if (!global.hasOwnProperty('Worker')) {
+  class Worker {
+    constructor(stringUrl) {
+      this.url = stringUrl;
+      this.onmessage = () => {};
+    }
+
+    postMessage(msg) {
+      this.onmessage(msg);
+    }
+  }
+
+  global.Worker = Worker;
+}

--- a/packages/kbn-ui-shared-deps-src/src/polyfills.js
+++ b/packages/kbn-ui-shared-deps-src/src/polyfills.js
@@ -18,9 +18,31 @@ if (typeof window.Event === 'object') {
 require('whatwg-fetch');
 require('symbol-observable');
 
-/**
- * @description Adapted from https://github.com/jantimon/remote-web-worker/blob/main/src/index.ts
- * with a modification to check that the requested worker url isn't already a blob, because of how workers are loaded for ace editor
+/* @notice
+ *
+ * Adapted from remote-web-worker, which was available under a "MIT" license.
+ *
+ * MIT License (MIT)
+ *
+ * Copyright (c) 2022 Jan Nicklas
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
  */
 typeof window !== 'undefined' &&
   // eslint-disable-next-line no-global-assign

--- a/packages/kbn-ui-shared-deps-src/src/polyfills.js
+++ b/packages/kbn-ui-shared-deps-src/src/polyfills.js
@@ -49,14 +49,14 @@ typeof window !== 'undefined' &&
   (Worker = ((BaseWorker) =>
     class Worker extends BaseWorker {
       constructor(url, options) {
-        let scriptUrl;
+        let scriptUrl = String(url);
         let objectURLRef;
 
         try {
           const isCrossOrigin = (URLObject) =>
             URLObject.protocol === 'https:' && URLObject.origin !== window.location.origin;
 
-          scriptUrl = isCrossOrigin(new URL(String(url))) // to bootstrap the actual script to work around the same origin policy.
+          scriptUrl = isCrossOrigin(new URL(scriptUrl)) // to bootstrap the actual script to work around the same origin policy.
             ? (objectURLRef = URL.createObjectURL(
                 new Blob(
                   [
@@ -73,16 +73,16 @@ typeof window !== 'undefined' &&
                     // i = original importScripts
                     // a = arguments
                     // u = URL
-                    `importScripts=((i)=>(...a)=>i(...a.map((u)=>''+new URL(u,"${url}"))))(importScripts);importScripts("${url}");`,
+                    `importScripts=((i)=>(...a)=>i(...a.map((u)=>''+new URL(u,"${scriptUrl}"))))(importScripts);importScripts("${scriptUrl}");`,
                   ],
                   {
                     type: 'text/javascript',
                   }
                 )
               ))
-            : String(url);
+            : scriptUrl;
         } catch {
-          scriptUrl = String(url);
+          // provided url doesn't match the expectation for URL constructor, it will be used as is
         }
 
         super(scriptUrl, options);

--- a/src/dev/build/tasks/create_cdn_assets_task.ts
+++ b/src/dev/build/tasks/create_cdn_assets_task.ts
@@ -76,7 +76,10 @@ export const CreateCdnAssets: Task = {
       resolve(buildSource, 'node_modules/@kbn/core/target/public'),
       resolve(bundles, 'core')
     );
-    await copyAll(resolve(buildSource, 'node_modules/@kbn/monaco'), resolve(bundles, 'kbn-monaco'));
+    await copyAll(
+      resolve(buildSource, 'node_modules/@kbn/monaco/target_workers'),
+      resolve(bundles, 'kbn-monaco')
+    );
 
     // packages/core/apps/core-apps-server-internal/src/core_app.ts
     await copyAll(

--- a/yarn.lock
+++ b/yarn.lock
@@ -26662,11 +26662,6 @@ remark-stringify@^8.0.3:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
-remote-web-worker@^0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/remote-web-worker/-/remote-web-worker-0.0.9.tgz#3a96a84063e6c1a5fa3792abe0fd97eb7a97aab3"
-  integrity sha512-TguJhQVWeeL2zWqLQpTfq/uIOpXRHHq7SI6fw6xTIJfSN/ojiKUqV16oAhPD8zH71MFy3FHqSoQEx2cks5gcAA==
-
 remove-accents@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -26662,6 +26662,11 @@ remark-stringify@^8.0.3:
     unherit "^1.0.4"
     xtend "^4.0.1"
 
+remote-web-worker@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/remote-web-worker/-/remote-web-worker-0.0.9.tgz#3a96a84063e6c1a5fa3792abe0fd97eb7a97aab3"
+  integrity sha512-TguJhQVWeeL2zWqLQpTfq/uIOpXRHHq7SI6fw6xTIJfSN/ojiKUqV16oAhPD8zH71MFy3FHqSoQEx2cks5gcAA==
+
 remove-accents@0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"


### PR DESCRIPTION
## Summary

Closes #178448

Per the configuration in kibana, Monaco by default will attempt to load the specific worker for each language using the public path record defined on `window.__kbnPublicPath__` [see here](https://github.com/elastic/kibana/blob/main/packages/kbn-monaco/src/register_globals.ts#L42) but an error occurs whilst attempting to request the script at the url we expect it to be at because it doesn't exist there, as seen here; 
<img width="1071" alt="Screenshot 2024-03-13 at 17 21 36" src="https://github.com/elastic/kibana/assets/7893459/012dd841-ba5c-4744-bb32-708bc6efc976">

Ideally this works but with the current setup for CDN assets it doesn't map 1:1 to how the assets are expected,  we should be copying from the directory `target_workers` to match the same definition for [building packages
](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/build_packages_task.ts#L111-L113), similar to what we have [here](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/create_cdn_assets_task.ts#L67-L74) which is what this PR introduces. 

The hypothesis above is verifiable by attempting to request the same resource on the same build of the deployment where the error is reported, with the `target_workers` path prepended, like so  https://kibana.estccdn.com/552e8adcca05/bundles/kbn-monaco/target_workers/json.editor.worker.js we get the file.

<!-- ### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process) -->
