### PR TITLE
[DOCS] Discover troubleshooting blog link

### DIFF
--- a/docs/user/discover.asciidoc
+++ b/docs/user/discover.asciidoc
@@ -334,6 +334,11 @@ For more about this and other rules provided in {alert-features}, go to <<alerti
 
 * <<document-explorer, Configure the chart and document table>> to better meet your needs.
 
+[float]
+=== Troubleshooting
+
+* {blog-ref}troubleshooting-guide-common-issues-kibana-discover-load[Learn how to resolve common issues with Discover.]
+
 
 --
 include::{kibana-root}/docs/discover/document-explorer.asciidoc[]


### PR DESCRIPTION
Request to link from Discover page to a blog [troubleshooting guide for Discover](https://www.elastic.co/blog/troubleshooting-guide-common-issues-kibana-discover-load). I've put it under a Troubleshooting heading on the [Discover index page](https://www.elastic.co/guide/en/kibana/current/discover.html), but if you think it would be better included in the What's next? section just let me know and I'll move it. 

<img width="1366" alt="Screenshot 2024-03-20 at 20 18 45" src="https://github.com/elastic/kibana/assets/61687663/c0a9d410-c0e2-4350-985f-07d432dbcdf0">

Relates to:#178046 

<!--ONMERGE {"backportTargets":["8.12","8.13"]} ONMERGE-->