### PR TITLE
[ES|QL][Discover] Show all non-empty values in the grid

### DIFF
--- a/packages/kbn-unified-data-table/src/components/source_document.tsx
+++ b/packages/kbn-unified-data-table/src/components/source_document.tsx
@@ -66,7 +66,7 @@ export function SourceDocument({
       {pairs.map(([fieldDisplayName, value, fieldName]) => {
         // temporary solution for text based mode. As there are a lot of unsupported fields we want to
         // hide the empty one from the Document view
-        if (isPlainRecord && fieldName && !row.flattened[fieldName]) return null;
+        if (isPlainRecord && fieldName && (row.flattened[fieldName] ?? null) === null) return null;
         return (
           <Fragment key={fieldDisplayName}>
             <EuiDescriptionListTitle className="unifiedDataTable__descriptionListTitle">


### PR DESCRIPTION
- Followup for https://github.com/elastic/kibana/pull/174585

## Summary

This PR hides only `null`, `undefined` values and keeps `false`, `0`, `(empty)`.

Before:
<img width="500" alt="Screenshot 2024-03-14 at 10 07 13" src="https://github.com/elastic/kibana/assets/1415710/c5d49362-09e3-48f2-9ecc-247560950d68">

After:
<img width="500" alt="Screenshot 2024-03-14 at 10 06 25" src="https://github.com/elastic/kibana/assets/1415710/3c1adcfd-bec9-4b4a-b94f-78b1d916e9dd">



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->