### PR TITLE
fix dark mode for `CodeFieldEditor`

### DIFF
--- a/packages/shared-ux/code_editor/impl/index.tsx
+++ b/packages/shared-ux/code_editor/impl/index.tsx
@@ -13,6 +13,7 @@ import {
   EuiSkeletonText,
   EuiFormControlLayout,
   EuiErrorBoundary,
+  useEuiTheme,
 } from '@elastic/eui';
 import type { CodeEditorProps } from './code_editor';
 export type { CodeEditorProps } from './code_editor';
@@ -56,8 +57,11 @@ export const CodeEditor: React.FunctionComponent<CodeEditorProps> = (props) => {
  * Renders a Monaco code editor in the same style as other EUI form fields.
  */
 export const CodeEditorField: React.FunctionComponent<CodeEditorProps> = (props) => {
-  const { width, height, options, fullWidth, useDarkTheme } = props;
+  const { width, height, options, fullWidth, useDarkTheme: useDarkThemeProp } = props;
+  const { colorMode } = useEuiTheme();
+  const useDarkTheme = useDarkThemeProp ?? colorMode === 'DARK';
   const theme = useDarkTheme ? darkTheme : lightTheme;
+
   const style = {
     width,
     height,


### PR DESCRIPTION
## Summary

Fix https://github.com/elastic/kibana/issues/178740

This fixed the background color for the `CodeFieldEditor` component, a wrapper around `CodeEditor`. For the background color theme, we should fallback to the eui theme context value if the explicit prop is missing, the same way we do for the theme of the inner `CodeEditor` component

![Screenshot 2024-03-18 at 12 10 41](https://github.com/elastic/kibana/assets/7784120/5c396608-da88-4377-a09e-46464b1bb028)




<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->