### PR TITLE
[Security Solution] persists the alert details flyout overview panel expandable section open/collapsed state in localStorage

### DIFF
--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.test.tsx
@@ -13,111 +13,128 @@ import {
   ALERT_DESCRIPTION_TITLE_TEST_ID,
   EVENT_KIND_DESCRIPTION_TEST_ID,
   EVENT_CATEGORY_DESCRIPTION_TEST_ID,
+  REASON_TITLE_TEST_ID,
+  MITRE_ATTACK_TITLE_TEST_ID,
 } from './test_ids';
 import { TestProviders } from '../../../../common/mock';
 import { AboutSection } from './about_section';
 import { RightPanelContext } from '../context';
 import { mockContextValue } from '../mocks/mock_context';
+import { useExpandSection } from '../hooks/use_expand_section';
 
 jest.mock('../../../../common/components/link_to');
+jest.mock('../hooks/use_expand_section');
 
-const renderAboutSection = (expanded: boolean = false) => {
-  const mockGetFieldsData = (field: string) => {
-    switch (field) {
-      case 'event.kind':
-        return 'signal';
-    }
+const mockGetFieldsData: (field: string) => string = (field: string) => {
+  switch (field) {
+    case 'event.kind':
+      return 'signal';
+    default:
+      return '';
+  }
+};
+
+const renderAboutSection = (getFieldsData = mockGetFieldsData) => {
+  const contextValue = {
+    ...mockContextValue,
+    getFieldsData,
   };
   return render(
     <TestProviders>
-      <RightPanelContext.Provider value={{ ...mockContextValue, getFieldsData: mockGetFieldsData }}>
-        <AboutSection expanded={expanded} />
+      <RightPanelContext.Provider value={contextValue}>
+        <AboutSection />
       </RightPanelContext.Provider>
     </TestProviders>
   );
 };
 
 describe('<AboutSection />', () => {
-  it('should render the component collapsed', async () => {
+  it('should render about component', async () => {
     const { getByTestId } = renderAboutSection();
     await act(async () => {
       expect(getByTestId(ABOUT_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
-    });
-  });
-
-  it('should render the component expanded', async () => {
-    const { getByTestId } = renderAboutSection(true);
-    await act(async () => {
-      expect(getByTestId(ABOUT_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(ABOUT_SECTION_HEADER_TEST_ID)).toHaveTextContent('About');
       expect(getByTestId(ABOUT_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
     });
   });
 
-  it('should expand the component when clicking on the arrow on header', async () => {
+  it('should render the component collapsed if value is false in local storage', async () => {
+    (useExpandSection as jest.Mock).mockReturnValue(false);
+
     const { getByTestId } = renderAboutSection();
     await act(async () => {
-      getByTestId(ABOUT_SECTION_HEADER_TEST_ID).click();
-      expect(getByTestId(ABOUT_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(ABOUT_SECTION_CONTENT_TEST_ID)).not.toBeVisible();
+    });
+  });
+
+  it('should render the component expanded if value is true in local storage', async () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderAboutSection();
+    await act(async () => {
+      expect(getByTestId(ABOUT_SECTION_CONTENT_TEST_ID)).toBeVisible();
     });
   });
 
   it('should render about section for signal document', async () => {
-    const { getByTestId } = renderAboutSection(true);
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderAboutSection();
     await act(async () => {
       expect(getByTestId(ALERT_DESCRIPTION_TITLE_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(REASON_TITLE_TEST_ID)).toBeInTheDocument();
+      expect(getByTestId(MITRE_ATTACK_TITLE_TEST_ID)).toBeInTheDocument();
     });
   });
 
   it('should render event kind description if event.kind is not event', async () => {
-    const mockGetFieldsData = (field: string) => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+    const _mockGetFieldsData = (field: string) => {
       switch (field) {
         case 'event.kind':
           return 'alert';
         case 'event.category':
           return 'behavior';
+        default:
+          return '';
       }
     };
-    const { getByTestId, queryByTestId } = render(
-      <TestProviders>
-        <RightPanelContext.Provider
-          value={{
-            ...mockContextValue,
-            getFieldsData: mockGetFieldsData,
-          }}
-        >
-          <AboutSection expanded />
-        </RightPanelContext.Provider>
-      </TestProviders>
-    );
+
+    const { getByTestId, queryByTestId } = renderAboutSection(_mockGetFieldsData);
     await act(async () => {
       expect(queryByTestId(ALERT_DESCRIPTION_TITLE_TEST_ID)).not.toBeInTheDocument();
+      expect(queryByTestId(REASON_TITLE_TEST_ID)).not.toBeInTheDocument();
+      expect(queryByTestId(MITRE_ATTACK_TITLE_TEST_ID)).not.toBeInTheDocument();
+
       expect(getByTestId(EVENT_KIND_DESCRIPTION_TEST_ID)).toBeInTheDocument();
+
+      expect(
+        queryByTestId(`${EVENT_CATEGORY_DESCRIPTION_TEST_ID}-behavior`)
+      ).not.toBeInTheDocument();
     });
   });
 
   it('should render event category description if event.kind is event', async () => {
-    const mockGetFieldsData = (field: string) => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+    const _mockGetFieldsData = (field: string) => {
       switch (field) {
         case 'event.kind':
           return 'event';
         case 'event.category':
           return 'behavior';
+        default:
+          return '';
       }
     };
-    const { getByTestId, queryByTestId } = render(
-      <TestProviders>
-        <RightPanelContext.Provider
-          value={{
-            ...mockContextValue,
-            getFieldsData: mockGetFieldsData,
-          }}
-        >
-          <AboutSection expanded />
-        </RightPanelContext.Provider>
-      </TestProviders>
-    );
+
+    const { getByTestId, queryByTestId } = renderAboutSection(_mockGetFieldsData);
     await act(async () => {
       expect(queryByTestId(ALERT_DESCRIPTION_TITLE_TEST_ID)).not.toBeInTheDocument();
+      expect(queryByTestId(REASON_TITLE_TEST_ID)).not.toBeInTheDocument();
+      expect(queryByTestId(MITRE_ATTACK_TITLE_TEST_ID)).not.toBeInTheDocument();
+
+      expect(queryByTestId(EVENT_KIND_DESCRIPTION_TEST_ID)).not.toBeInTheDocument();
+
       expect(getByTestId(`${EVENT_CATEGORY_DESCRIPTION_TEST_ID}-behavior`)).toBeInTheDocument();
     });
   });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -8,7 +8,6 @@
 import type { FC } from 'react';
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useKibana } from '../../../../common/lib/kibana';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { ExpandableSection } from './expandable_section';
 import { ABOUT_SECTION_TEST_ID } from './test_ids';
@@ -35,8 +34,7 @@ export const AboutSection: FC = memo(() => {
   const eventKind = getField(getFieldsData('event.kind'));
   const eventKindInECS = eventKind && isEcsAllowedValue('event.kind', eventKind);
 
-  const { storage } = useKibana().services;
-  const expanded = useExpandSection({ title: KEY, defaultValue: true, storage });
+  const expanded = useExpandSection({ title: KEY, defaultValue: true });
 
   const content =
     eventKind === EventKind.signal ? (
@@ -69,7 +67,6 @@ export const AboutSection: FC = memo(() => {
       }
       localStorageKey={KEY}
       gutterSize="s"
-      storage={storage}
       data-test-subj={ABOUT_SECTION_TEST_ID}
     >
       {content}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/about_section.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import type { VFC } from 'react';
-import React from 'react';
+import type { FC } from 'react';
+import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useExpandSection } from '../hooks/use_expand_section';
 import { ExpandableSection } from './expandable_section';
 import { ABOUT_SECTION_TEST_ID } from './test_ids';
 import { AlertDescription } from './alert_description';
@@ -19,14 +21,8 @@ import { useRightPanelContext } from '../context';
 import { isEcsAllowedValue } from '../utils/event_utils';
 import { EventCategoryDescription } from './event_category_description';
 import { EventKindDescription } from './event_kind_description';
-import { EventRenderer } from './event_renderer';
 
-export interface AboutSectionProps {
-  /**
-   * Boolean to allow the component to be expanded or collapsed on first render
-   */
-  expanded?: boolean;
-}
+const KEY = 'about';
 
 /**
  * Most top section of the overview tab.
@@ -34,30 +30,33 @@ export interface AboutSectionProps {
  * For generic events (event.kind is event), it shows the event category description and event renderer.
  * For all other events, it shows the event kind description, a list of event categories and event renderer.
  */
-export const AboutSection: VFC<AboutSectionProps> = ({ expanded = true }) => {
+export const AboutSection: FC = memo(() => {
   const { getFieldsData } = useRightPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
   const eventKindInECS = eventKind && isEcsAllowedValue('event.kind', eventKind);
 
-  if (eventKind === EventKind.signal) {
-    return (
-      <ExpandableSection
-        expanded={expanded}
-        title={
-          <FormattedMessage
-            id="xpack.securitySolution.flyout.right.about.sectionTitle"
-            defaultMessage="About"
-          />
-        }
-        data-test-subj={ABOUT_SECTION_TEST_ID}
-        gutterSize="s"
-      >
+  const { storage } = useKibana().services;
+  const expanded = useExpandSection({ title: KEY, defaultValue: true, storage });
+
+  const content =
+    eventKind === EventKind.signal ? (
+      <>
         <AlertDescription />
         <Reason />
         <MitreAttack />
-      </ExpandableSection>
+      </>
+    ) : (
+      <>
+        {eventKindInECS &&
+          (eventKind === 'event' ? (
+            // if event kind is event, show a detailed description based on event category
+            <EventCategoryDescription />
+          ) : (
+            // if event kind is not event, show a higher level description on event kind
+            <EventKindDescription eventKind={eventKind} />
+          ))}
+      </>
     );
-  }
 
   return (
     <ExpandableSection
@@ -68,20 +67,14 @@ export const AboutSection: VFC<AboutSectionProps> = ({ expanded = true }) => {
           defaultMessage="About"
         />
       }
-      data-test-subj={ABOUT_SECTION_TEST_ID}
+      localStorageKey={KEY}
       gutterSize="s"
+      storage={storage}
+      data-test-subj={ABOUT_SECTION_TEST_ID}
     >
-      {eventKindInECS &&
-        (eventKind === 'event' ? (
-          // if event kind is event, show a detailed description based on event category
-          <EventCategoryDescription />
-        ) : (
-          // if event kind is not event, show a higher level description on event kind
-          <EventKindDescription eventKind={eventKind} />
-        ))}
-      <EventRenderer />
+      {content}
     </ExpandableSection>
   );
-};
+});
 
 AboutSection.displayName = 'AboutSection';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.test.tsx
@@ -23,17 +23,24 @@ const renderExpandableSection = (expanded: boolean) =>
   );
 
 describe('<ExpandableSection />', () => {
-  it('should render the component collapsed', () => {
+  it('should render ExpandableSection component', () => {
     const { getByTestId } = renderExpandableSection(false);
 
     expect(getByTestId(headerTestId)).toBeInTheDocument();
+    expect(getByTestId(headerTestId)).toHaveTextContent('title');
+    expect(getByTestId(contentTestId)).toBeInTheDocument();
+  });
+
+  it('should render the component collapsed', () => {
+    const { getByTestId } = renderExpandableSection(false);
+
+    expect(getByTestId(contentTestId)).not.toBeVisible();
   });
 
   it('should render the component expanded', () => {
     const { getByTestId } = renderExpandableSection(true);
 
-    expect(getByTestId(headerTestId)).toBeInTheDocument();
-    expect(getByTestId(contentTestId)).toBeInTheDocument();
+    expect(getByTestId(contentTestId)).toBeVisible();
   });
 
   it('should expand the component when clicking on the arrow on header', () => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.tsx
@@ -9,7 +9,6 @@ import { EuiAccordion, EuiFlexGroup, EuiSpacer, EuiTitle, useGeneratedHtmlId } f
 import type { EuiFlexGroupProps } from '@elastic/eui';
 import type { ReactElement } from 'react';
 import React, { type VFC } from 'react';
-import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { useAccordionState } from '../hooks/use_accordion_state';
 
 export const HEADER_TEST_ID = 'Header';
@@ -33,10 +32,6 @@ export interface ExpandableSectionProps {
    */
   children: React.ReactNode;
   /**
-   * From useKibana().services.storage
-   */
-  storage?: Storage;
-  /**
    * Optional string, if provided it will be used as the key to store the expanded/collapsed state boolean in local storage
    */
   localStorageKey?: string;
@@ -52,7 +47,6 @@ export interface ExpandableSectionProps {
  * This allows the state to be preserved when opening new flyouts or when refreshing the page.
  */
 export const ExpandableSection: VFC<ExpandableSectionProps> = ({
-  storage,
   expanded,
   title,
   children,
@@ -61,7 +55,7 @@ export const ExpandableSection: VFC<ExpandableSectionProps> = ({
   'data-test-subj': dataTestSub,
 }) => {
   const accordionId = useGeneratedHtmlId({ prefix: 'accordion' });
-  const { renderContent, toggle, state } = useAccordionState(expanded);
+  const { renderContent, state, toggle } = useAccordionState(expanded);
 
   const headerDataTestSub = dataTestSub + HEADER_TEST_ID;
   const contentDataTestSub = dataTestSub + CONTENT_TEST_ID;
@@ -75,7 +69,7 @@ export const ExpandableSection: VFC<ExpandableSectionProps> = ({
   return (
     <EuiAccordion
       forceState={state}
-      onToggle={() => toggle({ storage, localStorageKey })}
+      onToggle={() => toggle(localStorageKey)}
       id={accordionId}
       buttonContent={header}
     >

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/expandable_section.tsx
@@ -9,12 +9,13 @@ import { EuiAccordion, EuiFlexGroup, EuiSpacer, EuiTitle, useGeneratedHtmlId } f
 import type { EuiFlexGroupProps } from '@elastic/eui';
 import type { ReactElement } from 'react';
 import React, { type VFC } from 'react';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import { useAccordionState } from '../hooks/use_accordion_state';
 
 export const HEADER_TEST_ID = 'Header';
 export const CONTENT_TEST_ID = 'Content';
 
-export interface DescriptionSectionProps {
+export interface ExpandableSectionProps {
   /**
    * Boolean to allow the component to be expanded or collapsed on first render
    */
@@ -32,27 +33,34 @@ export interface DescriptionSectionProps {
    */
   children: React.ReactNode;
   /**
+   * From useKibana().services.storage
+   */
+  storage?: Storage;
+  /**
+   * Optional string, if provided it will be used as the key to store the expanded/collapsed state boolean in local storage
+   */
+  localStorageKey?: string;
+  /**
    * Prefix data-test-subj to use for the header and expandable section of the accordion
    */
   ['data-test-subj']?: string;
 }
 
 /**
- * Component used to render multiple sections in the Overview tab
- * - About
- * - Investigation
- * - Visualizations
- * - Insights
+ * Component used to render multiple sections in the Overview tab.
+ * The state (expanded vs collapsed) can be saved in local storage if the localStorageKey is provided.
+ * This allows the state to be preserved when opening new flyouts or when refreshing the page.
  */
-export const ExpandableSection: VFC<DescriptionSectionProps> = ({
+export const ExpandableSection: VFC<ExpandableSectionProps> = ({
+  storage,
   expanded,
   title,
   children,
   gutterSize = 'none',
+  localStorageKey,
   'data-test-subj': dataTestSub,
 }) => {
   const accordionId = useGeneratedHtmlId({ prefix: 'accordion' });
-
   const { renderContent, toggle, state } = useAccordionState(expanded);
 
   const headerDataTestSub = dataTestSub + HEADER_TEST_ID;
@@ -65,7 +73,12 @@ export const ExpandableSection: VFC<DescriptionSectionProps> = ({
   );
 
   return (
-    <EuiAccordion forceState={state} onToggle={toggle} id={accordionId} buttonContent={header}>
+    <EuiAccordion
+      forceState={state}
+      onToggle={() => toggle({ storage, localStorageKey })}
+      id={accordionId}
+      buttonContent={header}
+    >
       <EuiSpacer size="m" />
       <EuiFlexGroup gutterSize={gutterSize} direction="column" data-test-subj={contentDataTestSub}>
         {renderContent && children}

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.test.tsx
@@ -12,6 +12,9 @@ import {
   INSIGHTS_HEADER_TEST_ID,
   INSIGHTS_THREAT_INTELLIGENCE_TEST_ID,
   CORRELATIONS_TEST_ID,
+  INSIGHTS_CONTENT_TEST_ID,
+  INSIGHTS_ENTITIES_TEST_ID,
+  PREVALENCE_TEST_ID,
 } from './test_ids';
 import { TestProviders } from '../../../../common/mock';
 import { useFirstLastSeen } from '../../../../common/containers/use_first_last_seen';
@@ -24,6 +27,7 @@ import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_f
 import { InsightsSection } from './insights_section';
 import { useAlertPrevalence } from '../../../../common/containers/alerts/use_alert_prevalence';
 import { useRiskScore } from '../../../../entity_analytics/api/hooks/use_risk_score';
+import { useExpandSection } from '../hooks/use_expand_section';
 
 jest.mock('../../../../common/containers/alerts/use_alert_prevalence');
 
@@ -55,6 +59,7 @@ const from = '2022-04-05T12:00:00.000Z';
 const to = '2022-04-08T12:00:00.;000Z';
 const selectedPatterns = 'alerts';
 
+jest.mock('../hooks/use_expand_section');
 const mockUseGlobalTime = jest.fn().mockReturnValue({ from, to });
 jest.mock('../../../../common/containers/use_global_time', () => {
   return {
@@ -85,11 +90,11 @@ jest.mock('../hooks/use_fetch_threat_intelligence');
 
 jest.mock('../../shared/hooks/use_prevalence');
 
-const renderInsightsSection = (contextValue: RightPanelContext, expanded: boolean) =>
+const renderInsightsSection = (contextValue: RightPanelContext) =>
   render(
     <TestProviders>
       <RightPanelContext.Provider value={contextValue}>
-        <InsightsSection expanded={expanded} />
+        <InsightsSection />
       </RightPanelContext.Provider>
     </TestProviders>
   );
@@ -118,28 +123,65 @@ describe('<InsightsSection />', () => {
       getFieldsData: mockGetFieldsData,
     } as unknown as RightPanelContext;
 
-    const wrapper = renderInsightsSection(contextValue, false);
+    const wrapper = renderInsightsSection(contextValue);
 
     expect(wrapper.getByTestId(INSIGHTS_HEADER_TEST_ID)).toBeInTheDocument();
-    expect(wrapper.getAllByRole('button')[0]).toHaveAttribute('aria-expanded', 'false');
-    expect(wrapper.getAllByRole('button')[0]).not.toHaveAttribute('disabled');
+    expect(wrapper.getByTestId(INSIGHTS_HEADER_TEST_ID)).toHaveTextContent('Insights');
+    expect(wrapper.getByTestId(INSIGHTS_CONTENT_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should render insights component as expanded when expanded is true', () => {
+  it('should render the component collapsed if value is false in local storage', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(false);
+
     const contextValue = {
       eventId: 'some_Id',
       dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
       getFieldsData: mockGetFieldsData,
     } as unknown as RightPanelContext;
 
-    const wrapper = renderInsightsSection(contextValue, true);
+    const wrapper = renderInsightsSection(contextValue);
+    expect(wrapper.getByTestId(INSIGHTS_CONTENT_TEST_ID)).not.toBeVisible();
+  });
 
-    expect(wrapper.getByTestId(INSIGHTS_HEADER_TEST_ID)).toBeInTheDocument();
-    expect(wrapper.getAllByRole('button')[0]).toHaveAttribute('aria-expanded', 'true');
-    expect(wrapper.getAllByRole('button')[0]).not.toHaveAttribute('disabled');
+  it('should render the component expanded if value is true in local storage', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const contextValue = {
+      eventId: 'some_Id',
+      dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
+      getFieldsData: mockGetFieldsData,
+    } as unknown as RightPanelContext;
+
+    const wrapper = renderInsightsSection(contextValue);
+    expect(wrapper.getByTestId(INSIGHTS_CONTENT_TEST_ID)).toBeVisible();
+  });
+
+  it('should render all children when event kind is signal', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const getFieldsData = (field: string) => {
+      switch (field) {
+        case 'event.kind':
+          return 'signal';
+      }
+    };
+    const contextValue = {
+      eventId: 'some_Id',
+      getFieldsData,
+      documentIsSignal: true,
+    } as unknown as RightPanelContext;
+
+    const { getByTestId } = renderInsightsSection(contextValue);
+
+    expect(getByTestId(`${INSIGHTS_ENTITIES_TEST_ID}LeftSection`)).toBeInTheDocument();
+    expect(getByTestId(`${INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}LeftSection`)).toBeInTheDocument();
+    expect(getByTestId(`${CORRELATIONS_TEST_ID}LeftSection`)).toBeInTheDocument();
+    expect(getByTestId(`${PREVALENCE_TEST_ID}LeftSection`)).toBeInTheDocument();
   });
 
   it('should not render threat intel and correlations insights component when document is not signal', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
     const getFieldsData = (field: string) => {
       switch (field) {
         case 'event.kind':
@@ -152,10 +194,13 @@ describe('<InsightsSection />', () => {
       documentIsSignal: false,
     } as unknown as RightPanelContext;
 
-    const { getByTestId, queryByTestId } = renderInsightsSection(contextValue, false);
+    const { getByTestId, queryByTestId } = renderInsightsSection(contextValue);
 
-    expect(getByTestId(INSIGHTS_HEADER_TEST_ID)).toBeInTheDocument();
-    expect(queryByTestId(INSIGHTS_THREAT_INTELLIGENCE_TEST_ID)).not.toBeInTheDocument();
-    expect(queryByTestId(CORRELATIONS_TEST_ID)).not.toBeInTheDocument();
+    expect(getByTestId(`${INSIGHTS_ENTITIES_TEST_ID}LeftSection`)).toBeInTheDocument();
+    expect(
+      queryByTestId(`${INSIGHTS_THREAT_INTELLIGENCE_TEST_ID}LeftSection`)
+    ).not.toBeInTheDocument();
+    expect(queryByTestId(`${CORRELATIONS_TEST_ID}LeftSection`)).not.toBeInTheDocument();
+    expect(getByTestId(`${PREVALENCE_TEST_ID}LeftSection`)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
@@ -19,7 +19,6 @@ import { ExpandableSection } from './expandable_section';
 import { useRightPanelContext } from '../context';
 import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
-import { useKibana } from '../../../../common/lib/kibana';
 
 const KEY = 'insights';
 
@@ -30,8 +29,7 @@ export const InsightsSection: FC = memo(() => {
   const { getFieldsData } = useRightPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
 
-  const { storage } = useKibana().services;
-  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+  const expanded = useExpandSection({ title: KEY, defaultValue: false });
 
   return (
     <ExpandableSection
@@ -43,7 +41,6 @@ export const InsightsSection: FC = memo(() => {
         />
       }
       localStorageKey={KEY}
-      storage={storage}
       data-test-subj={INSIGHTS_TEST_ID}
     >
       <EntitiesOverview />

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/insights_section.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import React from 'react';
+import type { FC } from 'react';
+import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useExpandSection } from '../hooks/use_expand_section';
 import { CorrelationsOverview } from './correlations_overview';
 import { PrevalenceOverview } from './prevalence_overview';
 import { ThreatIntelligenceOverview } from './threat_intelligence_overview';
@@ -17,30 +19,31 @@ import { ExpandableSection } from './expandable_section';
 import { useRightPanelContext } from '../context';
 import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
+import { useKibana } from '../../../../common/lib/kibana';
 
-export interface InsightsSectionProps {
-  /**
-   * Boolean to allow the component to be expanded or collapsed on first render
-   */
-  expanded?: boolean;
-}
+const KEY = 'insights';
 
 /**
  * Insights section under overview tab. It contains entities, threat intelligence, prevalence and correlations.
  */
-export const InsightsSection: React.FC<InsightsSectionProps> = ({ expanded = false }) => {
+export const InsightsSection: FC = memo(() => {
   const { getFieldsData } = useRightPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
 
+  const { storage } = useKibana().services;
+  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+
   return (
     <ExpandableSection
+      expanded={expanded}
       title={
         <FormattedMessage
           id="xpack.securitySolution.flyout.right.insights.sectionTitle"
           defaultMessage="Insights"
         />
       }
-      expanded={expanded}
+      localStorageKey={KEY}
+      storage={storage}
       data-test-subj={INSIGHTS_TEST_ID}
     >
       <EntitiesOverview />
@@ -56,6 +59,6 @@ export const InsightsSection: React.FC<InsightsSectionProps> = ({ expanded = fal
       <PrevalenceOverview />
     </ExpandableSection>
   );
-};
+});
 
 InsightsSection.displayName = 'InsightsSection';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -5,10 +5,12 @@
  * 2.0.
  */
 
-import type { VFC } from 'react';
-import React from 'react';
+import type { FC } from 'react';
+import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useExpandSection } from '../hooks/use_expand_section';
 import { ExpandableSection } from './expandable_section';
 import { HighlightedFields } from './highlighted_fields';
 import { INVESTIGATION_SECTION_TEST_ID } from './test_ids';
@@ -17,20 +19,18 @@ import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
 import { useRightPanelContext } from '../context';
 
-export interface DescriptionSectionProps {
-  /**
-   * Boolean to allow the component to be expanded or collapsed on first render
-   */
-  expanded?: boolean;
-}
+const KEY = 'investigation';
 
 /**
  * Second section of the overview tab in details flyout.
  * It contains investigation guide (alerts only) and highlighted fields
  */
-export const InvestigationSection: VFC<DescriptionSectionProps> = ({ expanded = true }) => {
+export const InvestigationSection: FC = memo(() => {
   const { getFieldsData } = useRightPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
+
+  const { storage } = useKibana().services;
+  const expanded = useExpandSection({ title: KEY, defaultValue: true, storage });
 
   return (
     <ExpandableSection
@@ -41,8 +41,10 @@ export const InvestigationSection: VFC<DescriptionSectionProps> = ({ expanded = 
           defaultMessage="Investigation"
         />
       }
-      data-test-subj={INVESTIGATION_SECTION_TEST_ID}
+      localStorageKey={KEY}
       gutterSize="s"
+      storage={storage}
+      data-test-subj={INVESTIGATION_SECTION_TEST_ID}
     >
       {eventKind === EventKind.signal && (
         <>
@@ -53,6 +55,6 @@ export const InvestigationSection: VFC<DescriptionSectionProps> = ({ expanded = 
       <HighlightedFields />
     </ExpandableSection>
   );
-};
+});
 
 InvestigationSection.displayName = 'InvestigationSection';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/investigation_section.tsx
@@ -9,7 +9,6 @@ import type { FC } from 'react';
 import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useKibana } from '../../../../common/lib/kibana';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { ExpandableSection } from './expandable_section';
 import { HighlightedFields } from './highlighted_fields';
@@ -29,8 +28,7 @@ export const InvestigationSection: FC = memo(() => {
   const { getFieldsData } = useRightPanelContext();
   const eventKind = getField(getFieldsData('event.kind'));
 
-  const { storage } = useKibana().services;
-  const expanded = useExpandSection({ title: KEY, defaultValue: true, storage });
+  const expanded = useExpandSection({ title: KEY, defaultValue: true });
 
   return (
     <ExpandableSection
@@ -43,7 +41,6 @@ export const InvestigationSection: FC = memo(() => {
       }
       localStorageKey={KEY}
       gutterSize="s"
-      storage={storage}
       data-test-subj={INVESTIGATION_SECTION_TEST_ID}
     >
       {eventKind === EventKind.signal && (

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.test.tsx
@@ -8,11 +8,18 @@
 import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
-import { RESPONSE_SECTION_CONTENT_TEST_ID, RESPONSE_SECTION_HEADER_TEST_ID } from './test_ids';
+import {
+  RESPONSE_BUTTON_TEST_ID,
+  RESPONSE_SECTION_CONTENT_TEST_ID,
+  RESPONSE_SECTION_HEADER_TEST_ID,
+} from './test_ids';
 import { RightPanelContext } from '../context';
 import { mockContextValue } from '../mocks/mock_context';
 import { ResponseSection } from './response_section';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
+import { useExpandSection } from '../hooks/use_expand_section';
+
+jest.mock('../hooks/use_expand_section');
 
 const PREVIEW_MESSAGE = 'Response is not available in alert preview.';
 
@@ -28,27 +35,58 @@ const renderResponseSection = () =>
   );
 
 describe('<ResponseSection />', () => {
-  it('should render the component collapsed', () => {
+  it('should render response component', () => {
     const { getByTestId } = renderResponseSection();
 
     expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
-  });
-
-  it('should render the component expanded', () => {
-    const { getByTestId } = renderResponseSection();
-
-    expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
+    expect(getByTestId(RESPONSE_SECTION_HEADER_TEST_ID)).toHaveTextContent('Response');
     expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should expand the component when clicking on the arrow on header', () => {
-    const { getByTestId } = renderResponseSection();
+  it('should render the component collapsed if value is false in local storage', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(false);
 
-    getByTestId(RESPONSE_SECTION_HEADER_TEST_ID).click();
-    expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
+    const { getByTestId } = renderResponseSection();
+    expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).not.toBeVisible();
+  });
+
+  it('should render the component expanded if value is true in local storage', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderResponseSection();
+    expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toBeVisible();
+  });
+
+  it('should render response button for event kind signal', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const mockGetFieldsData = (field: string) => {
+      switch (field) {
+        case 'event.kind':
+          return 'signal';
+      }
+    };
+
+    const { getByTestId } = render(
+      <IntlProvider locale="en">
+        <TestProvider>
+          <RightPanelContext.Provider
+            value={{
+              ...mockContextValue,
+              getFieldsData: mockGetFieldsData,
+            }}
+          >
+            <ResponseSection />
+          </RightPanelContext.Provider>
+        </TestProvider>
+      </IntlProvider>
+    );
+    expect(getByTestId(RESPONSE_BUTTON_TEST_ID)).toBeInTheDocument();
   });
 
   it('should render preview message if flyout is in preview', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
     const { getByTestId } = render(
       <IntlProvider locale="en">
         <TestProvider>
@@ -58,11 +96,12 @@ describe('<ResponseSection />', () => {
         </TestProvider>
       </IntlProvider>
     );
-    getByTestId(RESPONSE_SECTION_HEADER_TEST_ID).click();
     expect(getByTestId(RESPONSE_SECTION_CONTENT_TEST_ID)).toHaveTextContent(PREVIEW_MESSAGE);
   });
 
   it('should render empty component if document is not signal', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
     const mockGetFieldsData = (field: string) => {
       switch (field) {
         case 'event.kind':

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -8,7 +8,6 @@
 import type { FC } from 'react';
 import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useKibana } from '../../../../common/lib/kibana';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { ResponseButton } from './response_button';
 import { ExpandableSection } from './expandable_section';
@@ -25,8 +24,7 @@ const KEY = 'response';
 export const ResponseSection: FC = memo(() => {
   const { isPreview, getFieldsData } = useRightPanelContext();
 
-  const { storage } = useKibana().services;
-  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+  const expanded = useExpandSection({ title: KEY, defaultValue: false });
 
   const eventKind = getField(getFieldsData('event.kind'));
   if (eventKind !== EventKind.signal) {
@@ -43,7 +41,6 @@ export const ResponseSection: FC = memo(() => {
         />
       }
       localStorageKey={KEY}
-      storage={storage}
       data-test-subj={RESPONSE_SECTION_TEST_ID}
     >
       {isPreview ? (

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/response_section.tsx
@@ -5,9 +5,11 @@
  * 2.0.
  */
 
-import type { VFC } from 'react';
-import React from 'react';
+import type { FC } from 'react';
+import React, { memo } from 'react';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useExpandSection } from '../hooks/use_expand_section';
 import { ResponseButton } from './response_button';
 import { ExpandableSection } from './expandable_section';
 import { useRightPanelContext } from '../context';
@@ -15,18 +17,17 @@ import { getField } from '../../shared/utils';
 import { EventKind } from '../../shared/constants/event_kinds';
 import { RESPONSE_SECTION_TEST_ID } from './test_ids';
 
-export interface ResponseSectionProps {
-  /**
-   * Boolean to allow the component to be expanded or collapsed on first render
-   */
-  expanded?: boolean;
-}
+const KEY = 'response';
 
 /**
  * Most bottom section of the overview tab. It contains a summary of the response tab.
  */
-export const ResponseSection: VFC<ResponseSectionProps> = ({ expanded = false }) => {
+export const ResponseSection: FC = memo(() => {
   const { isPreview, getFieldsData } = useRightPanelContext();
+
+  const { storage } = useKibana().services;
+  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+
   const eventKind = getField(getFieldsData('event.kind'));
   if (eventKind !== EventKind.signal) {
     return null;
@@ -41,6 +42,8 @@ export const ResponseSection: VFC<ResponseSectionProps> = ({ expanded = false })
           defaultMessage="Response"
         />
       }
+      localStorageKey={KEY}
+      storage={storage}
       data-test-subj={RESPONSE_SECTION_TEST_ID}
     >
       {isPreview ? (
@@ -53,6 +56,6 @@ export const ResponseSection: VFC<ResponseSectionProps> = ({ expanded = false })
       )}
     </ExpandableSection>
   );
-};
+});
 
 ResponseSection.displayName = 'ResponseSection';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/test_ids.ts
@@ -80,7 +80,8 @@ export const HIGHLIGHTED_FIELDS_AGENT_STATUS_CELL_TEST_ID =
 /* Insights section */
 
 export const INSIGHTS_TEST_ID = `${PREFIX}Insights` as const;
-export const INSIGHTS_HEADER_TEST_ID = `${INSIGHTS_TEST_ID}Header` as const;
+export const INSIGHTS_HEADER_TEST_ID = INSIGHTS_TEST_ID + HEADER_TEST_ID;
+export const INSIGHTS_CONTENT_TEST_ID = INSIGHTS_TEST_ID + CONTENT_TEST_ID;
 
 /* Summary row */
 
@@ -140,7 +141,8 @@ export const PREVALENCE_TEST_ID = `${PREFIX}InsightsPrevalence` as const;
 /* Visualizations section */
 
 export const VISUALIZATIONS_TEST_ID = `${PREFIX}Visualizations` as const;
-export const VISUALIZATIONS_SECTION_HEADER_TEST_ID = `${VISUALIZATIONS_TEST_ID}Header` as const;
+export const VISUALIZATIONS_SECTION_HEADER_TEST_ID = VISUALIZATIONS_TEST_ID + HEADER_TEST_ID;
+export const VISUALIZATIONS_SECTION_CONTENT_TEST_ID = VISUALIZATIONS_TEST_ID + CONTENT_TEST_ID;
 export const ANALYZER_PREVIEW_TEST_ID = `${PREFIX}AnalyzerPreview` as const;
 export const ANALYZER_PREVIEW_LOADING_TEST_ID = `${ANALYZER_PREVIEW_TEST_ID}Loading` as const;
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.test.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.test.tsx
@@ -8,8 +8,12 @@
 import React from 'react';
 import { __IntlProvider as IntlProvider } from '@kbn/i18n-react';
 import { render } from '@testing-library/react';
-import { VISUALIZATIONS_SECTION_HEADER_TEST_ID } from './test_ids';
-import { TestProviders } from '../../../../common/mock';
+import {
+  ANALYZER_PREVIEW_TEST_ID,
+  SESSION_PREVIEW_TEST_ID,
+  VISUALIZATIONS_SECTION_CONTENT_TEST_ID,
+  VISUALIZATIONS_SECTION_HEADER_TEST_ID,
+} from './test_ids';
 import { VisualizationsSection } from './visualizations_section';
 import { mockContextValue } from '../mocks/mock_context';
 import { mockDataFormattedForFieldBrowser } from '../../shared/mocks/mock_data_formatted_for_field_browser';
@@ -17,7 +21,11 @@ import { RightPanelContext } from '../context';
 import { useAlertPrevalenceFromProcessTree } from '../../../../common/containers/alerts/use_alert_prevalence_from_process_tree';
 import { useTimelineDataFilters } from '../../../../timelines/containers/use_timeline_data_filters';
 import { TestProvider } from '@kbn/expandable-flyout/src/test/provider';
+import { useExpandSection } from '../hooks/use_expand_section';
+import { useInvestigateInTimeline } from '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline';
+import { useIsInvestigateInResolverActionEnabled } from '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver';
 
+jest.mock('../hooks/use_expand_section');
 jest.mock('../../../../common/containers/alerts/use_alert_prevalence_from_process_tree', () => ({
   useAlertPrevalenceFromProcessTree: jest.fn(),
 }));
@@ -27,11 +35,36 @@ jest.mock('../../../../timelines/containers/use_timeline_data_filters', () => ({
   useTimelineDataFilters: jest.fn(),
 }));
 const mockUseTimelineDataFilters = useTimelineDataFilters as jest.Mock;
+jest.mock('react-redux', () => {
+  const original = jest.requireActual('react-redux');
 
-const contextValue = {
+  return {
+    ...original,
+    useDispatch: () => jest.fn(),
+  };
+});
+jest.mock(
+  '../../../../detections/components/alerts_table/timeline_actions/use_investigate_in_timeline'
+);
+jest.mock(
+  '../../../../detections/components/alerts_table/timeline_actions/investigate_in_resolver'
+);
+
+const panelContextValue = {
   ...mockContextValue,
   dataFormattedForFieldBrowser: mockDataFormattedForFieldBrowser,
 };
+
+const renderVisualizationsSection = (contextValue = panelContextValue) =>
+  render(
+    <IntlProvider locale="en">
+      <TestProvider>
+        <RightPanelContext.Provider value={contextValue}>
+          <VisualizationsSection />
+        </RightPanelContext.Provider>
+      </TestProvider>
+    </IntlProvider>
+  );
 
 describe('<VisualizationsSection />', () => {
   beforeEach(() => {
@@ -45,32 +78,31 @@ describe('<VisualizationsSection />', () => {
   });
 
   it('should render visualizations component', () => {
-    const { getByTestId, getAllByRole } = render(
-      <IntlProvider locale="en">
-        <TestProvider>
-          <RightPanelContext.Provider value={contextValue}>
-            <VisualizationsSection />
-          </RightPanelContext.Provider>
-        </TestProvider>
-      </IntlProvider>
-    );
+    const { getByTestId } = renderVisualizationsSection();
 
     expect(getByTestId(VISUALIZATIONS_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
-    expect(getAllByRole('button')[0]).toHaveAttribute('aria-expanded', 'false');
-    expect(getAllByRole('button')[0]).not.toHaveAttribute('disabled');
+    expect(getByTestId(VISUALIZATIONS_SECTION_HEADER_TEST_ID)).toHaveTextContent('Visualizations');
+    expect(getByTestId(VISUALIZATIONS_SECTION_CONTENT_TEST_ID)).toBeInTheDocument();
   });
 
-  it('should render visualization component as expanded when expanded is true', () => {
-    const { getByTestId, getAllByRole } = render(
-      <TestProviders>
-        <RightPanelContext.Provider value={contextValue}>
-          <VisualizationsSection expanded={true} />
-        </RightPanelContext.Provider>
-      </TestProviders>
-    );
+  it('should render the component collapsed if value is false in local storage', () => {
+    (useExpandSection as jest.Mock).mockReturnValue(false);
 
-    expect(getByTestId(VISUALIZATIONS_SECTION_HEADER_TEST_ID)).toBeInTheDocument();
-    expect(getAllByRole('button')[0]).toHaveAttribute('aria-expanded', 'true');
-    expect(getAllByRole('button')[0]).not.toHaveAttribute('disabled');
+    const { getByTestId } = renderVisualizationsSection();
+    expect(getByTestId(VISUALIZATIONS_SECTION_CONTENT_TEST_ID)).not.toBeVisible();
+  });
+
+  it('should render the component expanded if value is true in local storage', () => {
+    (useInvestigateInTimeline as jest.Mock).mockReturnValue({
+      investigateInTimelineAlertClick: jest.fn(),
+    });
+    (useIsInvestigateInResolverActionEnabled as jest.Mock).mockReturnValue(true);
+    (useExpandSection as jest.Mock).mockReturnValue(true);
+
+    const { getByTestId } = renderVisualizationsSection();
+    expect(getByTestId(VISUALIZATIONS_SECTION_CONTENT_TEST_ID)).toBeVisible();
+
+    expect(getByTestId(`${SESSION_PREVIEW_TEST_ID}LeftSection`)).toBeInTheDocument();
+    expect(getByTestId(`${ANALYZER_PREVIEW_TEST_ID}LeftSection`)).toBeInTheDocument();
   });
 });

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.tsx
@@ -9,7 +9,6 @@ import type { FC } from 'react';
 import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
-import { useKibana } from '../../../../common/lib/kibana';
 import { useExpandSection } from '../hooks/use_expand_section';
 import { AnalyzerPreviewContainer } from './analyzer_preview_container';
 import { SessionPreviewContainer } from './session_preview_container';
@@ -22,8 +21,7 @@ const KEY = 'visualizations';
  * Visualizations section in overview. It contains analyzer preview and session view preview.
  */
 export const VisualizationsSection: FC = memo(() => {
-  const { storage } = useKibana().services;
-  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+  const expanded = useExpandSection({ title: KEY, defaultValue: false });
 
   return (
     <ExpandableSection
@@ -35,7 +33,6 @@ export const VisualizationsSection: FC = memo(() => {
         />
       }
       localStorageKey={KEY}
-      storage={storage}
       data-test-subj={VISUALIZATIONS_TEST_ID}
     >
       <SessionPreviewContainer />

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.tsx
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/components/visualizations_section.tsx
@@ -5,27 +5,26 @@
  * 2.0.
  */
 
-import React from 'react';
+import type { FC } from 'react';
+import React, { memo } from 'react';
 import { EuiSpacer } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
+import { useKibana } from '../../../../common/lib/kibana';
+import { useExpandSection } from '../hooks/use_expand_section';
 import { AnalyzerPreviewContainer } from './analyzer_preview_container';
 import { SessionPreviewContainer } from './session_preview_container';
 import { ExpandableSection } from './expandable_section';
 import { VISUALIZATIONS_TEST_ID } from './test_ids';
 
-export interface VisualizationsSectionProps {
-  /**
-   * Boolean to allow the component to be expanded or collapsed on first render
-   */
-  expanded?: boolean;
-}
+const KEY = 'visualizations';
 
 /**
  * Visualizations section in overview. It contains analyzer preview and session view preview.
  */
-export const VisualizationsSection: React.FC<VisualizationsSectionProps> = ({
-  expanded = false,
-}) => {
+export const VisualizationsSection: FC = memo(() => {
+  const { storage } = useKibana().services;
+  const expanded = useExpandSection({ title: KEY, defaultValue: false, storage });
+
   return (
     <ExpandableSection
       expanded={expanded}
@@ -35,15 +34,15 @@ export const VisualizationsSection: React.FC<VisualizationsSectionProps> = ({
           defaultMessage="Visualizations"
         />
       }
+      localStorageKey={KEY}
+      storage={storage}
       data-test-subj={VISUALIZATIONS_TEST_ID}
     >
       <SessionPreviewContainer />
-
       <EuiSpacer />
-
       <AnalyzerPreviewContainer />
     </ExpandableSection>
   );
-};
+});
 
 VisualizationsSection.displayName = 'VisualizationsSection';

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
@@ -12,6 +12,7 @@ import { renderHook } from '@testing-library/react-hooks';
 import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 
 const mockSet = jest.fn();
+
 describe('useAccordionState', () => {
   let hookResult: RenderHookResult<boolean, UseAccordionStateValue>;
 
@@ -38,7 +39,7 @@ describe('toggleReducer', () => {
     const mockLocalStorageKey = 'test';
     const mockAction = {
       storage: mockStorage,
-      localStorageKey: mockLocalStorageKey,
+      title: mockLocalStorageKey,
     } as unknown as ToggleReducerAction;
     const mockState = 'closed';
 

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ToggleReducerAction, UseAccordionStateValue } from './use_accordion_state';
+import { useAccordionState, toggleReducer } from './use_accordion_state';
+import type { RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
+
+const mockSet = jest.fn();
+describe('useAccordionState', () => {
+  let hookResult: RenderHookResult<boolean, UseAccordionStateValue>;
+
+  it('should return initial value', () => {
+    hookResult = renderHook((props: boolean) => useAccordionState(props), {
+      initialProps: true,
+    });
+
+    expect(hookResult.result.current.renderContent).toBe(true);
+    expect(hookResult.result.current.state).toBe('open');
+  });
+});
+
+describe('toggleReducer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return correct state and pass values to localStorage', () => {
+    const mockStorage = {
+      get: jest.fn(),
+      set: mockSet,
+    };
+    const mockLocalStorageKey = 'test';
+    const mockAction = {
+      storage: mockStorage,
+      localStorageKey: mockLocalStorageKey,
+    } as unknown as ToggleReducerAction;
+    const mockState = 'closed';
+
+    const result = toggleReducer(mockState, mockAction);
+    expect(result).toBe('open');
+    expect(mockSet).toHaveBeenCalledWith(FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS, {
+      [mockLocalStorageKey]: true,
+    });
+  });
+
+  it(`should not pass values to localStorage if key isn't provided`, () => {
+    const mockStorage = {
+      get: jest.fn(),
+      set: mockSet,
+    };
+    const mockAction = {
+      storage: mockStorage,
+    } as unknown as ToggleReducerAction;
+    const mockState = 'open';
+
+    const result = toggleReducer(mockState, mockAction);
+    expect(result).toBe('closed');
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_accordion_state.ts
@@ -5,13 +5,41 @@
  * 2.0.
  */
 
+import type { Dispatch } from 'react';
 import { useReducer } from 'react';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 
 const CLOSED = 'closed' as const;
 const OPEN = 'open' as const;
-
 type ToggleReducerState = typeof CLOSED | typeof OPEN;
-const toggleReducer = (state: ToggleReducerState) => {
+
+export interface ToggleReducerAction {
+  /**
+   * From useKibana().services.storage
+   */
+  storage: Storage | undefined;
+  /**
+   * Key to store in local storage
+   */
+  localStorageKey: string | undefined;
+}
+
+/**
+ * Reducer for toggling between expanded and collapsed states.
+ * Every time the user takes an action, we store the new state in local storage. This allows to preserve the state when opening new flyouts or when refreshing the page.
+ * The object stored is a map of section names to expanded boolean values.
+ */
+export const toggleReducer = (state: ToggleReducerState, action: ToggleReducerAction) => {
+  const { storage, localStorageKey } = action;
+  if (storage && localStorageKey) {
+    const localStorage = storage.get(FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS);
+    storage.set(FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS, {
+      ...localStorage,
+      [localStorageKey]: state !== OPEN,
+    });
+  }
+
   return state === CLOSED ? OPEN : CLOSED;
 };
 
@@ -28,11 +56,11 @@ export interface UseAccordionStateValue {
   /**
    * Handler function for cycling between the states
    */
-  toggle: VoidFunction;
+  toggle: Dispatch<ToggleReducerAction>;
 }
 
 /**
- * Tiny hook for controlled AccordionState
+ * Hook to control the state of the EuiAccordion. It will store the state in local storage if the localStorageKey is provided.
  * @param expandedInitially - is accordion expanded on first render
  */
 export const useAccordionState = (expandedInitially: boolean): UseAccordionStateValue => {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
@@ -7,21 +7,27 @@
 
 import type { RenderHookResult } from '@testing-library/react-hooks';
 import { renderHook } from '@testing-library/react-hooks';
-import type { Storage } from '@kbn/kibana-utils-plugin/public';
 import type { UseExpandSectionParams } from './use_expand_section';
 import { useExpandSection } from './use_expand_section';
+import { useKibana } from '../../../../common/lib/kibana';
+
+jest.mock('../../../../common/lib/kibana');
 
 describe('useExpandSection', () => {
   let hookResult: RenderHookResult<UseExpandSectionParams, boolean>;
 
   it('should return default value if nothing in localStorage', () => {
-    const mockStorage = {
-      get: jest.fn().mockReturnValue(undefined),
-    };
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => undefined,
+        },
+      },
+    });
+
     const initialProps: UseExpandSectionParams = {
       title: 'test',
       defaultValue: true,
-      storage: mockStorage as unknown as Storage,
     };
 
     hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
@@ -32,13 +38,16 @@ describe('useExpandSection', () => {
   });
 
   it(`should return default value if localStorage doesn't have the correct key`, () => {
-    const mockStorage = {
-      get: jest.fn().mockReturnValue({ other: false }),
-    };
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => ({ other: false }),
+        },
+      },
+    });
     const initialProps: UseExpandSectionParams = {
       title: 'test',
       defaultValue: true,
-      storage: mockStorage as unknown as Storage,
     };
 
     hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
@@ -49,13 +58,36 @@ describe('useExpandSection', () => {
   });
 
   it('should return value from local storage', () => {
-    const mockStorage = {
-      get: jest.fn().mockReturnValue({ test: false }),
-    };
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => ({ test: false }),
+        },
+      },
+    });
     const initialProps: UseExpandSectionParams = {
       title: 'test',
       defaultValue: true,
-      storage: mockStorage as unknown as Storage,
+    };
+
+    hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
+      initialProps,
+    });
+
+    expect(hookResult.result.current).toBe(false);
+  });
+
+  it('should check against lowercase values', () => {
+    (useKibana as jest.Mock).mockReturnValue({
+      services: {
+        storage: {
+          get: () => ({ test: false }),
+        },
+      },
+    });
+    const initialProps: UseExpandSectionParams = {
+      title: 'Test',
+      defaultValue: true,
     };
 
     hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RenderHookResult } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import type { UseExpandSectionParams } from './use_expand_section';
+import { useExpandSection } from './use_expand_section';
+
+describe('useExpandSection', () => {
+  let hookResult: RenderHookResult<UseExpandSectionParams, boolean>;
+
+  it('should return default value if nothing in localStorage', () => {
+    const mockStorage = {
+      get: jest.fn().mockReturnValue(undefined),
+    };
+    const initialProps: UseExpandSectionParams = {
+      title: 'test',
+      defaultValue: true,
+      storage: mockStorage as unknown as Storage,
+    };
+
+    hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
+      initialProps,
+    });
+
+    expect(hookResult.result.current).toBe(true);
+  });
+
+  it(`should return default value if localStorage doesn't have the correct key`, () => {
+    const mockStorage = {
+      get: jest.fn().mockReturnValue({ other: false }),
+    };
+    const initialProps: UseExpandSectionParams = {
+      title: 'test',
+      defaultValue: true,
+      storage: mockStorage as unknown as Storage,
+    };
+
+    hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
+      initialProps,
+    });
+
+    expect(hookResult.result.current).toBe(true);
+  });
+
+  it('should return value from local storage', () => {
+    const mockStorage = {
+      get: jest.fn().mockReturnValue({ test: false }),
+    };
+    const initialProps: UseExpandSectionParams = {
+      title: 'test',
+      defaultValue: true,
+      storage: mockStorage as unknown as Storage,
+    };
+
+    hookResult = renderHook((props: UseExpandSectionParams) => useExpandSection(props), {
+      initialProps,
+    });
+
+    expect(hookResult.result.current).toBe(false);
+  });
+});

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import { useKibana } from '../../../../common/lib/kibana';
 import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
 
 export interface UseExpandSectionParams {
@@ -17,20 +17,14 @@ export interface UseExpandSectionParams {
    * Default value for the section
    */
   defaultValue: boolean;
-  /**
-   * From useKibana().services.storage
-   */
-  storage: Storage;
 }
 
 /**
  * Hook to get the expanded state of a section from local storage.
  */
-export const useExpandSection = ({
-  title,
-  defaultValue,
-  storage,
-}: UseExpandSectionParams): boolean => {
+export const useExpandSection = ({ title, defaultValue }: UseExpandSectionParams): boolean => {
+  const { storage } = useKibana().services;
+
   const localStorage = storage.get(FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS);
   const key = title.toLowerCase();
   const expanded =

--- a/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/right/hooks/use_expand_section.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { Storage } from '@kbn/kibana-utils-plugin/public';
+import { FLYOUT_STORAGE_KEYS } from '../../shared/constants/local_storage';
+
+export interface UseExpandSectionParams {
+  /**
+   * Title of the section
+   */
+  title: string;
+  /**
+   * Default value for the section
+   */
+  defaultValue: boolean;
+  /**
+   * From useKibana().services.storage
+   */
+  storage: Storage;
+}
+
+/**
+ * Hook to get the expanded state of a section from local storage.
+ */
+export const useExpandSection = ({
+  title,
+  defaultValue,
+  storage,
+}: UseExpandSectionParams): boolean => {
+  const localStorage = storage.get(FLYOUT_STORAGE_KEYS.OVERVIEW_TAB_EXPANDED_SECTIONS);
+  const key = title.toLowerCase();
+  const expanded =
+    localStorage && localStorage[key] !== undefined ? localStorage[key] : defaultValue;
+
+  return expanded;
+};

--- a/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
+++ b/x-pack/plugins/security_solution/public/flyout/document_details/shared/constants/local_storage.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export const FLYOUT_STORAGE_KEYS = {
+  OVERVIEW_TAB_EXPANDED_SECTIONS:
+    'securitySolution.documentDetailsFlyout.overviewSectionExpanded.v8.14',
+};


### PR DESCRIPTION
## Summary

This PR is the first of a few that are adding some UI persistence to the alert details expandable flyout to improve usability.

This one focuses on saving the expanded/collapsed state of each section (`About`, `Investigation`, `Visualizations`, `Insights` and `Response`) of the `Overview` tab only. This will allow users to navigate between alerts in the alerts table in the backend, open new flyouts and see their layout retained.

The value store in local storage it pretty basic:
```
{
  about: true/false,
  investigation: true/false,
  visualizations: true/false,
  insights: true/false,
  response: true/false,
}
```

Each section still have their default value (all collapsed except for `About` and `Investigation` which are expanded by default). The values saved in localStorage will override this default value.

https://github.com/elastic/kibana/assets/17276605/7b253ab4-0103-4a23-9c66-b5d9cdc18720

https://github.com/elastic/security-team/issues/7670

#### Notes:
_We had a discussion during standup to go through the Redux store and have a middleware handle the storing in localStorage. I decided to not apply this logic at the moment for the following reasons:_
- _the code was already finished, working and fully unit tested_
- _that would increase the size and complexity of this PR_
- _we do not have currently anything related to the flyout panels saved in localStorage and I felt this small feature was not the best candidate to get started_
- _this can be added later when we have a clearer picture on how much we'll be handling, with no impact on users as the value stored in localStorage should remain the same_
_Let me know if you disagree with these thoughts and I can revisit the approach!_

### Checklist

- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios