### PR TITLE
[ci] Disable post-build manual retries

### DIFF
--- a/.buildkite/pipelines/pull_request/post_build.yml
+++ b/.buildkite/pipelines/pull_request/post_build.yml
@@ -4,5 +4,7 @@ steps:
 
   - command: .buildkite/scripts/lifecycle/post_build.sh
     label: Post-Build
+    retry:
+      manual: false
     agents:
       queue: kibana-default

--- a/.buildkite/pipelines/pull_request/post_build.yml
+++ b/.buildkite/pipelines/pull_request/post_build.yml
@@ -4,7 +4,5 @@ steps:
 
   - command: .buildkite/scripts/lifecycle/post_build.sh
     label: Post-Build
-    retry:
-      manual: false
     agents:
       queue: kibana-default

--- a/.buildkite/scripts/lifecycle/post_build.sh
+++ b/.buildkite/scripts/lifecycle/post_build.sh
@@ -9,7 +9,10 @@ if [[ "${GITHUB_BUILD_COMMIT_STATUS_ENABLED:-}" != "true" ]]; then
   "$(dirname "${0}")/commit_status_complete.sh"
 fi
 
-ts-node "$(dirname "${0}")/ci_stats_complete.ts"
+# Skip indexing the same metrics twice
+if [[ "${BUILDKITE_RETRY_COUNT:-0}" == "0" ]]; then
+  ts-node "$(dirname "${0}")/ci_stats_complete.ts"
+fi
 
 if [[ "${GITHUB_PR_NUMBER:-}" ]]; then
   DOCS_CHANGES_URL="https://kibana_bk_$GITHUB_PR_NUMBER}.docs-preview.app.elstc.co/diff"


### PR DESCRIPTION
This will cause metrics to be collected twice.  See linked issue for more information.

<!--ONMERGE {"backportTargets":["7.17","8.13"]} ONMERGE-->