### PR TITLE
[Security Solution] [Analyzer] Do not clear analyzer state when mounting/unmounting

### DIFF
--- a/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.ts
+++ b/x-pack/plugins/security_solution/public/resolver/view/use_resolver_query_params_cleaner.ts
@@ -8,7 +8,6 @@
 import { useRef, useEffect } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
-import { clearResolver } from '../store/actions';
 import { parameterName } from '../store/parameter_name';
 /**
  * Cleanup any query string keys that were added by this Resolver instance.
@@ -49,7 +48,6 @@ export function useResolverQueryParamCleaner(id: string) {
       urlSearchParams.delete(oldResolverKey);
       const relativeURL = { search: urlSearchParams.toString() };
       history.replace(relativeURL);
-      dispatch(clearResolver({ id }));
     };
   }, [resolverKey, history, dispatch, id]);
 }


### PR DESCRIPTION
## Summary

Related issue: https://github.com/elastic/kibana/issues/178697

Clearing the state of analyzer completely when this hook dismounts is not actually needed, as analyzer will refetch data with any new parameters are passed from the security solution code, and doing so also caused the related bug. Removing this line fixes the problem.

![fullscreen_back](https://github.com/elastic/kibana/assets/56408403/e1e53e02-c402-4560-b4bc-a021c21093bb)



### Checklist


- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->