### PR TITLE
[CodeEditor] fix indent lines color issue in dark mode

### DIFF
--- a/packages/shared-ux/code_editor/impl/editor.styles.ts
+++ b/packages/shared-ux/code_editor/impl/editor.styles.ts
@@ -127,7 +127,7 @@ export function createTheme(
       'editor.background': backgroundColor ?? euiTheme.euiFormBackgroundColor,
       'editorLineNumber.foreground': euiTheme.euiColorDarkShade,
       'editorLineNumber.activeForeground': euiTheme.euiColorDarkShade,
-      'editorIndentGuide.background': euiTheme.euiColorLightShade,
+      'editorIndentGuide.background1': euiTheme.euiColorLightShade,
       'editor.selectionBackground': selectionBackgroundColor,
       'editorWidget.border': euiTheme.euiColorLightShade,
       'editorWidget.background': euiTheme.euiColorLightestShade,


### PR DESCRIPTION
## Summary

fix https://github.com/elastic/kibana/issues/178882

before (see the vertical nesting lines having incorrect color - white):

 
<img width="749" alt="Screenshot 2024-03-18 at 16 32 29" src="https://github.com/elastic/kibana/assets/7784120/ed837542-f0c6-45b4-9f2e-cf3dc3307a64">


after:

<img width="733" alt="Screenshot 2024-03-18 at 16 59 28" src="https://github.com/elastic/kibana/assets/7784120/d29f5f23-9693-4a39-aa2d-7b2b43e37c75">



<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->