### PR TITLE
[Security Solution][Investigations] Fixes `notes tab` test in MKI

### DIFF
--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
@@ -26,7 +26,12 @@ import { addNotesToTimeline, goToNotesTab } from '../../../tasks/timeline';
 
 import { deleteTimelines } from '../../../tasks/api_calls/common';
 
-const text = 'system_indices_superuser';
+const systemIndicesSuperuserName = 'system_indices_superuser';
+const serverlessCloudUserName = Cypress.env('ELASTICSEARCH_USERNAME');
+const isCloudServerless = Cypress.env('CLOUD_SERVERLESS');
+
+const author = isCloudServerless ? serverlessCloudUserName : systemIndicesSuperuserName;
+
 const link = 'https://www.elastic.co/';
 
 describe('Timeline notes tab', { tags: ['@ess', '@serverless'] }, () => {
@@ -69,12 +74,12 @@ describe('Timeline notes tab', { tags: ['@ess', '@serverless'] }, () => {
 
   it('should render the right author', () => {
     addNotesToTimeline(getTimelineNonValidQuery().notes);
-    cy.get(NOTES_AUTHOR).first().should('have.text', text);
+    cy.get(NOTES_AUTHOR).first().should('have.text', author);
   });
 
   it('should be able to render a link', () => {
-    addNotesToTimeline(`[${text}](${link})`);
-    cy.get(NOTES_LINK).last().should('have.text', `${text}(opens in a new tab or window)`);
+    addNotesToTimeline(`[${author}](${link})`);
+    cy.get(NOTES_LINK).last().should('have.text', `${author}(opens in a new tab or window)`);
     cy.get(NOTES_LINK).last().click();
   });
 

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
@@ -26,12 +26,7 @@ import { addNotesToTimeline, goToNotesTab } from '../../../tasks/timeline';
 
 import { deleteTimelines } from '../../../tasks/api_calls/common';
 
-const systemIndicesSuperUserName = 'system_indices_superuser';
-const serverlessCloudUserName = Cypress.env('ELASTICSEARCH_USERNAME');
-const isCloudServerless = Cypress.env('CLOUD_SERVERLESS');
-
-const author = isCloudServerless ? serverlessCloudUserName : systemIndicesSuperuserName;
-
+const author = Cypress.env('ELASTICSEARCH_USERNAME');
 const link = 'https://www.elastic.co/';
 
 describe('Timeline notes tab', { tags: ['@ess', '@serverless'] }, () => {

--- a/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
+++ b/x-pack/test/security_solution_cypress/cypress/e2e/investigations/timelines/notes_tab.cy.ts
@@ -26,7 +26,7 @@ import { addNotesToTimeline, goToNotesTab } from '../../../tasks/timeline';
 
 import { deleteTimelines } from '../../../tasks/api_calls/common';
 
-const systemIndicesSuperuserName = 'system_indices_superuser';
+const systemIndicesSuperUserName = 'system_indices_superuser';
 const serverlessCloudUserName = Cypress.env('ELASTICSEARCH_USERNAME');
 const isCloudServerless = Cypress.env('CLOUD_SERVERLESS');
 


### PR DESCRIPTION
## Summary

The tests that were using the `author` in assertions for the notes tab tests in timeline, are failing in MKI

This is because we are hardcoding the username as `system_indices_superuser`, but that one, does not exist on MKI projects. 

In this PR we are fixing the issue.

