### PR TITLE
[Console] refactor(console): update embeddable console to provide a FC

### DIFF
--- a/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/embeddable_console.tsx
@@ -141,7 +141,3 @@ export const EmbeddableConsole = ({
     </EuiPortal>
   );
 };
-
-// Default Export is needed to lazy load this react component
-// eslint-disable-next-line import/no-default-export
-export default EmbeddableConsole;

--- a/src/plugins/console/public/application/containers/embeddable/index.tsx
+++ b/src/plugins/console/public/application/containers/embeddable/index.tsx
@@ -6,21 +6,24 @@
  * Side Public License, v 1.
  */
 
-import React, { ReactElement, lazy, Suspense } from 'react';
+import React, { ComponentType, lazy, Suspense } from 'react';
 import {
   EmbeddableConsoleProps,
   EmbeddableConsoleDependencies,
 } from '../../../types/embeddable_console';
 
-const RemoteConsole = lazy(() => import('./embeddable_console'));
+type EmbeddableConsoleInternalProps = EmbeddableConsoleProps & EmbeddableConsoleDependencies;
 
-export function renderEmbeddableConsole(
-  props: EmbeddableConsoleProps | undefined,
-  deps: EmbeddableConsoleDependencies
-): ReactElement | null {
+const Console = lazy<ComponentType<EmbeddableConsoleInternalProps>>(async () => {
+  return {
+    default: (await import('./embeddable_console')).EmbeddableConsole,
+  };
+});
+
+export const EmbeddableConsole: React.FC<EmbeddableConsoleInternalProps> = (props) => {
   return (
-    <Suspense fallback={<></>}>
-      <RemoteConsole {...props} {...deps} />
+    <Suspense fallback={null}>
+      <Console {...props} />
     </Suspense>
   );
-}
+};

--- a/src/plugins/console/public/plugin.ts
+++ b/src/plugins/console/public/plugin.ts
@@ -9,7 +9,7 @@ import { i18n } from '@kbn/i18n';
 import { Plugin, CoreSetup, CoreStart, PluginInitializerContext } from '@kbn/core/public';
 import { ENABLE_PERSISTENT_CONSOLE_UI_SETTING_ID } from '@kbn/dev-tools-plugin/public';
 
