### PR TITLE
[Synthetics] Make core API key include `read_ilm` privilege in Stateful only

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
@@ -45,10 +45,6 @@ export class Plugin implements PluginType {
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
   }
 
-  private get _isServerless(): boolean {
-    return this.initContext.env.packageInfo.buildFlavor === 'serverless';
-  }
-
   public setup(core: CoreSetup, plugins: SyntheticsPluginsSetupDependencies) {
     const config = this.initContext.config.get<UptimeConfig>();
 
@@ -79,7 +75,6 @@ export class Plugin implements PluginType {
       logger: this.logger,
       telemetry: this.telemetryEventsSender,
       isDev: this.initContext.env.mode.dev,
-      isServerless: this._isServerless,
       share: plugins.share,
     } as SyntheticsServerSetup;
 

--- a/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
@@ -107,6 +107,7 @@ export class Plugin implements PluginType {
       this.server.encryptedSavedObjects = pluginsStart.encryptedSavedObjects;
       this.server.savedObjectsClient = this.savedObjectsClient;
       this.server.spaces = pluginsStart.spaces;
+      this.server.isElasticsearchServerless = coreStart.elasticsearch.getCapabilities().serverless;
     }
 
     this.syntheticsService?.start(pluginsStart.taskManager);

--- a/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
@@ -34,17 +34,19 @@ import { uptimeRuleTypeFieldMap } from './alert_rules/common';
 
 export class Plugin implements PluginType {
   private savedObjectsClient?: SavedObjectsClientContract;
-  private initContext: PluginInitializerContext;
   private logger: Logger;
   private server?: SyntheticsServerSetup;
   private syntheticsService?: SyntheticsService;
   private syntheticsMonitorClient?: SyntheticsMonitorClient;
   private readonly telemetryEventsSender: TelemetryEventsSender;
 
-  constructor(initializerContext: PluginInitializerContext<UptimeConfig>) {
-    this.initContext = initializerContext;
-    this.logger = initializerContext.logger.get();
+  constructor(private readonly initContext: PluginInitializerContext<UptimeConfig>) {
+    this.logger = initContext.logger.get();
     this.telemetryEventsSender = new TelemetryEventsSender(this.logger);
+  }
+
+  private get _isServerless(): boolean {
+    return this.initContext.env.packageInfo.buildFlavor === 'serverless';
   }
 
   public setup(core: CoreSetup, plugins: SyntheticsPluginsSetupDependencies) {
@@ -77,6 +79,7 @@ export class Plugin implements PluginType {
       logger: this.logger,
       telemetry: this.telemetryEventsSender,
       isDev: this.initContext.env.mode.dev,
+      isServerless: this._isServerless,
       share: plugins.share,
     } as SyntheticsServerSetup;
 

--- a/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/plugin.ts
@@ -34,7 +34,7 @@ import { uptimeRuleTypeFieldMap } from './alert_rules/common';
 
 export class Plugin implements PluginType {
   private savedObjectsClient?: SavedObjectsClientContract;
-  private logger: Logger;
+  private readonly logger: Logger;
   private server?: SyntheticsServerSetup;
   private syntheticsService?: SyntheticsService;
   private syntheticsMonitorClient?: SyntheticsMonitorClient;
@@ -50,7 +50,6 @@ export class Plugin implements PluginType {
 
     savedObjectsAdapter.config = config;
 
-    this.logger = this.initContext.logger.get();
     const { ruleDataService } = plugins.ruleRegistry;
 
     const ruleDataClient = ruleDataService.initializeIndex({

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -11,13 +11,13 @@ import { SyntheticsServerSetup } from '../../types';
 import { getFakeKibanaRequest } from '../utils/fake_kibana_request';
 import { getServiceApiKeyPrivileges, syntheticsIndex } from '../get_api_key';
 
-export const checkHasPrivileges = async (
+export const checkHasPrivileges = (
   server: SyntheticsServerSetup,
   apiKey: { id: string; apiKey: string }
 ) => {
   const { isServerless } = server;
   const { indices: index, cluster } = getServiceApiKeyPrivileges(isServerless);
-  return await server.coreStart.elasticsearch.client
+  return server.coreStart.elasticsearch.client
     .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))
     .asCurrentUser.security.hasPrivileges({
       body: {
@@ -27,8 +27,8 @@ export const checkHasPrivileges = async (
     });
 };
 
-export const checkIndicesReadPrivileges = async (uptimeEsClient: UptimeEsClient) => {
-  return await uptimeEsClient.baseESClient.security.hasPrivileges({
+export const checkIndicesReadPrivileges = (uptimeEsClient: UptimeEsClient) => {
+  return uptimeEsClient.baseESClient.security.hasPrivileges({
     body: {
       index: [
         {

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -9,18 +9,20 @@ import { SecurityIndexPrivilege } from '@elastic/elasticsearch/lib/api/types';
 import { UptimeEsClient } from '../../lib';
 import { SyntheticsServerSetup } from '../../types';
 import { getFakeKibanaRequest } from '../utils/fake_kibana_request';
-import { serviceApiKeyPrivileges, syntheticsIndex } from '../get_api_key';
+import { getServiceApiKeyPrivileges, syntheticsIndex } from '../get_api_key';
 
 export const checkHasPrivileges = async (
   server: SyntheticsServerSetup,
   apiKey: { id: string; apiKey: string }
 ) => {
+  const { isServerless } = server;
+  const { indices: index, cluster } = getServiceApiKeyPrivileges(isServerless);
   return await server.coreStart.elasticsearch.client
     .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))
     .asCurrentUser.security.hasPrivileges({
       body: {
-        index: serviceApiKeyPrivileges.indices,
-        cluster: serviceApiKeyPrivileges.cluster,
+        index,
+        cluster,
       },
     });
 };

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -15,8 +15,10 @@ export const checkHasPrivileges = (
   server: SyntheticsServerSetup,
   apiKey: { id: string; apiKey: string }
 ) => {
-  const { isServerless } = server;
-  const { indices: index, cluster } = getServiceApiKeyPrivileges(isServerless);
+  const { coreStart } = server;
+  const { indices: index, cluster } = getServiceApiKeyPrivileges(
+    coreStart.elasticsearch.getCapabilities().serverless
+  );
   return server.coreStart.elasticsearch.client
     .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))
     .asCurrentUser.security.hasPrivileges({

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -15,9 +15,7 @@ export const checkHasPrivileges = (
   server: SyntheticsServerSetup,
   apiKey: { id: string; apiKey: string }
 ) => {
-  const { indices: index, cluster } = getServiceApiKeyPrivileges(
-    server.coreStart.elasticsearch.getCapabilities().serverless
-  );
+  const { indices: index, cluster } = getServiceApiKeyPrivileges(server.isElasticsearchServerless);
   return server.coreStart.elasticsearch.client
     .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))
     .asCurrentUser.security.hasPrivileges({

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/authentication/check_has_privilege.ts
@@ -15,9 +15,8 @@ export const checkHasPrivileges = (
   server: SyntheticsServerSetup,
   apiKey: { id: string; apiKey: string }
 ) => {
-  const { coreStart } = server;
   const { indices: index, cluster } = getServiceApiKeyPrivileges(
-    coreStart.elasticsearch.getCapabilities().serverless
+    server.coreStart.elasticsearch.getCapabilities().serverless
   );
   return server.coreStart.elasticsearch.client
     .asScoped(getFakeKibanaRequest({ id: apiKey.id, api_key: apiKey.apiKey }))

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.test.ts
@@ -5,7 +5,11 @@
  * 2.0.
  */
 
-import { getAPIKeyForSyntheticsService, syntheticsIndex } from './get_api_key';
+import {
+  getAPIKeyForSyntheticsService,
+  getServiceApiKeyPrivileges,
+  syntheticsIndex,
+} from './get_api_key';
 import { encryptedSavedObjectsMock } from '@kbn/encrypted-saved-objects-plugin/server/mocks';
 import { securityMock } from '@kbn/security-plugin/server/mocks';
 import { coreMock } from '@kbn/core/server/mocks';
@@ -83,6 +87,18 @@ describe('getAPIKeyTest', function () {
       'ba997842-b0cf-4429-aa9d-578d9bf0d391'
     );
   });
+
+  it.each([
+    [true, ['monitor', 'read_pipeline']],
+    [false, ['monitor', 'read_pipeline', 'read_ilm']],
+  ])(
+    'Includes/excludes `read_ilm` priv when serverless is mode is %s',
+    (isServerless, expectedClusterPrivs) => {
+      const { cluster } = getServiceApiKeyPrivileges(isServerless);
+
+      expect(cluster).toEqual(expectedClusterPrivs);
+    }
+  );
 
   it('invalidates api keys with missing read permissions', async () => {
     jest.spyOn(authUtils, 'checkHasPrivileges').mockResolvedValue({

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.test.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.test.ts
@@ -93,8 +93,8 @@ describe('getAPIKeyTest', function () {
     [false, ['monitor', 'read_pipeline', 'read_ilm']],
   ])(
     'Includes/excludes `read_ilm` priv when serverless is mode is %s',
-    (isServerless, expectedClusterPrivs) => {
-      const { cluster } = getServiceApiKeyPrivileges(isServerless);
+    (isServerlessEs, expectedClusterPrivs) => {
+      const { cluster } = getServiceApiKeyPrivileges(isServerlessEs);
 
       expect(cluster).toEqual(expectedClusterPrivs);
     }

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
@@ -223,8 +223,8 @@ const hasEnablePermissions = async ({ uptimeEsClient, coreStart }: SyntheticsSer
     manage_api_key: manageApiKey,
     manage_own_api_key: manageOwnApiKey,
     monitor,
-    // this is going to be undefined in serverless mode (and break the API key flow),
-    // otherwise use the value supplied by ES
+    // `read_ilm` is going to be `undefined` when ES is in serverless mode,
+    // so we default it to the ES capabilities value.
     read_ilm: readILM = isServerlessEs,
     read_pipeline: readPipeline,
   } = cluster || {};

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
@@ -19,9 +19,9 @@ import { checkHasPrivileges } from './authentication/check_has_privilege';
 
 export const syntheticsIndex = 'synthetics-*';
 
-export const getServiceApiKeyPrivileges = (isServerless?: boolean) => {
+export const getServiceApiKeyPrivileges = (isServerless: boolean) => {
   const cluster: SecurityClusterPrivilege[] = ['monitor', 'read_pipeline'];
-  if (!isServerless) cluster.push('read_ilm');
+  if (isServerless === false) cluster.push('read_ilm');
   return {
     cluster,
     indices: [

--- a/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/synthetics_service/get_api_key.ts
@@ -19,20 +19,24 @@ import { checkHasPrivileges } from './authentication/check_has_privilege';
 
 export const syntheticsIndex = 'synthetics-*';
 
-export const serviceApiKeyPrivileges = {
-  cluster: ['monitor', 'read_ilm', 'read_pipeline'] as SecurityClusterPrivilege[],
-  indices: [
-    {
-      names: [syntheticsIndex],
-      privileges: [
-        'view_index_metadata',
-        'create_doc',
-        'auto_configure',
-        'read',
-      ] as SecurityIndexPrivilege[],
-    },
-  ],
-  run_as: [],
+export const getServiceApiKeyPrivileges = (isServerless?: boolean) => {
+  const cluster: SecurityClusterPrivilege[] = ['monitor', 'read_pipeline'];
+  if (!isServerless) cluster.push('read_ilm');
+  return {
+    cluster,
+    indices: [
+      {
+        names: [syntheticsIndex],
+        privileges: [
+          'view_index_metadata',
+          'create_doc',
+          'auto_configure',
+          'read',
+        ] as SecurityIndexPrivilege[],
+      },
+    ],
+    run_as: [],
+  };
 };
 
 export const getAPIKeyForSyntheticsService = async ({
@@ -84,7 +88,7 @@ export const generateAPIKey = async ({
   server: SyntheticsServerSetup;
   request: KibanaRequest;
 }) => {
-  const { security } = server;
+  const { isServerless, security } = server;
   const isApiKeysEnabled = await security.authc.apiKeys?.areAPIKeysEnabled();
 
   if (!isApiKeysEnabled) {
@@ -100,7 +104,7 @@ export const generateAPIKey = async ({
   return security.authc.apiKeys?.grantAsInternalUser(request, {
     name: 'synthetics-api-key (required for Synthetics App)',
     role_descriptors: {
-      synthetics_writer: serviceApiKeyPrivileges,
+      synthetics_writer: getServiceApiKeyPrivileges(isServerless),
     },
     metadata: {
       description:
@@ -202,16 +206,12 @@ export const getSyntheticsEnablement = async ({ server }: { server: SyntheticsSe
   };
 };
 
-const hasEnablePermissions = async ({ uptimeEsClient }: SyntheticsServerSetup) => {
+const hasEnablePermissions = async ({ uptimeEsClient, isServerless }: SyntheticsServerSetup) => {
+  const { cluster: clusterPrivs, indices: index } = getServiceApiKeyPrivileges(isServerless);
   const hasPrivileges = await uptimeEsClient.baseESClient.security.hasPrivileges({
     body: {
-      cluster: [
-        'manage_security',
-        'manage_api_key',
-        'manage_own_api_key',
-        ...serviceApiKeyPrivileges.cluster,
-      ],
-      index: serviceApiKeyPrivileges.indices,
+      cluster: ['manage_security', 'manage_api_key', 'manage_own_api_key', ...clusterPrivs],
+      index,
     },
   });
 
@@ -221,7 +221,9 @@ const hasEnablePermissions = async ({ uptimeEsClient }: SyntheticsServerSetup) =
     manage_api_key: manageApiKey,
     manage_own_api_key: manageOwnApiKey,
     monitor,
-    read_ilm: readILM,
+    // this is going to be undefined in serverless mode (and break the API key flow),
+    // otherwise use the value supplied by ES
+    read_ilm: readILM = isServerless,
     read_pipeline: readPipeline,
   } = cluster || {};
 

--- a/x-pack/plugins/observability_solution/synthetics/server/types.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/types.ts
@@ -59,6 +59,7 @@ export interface SyntheticsServerSetup {
   isDev?: boolean;
   coreStart: CoreStart;
   pluginsStart: SyntheticsPluginsStartDependencies;
+  isElasticsearchServerless: boolean;
 }
 
 export interface SyntheticsPluginsSetupDependencies {

--- a/x-pack/plugins/observability_solution/synthetics/server/types.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/types.ts
@@ -57,6 +57,7 @@ export interface SyntheticsServerSetup {
   uptimeEsClient: UptimeEsClient;
   basePath: IBasePath;
   isDev?: boolean;
+  isServerless?: boolean;
   coreStart: CoreStart;
   pluginsStart: SyntheticsPluginsStartDependencies;
 }

--- a/x-pack/plugins/observability_solution/synthetics/server/types.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/types.ts
@@ -57,7 +57,7 @@ export interface SyntheticsServerSetup {
   uptimeEsClient: UptimeEsClient;
   basePath: IBasePath;
   isDev?: boolean;
-  isServerless?: boolean;
+  isServerless: boolean;
   coreStart: CoreStart;
   pluginsStart: SyntheticsPluginsStartDependencies;
 }

--- a/x-pack/plugins/observability_solution/synthetics/server/types.ts
+++ b/x-pack/plugins/observability_solution/synthetics/server/types.ts
@@ -57,7 +57,6 @@ export interface SyntheticsServerSetup {
   uptimeEsClient: UptimeEsClient;
   basePath: IBasePath;
   isDev?: boolean;
-  isServerless: boolean;
   coreStart: CoreStart;
   pluginsStart: SyntheticsPluginsStartDependencies;
 }

--- a/x-pack/test/api_integration/apis/security/api_keys.ts
+++ b/x-pack/test/api_integration/apis/security/api_keys.ts
@@ -7,7 +7,7 @@
 
 import expect from '@kbn/expect';
 import { ALL_SPACES_ID } from '@kbn/security-plugin/common/constants';
-import { serviceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
+import { getServiceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
 export default function ({ getService }: FtrProviderContext) {
@@ -116,7 +116,7 @@ export default function ({ getService }: FtrProviderContext) {
               expiration: '12d',
               kibana_role_descriptors: {
                 uptime_save: {
-                  elasticsearch: serviceApiKeyPrivileges,
+                  elasticsearch: getServiceApiKeyPrivileges(false),
                   kibana: [
                     {
                       base: [],

--- a/x-pack/test/api_integration/apis/synthetics/add_monitor.ts
+++ b/x-pack/test/api_integration/apis/synthetics/add_monitor.ts
@@ -21,7 +21,7 @@ import { ALL_SPACES_ID } from '@kbn/security-plugin/common/constants';
 import { format as formatUrl } from 'url';
 
 import supertest from 'supertest';
-import { serviceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
+import { getServiceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
 import { syntheticsMonitorType } from '@kbn/synthetics-plugin/common/types/saved_objects';
 import { FtrProviderContext } from '../../ftr_provider_context';
 import { getFixtureJson } from './helper/get_fixture_json';
@@ -217,7 +217,7 @@ export default function ({ getService }: FtrProviderContext) {
           expiration: '12d',
           kibana_role_descriptors: {
             uptime_save: {
-              elasticsearch: serviceApiKeyPrivileges,
+              elasticsearch: getServiceApiKeyPrivileges(false),
               kibana: [
                 {
                   base: [],
@@ -260,7 +260,7 @@ export default function ({ getService }: FtrProviderContext) {
           expiration: '12d',
           kibana_role_descriptors: {
             uptime_save: {
-              elasticsearch: serviceApiKeyPrivileges,
+              elasticsearch: getServiceApiKeyPrivileges(false),
               kibana: [
                 {
                   base: [],

--- a/x-pack/test/api_integration/apis/synthetics/synthetics_enablement.ts
+++ b/x-pack/test/api_integration/apis/synthetics/synthetics_enablement.ts
@@ -17,7 +17,7 @@ import { FtrProviderContext } from '../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const correctPrivileges = {
     applications: [],
-    cluster: ['monitor', 'read_ilm', 'read_pipeline'],
+    cluster: ['monitor', 'read_pipeline', 'read_ilm'],
     indices: [
       {
         allow_restricted_indices: false,

--- a/x-pack/test/api_integration/apis/synthetics/synthetics_enablement.ts
+++ b/x-pack/test/api_integration/apis/synthetics/synthetics_enablement.ts
@@ -10,7 +10,7 @@ import {
   syntheticsApiKeyID,
   syntheticsApiKeyObjectType,
 } from '@kbn/synthetics-plugin/server/saved_objects/service_api_key';
-import { serviceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
+import { getServiceApiKeyPrivileges } from '@kbn/synthetics-plugin/server/synthetics_service/get_api_key';
 import expect from '@kbn/expect';
 import { FtrProviderContext } from '../../ftr_provider_context';
 
@@ -74,7 +74,7 @@ export default function ({ getService }: FtrProviderContext) {
               ],
               elasticsearch: {
                 cluster: [privilege],
-                indices: serviceApiKeyPrivileges.indices,
+                indices: getServiceApiKeyPrivileges(false).indices,
               },
             });
 
@@ -119,8 +119,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 
@@ -167,8 +167,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 
@@ -233,7 +233,7 @@ export default function ({ getService }: FtrProviderContext) {
               expiration: '1d',
               role_descriptors: {
                 'role-a': {
-                  cluster: serviceApiKeyPrivileges.cluster,
+                  cluster: getServiceApiKeyPrivileges(false).cluster,
                   indices: [
                     {
                       names: ['synthetics-*'],
@@ -269,8 +269,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 
@@ -318,8 +318,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 
@@ -449,8 +449,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 
@@ -562,8 +562,8 @@ export default function ({ getService }: FtrProviderContext) {
               },
             ],
             elasticsearch: {
-              cluster: serviceApiKeyPrivileges.cluster,
-              indices: serviceApiKeyPrivileges.indices,
+              cluster: getServiceApiKeyPrivileges(false).cluster,
+              indices: getServiceApiKeyPrivileges(false).indices,
             },
           });
 


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/synthetics-dev/issues/332.

ILM is not a concept in Serverless. As such, when the Synthetics plugin requests the `read_ilm` permission for its core API key during bootstrapping, it's asking for a priv that will eventually not exist on Serverless, and ES will give an explicit deny for the request, which will probably cause Synthetics to crash and not be functional.

The fix is to detect the build type at startup time and enable the server plugin to determine whether it needs to include this privilege or not, based on whether Kibana is running in stateful or serverless mode.

## Testing

You can easily test this in both modes. The steps are the same.

_NOTE:_ when testing serverless, if you include the flag ` -E xpack.security.authz.has_privileges.strict_request_validation.enabled=true` this will simulate the manner in which Elasticsearch will explicit deny the API creation request when this is enabled in the MKI environment, and thus you should include it in your testing.

1. Start up Kibana in serverless | stateful mode.
2. As an admin, navigate to Synthetics and wait for the startup flow to display.
3. Navigate to Kibana management's API key page. You should see the Synthetics API key. Click it.
4. For stateful, you should see `read_ilm` included under the `synthetics_writer` object, shown below. For serverless, you should not see this priv in the list.

### Stateful API key perms

<img width="1834" alt="image" src="https://github.com/elastic/kibana/assets/18429259/09048a7d-dcea-420e-bef5-87f86e447791">

### Serverless API key perms

<img width="1844" alt="image" src="https://github.com/elastic/kibana/assets/18429259/9a2a7f6b-6c6a-42f9-a47a-2ee157b2692b">
