### PR TITLE
[apm/config] Omit apiKey from RUM agent

### DIFF
--- a/packages/core/http/core-http-resources-server-internal/src/get_apm_config.test.ts
+++ b/packages/core/http/core-http-resources-server-internal/src/get_apm_config.test.ts
@@ -66,6 +66,16 @@ describe('getApmConfig', () => {
     expect(config).not.toHaveProperty('secretToken');
   });
 
+  it('omits apiKey', () => {
+    getConfigurationMock.mockReturnValue({
+      ...defaultApmConfig,
+      apiKey: 'smurfs',
+    });
+    const config = getApmConfig('/some-other-path');
+
+    expect(config).not.toHaveProperty('apiKey');
+  });
+
   it('enhance the configuration with values from the current server-side transaction', () => {
     agentMock.currentTransaction = {
       sampled: 'sampled',

--- a/packages/core/http/core-http-resources-server-internal/src/get_apm_config.ts
+++ b/packages/core/http/core-http-resources-server-internal/src/get_apm_config.ts
@@ -9,7 +9,7 @@
 import agent, { AgentConfigOptions } from 'elastic-apm-node';
 import { getConfiguration, shouldInstrumentClient } from '@kbn/apm-config-loader';
 
-const OMIT_APM_CONFIG: Array<keyof AgentConfigOptions> = ['secretToken'];
+const OMIT_APM_CONFIG: Array<keyof AgentConfigOptions> = ['secretToken', 'apiKey'];
 
 export const getApmConfig = (requestPath: string) => {
   const baseConfig = getConfiguration('kibana-frontend') || {};

--- a/packages/core/http/core-http-resources-server-internal/src/get_apm_config.ts
+++ b/packages/core/http/core-http-resources-server-internal/src/get_apm_config.ts
@@ -9,7 +9,12 @@
 import agent, { AgentConfigOptions } from 'elastic-apm-node';
 import { getConfiguration, shouldInstrumentClient } from '@kbn/apm-config-loader';
 
-const OMIT_APM_CONFIG: Array<keyof AgentConfigOptions> = ['secretToken', 'apiKey'];
+const OMIT_APM_CONFIG: Array<keyof AgentConfigOptions> = [
+  'secretToken',
+  'apiKey',
+  'captureSpanStackTraces',
+  'metricsInterval',
+];
 
 export const getApmConfig = (requestPath: string) => {
   const baseConfig = getConfiguration('kibana-frontend') || {};


### PR DESCRIPTION
Follow up to https://github.com/elastic/kibana/pull/163153

Fixes `[00:10:16]           â”‚ debg browser[WARNING] http://localhost:5620/de844665f756/bundles/core/core.entry.js 0:140730 "[Elastic APM] Unknown config options are specified for RUM agent: apiKey"`

Can be tested locally by setting `ELASTIC_APM_ACTIVE=true; ELASTIC_APM_SERVER_URL='...';ELASTIC_APM_API_KEY='...'`

