### PR TITLE
[Fleet] Fix concurent package policies create

### DIFF
--- a/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.test.ts
@@ -268,6 +268,7 @@ description: Elasticsearch description`,
               name: 'elasticsearch',
               version: '0.0.1',
               install_source: 'upload',
+              install_status: 'installed',
               package_assets: [],
               data_utf8: `
             name: elasticsearch
@@ -360,6 +361,7 @@ test: invalid manifest`,
               name: 'invalidpackage',
               version: '0.0.1',
               install_source: 'upload',
+              install_status: 'installed',
               package_assets: [],
               data_utf8: `
             name: invalidpackage
@@ -414,6 +416,7 @@ test: invalid manifest
               version: '0.0.1',
               install_source: 'upload',
               install_version: '0.0.1',
+              install_status: 'installed',
             },
             score: 0,
             type: PACKAGES_SAVED_OBJECT_TYPE,
@@ -442,6 +445,7 @@ description: Elasticsearch description`,
             attributes: {
               name: 'elasticsearch',
               version: '0.0.1',
+              install_status: 'installed',
               install_source: 'upload',
               package_assets: [],
               data_utf8: `

--- a/x-pack/plugins/fleet/server/services/epm/packages/get.ts
+++ b/x-pack/plugins/fleet/server/services/epm/packages/get.ts
@@ -542,7 +542,11 @@ export async function getPackageFromSource(options: {
   let res: GetPackageResponse;
 
   // If the package is installed
-  if (installedPkg && installedPkg.version === pkgVersion) {
+  if (
+    installedPkg &&
+    installedPkg.install_status === 'installed' &&
+    installedPkg.version === pkgVersion
+  ) {
     const { install_source: pkgInstallSource } = installedPkg;
     if (!res && installedPkg.package_assets) {
       res = await getEsPackage(


### PR DESCRIPTION
## Description 

Resolve https://github.com/elastic/elastic-agent/issues/4102

Fix concurrent package policies create, when two custom log package policies are create at the same time it happen to have a conflict where we try to retrieve the package from ES before it's installed this should fix it.

## Todo

- [x] add some test
- [x] check for side effects