### PR TITLE
Fix serverless tests for ingest pipelines and dataset quality

### DIFF
--- a/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
+++ b/x-pack/plugins/ingest_pipelines/public/application/sections/pipelines_list/table.tsx
@@ -212,6 +212,7 @@ export const PipelineTable: FunctionComponent<Props> = ({
       ],
       box: {
         incremental: true,
+        'data-test-subj': 'pipelineTableSearch',
       },
       filters: [
         {

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_flyout.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_flyout.ts
@@ -28,6 +28,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('opens the flyout for the right dataset', async () => {

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table.ts
@@ -29,6 +29,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('shows the right number of rows in correct order', async () => {

--- a/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test/functional/apps/dataset_quality/dataset_quality_table_filters.ts
@@ -28,6 +28,7 @@ export default function ({ getService, getPageObjects }: DatasetQualityFtrProvid
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('hides inactive datasets when toggled', async () => {

--- a/x-pack/test/functional/page_objects/ingest_pipelines_page.ts
+++ b/x-pack/test/functional/page_objects/ingest_pipelines_page.ts
@@ -56,7 +56,11 @@ export function IngestPipelinesPageProvider({ getService, getPageObjects }: FtrP
       await pageObjects.header.waitUntilLoadingHasFinished();
     },
 
-    async getPipelinesList() {
+    async getPipelinesList(options?: { searchFor?: string }) {
+      if (options?.searchFor) {
+        await this.searchPipelineList(options.searchFor);
+      }
+
       const pipelines = await testSubjects.findAll('pipelineTableRow');
 
       const getPipelineName = async (pipeline: WebElementWrapper) => {
@@ -65,6 +69,11 @@ export function IngestPipelinesPageProvider({ getService, getPageObjects }: FtrP
       };
 
       return await Promise.all(pipelines.map((pipeline) => getPipelineName(pipeline)));
+    },
+
+    async searchPipelineList(searchTerm: string) {
+      await pageObjects.header.waitUntilLoadingHasFinished();
+      await testSubjects.setValue('pipelineTableSearch', searchTerm);
     },
 
     async clickPipelineLink(index: number) {

--- a/x-pack/test_serverless/functional/test_suites/common/management/ingest_pipelines.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/management/ingest_pipelines.ts
@@ -59,7 +59,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
       it('Displays the test pipeline in the list of pipelines', async () => {
         log.debug('Checking that the test pipeline is in the pipelines list.');
         await pageObjects.ingestPipelines.increasePipelineListPageSize();
-        const pipelines = await pageObjects.ingestPipelines.getPipelinesList();
+        const pipelines = await pageObjects.ingestPipelines.getPipelinesList({
+          searchFor: TEST_PIPELINE_NAME,
+        });
         expect(pipelines).to.contain(TEST_PIPELINE_NAME);
       });
 
@@ -83,7 +85,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         await pageObjects.ingestPipelines.closePipelineDetailsFlyout();
         await pageObjects.ingestPipelines.increasePipelineListPageSize();
-        const pipelinesList = await pageObjects.ingestPipelines.getPipelinesList();
+        const pipelinesList = await pageObjects.ingestPipelines.getPipelinesList({
+          searchFor: TEST_PIPELINE_NAME,
+        });
         const newPipelineExists = Boolean(
           pipelinesList.find((pipelineName) => pipelineName === PIPELINE.name)
         );
@@ -96,7 +100,9 @@ export default ({ getPageObjects, getService }: FtrProviderContext) => {
 
         await pageObjects.ingestPipelines.closePipelineDetailsFlyout();
         await pageObjects.ingestPipelines.increasePipelineListPageSize();
-        const pipelinesList = await pageObjects.ingestPipelines.getPipelinesList();
+        const pipelinesList = await pageObjects.ingestPipelines.getPipelinesList({
+          searchFor: TEST_PIPELINE_NAME,
+        });
         const newPipelineExists = Boolean(
           pipelinesList.find((pipelineName) => pipelineName === PIPELINE.name)
         );

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_flyout.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_flyout.ts
@@ -31,6 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('opens the flyout for the right dataset', async () => {

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table.ts
@@ -32,6 +32,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('shows the right number of rows in correct order', async () => {

--- a/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table_filters.ts
+++ b/x-pack/test_serverless/functional/test_suites/observability/dataset_quality/dataset_quality_table_filters.ts
@@ -31,6 +31,7 @@ export default function ({ getService, getPageObjects }: FtrProviderContext) {
 
     after(async () => {
       await synthtrace.clean();
+      await PageObjects.observabilityLogsExplorer.removeInstalledPackages();
     });
 
     it('hides inactive datasets when toggled', async () => {


### PR DESCRIPTION
## Summary

This PR fixes test failures that came up when the serverless observability functional tests for dataset quality and ingest pipelines were run against the same project.

### Details

The problem that we saw:
* The dataset quality tests are calling `PageObjects.observabilityLogsExplorer.setupInitialIntegrations()`, which sets up a list of integrations, including many ingest pipelines. However, there was no cleanup of these installed integrations so the test suite left all the integrations and ingest pipelines behind.
* The ingest pipelines tests were looking for a newly created pipeline in the list, but only checking the first page of 50 items in the UI, assuming that there are less than 50 pipelines existing. With the many pipelines left behind by the dataset quality tests, this suite failed as it couldn't find the created pipeline.

How this PR fixes it:
* The ingest pipeline tests have been stabilized so they can deal with more existing pipelines by adding an optional `searchFor` parameter to `getPipelinesList`. If this parameter is provided, the pipeline list will be searched for the provided search term before returning the list items. That way long lists can be filtered down to the items relevant to the test.
* The dataset quality tests (stateful and serverless version) have been updated to include `PageObjects.observabilityLogsExplorer.removeInstalledPackages()` in the `after` method of the suite so they don't leave integrations behind.

Flaky test runner for the three impacted configurations: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5492 - passed :heavy_check_mark: 