### PR TITLE
[Discover] Hide "Save"/"Save as" actions from "Unsaved changes" badge  for read-only users

### DIFF
--- a/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
+++ b/src/plugins/discover/public/application/main/components/top_nav/get_top_nav_badges.tsx
@@ -46,14 +46,17 @@ export const getTopNavBadges = ({
     entries.push({
       data: getTopNavUnsavedChangesBadge({
         onRevert: stateContainer.actions.undoSavedSearchChanges,
-        onSave: !isManaged
+        onSave:
+          services.capabilities.discover.save && !isManaged
+            ? async () => {
+                await saveSearch();
+              }
+            : undefined,
+        onSaveAs: services.capabilities.discover.save
           ? async () => {
-              await saveSearch();
+              await saveSearch(true);
             }
           : undefined,
-        onSaveAs: async () => {
-          await saveSearch(true);
-        },
       }),
       order: defaultBadges?.unsavedChangesBadge?.order ?? 100,
     });


### PR DESCRIPTION
## Summary

This PR hides "Save"/"Save as" actions from "Unsaved changes" badge  for read-only users. "Revert changes" action stays.

Before (the read-only user would see an error toast when clicked):

<img width="300" alt="Screenshot 2024-03-21 at 10 33 28" src="https://github.com/elastic/kibana/assets/1415710/31f9a1ac-4776-46d8-a253-15c013ecb2e4">

After:

<img width="299" alt="Screenshot 2024-03-21 at 10 59 33" src="https://github.com/elastic/kibana/assets/1415710/f7320f92-8232-4cb1-b634-4a303ec4db05">

### Checklist

- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios


<!--ONMERGE {"backportTargets":["8.13"]} ONMERGE-->