### PR TITLE
[Dataset quality] Align size units

### DIFF
--- a/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/table/columns.tsx
+++ b/x-pack/plugins/observability_solution/dataset_quality/public/components/dataset_quality/table/columns.tsx
@@ -23,6 +23,7 @@ import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import React from 'react';
 import { css } from '@emotion/react';
+import { formatBytes } from '@kbn/formatters';
 import {
   DEGRADED_QUALITY_MINIMUM_PERCENTAGE,
   POOR_QUALITY_MINIMUM_PERCENTAGE,
@@ -194,8 +195,9 @@ export const getDatasetQualityTableColumns = ({
     },
     {
       name: sizeColumnName,
-      field: 'size',
+      field: 'sizeBytes',
       sortable: true,
+      render: (_, dataStreamStat: DataStreamStat) => formatBytes(dataStreamStat.sizeBytes || 0),
       width: '100px',
     },
     {


### PR DESCRIPTION
closes https://github.com/elastic/kibana/issues/178614

## 📝  Summary

This PR aligns the size column units format to match the format of the one in the summary panel.

<img width="1472" alt="Screenshot 2024-03-14 at 15 52 41" src="https://github.com/elastic/kibana/assets/11225826/3e54d54d-5c8e-41af-afaa-5d63bfd5b1cf">

