### PR TITLE
deepmerge in merging apm-configuration

### DIFF
--- a/packages/kbn-apm-config-loader/src/config.test.ts
+++ b/packages/kbn-apm-config-loader/src/config.test.ts
@@ -152,6 +152,7 @@ describe('ApmConfiguration', () => {
       delete process.env.ELASTIC_APM_SECRET_TOKEN;
       delete process.env.ELASTIC_APM_API_KEY;
       delete process.env.ELASTIC_APM_SERVER_URL;
+      delete process.env.ELASTIC_APM_GLOBAL_LABELS;
       delete process.env.NODE_ENV;
     });
 
@@ -195,7 +196,7 @@ describe('ApmConfiguration', () => {
               git_rev: 'sha',
               test1: '1',
               test2: '4',
-            }
+            },
           })
         );
       });

--- a/packages/kbn-apm-config-loader/src/config.test.ts
+++ b/packages/kbn-apm-config-loader/src/config.test.ts
@@ -5,7 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type {AgentConfigOptions, Labels} from 'elastic-apm-node';
+import type { AgentConfigOptions, Labels } from 'elastic-apm-node';
 import {
   gitRevExecMock,
   mockedRootDir,
@@ -14,7 +14,7 @@ import {
   resetAllMocks,
 } from './config.test.mocks';
 
-import {ApmConfiguration, CENTRALIZED_SERVICE_BASE_CONFIG} from './config';
+import { ApmConfiguration, CENTRALIZED_SERVICE_BASE_CONFIG } from './config';
 
 describe('ApmConfiguration', () => {
   beforeEach(() => {

--- a/packages/kbn-apm-config-loader/src/config.test.ts
+++ b/packages/kbn-apm-config-loader/src/config.test.ts
@@ -5,16 +5,16 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-import type { AgentConfigOptions, Labels } from 'elastic-apm-node';
+import type {AgentConfigOptions, Labels} from 'elastic-apm-node';
 import {
-  packageMock,
-  mockedRootDir,
   gitRevExecMock,
+  mockedRootDir,
+  packageMock,
   readUuidFileMock,
   resetAllMocks,
 } from './config.test.mocks';
 
-import { ApmConfiguration, CENTRALIZED_SERVICE_BASE_CONFIG } from './config';
+import {ApmConfiguration, CENTRALIZED_SERVICE_BASE_CONFIG} from './config';
 
 describe('ApmConfiguration', () => {
   beforeEach(() => {
@@ -181,6 +181,21 @@ describe('ApmConfiguration', () => {
         expect(config.getConfig('serviceName')).toEqual(
           expect.objectContaining({
             environment: 'ci',
+          })
+        );
+      });
+
+      it('ELASTIC_APM_GLOBAL_LABELS', () => {
+        process.env.ELASTIC_APM_GLOBAL_LABELS = 'test1=1,test2=2';
+        const config = new ApmConfiguration(mockedRootDir, {}, true);
+
+        expect(config.getConfig('serviceName')).toEqual(
+          expect.objectContaining({
+            globalLabels: {
+              git_rev: "sha",
+              test1: "1",
+              test2: "4"
+            }
           })
         );
       });

--- a/packages/kbn-apm-config-loader/src/config.test.ts
+++ b/packages/kbn-apm-config-loader/src/config.test.ts
@@ -195,7 +195,7 @@ describe('ApmConfiguration', () => {
             globalLabels: {
               git_rev: 'sha',
               test1: '1',
-              test2: '4',
+              test2: '2',
             },
           })
         );

--- a/packages/kbn-apm-config-loader/src/config.test.ts
+++ b/packages/kbn-apm-config-loader/src/config.test.ts
@@ -192,9 +192,9 @@ describe('ApmConfiguration', () => {
         expect(config.getConfig('serviceName')).toEqual(
           expect.objectContaining({
             globalLabels: {
-              git_rev: "sha",
-              test1: "1",
-              test2: "4"
+              git_rev: 'sha',
+              test1: '1',
+              test2: '4',
             }
           })
         );

--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -296,7 +296,10 @@ export class ApmConfiguration {
     const { servicesOverrides, redactUsers, ...configFromKibanaConfig } =
       this.getConfigFromKibanaConfig();
     const configFromEnv = this.getConfigFromEnv(configFromKibanaConfig);
-    const config = deepmerge({}, configFromKibanaConfig, configFromEnv);
+    const config = [configFromKibanaConfig, configFromEnv].reduce<AgentConfigOptions>(
+      (acc, conf) => deepmerge(acc, conf),
+      {}
+    );
 
     if (config.active === false && config.contextPropagationOnly !== false) {
       throw new Error(

--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { deepMerge } from 'deepmerge';
+import deepmerge from 'deepmerge';
 import { execSync } from 'child_process';
 import { getDataPath } from '@kbn/utils';
 import { readFileSync } from 'fs';
@@ -295,7 +295,7 @@ export class ApmConfiguration {
     const { servicesOverrides, redactUsers, ...configFromKibanaConfig } =
       this.getConfigFromKibanaConfig();
     const configFromEnv = this.getConfigFromEnv(configFromKibanaConfig);
-    const config = deepMerge({}, configFromKibanaConfig, configFromEnv);
+    const config = deepmerge({}, configFromKibanaConfig, configFromEnv);
 
     if (config.active === false && config.contextPropagationOnly !== false) {
       throw new Error(

--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { deepmerge } from 'deepmerge';
+import { deepMerge } from 'deepmerge';
 import { execSync } from 'child_process';
 import { getDataPath } from '@kbn/utils';
 import { readFileSync } from 'fs';
@@ -295,7 +295,7 @@ export class ApmConfiguration {
     const { servicesOverrides, redactUsers, ...configFromKibanaConfig } =
       this.getConfigFromKibanaConfig();
     const configFromEnv = this.getConfigFromEnv(configFromKibanaConfig);
-    const config = deepmerge({}, configFromKibanaConfig, configFromEnv);
+    const config = deepMerge({}, configFromKibanaConfig, configFromEnv);
 
     if (config.active === false && config.contextPropagationOnly !== false) {
       throw new Error(

--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -8,6 +8,7 @@
 
 import { join } from 'path';
 import deepmerge from 'deepmerge';
+import { merge } from 'lodash';
 import { execSync } from 'child_process';
 import { getDataPath } from '@kbn/utils';
 import { readFileSync } from 'fs';

--- a/packages/kbn-apm-config-loader/src/config.ts
+++ b/packages/kbn-apm-config-loader/src/config.ts
@@ -7,7 +7,7 @@
  */
 
 import { join } from 'path';
-import { merge } from 'lodash';
+import { deepmerge } from 'deepmerge';
 import { execSync } from 'child_process';
 import { getDataPath } from '@kbn/utils';
 import { readFileSync } from 'fs';
@@ -295,7 +295,7 @@ export class ApmConfiguration {
     const { servicesOverrides, redactUsers, ...configFromKibanaConfig } =
       this.getConfigFromKibanaConfig();
     const configFromEnv = this.getConfigFromEnv(configFromKibanaConfig);
-    const config = merge({}, configFromKibanaConfig, configFromEnv);
+    const config = deepmerge({}, configFromKibanaConfig, configFromEnv);
 
     if (config.active === false && config.contextPropagationOnly !== false) {
       throw new Error(


### PR DESCRIPTION
We faced an issue where APM global labels sourced from the kibana configuration were overriden when `ELASTIC_APM_GLOBAL_LABELS` was set in the run-time.

I suspect this is due to the fact hat the use a shallow merge at this point, 
and the labels are nested inside both configuration ( `configFromKibanaConfig`, and `configFromEnv` ).
```
config =  Object {
         ...
         "globalLabels": Object {
                ....
         },
         ...
}
```

Didn't set up my IDE to actually test this. But added a unit test which will hopefully give some feedback