### PR TITLE
[HTTP] Workaround for loading worker from non origin

### DIFF
--- a/packages/kbn-mapbox-gl/index.ts
+++ b/packages/kbn-mapbox-gl/index.ts
@@ -43,13 +43,6 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 
 const maplibregl: any = maplibreglDist;
 
-/**
- * Worker URLs must adhere to the same-origin policy.
- * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
- *
- * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
- * function to load the worker code via JS APIs instead.
- */
 maplibregl.workerUrl = prepareWorkerURL(mbWorkerUrl);
 maplibregl.setRTLTextPlugin(mbRtlPlugin);
 

--- a/packages/kbn-mapbox-gl/index.ts
+++ b/packages/kbn-mapbox-gl/index.ts
@@ -39,7 +39,17 @@ import mbWorkerUrl from '!!file-loader!maplibre-gl/dist/maplibre-gl-csp-worker';
 import 'maplibre-gl/dist/maplibre-gl.css';
 
 const maplibregl: any = maplibreglDist;
-maplibregl.workerUrl = mbWorkerUrl;
+
+/**
+ * Worker URLs must adhere to the same-origin policy.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
+ *
+ * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
+ * function to load the worker code via JS APIs instead.
+ */
+maplibregl.workerUrl = URL.createObjectURL(
+  new Blob([`importScripts("${mbWorkerUrl}");`], { type: 'text/javascript' })
+);
 maplibregl.setRTLTextPlugin(mbRtlPlugin);
 
 export { maplibregl };

--- a/packages/kbn-mapbox-gl/index.ts
+++ b/packages/kbn-mapbox-gl/index.ts
@@ -32,6 +32,9 @@ import type {
 
 // @ts-expect-error
 import maplibreglDist from 'maplibre-gl/dist/maplibre-gl-csp';
+
+import { prepareWorkerURL } from './prepare_worker_url';
+
 // @ts-expect-error
 import mbRtlPlugin from '!!file-loader!@mapbox/mapbox-gl-rtl-text/mapbox-gl-rtl-text.min.js';
 // @ts-expect-error
@@ -47,9 +50,7 @@ const maplibregl: any = maplibreglDist;
  * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
  * function to load the worker code via JS APIs instead.
  */
-maplibregl.workerUrl = URL.createObjectURL(
-  new Blob([`importScripts("${mbWorkerUrl}");`], { type: 'text/javascript' })
-);
+maplibregl.workerUrl = prepareWorkerURL(mbWorkerUrl);
 maplibregl.setRTLTextPlugin(mbRtlPlugin);
 
 export { maplibregl };

--- a/packages/kbn-mapbox-gl/prepare_worker_url.ts
+++ b/packages/kbn-mapbox-gl/prepare_worker_url.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Worker URLs must adhere to the same-origin policy.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
+ *
+ * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
+ * IF we have a full URL to load the worker code via JS APIs instead.
+ */
+export const prepareWorkerURL = (url: string) => {
+  let isFullURL = false;
+  try {
+    new URL(url);
+    isFullURL = true;
+  } catch (e) {
+    // ignore
+  }
+  return isFullURL
+    ? URL.createObjectURL(new Blob([`importScripts("${url}");`], { type: 'text/javascript' }))
+    : url;
+};

--- a/packages/kbn-mapbox-gl/prepare_worker_url.ts
+++ b/packages/kbn-mapbox-gl/prepare_worker_url.ts
@@ -10,8 +10,8 @@
  * Worker URLs must adhere to the same-origin policy.
  * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
  *
- * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
- * IF we have a full URL to load the worker code via JS APIs instead.
+ * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`.
+ * So IF we have a full URL to load the worker code via JS APIs instead.
  */
 export const prepareWorkerURL = (url: string) => {
   let isFullURL = false;

--- a/packages/kbn-monaco/src/prepare_worker_url.ts
+++ b/packages/kbn-monaco/src/prepare_worker_url.ts
@@ -11,7 +11,7 @@
  * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
  *
  * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
- * IF we have a full URL to load the worker code via JS APIs instead.
+ * So IF we have a full URL to load the worker code via JS APIs instead.
  */
 export const prepareWorkerURL = (url: string) => {
   let isFullURL = false;

--- a/packages/kbn-monaco/src/prepare_worker_url.ts
+++ b/packages/kbn-monaco/src/prepare_worker_url.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+/**
+ * Worker URLs must adhere to the same-origin policy.
+ * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
+ *
+ * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
+ * IF we have a full URL to load the worker code via JS APIs instead.
+ */
+export const prepareWorkerURL = (url: string) => {
+  let isFullURL = false;
+  try {
+    new URL(url);
+    isFullURL = true;
+  } catch (e) {
+    // ignore
+  }
+  return isFullURL
+    ? URL.createObjectURL(new Blob([`importScripts("${url}");`], { type: 'text/javascript' }))
+    : url;
+};

--- a/packages/kbn-monaco/src/register_globals.ts
+++ b/packages/kbn-monaco/src/register_globals.ts
@@ -14,6 +14,7 @@ import { ESQL_THEME_ID, ESQLLang, buildESQlTheme } from './esql';
 import { YAML_LANG_ID } from './yaml';
 import { registerLanguage, registerTheme } from './helpers';
 import { ConsoleLang } from './console';
+import { prepareWorkerURL } from './prepare_worker_url';
 
 export const DEFAULT_WORKER_ID = 'default';
 const langSpecificWorkerIds = [
@@ -54,18 +55,7 @@ window.MonacoEnvironment = {
         const workerId = langSpecificWorkerIds.includes(languageId)
           ? languageId
           : DEFAULT_WORKER_ID;
-        /**
-         * Worker URLs must adhere to the same-origin policy.
-         * See https://developer.mozilla.org/en-US/docs/Web/API/Worker/Worker.
-         *
-         * To satisfy the policy we construct a `blob:` URL and use the worker global `importScripts`
-         * function to load the worker code via JS APIs instead.
-         */
-        const workerURL = window.URL.createObjectURL(
-          new Blob([`importScripts("${monacoBundleDir}${workerId}.editor.worker.js")`], {
-            type: 'application/javascript',
-          })
-        );
+        const workerURL = prepareWorkerURL(`${monacoBundleDir}${workerId}.editor.worker.js`);
         workerURLMap.set(languageId, workerURL);
         return workerURL;
       }


### PR DESCRIPTION
## Summary

Based on the documentation for `worker-src` it looks like this should not be an issue but in practice loading workers from non-origin domains requires a workaround. In this case the script loading gets done by JS APIs that are allowed to make connections based on our CSP.

## Test

- Configure non origin CDN, e.g., `server.cdn.url: "<url>"`
- Ensure that a CDN asset is being served at the URL (I built CDN assets using `node scripts/build.js` and served them locally)
- Start Kibana and create a new dashboard with a Map, the worker should successfully instantiate when loaded from the non origin domain.

## Notes

- It's possible that I'm missing something else here, the fact that setting `worker-src` is not working [seems fishy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/worker-src) but the worker [docs on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Worker) state that the script URL must be origin.