### PR TITLE
[Obs ai assistant] Add dataview on the dependencies

### DIFF
--- a/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant/kibana.jsonc
@@ -13,6 +13,7 @@
       "licensing",
       "security",
       "taskManager",
+      "dataViews",
     ],
     "requiredBundles": ["kibanaReact", "kibanaUtils"],
     "optionalPlugins": ["cloud", "serverless"],

--- a/x-pack/plugins/observability_solution/observability_ai_assistant_app/kibana.jsonc
+++ b/x-pack/plugins/observability_solution/observability_ai_assistant_app/kibana.jsonc
@@ -16,7 +16,6 @@
       "lens",
       "ruleRegistry",
       "uiActions",
-      "dataViews",
       "triggersActionsUi",
       "share",
       "security",


### PR DESCRIPTION
## Summary

Adds the dataViews in the required plugins. Without this the get_dataset_info doesn't work properly.
Bonus: A small cleanup