### PR TITLE
[Synthetics] Fix data retention error handling in Serverless

### DIFF
--- a/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/settings/data_retention/dsl_retention_tab.tsx
+++ b/x-pack/plugins/observability_solution/synthetics/public/apps/synthetics/components/settings/data_retention/dsl_retention_tab.tsx
@@ -16,11 +16,12 @@ import { useManagementLocator } from './use_management_locator';
 
 export const DslRetentionTab = () => {
   const { dataStreamStatuses = [], loading, error } = useGetDataStreamStatuses();
-  if (loading === false && dataStreamStatuses.length === 0)
-    return <ErrorEmptyPrompt error={error?.message} />;
 
   if (error && (error as unknown as IHttpFetchError<ResponseErrorBody>).body?.statusCode === 403)
     return <Unprivileged hideIlmMessage={true} />;
+
+  if (loading === false && dataStreamStatuses.length === 0)
+    return <ErrorEmptyPrompt error={error?.message} />;
 
   return (
     <EuiBasicTable


### PR DESCRIPTION
## Summary

Resolves https://github.com/elastic/kibana/issues/178905.

As part of https://github.com/elastic/kibana/pull/177764 we merged a new UI view for Serverless Kibana where we display DSL-related retention metrics in place of the ILM-centric version we use in Stateful Kibana. Unfortunately, this new view handles the case where loading has finished and there are no data streams to report before it handles a case where the management API responded with a 403.

Today, this is what is shown to a user with the `viewer` role in Serverless projects; it's the error we display in the event of an unhandled request error (i.e. 4xx other than 403).

<img width="1056" alt="image" src="https://github.com/elastic/kibana/assets/18429259/a9712984-a600-45ac-8637-cfc249aafb0a">

What they should see (in the event of a 403, which is what they receive when trying to fetch retention data) is something like this:

<img width="1485" alt="image" src="https://github.com/elastic/kibana/assets/18429259/7bf9f784-49ce-4820-84f7-d55ae44bcdb7">

This PR simply switches the order of these blocks, which causes the correct empty prompt to show up for users.

Related to https://github.com/elastic/synthetics-dev/issues/291.