### PR TITLE
[ESLint i18n Rule] Smarter autofixing of incorrect i18n app identifier

### DIFF
--- a/packages/kbn-eslint-plugin-i18n/rules/i18n_translate_should_start_with_the_right_id.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/i18n_translate_should_start_with_the_right_id.test.ts
@@ -43,7 +43,7 @@ const babelTester = [
 
 const invalid: RuleTester.InvalidTestCase[] = [
   {
-    name: 'When a string literal is passed to i18n.translate, it should start with the correct i18n identifier.',
+    name: 'When a string literal is passed to i18n.translate, it should start with the correct i18n identifier, and if no existing defaultMessage is passed, it should add an empty default.',
     filename: '/x-pack/plugins/observability_solution/observability/public/test_component.ts',
     code: `
 import { i18n } from '@kbn/i18n';
@@ -61,7 +61,51 @@ function TestComponent() {
 import { i18n } from '@kbn/i18n';
 
 function TestComponent() {
-  const foo = i18n.translate('xpack.observability.testComponent.', { defaultMessage: '' });
+  const foo = i18n.translate('xpack.observability.', { defaultMessage: '' });
+}`,
+  },
+  {
+    name: 'When a string literal is passed to i18n.translate, and the root of the i18n identifier is not correct, it should keep the existing identifier but only update the right base app.',
+    filename: '/x-pack/plugins/observability_solution/observability/public/test_component.ts',
+    code: `
+import { i18n } from '@kbn/i18n';
+
+function TestComponent() {
+  const foo = i18n.translate('foo.bar.baz');
+}`,
+    errors: [
+      {
+        line: 5,
+        message: RULE_WARNING_MESSAGE,
+      },
+    ],
+    output: `
+import { i18n } from '@kbn/i18n';
+
+function TestComponent() {
+  const foo = i18n.translate('xpack.observability.bar.baz', { defaultMessage: '' });
+}`,
+  },
+  {
+    name: 'When a string literal is passed to i18n.translate, and the root of the i18n identifier is not correct, it should keep the existing identifier but only update the right base app, and keep the default message if available.',
+    filename: '/x-pack/plugins/observability_solution/observability/public/test_component.ts',
+    code: `
+import { i18n } from '@kbn/i18n';
+
+function TestComponent() {
+  const foo = i18n.translate('foo.bar.baz', { defaultMessage: 'giraffe' });
+}`,
+    errors: [
+      {
+        line: 5,
+        message: RULE_WARNING_MESSAGE,
+      },
+    ],
+    output: `
+import { i18n } from '@kbn/i18n';
+
+function TestComponent() {
+  const foo = i18n.translate('xpack.observability.bar.baz', { defaultMessage: 'giraffe' });
 }`,
   },
   {

--- a/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_formatted_message.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_formatted_message.test.ts
@@ -181,7 +181,7 @@ function TestComponent() {
 }`,
   },
   {
-    name: 'JSX elements that have a label or aria-label prop with a string value should be translated with i18n',
+    name: 'JSX elements that have a label, aria-label or title prop with a string value should be translated with i18n',
     filename: '/x-pack/plugins/observability_solution/observability/public/test_component.tsx',
     code: `
 import React from 'react';
@@ -191,10 +191,28 @@ function TestComponent() {
   return (
     <SomeChildComponent label="This is a test" />
   )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label="This is a test" />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title="This is a test" />
+  )
 }`,
     errors: [
       {
         line: 7,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 12,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 17,
         message: RULE_WARNING_MESSAGE,
       },
     ],
@@ -206,10 +224,20 @@ function TestComponent() {
   return (
     <SomeChildComponent label={<FormattedMessage id="xpack.observability.testComponent.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
   )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label={<FormattedMessage id="xpack.observability.testComponent2.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title={<FormattedMessage id="xpack.observability.testComponent3.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
+  )
 }`,
   },
   {
-    name: 'JSX elements that have a label or aria-label prop with a JSXExpression value that is a string should be translated with i18n',
+    name: 'JSX elements that have a label, aria-label or title prop with a JSXExpression value that is a string should be translated with i18n',
     filename: '/x-pack/plugins/observability_solution/observability/public/test_component.tsx',
     code: `
   import React from 'react';
@@ -219,10 +247,28 @@ function TestComponent() {
     return (
       <SomeChildComponent label={'This is a test'} />
     )
+  }
+  function TestComponent2() {
+    return (
+      <SomeChildComponent aria-label={'This is a test'} />
+    )
+  }
+  function TestComponent3() {
+    return (
+      <SomeChildComponent title={'This is a test'} />
+    )
   }`,
     errors: [
       {
         line: 7,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 12,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 17,
         message: RULE_WARNING_MESSAGE,
       },
     ],
@@ -233,6 +279,16 @@ function TestComponent() {
   function TestComponent() {
     return (
       <SomeChildComponent label={<FormattedMessage id="xpack.observability.testComponent.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
+    )
+  }
+  function TestComponent2() {
+    return (
+      <SomeChildComponent aria-label={<FormattedMessage id="xpack.observability.testComponent2.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
+    )
+  }
+  function TestComponent3() {
+    return (
+      <SomeChildComponent title={<FormattedMessage id="xpack.observability.testComponent3.someChildComponent.thisIsATestLabel" defaultMessage="This is a test" />} />
     )
   }`,
   },

--- a/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_formatted_message.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_formatted_message.ts
@@ -75,7 +75,12 @@ export const StringsShouldBeTranslatedWithFormattedMessage: Rule.RuleModule = {
         });
       },
       JSXAttribute: (node: TSESTree.JSXAttribute) => {
-        if (node.name.name !== 'aria-label' && node.name.name !== 'label') return;
+        if (
+          node.name.name !== 'aria-label' &&
+          node.name.name !== 'label' &&
+          node.name.name !== 'title'
+        )
+          return;
 
         let val: string = '';
 

--- a/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_i18n.test.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_i18n.test.ts
@@ -169,7 +169,7 @@ function TestComponent() {
 }`,
   },
   {
-    name: 'JSX elements that have a label or aria-label prop with a string value should be translated with i18n',
+    name: 'JSX elements that have a label, aria-label or title prop with a string value should be translated with i18n',
     filename: '/x-pack/plugins/observability_solution/observability/public/test_component.tsx',
     code: `
 import React from 'react';
@@ -179,10 +179,28 @@ function TestComponent() {
   return (
     <SomeChildComponent label="This is a test" />
   )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label="This is a test" />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title="This is a test" />
+  )
 }`,
     errors: [
       {
         line: 7,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 12,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 17,
         message: RULE_WARNING_MESSAGE,
       },
     ],
@@ -194,10 +212,20 @@ function TestComponent() {
   return (
     <SomeChildComponent label={i18n.translate('xpack.observability.testComponent.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
   )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label={i18n.translate('xpack.observability.testComponent2.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title={i18n.translate('xpack.observability.testComponent3.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
+  )
 }`,
   },
   {
-    name: 'JSX elements that have a label or aria-label prop with a JSXExpression value that is a string should be translated with i18n',
+    name: 'JSX elements that have a label, aria-label or title prop with a JSXExpression value that is a string should be translated with i18n',
     filename: '/x-pack/plugins/observability_solution/observability/public/test_component.tsx',
     code: `
 import React from 'react';
@@ -207,10 +235,28 @@ function TestComponent() {
   return (
     <SomeChildComponent label={'This is a test'} />
   )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label={'This is a test'} />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title={'This is a test'} />
+  )
 }`,
     errors: [
       {
         line: 7,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 12,
+        message: RULE_WARNING_MESSAGE,
+      },
+      {
+        line: 17,
         message: RULE_WARNING_MESSAGE,
       },
     ],
@@ -221,6 +267,16 @@ import { i18n } from '@kbn/i18n';
 function TestComponent() {
   return (
     <SomeChildComponent label={i18n.translate('xpack.observability.testComponent.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
+  )
+}
+function TestComponent2() {
+  return (
+    <SomeChildComponent aria-label={i18n.translate('xpack.observability.testComponent2.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
+  )
+}
+function TestComponent3() {
+  return (
+    <SomeChildComponent title={i18n.translate('xpack.observability.testComponent3.someChildComponent.thisIsATestLabel', { defaultMessage: 'This is a test' })} />
   )
 }`,
   },

--- a/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_i18n.ts
+++ b/packages/kbn-eslint-plugin-i18n/rules/strings_should_be_translated_with_i18n.ts
@@ -73,7 +73,12 @@ export const StringsShouldBeTranslatedWithI18n: Rule.RuleModule = {
         });
       },
       JSXAttribute: (node: TSESTree.JSXAttribute) => {
-        if (node.name.name !== 'aria-label' && node.name.name !== 'label') return;
+        if (
+          node.name.name !== 'aria-label' &&
+          node.name.name !== 'label' &&
+          node.name.name !== 'title'
+        )
+          return;
 
         let val: string = '';
 


### PR DESCRIPTION
## Summary

This adds two things to the ESLint rule for Translations package:

1. The `i18n_translate_should_start_with_the_right_id` rule has been updated so that it updates the part of the identifier that corresponds to the app identifier but keeps the rest of the identifier intact, including the `defaultMessage`. This allows engineers to 'transplant' translated strings from one app to another, with the rule updating the necessary parts for you while keeping its greedy mitts off the parts that shouldn't be updated.
2. `strings_should_be_translated_with_i18n` and `strings_should_be_translated_with_formatted_message` have been updated so they also kick in on `title` props, in addition to the existing `label` and `aria-label` props.

**Before (sad!)**

https://github.com/elastic/kibana/assets/535564/5ab8bbcc-d560-4bc2-9616-77513070f779


**New (happy!)**

https://github.com/elastic/kibana/assets/535564/d4b5e504-8b71-4639-87a7-59c8825c043d

