### PR TITLE
[Cloud Security] Add checking for null clusterId on the trend line function

### DIFF
--- a/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
+++ b/x-pack/plugins/cloud_security_posture/server/tasks/findings_stats_task.ts
@@ -288,7 +288,7 @@ const getFindingsScoresDocIndexingPromises = (
     // creating score per cluster id objects
     const clustersStats = Object.fromEntries(
       policyTemplateTrend.score_by_cluster_id.buckets.map((clusterStats) => {
-        const clusterId = clusterStats.key;
+        const clusterId = clusterStats?.key || 'unknown';
 
         return [
           clusterId,


### PR DESCRIPTION
## Summary

It fixes https://github.com/elastic/security-team/issues/8874

This PR fixes the issue with the TrendLine not being generated when there are findings where `cloud.account.id` is `null`, as the findings is generated by a valid CIS rule, we still want to consider it for the calculation instead of filtering them out.