### PR TITLE
[discover] esql reduce field_caps usage

### DIFF
--- a/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
+++ b/src/plugins/discover/public/application/main/services/discover_data_state_container.ts
@@ -301,6 +301,7 @@ export function getDataStateContainer({
     const currentDataView = getSavedSearch().searchSource.getField('index');
 
     if (isTextBasedQuery(query)) {
+      // this is where the dataView gets set to state, making it difficult to swap with dataViewLazy
       const nextDataView = await getDataViewByTextBasedQueryLang(query, currentDataView, services);
       if (nextDataView !== currentDataView) {
         setDataView(nextDataView);

--- a/src/plugins/discover/public/application/main/services/load_saved_search.ts
+++ b/src/plugins/discover/public/application/main/services/load_saved_search.ts
@@ -60,6 +60,7 @@ export const loadSavedSearch = async (
   let nextSavedSearch = savedSearchId
     ? await savedSearchContainer.load(savedSearchId)
     : await savedSearchContainer.new(
+        // change this to use DataViewLazy?
         await getStateDataView(params, { services, appState, internalStateContainer })
       );
 
@@ -88,6 +89,7 @@ export const loadSavedSearch = async (
     if (savedSearchId && appState.index) {
       // This is for the case appState is overwriting the loaded saved search data view
       const savedSearchDataViewId = nextSavedSearch.searchSource.getField('index')?.id;
+      // change this to use DataViewLazy?
       const stateDataView = await getStateDataView(params, {
         services,
         appState,
@@ -190,9 +192,11 @@ const getStateDataView = async (
   const query = appState?.query;
 
   if (isTextBasedQuery(query)) {
+    // also used here
     return await getDataViewByTextBasedQueryLang(query, dataView, services);
   }
 
+  // seems like it would make sense to convert this to DataViewLazy
   const result = await loadAndResolveDataView(
     {
       id: appState?.index,

--- a/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
+++ b/src/plugins/discover/public/application/main/utils/get_data_view_by_text_based_query_lang.ts
@@ -33,6 +33,7 @@ export async function getDataViewByTextBasedQueryLang(
     currentDataView?.isPersisted() ||
     indexPatternFromQuery !== currentDataView?.getIndexPattern()
   ) {
+    // I could use DataViewLazy here BUT this function returns a DataView - where is that DataView being used?
     const dataViewObj = await getESQLAdHocDataview(indexPatternFromQuery, services.dataViews);
 
     if (dataViewObj.fields.getByName('@timestamp')?.type === 'date') {


### PR DESCRIPTION
## Summary

Summarize your PR. If it involves visual changes include a screenshot or gif.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