-import { renderEmbeddableConsole } from './application/containers/embeddable';
+import { EmbeddableConsole } from './application/containers/embeddable';
 import {
   AppSetupUIPluginDependencies,
   AppStartUIPluginDependencies,
@@ -18,11 +18,12 @@ import {
   ConsolePluginStart,
   ConsoleUILocatorParams,
   EmbeddableConsoleProps,
-  EmbeddableConsoleDependencies,
 } from './types';
 import { AutocompleteInfo, setAutocompleteInfo, EmbeddableConsoleInfo } from './services';
 
-export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDependencies> {
+export class ConsoleUIPlugin
+  implements Plugin<ConsolePluginSetup, ConsolePluginStart, AppSetupUIPluginDependencies>
+{
   private readonly autocompleteInfo = new AutocompleteInfo();
   private _embeddableConsole: EmbeddableConsoleInfo = new EmbeddableConsoleInfo();
 
@@ -122,15 +123,15 @@ export class ConsoleUIPlugin implements Plugin<void, void, AppSetupUIPluginDepen
       embeddedConsoleUiSetting;
 
     if (embeddedConsoleAvailable) {
-      consoleStart.renderEmbeddableConsole = (props?: EmbeddableConsoleProps) => {
-        const consoleDeps: EmbeddableConsoleDependencies = {
+      consoleStart.EmbeddableConsole = (props: EmbeddableConsoleProps) => {
+        return EmbeddableConsole({
+          ...props,
           core,
           usageCollection: deps.usageCollection,
           setDispatch: (d) => {
             this._embeddableConsole.setDispatch(d);
           },
-        };
-        return renderEmbeddableConsole(props, consoleDeps);
+        });
       };
       consoleStart.isEmbeddedConsoleAvailable = () =>
         this._embeddableConsole.isEmbeddedConsoleAvailable();

--- a/src/plugins/console/public/types/plugin_dependencies.ts
+++ b/src/plugins/console/public/types/plugin_dependencies.ts
@@ -6,7 +6,7 @@
  * Side Public License, v 1.
  */
 
-import { ReactElement } from 'react';
+import type { FC } from 'react';
 import { HomePublicPluginSetup, HomePublicPluginStart } from '@kbn/home-plugin/public';
 import { DevToolsSetup } from '@kbn/dev-tools-plugin/public';
 import { UsageCollectionSetup, UsageCollectionStart } from '@kbn/usage-collection-plugin/public';
@@ -43,11 +43,6 @@ export interface ConsolePluginSetup {
  */
 export interface ConsolePluginStart {
   /**
-   * renderEmbeddableConsole is available if the console UI is enabled. This function can be called to
-   * render an embeddable version of the developer console on the page.
-   */
-  renderEmbeddableConsole?: (props?: EmbeddableConsoleProps) => ReactElement | null;
-  /**
    * isEmbeddedConsoleAvailable is available if the embedded console can be rendered. Returns true when
    * called if the Embedded Console is currently rendered.
    */
@@ -57,4 +52,8 @@ export interface ConsolePluginStart {
    * this function will open the embedded console on the page if it is currently rendered.
    */
   openEmbeddedConsole?: (content?: string) => void;
+  /**
+   * EmbeddableConsole is a functional component used to render a portable version of the dev tools console on any page in Kibana
+   */
+  EmbeddableConsole?: FC<EmbeddableConsoleProps>;
 }

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.test.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.test.tsx
@@ -231,38 +231,38 @@ describe('EnterpriseSearchPageTemplateWrapper', () => {
 
   describe('Embedded Console', () => {
     it('renders embedded console if available', () => {
-      const renderMock = jest.fn();
-      renderMock.mockReturnValue(null);
+      const FakeEmbeddedConsole: React.FC = () => <div className="embedded_console">foo</div>;
+      const consolePlugin = { EmbeddableConsole: FakeEmbeddedConsole };
 
       setMockValues({
         readOnlyMode: false,
-        consolePlugin: { renderEmbeddableConsole: renderMock },
+        consolePlugin,
       });
 
-      shallow(
+      const wrapper = shallow(
         <EnterpriseSearchPageTemplateWrapper>
           <div className="hello">world</div>
         </EnterpriseSearchPageTemplateWrapper>
       );
 
-      expect(renderMock).toHaveBeenCalled();
+      expect(wrapper.find(consolePlugin.EmbeddableConsole).exists()).toBe(true);
     });
     it('Hides embedded console if available but page template prop set to hide', () => {
-      const renderMock = jest.fn();
-      renderMock.mockReturnValue(null);
+      const FakeEmbeddedConsole: React.FC = () => <div className="embedded_console">foo</div>;
+      const consolePlugin = { EmbeddableConsole: FakeEmbeddedConsole };
 
       setMockValues({
         readOnlyMode: false,
-        consolePlugin: { renderEmbeddableConsole: renderMock },
+        consolePlugin,
       });
 
-      shallow(
+      const wrapper = shallow(
         <EnterpriseSearchPageTemplateWrapper hideEmbeddedConsole>
           <div className="hello">world</div>
         </EnterpriseSearchPageTemplateWrapper>
       );
 
-      expect(renderMock).not.toHaveBeenCalled();
+      expect(wrapper.find(consolePlugin.EmbeddableConsole).exists()).toBe(false);
     });
   });
 });

--- a/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
+++ b/x-pack/plugins/enterprise_search/public/applications/shared/layout/page_template.tsx
@@ -120,8 +120,8 @@ export const EnterpriseSearchPageTemplateWrapper: React.FC<PageTemplateProps> = 
       ) : (
         <KibanaPageTemplate.Section>{children}</KibanaPageTemplate.Section>
       )}
-      {!hideEmbeddedConsole && consolePlugin?.renderEmbeddableConsole !== undefined ? (
-        consolePlugin.renderEmbeddableConsole()
+      {!hideEmbeddedConsole && consolePlugin?.EmbeddableConsole !== undefined ? (
+        <consolePlugin.EmbeddableConsole />
       ) : (
         <></>
       )}

--- a/x-pack/plugins/index_management/public/application/sections/home/home.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/home.tsx
@@ -145,7 +145,7 @@ export const IndexManagementHome: React.FunctionComponent<RouteComponentProps<Ma
         />
         <Route exact path={`/${Section.EnrichPolicies}`} component={EnrichPoliciesList} />
       </Routes>
-      {consolePlugin?.renderEmbeddableConsole?.() ?? <></>}
+      {consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null}
     </>
   );
   return (

--- a/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
+++ b/x-pack/plugins/index_management/public/application/sections/home/index_list/details_page/details_page_content.tsx
@@ -181,7 +181,7 @@ export const DetailsPageContent: FunctionComponent<Props> = ({
       >
         <DetailsPageTab tabs={tabs} tab={tab} index={index} />
       </div>
-      {consolePlugin?.renderEmbeddableConsole?.() ?? <></>}
+      {consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null}
     </>
   );
 };

--- a/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/connectors_overview.tsx
@@ -31,7 +31,7 @@ export const ConnectorsOverview = () => {
   const { http, console: consolePlugin } = useKibanaServices();
   const { createConnector, isLoading } = useCreateConnector();
   const embeddableConsole = useMemo(
-    () => consolePlugin?.renderEmbeddableConsole?.() ?? <></>,
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
     [consolePlugin]
   );
 

--- a/x-pack/plugins/serverless_search/public/application/components/overview.tsx
+++ b/x-pack/plugins/serverless_search/public/application/components/overview.tsx
@@ -76,7 +76,7 @@ export const ElasticsearchOverview = () => {
     }
   }, [hash]);
   const embeddableConsole = useMemo(
-    () => consolePlugin?.renderEmbeddableConsole?.() ?? <></>,
+    () => (consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null),
     [consolePlugin]
   );
 


### PR DESCRIPTION
## Summary

Updated the way EmbeddableConsole is exported from the console start object to be a FunctionalComponent type instead of a render functions that returns an element. These are essentially the same but the usage of the FC is cleaner and more idiomatic for React.

before:
```typescript
{consolePlugin?.renderEmbeddableConsole?.() ?? <></>}
```

After:
```typescript
{consolePlugin?.EmbeddableConsole ? <consolePlugin.EmbeddableConsole /> : null}
```