### PR TITLE
[Security Solution][Cypress] Deletes unnecessary query

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
+++ b/x-pack/test/security_solution_cypress/cypress/tasks/api_calls/common.ts
@@ -37,7 +37,6 @@ export const rootRequest = <T = unknown>({
 
 export const deleteAlertsAndRules = () => {
   cy.log('Delete all alerts and rules');
-  const kibanaIndexUrl = `${Cypress.env('ELASTICSEARCH_URL')}/.kibana_\*`;
 
   rootRequest({
     method: 'POST',
@@ -48,24 +47,6 @@ export const deleteAlertsAndRules = () => {
     },
     failOnStatusCode: false,
     timeout: 300000,
-  });
-
-  rootRequest({
-    method: 'POST',
-    url: `${kibanaIndexUrl}/_delete_by_query?conflicts=proceed&refresh`,
-    body: {
-      query: {
-        bool: {
-          filter: [
-            {
-              match: {
-                type: 'alert',
-              },
-            },
-          ],
-        },
-      },
-    },
   });
 
   deleteAllDocuments(`.lists-*,.items-*,${DEFAULT_ALERTS_INDEX_PATTERN}`);


### PR DESCRIPTION
## Summary

Inside `deleteAlertsAndRules` we are using `delete_by_query` to delete the alerts generated by the tests. At the same time, we are deleting the document that includes the alerts, with that action, is more than enough to remove the alerts.