### PR TITLE
[8.13] [ES|QL] case only requires two parameters (#179011)

### DIFF
--- a/packages/kbn-monaco/src/esql/lib/ast/definitions/functions.ts
+++ b/packages/kbn-monaco/src/esql/lib/ast/definitions/functions.ts
@@ -592,7 +592,7 @@ export const evalFunctionsDefinitions: FunctionDefinition[] = [
           { name: 'condition', type: 'boolean' },
           { name: 'value', type: 'any' },
         ],
-        minParams: 3,
+        minParams: 2,
         returnType: 'any',
         examples: [
           `from index | eval type = case(languages <= 1, "monolingual", languages <= 2, "bilingual", "polyglot")`,


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.13`:
 - [[ES|QL] case only requires two parameters (#179011)](https://github.com/elastic/kibana/pull/179011)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)

<!--BACKPORT [{"author":{"name":"Drew Tate","email":"drew.tate@elastic.co"},"sourceCommit":{"committedDate":"2024-03-21T14:34:38Z","message":"[ES|QL] case only requires two parameters (#179011)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/177699\r\n\r\nWe had `case` marked as if it required three parameters when in reality\r\nit only requires two.\r\n\r\n<img width=\"600\" alt=\"Screenshot 2024-03-19 at 4 23 29 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/45f7578a-e6ad-4ba9-b71a-05bb1978a384\">\r\n\r\nNote: we could consider testing these n-1 cases to prevent this kind of\r\nbug in the future.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"28277c25df26796a8aa51cb4b8e82b0483c9cf83","branchLabelMapping":{"^v8.14.0$":"main","^v(\\d+).(\\d+).\\d+$":"$1.$2"}},"sourcePullRequest":{"labels":["release_note:fix","backport:prev-minor","v8.14.0"],"number":179011,"url":"https://github.com/elastic/kibana/pull/179011","mergeCommit":{"message":"[ES|QL] case only requires two parameters (#179011)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/177699\r\n\r\nWe had `case` marked as if it required three parameters when in reality\r\nit only requires two.\r\n\r\n<img width=\"600\" alt=\"Screenshot 2024-03-19 at 4 23 29 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/45f7578a-e6ad-4ba9-b71a-05bb1978a384\">\r\n\r\nNote: we could consider testing these n-1 cases to prevent this kind of\r\nbug in the future.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"28277c25df26796a8aa51cb4b8e82b0483c9cf83"}},"sourceBranch":"main","suggestedTargetBranches":[],"targetPullRequestStates":[{"branch":"main","label":"v8.14.0","labelRegex":"^v8.14.0$","isSourceBranch":true,"state":"MERGED","url":"https://github.com/elastic/kibana/pull/179011","number":179011,"mergeCommit":{"message":"[ES|QL] case only requires two parameters (#179011)\n\n## Summary\r\n\r\nPart of https://github.com/elastic/kibana/issues/177699\r\n\r\nWe had `case` marked as if it required three parameters when in reality\r\nit only requires two.\r\n\r\n<img width=\"600\" alt=\"Screenshot 2024-03-19 at 4 23 29 PM\"\r\nsrc=\"https://github.com/elastic/kibana/assets/315764/45f7578a-e6ad-4ba9-b71a-05bb1978a384\">\r\n\r\nNote: we could consider testing these n-1 cases to prevent this kind of\r\nbug in the future.\r\n\r\nCo-authored-by: Kibana Machine <42973632+kibanamachine@users.noreply.github.com>\r\nCo-authored-by: Marta Bondyra <4283304+mbondyra@users.noreply.github.com>","sha":"28277c25df26796a8aa51cb4b8e82b0483c9cf83"}}]}] BACKPORT-->