### PR TITLE
[Fleet] fix bug where secret was not deleted on type change

### DIFF
--- a/x-pack/plugins/fleet/server/services/secrets.test.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.test.ts
@@ -27,6 +27,7 @@ import {
   diffOutputSecretPaths,
   extractAndWriteSecrets,
   extractAndUpdateSecrets,
+  extractAndUpdateOutputSecrets,
 } from './secrets';
 
 describe('secrets', () => {
@@ -1358,6 +1359,85 @@ describe('secrets', () => {
 
         expect(result.secretsToDelete).toHaveLength(2);
       });
+    });
+  });
+
+  describe('extractAndUpdateOutputSecrets', () => {
+    const esClientMock = elasticsearchServiceMock.createInternalClient();
+
+    esClientMock.transport.request.mockImplementation(async (req) => {
+      return {
+        id: uuidv4(),
+      };
+    });
+
+    beforeEach(() => {
+      esClientMock.transport.request.mockClear();
+    });
+
+    it('should delete secret if type changed from kafka to remote es', async () => {
+      const result = await extractAndUpdateOutputSecrets({
+        oldOutput: {
+          id: 'id1',
+          name: 'kafka to remote es',
+          is_default: false,
+          is_default_monitoring: false,
+          type: 'kafka',
+          secrets: {
+            password: {
+              id: 'pass',
+            },
+          },
+        },
+        outputUpdate: {
+          name: 'kafka to remote es',
+          type: 'remote_elasticsearch',
+          hosts: ['http://192.168.178.216:9200'],
+          is_default: false,
+          is_default_monitoring: false,
+          preset: 'balanced',
+          config_yaml: '',
+          secrets: {
+            service_token: 'token1',
+          },
+          proxy_id: null,
+        },
+        esClient: esClientMock,
+      });
+
+      expect(result.secretsToDelete).toEqual([{ id: 'pass' }]);
+    });
+
+    it('should delete secret if type changed from remote es to kafka', async () => {
+      const result = await extractAndUpdateOutputSecrets({
+        oldOutput: {
+          id: 'id2',
+          name: 'remote es to kafka',
+          is_default: false,
+          is_default_monitoring: false,
+          type: 'remote_elasticsearch',
+          secrets: {
+            service_token: {
+              id: 'token',
+            },
+          },
+        },
+        outputUpdate: {
+          name: 'remote es to kafka',
+          type: 'kafka',
+          is_default: false,
+          is_default_monitoring: false,
+          preset: 'balanced',
+          config_yaml: '',
+          secrets: {
+            password: 'pass',
+          },
+          proxy_id: null,
+        },
+        esClient: esClientMock,
+      });
+
+      expect(result.secretsToDelete).toEqual([{ id: 'token' }]);
     });
   });
 });

--- a/x-pack/plugins/fleet/server/services/secrets.ts
+++ b/x-pack/plugins/fleet/server/services/secrets.ts
@@ -457,7 +457,7 @@ export async function extractAndUpdateOutputSecrets(opts: {
 }> {
   const { oldOutput, outputUpdate, esClient, secretHashes } = opts;
   const outputType = outputUpdate.type || oldOutput.type;
-  const oldSecretPaths = getOutputSecretPaths(outputType, oldOutput);
+  const oldSecretPaths = getOutputSecretPaths(oldOutput.type, oldOutput);
   const updatedSecretPaths = getOutputSecretPaths(outputType, outputUpdate);
 
   if (!oldSecretPaths.length && !updatedSecretPaths.length) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/elastic/kibana/issues/178526

Found a bug where changing an output type didn't properly delete secret values.

One thing I noticed is that when updating a saved object, even if `secrets` is being changed from `secrets: {password: {id: ""}}` to `secrets: {service_token: {id: ""}}`, the result will contain both. There doesn't seem to be an easy way to get rid of the old keys, only if we explicitly set null, e.g. `secrets: {password: null}`. For now I didn't touch this part, as setting null causes an issue somewhere else when loading the secrets. The old keys don't seem to cause an issue, the secret itself is being deleted.

Code where we do an update of the SO: https://github.com/juliaElastic/kibana/blob/ae8bfe6225868607fe4cbdf2b93e9da362434e02/x-pack/plugins/fleet/server/services/output.ts#L1041

```
GET .kibana_ingest/_doc/ingest-outputs:dbd56679-819a-422a-bcf8-fade1ec76a72

      "secrets": {
        "password": {
          "id": "4Zy4Vo4B1OCaun07Mg6J"
        },
        "service_token": {
          "id": "45y4Vo4B1OCaun07hQ7m"
        }
      },
```

To verify:
- start kibana with 8.12+ fleet-server to enable secrets
- create kafka output with username/password authentication
- use kafka output in an agent policy and enroll an agent
- change the kafka output to a remote es output
- verify that the agent can send data to the remote es output
- verify that the kafka password is deleted from `.fleet-secrets`

<img width="536" alt="image" src="https://github.com/elastic/kibana/assets/90178898/361073be-991d-43ae-9622-960f0934d264">
<img width="968" alt="image" src="https://github.com/elastic/kibana/assets/90178898/7e04dfe5-db46-4dd7-b54d-9005135c8cd8">
<img width="966" alt="image" src="https://github.com/elastic/kibana/assets/90178898/f9006d68-2967-47ef-bed8-a9bf54884f4c">




### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->