### PR TITLE
[DOCS] Port forward link fix

### DIFF
--- a/docs/developer/plugin/external-plugin-functional-tests.asciidoc
+++ b/docs/developer/plugin/external-plugin-functional-tests.asciidoc
@@ -10,7 +10,7 @@ Every project or plugin should have its own `FunctionalTestRunner` config file. 
 
 To get started copy and paste this example to `test/functional/config.js`:
 
-["source","js"]
+["source","js",subs="attributes"]
 -----------
 import { resolve } from 'path';
 import { REPO_ROOT } from '@kbn/utils';
@@ -64,7 +64,8 @@ export default async function ({ readConfigFile }) {
     }
 
     // more settings, like timeouts, mochaOpts, etc are
-    // defined in the config schema. See {kibana-blob}src/functional_test_runner/lib/config/schema.js[src/functional_test_runner/lib/config/schema.js]
+    // defined in the config schema.
+    // See {kibana-blob}packages/kbn-test/src/functional_test_runner/lib/config/schema.ts
   };
 }
 


### PR DESCRIPTION
## Summary

Discovered a broken link when [backporting attribute replacement changes](https://github.com/elastic/kibana/pull/178759).  Porting forward the link fix so the link is valid and attributes render as expected in the code block


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->