### PR TITLE
[kbn-journeys] use TEST_INGEST_ES_DATA to determine synthtrace usage

### DIFF
--- a/packages/kbn-journeys/journey/journey_ftr_harness.ts
+++ b/packages/kbn-journeys/journey/journey_ftr_harness.ts
@@ -70,9 +70,9 @@ export class JourneyFtrHarness {
   private apm: apmNode.Agent | null = null;
 
   // journey can be run to collect EBT/APM metrics or just as a functional test
-  // TEST_PERFORMANCE_PHASE is defined via scripts/run_perfomance.js run only
+  // TEST_INGEST_ES_DATA is defined via scripts/run_perfomance.js run only
   private readonly isPerformanceRun = process.env.TEST_PERFORMANCE_PHASE || false;
-  private readonly isWarmupPhase = process.env.TEST_PERFORMANCE_PHASE === 'WARMUP';
+  private readonly shouldIngestEsData = !!process.env.TEST_INGEST_ES_DATA;
 
   // Update the Telemetry and APM global labels to link traces with journey
   private async updateTelemetryAndAPMLabels(labels: { [k: string]: string }) {
@@ -206,7 +206,7 @@ export class JourneyFtrHarness {
      */
 
     // To insure we ingest data with synthtrace only once during performance run
-    if (!this.isPerformanceRun || this.isWarmupPhase) {
+    if (!this.isPerformanceRun || this.shouldIngestEsData) {
       await this.runSynthtrace();
     }
 


### PR DESCRIPTION
## Summary

In #178599 we moved synthrace logic inside kbn-journey. It works well except the case when we run journeys in [kibana / performance-data-set-extraction](https://buildkite.com/elastic/kibana-performance-data-set-extraction) pipeline:
we run it with `--skip-warmup` flag which runs only TEST phase but without ES data being ingested, causing journey to [fail](https://buildkite.com/elastic/kibana-performance-data-set-extraction/builds/1322#018e5629-deb8-4707-b5cf-25191d7d45d6).

Synthtrace has no soft ingest option like esArchiver `loadIfNeeded`, so we can't re-use the approach we do with es/kbn archives. We must know explicitly when to run synthtrace and the easy way is to pass env var directly from the managing script:
`TEST_INGEST_ES_DATA` is set via performance run script and is used to define when synthrace indexing to be run.

Validating fix in [pipeline](https://buildkite.com/elastic/kibana-performance-data-set-extraction/builds/1323)