### PR TITLE
[8.13] [Obs AI Assistant] Relax process contextual insight (#178840)

### DIFF
--- a/x-pack/plugins/infra/public/components/asset_details/tabs/processes/process_row.tsx
+++ b/x-pack/plugins/infra/public/components/asset_details/tabs/processes/process_row.tsx
@@ -54,9 +54,7 @@ export const ContextualInsightProcessRow = ({ command }: { command: string }) =>
           with the arguments to the process you should then explain its arguments and how they influence the behaviour
           of the process. If I do not provide any arguments then explain the behaviour of the process when no arguments are
           provided.
-          If you do not recognise the process say "No information available for this process". If I provide an argument
-          to the process that you do not recognise then say "No information available for this argument" when explaining
-          that argument.
+          
           Here is an example with arguments.
           Process: metricbeat -c /etc/metricbeat.yml -d autodiscover,kafka -e -system.hostfs=/hostfs
           Explanation: Metricbeat is part of the Elastic Stack. It is a lightweight shipper that you can install on your


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[Obs AI Assistant] Relax process contextual insight (#178840)](https://github.com/elastic/kibana/pull/178840)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Dario Gieselaar","email":"dario.gieselaar@elastic.co"},"sourceCommit":{"committedDate":"2024-03-19T07:45:20Z","message":"[Obs AI Assistant] Relax process contextual insight (#178840)\n\n@LucaWintergerst reported that the contextual insight for processes is a\r\nlittle bit too eager to report that there is no information available\r\nfor a process. The system prompt tells the LLM that it should fall back\r\nto this if it feels it doesn't know what the process does. This change\r\nremoves that instruction so the LLM tries to be more helpful here.","sha":"2914c41947150f8900097bc993e8a1a23299bf00","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:skip","v8.13.0","v8.14.0"],"number":178840,"url":"https://github.com/elastic/kibana/pull/178840","mergeCommit":{"message":"[Obs AI Assistant] Relax process contextual insight (#178840)\n\n@LucaWintergerst reported that the contextual insight for processes is a\r\nlittle bit too eager to report that there is no information available\r\nfor a process. The system prompt tells the LLM that it should fall back\r\nto this if it feels it doesn't know what the process does. This change\r\nremoves that instruction so the LLM tries to be more helpful here.","sha":"2914c41947150f8900097bc993e8a1a23299bf00"}},"sourceBranch":"main","suggestedTargetBranches":["8.13"],"targetPullRequestStates":[{"branch":"8.13","label":"v8.13.0","labelRegex":"^v(\\d+).(\\d+).\\d+$","isSourceBranch":false,"state":"NOT_CREATED"},{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/178840","number":178840,"mergeCommit":{"message":"[Obs AI Assistant] Relax process contextual insight (#178840)\n\n@LucaWintergerst reported that the contextual insight for processes is a\r\nlittle bit too eager to report that there is no information available\r\nfor a process. The system prompt tells the LLM that it should fall back\r\nto this if it feels it doesn't know what the process does. This change\r\nremoves that instruction so the LLM tries to be more helpful here.","sha":"2914c41947150f8900097bc993e8a1a23299bf00"}}]}] BACKPORT-->