### PR TITLE
[Data Views] Fix flaky test skipped in #170047

### DIFF
--- a/test/examples/data_view_field_editor_example/data_view_field_editor_example.ts
+++ b/test/examples/data_view_field_editor_example/data_view_field_editor_example.ts
@@ -13,9 +13,9 @@ import { PluginFunctionalProviderContext } from '../../plugin_functional/service
 export default function ({ getService }: PluginFunctionalProviderContext) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
+  const retry = getService('retry');
 
-  // FLAKY: https://github.com/elastic/kibana/issues/170047
-  describe.skip('', () => {
+  describe('', () => {
     it('finds a data view', async () => {
       await testSubjects.existOrFail('dataViewTitle');
     });
@@ -23,7 +23,10 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
     it('opens the field editor', async () => {
       await testSubjects.click('addField');
       await testSubjects.existOrFail('flyoutTitle');
-      await testSubjects.click('closeFlyoutButton');
+      await retry.try(async () => {
+        await testSubjects.click('closeFlyoutButton');
+        await testSubjects.missingOrFail('flyoutTitle');
+      });
     });
 
     it('uses preconfigured options for a new field', async () => {

--- a/test/examples/data_view_field_editor_example/data_view_field_editor_example.ts
+++ b/test/examples/data_view_field_editor_example/data_view_field_editor_example.ts
@@ -15,7 +15,7 @@ export default function ({ getService }: PluginFunctionalProviderContext) {
   const find = getService('find');
   const retry = getService('retry');
 
-  describe('', () => {
+  describe('data_view_field_editor_example', () => {
     it('finds a data view', async () => {
       await testSubjects.existOrFail('dataViewTitle');
     });

--- a/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/data_view_field_editor_example.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/data_view_field_editor_example.ts
@@ -12,6 +12,7 @@ import type { FtrProviderContext } from '../../../../ftr_provider_context';
 export default function ({ getService }: FtrProviderContext) {
   const testSubjects = getService('testSubjects');
   const find = getService('find');
+  const retry = getService('retry');
 
   describe('', () => {
     it('finds a data view', async () => {
@@ -21,7 +22,10 @@ export default function ({ getService }: FtrProviderContext) {
     it('opens the field editor', async () => {
       await testSubjects.click('addField');
       await testSubjects.existOrFail('flyoutTitle');
-      await testSubjects.click('closeFlyoutButton');
+      await retry.try(async () => {
+        await testSubjects.click('closeFlyoutButton');
+        await testSubjects.missingOrFail('flyoutTitle');
+      });
     });
 
     it('uses preconfigured options for a new field', async () => {

--- a/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/data_view_field_editor_example.ts
+++ b/x-pack/test_serverless/functional/test_suites/common/examples/data_view_field_editor_example/data_view_field_editor_example.ts
@@ -14,7 +14,7 @@ export default function ({ getService }: FtrProviderContext) {
   const find = getService('find');
   const retry = getService('retry');
 
-  describe('', () => {
+  describe('data_view_field_editor_example', () => {
     it('finds a data view', async () => {
       await testSubjects.existOrFail('dataViewTitle');
     });


### PR DESCRIPTION
## Summary

This PR fixes the flaky test skipped in #170047.

Flaky test runner x200: https://buildkite.com/elastic/kibana-flaky-test-suite-runner/builds/5525.

Resolves #170047.

### Checklist

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [x] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)

<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->