### PR TITLE
[8.13] [ML] Preserve field formatters between rule executions  (#178621)

### DIFF
--- a/x-pack/plugins/ml/public/alerting/anomaly_detection_rule/register_anomaly_detection_rule.tsx
+++ b/x-pack/plugins/ml/public/alerting/anomaly_detection_rule/register_anomaly_detection_rule.tsx
@@ -22,6 +22,8 @@ export function registerAnomalyDetectionRule(
   getStartServices: MlCoreSetup['getStartServices'],
   mlCapabilities: MlCapabilities
 ) {
+  const MlAlertTrigger = lazy(() => import('./ml_anomaly_alert_trigger'));
+
   triggersActionsUi.ruleTypeRegistry.register({
     id: ML_ALERT_TYPES.ANOMALY_DETECTION,
     description: i18n.translate('xpack.ml.alertTypes.anomalyDetection.description', {
@@ -32,7 +34,6 @@ export function registerAnomalyDetectionRule(
       return docLinks.links.ml.alertingRules;
     },
     ruleParamsExpression: (props: RuleTypeParamsExpressionProps<MlAnomalyDetectionAlertParams>) => {
-      const MlAlertTrigger = lazy(() => import('./ml_anomaly_alert_trigger'));
       return (
         <MlAlertTrigger
           {...props}

--- a/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
+++ b/x-pack/plugins/ml/server/lib/alerts/alerting_service.ts
@@ -26,7 +26,8 @@ import {
 } from '@kbn/ml-anomaly-utils';
 import { DEFAULT_SPACE_ID } from '@kbn/spaces-plugin/common';
 import { ALERT_REASON, ALERT_URL } from '@kbn/rule-data-utils';
-import { MlJob } from '@elastic/elasticsearch/lib/api/types';
+import type { MlJob } from '@elastic/elasticsearch/lib/api/types';
+import { isPopulatedObject } from '@kbn/ml-is-populated-object';
 import { getAnomalyDescription } from '../../../common/util/anomaly_description';
 import { getMetricChangeDescription } from '../../../common/util/metric_change_description';
 import type { MlClient } from '../ml_client';
@@ -52,7 +53,6 @@ import { resolveMaxTimeInterval } from '../../../common/util/job_utils';
 import { getTopNBuckets, resolveLookbackInterval } from '../../../common/util/alerts';
 import type { DatafeedsService } from '../../models/job_service/datafeeds';
 import type { FieldFormatsRegistryProvider } from '../../../common/types/kibana';
-import type { AwaitReturnType } from '../../../common/types/common';
 import { getTypicalAndActualValues } from '../../models/results_service/results_service';
 import type { GetDataViewsService } from '../data_views_utils';
 
@@ -175,6 +175,15 @@ const resultTypeScoreMapping = {
   [ML_ANOMALY_RESULT_TYPE.INFLUENCER]: 'influencer_score',
 };
 
+export interface AnomalyDetectionAlertFieldFormatters {
+  numberFormatter: IFieldFormat['convert'];
+  fieldFormatters: Record<string, IFieldFormat['convert']>;
+}
+
+export interface AnomalyDetectionRuleState {
+  contextFieldFormatters?: AnomalyDetectionAlertFieldFormatters;
+}
+
 /**
  * Alerting related server-side methods
  * @param mlClient
@@ -186,9 +195,9 @@ export function alertingServiceProvider(
   getFieldsFormatRegistry: FieldFormatsRegistryProvider,
   getDataViewsService: GetDataViewsService
 ) {
-  type FieldFormatters = AwaitReturnType<ReturnType<typeof getFormatters>>;
-
   let jobs: MlJob[] = [];
+
+  let contextFieldFormatters: AnomalyDetectionAlertFieldFormatters | undefined;
 
   /**
    * Provides formatters based on the data view of the datafeed index pattern
@@ -208,10 +217,13 @@ export function alertingServiceProvider(
         }, {} as Record<string, IFieldFormat['convert']>)
       : {};
 
-    return {
+    // store formatters to pass to the executor state update
+    contextFieldFormatters = {
       numberFormatter: numberFormatter.convert.bind(numberFormatter),
       fieldFormatters,
     };
+
+    return contextFieldFormatters;
   });
 
   /**
@@ -223,7 +235,7 @@ export function alertingServiceProvider(
         const dataViewsService = await getDataViewsService();
 
         const dataViews = await dataViewsService.find(indexPattern);
-        const dataView = dataViews.find(({ title }) => title === indexPattern);
+        const dataView = dataViews.find((dView) => dView.getIndexPattern() === indexPattern);
 
         if (!dataView) return;
 
@@ -550,7 +562,7 @@ export function alertingServiceProvider(
   const getResultsToContextFormatter = (
     resultType: MlAnomalyResultType,
     useInitialScore: boolean = false,
-    formatters: FieldFormatters
+    formatters: AnomalyDetectionAlertFieldFormatters
   ) => {
     const resultsLabel = getAggResultsLabel(resultType);
     return (v: AggResultsResponse): AlertExecutionResult | undefined => {
@@ -719,7 +731,8 @@ export function alertingServiceProvider(
 
     const resultsLabel = getAggResultsLabel(params.resultType);
 
-    const fieldsFormatters = await getFormatters(datafeeds![0]!.indices[0]);
+    const fieldsFormatters =
+      contextFieldFormatters ?? (await getFormatters(datafeeds![0]!.indices[0]));
 
     const formatter = getResultsToContextFormatter(
       params.resultType,
@@ -926,7 +939,7 @@ export function alertingServiceProvider(
     | { payload: AnomalyDetectionAlertPayload; context: AnomalyDetectionAlertContext; name: string }
     | undefined
   > => {
-    const formatters = await getFormatters(indexPattern);
+    const formatters = contextFieldFormatters ?? (await getFormatters(indexPattern));
 
     const context = getResultsToContextFormatter(resultType, false, formatters)(value);
     const payload = getResultsToPayloadFormatter(resultType, false)(value);
@@ -963,13 +976,15 @@ export function alertingServiceProvider(
      */
     execute: async (
       params: MlAnomalyDetectionAlertParams,
-      spaceId: string
+      spaceId: string,
+      state?: AnomalyDetectionRuleState
     ): Promise<
       | {
           payload: AnomalyDetectionAlertPayload;
           context: AnomalyDetectionAlertContext;
           name: string;
           isHealthy: boolean;
+          stateUpdate: AnomalyDetectionRuleState;
         }
       | undefined
     > => {
@@ -981,9 +996,17 @@ export function alertingServiceProvider(
 
       const result = await fetchResult(queryParams);
 
+      if (state && isPopulatedObject(state?.contextFieldFormatters)) {
+        contextFieldFormatters = state.contextFieldFormatters;
+      }
+
       const formattedResult = result
         ? await getFormatted(queryParams.indexPattern, queryParams.resultType, spaceId, result)
         : undefined;
+
+      const stateUpdate: AnomalyDetectionRuleState = {
+        contextFieldFormatters,
+      };
 
       if (!formattedResult) {
         // If no anomalies found, report as recovered.
@@ -1032,6 +1055,7 @@ export function alertingServiceProvider(
             jobIds: queryParams.jobIds,
             message: contextMessage,
           } as AnomalyDetectionAlertContext,
+          stateUpdate,
         };
       }
 
@@ -1040,6 +1064,7 @@ export function alertingServiceProvider(
         payload: formattedResult.payload,
         name: formattedResult.name,
         isHealthy: false,
+        stateUpdate,
       };
     },
     /**


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[ML] Preserve field formatters between rule executions  (#178621)](https://github.com/elastic/kibana/pull/178621)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dima Arnautov","email":"dmitrii.arnautov@elastic.co"},"sourceCommit":{"committedDate":"2024-03-13T17:35:35Z","message":"[ML] Preserve field formatters between rule executions  (#178621)","sha":"51235a9c7a53d1a8ef9340f01c028389b9dda61e","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix",":ml","Feature:Alerting/RuleTypes","Team:ML","v8.13.0","v8.14.0"],"number":178621,"url":"https://github.com/elastic/kibana/pull/178621","mergeCommit":{"message":"[ML] Preserve field formatters between rule executions  (#178621)","sha":"51235a9c7a53d1a8ef9340f01c028389b9dda61e"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178621","number":178621,"mergeCommit":{"message":"[ML] Preserve field formatters between rule executions  (#178621)","sha":"51235a9c7a53d1a8ef9340f01c028389b9dda61e"}}]}] BACKPORT-->