### PR TITLE
[Security Solution] add error handling for buildEsQuery calls

### DIFF
--- a/x-pack/plugins/security_solution/public/common/components/top_n/index.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/index.test.tsx
@@ -221,7 +221,7 @@ describe('StatefulTopN', () => {
     test('it has undefined combinedQueries when rendering in a global context', () => {
       const props = wrapper.find('[data-test-subj="top-n"]').first().props() as Props;
 
-      expect(props.combinedQueries).toBeUndefined();
+      expect(props.filterQuery).toBeUndefined();
     });
 
     test(`defaults to the 'Raw events' view when rendering in a global context`, () => {
@@ -298,7 +298,7 @@ describe('StatefulTopN', () => {
     test('it has a combinedQueries value from Redux state composed of the timeline [data providers + kql + filter-bar-filters] when rendering in a timeline context', () => {
       const props = wrapper.find('[data-test-subj="top-n"]').first().props() as Props;
 
-      expect(props.combinedQueries).toEqual(
+      expect(props.filterQuery).toEqual(
         '{"bool":{"must":[],"filter":[{"bool":{"filter":[{"bool":{"should":[{"match_phrase":{"network.transport":"tcp"}}],"minimum_should_match":1}},{"bool":{"should":[{"exists":{"field":"host.name"}}],"minimum_should_match":1}}]}},{"match_phrase":{"source.port":{"query":"30045"}}}],"should":[],"must_not":[]}}'
       );
     });

--- a/x-pack/plugins/security_solution/public/common/components/top_n/index.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/index.tsx
@@ -126,7 +126,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
               language: 'kuery',
               query: activeTimelineKqlQueryExpression ?? '',
             },
-          })?.filterQuery
+          })
         : undefined,
     [
       scopeId,
@@ -147,7 +147,7 @@ const StatefulTopNComponent: React.FC<Props> = ({
 
   return (
     <TopN
-      combinedQueries={combinedQueries}
+      filterQuery={combinedQueries?.filterQuery}
       data-test-subj="top-n"
       defaultView={defaultView}
       deleteQuery={isActiveTimeline(scopeId ?? '') ? undefined : deleteQuery}

--- a/x-pack/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/top_n.test.tsx
@@ -44,7 +44,7 @@ jest.mock('uuid', () => {
 });
 
 const field = 'host.name';
-const combinedQueries = {
+const filterQuery = {
   bool: {
     must: [],
     filter: [
@@ -200,7 +200,7 @@ describe('TopN', () => {
       };
       wrapper = mount(
         <TestProviders>
-          <TopN {...testProps} combinedQueries={JSON.stringify(combinedQueries)} />
+          <TopN {...testProps} filterQuery={JSON.stringify(filterQuery)} />
         </TestProviders>
       );
     });

--- a/x-pack/plugins/security_solution/public/common/components/top_n/top_n.tsx
+++ b/x-pack/plugins/security_solution/public/common/components/top_n/top_n.tsx
@@ -45,7 +45,7 @@ const TopNContent = styled.div`
 `;
 
 export interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery' | 'setQuery'> {
-  combinedQueries?: string;
+  filterQuery?: string;
   defaultView: TimelineEventsType;
   field: AlertsStackByField;
   filters: Filter[];
@@ -61,7 +61,7 @@ export interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery
 }
 
 const TopNComponent: React.FC<Props> = ({
-  combinedQueries,
+  filterQuery,
   defaultView,
   deleteQuery,
   filters,
@@ -115,7 +115,7 @@ const TopNComponent: React.FC<Props> = ({
       <TopNContent>
         {view === 'raw' || view === 'all' ? (
           <EventsByDataset
-            combinedQueries={combinedQueries}
+            filterQuery={filterQuery}
             deleteQuery={deleteQuery}
             filters={applicableFilters}
             from={from}

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.test.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.test.tsx
@@ -1,0 +1,275 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { createMockStore, kibanaMock, mockGlobalState, TestProviders } from '../mock';
+import type { Query } from '@kbn/es-query';
+import { genHash, useInvalidFilterQuery } from './use_invalid_filter_query';
+
+const getStore = () =>
+  createMockStore(
+    {
+      ...mockGlobalState,
+      app: {
+        ...mockGlobalState.app,
+        errors: [],
+      },
+    },
+    undefined,
+    kibanaMock
+  );
+
+const getProps = () => ({
+  id: 'test-id',
+  kqlError: new Error('boom'),
+  query: { query: ': :', language: 'kuery' },
+  startDate: '2017-01-01T00:00:00.000Z',
+  endDate: '2018-01-02T00:00:00.000Z',
+});
+
+describe('useInvalidFilterQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('invokes error toast with error title and error instance without original stack', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+
+    expect(store.getState().app.errors).toEqual([
+      {
+        displayError: true,
+        id: props.id,
+        hash: genHash(props.kqlError.message),
+        message: [props.kqlError.message],
+        title: props.kqlError.name,
+      },
+    ]);
+
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledWith(props.kqlError, {
+      title: props.kqlError.name,
+    });
+    expect(props.kqlError.stack).toBeUndefined();
+  });
+
+  it('does not invoke error toast, when kqlError is missing', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery({
+        id: props.id,
+        query: props.query,
+        startDate: props.startDate,
+        endDate: props.endDate,
+      });
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke error toast, when kqlError misses name property', () => {
+    const store = getStore();
+    const props = getProps();
+    // @ts-expect-error
+    props.kqlError.name = null;
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke error toast, when kqlError misses message property', () => {
+    const store = getStore();
+    const props = getProps();
+    // @ts-expect-error
+    props.kqlError.message = null;
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke error toast, when filterQuery is present', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery({
+        ...props,
+        filterQuery: 'filterQuery',
+      });
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  // POTENTIAL BUG: the idea of having an id is usually to prevent multiple toasts from being shown
+  // when you have different errors with the same id, but this test shows that it will show multiple toasts
+  // so we need to double check if this is the intended behavior
+  it('invokes toast for each error, when called multiple times with same id and different errors', () => {
+    const store = getStore();
+    const props = getProps();
+
+    const kqlError2 = new Error('boom2');
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      useInvalidFilterQuery({
+        ...props,
+        kqlError: kqlError2,
+      });
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(2);
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledWith(props.kqlError, {
+      title: props.kqlError.name,
+    });
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledWith(kqlError2, {
+      title: kqlError2.name,
+    });
+  });
+
+  // BUG: when invoked multiple times with same id and and error it should invoke the toast exactly once
+  //
+  // this test simply documents the current behavior
+  // so it's visible and people dont need to guess how this exactly works
+  // before this is fixed via ticket
+  it('does not invoke any toast, when called multiple times with same id and same error', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  it('invokes error toast with only the first error, when called multiple times with different id and same error', () => {
+    const store = getStore();
+    const props = getProps();
+
+    const InvalidFilterComponent = () => {
+      useInvalidFilterQuery(props);
+      useInvalidFilterQuery({
+        ...props,
+        id: 'test-id2',
+      });
+      return null;
+    };
+    render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledWith(props.kqlError, {
+      title: props.kqlError.name,
+    });
+  });
+
+  it('does not invoke error toast, when query prop is changed', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent: React.FC<{ query: Query }> = ({ query }) => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    const { rerender } = render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent query={{ query: ': ::', language: 'kuery' }} />
+      </TestProviders>
+    );
+    rerender(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent query={{ query: ': :::', language: 'kuery' }} />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke error toast, when startDate prop is changed', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent: React.FC<{ startDate: string }> = ({ startDate }) => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    const { rerender } = render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent startDate="2017-01-01T00:00:00.000Z" />
+      </TestProviders>
+    );
+    rerender(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent startDate="2015-01-01T00:00:00.000Z" />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke error toast, when endDate prop is changed', () => {
+    const store = getStore();
+    const props = getProps();
+    const InvalidFilterComponent: React.FC<{ endDate: string }> = ({ endDate }) => {
+      useInvalidFilterQuery(props);
+      return null;
+    };
+    const { rerender } = render(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent endDate="2018-01-02T00:00:00.000Z" />
+      </TestProviders>
+    );
+    rerender(
+      <TestProviders store={store} startServices={kibanaMock}>
+        <InvalidFilterComponent endDate="2019-01-02T00:00:00.000Z" />
+      </TestProviders>
+    );
+    expect(kibanaMock.notifications.toasts.addError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
+++ b/x-pack/plugins/security_solution/public/common/hooks/use_invalid_filter_query.tsx
@@ -13,6 +13,22 @@ import { appActions } from '../store/app';
 import { useAppToasts } from './use_app_toasts';
 import { useDeepEqualSelector } from './use_selector';
 
+export const genHash = (message: string) =>
+  message
+    .split('')
+    // eslint-disable-next-line no-bitwise
+    .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0)
+    .toString();
+
+interface UseInvalidFilterQueryProps {
+  id: string;
+  filterQuery?: string;
+  kqlError?: Error;
+  query?: Query;
+  startDate?: string;
+  endDate?: string;
+}
+
 /**
  * Adds a toast error message whenever invalid KQL is submitted through the search bar
  */
@@ -20,17 +36,12 @@ export const useInvalidFilterQuery = ({
   id,
   filterQuery,
   kqlError,
+  // TODO: Review and remove these (query, startDate, endDate) props.
+  // Change of any of these props will not trigger new error toast.
   query,
   startDate,
   endDate,
-}: {
-  id: string;
-  filterQuery?: string;
-  kqlError?: Error;
-  query: Query;
-  startDate: string;
-  endDate: string;
-}) => {
+}: UseInvalidFilterQueryProps): void => {
   const { addError } = useAppToasts();
   const dispatch = useDispatch();
   const getErrorsSelector = useMemo(() => appSelectors.errorsSelector(), []);
@@ -41,16 +52,10 @@ export const useInvalidFilterQuery = ({
 
   useEffect(() => {
     if (!filterQuery && message && name) {
-      // Local util for creating an replicatable error hash
-      const hashCode = message
-        .split('')
-        // eslint-disable-next-line no-bitwise
-        .reduce((a, b) => ((a << 5) - a + b.charCodeAt(0)) | 0, 0)
-        .toString();
       dispatch(
         appActions.addErrorHash({
           id,
-          hash: hashCode,
+          hash: genHash(message),
           title: name,
           message: [message],
         })

--- a/x-pack/plugins/security_solution/public/common/lib/kibana/kibana_react.mock.ts
+++ b/x-pack/plugins/security_solution/public/common/lib/kibana/kibana_react.mock.ts
@@ -266,10 +266,16 @@ export const createKibanaContextProviderMock = () => {
   const services = createStartServicesMock();
 
   // eslint-disable-next-line react/display-name
-  return ({ children }: { children: React.ReactNode }) =>
+  return ({
+    children,
+    startServices: startServicesMock,
+  }: {
+    children: React.ReactNode;
+    startServices?: StartServices;
+  }) =>
     React.createElement(
       KibanaContextProvider,
-      { services },
+      { services: startServicesMock || services },
       React.createElement(NavigationProvider, { core: services }, children)
     );
 };

--- a/x-pack/plugins/security_solution/public/common/mock/test_providers.tsx
+++ b/x-pack/plugins/security_solution/public/common/mock/test_providers.tsx
@@ -34,11 +34,14 @@ import { ASSISTANT_FEATURE_ID, CASES_FEATURE_ID } from '../../../common/constant
 import { UserPrivilegesProvider } from '../components/user_privileges/user_privileges_context';
 import { MockDiscoverInTimelineContext } from '../components/discover_in_timeline/mocks/discover_in_timeline_provider';
 import { createMockStore } from './create_store';
+import type { StartServices } from '../../types';
+
 interface Props {
   children?: React.ReactNode;
   store?: Store;
   onDragEnd?: (result: DropResult, provided: ResponderProvided) => void;
   cellActions?: Action[];
+  startServices?: StartServices;
 }
 
 export const kibanaMock = createStartServicesMock();
@@ -53,6 +56,7 @@ const MockKibanaContextProvider = createKibanaContextProviderMock();
 export const TestProvidersComponent: React.FC<Props> = ({
   children,
   store = createMockStore(),
+  startServices,
   onDragEnd = jest.fn(),
   cellActions = [],
 }) => {
@@ -71,7 +75,7 @@ export const TestProvidersComponent: React.FC<Props> = ({
 
   return (
     <I18nProvider>
-      <MockKibanaContextProvider>
+      <MockKibanaContextProvider startServices={startServices}>
         <UpsellingProviderMock>
           <ReduxStoreProvider store={store}>
             <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
@@ -112,6 +116,7 @@ const TestProvidersWithPrivilegesComponent: React.FC<Props> = ({
   children,
   store = createMockStore(),
   onDragEnd = jest.fn(),
+  startServices,
   cellActions = [],
 }) => {
   const queryClient = new QueryClient({
@@ -123,7 +128,7 @@ const TestProvidersWithPrivilegesComponent: React.FC<Props> = ({
   });
   return (
     <I18nProvider>
-      <MockKibanaContextProvider>
+      <MockKibanaContextProvider startServices={startServices}>
         <ReduxStoreProvider store={store}>
           <ThemeProvider theme={() => ({ eui: euiDarkVars, darkMode: true })}>
             <QueryClientProvider client={queryClient}>

--- a/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/helpers.tsx
+++ b/x-pack/plugins/security_solution/public/detections/components/alerts_kpis/alerts_histogram_panel/helpers.tsx
@@ -108,7 +108,7 @@ export const showInitialLoadingSpinner = ({
   isLoadingAlerts: boolean;
 }): boolean => isInitialLoading && isLoadingAlerts;
 
-export const parseCombinedQueries = (query?: string) => {
+export const parseFilterQuery = (query?: string) => {
   try {
     return query != null && !isEmpty(query) ? JSON.parse(query) : {};
   } catch {
@@ -116,9 +116,9 @@ export const parseCombinedQueries = (query?: string) => {
   }
 };
 
-export const buildCombinedQueries = (query?: string) => {
+export const buildFilterQuery = (query?: string) => {
   try {
-    return isEmpty(query) ? [] : [parseCombinedQueries(query)];
+    return isEmpty(query) ? [] : [parseFilterQuery(query)];
   } catch {
     return [];
   }

--- a/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
+++ b/x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx
@@ -100,21 +100,21 @@ export const useBulkAlertActionItems = ({
         clearSelection,
         refresh
       ) => {
-        let ids: string[] | undefined = items.map((item) => item._id);
-        let query: Record<string, unknown> | undefined;
-
-        if (isSelectAllChecked) {
-          const timeFilter = buildTimeRangeFilter(from, to);
-          query = buildEsQuery(undefined, [], [...timeFilter, ...filters], undefined);
-          ids = undefined;
-          startTransaction({ name: APM_USER_INTERACTIONS.BULK_QUERY_STATUS_UPDATE });
-        } else if (items.length > 1) {
-          startTransaction({ name: APM_USER_INTERACTIONS.BULK_STATUS_UPDATE });
-        } else {
-          startTransaction({ name: APM_USER_INTERACTIONS.STATUS_UPDATE });
-        }
-
         try {
+          let ids: string[] | undefined = items.map((item) => item._id);
+          let query: Record<string, unknown> | undefined;
+
+          if (isSelectAllChecked) {
+            const timeFilter = buildTimeRangeFilter(from, to);
+            query = buildEsQuery(undefined, [], [...timeFilter, ...filters], undefined);
+            ids = undefined;
+            startTransaction({ name: APM_USER_INTERACTIONS.BULK_QUERY_STATUS_UPDATE });
+          } else if (items.length > 1) {
+            startTransaction({ name: APM_USER_INTERACTIONS.BULK_STATUS_UPDATE });
+          } else {
+            startTransaction({ name: APM_USER_INTERACTIONS.STATUS_UPDATE });
+          }
+
           setAlertLoading(true);
           const response = await updateAlertStatus({
             status,

--- a/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
+++ b/x-pack/plugins/security_solution/public/overview/components/events_by_dataset/index.tsx
@@ -44,7 +44,7 @@ const ID = 'eventsByDatasetOverview';
 const CHART_HEIGHT = 160;
 
 interface Props extends Pick<GlobalTimeArgs, 'from' | 'to' | 'deleteQuery' | 'setQuery'> {
-  combinedQueries?: string;
+  filterQuery?: string;
   filters: Filter[];
   headerChildren?: React.ReactNode;
   indexPattern: DataViewBase;
@@ -77,7 +77,7 @@ const StyledLinkButton = styled(EuiButton)`
 `;
 
 const EventsByDatasetComponent: React.FC<Props> = ({
-  combinedQueries,
+  filterQuery: filterQueryFromProps,
   deleteQuery,
   filters,
   from,
@@ -138,7 +138,7 @@ const EventsByDatasetComponent: React.FC<Props> = ({
   );
 
   const [filterQuery, kqlError] = useMemo(() => {
-    if (combinedQueries == null) {
+    if (filterQueryFromProps == null) {
       return convertToBuildEsQuery({
         config: getEsQueryConfig(kibana.services.uiSettings),
         indexPattern,
@@ -146,8 +146,8 @@ const EventsByDatasetComponent: React.FC<Props> = ({
         filters,
       });
     }
-    return [combinedQueries];
-  }, [combinedQueries, kibana, indexPattern, query, filters]);
+    return [filterQueryFromProps];
+  }, [filterQueryFromProps, kibana, indexPattern, query, filters]);
 
   useInvalidFilterQuery({
     id: uniqueQueryId,


### PR DESCRIPTION
This PR addresses issue #155419 by adding missing error handling to `buildEsQuery()` calls within investigation/explore domains.

This PR underwent numerous iterations and remained in draft status for an extended period before reaching it's final shape. Initially, many changes were made to the `useInvalidFilterQuery()` hook, which manages the notification toasts in various locations under an assumption that some error toasts are not invoked when calling `buildEsQuery()`. During iteration the hook was corrected, and tests were written to better comprehend its behavior.

After eventual realization that error toasts are invoked in most of the cases and subsequent cancellation of most of the work related to `useInvalidFilterQuery()` calls, it was decided to retain the tests and refactoring that occurred during the process as part of this PR anyways.

Scope:
The only file affected after numerous scope cuts is this `x-pack/plugins/security_solution/public/detections/hooks/trigger_actions_alert_table/use_alert_actions.tsx`