### PR TITLE
fix(fleet): i icon tooltip with namespace is not available for first system integration added with Agent policy.

### DIFF
--- a/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
+++ b/x-pack/plugins/fleet/public/applications/fleet/sections/agent_policy/details_page/components/package_policies/package_policies_table.tsx
@@ -224,7 +224,7 @@ export const PackagePoliciesTable: React.FunctionComponent<Props> = ({
           }
         ),
         render: (namespace: InMemoryPackagePolicy['namespace']) => {
-          return namespace ? (
+          return (namespace && namespace != agentPolicy.namespace) ? (
             <EuiBadge color="hollow">{namespace}</EuiBadge>
           ) : (
             <>


### PR DESCRIPTION
## Summary
Fixes #175870

If namespace of integration is same as agent policy namespace, it is greyed out and displays with tooltip.
<img width="1440" alt="Screenshot 2024-03-18 at 8 40 11 AM" src="https://github.com/elastic/kibana/assets/61898522/92f4534d-cdee-47a4-ac9d-500de0249bbe">
