### PR TITLE
[Fleet] Fix flaky serverless API integration tests

### DIFF
--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -8,35 +8,38 @@
 import { FtrProviderContext } from '../../../ftr_provider_context';
 
 const defaultFleetServerHostId = 'default-fleet-server';
-const defaultFleetServerHostUrl = 'https://localhost:8220';
 const defaultElasticsearchOutputId = 'es-default-output';
-const defaultElasticsearchOutputHostUrl = 'https://localhost:9200';
 
 export async function expectDefaultFleetServer({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const retry = getService('retry');
+  let defaultFleetServerHostUrl: string = '';
 
   await retry.waitForWithTimeout('get default fleet server', 30_000, async () => {
     const { body, status } = await supertest.get(
       `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
     );
     if (status === 200 && body.item.host_urls.length > 0) {
+      defaultFleetServerHostUrl = body.item.host_urls;
       return true;
     } else {
       throw new Error(`Expected default Fleet Server id ${defaultFleetServerHostId} to exist`);
     }
   });
+  return defaultFleetServerHostUrl[0];
 }
 
 export async function expectDefaultElasticsearchOutput({ getService }: FtrProviderContext) {
   const supertest = getService('supertest');
   const retry = getService('retry');
+  let defaultEsOutputUrl: string = '';
 
   await retry.waitForWithTimeout('get default Elasticsearch output', 30_000, async () => {
     const { body, status } = await supertest.get(
       `/api/fleet/outputs/${defaultElasticsearchOutputId}`
     );
     if (status === 200 && body.item.hosts.length > 0) {
+      defaultEsOutputUrl = body.item.hosts;
       return true;
     } else {
       throw new Error(
@@ -44,6 +47,7 @@ export async function expectDefaultElasticsearchOutput({ getService }: FtrProvid
       );
     }
   });
+  return defaultEsOutputUrl[0];
 }
 
 export const kbnServerArgs = [
@@ -52,7 +56,7 @@ export const kbnServerArgs = [
     id: defaultFleetServerHostId,
     name: 'Default Fleet Server',
     is_default: true,
-    host_urls: [defaultFleetServerHostUrl],
+    host_urls: ['https://localhost:8220'],
   })}]`,
   `--xpack.fleet.outputs=[${JSON.stringify({
     id: defaultElasticsearchOutputId,
@@ -60,6 +64,6 @@ export const kbnServerArgs = [
     type: 'elasticsearch',
     is_default: true,
     is_default_monitoring: true,
-    hosts: [defaultElasticsearchOutputHostUrl],
+    hosts: ['https://localhost:9200'],
   })}]`,
 ];

--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -39,7 +39,7 @@ export async function expectDefaultElasticsearchOutput({ getService }: FtrProvid
       `/api/fleet/outputs/${defaultElasticsearchOutputId}`
     );
     if (status === 200 && body.item.hosts.length > 0) {
-      defaultEsOutputUrl = body.item.hosts;
+      defaultEsOutputUrl = body.item.hosts[0];
       return true;
     } else {
       throw new Error(
@@ -47,7 +47,7 @@ export async function expectDefaultElasticsearchOutput({ getService }: FtrProvid
       );
     }
   });
-  return defaultEsOutputUrl[0];
+  return defaultEsOutputUrl;
 }
 
 export const kbnServerArgs = [

--- a/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/common/fleet/default_setup.ts
@@ -20,13 +20,13 @@ export async function expectDefaultFleetServer({ getService }: FtrProviderContex
       `/api/fleet/fleet_server_hosts/${defaultFleetServerHostId}`
     );
     if (status === 200 && body.item.host_urls.length > 0) {
-      defaultFleetServerHostUrl = body.item.host_urls;
+      defaultFleetServerHostUrl = body.item.host_urls[0];
       return true;
     } else {
       throw new Error(`Expected default Fleet Server id ${defaultFleetServerHostId} to exist`);
     }
   });
-  return defaultFleetServerHostUrl[0];
+  return defaultFleetServerHostUrl;
 }
 
 export async function expectDefaultElasticsearchOutput({ getService }: FtrProviderContext) {

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
@@ -16,8 +16,7 @@ export default function (ctx: FtrProviderContext) {
   const svlCommonApi = ctx.getService('svlCommonApi');
   const supertest = ctx.getService('supertest');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/178780
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     let defaultFleetServerHostUrl: string = '';
     let defaultEsOutputUrl: string = '';
     before(async () => {

--- a/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/observability/fleet/fleet.ts
@@ -19,29 +19,16 @@ export default function (ctx: FtrProviderContext) {
   describe('fleet', function () {
     let defaultFleetServerHostUrl: string = '';
     let defaultEsOutputUrl: string = '';
+
     before(async () => {
-      const { body, status } = await supertest
-        .get('/api/fleet/fleet_server_hosts')
-        .set(svlCommonApi.getInternalRequestHeader());
-
-      expect(status).toBe(200);
-
-      defaultFleetServerHostUrl =
-        body.items.find((item: any) => item.is_default)?.host_urls?.[0] ?? '';
+      defaultFleetServerHostUrl = await expectDefaultFleetServer(ctx);
       expect(defaultFleetServerHostUrl).not.toBe('');
-    });
-    before(async () => {
-      const { body, status } = await supertest
-        .get('/api/fleet/outputs')
-        .set(svlCommonApi.getInternalRequestHeader());
 
-      expect(status).toBe(200);
-      defaultEsOutputUrl = body.items.find((item: any) => item.is_default)?.hosts?.[0] ?? '';
+      defaultEsOutputUrl = await expectDefaultElasticsearchOutput(ctx);
       expect(defaultEsOutputUrl).not.toBe('');
     });
-    it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
-      await expectDefaultFleetServer(ctx);
 
+    it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -60,8 +47,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('accepts request to create a new fleet server hosts if host url is same as default', async () => {
-      await expectDefaultFleetServer(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -80,8 +65,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('rejects request to create a new elasticsearch output if host is different from default', async () => {
-      await expectDefaultElasticsearchOutput(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -100,8 +83,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('accepts request to create a new elasticsearch output if host url is same as default', async () => {
-      await expectDefaultElasticsearchOutput(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
@@ -16,8 +16,7 @@ export default function (ctx: FtrProviderContext) {
   const svlCommonApi = ctx.getService('svlCommonApi');
   const supertest = ctx.getService('supertest');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/178779
-  describe.skip('fleet', function () {
+  describe('fleet', function () {
     let defaultFleetServerHostUrl: string = '';
     let defaultEsOutputUrl: string = '';
     before(async () => {

--- a/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
+++ b/x-pack/test_serverless/api_integration/test_suites/security/fleet/fleet.ts
@@ -19,29 +19,16 @@ export default function (ctx: FtrProviderContext) {
   describe('fleet', function () {
     let defaultFleetServerHostUrl: string = '';
     let defaultEsOutputUrl: string = '';
+
     before(async () => {
-      const { body, status } = await supertest
-        .get('/api/fleet/fleet_server_hosts')
-        .set(svlCommonApi.getInternalRequestHeader());
-
-      expect(status).toBe(200);
-
-      defaultFleetServerHostUrl =
-        body.items.find((item: any) => item.is_default)?.host_urls?.[0] ?? '';
+      defaultFleetServerHostUrl = await expectDefaultFleetServer(ctx);
       expect(defaultFleetServerHostUrl).not.toBe('');
-    });
-    before(async () => {
-      const { body, status } = await supertest
-        .get('/api/fleet/outputs')
-        .set(svlCommonApi.getInternalRequestHeader());
 
-      expect(status).toBe(200);
-      defaultEsOutputUrl = body.items.find((item: any) => item.is_default)?.hosts?.[0] ?? '';
+      defaultEsOutputUrl = await expectDefaultElasticsearchOutput(ctx);
       expect(defaultEsOutputUrl).not.toBe('');
     });
-    it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
-      await expectDefaultFleetServer(ctx);
 
+    it('rejects request to create a new fleet server hosts if host url is different from default', async () => {
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -60,8 +47,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('accepts request to create a new fleet server hosts if host url is same as default', async () => {
-      await expectDefaultFleetServer(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/fleet_server_hosts')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -80,8 +65,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('rejects request to create a new elasticsearch output if host is different from default', async () => {
-      await expectDefaultElasticsearchOutput(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())
@@ -100,8 +83,6 @@ export default function (ctx: FtrProviderContext) {
     });
 
     it('accepts request to create a new elasticsearch output if host url is same as default', async () => {
-      await expectDefaultElasticsearchOutput(ctx);
-
       const { body, status } = await supertest
         .post('/api/fleet/outputs')
         .set(svlCommonApi.getInternalRequestHeader())


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/178779
Closes https://github.com/elastic/kibana/issues/178780

Followup to https://github.com/elastic/kibana/pull/178764, which was causing flakiness due to [this check outside of the retry block](https://github.com/elastic/kibana/pull/178764/files#diff-6ab6ea5fa5d071f51258738e92a673dc3a21d7261c94ecea0e60ca9b8e4f111cR31). This change returns the host URLs from the retry blocks.

### Flaky Test Runner

* 🟢 [x-pack/test_serverless/api_integration/test_suites/observability/fleet/config.ts x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5520)
* 🟢 [x-pack/test_serverless/api_integration/test_suites/security/fleet/config.ts x 200](https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5523)