### PR TITLE
[Ops] Emit trigger step, even in DRY_RUN

### DIFF
--- a/.buildkite/scripts/serverless/create_deploy_tag/generate_gpctl_trigger.ts
+++ b/.buildkite/scripts/serverless/create_deploy_tag/generate_gpctl_trigger.ts
@@ -33,11 +33,7 @@ function uploadTriggerStep(commitSha: string) {
     },
   };
 
-  if (IS_DRY_RUN) {
-    console.log('Dry run: skipping upload of GPCTL trigger step. Step definition:', triggerStep);
-  } else {
-    buildkite.uploadSteps([triggerStep]);
-  }
+  buildkite.uploadSteps([triggerStep]);
 }
 
 main()


### PR DESCRIPTION
## Summary
Missed adding this change in https://github.com/elastic/kibana/pull/178658

Tested in https://buildkite.com/elastic/kibana-serverless-release-1/builds/138 - the receiving pipeline is now prepared for `DRY_RUN` and we can happily trigger the downstream `gpctl-promote` job.

